### PR TITLE
Fix bug in FerrersPotential.Rzderiv

### DIFF
--- a/galpy/potential_src/FerrersPotential.py
+++ b/galpy/potential_src/FerrersPotential.py
@@ -276,7 +276,7 @@ class FerrersPotential(Potential):
         ang = self._omegab*t + self._pa
         c, s = np.cos(ang), np.sin(ang)
         phixz = c*phixza + s*phiyza
-        phiyz = c*phixza - s*phiyza
+        phiyz = -s*phixza + c*phiyza
         return np.cos(phi)*phixz + np.sin(phi)*phiyz
 
     def _z2deriv(self,R,z,phi=0.,t=0.):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -436,7 +436,6 @@ def test_2ndDeriv_potential():
                     #Excluding KuzminDiskPotential at z = 0
                     if p == 'KuzminDiskPotential' and Zs[jj] == 0: continue 
 #                    if p == 'RazorThinExponentialDiskPotential': continue #Not implemented, or badly defined
-                    if p == 'FerrersPotential': continue 
                     dz= 10.**-8.
                     newz= Zs[jj]+dz
                     dz= newz-Zs[jj] #Representable number

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1923,7 +1923,6 @@ def test_vtermnegl_issue314():
     assert numpy.fabs(rp.vterm(0.5)+rp.vterm(-0.5)) < 10.**-8., 'vterm for negative l does not behave as expected'
     return None
 
-@pytest.mark.xfail
 def test_Ferrers_Rzderiv_issue319():
     # Test that the Rz derivative works for the FerrersPotential (issue 319)
      fp= potential.FerrersPotential(normalize=1.)


### PR DESCRIPTION
Hi Jo,
This is to fix #319. I think it was from a trivial mistake in rotating back xy/xz derivatives from bar-aligned to non-rotating frame. Please let me know if everything looks good.

```sh
galpy git/fix-ferrers-rzderiv
$git show
commit 4a50d2934bbc9bab15b6ddca893ac4f3e15552ac
Author: Semyeong Oh <semyeong.oh@gmail.com>
Date:   Wed Oct 18 14:38:55 2017 -0400

    Fix trivial mistake in rotating back phixza, phiyza

diff --git a/galpy/potential_src/FerrersPotential.py b/galpy/potential_src/FerrersPotential.py
index e34f3cd..a4f4106 100644
--- a/galpy/potential_src/FerrersPotential.py
+++ b/galpy/potential_src/FerrersPotential.py
@@ -276,7 +276,7 @@ class FerrersPotential(Potential):
         ang = self._omegab*t + self._pa
         c, s = np.cos(ang), np.sin(ang)
         phixz = c*phixza + s*phiyza
-        phiyz = c*phixza - s*phiyza
+        phiyz = -s*phixza + c*phiyza
         return np.cos(phi)*phixz + np.sin(phi)*phiyz

     def _z2deriv(self,R,z,phi=0.,t=0.):

galpy git/fix-ferrers-rzderiv
$py.test -v -k 'test_Ferrers_Rzderiv' tests/test_potential.py
============================ test session starts ============================
platform darwin -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /Users/semyeong/anaconda2/envs/research/bin/python
cachedir: .cache
rootdir: /Users/semyeong/projects/usrp/galpy, inifile:
collected 59 items

tests/test_potential.py::test_Ferrers_Rzderiv_issue319 XPASS

============================ 58 tests deselected ============================
================= 58 deselected, 1 xpassed in 2.15 seconds ==================
```