### PR TITLE
Use astropy.coordinates for internal coordinate transformations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env: #split tests
     - REQUIRES_PYNBODY=false
     - REQUIRES_ASTROPY=false
   matrix:
-    - NOSE_IGNORE_FILES='test_qdf|test_pv2qdf|test_diskdf|test_orbit|test_streamdf|test_streamgapdf|test_evolveddiskdf|test_quantity|test_nemo' REQUIRES_PYNBODY=true
-    - NOSE_IGNORE_FILES='^((?!test_quantity).)*$' REQUIRES_ASTROPY=true # needs to be separate for different config
+    - NOSE_IGNORE_FILES='test_qdf|test_pv2qdf|test_diskdf|test_orbit|test_streamdf|test_streamgapdf|test_evolveddiskdf|test_quantity|test_nemo|test_coords' REQUIRES_PYNBODY=true
+    - NOSE_IGNORE_FILES='^((?!test_quantity|test_coords).)*$' REQUIRES_ASTROPY=true # needs to be separate for different config
     - NOSE_IGNORE_FILES='^((?!test_orbit).)*$' REQUIRES_PYNBODY=true REQUIRES_ASTROPY=true
     - NOSE_IGNORE_FILES='^((?!test_evolveddiskdf).)*$'
     - NOSE_IGNORE_FILES='^((?!test_diskdf).)*$'

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -6,6 +6,10 @@ v1.2 (2016-XX-XX)
   astropy Quantities. See pull request #258 and the documentation for
   full details.
 
+- Internally use astropy.coordinates transformations to transform
+  between (ra,dec) and (l,b). Can be tuned using the astropy-coords
+  configuration parameter.
+
 - quasiisothermaldf input ro replaced by refr to avoid clash with ro
   that specifies units (see above).
 

--- a/doc/source/examples/galpyrc
+++ b/doc/source/examples/galpyrc
@@ -4,4 +4,5 @@ vo = 220.
 
 [astropy]
 astropy-units = False
+astropy-coords = True
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -141,11 +141,15 @@ of configuration variables. This configuration file is parsed using
 <https://docs.python.org/3/library/configparser.html>`__. It is
 currently used to set a default set of distance and velocity scales
 (``ro`` and ``vo`` throughout galpy) for conversion between physical
-and internal galpy units and to specify whether output from functions
-or methods should be given as an `astropy Quantity
+and internal galpy units, to specify whether output from functions or
+methods should be given as an `astropy Quantity
 <http://docs.astropy.org/en/stable/api/astropy.units.Quantity.html>`__
-with units as much as possible or not. The current configuration file
-therefore looks like this::
+with units as much as possible or not, and whether or not to use
+astropy's `coordinate transformations
+<http://docs.astropy.org/en/stable/coordinates/index.html>`__ (these
+are typically somewhat slower than galpy's own coordinate
+transformations, but they are more accurate and more general). The
+current configuration file therefore looks like this::
 
 	  [normalization]
 	  ro = 8.
@@ -153,6 +157,7 @@ therefore looks like this::
 
 	  [astropy]
 	  astropy-units = False
+	  astropy-coords = True
 
 where ``ro`` is the distance scale specified in kpc, ``vo`` the
 velocity scale in km/s, and the setting is to *not* return output as a

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -24,6 +24,11 @@ v1.2
 * ``galpy.potential.PseudoIsothermalPotential``, a standard
   pseudo-isothermal-sphere potential.
 
+* Internal transformations between equatorial and Galactic coordinates
+  are now performed by default using astropy's `coordinates
+  <http://docs.astropy.org/en/stable/coordinates/index.html>`__
+  module.
+
 v1.1
 +++++
 

--- a/galpy/df_src/streamdf.py
+++ b/galpy/df_src/streamdf.py
@@ -1370,7 +1370,7 @@ class streamdf(df):
                                               self._ObsTrack[:,2]*vo,
                                               self._ObsTrack[:,4]*vo,
                                               self._ObsTrack[:,5],
-                                              vsun=vsun)
+                                              vsun=vsun,Xsun=R0,Zsun=Zsun)
         slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                     degree=True)
         svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],
@@ -1397,7 +1397,7 @@ class streamdf(df):
                 self._interpolatedObsTrackXY[:,3]*vo,
                 self._interpolatedObsTrackXY[:,4]*vo,
                 self._interpolatedObsTrackXY[:,5]*vo,
-                vsun=vsun)
+                vsun=vsun,Xsun=R0,Zsun=Zsun)
             slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                         degree=True)
             svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],
@@ -2621,7 +2621,8 @@ class streamdf(df):
                                                          tvxvyvz[:,2],
                                                          iR,iphi,iZ,
                                                          galcen=True,
-                                                         vsun=vsun)
+                                                         vsun=vsun,
+                                                         Xsun=R0,Zsun=Zsun)
             iR/= ro
             iZ/= ro
             ivR/= vo
@@ -2869,7 +2870,7 @@ class streamdf(df):
                                                   RvR[2]*vo,
                                                   RvR[4]*vo,
                                                   RvR[5],
-                                                  vsun=vsun)
+                                                  vsun=vsun,Xsun=R0,Zsun=Zsun)
             slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                         degree=True)
             svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],
@@ -3188,7 +3189,7 @@ def lbCoordFunc(xv,vo,ro,R0,Zsun,vsun):
     vx,vy,vz= bovy_coords.vrpmllpmbb_to_vxvyvz(xv[3],xv[4],xv[5],
                                                X,Y,Z,XYZ=True)
     vR,vT,vZ= bovy_coords.vxvyvz_to_galcencyl(vx,vy,vz,R,phi,Z,galcen=True,
-                                              vsun=vsun)
+                                              vsun=vsun,Xsun=R0,Zsun=Zsun)
     R/= ro
     Z/= ro
     vR/= vo

--- a/galpy/df_src/streamdf.py
+++ b/galpy/df_src/streamdf.py
@@ -2610,7 +2610,7 @@ class streamdf(df):
                                          degree=True)
             iR,iphi,iZ= bovy_coords.XYZ_to_galcencyl(tXYZ[:,0],tXYZ[:,1],
                                                      tXYZ[:,2],
-                                                     Xsun=R0,Ysun=0.,Zsun=Zsun)
+                                                     Xsun=R0,Zsun=Zsun)
             tvxvyvz= bovy_coords.vrpmllpmbb_to_vxvyvz(ivX.flatten(),
                                                       ivY.flatten(),
                                                       ivZ.flatten(),
@@ -3184,7 +3184,7 @@ def lbCoordFunc(xv,vo,ro,R0,Zsun,vsun):
     #Input is (l,b,D,vlos,pmll,pmbb) in (deg,deg,kpc,km/s,mas/yr,mas/yr)
     X,Y,Z= bovy_coords.lbd_to_XYZ(xv[0],xv[1],xv[2],degree=True)
     R,phi,Z= bovy_coords.XYZ_to_galcencyl(X,Y,Z,
-                                          Xsun=R0,Ysun=0.,Zsun=Zsun)
+                                          Xsun=R0,Zsun=Zsun)
     vx,vy,vz= bovy_coords.vrpmllpmbb_to_vxvyvz(xv[3],xv[4],xv[5],
                                                X,Y,Z,XYZ=True)
     vR,vT,vZ= bovy_coords.vxvyvz_to_galcencyl(vx,vy,vz,R,phi,Z,galcen=True,

--- a/galpy/df_src/streamdf.py
+++ b/galpy/df_src/streamdf.py
@@ -1365,12 +1365,12 @@ class streamdf(df):
         XYZ= bovy_coords.galcencyl_to_XYZ(self._ObsTrack[:,0]*ro,
                                           self._ObsTrack[:,5],
                                           self._ObsTrack[:,3]*ro,
-                                          Xsun=R0,Zsun=Zsun)
+                                          Xsun=R0,Zsun=Zsun).T
         vXYZ= bovy_coords.galcencyl_to_vxvyvz(self._ObsTrack[:,1]*vo,
                                               self._ObsTrack[:,2]*vo,
                                               self._ObsTrack[:,4]*vo,
                                               self._ObsTrack[:,5],
-                                              vsun=vsun,Xsun=R0,Zsun=Zsun)
+                                              vsun=vsun,Xsun=R0,Zsun=Zsun).T
         slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                     degree=True)
         svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],
@@ -1391,13 +1391,13 @@ class streamdf(df):
                 self._interpolatedObsTrackXY[:,0]*ro,
                 self._interpolatedObsTrackXY[:,1]*ro,
                 self._interpolatedObsTrackXY[:,2]*ro,
-                Xsun=R0,Zsun=Zsun)
+                Xsun=R0,Zsun=Zsun).T
             vXYZ=\
                 bovy_coords.galcenrect_to_vxvyvz(\
                 self._interpolatedObsTrackXY[:,3]*vo,
                 self._interpolatedObsTrackXY[:,4]*vo,
                 self._interpolatedObsTrackXY[:,5]*vo,
-                vsun=vsun,Xsun=R0,Zsun=Zsun)
+                vsun=vsun,Xsun=R0,Zsun=Zsun).T
             slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                         degree=True)
             svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],
@@ -2610,7 +2610,7 @@ class streamdf(df):
                                          degree=True)
             iR,iphi,iZ= bovy_coords.XYZ_to_galcencyl(tXYZ[:,0],tXYZ[:,1],
                                                      tXYZ[:,2],
-                                                     Xsun=R0,Zsun=Zsun)
+                                                     Xsun=R0,Zsun=Zsun).T
             tvxvyvz= bovy_coords.vrpmllpmbb_to_vxvyvz(ivX.flatten(),
                                                       ivY.flatten(),
                                                       ivZ.flatten(),
@@ -2622,7 +2622,7 @@ class streamdf(df):
                                                          iR,iphi,iZ,
                                                          galcen=True,
                                                          vsun=vsun,
-                                                         Xsun=R0,Zsun=Zsun)
+                                                         Xsun=R0,Zsun=Zsun).T
             iR/= ro
             iZ/= ro
             ivR/= vo
