### PR TITLE
Implement 1D orbit integration in C

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,13 @@
 v1.5 (????-??-??)
 =================
 
+- Added support for 1D orbit integration in C.
+
+- Added potential.toVerticalPotential to convert any 3D potential to a
+  1D potential at a given (R,phi) [generalizes RZToverticalPotential
+  to non-axi potentials; RZToverticalPotential retained for backwards
+  compatibility].
+
 - Added nemo_accname and nemo_accpars for the HernquistPotential,
   allowing it to be converted to NEMO.
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,7 +1,7 @@
 v1.5 (????-??-??)
 =================
 
-- Added support for 1D orbit integration in C.
+- Added support for 1D orbit integration in C (PR #354).
 
 - Added potential.toVerticalPotential to convert any 3D potential to a
   1D potential at a given (R,phi) [generalizes RZToverticalPotential

--- a/README.dev
+++ b/README.dev
@@ -35,3 +35,11 @@ potential in question (after the initialization of the super class)
 10) If you implement the second derivatives of the potential necessary
 to integrate phase-space volumes, also set self.hasC_dxdv=True to the
 initialization of the potential in question.
+
+11) If you add a potential that gets passed to C as a list, you need
+to edit orbit/integrateLinearOrbit.py and
+orbit/orbit_c_ext/integrateLinearPotential.c to parse it properly (for
+regular 3D potentials this works out of the box).
+
+12) If you add a 1D potential, do the steps above, but for
+integrateLinearOrbit.*

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -401,6 +401,7 @@ One-dimensional potentials can also be derived from 3D axisymmetric potentials a
 .. toctree::
    :maxdepth: 2
 
+   toVerticalPotential (general) <potential1dtolinear.rst>
    RZToverticalPotential <potential1dRZtolinear.rst>
 
 .. _potwrapperapi:

--- a/doc/source/reference/potential1dtolinear.rst
+++ b/doc/source/reference/potential1dtolinear.rst
@@ -1,0 +1,4 @@
+galpy.potential.toVerticalPotential
+===================================
+
+.. autofunction:: galpy.potential.toVerticalPotential

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -1,0 +1,139 @@
+import sys
+import distutils.sysconfig as sysconfig
+import warnings
+import numpy as nu
+import ctypes
+import ctypes.util
+from numpy.ctypeslib import ndpointer
+import os
+from galpy import potential
+from galpy.util import galpyWarning
+from .integratePlanarOrbit import _parse_integrator, _parse_tol
+from .integrateFullOrbit import _parse_pot as _parse_pot_full
+from galpy.potential.verticalPotential import verticalPotential
+from galpy.potential.WrapperPotential import parentWrapperPotential
+#Find and load the library
+_lib= None
+outerr= None
+PY3= sys.version > '3'
+if PY3:
+    _ext_suffix= sysconfig.get_config_var('EXT_SUFFIX')
+else: #pragma: no cover
+    _ext_suffix= '.so'
+for path in sys.path:
+    try:
+        _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+    except OSError as e:
+        if os.path.exists(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)): #pragma: no cover
+            outerr= e
+        _lib = None
+    else:
+        break
+if _lib is None: #pragma: no cover
+    if not outerr is None:
+        warnings.warn("integrateLinearOrbit_c extension module not loaded, because of error '%s' " % outerr,
+                      galpyWarning)
+    else:
+        warnings.warn("integrateLinearOrbit_c extension module not loaded, because galpy_integrate_c%s image was not found" % _ext_suffix,
+                      galpyWarning)
+    _ext_loaded= False
+else:
+    _ext_loaded= True
+
+def _parse_pot(pot):
+    """Parse the potential so it can be fed to C"""
+    #Figure out what's in pot
+    if not isinstance(pot,list):
+        pot= [pot]
+    #Initialize everything
+    pot_type= []
+    pot_args= []
+    npot= len(pot)
+    for p in pot:
+        # Prepare for wrappers NOT CURRENTLY SUPPORTED, SEE PLANAR OR FULL
+        if isinstance(p,verticalPotential):
+            _,pt,pa= _parse_pot_full(p._Pot)
+            pot_type.extend(pt)
+            pot_args.extend(pa)
+            pot_args.append(p._R)
+    pot_type= nu.array(pot_type,dtype=nu.int32,order='C')
+    pot_args= nu.array(pot_args,dtype=nu.float64,order='C')
+    return (npot,pot_type,pot_args)
+
+def integrateLinearOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
+    """
+    NAME:
+       integrateLinearOrbit_c
+    PURPOSE:
+       C integrate an ode for a LinearOrbit
+    INPUT:
+       pot - Potential or list of such instances
+       yo - initial condition [q,p]
+       t - set of times at which one wants the result
+       int_method= 'leapfrog_c', 'rk4_c', 'rk6_c', 'symplec4_c'
+       rtol, atol
+       dt= (None) force integrator to use this stepsize (default is to automatically determine one))
+    OUTPUT:
+       (y,err)
+       y : array, shape (len(y0), len(t))
+       Array containing the value of y for each desired time in t, \
+       with the initial value y0 in the first row.
+       err: error message, if not zero: 1 means maximum step reduction happened for adaptive integrators
+    HISTORY:
+       2018-10-06 - Written - Bovy (UofT)
+    """
+    rtol, atol= _parse_tol(rtol,atol)
+    npot, pot_type, pot_args= _parse_pot(pot)
+    int_method_c= _parse_integrator(int_method)
+    if dt is None: 
+        dt= -9999.99
+
+    #Set up result array
+    result= nu.empty((len(t),2))
+    err= ctypes.c_int(0)
+
+    #Set up the C code
+    ndarrayFlags= ('C_CONTIGUOUS','WRITEABLE')
+    integrationFunc= _lib.integrateLinearOrbit
+    integrationFunc.argtypes= [ndpointer(dtype=nu.float64,flags=ndarrayFlags),
+                               ctypes.c_int,                             
+                               ndpointer(dtype=nu.float64,flags=ndarrayFlags),
+                               ctypes.c_int,
+                               ndpointer(dtype=nu.int32,flags=ndarrayFlags),
+                               ndpointer(dtype=nu.float64,flags=ndarrayFlags),
+                               ctypes.c_double,
+                               ctypes.c_double,
+                               ctypes.c_double,
+                               ndpointer(dtype=nu.float64,flags=ndarrayFlags),
+                               ctypes.POINTER(ctypes.c_int),
+                               ctypes.c_int]
+
+    #Array requirements, first store old order
+    f_cont= [yo.flags['F_CONTIGUOUS'],
+             t.flags['F_CONTIGUOUS']]
+    yo= nu.require(yo,dtype=nu.float64,requirements=['C','W'])
+    t= nu.require(t,dtype=nu.float64,requirements=['C','W'])
+    result= nu.require(result,dtype=nu.float64,requirements=['C','W'])
+
+    #Run the C code
+    integrationFunc(yo,
+                    ctypes.c_int(len(t)),
+                    t,
+                    ctypes.c_int(npot),
+                    pot_type,
+                    pot_args,
+                    ctypes.c_double(dt),
+                    ctypes.c_double(rtol),ctypes.c_double(atol),
+                    result,
+                    ctypes.byref(err),
+                    ctypes.c_int(int_method_c))
+    
+    if int(err.value) == -10: #pragma: no cover
+        raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")
+
+    #Reset input arrays
+    if f_cont[0]: yo= nu.asfortranarray(yo)
+    if f_cont[1]: t= nu.asfortranarray(t)
+
+    return (result,err.value)
+

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -56,6 +56,7 @@ def _parse_pot(pot):
             pot_type.extend(pt)
             pot_args.extend(pa)
             pot_args.append(p._R)
