### PR TITLE
Fix frame as a positional argument is deprecated in astropy

### DIFF
--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -2322,7 +2322,7 @@ def get_epoch_angles(epoch=2000.0):
 
 # Get ICRS angles once when astropy is installed
 if _APY_LOADED:
-    c= apycoords.SkyCoord(180.*units.deg,90.*units.deg,'icrs')
+    c= apycoords.SkyCoord(180.*units.deg,90.*units.deg,frame='icrs')
     c= c.transform_to(apycoords.Galactic)
     theta_icrs= c.l.to(units.rad).value
     c= apycoords.SkyCoord(180.*units.deg,90.*units.deg,


### PR DESCRIPTION
Fix frame as a positional argument is deprecated in astropy, adding frame="xxx" to prevent `AstropyDeprecationWarning` from displaying every time

Related:
#337