### PR TITLE
issue warning when integration method changes

### DIFF
--- a/galpy/orbit_src/FullOrbit.py
+++ b/galpy/orbit_src/FullOrbit.py
@@ -566,14 +566,11 @@ def _integrateFullOrbit(vxvv,pot,t,method,dt):
             allHasC= nu.prod([p.hasC for p in pot])
         else:
             allHasC= pot.hasC
-        fallback = False
-        if not allHasC and ('leapfrog' in method or 'symplec' in method):
-            fallback = True
-            method= 'leapfrog'
-        elif not allHasC:
-            fallback = True
-            method= 'odeint'
-        if fallback:
+        if not allHasC:
+            if ('leapfrog' in method or 'symplec' in method):
+                method= 'leapfrog'
+            else:
+                method= 'odeint'
             warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
     if method.lower() == 'leapfrog':
         #go to the rectangular frame

--- a/galpy/orbit_src/FullOrbit.py
+++ b/galpy/orbit_src/FullOrbit.py
@@ -566,10 +566,15 @@ def _integrateFullOrbit(vxvv,pot,t,method,dt):
             allHasC= nu.prod([p.hasC for p in pot])
         else:
             allHasC= pot.hasC
+        fallback = False
         if not allHasC and ('leapfrog' in method or 'symplec' in method):
+            fallback = True
             method= 'leapfrog'
         elif not allHasC:
+            fallback = True
             method= 'odeint'