@@ -2865,12 +2865,12 @@ class streamdf(df):
             XYZ= bovy_coords.galcencyl_to_XYZ(RvR[0]*ro,
                                               RvR[5],
                                               RvR[3]*ro,
-                                              Xsun=R0,Zsun=Zsun)
+                                              Xsun=R0,Zsun=Zsun).T
             vXYZ= bovy_coords.galcencyl_to_vxvyvz(RvR[1]*vo,
                                                   RvR[2]*vo,
                                                   RvR[4]*vo,
                                                   RvR[5],
-                                                  vsun=vsun,Xsun=R0,Zsun=Zsun)
+                                                  vsun=vsun,Xsun=R0,Zsun=Zsun).T
             slbd=bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],
                                         degree=True)
             svlbd= bovy_coords.vxvyvz_to_vrpmllpmbb(vXYZ[0],vXYZ[1],vXYZ[2],

--- a/galpy/orbit_src/FullOrbit.py
+++ b/galpy/orbit_src/FullOrbit.py
@@ -745,12 +745,11 @@ def _fit_orbit_mlogl(new_vxvv,vxvv,vxvv_err,pot,radec,lb,
         X,Y,Z = coords.galcencyl_to_XYZ(iR.flatten(),iphi.flatten(),
                                         iz.flatten(),
                                         Xsun=obs[0]/ro,
-                                        Ysun=obs[1]/ro,
                                         Zsun=obs[2]/ro)
         vX,vY,vZ = coords.galcencyl_to_vxvyvz(ivR.flatten(),ivT.flatten(),
                                               ivz.flatten(),iphi.flatten(),
                                               vsun=nu.array(\
-                obs[3:6])/vo)
+                obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
         bad_indx= (X == 0.)*(Y == 0.)*(Z == 0.)
         if True in bad_indx: X[bad_indx]+= ro/10000.
         lbdvrpmllpmbb= coords.rectgal_to_sphergal(X*ro,Y*ro,Z*ro,

--- a/galpy/orbit_src/FullOrbit.py
+++ b/galpy/orbit_src/FullOrbit.py
@@ -392,7 +392,7 @@ class FullOrbit(OrbitTop):
            pot= Potential to fit the orbit in
 
            Keywords related to the input data:
-               radec= if True, input vxvv and vxvv_err are [ra,dec,d,mu_ra, mu_dec,vlos] in [deg,deg,kpc,mas/yr,mas/yr,km/s] (all J2000.0; mu_ra = mu_ra * cos dec); the attributes of the current Orbit are used to convert between these coordinates and Galactocentric coordinates
+               radec= if True, input vxvv and vxvv_err are [ra,dec,d,mu_ra, mu_dec,vlos] in [deg,deg,kpc,mas/yr,mas/yr,km/s] (all J2000.0; mu_ra = mu_ra * cos dec); the attributes of the current Orbit are used to convert between these coordinates and Galactocentric coordinates; Note that for speed reasons, galpy's internal transformation between (l,b) and (ra,dec) is used, rather than astropy's
                lb= if True, input vxvv and vxvv_err are [long,lat,d,mu_ll, mu_bb,vlos] in [deg,deg,kpc,mas/yr,mas/yr,km/s] (mu_ll = mu_ll * cos lat); the attributes of the current Orbit are used to convert between these coordinates and Galactocentric coordinates
                customsky= if True, input vxvv and vxvv_err are [custom long,custom lat,d,mu_customll, mu_custombb,vlos] in [deg,deg,kpc,mas/yr,mas/yr,km/s] (mu_ll = mu_ll * cos lat) where custom longitude and custom latitude are a custom set of sky coordinates (e.g., ecliptic) and the proper motions are also expressed in these coordinats; you need to provide the functions lb_to_customsky and pmllpmbb_to_customsky to convert to the custom sky coordinates (these should have the same inputs and outputs as lb_to_radec and pmllpmbb_to_pmrapmdec); the attributes of the current Orbit are used to convert between these coordinates and Galactocentric coordinates
                obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer 
@@ -699,6 +699,8 @@ def _fit_orbit(orb,vxvv,vxvv_err,pot,radec=False,lb=False,
                tintJ=100,ntintJ=1000,integrate_method='dopr54_c',
                ro=None,vo=None,obs=None,disp=False):
     """Fit an orbit to data in a given potential"""
+    # Need to turn this off for speed
+    coords._APY_COORDS= False
     #Import here, because otherwise there is an infinite loop of imports
     from galpy.actionAngle import actionAngleIsochroneApprox, actionAngle
     #Mock this up, bc we want to use its orbit-integration routines
@@ -724,6 +726,7 @@ def _fit_orbit(orb,vxvv,vxvv_err,pot,radec=False,lb=False,
                                customsky,lb_to_customsky,pmllpmbb_to_customsky,
                                tmockAA,
                                ro,vo,obs)
+    coords._APY_COORDS= True
     return (opt_vxvv,maxLogL)
 
 def _fit_orbit_mlogl(new_vxvv,vxvv,vxvv_err,pot,radec,lb,

--- a/galpy/orbit_src/FullOrbit.py
+++ b/galpy/orbit_src/FullOrbit.py
@@ -745,11 +745,11 @@ def _fit_orbit_mlogl(new_vxvv,vxvv,vxvv_err,pot,radec,lb,
         X,Y,Z = coords.galcencyl_to_XYZ(iR.flatten(),iphi.flatten(),
                                         iz.flatten(),
                                         Xsun=obs[0]/ro,
-                                        Zsun=obs[2]/ro)
+                                        Zsun=obs[2]/ro).T
         vX,vY,vZ = coords.galcencyl_to_vxvyvz(ivR.flatten(),ivT.flatten(),
                                               ivz.flatten(),iphi.flatten(),
                                               vsun=nu.array(\
-                obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
+                obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro).T
         bad_indx= (X == 0.)*(Y == 0.)*(Z == 0.)
         if True in bad_indx: X[bad_indx]+= ro/10000.
         lbdvrpmllpmbb= coords.rectgal_to_sphergal(X*ro,Y*ro,Z*ro,

--- a/galpy/orbit_src/Orbit.py
+++ b/galpy/orbit_src/Orbit.py
@@ -173,7 +173,9 @@ class Orbit(object):
             R, phi, z= coords.XYZ_to_galcencyl(X,Y,Z,Zsun=zo/ro)
             vR, vT,vz= coords.vxvyvz_to_galcencyl(vx,vy,vz,
                                                   R,phi,z,
-                                                  vsun=vsun,galcen=True)
+                                                  vsun=vsun,
+                                                  Xsun=1.,Zsun=zo/ro,
+                                                  galcen=True)
             if lb and len(vxvv) == 4: vxvv= [R,vR,vT,phi]
             else: vxvv= [R,vR,vT,z,vz,phi]
         # Parse vxvv if it consists of Quantities

--- a/galpy/orbit_src/Orbit.py
+++ b/galpy/orbit_src/Orbit.py
@@ -638,6 +638,7 @@ class Orbit(object):
                obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer 
                                       (in kpc and km/s; entries can be Quantity) (default=Object-wide default)
                                       Cannot be an Orbit instance with the orbit of the reference point, as w/ the ra etc. functions
+                                      Y is ignored and always assumed to be zero
 
                 ro= distance in kpc corresponding to R=1. (default: taken from object; can be Quantity)
 
@@ -2036,6 +2037,7 @@ class Orbit(object):
            obs=[X,Y,Z] - (optional) position of observer (in kpc; entries can be Quantity) 
            (default=[8.0,0.,0.]) OR Orbit object that corresponds to the orbit of the observer
 (default=Object-wide default; can be Quantity)
+           Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2066,6 +2068,7 @@ class Orbit(object):
 
            obs=[X,Y,Z] - (optional) position of observer (in kpc; entries can be Quantity) 
            (default=[8.0,0.,0.]) OR Orbit object that corresponds to the orbit of the observer
+           Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2096,6 +2099,7 @@ class Orbit(object):
 
            obs=[X,Y,Z] - (optional) position of observer (in kpc; entries can be Quantity) 
            (default=[8.0,0.,0.]) OR Orbit object that corresponds to the orbit of the observer
+           Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2126,6 +2130,7 @@ class Orbit(object):
 
            obs=[X,Y,Z] - (optional) position of observer (in kpc; entries can be Quantity) 
            (default=[8.0,0.,0.]) OR Orbit object that corresponds to the orbit of the observer
+           Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2156,6 +2161,7 @@ class Orbit(object):
 
            obs=[X,Y,Z] - (optional) position of observer (in kpc; entries can be Quantity) 
            (default=[8.0,0.,0.]) OR Orbit object that corresponds to the orbit of the observer
+           Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2189,6 +2195,7 @@ class Orbit(object):
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantities)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2224,6 +2231,7 @@ class Orbit(object):
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantities)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2259,6 +2267,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantities)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2294,6 +2303,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2329,7 +2339,8 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
-
+                         Y is ignored and always assumed to be zero
+           
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
            vo= (Object-wide default) physical scale for velocities to use to convert (can be Quantity)
@@ -2364,6 +2375,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2409,6 +2421,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2454,6 +2467,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2499,6 +2513,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2544,6 +2559,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2577,6 +2593,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.]; entries can be Quantity))
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2610,6 +2627,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2643,6 +2661,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2678,6 +2697,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2713,6 +2733,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (in kpc and km/s) (default=[8.0,0.,0.,0.,220.,0.]; entries can be Quantity)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 
@@ -2747,6 +2768,7 @@ v           obs=[X,Y,Z,vx,vy,vz] - (optional) position and velocity of observer
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
 
            ro= (Object-wide default) physical scale for distances to use to convert (can be Quantity)
 