+            pot_args.append(p._phi)
         elif isinstance(p,potential.KGPotential):
             pot_type.append(31)
             pot_args.extend([p._amp,p._K,p._D2,2.*p._F]) 

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -56,6 +56,9 @@ def _parse_pot(pot):
             pot_type.extend(pt)
             pot_args.extend(pa)
             pot_args.append(p._R)
+        elif isinstance(p,potential.KGPotential):
+            pot_type.append(31)
+            pot_args.extend([p._amp,p._K,p._D2,2.*p._F]) 
     pot_type= nu.array(pot_type,dtype=nu.int32,order='C')
     pot_args= nu.array(pot_args,dtype=nu.float64,order='C')
     return (npot,pot_type,pot_args)

--- a/galpy/orbit/linearOrbit.py
+++ b/galpy/orbit/linearOrbit.py
@@ -2,8 +2,9 @@ import warnings
 import numpy as nu
 from scipy import integrate
 from .OrbitTop import OrbitTop
-from .linearPotential import _evaluatelinearForces, evaluatelinearPotentials
-from .Potential import _check_c
+from ..potential.linearPotential import \
+    _evaluatelinearForces, evaluatelinearPotentials
+from ..potential.Potential import _check_c
 import galpy.util.bovy_symplecticode as symplecticode
 from galpy.util.bovy_conversion import physical_conversion
 from galpy.util import galpyWarning, galpyWarningVerbose

--- a/galpy/orbit/linearOrbit.py
+++ b/galpy/orbit/linearOrbit.py
@@ -157,11 +157,6 @@ def _integrateLinearOrbit(vxvv,pot,t,method,dt):
                 warnings.warn("Cannot use C integration because C extension not loaded (using %s instead)" % (method), galpyWarning)
             else:
                 warnings.warn("Cannot use C integration because some of the potentials are not implemented in C (using %s instead)" % (method), galpyWarning)
-    if '_c' in method:
-        if 'leapfrog' in method or 'symplec' in method:
-            method= 'leapfrog'
-        else:
-            method= 'odeint'
     if method.lower() == 'leapfrog':
         return symplecticode.leapfrog(lambda x,t=t: _evaluatelinearForces(pot,x,
                                                                          t=t),

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -322,6 +322,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
 					    + (int) (*(*pot_args+7) + 20)));
       break;    