+        if fallback:
+            warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
     if method.lower() == 'leapfrog':
         #go to the rectangular frame
         this_vxvv= nu.array([vxvv[0]*nu.cos(vxvv[5]),

--- a/galpy/orbit_src/RZOrbit.py
+++ b/galpy/orbit_src/RZOrbit.py
@@ -4,6 +4,7 @@ import numpy as nu
 from scipy import integrate
 from galpy.potential_src.Potential import _evaluateRforces, _evaluatezforces,\
     evaluatePotentials, evaluateDensities
+from galpy.util import galpyWarning
 import galpy.util.bovy_plot as plot
 import galpy.util.bovy_symplecticode as symplecticode
 from galpy.orbit_src.FullOrbit import _integrateFullOrbit

--- a/galpy/orbit_src/RZOrbit.py
+++ b/galpy/orbit_src/RZOrbit.py
@@ -470,10 +470,12 @@ def _integrateRZOrbit(vxvv,pot,t,method,dt):
             allHasC= nu.prod([p.hasC for p in pot])
         else:
             allHasC= pot.hasC
-        if not allHasC and ('leapfrog' in method or 'symplec' in method):
-            method= 'leapfrog'
-        elif not allHasC:
-            method= 'odeint'
+        if not allHasC:
+            if ('leapfrog' in method or 'symplec' in method):
+                method= 'leapfrog'
+            else:
+                method= 'odeint'
+            warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
     if method.lower() == 'leapfrog' \
             or method.lower() == 'leapfrog_c' or method.lower() == 'rk4_c' \
             or method.lower() == 'rk6_c' or method.lower() == 'symplec4_c' \

--- a/galpy/orbit_src/RZOrbit.py
+++ b/galpy/orbit_src/RZOrbit.py
@@ -1,3 +1,4 @@
+import warnings
 import math as m
 import numpy as nu
 from scipy import integrate

--- a/galpy/orbit_src/planarOrbit.py
+++ b/galpy/orbit_src/planarOrbit.py
@@ -501,10 +501,12 @@ def _integrateROrbit(vxvv,pot,t,method,dt):
             allHasC= nu.prod([p.hasC for p in pot])
         else:
             allHasC= pot.hasC
-        if not allHasC and ('leapfrog' in method or 'symplec' in method):
-            method= 'leapfrog'
-        elif not allHasC:
-            method= 'odeint'
+        if not allHasC:
+            if ('leapfrog' in method or 'symplec' in method):
+                method= 'leapfrog'
+            else:
+                method= 'odeint'
+            warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
     if method.lower() == 'leapfrog':
         #We hack this by putting in a dummy phi
         this_vxvv= nu.zeros(len(vxvv)+1)
@@ -582,10 +584,12 @@ def _integrateOrbit(vxvv,pot,t,method,dt):
             allHasC= nu.prod([p.hasC for p in pot])
         else:
             allHasC= pot.hasC
-        if not allHasC and ('leapfrog' in method or 'symplec' in method):
-            method= 'leapfrog'
-        elif not allHasC:
-            method= 'odeint'
+        if not allHasC:
+            if ('leapfrog' in method or 'symplec' in method):
+                method= 'leapfrog'
+            else:
+                method= 'odeint'
+            warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
     if method.lower() == 'leapfrog':
         #go to the rectangular frame
         this_vxvv= nu.array([vxvv[0]*nu.cos(vxvv[3]),

--- a/nose/test_orbit.py
+++ b/nose/test_orbit.py
@@ -3023,6 +3023,27 @@ def test_orbit_c_sigint_planardxdv():
             raise AssertionError("Full orbit integration using %s should have been interrupted by SIGINT (CTRL-C), but was not because p.poll() == %i" % (integrator,p.poll()))
     return None
 
+def test_orbitint_pythonfallback():
+    # Check if a warning is raised when the potential has no C integrator
+    from galpy.orbit import Orbit
+    bp= BurkertPotentialNoC() # BurkertPotentialNoC is already imported at the top of test_orbit.py
+    bp.normalize(1.)
+    ts= numpy.linspace(0.,1.,101)
+    import warnings
+    for orb in [Orbit([1.,0.1,1.1,0.1,0.,1.]),Orbit([1.,0.1,1.1,0.1,0.]),
+                Orbit([1.,0.1,1.1,1.]),Orbit([1.,0.1,1.1])]:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", galpyWarning)
+            #Test w/ dopr54_c
+            orb.integrate(ts,bp, method='dopr54_c')
+            # Should raise warning bc of python fallback, might raise others
+            raisedWarning= False
+            for wa in w:
+                raisedWarning= ( "Cannot use C integration because some of the potentials are not implemented in C" in str(wa.message) )
+                if raisedWarning: break
+            assert raisedWarning, "Orbit integration did not raise fallback warning"
+    return None
+
 def test_linear_plotting():
     from galpy.orbit import Orbit
     from galpy.potential_src.verticalPotential import RZToverticalPotential
@@ -3553,21 +3574,3 @@ def check_integrate_t_asQuantity_warning(o,funcName):
             if raisedWarning: break
         assert raisedWarning, "Orbit method %s wit unitless time after integrating with unitful time should have thrown a warning, but didn't" % funcName
     return None  
-
-def test_orbitint_pythonfallback():
-    # Check if a warning is raised when the potential has no C integrator
-    from galpy.orbit import Orbit
-    bp= BurkertPotentialNoC() # BurkertPotentialNoC is already imported at the top of test_orbit.py
-    orb= Orbit([1.,0.1,1.1,0.1,0.,1.])
-    ts= numpy.linspace(0.,1.,101)
-    import warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always", galpyWarning)
-        #Test w/ dopr54_c
-        orb.integrate(ts,bp, method='dopr54_c')
-        # Should raise warning bc of python fallback, might raise others
-        raisedWarning= False
-        for wa in w:
-            raisedWarning= ( "Cannot use C integration because some of the potentials are not implemented in C" in str(wa.message) )
-            if raisedWarning: break
-        assert raisedWarning, "Orbit integration did not raise fallback warning"

--- a/nose/test_orbit.py
+++ b/nose/test_orbit.py
@@ -3554,3 +3554,20 @@ def check_integrate_t_asQuantity_warning(o,funcName):
         assert raisedWarning, "Orbit method %s wit unitless time after integrating with unitful time should have thrown a warning, but didn't" % funcName
     return None  
 
+def test_orbitint_pythonfallback():
+    # Check if a warning is raised when the potential has no C integrator
+    from galpy.orbit import Orbit
+    bp= BurkertPotentialNoC() # BurkertPotentialNoC is already imported at the top of test_orbit.py
+    orb= Orbit([1.,0.1,1.1,0.1,0.,1.])
+    ts= numpy.linspace(0.,1.,101)
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always", galpyWarning)
+        #Test w/ dopr54_c
+        orb.integrate(ts,bp, method='dopr54_c')
+        # Should raise warning bc of python fallback, might raise others
+        raisedWarning= False
+        for wa in w:
+            raisedWarning= ( "Cannot use C integration because some of the potentials are not implemented in C" in str(wa.message) )
+            if raisedWarning: break
+        assert raisedWarning, "Orbit integration did not raise fallback warning"


### PR DESCRIPTION
I noticed that the integration routines silently falls back to python methods when C methods are selected, and thought it'd be better to issue a warning of the change explicitly.

I think there are couple of other integration routines for e.g., planar orbits, but I submit this example to see if you think this is a good idea. (Although right now, the methods in classes default to C, and you are warned when C integrations are actually used..)