--- a/galpy/orbit_src/OrbitTop.py
+++ b/galpy/orbit_src/OrbitTop.py
@@ -920,36 +920,36 @@ class OrbitTop(object):
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                 Xsun=obs[0]/ro,
-                                                Zsun=obs[2]/ro)
+                                                Zsun=obs[2]/ro).T
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=0.)
+                                                    Zsun=0.).T
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=obs.z(*args,**kwargs))
+                                                    Zsun=obs.z(*args,**kwargs)).T
                 obs.turn_physical_on()
         else: #FullOrbit
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                 thiso[3,:],
                                                 Xsun=obs[0]/ro,
-                                                Zsun=obs[2]/ro)
+                                                Zsun=obs[2]/ro).T
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=0.)
+                                                    Zsun=0.).T
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=obs.z(*args,**kwargs))
+                                                    Zsun=obs.z(*args,**kwargs)).T
                 obs.turn_physical_on()
         return (X,Y,Z)
 
@@ -973,17 +973,17 @@ class OrbitTop(object):
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                 Xsun=obs[0]/ro,
-                                                Zsun=obs[2]/ro)
+                                                Zsun=obs[2]/ro).T
                 vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],thiso[2,:],0.,
                                                       thiso[3,:],
                                                       vsun=nu.array(\
-                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
+                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro).T
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=0.)
+                                                    Zsun=0.).T
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
                                                           0.,
@@ -992,11 +992,11 @@ class OrbitTop(object):
                                 obs.vx(*args,**kwargs),obs.vy(*args,**kwargs),
                                 nu.zeros(len(thiso[0,:]))]),
                                                           Xsun=obs.x(*args,**kwargs),
-                                                          Zsun=0.)
+                                                          Zsun=0.).T
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=obs.z(*args,**kwargs))
+                                                    Zsun=obs.z(*args,**kwargs)).T
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
                                                           0.,
@@ -1006,39 +1006,39 @@ class OrbitTop(object):
                                 obs.vy(*args,**kwargs),
                                 obs.vz(*args,**kwargs)]),
                                                           Xsun=obs.x(*args,**kwargs),
-                                                          Zsun=obs.z(*args,**kwargs))
+                                                          Zsun=obs.z(*args,**kwargs)).T
                 obs.turn_physical_on()
         else: #FullOrbit
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                 thiso[3,:],
                                                 Xsun=obs[0]/ro,
-                                                Zsun=obs[2]/ro)
+                                                Zsun=obs[2]/ro).T
                 vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                       thiso[2,:],
                                                       thiso[4,:],
                                                       thiso[5,:],
                                                       vsun=nu.array(\
-                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
+                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro).T
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=0.)
+                                                    Zsun=0.).T
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
                                                           thiso[4,:],
                                                           thiso[5,:],
                                                           vsun=nu.array([\
                                 obs.vx(*args,**kwargs),obs.vy(*args,**kwargs),
-                                nu.zeros(len(thiso[0,:]))]),Xsun=obs.x(*args,**kwargs),Zsun=0.)
+                                nu.zeros(len(thiso[0,:]))]),Xsun=obs.x(*args,**kwargs),Zsun=0.).T
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Zsun=obs.z(*args,**kwargs))
+                                                    Zsun=obs.z(*args,**kwargs)).T
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
                                                           thiso[4,:],
@@ -1048,7 +1048,7 @@ class OrbitTop(object):
                                 obs.vy(*args,**kwargs),
                                 obs.vz(*args,**kwargs)]),
                                                           Xsun=obs.x(*args,**kwargs),
-                                                          Zsun=obs.z(*args,**kwargs))
+                                                          Zsun=obs.z(*args,**kwargs)).T
                 obs.turn_physical_on()
         return (X*ro,Y*ro,Z*ro,vX*vo,vY*vo,vZ*vo)
 

--- a/galpy/orbit_src/OrbitTop.py
+++ b/galpy/orbit_src/OrbitTop.py
@@ -977,7 +977,7 @@ class OrbitTop(object):
                 vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],thiso[2,:],0.,
                                                       thiso[3,:],
                                                       vsun=nu.array(\
-                        obs[3:6])/vo)
+                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
@@ -990,7 +990,9 @@ class OrbitTop(object):
                                                           thiso[3,:],
                                                           vsun=nu.array([\
                                 obs.vx(*args,**kwargs),obs.vy(*args,**kwargs),
-                                nu.zeros(len(thiso[0,:]))]))
+                                nu.zeros(len(thiso[0,:]))]),
+                                                          Xsun=obs.x(*args,**kwargs),
+                                                          Zsun=0.)
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
@@ -1002,7 +1004,9 @@ class OrbitTop(object):
                                                           vsun=nu.array([\
                                 obs.vx(*args,**kwargs),
                                 obs.vy(*args,**kwargs),
-                                obs.vz(*args,**kwargs)]))
+                                obs.vz(*args,**kwargs)]),
+                                                          Xsun=obs.x(*args,**kwargs),
+                                                          Zsun=obs.z(*args,**kwargs))
                 obs.turn_physical_on()
         else: #FullOrbit
             if isinstance(obs,(nu.ndarray,list)):
@@ -1015,7 +1019,7 @@ class OrbitTop(object):
                                                       thiso[4,:],
                                                       thiso[5,:],
                                                       vsun=nu.array(\
-                        obs[3:6])/vo)
+                        obs[3:6])/vo,Xsun=obs[0]/ro,Zsun=obs[2]/ro)
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
@@ -1029,7 +1033,7 @@ class OrbitTop(object):
                                                           thiso[5,:],
                                                           vsun=nu.array([\
                                 obs.vx(*args,**kwargs),obs.vy(*args,**kwargs),
-                                nu.zeros(len(thiso[0,:]))]))
+                                nu.zeros(len(thiso[0,:]))]),Xsun=obs.x(*args,**kwargs),Zsun=0.)
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
@@ -1042,7 +1046,9 @@ class OrbitTop(object):
                                                           vsun=nu.array([\
                                 obs.vx(*args,**kwargs),
                                 obs.vy(*args,**kwargs),
-                                obs.vz(*args,**kwargs)]))
+                                obs.vz(*args,**kwargs)]),
+                                                          Xsun=obs.x(*args,**kwargs),
+                                                          Zsun=obs.z(*args,**kwargs))
                 obs.turn_physical_on()
         return (X*ro,Y*ro,Z*ro,vX*vo,vY*vo,vZ*vo)
 

--- a/galpy/orbit_src/OrbitTop.py
+++ b/galpy/orbit_src/OrbitTop.py
@@ -473,6 +473,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)
         OUTPUT:
            ra(t)
@@ -496,6 +497,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)
         OUTPUT:
            dec(t)
@@ -519,6 +521,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            l(t)
@@ -542,6 +545,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            b(t)
@@ -565,6 +569,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            dist(t) in kpc
@@ -588,6 +593,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)    
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -613,6 +619,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -638,6 +645,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -663,6 +671,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -688,6 +697,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -713,6 +723,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            helioX(t) in kpc
@@ -736,6 +747,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            helioY(t) in kpc
@@ -759,6 +771,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
         OUTPUT:
            helioZ(t) in kpc
@@ -782,6 +795,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -807,6 +821,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -832,6 +847,7 @@ class OrbitTop(object):
                          (in kpc and km/s) (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)         
            vo= velocity in km/s corresponding to v=1. (default=Object-wide default)
         OUTPUT:
@@ -856,6 +872,7 @@ class OrbitTop(object):
                          (default=Object-wide default)
                          OR Orbit object that corresponds to the orbit
                          of the observer
+                         Y is ignored and always assumed to be zero
            ro= distance in kpc corresponding to R=1. (default=Object-wide default)
         OUTPUT:
            SkyCoord(t)
@@ -903,19 +920,16 @@ class OrbitTop(object):
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                 Xsun=obs[0]/ro,
-                                                Ysun=obs[1]/ro,
                                                 Zsun=obs[2]/ro)
             else: #Orbit instance
                 obs.turn_physical_off()
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=0.)
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=obs.z(*args,**kwargs))
                 obs.turn_physical_on()
         else: #FullOrbit
@@ -923,7 +937,6 @@ class OrbitTop(object):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                 thiso[3,:],
                                                 Xsun=obs[0]/ro,
-                                                Ysun=obs[1]/ro,
                                                 Zsun=obs[2]/ro)
             else: #Orbit instance
                 obs.turn_physical_off()
@@ -931,13 +944,11 @@ class OrbitTop(object):
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=0.)
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=obs.z(*args,**kwargs))
                 obs.turn_physical_on()
         return (X,Y,Z)
@@ -962,7 +973,6 @@ class OrbitTop(object):
             if isinstance(obs,(nu.ndarray,list)):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                 Xsun=obs[0]/ro,
-                                                Ysun=obs[1]/ro,
                                                 Zsun=obs[2]/ro)
                 vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],thiso[2,:],0.,
                                                       thiso[3,:],
@@ -973,7 +983,6 @@ class OrbitTop(object):
                 if obs.dim() == 2:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=0.)
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
@@ -985,7 +994,6 @@ class OrbitTop(object):
                 else:
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[3,:],0.,
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=obs.z(*args,**kwargs))
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
@@ -1001,7 +1009,6 @@ class OrbitTop(object):
                 X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                 thiso[3,:],
                                                 Xsun=obs[0]/ro,
