### PR TITLE
Handle ctrl-c on windows too

### DIFF
--- a/galpy/util/bovy_rk.c
+++ b/galpy/util/bovy_rk.c
@@ -98,14 +98,7 @@ void bovy_rk4(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)) {}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -209,14 +202,7 @@ void bovy_rk6(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)) {}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -542,14 +528,7 @@ void bovy_dopr54(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)) {}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {

--- a/galpy/util/bovy_rk.c
+++ b/galpy/util/bovy_rk.c
@@ -34,9 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include <bovy_symplecticode.h>
 #include <bovy_rk.h>
-#ifndef _WIN32
 #include "signal.h"
-#endif
 #define _MAX_STEPCHANGE_POWERTWO 3.
 #define _MIN_STEPCHANGE_POWERTWO -3.
 #define _MAX_STEPREDUCE 10000.
@@ -99,6 +97,15 @@ void bovy_rk4(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -201,6 +208,15 @@ void bovy_rk6(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -277,14 +293,14 @@ void bovy_rk6_onestep(void (*func)(double t, double *q, double *a,
   func(tn+2.*dt/3.,ynk,a,nargs,potentialArgs);
   for (ii=0; ii < dim; ii++) *(yn1+ii) += 81. * dt * *(a+ii) / 120.;
   for (ii=0; ii < dim; ii++) *(k3+ii)= dt * *(a+ii);
-  for (ii=0; ii < dim; ii++) *(ynk+ii)= *(yn+ii) + ( *(k1+ii) 
+  for (ii=0; ii < dim; ii++) *(ynk+ii)= *(yn+ii) + ( *(k1+ii)
 						     + 4. * *(k2+ii)
 						     - *(k3+ii))/12.;
   //calculate k4
   func(tn+dt/3.,ynk,a,nargs,potentialArgs);
   for (ii=0; ii < dim; ii++) *(yn1+ii) += 81.* dt * *(a+ii) / 120.;
   for (ii=0; ii < dim; ii++) *(k4+ii)= dt * *(a+ii);
-  for (ii=0; ii < dim; ii++) *(ynk+ii)= *(yn+ii) + ( -*(k1+ii) 
+  for (ii=0; ii < dim; ii++) *(ynk+ii)= *(yn+ii) + ( -*(k1+ii)
 						     + 18. * *(k2+ii)
 						     - 3. * *(k3+ii)
 						     -6.* *(k4+ii))/16.;
@@ -307,7 +323,7 @@ void bovy_rk6_onestep(void (*func)(double t, double *q, double *a,
 						     -64. * *(k5+ii))/44.;
   //calculate k7
   func(tn+dt,ynk,a,nargs,potentialArgs);
-  for (ii=0; ii < dim; ii++) *(yn1+ii) += 11.* dt * *(a+ii) / 120.;  
+  for (ii=0; ii < dim; ii++) *(yn1+ii) += 11.* dt * *(a+ii) / 120.;
   //yn1 is new value
 }
 
@@ -360,10 +376,10 @@ double rk4_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
       err+= exp(2.*log(fabs(*(y1+ii)-*(y2+ii)))-2.* *(scale+ii));
     }
     err= sqrt(err/dim);
-    if ( ceil(pow(err,1./5.)) > 1. 
+    if ( ceil(pow(err,1./5.)) > 1.
 	 && init_dt / dt * ceil(pow(err,1./5.)) < _MAX_DT_REDUCE)
       dt/= ceil(pow(err,1./5.));
-    else 
+    else
       break;
   }
   //free what we allocated
@@ -378,7 +394,7 @@ double rk4_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
   //printf("%f\n",dt);
   //fflush(stdout);
   return dt;
-} 
+}
 double rk6_estimate_step(void (*func)(double t, double *y, double *a,int nargs, struct potentialArg *),
 			 int dim, double *yo,
 			 double dt, double *t,
@@ -436,10 +452,10 @@ double rk6_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
       err+= exp(2.*log(fabs(*(y1+ii)-*(y2+ii)))-2.* *(scale+ii));
     }
     err= sqrt(err/dim);
-    if ( ceil(pow(err,1./7.)) > 1. 
+    if ( ceil(pow(err,1./7.)) > 1.
 	 && init_dt / dt * ceil(pow(err,1./7.)) < _MAX_DT_REDUCE)
       dt/= ceil(pow(err,1./7.));
-    else 
+    else
       break;
   }
   //free what we allocated
@@ -459,7 +475,7 @@ double rk6_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
   //printf("%f\n",dt);
   //fflush(stdout);
   return dt;
-} 
+}
 /*
 Runge-Kutta Dormand-Prince 5/4 integrator
 Usage:
@@ -525,6 +541,15 @@ void bovy_dopr54(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {

--- a/galpy/util/bovy_symplecticode.c
+++ b/galpy/util/bovy_symplecticode.c
@@ -140,14 +140,7 @@ void leapfrog(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)){}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -267,14 +260,7 @@ void symplec4(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)) {}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -429,14 +415,7 @@ void symplec6(void (*func)(double t, double *q, double *a,
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
 #else
-    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
-    {}
-    else
-    {
-        // for whatever reason cant install handler, print to warn
-        printf("\nERROR: Could not set control handler");
-        return 1;
-    }
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE)) {}
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {

--- a/galpy/util/bovy_symplecticode.c
+++ b/galpy/util/bovy_symplecticode.c
@@ -34,16 +34,31 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include <bovy_symplecticode.h>
 #define _MAX_DT_REDUCE 10000.
-//CTRL-C only works on UNIX systems with signal library
-#ifndef _WIN32
 #include "signal.h"
 volatile sig_atomic_t interrupted= 0;
+
+// handle CTRL-C differently on UNIX systems and Windows
+#ifndef _WIN32
 void handle_sigint(int signum)
 {
   interrupted= 1;
 }
 #else
-int interrupted= 0;
+#include <windows.h>
+BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
+{
+    switch (fdwCtrlType)
+    {
+    // Handle the CTRL-C signal.
+    case CTRL_C_EVENT:
+        interrupted= 1;
+        // needed to avoid other control handlers like python from being called before us
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
 #endif
 static inline void leapfrog_leapq(int dim, double *q,double *p,double dt,
 				  double *qn){
@@ -124,6 +139,15 @@ void leapfrog(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -242,6 +266,15 @@ void symplec4(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {
@@ -395,6 +428,15 @@ void symplec6(void (*func)(double t, double *q, double *a,
   memset(&action, 0, sizeof(struct sigaction));
   action.sa_handler= handle_sigint;
   sigaction(SIGINT,&action,NULL);
+#else
+    if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
+    {}
+    else
+    {
+        // for whatever reason cant install handler, print to warn
+        printf("\nERROR: Could not set control handler");
+        return 1;
+    }
 #endif
   for (ii=0; ii < (nt-1); ii++){
     if ( interrupted ) {

--- a/galpy/util/bovy_symplecticode.h
+++ b/galpy/util/bovy_symplecticode.h
@@ -34,23 +34,20 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifndef _WIN32
 #include "signal.h"
-#endif
 #include <galpy_potentials.h>
 /*
   Global variables
 */
-#ifndef _WIN32
 extern volatile sig_atomic_t interrupted;
-#else
-extern int interrupted;
-#endif
 /*
   Function declarations
 */
 #ifndef _WIN32
 void handle_sigint(int);
+#else
+#include "windows.h"
+BOOL WINAPI CtrlHandler(DWORD fdwCtrlType);
 #endif
 void leapfrog(void (*func)(double, double *, double *,
 			   int, struct potentialArg *),


### PR DESCRIPTION
I have added the functionality to handle ctrl-c on windows

It works fine for Visual Studio 2017 15.9.2 on my Windows 10 v1809 x64 with Python 3.7 which leads to `KeyboardInterrupt: Orbit integration interrupted by CTRL-C (SIGINT)` on windows while pressing CTRL-C during integration with C code