### PR TITLE
Codecov coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_install:
 # command to install dependencies
 install:
  - pip install nose-cov
- - pip install coveralls-merge
  - gem install coveralls-lcov
  - easy_install --upgrade requests
  - easy_install --upgrade coveralls
@@ -50,12 +49,8 @@ install:
 script:
  - nosetests -v -w nose/ --with-cov --cov galpy --cov-config .coveragerc_travis
 after_success:
- # Generate lcov output 
  - lcov --capture --base-directory . --directory build/temp.linux-x86_64-2.7/galpy/ --output-file coverage.info
- # combine, generate json, and upload
- - coveralls-lcov -v -n coverage.info > coverage.c.json
- - coveralls-merge coverage.c.json
-# - coveralls
+ - bash <(curl -s https://codecov.io/bash)
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Hey there, I found your repo and saw some complex methods to generate coverage reports. I wanted to see how Codecov (I'm the founder of Codecov) would handle the lcov and cobertura together. It merges them automatically so no need for `coveralls-merge`

If your interested in switching to Codecov that would be great. You can see the report from [my build here](https://codecov.io/github/stevepeak/galpy?ref=cc537e91ecddff3794f24e9097242100f14eb2f7)

Cheer!

Steve