-                                                Ysun=obs[1]/ro,
                                                 Zsun=obs[2]/ro)
                 vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                       thiso[2,:],
@@ -1015,7 +1022,6 @@ class OrbitTop(object):
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=0.)
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],
@@ -1028,7 +1034,6 @@ class OrbitTop(object):
                     X,Y,Z = coords.galcencyl_to_XYZ(thiso[0,:],thiso[5,:],
                                                     thiso[3,:],
                                                     Xsun=obs.x(*args,**kwargs),
-                                                    Ysun=obs.y(*args,**kwargs),
                                                     Zsun=obs.z(*args,**kwargs))
                     vX,vY,vZ = coords.galcencyl_to_vxvyvz(thiso[1,:],
                                                           thiso[2,:],

--- a/galpy/orbit_src/OrbitTop.py
+++ b/galpy/orbit_src/OrbitTop.py
@@ -885,7 +885,7 @@ class OrbitTop(object):
         return coordinates.SkyCoord(radec[:,0]*units.degree,
                                     radec[:,1]*units.degree,
                                     distance=tdist*units.kpc,
-                                    frame='icrs')
+                                    frame='fk5',equinox='J2000')
 
     def _radec(self,*args,**kwargs):
         """Calculate ra and dec"""

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -831,7 +831,7 @@ def cov_dvrpmllbb_to_vxyz_single(d,e_d,e_vr,pmll,pmbb,cov_pmllbb,l,b):
                  [-m.cos(l)*m.sin(b),-m.sin(l)*m.sin(b), m.cos(b)]])
     return sc.dot(R.T,sc.dot(cov_vrvlvb,R))
 
-def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
+def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
 
@@ -857,8 +857,15 @@ def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
 
        2010-09-24 - Written - Bovy (NYU)
 
+       2016-05-12 - Edited to properly take into account the Sun's vertical position; droped Ysun keyword - Bovy (UofT)
+
     """
-    return (-X+Xsun,Y+Ysun,Z+Zsun)
+    dgc= nu.sqrt(Xsun**2.+Zsun**2.)
+    costheta, sintheta= Xsun/dgc, Zsun/dgc
+    return nu.dot(nu.array([[costheta,0.,-sintheta],
+                            [0.,1.,0.],
+                            [sintheta,0.,costheta]]),
+                  nu.array([-X+Xsun,Y,Z])).T
 
 def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
     """
@@ -939,7 +946,7 @@ def cyl_to_rect(R,phi,Z):
     """
     return (R*sc.cos(phi),R*sc.sin(phi),Z)
 
-def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
+def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
 
@@ -966,8 +973,8 @@ def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
        2010-09-24 - Written - Bovy (NYU)
 
     """
-    Xg,Yg,Zg= XYZ_to_galcenrect(X,Y,Z,Xsun=Xsun,Ysun=Ysun,Zsun=Zsun)
-    return rect_to_cyl(Xg,Yg,Zg)
+    XYZ= nu.atleast_2d(XYZ_to_galcenrect(X,Y,Z,Xsun=Xsun,Zsun=Zsun))
+    return rect_to_cyl(XYZ[:,0],XYZ[:,1],XYZ[:,2])
     
 def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Ysun=0.,Zsun=0.):
     """

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -831,6 +831,7 @@ def cov_dvrpmllbb_to_vxyz_single(d,e_d,e_vr,pmll,pmbb,cov_pmllbb,l,b):
                  [-m.cos(l)*m.sin(b),-m.sin(l)*m.sin(b), m.cos(b)]])
     return sc.dot(R.T,sc.dot(cov_vrvlvb,R))
 
+@scalarDecorator
 def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -871,6 +872,7 @@ def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
                             [sintheta,0.,costheta]]),
                   nu.array([-X+dgc,Y,Z])).T
 
+@scalarDecorator
 def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -961,6 +963,7 @@ def cyl_to_rect(R,phi,Z):
     """
     return (R*sc.cos(phi),R*sc.sin(phi),Z)
 
+@scalarDecorator
 def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -993,8 +996,9 @@ def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Zsun=0.):
 
     """
     XYZ= nu.atleast_2d(XYZ_to_galcenrect(X,Y,Z,Xsun=Xsun,Zsun=Zsun))
-    return rect_to_cyl(XYZ[:,0],XYZ[:,1],XYZ[:,2])
+    return nu.array(rect_to_cyl(XYZ[:,0],XYZ[:,1],XYZ[:,2])).T
     
+@scalarDecorator
 def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -1025,6 +1029,7 @@ def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Zsun=0.):
     Xr,Yr,Zr= cyl_to_rect(R,phi,Z)
     return galcenrect_to_XYZ(Xr,Yr,Zr,Xsun=Xsun,Zsun=Zsun)
     
+@scalarDecorator
 def vxvyvz_to_galcenrect(vx,vy,vz,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -1067,6 +1072,7 @@ def vxvyvz_to_galcenrect(vx,vy,vz,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
                             [sintheta,0.,costheta]]),
                   nu.array([vx,vy,vz])).T+nu.array(vsun)
 
+@scalarDecorator
 def vxvyvz_to_galcencyl(vx,vy,vz,X,Y,Z,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.,
                         galcen=False):
     """
@@ -1109,9 +1115,11 @@ def vxvyvz_to_galcencyl(vx,vy,vz,X,Y,Z,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.,
        2010-09-24 - Written - Bovy (NYU)
 
     """
-    vx,vy,vz= vxvyvz_to_galcenrect(vx,vy,vz,vsun=vsun,Xsun=Xsun,Zsun=Zsun)
-    return rect_to_cyl_vec(vx,vy,vz,X,Y,Z,cyl=galcen)
+    vxyz= vxvyvz_to_galcenrect(vx,vy,vz,vsun=vsun,Xsun=Xsun,Zsun=Zsun)
+    return nu.array(\
+        rect_to_cyl_vec(vxyz[:,0],vxyz[:,1],vxyz[:,2],X,Y,Z,cyl=galcen)).T
 
+@scalarDecorator
 def galcenrect_to_vxvyvz(vXg,vYg,vZg,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
     """
     NAME:
@@ -1154,6 +1162,7 @@ def galcenrect_to_vxvyvz(vXg,vYg,vZg,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
                             [-sintheta,0.,costheta]]),
                   nu.array([-vXg+vsun[0],vYg-vsun[1],vZg-vsun[2]])).T
 
