### PR TITLE
Enable multiprocessing for multi=True in streamdf.py

### DIFF
--- a/galpy/df_src/streamdf.py
+++ b/galpy/df_src/streamdf.py
@@ -100,7 +100,10 @@ class streamdf:
         if not self._aA._pot == self._pot:
             raise IOError("Potential in aA does not appear to be the same as given potential pot")
         self._progenitor= progenitor
-        self._multi= multi
+        if (multi is True):   #if set to boolean, enable cpu_count processes
+            self._multi= multiprocessing.cpu_count()
+        else:
+            self._multi= multi
         #Progenitor orbit: Calculate actions, frequencies, and angles for the progenitor
         acfs= aA.actionsFreqsAngles(self._progenitor,maxn=3,
                                     _firstFlip=(not leading))


### PR DESCRIPTION
I think either the docstring or preferably the code should be changed.  I initially ran streamdf with multi=True and wondered why there was no speedup, then found I was running in parallel on one process.  Am I missing something?

Of course I could have just reported this in the issue tracker but I'm trying out your model of isolating code changes on separate branches.
