### PR TITLE
Implement general potential framework for MovingObjectPotential

### DIFF
--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -121,7 +121,6 @@ def test_forceAsDeriv_potential():
     pots.append('mockTransientLogSpiralPotential')
     pots.append('mockFlatEllipticalDiskPotential') #for evaluate w/ nonaxi lists
     pots.append('mockMovingObjectPotential')
-    pots.append('mockMovingObjectExplSoftPotential')
     pots.append('oblateHernquistPotential')
     pots.append('oblateNFWPotential')
     pots.append('oblatenoGLNFWPotential')
@@ -3275,6 +3274,7 @@ class mockSimpleLinearPotential(testlinearMWPotential):
         testlinearMWPotential.__init__(self,
                                        potlist=potential.MiyamotoNagaiPotential(normalize=1.).toVertical(1.))
 
+from galpy.potential import PlummerPotential
 class mockMovingObjectPotential(testMWPotential):
     def __init__(self,rc=0.75,maxt=1.,nt=50):
         from galpy.orbit import Orbit
@@ -3285,8 +3285,9 @@ class mockMovingObjectPotential(testMWPotential):
         times= numpy.linspace(0.,maxt,nt)
         o1.integrate(times,lp,method='dopr54_c')
         o2.integrate(times,lp,method='dopr54_c')
-        self._o1p= potential.MovingObjectPotential(o1)
-        self._o2p= potential.MovingObjectPotential(o2)
+        oplum = potential.PlummerPotential(amp=0.06, b=0.01)
+        self._o1p= potential.MovingObjectPotential(o1, pot=oplum)
+        self._o2p= potential.MovingObjectPotential(o2, pot=oplum)
         testMWPotential.__init__(self,[self._o1p,self._o2p])
         self.isNonAxi= True
         return None
@@ -3294,24 +3295,6 @@ class mockMovingObjectPotential(testMWPotential):
         raise AttributeError
     def OmegaP(self):
         return 1./self._rc
-from galpy.potential.ForceSoftening import PlummerSoftening
-class mockMovingObjectExplSoftPotential(testMWPotential):
-    def __init__(self,rc=0.75,maxt=1.,nt=50):
-        from galpy.orbit import Orbit
-        self._rc= rc
-        o1= Orbit([self._rc,0.,1.,0.,0.,0.])
-        o2= Orbit([self._rc,0.,1.,0.,0.,numpy.pi])
-        lp= potential.LogarithmicHaloPotential(normalize=1.)
-        times= numpy.linspace(0.,maxt,nt)
-        o1.integrate(times,lp,method='dopr54_c')
-        o2.integrate(times,lp,method='dopr54_c')
-        self._o1p= potential.MovingObjectPotential(o1,
-                                                   softening=PlummerSoftening(softening_length=0.05))
-        self._o2p= potential.MovingObjectPotential(o2,
-                                                   softening=PlummerSoftening(softening_length=0.05))
-        testMWPotential.__init__(self,[self._o1p,self._o2p])
-        self.isNonAxi= True
-        return None
 class mockMovingObjectLongIntPotential(mockMovingObjectPotential):
     def __init__(self,rc=0.75):
         mockMovingObjectPotential.__init__(self,rc=rc,maxt=15.,nt=3001)


### PR DESCRIPTION
MovingObjectPotential now takes a `pot` keyword, which could be a `galpy` `Potential` object or a list of such objects. Generalized methods for evaluating the potential, forces, and the density are implemented. The `amp`, `GM`, `softening`, `softening_model`, and `softening_length` keywords are no longer accepted, and the user is warned if they are supplied.

`tests/test_potential.py` has been updated to reflect the new class. `mockMovingObjectPotential` now explicitly creates a Plummer potential, and `mockMovingObjectExplSoftPotential` has been removed. 