+@scalarDecorator
 def galcencyl_to_vxvyvz(vR,vT,vZ,phi,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
     """
     NAME:

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -1067,10 +1067,10 @@ def vxvyvz_to_galcenrect(vx,vy,vz,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
     """
     dgc= nu.sqrt(Xsun**2.+Zsun**2.)
     costheta, sintheta= Xsun/dgc, Zsun/dgc
-    return nu.dot(nu.array([[-costheta,0.,sintheta],
+    return nu.dot(nu.array([[costheta,0.,-sintheta],
                             [0.,1.,0.],
                             [sintheta,0.,costheta]]),
-                  nu.array([vx,vy,vz])).T+nu.array(vsun)
+                  nu.array([-vx,vy,vz])).T+nu.array(vsun)
 
 @scalarDecorator
 def vxvyvz_to_galcencyl(vx,vy,vz,X,Y,Z,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.,
@@ -1157,10 +1157,10 @@ def galcenrect_to_vxvyvz(vXg,vYg,vZg,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
     """
     dgc= nu.sqrt(Xsun**2.+Zsun**2.)
     costheta, sintheta= Xsun/dgc, Zsun/dgc
-    return nu.dot(nu.array([[costheta,0.,sintheta],
+    return nu.dot(nu.array([[-costheta,0.,-sintheta],
                             [0.,1.,0.],
                             [-sintheta,0.,costheta]]),
-                  nu.array([-vXg+vsun[0],vYg-vsun[1],vZg-vsun[2]])).T
+                  nu.array([vXg-vsun[0],vYg-vsun[1],vZg-vsun[2]])).T
 
 @scalarDecorator
 def galcencyl_to_vxvyvz(vR,vT,vZ,phi,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
@@ -1184,6 +1184,10 @@ def galcencyl_to_vxvyvz(vR,vT,vZ,phi,vsun=[0.,1.,0.],Xsun=1.,Zsun=0.):
        phi - Galactocentric azimuth
 
        vsun - velocity of the sun in the GC frame ndarray[3]
+
+       Xsun - cylindrical distance to the GC
+       
+       Zsun - Sun's height above the midplane
 
     OUTPUT:
 
@@ -1348,6 +1352,10 @@ def galcenrect_to_XYZ_jac(*args,**kwargs):
 
        if 3: X,Y,Z
 
+       Xsun - cylindrical distance to the GC
+       
+       Zsun - Sun's height above the midplane
+
     OUTPUT:
 
        jacobian d(galcen.)/d(Galactic)
@@ -1357,14 +1365,20 @@ def galcenrect_to_XYZ_jac(*args,**kwargs):
        2013-12-09 - Written - Bovy (IAS)
 
     """
+    dgc= nu.sqrt(kwargs.get('Xsun',1.)**2.+kwargs.get('Zsun',0.)**2.)
+    costheta, sintheta= kwargs.get('Xsun',1.)/dgc, kwargs.get('Zsun',0.)/dgc
     out= sc.zeros((6,6))
-    out[0,0]= -1.
+    out[0,0]= -costheta
+    out[0,2]= -sintheta
     out[1,1]= 1.
-    out[2,2]= 1.
+    out[2,0]= -sintheta
+    out[2,2]= costheta
     if len(args) == 3: return out[:3,:3]
-    out[3,3]= -1.
+    out[3,3]= -costheta
+    out[3,5]= -sintheta
     out[4,4]= 1.
-    out[5,5]= 1.
+    out[5,3]= -sintheta
+    out[5,5]= costheta
     return out
 
 def lbd_to_XYZ_jac(*args,**kwargs):

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -869,7 +869,7 @@ def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
     return nu.dot(nu.array([[costheta,0.,-sintheta],
                             [0.,1.,0.],
                             [sintheta,0.,costheta]]),
-                  nu.array([-X+Xsun,Y,Z])).T
+                  nu.array([-X+dgc,Y,Z])).T
 
 def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Zsun=0.):
     """
@@ -905,7 +905,7 @@ def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Zsun=0.):
     return nu.dot(nu.array([[-costheta,0.,-sintheta],
                             [0.,1.,0.],
                             [-sintheta,0.,costheta]]),
-                  nu.array([X,Y,Z])).T+nu.array([Xsun,0.,0.])
+                  nu.array([X,Y,Z])).T+nu.array([dgc,0.,0.])
 
 def rect_to_cyl(X,Y,Z):
     """

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -857,7 +857,7 @@ def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
 
        2010-09-24 - Written - Bovy (NYU)
 
-       2016-05-12 - Edited to properly take into account the Sun's vertical position; droped Ysun keyword - Bovy (UofT)
+       2016-05-12 - Edited to properly take into account the Sun's vertical position; dropped Ysun keyword - Bovy (UofT)
 
     """
     dgc= nu.sqrt(Xsun**2.+Zsun**2.)
@@ -867,7 +867,7 @@ def XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.):
                             [sintheta,0.,costheta]]),
                   nu.array([-X+Xsun,Y,Z])).T
 
-def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
+def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
 
@@ -889,8 +889,15 @@ def galcenrect_to_XYZ(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.):
 
        2011-02-23 - Written - Bovy (NYU)
 
+       2016-05-12 - Edited to properly take into account the Sun's vertical position; dropped Ysun keyword - Bovy (UofT)
+
     """
-    return (-X+Xsun,Y-Ysun,Z-Zsun)
+    dgc= nu.sqrt(Xsun**2.+Zsun**2.)
+    costheta, sintheta= Xsun/dgc, Zsun/dgc
+    return nu.dot(nu.array([[-costheta,0.,-sintheta],
+                            [0.,1.,0.],
+                            [-sintheta,0.,costheta]]),
+                  nu.array([X,Y,Z])).T+nu.array([Xsun,0.,0.])
 
 def rect_to_cyl(X,Y,Z):
     """
@@ -976,7 +983,7 @@ def XYZ_to_galcencyl(X,Y,Z,Xsun=1.,Zsun=0.):
     XYZ= nu.atleast_2d(XYZ_to_galcenrect(X,Y,Z,Xsun=Xsun,Zsun=Zsun))
     return rect_to_cyl(XYZ[:,0],XYZ[:,1],XYZ[:,2])
     
-def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Ysun=0.,Zsun=0.):
+def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Zsun=0.):
     """
     NAME:
 
@@ -1000,7 +1007,7 @@ def galcencyl_to_XYZ(R,phi,Z,Xsun=1.,Ysun=0.,Zsun=0.):
 
     """
     Xr,Yr,Zr= cyl_to_rect(R,phi,Z)
-    return galcenrect_to_XYZ(Xr,Yr,Zr,Xsun=Xsun,Ysun=Ysun,Zsun=Zsun)
+    return galcenrect_to_XYZ(Xr,Yr,Zr,Xsun=Xsun,Zsun=Zsun)
     
 def vxvyvz_to_galcenrect(vx,vy,vz,vsun=[0.,1.,0.]):
     """

--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -580,7 +580,7 @@ def pmrapmdec_to_pmllpmbb(pmra,pmdec,ra,dec,degree=False,epoch=2000.0):
 
        degree - if True, ra and dec are given in degrees (default=False)
 
-       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported)
+       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported when not using astropy's transformations internally; when internally using astropy's coordinate transformations, epoch can be None for ICRS, 'JXXXX' for FK5, and 'BXXXX' for FK4)
 
     OUTPUT:
 
@@ -637,7 +637,7 @@ def pmllpmbb_to_pmrapmdec(pmll,pmbb,l,b,degree=False,epoch=2000.0):
 
        degree - if True, l and b are given in degrees (default=False)
 
-       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported)
+       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported when not using astropy's transformations internally; when internally using astropy's coordinate transformations, epoch can be None for ICRS, 'JXXXX' for FK5, and 'BXXXX' for FK4)
 
     OUTPUT:
 
@@ -693,7 +693,7 @@ def cov_pmrapmdec_to_pmllpmbb(cov_pmradec,ra,dec,degree=False,epoch=2000.0):
 
        degree - if True, ra and dec are given in degrees (default=False)
 
-       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported)
+       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported when not using astropy's transformations internally; when internally using astropy's coordinate transformations, epoch can be None for ICRS, 'JXXXX' for FK5, and 'BXXXX' for FK4)
 
     OUTPUT:
 
@@ -730,7 +730,7 @@ def cov_pmradec_to_pmllbb_single(cov_pmradec,ra,dec,b,degree=False,epoch=2000.0)
        ra - right ascension
        dec - declination
        degree - if True, ra and dec are given in degrees (default=False)
-       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported)
+       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported when not using astropy's transformations internally; when internally using astropy's coordinate transformations, epoch can be None for ICRS, 'JXXXX' for FK5, and 'BXXXX' for FK4)
     OUTPUT:
        cov_pmllbb
     HISTORY:
@@ -1915,8 +1915,6 @@ def radec_to_custom(ra,dec,T=None,degree=False,epoch=2000.0):
        T= matrix defining the transformation: new_rect= T dot old_rect, where old_rect = [cos(dec)cos(ra),cos(dec)sin(ra),sin(dec)] and similar for new_rect
 
        degree - (Bool) if True, ra and dec are given in degree and l and b will be as well
-
-       epoch - epoch of ra,dec (right now only 2000.0 and 1950.0 are supported)
 
     OUTPUT:
 

--- a/galpy/util/config.py
+++ b/galpy/util/config.py
@@ -10,6 +10,7 @@ except ImportError:
     _APY_LOADED= False
 # The default configuration
 default_configuration= {'astropy-units':'False',
+                        'astropy-coords':'True',
                         'ro':'8.',
                         'vo':'220.'}
 default_filename= os.path.join(os.path.expanduser('~'),'.galpyrc')
@@ -24,6 +25,8 @@ def write_default(filename):
     writeconfig.add_section('astropy')
     writeconfig.set('astropy','astropy-units',
                     default_configuration['astropy-units'])
+    writeconfig.set('astropy','astropy-coords',
+                    default_configuration['astropy-coords'])
     with open(filename,'w') as configfile:
         writeconfig.write(configfile)
     return None

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -5,6 +5,7 @@ from nose.tools import raises
 from test_streamdf import expected_failure
 
 def test_radec_to_lb_ngp():
+    _turn_off_apy()
     # Test that the NGP is at b=90
     ra, dec= 192.25, 27.4
     lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=1950.)
@@ -13,9 +14,11 @@ def test_radec_to_lb_ngp():
     lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
                                 degree=False,epoch=1950.)
     assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-8., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    _turn_on_apy()
     return None
 
 def test_radec_to_lb_sgp():
+    _turn_off_apy()
     # Test that the SGP is at b=90
     ra, dec= 12.25, -27.4
     lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=1950.)
@@ -24,10 +27,12 @@ def test_radec_to_lb_sgp():
     lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
                                 degree=False,epoch=1950.)
     assert numpy.fabs(lb[1]+numpy.pi/2.) < 10.**-8., 'Galactic latitude of the SGP given in ra,dec is not pi/2'
+    _turn_on_apy()
     return None
 
 # Test the longitude of the north celestial pole
 def test_radec_to_lb_ncp():
+    _turn_off_apy()
     ra, dec= 180., 90.
     lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=1950.)
     assert numpy.fabs(lb[0]-123.) < 10.**-8., 'Galactic longitude of the NCP given in ra,dec is not 123'
@@ -40,10 +45,12 @@ def test_radec_to_lb_ncp():
     lb= bovy_coords.radec_to_lb(os*ra/180.*numpy.pi,os*dec/180.*numpy.pi,
                                 degree=False,epoch=1950.)
     assert numpy.all(numpy.fabs(lb[:,0]-123./180.*numpy.pi) < 10.**-8.), 'Galactic longitude of the NCP given in ra,dec is not 123'
+    _turn_on_apy()
     return None
 
 # Test that other epochs do not work
 def test_radec_to_lb_otherepochs():
+    _turn_off_apy()
     ra, dec= 180., 90.
     try:
         lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
@@ -52,6 +59,8 @@ def test_radec_to_lb_otherepochs():
         pass
     else:
         raise AssertionError('radec functions with epoch not equal to 1950 or 2000 did not raise IOError')
+    _turn_on_apy()
+    return None
 
 # Test that radec_to_lb and lb_to_radec are each other's inverse
 def test_lb_to_radec():
@@ -750,6 +759,7 @@ def test_radec_to_custom_valueerror():
     return None
 
 def test_radec_to_custom_againstlb():
