### PR TITLE
SCFPotential for v1 and v2 of GSL

### DIFF
--- a/galpy/potential_src/potential_c_ext/SCFPotential.c
+++ b/galpy/potential_src/potential_c_ext/SCFPotential.c
@@ -349,10 +349,14 @@ inline void computeNonAxi(double a, int N, int L, int M,
     int Pindex = 0;
     for (l = 0; l < L; l++)
     {
-        
+        v1counter = 0;
         for (m = 0; m<=l; m++)
         {
-            v1counter = m*(m + 1)/2 + l; 
+            #if GSL_MAJOR_VERSION == 2
+                Pindex = v2counter;
+            #else
+                Pindex = v1counter + l;
+            #endif
             
             double mCos = cos(m*phi);
             double mSin = sin(m*phi);
@@ -375,12 +379,9 @@ inline void computeNonAxi(double a, int N, int L, int M,
             
                 v2counter++; 
                  
-                #if GSL_MAJOR_VERSION == 2
-                Pindex = v2counter;
-                #else
-                Pindex = v1counter;
-                #endif
+                
         }
+        v1counter+=M-m - 1;
         
             
         

--- a/galpy/potential_src/potential_c_ext/SCFPotential.c
+++ b/galpy/potential_src/potential_c_ext/SCFPotential.c
@@ -227,20 +227,19 @@ inline void compute_d2phiTilde(double r, double a, int N, int L, double * C, dou
 inline void compute_P(double x, int L, int M, double * P_array)
 {
     if (M == 1){
-    gsl_sf_legendre_Pl_array (L - 1, x, P_array);
-    return;
+        gsl_sf_legendre_Pl_array (L - 1, x, P_array);
+    } else {
+        #if GSL_MAJOR_VERSION == 2
+            gsl_sf_legendre_array_e(GSL_SF_LEGENDRE_NONE,L - 1, x, -1, P_array);
+        #else
+            int m;
+            for (m = 1; m < M; m++)
+            {
+                gsl_sf_legendre_Plm_array(L - 1, m, x, P_array);
+                P_array += L - m;
+            }
+        #endif
     }
-    #if GSL_MAJOR_VERSION == 2
-        gsl_sf_legendre_array_e(GSL_SF_LEGENDRE_NONE,L - 1, x, -1, P_array);
-       
-    #else
-        int m;
-        for (m = 1; m < M; m++)
-        {
-            gsl_sf_legendre_Plm_array(L - 1, m, x, P_array);
-            P_array += L - m;
-        }
-    #endif
     
       
     
@@ -250,21 +249,21 @@ inline void compute_P(double x, int L, int M, double * P_array)
 inline void compute_P_dP(double x, int L, int M, double * P_array, double *dP_array)
 {
     if (M == 1){
-    gsl_sf_legendre_Pl_deriv_array (L - 1, x, P_array, dP_array);
-    return;
-    }
-    #if GSL_MAJOR_VERSION == 2
-        gsl_sf_legendre_deriv_array_e(GSL_SF_LEGENDRE_NONE, L - 1, x, -1,P_array, dP_array);
+        gsl_sf_legendre_Pl_deriv_array (L - 1, x, P_array, dP_array);
+    } else {
+        #if GSL_MAJOR_VERSION == 2
+            gsl_sf_legendre_deriv_array_e(GSL_SF_LEGENDRE_NONE, L - 1, x, -1,P_array, dP_array);
         
-    #else
-        int m;
-        for (m = 1; m < M; m++)
-        {
-            gsl_sf_legendre_Plm_deriv_array(L - 1, m, x, P_array, dP_array);
-            P_array += L - m;
-            dP_array += L - m;
-        }
-    #endif
+        #else
+            int m;
+            for (m = 1; m < M; m++)
+            {
+                gsl_sf_legendre_Plm_deriv_array(L - 1, m, x, P_array, dP_array);
+                P_array += L - m;
+                dP_array += L - m;
+            }
+        #endif
+    }
 }
 
 

--- a/galpy/potential_src/potential_c_ext/SCFPotential.c
+++ b/galpy/potential_src/potential_c_ext/SCFPotential.c
@@ -233,7 +233,7 @@ inline void compute_P(double x, int L, int M, double * P_array)
             gsl_sf_legendre_array_e(GSL_SF_LEGENDRE_NONE,L - 1, x, -1, P_array);
         #else
             int m;
-            for (m = 1; m < M; m++)
+            for (m = 0; m < M; m++)
             {
                 gsl_sf_legendre_Plm_array(L - 1, m, x, P_array);
                 P_array += L - m;
@@ -256,7 +256,7 @@ inline void compute_P_dP(double x, int L, int M, double * P_array, double *dP_ar
         
         #else
             int m;
-            for (m = 1; m < M; m++)
+            for (m = 0; m < M; m++)
             {
                 gsl_sf_legendre_Plm_deriv_array(L - 1, m, x, P_array, dP_array);
                 P_array += L - m;

--- a/galpy/potential_src/potential_c_ext/SCFPotential.c
+++ b/galpy/potential_src/potential_c_ext/SCFPotential.c
@@ -378,10 +378,10 @@ inline void computeNonAxi(double a, int N, int L, int M,
            
             
                 v2counter++; 
-                 
+                v1counter+=M-m - 1;  
                 
         }
-        v1counter+=M-m - 1;
+        
         
             
         


### PR DESCRIPTION
Replaced deprecated gsl_sf_legendre_Plm_array with gsl_sf_legendre_array_e for GSL v2.

Optimized axisymmetric case by using gsl_sf_legendre_Pl_array.