+      // 31: KGPotential
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -1,0 +1,175 @@
+/*
+  Wrappers around the C integration code for linear Orbits
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include <bovy_symplecticode.h>
+#include <bovy_rk.h>
+//Potentials
+#include <galpy_potentials.h>
+#include <integrateFullOrbit.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+//Macros to export functions in DLL on different OS
+#if defined(_WIN32)
+#define EXPORT __declspec(dllexport)
+#elif defined(__GNUC__)
+#define EXPORT __attribute__((visibility("default")))
+#else
+// Just do nothing?
+#define EXPORT
+#endif
+/*
+  Function Declarations
+*/
+void evalLinearForce(double, double *, double *,
+		     int, struct potentialArg *);
+void evalLinearDeriv(double, double *, double *,
+		     int, struct potentialArg *);
+/*
+  Actual functions
+*/
+void parse_leapFuncArgs_Linear(int npot,struct potentialArg * potentialArgs,
+			       int ** pot_type,
+			       double ** pot_args){
+  int ii,jj;
+  init_potentialArgs(npot,potentialArgs);
+  for (ii=0; ii < npot; ii++){
+    switch ( *(*pot_type)++ ) {
+    default: //verticalPotential
+      potentialArgs->linearForce= &verticalPotentialLinearForce;
+      break;
+//////////////////////////////// WRAPPERS /////////////////////////////////////
+      // NOT CURRENTLY SUPPORTED
+      /*
+    case -1: //DehnenSmoothWrapperPotential
+      potentialArgs->linearForce= &DehnenSmoothWrapperPotentialPlanarRforce;
+      potentialArgs->nargs= (int) 3;
+      break;
+    case -2: //SolidBodyRotationWrapperPotential
+      potentialArgs->linearForce= &SolidBodyRotationWrapperPotentialPlanarRforce;
+      potentialArgs->nargs= (int) 3;
+      break;
+    case -4: //CorotatingRotationWrapperPotential
+      potentialArgs->linearForce= &CorotatingRotationWrapperPotentialPlanarRforce;
+      potentialArgs->nargs= (int) 5;
+      break;
+    case -5: //GaussianAmplitudeWrapperPotential
+      potentialArgs->linearForce= &GaussianAmplitudeWrapperPotentialPlanarRforce;
+      potentialArgs->nargs= (int) 3;
+      break;
+      */
+    }
+    /*
+    if ( *(*pot_type-1) < 0) { // Parse wrapped potential for wrappers
+      potentialArgs->nwrapped= (int) *(*pot_args)++;
+      potentialArgs->wrappedPotentialArg= \
+	(struct potentialArg *) malloc ( potentialArgs->nwrapped	\
+					 * sizeof (struct potentialArg) );
+      parse_leapFuncArgs_Linear(potentialArgs->nwrapped,
+				potentialArgs->wrappedPotentialArg,
+				pot_type,pot_args);
+    }
+      */
+    // linear from 3D: assign R location parameter as the only one, rest
+    // of potential as wrapped
+    if ( potentialArgs->linearForce == &verticalPotentialLinearForce ) {
+      potentialArgs->nwrapped= (int) 1;
+      potentialArgs->wrappedPotentialArg= \
+	(struct potentialArg *) malloc ( potentialArgs->nwrapped	\
+					 * sizeof (struct potentialArg) );
+      *(pot_type)-= 1; // Do FullOrbit processing for same potential
+      parse_leapFuncArgs_Full(potentialArgs->nwrapped,
+			      potentialArgs->wrappedPotentialArg,
+			      pot_type,pot_args);
+      potentialArgs->nargs= 1; // R
+    }
+    potentialArgs->args= (double *) malloc( potentialArgs->nargs * sizeof(double));
+    for (jj=0; jj < potentialArgs->nargs; jj++){
+      *(potentialArgs->args)= *(*pot_args)++;
+      potentialArgs->args++;
+    }
+    potentialArgs->args-= potentialArgs->nargs;
+    potentialArgs++;
+  }
+  potentialArgs-= npot;
+}
+EXPORT void integrateLinearOrbit(double *yo,
+				 int nt, 
+				 double *t,
+				 int npot,
+				 int * pot_type,
+				 double * pot_args,
+				 double dt,
+				 double rtol,
+				 double atol,
+				 double *result,
+				 int * err,
+				 int odeint_type){
+  //Set up the forces, first count
+  int dim;
+  struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
+  parse_leapFuncArgs_Linear(npot,potentialArgs,&pot_type,&pot_args);
+  //Integrate
+  void (*odeint_func)(void (*func)(double, double *, double *,
+			   int, struct potentialArg *),
+		      int,
+		      double *,
+		      int, double, double *,
+		      int, struct potentialArg *,
+		      double, double,
+		      double *,int *);
+  void (*odeint_deriv_func)(double, double *, double *,
+			    int,struct potentialArg *);
+  switch ( odeint_type ) {
+  case 0: //leapfrog
+    odeint_func= &leapfrog;
+    odeint_deriv_func= &evalLinearForce;
+    dim= 1;
+    break;
+  case 1: //RK4
+    odeint_func= &bovy_rk4;
+    odeint_deriv_func= &evalLinearDeriv;
+    dim= 2;
+    break;
+  case 2: //RK6
+    odeint_func= &bovy_rk6;
+    odeint_deriv_func= &evalLinearDeriv;
+    dim= 2;
+    break;
+  case 3: //symplec4
+    odeint_func= &symplec4;
+    odeint_deriv_func= &evalLinearForce;
+    dim= 1;
+    break;
+  case 4: //symplec6
+    odeint_func= &symplec6;
+    odeint_deriv_func= &evalLinearForce;
+    dim= 1;
+    break;
+  case 5: //DOPR54
+    odeint_func= &bovy_dopr54;
+    odeint_deriv_func= &evalLinearDeriv;
+    dim= 2;
+    break;
+  }
+  odeint_func(odeint_deriv_func,dim,yo,nt,dt,t,npot,potentialArgs,rtol,atol,
+	      result,err);
+  //Free allocated memory
+  free_potentialArgs(npot,potentialArgs);
+  free(potentialArgs);
+  //Done!
+}
+
+void evalLinearForce(double t, double *q, double *a,
+		     int nargs, struct potentialArg * potentialArgs){
+  *a= calcLinearForce(*q,t,nargs,potentialArgs);
+}
+void evalLinearDeriv(double t, double *q, double *a,
+		     int nargs, struct potentialArg * potentialArgs){
+  *a++= *(q+1);
+  *a= calcLinearForce(*q,t,nargs,potentialArgs);
+}

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -89,7 +89,7 @@ void parse_leapFuncArgs_Linear(int npot,struct potentialArg * potentialArgs,
       parse_leapFuncArgs_Full(potentialArgs->nwrapped,
 			      potentialArgs->wrappedPotentialArg,
 			      pot_type,pot_args);
-      potentialArgs->nargs= 1; // R
+      potentialArgs->nargs= 2; // R, phi
     }
     potentialArgs->args= (double *) malloc( potentialArgs->nargs * sizeof(double));
     for (jj=0; jj < potentialArgs->nargs; jj++){

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -42,7 +42,7 @@ void parse_leapFuncArgs_Linear(int npot,struct potentialArg * potentialArgs,
     default: //verticalPotential
       potentialArgs->linearForce= &verticalPotentialLinearForce;
       break;
-    case 31:
+    case 31: // KGPotential
       potentialArgs->linearForce= &KGPotentialLinearForce;
       potentialArgs->nargs= 4;
       break; 

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -42,6 +42,10 @@ void parse_leapFuncArgs_Linear(int npot,struct potentialArg * potentialArgs,
     default: //verticalPotential
       potentialArgs->linearForce= &verticalPotentialLinearForce;
       break;
+    case 31:
+      potentialArgs->linearForce= &KGPotentialLinearForce;
+      potentialArgs->nargs= 4;
+      break; 
 //////////////////////////////// WRAPPERS /////////////////////////////////////
       // NOT CURRENTLY SUPPORTED
       /*

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -307,6 +307,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
 					    + (int) (*(*pot_args+7) + 20)));
       break;    
+      // 31: KGPotential
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;

--- a/galpy/potential/KGPotential.py
+++ b/galpy/potential/KGPotential.py
@@ -69,6 +69,7 @@ class KGPotential(linearPotential):
         self._F= F
         self._D= D
         self._D2= self._D**2.
+        self.hasC= True
         
     def _evaluate(self,x,t=0.):
         return self._K*(sc.sqrt(x**2.+self._D2)-self._D)+self._F*x**2.

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -2991,7 +2991,7 @@ def _check_c(Pot,dxdv=False):
 
     """
     Pot= flatten(Pot)
-    from galpy.potential import planarPotential
+    from galpy.potential import planarPotential, linearPotential
     if dxdv: hasC_attr= 'hasC_dxdv'
     else: hasC_attr= 'hasC'
     from .WrapperPotential import parentWrapperPotential
@@ -3000,7 +3000,8 @@ def _check_c(Pot,dxdv=False):
                                dtype='bool'))
     elif isinstance(Pot,parentWrapperPotential):
         return bool(Pot.__dict__[hasC_attr]*_check_c(Pot._pot))
-    elif isinstance(Pot,Potential) or isinstance(Pot,planarPotential):
+    elif isinstance(Pot,Potential) or isinstance(Pot,planarPotential) \
+            or isinstance(Pot,linearPotential):
         return Pot.__dict__[hasC_attr]
 
 def _dim(Pot):

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -717,7 +717,7 @@ class Potential(Force):
         from galpy.potential import toPlanarPotential
         return toPlanarPotential(self)
 
-    def toVertical(self,R):
+    def toVertical(self,R,phi=None):
         """
         NAME:
 
@@ -731,6 +731,8 @@ class Potential(Force):
 
            R - Galactocentric radius at which to create the vertical potential (can be Quantity)
 
+           phi= (None) Galactocentric azimuth at which to create the vertical potential (can be Quantity); required for non-axisymmetric potential
+
         OUTPUT:
 
            linear (vertical) potential
@@ -742,8 +744,10 @@ class Potential(Force):
         """
         if _APY_LOADED and isinstance(R,units.Quantity):
             R= R.to(units.kpc).value/self._ro
-        from galpy.potential import RZToverticalPotential
-        return RZToverticalPotential(self,R)
+        if _APY_LOADED and isinstance(phi,units.Quantity):
+            phi= phi.to(units.rad).value
+        from galpy.potential import toVerticalPotential
+        return toVerticalPotential(self,R,phi=phi)
 
     def plot(self,t=0.,rmin=0.,rmax=1.5,nrs=21,zmin=-0.5,zmax=0.5,nzs=21,
              effective=False,Lz=None,phi=None,xy=False,

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -25,7 +25,10 @@ def check_inputs_not_arrays(func):
     """
     @wraps(func)
     def func_wrapper(self, R, z, phi, t):
-        if hasattr(R, '__len__') or hasattr(z, '__len__') or hasattr(phi, '__len__') or hasattr(t, '__len__'):
+        if (hasattr(R, '__len__') and len(R) > 1) \
+                or (hasattr(z, '__len__') and len(z) > 1) \
+                or (hasattr(phi, '__len__') and len(phi) > 1) \
+                or (hasattr(t, '__len__') and len(t) > 1):
             raise TypeError('Methods in SpiralArmsPotential do not accept array inputs. Please input scalars.')
         return func(self, R, z, phi, t)
 
@@ -206,7 +209,6 @@ class SpiralArmsPotential(Potential):
         HISTORY:
             2017-05-25  Jack Hong (UBC) 
         """
-
         Ks = self._K(R)
         Bs = self._B(R)
         Ds = self._D(R)

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -64,6 +64,7 @@ evaluater2derivs= Potential.evaluater2derivs
 RZToplanarPotential= planarPotential.RZToplanarPotential
 toPlanarPotential= planarPotential.toPlanarPotential
 RZToverticalPotential= verticalPotential.RZToverticalPotential
+toVerticalPotential= verticalPotential.toVerticalPotential
 plotPotentials= Potential.plotPotentials
 plotDensities= Potential.plotDensities
 plotplanarPotentials= planarPotential.plotplanarPotentials

--- a/galpy/potential/potential_c_ext/KGPotential.c
+++ b/galpy/potential/potential_c_ext/KGPotential.c
@@ -1,0 +1,14 @@
+#import <math.h>
+#include <galpy_potentials.h>
+//KGPotential: 4 parameters: amp, K, D^2, 2F
+//Routines to evaluate forces etc. for a verticalPotential, i.e., a 1D 
+//potential derived from a 3D potential as the z potential at a given (R,phi)
+double KGPotentialLinearForce(double x, double t,
+			      struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //double amp= *args;
+  //double K= *(args+1);
+  //double D2= *(args+2);
+  //double F= *(args+3);
+  return - *args * x * ( *(args+1) / sqrt ( x * x + *(args+2) ) + *(args+3) );
+}

--- a/galpy/potential/potential_c_ext/KGPotential.c
+++ b/galpy/potential/potential_c_ext/KGPotential.c
@@ -1,4 +1,4 @@
-#import <math.h>
+#include <math.h>
 #include <galpy_potentials.h>
 //KGPotential: 4 parameters: amp, K, D^2, 2F
 //Routines to evaluate forces etc. for a verticalPotential, i.e., a 1D 

--- a/galpy/potential/potential_c_ext/galpy_potentials.c
+++ b/galpy/potential/potential_c_ext/galpy_potentials.c
@@ -196,3 +196,14 @@ double calcPlanarRphideriv(double R, double phi, double t,
   potentialArgs-= nargs;
   return Rphideriv;
 }
+double calcLinearForce(double x, double t, 
+		       int nargs, struct potentialArg * potentialArgs){
+  int ii;
+  double force= 0.;
+  for (ii=0; ii < nargs; ii++){
+    force+= potentialArgs->linearForce(x,t,potentialArgs);
+    potentialArgs++;
+  }
+  potentialArgs-= nargs;
+  return force;
+}

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -33,6 +33,8 @@ struct potentialArg{
 			    struct potentialArg *);
   double (*planarRphideriv)(double R,double phi, double t,
 			    struct potentialArg *);
+  double (*linearForce)(double x, double t,
+			 struct potentialArg *);
   int nargs;
   double * args;
   interp_2d * i2d;
@@ -81,11 +83,14 @@ double calcPlanarphi2deriv(double, double, double,
 			   int, struct potentialArg *);
 double calcPlanarRphideriv(double, double, double, 
 			   int, struct potentialArg *);
+double calcLinearForce(double, double, int, struct potentialArg *);
 //ZeroForce
 double ZeroPlanarForce(double,double,double,
 		       struct potentialArg *);
 double ZeroForce(double,double,double,double,
 		 struct potentialArg *);
+//verticalPotential
+double verticalPotentialLinearForce(double,double,struct potentialArg *);
 //LogarithmicHaloPotential
 double LogarithmicHaloPotentialEval(double ,double , double, double,
 				    struct potentialArg *);

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -516,6 +516,8 @@ double GaussianAmplitudeWrapperPotentialPlanarphi2deriv(double,double,double,
 						   struct potentialArg *);
 double GaussianAmplitudeWrapperPotentialPlanarRphideriv(double,double,double,
 						   struct potentialArg *);
+//KGPotential
+double KGPotentialLinearForce(double,double,struct potentialArg *);
 #ifdef __cplusplus
 }
 #endif

--- a/galpy/potential/potential_c_ext/verticalPotential.c
+++ b/galpy/potential/potential_c_ext/verticalPotential.c
@@ -4,7 +4,8 @@
 double verticalPotentialLinearForce(double x, double t,
 				    struct potentialArg * potentialArgs){
   double R= *potentialArgs->args;
-  return calczforce(R,x,0.,t,
+  double phi= *(potentialArgs->args+1);
+  return calczforce(R,x,phi,t,
 		    potentialArgs->nwrapped,
 		    potentialArgs->wrappedPotentialArg);
 }

--- a/galpy/potential/potential_c_ext/verticalPotential.c
+++ b/galpy/potential/potential_c_ext/verticalPotential.c
@@ -1,0 +1,10 @@
+#include <galpy_potentials.h>
+//Routines to evaluate forces etc. for a verticalPotential, i.e., a 1D 
+//potential derived from a 3D potential as the z potential at a given (R,phi)
+double verticalPotentialLinearForce(double x, double t,
+				    struct potentialArg * potentialArgs){
+  double R= *potentialArgs->args;
+  return calczforce(R,x,0.,t,
+		    potentialArgs->nwrapped,
+		    potentialArgs->wrappedPotentialArg);
+}

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -25,6 +25,7 @@ class verticalPotential(linearPotential):
         linearPotential.__init__(self,amp=1.,ro=RZPot._ro,vo=RZPot._vo)
         self._Pot= RZPot
         self._R= R
+        self.hasC= RZPot.hasC
         # Also transfer roSet and voSet
         self._roSet= RZPot._roSet
         self._voSet= RZPot._voSet

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -108,8 +108,10 @@ def RZToverticalPotential(RZPot,R):
         for pot in RZPot:
             if isinstance(pot,linearPotential):
                 out.append(pot)
-            else:
+            elif isinstance(pot,Potential):
                 out.append(verticalPotential(pot,R))
+            else:
+                raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
         return out
     elif isinstance(RZPot,Potential):
         return verticalPotential(RZPot,R)
@@ -158,8 +160,10 @@ def toVerticalPotential(Pot,R,phi=None):
         for pot in Pot:
             if isinstance(pot,linearPotential):
                 out.append(pot)
-            else:
+            elif isinstance(pot,Potential):
                 out.append(verticalPotential(pot,R,phi=phi))
+            else:
+                raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
         return out
     elif isinstance(Pot,Potential):
         return verticalPotential(Pot,R,phi=phi)

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -1,5 +1,5 @@
 from .linearPotential import linearPotential
-from .Potential import PotentialError, Potential
+from .Potential import PotentialError, Potential, flatten
 _APY_LOADED= True
 try:
     from astropy import units
@@ -98,6 +98,7 @@ def RZToverticalPotential(RZPot,R):
        2010-07-21 - Written - Bovy (NYU)
 
     """
+    RZPot= flatten(RZPot)
     if _APY_LOADED and isinstance(R,units.Quantity):
         if hasattr(RZPot,'_ro'):
             R= R.to(units.kpc).value/RZPot._ro
@@ -147,6 +148,7 @@ def toVerticalPotential(Pot,R,phi=None):
        2018-10-07 - Written - Bovy (UofT)
 
     """
+    Pot= flatten(Pot)
     if _APY_LOADED:
         if isinstance(R,units.Quantity):
             if hasattr(Pot,'_ro'):

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -1,4 +1,5 @@
 from .linearPotential import linearPotential
+from .planarPotential import planarPotential
 from .Potential import PotentialError, Potential, flatten
 _APY_LOADED= True
 try:
@@ -111,6 +112,8 @@ def RZToverticalPotential(RZPot,R):
                 out.append(pot)
             elif isinstance(pot,Potential):
                 out.append(verticalPotential(pot,R))
+            elif isinstance(pot,planarPotential):
+                raise PotentialError("Input to 'RZToverticalPotential' cannot be a planarPotential")
             else:
                 raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
         return out
@@ -118,7 +121,9 @@ def RZToverticalPotential(RZPot,R):
         return verticalPotential(RZPot,R)
     elif isinstance(RZPot,linearPotential):
         return RZPot
-    else: #pragma: no cover
+    elif isinstance(RZPot,planarPotential):
+        raise PotentialError("Input to 'RZToverticalPotential' cannot be a planarPotential")
+    else:
         raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
 
 def toVerticalPotential(Pot,R,phi=None):
@@ -164,13 +169,17 @@ def toVerticalPotential(Pot,R,phi=None):
                 out.append(pot)
             elif isinstance(pot,Potential):
                 out.append(verticalPotential(pot,R,phi=phi))
+            elif isinstance(pot,planarPotential):
+                raise PotentialError("Input to 'toVerticalPotential' cannot be a planarPotential")
             else:
-                raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
+                raise PotentialError("Input to 'toVerticalPotential' is neither an RZPotential-instance or a list of such instances")
         return out
     elif isinstance(Pot,Potential):
         return verticalPotential(Pot,R,phi=phi)
     elif isinstance(Pot,linearPotential):
         return Pot
-    else: #pragma: no cover
+    elif isinstance(Pot,planarPotential):
+        raise PotentialError("Input to 'toVerticalPotential' cannot be a planarPotential")
+    else:
         raise PotentialError("Input to 'toVerticalPotential' is neither an Potential-instance or a list of such instances")
 

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -8,27 +8,35 @@ except ImportError:
 class verticalPotential(linearPotential):
     """Class that represents a vertical potential derived from a RZPotential:
     phi(z;R)= phi(R,z)-phi(R,0.)"""
-    def __init__(self,RZPot,R=1.):
+    def __init__(self,Pot,R=1.,phi=None):
         """
         NAME:
            __init__
         PURPOSE:
            Initialize
         INPUT:
-           RZPot - RZPotential instance
+           Pot - Potential instance
            R  - Galactocentric radius at which to create the vertical potential
+           phi= (None) Galactocentric azimuth at which to create the vertical potential (rad); necessary for 
         OUTPUT:
            verticalPotential instance
         HISTORY:
            2010-07-13 - Written - Bovy (NYU)
+           2018-10-07 - Added support for non-axi potentials - Bovy (UofT)
         """
-        linearPotential.__init__(self,amp=1.,ro=RZPot._ro,vo=RZPot._vo)
-        self._Pot= RZPot
+        linearPotential.__init__(self,amp=1.,ro=Pot._ro,vo=Pot._vo)
+        self._Pot= Pot
         self._R= R
-        self.hasC= RZPot.hasC
+        if phi is None:
+            if Pot.isNonAxi:
+                raise PotentialError("The Potential instance to convert to a verticalPotential is non-axisymmetric, but you did not provide phi")
+            self._phi= 0.
+        else:
+            self._phi= phi
+        self.hasC= Pot.hasC
         # Also transfer roSet and voSet
-        self._roSet= RZPot._roSet
-        self._voSet= RZPot._voSet
+        self._roSet= Pot._roSet
+        self._voSet= Pot._voSet
         return None
 
     def _evaluate(self,z,t=0.):
@@ -45,8 +53,8 @@ class verticalPotential(linearPotential):
         HISTORY:
            2010-07-13 - Written - Bovy (NYU)
         """
-        return self._Pot(self._R,z,t=t,use_physical=False)\
-            -self._Pot(self._R,0.,t=t,use_physical=False)
+        return self._Pot(self._R,z,phi=self._phi,t=t,use_physical=False)\
+            -self._Pot(self._R,0.,phi=self._phi,t=t,use_physical=False)
             
     def _force(self,z,t=0.):
         """
@@ -62,8 +70,8 @@ class verticalPotential(linearPotential):
         HISTORY:
            2010-07-13 - Written - Bovy (NYU)
         """
-        return self._Pot.zforce(self._R,z,t=t,use_physical=False)\
-            -self._Pot.zforce(self._R,0.,t=t,use_physical=False)
+        return self._Pot.zforce(self._R,z,phi=self._phi,t=t,use_physical=False)\
+            -self._Pot.zforce(self._R,0.,phi=self._phi,t=t,use_physical=False)
 
 def RZToverticalPotential(RZPot,R):
     """
@@ -109,3 +117,54 @@ def RZToverticalPotential(RZPot,R):
         return RZPot
     else: #pragma: no cover
         raise PotentialError("Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances")
+
+def toVerticalPotential(Pot,R,phi=None):
+    """
+    NAME:
+
+       toVerticalPotential
+
+    PURPOSE:
+
+       convert a Potential to a vertical potential at a given R
+
+    INPUT:
+
+       Pot - Potential instance or list of such instances
+
+       R - Galactocentric radius at which to evaluate the vertical potential (can be Quantity)
+
+       phi= (None) Galactocentric azimuth at which to evaluate the vertical potential (can be Quantity); required if Pot is non-axisymmetric
+
+    OUTPUT:
+
+       (list of) linearPotential instance(s)
+
+    HISTORY:
+
+       2018-10-07 - Written - Bovy (UofT)
+
+    """
+    if _APY_LOADED:
+        if isinstance(R,units.Quantity):
+            if hasattr(Pot,'_ro'):
+                R= R.to(units.kpc).value/Pot._ro
+            else:
+                R= R.to(units.kpc).value/Pot[0]._ro
+        if isinstance(phi,units.Quantity):
+            phi= phi.to(units.rad).value
+    if isinstance(Pot,list):
+        out= []
+        for pot in Pot:
+            if isinstance(pot,linearPotential):
+                out.append(pot)
+            else:
+                out.append(verticalPotential(pot,R,phi=phi))
+        return out
+    elif isinstance(Pot,Potential):
+        return verticalPotential(Pot,R,phi=phi)
+    elif isinstance(Pot,linearPotential):
+        return Pot
+    else: #pragma: no cover
+        raise PotentialError("Input to 'toVerticalPotential' is neither an Potential-instance or a list of such instances")
+

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -526,9 +526,9 @@ def test_energy_conservation_linear():
             tclass= getattr(sys.modules[__name__],p)
         #if not p == 'NFWPotential' and not p == 'mockFlatGaussianAmplitudeBarPotential': continue
         tp= tclass()
-        if not hasattr(tp,'normalize'): continue #skip these
-        tp.normalize(1.)
         if hasattr(tp,'toVertical'):
+            if not hasattr(tp,'normalize'): continue #skip these
+            tp.normalize(1.)
             tp= tp.toVertical(1.2,phi=0.3)
         elif isinstance(tp,potential.linearPotential):
             pass

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1189,6 +1189,9 @@ def test_RZToverticalPotential():
     #Check that a verticalPotential through RZToverticalPotential is still vertical
     pplp= potential.RZToverticalPotential(plp,1.2)
     assert isinstance(pplp,potential.linearPotential), 'Running a linearPotential through RZToverticalPotential does not produce a linearPotential'
+    # Also for list
+    pplp= potential.RZToverticalPotential([plp],1.2)
+    assert isinstance(pplp[0],potential.linearPotential), 'Running a linearPotential through RZToverticalPotential does not produce a linearPotential'
     # Check that giving an object that is not a list or Potential instance produces an error
     with pytest.raises(potential.PotentialError) as excinfo:
         plp= potential.RZToverticalPotential('something else',1.2)
@@ -1197,6 +1200,12 @@ def test_RZToverticalPotential():
         plp= potential.RZToverticalPotential([3,4,45],1.2)
     with pytest.raises(potential.PotentialError) as excinfo:
         plp= potential.RZToverticalPotential([lp,3,4,45],1.2)
+    # Check that giving a planarPotential gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential(lp.toPlanar(),1.2)       
+    # Check that giving a list of planarPotential gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential([lp.toPlanar()],1.2)       
     # Check that using a non-axisymmetric potential gives an error
     lpna= potential.LogarithmicHaloPotential(normalize=1.,q=0.9,b=0.8)
     with pytest.raises(potential.PotentialError) as excinfo:
@@ -1223,17 +1232,24 @@ def test_toVerticalPotential():
     ptnp= potential.toVerticalPotential([tnp],1.2,phi=0.8)
     assert isinstance(ptnp[0],potential.linearPotential), 'Running a non-axisymmetric Potential through toVerticalPotential does not produce a linearPotential'
     #Check that a linearPotential through toVerticalPotential is still vertical
+    ptnp= potential.toVerticalPotential(tnp,1.2,phi=0.8)
     pptnp= potential.toVerticalPotential(ptnp,1.2,phi=0.8)
     assert isinstance(pptnp,potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
     # also for list
     pptnp= potential.toVerticalPotential([ptnp],1.2,phi=0.8)
-    assert isinstance(pptnp,potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
+    assert isinstance(pptnp[0],potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
     try:
         ptnp= potential.toVerticalPotential('something else',1.2,phi=0.8)
     except potential.PotentialError:
         pass
     else:
         raise AssertionError('Using toVerticalPotential with a string rather than an Potential or a linearPotential did not raise PotentialError')
+    # Check that giving a planarPotential gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.toVerticalPotential(tnp.toPlanar(),1.2,phi=0.8)       
+    # Check that giving a list of planarPotential gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.toVerticalPotential([tnp.toPlanar()],1.2,phi=0.8)       
     # Check that giving potential.ChandrasekharDynamicalFrictionForce
     # gives an error
     pp= potential.PlummerPotential(amp=1.12,b=2.)

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -20,7 +20,8 @@ def test_normalize_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('mockTwoPowerIntegerSphericalPotential')
     pots.append('specialTwoPowerSphericalPotential')
     pots.append('HernquistTwoPowerIntegerSphericalPotential')
@@ -87,7 +88,8 @@ def test_forceAsDeriv_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('mockTwoPowerIntegerSphericalPotential')
     pots.append('specialTwoPowerSphericalPotential')
     pots.append('HernquistTwoPowerIntegerSphericalPotential')
@@ -268,7 +270,8 @@ def test_2ndDeriv_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('mockTwoPowerIntegerSphericalPotential')
     pots.append('specialTwoPowerSphericalPotential')
     pots.append('HernquistTwoPowerIntegerSphericalPotential')
@@ -507,7 +510,8 @@ def test_poisson_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('mockTwoPowerIntegerSphericalPotential')
     pots.append('specialTwoPowerSphericalPotential')
     pots.append('HernquistTwoPowerIntegerSphericalPotential')
@@ -608,7 +612,8 @@ def test_poisson_surfdens_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('testMWPotential')
     """
     pots.append('mockTwoPowerIntegerSphericalPotential')
@@ -714,7 +719,8 @@ def test_evaluateAndDerivs_potential():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     pots.append('mockTwoPowerIntegerSphericalPotential')
     pots.append('specialTwoPowerSphericalPotential')
     pots.append('HernquistTwoPowerIntegerSphericalPotential')
@@ -1080,7 +1086,8 @@ def test_toVertical_toPlanar():
     pots= [p for p in dir(potential) 
            if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
                and not 'FullTo' in p and not 'toPlanar' in p
-               and not 'evaluate' in p and not 'Wrapper' in p)]
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1107,7 +1114,7 @@ def test_toVertical_toPlanar():
         tpp= tp.toPlanar()
         assert isinstance(tpp,potential.planarPotential), \
             "Conversion into planar potential of potential %s fails" % p
-        tlp= tp.toVertical(1.)
+        tlp= tp.toVertical(1.,phi=2.)
         assert isinstance(tlp,potential.linearPotential), \
             "Conversion into linear potential of potential %s fails" % p
 
@@ -1116,7 +1123,7 @@ def test_RZToplanarPotential():
     plp= potential.RZToplanarPotential(lp)
     assert isinstance(plp,potential.planarPotential), 'Running an RZPotential through RZToplanarPotential does not produce a planarPotential'
     #Check that a planarPotential through RZToplanarPotential is still planar
-    pplp= potential.RZToplanarPotential(lp)
+    pplp= potential.RZToplanarPotential(plp)
     assert isinstance(pplp,potential.planarPotential), 'Running a planarPotential through RZToplanarPotential does not produce a planarPotential'
     # Check that giving an object that is not a list or Potential instance produces an error
     with pytest.raises(potential.PotentialError) as excinfo:
@@ -1170,6 +1177,71 @@ def test_toPlanarPotential():
         plp= potential.toPlanarPotential([pp,cdfc])
     with pytest.raises(potential.PotentialError) as excinfo:
         plp= potential.toPlanarPotential(cdfc)
+    return None
+
+def test_RZToverticalPotential():
+    lp= potential.LogarithmicHaloPotential(normalize=1.)
+    plp= potential.RZToverticalPotential(lp,1.2)
+    assert isinstance(plp,potential.linearPotential), 'Running an RZPotential through RZToverticalPotential does not produce a linearPotential'
+    #Check that a verticalPotential through RZToverticalPotential is still vertical
+    pplp= potential.RZToverticalPotential(plp,1.2)
+    assert isinstance(pplp,potential.linearPotential), 'Running a linearPotential through RZToverticalPotential does not produce a linearPotential'
+    # Check that giving an object that is not a list or Potential instance produces an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential('something else',1.2)
+    # Check that given a list of objects that are not a Potential instances gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential([3,4,45],1.2)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential([lp,3,4,45],1.2)
+    # Check that using a non-axisymmetric potential gives an error
+    lpna= potential.LogarithmicHaloPotential(normalize=1.,q=0.9,b=0.8)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential(lpna,1.2)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential([lpna],1.2)
+    # Check that giving potential.ChandrasekharDynamicalFrictionForce
+    # gives an error
+    pp= potential.PlummerPotential(amp=1.12,b=2.)
+    cdfc= potential.ChandrasekharDynamicalFrictionForce(\
+        GMs=0.01,const_lnLambda=8.,
+        dens=pp,sigmar=lambda r: 1./numpy.sqrt(2.))
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential([pp,cdfc],1.2)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.RZToverticalPotential(cdfc,1.2)
+    return None
+
+def test_toVerticalPotential():
+    tnp= potential.TriaxialNFWPotential(normalize=1.,b=0.5)
+    ptnp= potential.toVerticalPotential(tnp,1.2,phi=0.8)
+    assert isinstance(ptnp,potential.linearPotential), 'Running a non-axisymmetric Potential through toVerticalPotential does not produce a linearPotential'
+    # Also for list
+    ptnp= potential.toVerticalPotential([tnp],1.2,phi=0.8)
+    assert isinstance(ptnp[0],potential.linearPotential), 'Running a non-axisymmetric Potential through toVerticalPotential does not produce a linearPotential'
+    #Check that a linearPotential through toVerticalPotential is still vertical
+    pptnp= potential.toVerticalPotential(tnp,1.2,phi=0.8)
+    assert isinstance(pptnp,potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
+    try:
+        ptnp= potential.toVerticalPotential('something else',1.2,phi=0.8)
+    except potential.PotentialError:
+        pass
+    else:
+        raise AssertionError('Using toVerticalPotential with a string rather than an Potential or a linearPotential did not raise PotentialError')
+    # Check that giving potential.ChandrasekharDynamicalFrictionForce
+    # gives an error
+    pp= potential.PlummerPotential(amp=1.12,b=2.)
+    cdfc= potential.ChandrasekharDynamicalFrictionForce(\
+        GMs=0.01,const_lnLambda=8.,
+        dens=pp,sigmar=lambda r: 1./numpy.sqrt(2.))
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.toVerticalPotential([pp,cdfc],1.2,phi=0.8)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        plp= potential.toVerticalPotential(cdfc,1.2,phi=0.8)
+    # Check that running a non-axisymmetric potential through toVertical w/o
+    # phi gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        ptnp= potential.toVerticalPotential(tnp,1.2)
     return None
 
 # Sanity check the derivative of the rotation curve and the frequencies in the plane

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1223,7 +1223,10 @@ def test_toVerticalPotential():
     ptnp= potential.toVerticalPotential([tnp],1.2,phi=0.8)
     assert isinstance(ptnp[0],potential.linearPotential), 'Running a non-axisymmetric Potential through toVerticalPotential does not produce a linearPotential'
     #Check that a linearPotential through toVerticalPotential is still vertical
-    pptnp= potential.toVerticalPotential(tnp,1.2,phi=0.8)
+    pptnp= potential.toVerticalPotential(ptnp,1.2,phi=0.8)
+    assert isinstance(pptnp,potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
+    # also for list
+    pptnp= potential.toVerticalPotential([ptnp],1.2,phi=0.8)
     assert isinstance(pptnp,potential.linearPotential), 'Running a linearPotential through toVerticalPotential does not produce a linearPotential'
     try:
         ptnp= potential.toVerticalPotential('something else',1.2,phi=0.8)

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1492,7 +1492,7 @@ def test_planarPotential_method_inputAsQuantity():
     return None
 
 def test_linearPotential_method_inputAsQuantity():
-    from galpy.potential import PlummerPotential
+    from galpy.potential import PlummerPotential, SpiralArmsPotential
     from galpy import potential
     ro, vo= 8.*units.kpc, 220.*units.km/units.s
     pot= PlummerPotential(normalize=True,ro=ro,vo=vo)
@@ -1504,6 +1504,18 @@ def test_linearPotential_method_inputAsQuantity():
     pot= pot.toVertical(1.1)
     potu= potential.RZToverticalPotential(PlummerPotential(normalize=True),
                                           1.1*ro)
+    assert numpy.fabs(pot(1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(pot.force(1.1*ro,use_physical=False)-potu.force(1.1)) < 10.**-4., 'Potential method force does not return the correct value as Quantity'
+    # also toVerticalPotential w/ non-axi
+    pot= SpiralArmsPotential(ro=ro,vo=vo)
+    # Force linearPotential setup with default
+    pot._ro= None
+    pot._roSet= False
+    pot._vo= None
+    pot._voSet= False
+    pot= pot.toVertical(1.1,10./180.*numpy.pi)
+    potu= potential.toVerticalPotential(SpiralArmsPotential(),
+                                        1.1*ro,phi=10*units.deg)
     assert numpy.fabs(pot(1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
     assert numpy.fabs(pot.force(1.1*ro,use_physical=False)-potu.force(1.1)) < 10.**-4., 'Potential method force does not return the correct value as Quantity'
     return None
@@ -1588,12 +1600,19 @@ def test_planarPotential_function_inputAsQuantity():
     return None
 
 def test_linearPotential_function_inputAsQuantity():
-    from galpy.potential import PlummerPotential
+    from galpy.potential import PlummerPotential, SpiralArmsPotential
     from galpy import potential
     ro, vo= 8.*units.kpc, 220.
     pot= [PlummerPotential(normalize=True,ro=ro,vo=vo).toVertical(1.1*ro)]
     potu= potential.RZToverticalPotential([PlummerPotential(normalize=True)],
                                           1.1*ro)
+    assert numpy.fabs(potential.evaluatelinearPotentials(pot,1.1*ro,use_physical=False)-potential.evaluatelinearPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluatelinearForces(pot,1.1*ro,use_physical=False)-potential.evaluatelinearForces(potu,1.1)) < 10.**-4., 'Potential function force does not return the correct value as Quantity'
+    # Also toVerticalPotential, with non-axi
+    pot= [SpiralArmsPotential(ro=ro,vo=vo)\
+              .toVertical((1.1*ro).to(units.kpc).value/8.,phi=20.*units.deg)]
+    potu= potential.toVerticalPotential([SpiralArmsPotential()],
+                                        1.1*ro,phi=20.*units.deg)
     assert numpy.fabs(potential.evaluatelinearPotentials(pot,1.1*ro,use_physical=False)-potential.evaluatelinearPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
     assert numpy.fabs(potential.evaluatelinearForces(pot,1.1*ro,use_physical=False)-potential.evaluatelinearForces(potu,1.1)) < 10.**-4., 'Potential function force does not return the correct value as Quantity'
     return None


### PR DESCRIPTION
This PR adds the general functionality to integrate ``linearOrbit`` instances in C and tests that this works for all currently available potentials.