### PR TITLE
Fix galpy with openmp compilation on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,13 +6,16 @@ environment:
 
   matrix:
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_coords.py"
-      ADDL_CONDA_PKGS: 
+      ADDL_CONDA_PKGS: intel-openmp
+      COMPILE_NOOPENMP: 
 
     - TEST_FILES: tests\test_orbit.py
       ADDL_CONDA_PKGS: astropy
+      COMPILE_NOOPENMP: --no-openmp
 
     - TEST_FILES: tests\test_quantity.py tests\test_coords.py
       ADDL_CONDA_PKGS: astropy
+      COMPILE_NOOPENMP: --no-openmp
 
 platform:
     - x64
@@ -22,6 +25,7 @@ install:
   - cmd: conda.exe update --yes --quiet conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels anaconda
   - conda update -q conda
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib setuptools pip cython>=0.20 pytest gsl %ADDL_CONDA_PKGS%"
@@ -34,7 +38,7 @@ install:
   - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
   - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
 
-  - python setup.py build_ext --single_ext --inplace --no-openmp
+  - python setup.py build_ext --single_ext --inplace %COMPILE_NOOPENMP%
   - python setup.py develop --single_ext
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,16 +6,16 @@ environment:
 
   matrix:
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_coords.py"
-      ADDL_CONDA_PKGS: intel-openmp
+      ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
 
     - TEST_FILES: tests\test_orbit.py
       ADDL_CONDA_PKGS: astropy
-      COMPILE_NOOPENMP: --no-openmp
+      COMPILE_NOOPENMP: "--no-openmp"
 
     - TEST_FILES: tests\test_quantity.py tests\test_coords.py
       ADDL_CONDA_PKGS: astropy
-      COMPILE_NOOPENMP: --no-openmp
+      COMPILE_NOOPENMP: "--no-openmp"
 
 platform:
     - x64
@@ -25,10 +25,9 @@ install:
   - cmd: conda.exe update --yes --quiet conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels anaconda
   - conda update -q conda
   - conda info -a
-  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib setuptools pip cython>=0.20 pytest gsl %ADDL_CONDA_PKGS%"
+  - "conda create -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib setuptools pip cython>=0.20 pytest gsl %ADDL_CONDA_PKGS%"
   - activate test-environment
   - pip install coverage
   - pip install pytest-cov
@@ -38,7 +37,7 @@ install:
   - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
   - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
 
-  - python setup.py build_ext --single_ext --inplace %COMPILE_NOOPENMP%
+  - "python setup.py build_ext --single_ext --inplace %COMPILE_NOOPENMP%"
   - python setup.py develop --single_ext
 
 test_script:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -64,15 +64,23 @@ Installing from source on Windows
 
 Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows this is done as::
 
-	 set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
-	 set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
-	 set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+     set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+     set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+     set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
 
 where in this example ``CONDA_PREFIX`` is the path of your current conda environment (the path that ends in ``\ENV_NAME``). If you have installed the GSL somewhere else, adjust these paths (but do not use ``YOUR_PATH\include\gsl`` or ``YOUR_PATH\lib\gsl`` as the paths, simply use ``YOUR_PATH\include`` and ``YOUR_PATH\lib``).
 
-To then compile the code, do::
+To compile with OpenMP on Windows, you have to install Intel OpenMP via::
 
-   python setup.py install --no-openmp
+    conda install -c anaconda intel-openmp
+
+and then to compile the code::
+
+   python setup.py install
+
+If you encounter any issue related to OpenMP during compilation, you can do::
+
+    python setup.py install --no-openmp
 
 
 Installing the TorusMapper code

--- a/setup.py
+++ b/setup.py
@@ -29,16 +29,21 @@ with open('README.rst') as dfile:
 # --actionAngle_ext: just compile the actionAngle extension (for use w/ --coverage)
 # --interppotential_ext: just compile the interppotential extension (for use w/ --coverage)
 
-pot_libraries= ['m','gsl','gslcblas','gomp']
+pot_libraries = ['m','gsl','gslcblas','gomp']
+
+if WIN32:  # windows does not need 'gomp' whether compiled with OpenMP or not
+    pot_libraries.remove('gomp')
+
 #Option to forego OpenMP
 try:
     openmp_pos = sys.argv.index('--no-openmp')
 except ValueError:
-    extra_compile_args=["-fopenmp"]
+    extra_compile_args = ["-fopenmp" if not WIN32 else "/openmp"]
 else:
     del sys.argv[openmp_pos]
     extra_compile_args= ["-DNO_OMP"]
-    pot_libraries.remove('gomp')
+    if not WIN32:  # Because windows guarantee do not have 'gomp' in the list
+        pot_libraries.remove('gomp')
 
 #Option to track coverage
 try:


### PR DESCRIPTION
Fix galpy with openmp compilation on Windows, performance tests:

```
from galpy.potential import MWPotential2014
from galpy.actionAngle import actionAngleAdiabatic
from galpy.orbit import Orbit
import numpy

aAA = actionAngleAdiabatic(pot=MWPotential2014, c=True)
ts = numpy.linspace(0., 100., 10001)
o = Orbit([1., 0.1, 1.1, 0., 0.05])
o.integrate(ts, MWPotential2014)
%timeit aAA(o.R(ts), o.vR(ts), o.vT(ts), o.z(ts), o.vz(ts))
```
**Win10 v1803 x64 py36 (4 cores 8 threads 4.2GHz)**
Compiled with OpenMP: 154 ms ± 2.12 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Compiled without OpenMP: 945 ms ± 1.07 ms per loop (mean ± std. dev. of 7 runs, 10 loop each)

And
```
from galpy.potential import MWPotential2014
from galpy.actionAngle import actionAngleStaeckel, estimateDeltaStaeckel
from galpy.orbit import Orbit
import numpy

ts = numpy.linspace(0., 100., 100000)
o= Orbit(vxvv=[1.,0.1,1.1,0.,0.1,0.])
o.integrate(ts, MWPotential2014)

aAS = actionAngleStaeckel(pot=MWPotential2014, delta=0.3)
R, vR, vT, z, vz, phi = o.getOrbit().T
delta = estimateDeltaStaeckel(MWPotential2014, R, z, no_median=True)

%timeit -n 10 es, zms, rps, ras = aAS.EccZmaxRperiRap(R,vR,vT,z,vz,phi,delta=delta)
```
**Win10 v1803 x64 py36 (4 cores 8 threads 4.2GHz)**
Compiled with OpenMP: 777 ms ± 4.37 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Compiled without OpenMP: 4.55 s ± 3.4 ms per loop (mean ± std. dev. of 7 runs, 10 loop each)