+    _turn_off_apy()
     ra, dec= 20., 30.
     theta,dec_ngp,ra_ngp= bovy_coords.get_epoch_angles(2000.)
     T= numpy.dot(numpy.array([[numpy.cos(ra_ngp),-numpy.sin(ra_ngp),0.],
@@ -772,6 +782,7 @@ def test_radec_to_custom_againstlb():
     lb_direct= bovy_coords.radec_to_lb(ra*s,dec*s,degree=True)
     lb_custom= bovy_coords.radec_to_custom(ra*s,dec*s,T=T.T,degree=True)
     assert numpy.all(numpy.fabs(lb_direct-lb_custom) < 10.**-8.), 'radec_to_custom for transformation to l,b does not work properly'
+    _turn_on_apy()
     return None
 
 def test_radec_to_custom_pal5():
@@ -792,3 +803,11 @@ def test_radec_to_custom_pal5():
     assert numpy.fabs(xieta[0]-11.) < 0.2, 'radec_to_custom does not work properly for Pal 5 transformation'
     assert numpy.fabs(xieta[1]-6.) < 0.2, 'radec_to_custom does not work properly for Pal 5 transformation'
     return None
+
+def _turn_off_apy():
+    bovy_coords._APY_COORDS= False
+    bovy_coords._APY_LOADED= False
+
+def _turn_on_apy():
+    bovy_coords._APY_COORDS= True
+    bovy_coords._APY_LOADED= True

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -17,6 +17,59 @@ def test_radec_to_lb_ngp():
     _turn_on_apy()
     return None
 
+def test_radec_to_lb_ngp_apyangles():
+    # Test, but using transformation angles derived from astropy
+    _turn_off_apy(keep_loaded=True)
+    # Test that the NGP is at b=90
+    ra, dec= 192.25, 27.4
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch='B1950')
+    assert numpy.fabs(lb[1]-90.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch='B1950')
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    _turn_on_apy()
+    return None
+
+def test_radec_to_lb_ngp_j2000():
+    _turn_off_apy()
+    # Test that the NGP is at b=90
+    ra, dec= 192.85948, 27.12825
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=2000.)
+    assert numpy.fabs(lb[1]-90.) < 10.**-8., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-8., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    _turn_on_apy()
+
+def test_radec_to_lb_ngp_j2000_apyangles():
+    # Same test, but using transformation angles derived from astropy
+    _turn_off_apy(keep_loaded=True)
+    # Test that the NGP is at b=90
+    ra, dec= 192.85948, 27.12825
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch='J2000')
+    assert numpy.fabs(lb[1]-90.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch='J2000')
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    _turn_on_apy()
+
+def test_radec_to_lb_ngp_j2000_apyangles_icrs():
+    # Test, but using transformation angles derived from astropy, for ICRS
+    _turn_off_apy(keep_loaded=True)
+    # Test that the NGP is at b=90
+    ra, dec= 192.85948, 27.12825
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=None)
+    assert numpy.fabs(lb[1]-90.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=None)
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    _turn_on_apy()
+    return None
+
 def test_radec_to_lb_sgp():
     _turn_off_apy()
     # Test that the SGP is at b=90
@@ -48,7 +101,41 @@ def test_radec_to_lb_ncp():
     _turn_on_apy()
     return None
 
-# Test that other epochs do not work
+def test_radec_to_lb_ncp_apyangles():
+    _turn_off_apy(keep_loaded=True)
+    ra, dec= 180., 90.
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch='B1950')
+    assert numpy.fabs(lb[0]-123.) < 10.**-4., 'Galactic longitude of the NCP given in ra,dec is not 123'
+    _turn_on_apy()
+    return None
+
+# Test the longitude of the north celestial pole
+def test_radec_to_lb_ncp_j2000():
+    _turn_off_apy()
+    ra, dec= 180., 90.
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=2000.)
+    assert numpy.fabs(lb[0]-122.932) < 10.**-8., 'Galactic longitude of the NCP given in ra,dec is not 122.932'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    assert numpy.fabs(lb[0]-122.932/180.*numpy.pi) < 10.**-8., 'Galactic longitude of the NCP given in ra,dec is not 122.932'
+    # Also test the latter for vector inputs
+    os= numpy.ones(2)
+    lb= bovy_coords.radec_to_lb(os*ra/180.*numpy.pi,os*dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    assert numpy.all(numpy.fabs(lb[:,0]-122.932/180.*numpy.pi) < 10.**-8.), 'Galactic longitude of the NCP given in ra,dec is not 122.932'
+    _turn_on_apy()
+    return None
+
+def test_radec_to_lb_ncp_j2000_apyangles():
+    _turn_off_apy(keep_loaded=True)
+    ra, dec= 180., 90.
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch='J2000')
+    assert numpy.fabs(lb[0]-122.932) < 10.**-4., 'Galactic longitude of the NCP given in ra,dec is not 122.932'
+    _turn_on_apy()
+    return None
+
+# Test that other epochs do not work when not using astropy
 def test_radec_to_lb_otherepochs():
     _turn_off_apy()
     ra, dec= 180., 90.
@@ -59,6 +146,20 @@ def test_radec_to_lb_otherepochs():
         pass
     else:
         raise AssertionError('radec functions with epoch not equal to 1950 or 2000 did not raise IOError')
+    _turn_on_apy()
+    return None
+
+# Test that other epochs do work when using astropy
+def test_radec_to_lb_otherepochs_apy():
+    _turn_off_apy(keep_loaded=True)
+    ra, dec= 180., 90.
+    try:
+        lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                    degree=False,epoch='J2015')   
+    except IOError:
+        raise AssertionError('radec functions with epoch not equal to 1950 or 2000 did not raise IOError')
+    else:
+        pass
     _turn_on_apy()
     return None
 
@@ -804,9 +905,10 @@ def test_radec_to_custom_pal5():
     assert numpy.fabs(xieta[1]-6.) < 0.2, 'radec_to_custom does not work properly for Pal 5 transformation'
     return None
 
-def _turn_off_apy():
+def _turn_off_apy(keep_loaded=False):
     bovy_coords._APY_COORDS= False
-    bovy_coords._APY_LOADED= False
+    if not keep_loaded:
+        bovy_coords._APY_LOADED= False
 
 def _turn_on_apy():
     bovy_coords._APY_COORDS= True

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -249,6 +249,36 @@ def test_lb_to_radec_apy():
     assert numpy.fabs(bt-b) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'   
     return None
 
+# Test that radec_to_lb and lb_to_radec are each other's inverse, using astropy
+def test_lb_to_radec_apy_icrs():
+    ra, dec= 120, 60.
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=None)
+    rat, dect= bovy_coords.lb_to_radec(lb[0],lb[1],degree=True,epoch=None)
+    assert numpy.fabs(ra-rat) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.fabs(dec-dect) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=None)
+    rat, dect= bovy_coords.lb_to_radec(lb[0],lb[1],degree=False,epoch=None)
+    assert numpy.fabs(ra/180.*numpy.pi-rat) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.fabs(dec/180.*numpy.pi-dect) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    # And also test this for arrays
+    os= numpy.ones(2)
+    lb= bovy_coords.radec_to_lb(os*ra/180.*numpy.pi,os*dec/180.*numpy.pi,
+                                degree=False,epoch=None)
+    ratdect= bovy_coords.lb_to_radec(lb[:,0],lb[:,1],degree=False,epoch=None)
+    rat= ratdect[:,0]
+    dect= ratdect[:,1]
+    assert numpy.all(numpy.fabs(ra/180.*numpy.pi-rat) < 10.**-10.), 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.all(numpy.fabs(dec/180.*numpy.pi-dect) < 10.**-10.), 'lb_to_radec is not the inverse of radec_to_lb'   
+    #Also test for a negative l
+    l,b= 240., 60.
+    ra,dec= bovy_coords.lb_to_radec(l,b,degree=True)
+    lt,bt= bovy_coords.radec_to_lb(ra,dec,degree=True)
+    assert numpy.fabs(lt-l) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'   
+    assert numpy.fabs(bt-b) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'   
+    return None
+
 # Test lb_to_XYZ
 def test_lbd_to_XYZ():
     l,b,d= 90., 30.,1.

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -31,6 +31,17 @@ def test_radec_to_lb_ngp_apyangles():
     _turn_on_apy()
     return None
 
+def test_radec_to_lb_ngp_apy():
+    # Test that the NGP is at b=90, using astropy's coordinate transformations
+    ra, dec= 192.25, 27.4
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=1950.)
+    assert numpy.fabs(lb[1]-90.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=1950.)
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    return None
+
 def test_radec_to_lb_ngp_j2000():
     _turn_off_apy()
     # Test that the NGP is at b=90
@@ -42,6 +53,18 @@ def test_radec_to_lb_ngp_j2000():
                                 degree=False,epoch=2000.)
     assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-8., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
     _turn_on_apy()
+    return None
+
+def test_radec_to_lb_ngp_j2000_apy():
+    # Test that the NGP is at b=90
+    ra, dec= 192.85948, 27.12825
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=2000.)
+    assert numpy.fabs(lb[1]-90.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not 90'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
+    return None
 
 def test_radec_to_lb_ngp_j2000_apyangles():
     # Same test, but using transformation angles derived from astropy
@@ -55,6 +78,7 @@ def test_radec_to_lb_ngp_j2000_apyangles():
                                 degree=False,epoch='J2000')
     assert numpy.fabs(lb[1]-numpy.pi/2.) < 10.**-4., 'Galactic latitude of the NGP given in ra,dec is not pi/2'
     _turn_on_apy()
+    return None
 
 def test_radec_to_lb_ngp_j2000_apyangles_icrs():
     # Test, but using transformation angles derived from astropy, for ICRS
@@ -165,6 +189,38 @@ def test_radec_to_lb_otherepochs_apy():
 
 # Test that radec_to_lb and lb_to_radec are each other's inverse
 def test_lb_to_radec():
