### PR TITLE
Increased test coverage for SCFPotential: axisymmetric case

### DIFF
--- a/nose/test_scf.py
+++ b/nose/test_scf.py
@@ -102,10 +102,20 @@ def test_coeffs_Asin_L_M_notLowerTriangular():
         raise Exception("Expected RuntimeWarning")
     except RuntimeWarning:
         pass
-
+        
+def testAxi_phiIsNone():
+    R = 1; z = 0; phi = 1.1;
+    scf = SCFPotential()
+    assert scf(R,z,None) == scf(R,z,phi), "The axisymmetric potential does not work at phi=None"
+    assert scf.dens(R,z,None) == scf.dens(R,z,phi), "The axisymmetric density does not work at phi=None"
+    assert scf.Rforce(R,z,None) == scf.Rforce(R,z,phi), "The axisymmetric Rforce does not work at phi=None"
+    assert scf.zforce(R,z,None) == scf.zforce(R,z,phi), "The axisymmetric zforce does not work at phi=None"
+    assert scf.phiforce(R,z,None) == scf.phiforce(R,z,phi), "The axisymmetric phiforce does not work at phi=None"
+         
+        
+        
 
 ##Tests user inputs as arrays    
-    
 
 def testArray_RArray():
     scf = SCFPotential()


### PR DESCRIPTION
Added an extra test that should cover the three missed lines from 

[https://codecov.io/gh/jobovy/galpy/src/6037e50cfc1dbbbd74053ea6433ba30f947d6ad7/galpy/potential_src/SCFPotential.py](https://codecov.io/gh/jobovy/galpy/src/6037e50cfc1dbbbd74053ea6433ba30f947d6ad7/galpy/potential_src/SCFPotential.py)

Did not make any test to cover that last miss since roundoff isn't used(although it could in the future?).