+    _turn_off_apy()
+    ra, dec= 120, 60.
+    lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=2000.)
+    rat, dect= bovy_coords.lb_to_radec(lb[0],lb[1],degree=True,epoch=2000.)
+    assert numpy.fabs(ra-rat) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.fabs(dec-dect) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    # Also test this for degree=False
+    lb= bovy_coords.radec_to_lb(ra/180.*numpy.pi,dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    rat, dect= bovy_coords.lb_to_radec(lb[0],lb[1],degree=False,epoch=2000.)
+    assert numpy.fabs(ra/180.*numpy.pi-rat) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.fabs(dec/180.*numpy.pi-dect) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'
+    # And also test this for arrays
+    os= numpy.ones(2)
+    lb= bovy_coords.radec_to_lb(os*ra/180.*numpy.pi,os*dec/180.*numpy.pi,
+                                degree=False,epoch=2000.)
+    ratdect= bovy_coords.lb_to_radec(lb[:,0],lb[:,1],degree=False,epoch=2000.)
+    rat= ratdect[:,0]
+    dect= ratdect[:,1]
+    assert numpy.all(numpy.fabs(ra/180.*numpy.pi-rat) < 10.**-10.), 'lb_to_radec is not the inverse of radec_to_lb'
+    assert numpy.all(numpy.fabs(dec/180.*numpy.pi-dect) < 10.**-10.), 'lb_to_radec is not the inverse of radec_to_lb'   
+    #Also test for a negative l
+    l,b= 240., 60.
+    ra,dec= bovy_coords.lb_to_radec(l,b,degree=True)
+    lt,bt= bovy_coords.radec_to_lb(ra,dec,degree=True)
+    assert numpy.fabs(lt-l) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'   
+    assert numpy.fabs(bt-b) < 10.**-10., 'lb_to_radec is not the inverse of radec_to_lb'   
+    _turn_on_apy()
+    return None
+
+# Test that radec_to_lb and lb_to_radec are each other's inverse, using astropy
+def test_lb_to_radec_apy():
     ra, dec= 120, 60.
     lb= bovy_coords.radec_to_lb(ra,dec,degree=True,epoch=2000.)
     rat, dect= bovy_coords.lb_to_radec(lb[0],lb[1],degree=True,epoch=2000.)

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -275,9 +275,9 @@ def test_galcenrect_to_vxvyvz():
     os= numpy.ones(2)
     vxyz= bovy_coords.galcenrect_to_vxvyvz(os*vxg,os*vyg,os*vzg,
                                            vsun=[-5.,10.,5.])
-    assert numpy.all(numpy.fabs(vxyz[0]-10.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
-    assert numpy.all(numpy.fabs(vxyz[1]+20.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
-    assert numpy.all(numpy.fabs(vxyz[2]-30.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
+    assert numpy.all(numpy.fabs(vxyz[:,0]-10.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
+    assert numpy.all(numpy.fabs(vxyz[:,1]+20.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
+    assert numpy.all(numpy.fabs(vxyz[:,2]-30.) < 10.**-10.), 'galcenrect_to_vxvyvz conversion did not work as expected'
     return None
 
 def test_galcencyl_to_vxvyvz():

--- a/nose/test_coords.py
+++ b/nose/test_coords.py
@@ -200,13 +200,13 @@ def test_vxvyvz_to_vrpmllpmbb():
 
 def test_XYZ_to_galcenrect():
     X,Y,Z= 1.,3.,-2.
-    gcXYZ= bovy_coords.XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.)
+    gcXYZ= bovy_coords.XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.)
     assert numpy.fabs(gcXYZ[0]) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
     assert numpy.fabs(gcXYZ[1]-3.) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
     assert numpy.fabs(gcXYZ[2]+2.) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
     #Another test
     X,Y,Z= -1.,3.,-2.
-    gcXYZ= bovy_coords.XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Ysun=0.,Zsun=0.)
+    gcXYZ= bovy_coords.XYZ_to_galcenrect(X,Y,Z,Xsun=1.,Zsun=0.)
     assert numpy.fabs(gcXYZ[0]-2.) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
     assert numpy.fabs(gcXYZ[1]-3.) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
     assert numpy.fabs(gcXYZ[2]+2.) < 10.**-10., 'XYZ_to_galcenrect conversion did not work as expected'
@@ -214,7 +214,7 @@ def test_XYZ_to_galcenrect():
 
 def test_galcenrect_to_XYZ():
     gcX, gcY, gcZ= -1.,4.,2.
-    XYZ= bovy_coords.galcenrect_to_XYZ(gcX,gcY,gcZ,Xsun=1.,Ysun=0.,Zsun=0.)
+    XYZ= bovy_coords.galcenrect_to_XYZ(gcX,gcY,gcZ,Xsun=1.,Zsun=0.)
     assert numpy.fabs(XYZ[0]-2.) < 10.**-10., 'galcenrect_to_XYZ conversion did not work as expected'
     assert numpy.fabs(XYZ[1]-4.) < 10.**-10., 'galcenrect_to_XYZ conversion did not work as expected'
     assert numpy.fabs(XYZ[2]-2.) < 10.**-10., 'galcenrect_to_XYZ conversion did not work as expected'
@@ -222,13 +222,13 @@ def test_galcenrect_to_XYZ():
 
 def test_XYZ_to_galcencyl():
     X,Y,Z= 5.,4.,-2.
-    gcRpZ= bovy_coords.XYZ_to_galcencyl(X,Y,Z,Xsun=8.,Ysun=0.,Zsun=0.)
+    gcRpZ= bovy_coords.XYZ_to_galcencyl(X,Y,Z,Xsun=8.,Zsun=0.)
     assert numpy.fabs(gcRpZ[0]-5.) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
     assert numpy.fabs(gcRpZ[1]-numpy.arctan(4./3.)) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
     assert numpy.fabs(gcRpZ[2]+2.) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
     #Another X
     X,Y,Z= 11.,4.,-2.
-    gcRpZ= bovy_coords.XYZ_to_galcencyl(X,Y,Z,Xsun=8.,Ysun=0.,Zsun=0.)
+    gcRpZ= bovy_coords.XYZ_to_galcencyl(X,Y,Z,Xsun=8.,Zsun=0.)
     assert numpy.fabs(gcRpZ[0]-5.) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
     assert numpy.fabs(gcRpZ[1]-numpy.pi+numpy.arctan(4./3.)) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
     assert numpy.fabs(gcRpZ[2]+2.) < 10.**-10., 'XYZ_to_galcencyl conversion did not work as expected'
@@ -236,7 +236,7 @@ def test_XYZ_to_galcencyl():
 
 def test_galcencyl_to_XYZ():
     gcR, gcp, gcZ= 5.,numpy.arctan(4./3.),2.
-    XYZ= bovy_coords.galcencyl_to_XYZ(gcR,gcp,gcZ,Xsun=8.,Ysun=0.,Zsun=0.)
+    XYZ= bovy_coords.galcencyl_to_XYZ(gcR,gcp,gcZ,Xsun=8.,Zsun=0.)
     assert numpy.fabs(XYZ[0]-5.) < 10.**-10., 'galcencyl_to_XYZ conversion did not work as expected'
     assert numpy.fabs(XYZ[1]-4.) < 10.**-10., 'galcencyl_to_XYZ conversion did not work as expected'
     assert numpy.fabs(XYZ[2]-2.) < 10.**-10., 'galcencyl_to_XYZ conversion did not work as expected'
@@ -771,7 +771,6 @@ def test_radec_to_custom_againstlb():
     s= numpy.arange(2)
     lb_direct= bovy_coords.radec_to_lb(ra*s,dec*s,degree=True)
     lb_custom= bovy_coords.radec_to_custom(ra*s,dec*s,T=T.T,degree=True)
-    print(lb_direct, lb_custom)
     assert numpy.all(numpy.fabs(lb_direct-lb_custom) < 10.**-8.), 'radec_to_custom for transformation to l,b does not work properly'
     return None
 

--- a/nose/test_galpypaper.py
+++ b/nose/test_galpypaper.py
@@ -181,8 +181,10 @@ def test_orbmethods():
     o.vR(5.,vo=220.) # Cyl. rad. velocity at time 5. in km/s
     assert numpy.fabs(o.vR(5.,vo=220.)-45.202530965094553) < 10.**-3., 'Orbit method does not work as expected'
     o.ra(1.), o.dec(1.) # RA and Dec at t=1. (default settings)
-    assert numpy.fabs(o.ra(1.)-numpy.array([ 288.19277])) < 10.**-3., 'Orbit method does not work as expected'
-    assert numpy.fabs(o.dec(1.)-numpy.array([ 18.98069155])) < 10.**-3., 'Orbit method does not work as expected'
+    # 5/12/2016: test weakened, because improved galcen<->heliocen 
+    #            transformation has changed these, but still close
+    assert numpy.fabs(o.ra(1.)-numpy.array([ 288.19277])) < 10.**-1., 'Orbit method does not work as expected'
+    assert numpy.fabs(o.dec(1.)-numpy.array([ 18.98069155])) < 10.**-1., 'Orbit method does not work as expected'
     o.jr(type='adiabatic'), o.jz() # R/z actions (ad. approx.)
     assert numpy.fabs(o.jr(type='adiabatic')-0.05285302231137586) < 10.**-3., 'Orbit method does not work as expected'
     assert numpy.fabs(o.jz()-0.006637988850751242) < 10.**-3., 'Orbit method does not work as expected'
@@ -424,10 +426,13 @@ def test_coords():
     # Assuming Sun's distance to GC is (8,0.025) in (R,z)
     R,phi,z= bovy_coords.XYZ_to_galcencyl(X,Y,Z,Xsun=8.,Zsun=0.025)
     vR,vT,vz= bovy_coords.vxvyvz_to_galcencyl(vX,vY,vZ,R,phi,Z,vsun=[-10.1,244.,6.7],galcen=True)
-    assert numpy.fabs(R-12.51328515156942) < 10.**-4., 'Coordinate transformation has changed'
-    assert numpy.fabs(phi-0.12177409073433249) < 10.**-4., 'Coordinate transformation has changed'
-    assert numpy.fabs(z-7.1241282354856228) < 10.**-4., 'Coordinate transformation has changed'
-    assert numpy.fabs(vR-78.961682923035966) < 10.**-4., 'Coordinate transformation has changed'
-    assert numpy.fabs(vT+241.49247772351964) < 10.**-4., 'Coordinate transformation has changed'
-    assert numpy.fabs(vz+102.83965442188689) < 10.**-4., 'Coordinate transformation has changed'
+    # 5/12/2016: test weakened, because improved galcen<->heliocen 
+    #            transformation has changed these, but still close
+    print(R,phi,z,vR,vT,vz)
+    assert numpy.fabs(R-12.51328515156942) < 10.**-1., 'Coordinate transformation has changed'
+    assert numpy.fabs(phi-0.12177409073433249) < 10.**-1., 'Coordinate transformation has changed'
+    assert numpy.fabs(z-7.1241282354856228) < 10.**-1., 'Coordinate transformation has changed'
+    assert numpy.fabs(vR-78.961682923035966) < 10.**-1., 'Coordinate transformation has changed'
+    assert numpy.fabs(vT+241.49247772351964) < 10.**-1., 'Coordinate transformation has changed'
+    assert numpy.fabs(vz+102.83965442188689) < 10.**-1., 'Coordinate transformation has changed'
     return None

--- a/nose/test_orbit.py
+++ b/nose/test_orbit.py
@@ -1745,7 +1745,7 @@ def test_orbit_setup():
     assert numpy.fabs(o.vbb()-0.8*4.74047) < 10.**-13., 'Orbit pmbb setup does not agree with o.vbb()'
     assert numpy.fabs(o.vlos()-30.) < 10.**-13., 'Orbit vlos setup does not agree with o.vlos()'
     #lb w/ default at the Sun
-    o= Orbit([120.,60.,0.,10.,20.,30.],uvw=True,lb=True)
+    o= Orbit([120.,60.,0.,10.,20.,30.],uvw=True,lb=True,zo=0.)
     assert numpy.fabs(o.dist()-0.) < 10.**-2., 'Orbit dist setup does not agree with o.dist()' #because of tweak in the code to deal with at the Sun
     assert (o.U()**2.+o.V()**2.+o.W()**2.-10.**2.-20.**2.-30.**2.) < 10.**-10., 'Velocity wrt the Sun when looking at Orbit at the Sun does not agree'
     assert (o.vlos()**2.-10.**2.-20.**2.-30.**2.) < 10.**-10., 'Velocity wrt the Sun when looking at Orbit at the Sun does not agree'

--- a/nose/test_orbit.py
+++ b/nose/test_orbit.py
@@ -2512,6 +2512,8 @@ def test_orbitfit_custom():
 
 def comp_orbfit(of,vxvv,ts,pot,lb=False,radec=False,ro=None,vo=None):
     """Compare the output of the orbit fit properly, ro and vo only implemented for radec"""
+    from galpy.util import bovy_coords
+    bovy_coords._APY_COORDS= False # too slow otherwise
     of.integrate(ts,pot)
     off= of.flip()
     off.integrate(ts,pot)
@@ -2544,6 +2546,7 @@ def comp_orbfit(of,vxvv,ts,pot,lb=False,radec=False,ro=None,vo=None):
     out= []
     for ii in range(vxvv.shape[0]):
         out.append(numpy.amin(numpy.sum((allvxvv-vxvv[ii])**2.,axis=1)))
+    bovy_coords._APY_COORDS= True
     return numpy.array(out)
 
 def test_MWPotential_warning():

--- a/nose/test_streamdf.py
+++ b/nose/test_streamdf.py
@@ -298,7 +298,6 @@ def test_density_ll_and_customra():
             sdf_bovy14._interpTrackZ(apar)*sdf_bovy14._ro
         X,Y,Z= bovy_coords.galcenrect_to_XYZ(X,Y,Z,
                                            Xsun=sdf_bovy14._R0,
-                                           Ysun=0.,
                                            Zsun=sdf_bovy14._Zsun)
         l,b,d= bovy_coords.XYZ_to_lbd(X,Y,Z,degree=True)
         dX,dY,dZ= sdf_bovy14._interpTrackX(apar+dapar)*sdf_bovy14._ro,\
@@ -306,7 +305,6 @@ def test_density_ll_and_customra():
             sdf_bovy14._interpTrackZ(apar+dapar)*sdf_bovy14._ro
         dX,dY,dZ= bovy_coords.galcenrect_to_XYZ(dX,dY,dZ,
                                                 Xsun=sdf_bovy14._R0,
-                                                Ysun=0.,
                                                 Zsun=sdf_bovy14._Zsun)
         dl,db,dd= bovy_coords.XYZ_to_lbd(dX,dY,dZ,degree=True)
         jac= numpy.fabs((dl-l)/dapar)
@@ -337,7 +335,6 @@ def test_density_ra():
             sdf_bovy14._interpTrackZ(apar)*sdf_bovy14._ro
         X,Y,Z= bovy_coords.galcenrect_to_XYZ(X,Y,Z,
                                            Xsun=sdf_bovy14._R0,
-                                           Ysun=0.,
                                            Zsun=sdf_bovy14._Zsun)
         l,b,d= bovy_coords.XYZ_to_lbd(X,Y,Z,degree=True)
         ra,dec= bovy_coords.lb_to_radec(l,b,degree=True)
@@ -346,7 +343,6 @@ def test_density_ra():
             sdf_bovy14._interpTrackZ(apar+dapar)*sdf_bovy14._ro
         dX,dY,dZ= bovy_coords.galcenrect_to_XYZ(dX,dY,dZ,
                                                 Xsun=sdf_bovy14._R0,
-                                                Ysun=0.,
                                                 Zsun=sdf_bovy14._Zsun)
         dl,db,dd= bovy_coords.XYZ_to_lbd(dX,dY,dZ,degree=True)
         dra,ddec= bovy_coords.lb_to_radec(dl,db,degree=True)
@@ -374,7 +370,6 @@ def test_density_ll_wsampling():
             sdf_bovy14._interpTrackZ(apar)*sdf_bovy14._ro
         X,Y,Z= bovy_coords.galcenrect_to_XYZ(X,Y,Z,
                                              Xsun=sdf_bovy14._R0,
-                                             Ysun=0.,
                                              Zsun=sdf_bovy14._Zsun)
         l,b,d= bovy_coords.XYZ_to_lbd(X,Y,Z,degree=True)
         return l   
@@ -413,7 +408,6 @@ def test_length_ang():
             sdf_bovy14._interpTrackZ(apar)*sdf_bovy14._ro
         X,Y,Z= bovy_coords.galcenrect_to_XYZ(X,Y,Z,
                                            Xsun=sdf_bovy14._R0,
-                                           Ysun=0.,
                                            Zsun=sdf_bovy14._Zsun)
         l,b,d= bovy_coords.XYZ_to_lbd(X,Y,Z,degree=True)
         dX,dY,dZ= sdf_bovy14._interpTrackX(apar+dapar)*sdf_bovy14._ro,\
@@ -421,7 +415,6 @@ def test_length_ang():
             sdf_bovy14._interpTrackZ(apar+dapar)*sdf_bovy14._ro
         dX,dY,dZ= bovy_coords.galcenrect_to_XYZ(dX,dY,dZ,
                                                 Xsun=sdf_bovy14._R0,
-                                                Ysun=0.,
                                                 Zsun=sdf_bovy14._Zsun)
         dl,db,dd= bovy_coords.XYZ_to_lbd(dX,dY,dZ,degree=True)
         jac= numpy.fabs((dl-l)/dapar)
@@ -1187,7 +1180,7 @@ def test_calcaAJacLB():
     R,vR,vT,z,vz,phi= 1.56148083,0.35081535,-1.15481504,\
         0.88719443,-0.47713334,0.12019596
     #First convert these to l,b,d,vlos,pmll,pmbb
-    XYZ= bovy_coords.galcencyl_to_XYZ(R*8.,phi,z*8.,Xsun=8.,Ysun=0.,Zsun=0.02)
+    XYZ= bovy_coords.galcencyl_to_XYZ(R*8.,phi,z*8.,Xsun=8.,Zsun=0.02)
     l,b,d= bovy_coords.XYZ_to_lbd(XYZ[0],XYZ[1],XYZ[2],degree=True)
     vXYZ= bovy_coords.galcencyl_to_vxvyvz(vR*220.,vT*220.,vz*220.,phi=phi,
                                           vsun=[10.,240.,-10.])

--- a/nose/test_streamdf.py
+++ b/nose/test_streamdf.py
@@ -774,7 +774,7 @@ def test_bovy14_gaussApproxLB_onemissing():
 def test_bovy14_gaussApproxLB_threemissing():
     #Test the Gaussian approximation
     #First, test near an interpolated point, without using interpolation (non-trivial)
-    tol= -2.
+    tol= -1.8
     trackp= 102
     LB= list(sdf_bovy14._interpolatedObsTrackLB[trackp,:].flatten())
     # l,vlos,pmll


### PR DESCRIPTION
This pull request adds support for using ``astropy.coordinates`` transformations, primarily to go from ``(ra,dec)`` to ``(l,b)``. Using astropy can be set by a configuration parameter (default: True), non-astropy is still supported and can use astropy to figure out the transformation for general epochs (incl. for the velocities).

Also fixes the way Galactocentric coordinates are computed, consistent with astropy.