### PR TITLE
Add Potential arithmetic

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -15,6 +15,23 @@ v1.5 (????-??-??)
   potential.MovingObjectPotential have changed because of this in a
   non-backwards-compatible manner.
 
+- Added support to combine Potential instances or lists thereof
+  through the addition operator. E.g., pot= pot1+pot2+pot3 to create
+  the combined potential of the three component potentials
+  (pot1,pot2,pot3). Each of these components can be a combined
+  potential itself. As before, combined potentials are simply lists of
+  potentials, so this is simply an alternative (and perhaps more
+  intuitive) way to create these lists.
+
+- Added support to adjust the amplitude of a Potential instance
+  through multiplication of the instance by a number or through
+  division by a numer. E.g., pot= 2.*pot1 returns a Potential instance
+  that is the same as pot1, except that the amplitude is twice
+  larger. Similarly, pot= pot1/2. decreases the amplitude by a factor
+  of two. This is useful, for example, to quickly change the mass of a
+  potential. Only works for Potential instances, not for lists of
+  Potential instances.
+
 - Added IsothermalDiskPotential, the one-dimensional potential of an
   isothermal self-gravitating disk (sech^2 profile).
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -21,7 +21,7 @@ v1.5 (????-??-??)
   (pot1,pot2,pot3). Each of these components can be a combined
   potential itself. As before, combined potentials are simply lists of
   potentials, so this is simply an alternative (and perhaps more
-  intuitive) way to create these lists.
+  intuitive) way to create these lists (#369).
 
 - Added support to adjust the amplitude of a Potential instance
   through multiplication of the instance by a number or through
@@ -30,7 +30,7 @@ v1.5 (????-??-??)
   larger. Similarly, pot= pot1/2. decreases the amplitude by a factor
   of two. This is useful, for example, to quickly change the mass of a
   potential. Only works for Potential instances, not for lists of
-  Potential instances.
+  Potential instances (#369).
 
 - Added IsothermalDiskPotential, the one-dimensional potential of an
   isothermal self-gravitating disk (sech^2 profile).

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -39,12 +39,14 @@ rotation curve
 >>> np= NFWPotential(a=4.5,normalize=.35)
 >>> hp= HernquistPotential(a=0.6/8,normalize=0.05)
 >>> from galpy.potential import plotRotcurve
->>> plotRotcurve([hp,mp,np],Rrange=[0.01,10.],grid=1001,yrange=[0.,1.2])
+>>> plotRotcurve(hp+mp+np,Rrange=[0.01,10.],grid=1001,yrange=[0.,1.2])
 
 Note that the ``normalize`` values add up to 1. such that the circular
-velocity will be 1 at R=1. The resulting rotation curve is
-approximately flat. To show the rotation curves of the three
-components do
+velocity will be 1 at R=1. Potentials can be combined into a composite
+potential either by combining them in a list as ``[hp,mp,np]`` or by
+adding them up ``hp+mp+np`` (the latter simply returns the list
+``[hp,mp,np]``). The resulting rotation curve is approximately
+flat. To show the rotation curves of the three components do
 
 >>> mp.plotRotcurve(Rrange=[0.01,10.],grid=1001,overplot=True)
 >>> hp.plotRotcurve(Rrange=[0.01,10.],grid=1001,overplot=True)
@@ -361,7 +363,7 @@ torus (this could take a minute)
 As before, we can also integrate orbits in combinations of potentials. Assuming ``mp, np,`` and ``hp`` were defined as above, we can
 
 >>> ts= numpy.linspace(0,100,10000)
->>> o.integrate(ts,[mp,hp,np])
+>>> o.integrate(ts,mp+hp+np)
 >>> o.plot()
 
 .. image:: images/mphpnp-orbit-integration.png
@@ -387,7 +389,7 @@ above
 or of the combination of potentials defined above
 
 >>> from galpy.potential import plotEscapecurve
->>> plotEscapecurve([mp,hp,np],Rrange=[0.01,10.],grid=1001)
+>>> plotEscapecurve(mp+hp+np,Rrange=[0.01,10.],grid=1001)
 
 .. image:: images/esc-comb.png
 

--- a/doc/source/orbit.rst
+++ b/doc/source/orbit.rst
@@ -783,14 +783,12 @@ We will use ``MWPotential2014`` as our Milky-Way potential
 model. Because the LMC is in fact unbound in ``MWPotential2014``, we
 increase the halo mass by 50% to make it bound (this corresponds to a
 Milky-Way halo mass of :math:`\approx 1.2\,\times 10^{12}\,M_\odot`, a
-not unreasonable value). We can hack this together as
+not unreasonable value). We can adjust a galpy Potential's amplitude simply by multiplying the potential by a number, so to increase the mass by 50% we do
 
->>> MWPotential2014[2]._amp*= 1.5
+>>> MWPotential2014[2]*= 1.5
 
-(Note that this is *not* a generally recommended route for changing
-the mass of an object, since it relies on editing a private
-attribute). Let us now integrate the orbit backwards in time for 10
-Gyr and plot it:
+Let us now integrate the orbit backwards in time for 10 Gyr and plot
+it:
 
 >>> ts= numpy.linspace(0.,-10.,1001)*units.Gyr
 >>> o.integrate(ts,MWPotential2014)
@@ -801,7 +799,7 @@ Gyr and plot it:
 
 We see that the LMC is indeed bound, with an apocenter just over 250
 kpc. Now let's add dynamical friction for the LMC, assuming that its
-mass if :math:`5\times 10^{10}\,M_\odot`. We setup the
+mass is :math:`5\times 10^{10}\,M_\odot`. We setup the
 dynamical-friction object:
 
 >>> cdf= ChandrasekharDynamicalFrictionForce(GMs=5.*10.**10.*units.Msun,rhm=5.*units.kpc,
@@ -816,13 +814,9 @@ for definiteness. We now make a copy of the orbit instance above and
 integrate it in the potential that includes dynamical friction:
 
 >>> odf= o()
->>> odf.integrate(ts,[MWPotential2014,cdf])
+>>> odf.integrate(ts,MWPotential2014+cdf)
 
-(Note that specifying the forces as the list ``[MWPotential2014,cdf]``
-works even though ``MWPotential2014`` is itself a list of potentials,
-because we can use nested lists of potentials or forces wherever a
-list is allowed in ``galpy``). Overlaying the orbits, we can see the
-difference in the evolution:
+Overlaying the orbits, we can see the difference in the evolution:
 
 >>> o.plot(d1='t',d2='r',label=r'$\mathrm{No\ DF}$')
 >>> odf.plot(d1='t',d2='r',overplot=True,label=r'$\mathrm{DF}, M=5\times10^{10}\,M_\odot$')
@@ -853,7 +847,7 @@ dispersion. Then we integrate the orbit and overplot it on the
 previous results:
 
 >>> odf2= o()
->>> odf2.integrate(ts,[MWPotential2014,cdf])
+>>> odf2.integrate(ts,MWPotential2014+cdf)
 
 and
 
@@ -875,7 +869,7 @@ Finally, let's see what will happen in the future if the LMC is as
 massive as :math:`10^{11}\,M_\odot`. We simply flip the sign of the
 integration times to get the future trajectory:
 
->>> odf2.integrate(-ts[-ts < 9*units.Gyr],[MWPotential2014,cdf])
+>>> odf2.integrate(-ts[-ts < 9*units.Gyr],MWPotential2014+cdf)
 >>> odf2.plot(d1='t',d2='r')
 
 .. image:: images/lmc-mwp14-plusdynfric-1011msun-future.png

--- a/doc/source/potential.rst
+++ b/doc/source/potential.rst
@@ -270,8 +270,8 @@ potential grown as above would be
 >>> print(evaluateRforces(pot,0.9,0.3,phi=3.,t=-2.))
 # -1.00965326579
 
-.. NOTE
-   To simply adjust the amplitude of a Potential instance, you can multiply the instance with a number. For example, ``pot= 2.*LogarithmicHaloPotential(amp=1.)`` is equivalent to ``pot= LogarithmicHaloPotential(amp=2.)``. This is useful if you want to, for instance, quickly adjust the mass of a potential.
+.. TIP::
+   To simply adjust the amplitude of a Potential instance, you can multiply the instance with a number or divide it by a number. For example, ``pot= 2.*LogarithmicHaloPotential(amp=1.)`` is equivalent to ``pot= LogarithmicHaloPotential(amp=2.)``. This is useful if you want to, for instance, quickly adjust the mass of a potential.
 
 Close-to-circular orbits and orbital frequencies
 -------------------------------------------------

--- a/doc/source/potential.rst
+++ b/doc/source/potential.rst
@@ -53,7 +53,7 @@ function
 # -1.3733506513947895
 
 .. TIP::
-   Lists of Potential instances can be nested, allowing you to easily add components to existing gravitational-potential models. For example, to add a ``DehnenBarPotential`` to ``MWPotential2014``, you can do: ``pot= [MWPotential2014,DehnenBarPotential()]`` and then use this ``pot`` everywhere where you can use a list of Potential instances.
+   Lists of Potential instances can be nested, allowing you to easily add components to existing gravitational-potential models. For example, to add a ``DehnenBarPotential`` to ``MWPotential2014``, you can do: ``pot= [MWPotential2014,DehnenBarPotential()]`` and then use this ``pot`` everywhere where you can use a list of Potential instances. You can also add potential simply as ``pot= MWPotential2014+DehnenBarPotential()``.
 
 .. WARNING::
    ``galpy`` potentials do *not* necessarily approach zero at infinity. To compute, for example, the escape velocity or whether or not an orbit is unbound, you need to take into account the value of the potential at infinity. E.g., :math:`v_{\mathrm{esc}}(r) = \sqrt{2[\Phi(\infty)-\Phi(r)]}`.
@@ -266,9 +266,12 @@ potential grown as above would be
 
 >>> from galpy.potential import LogarithmicHaloPotential, evaluateRforces
 >>> lp= LogarithmicHaloPotential(normalize=1.)
->>> pot= [lp,dswp]
+>>> pot= lp+dswp
 >>> print(evaluateRforces(pot,0.9,0.3,phi=3.,t=-2.))
 # -1.00965326579
+
+.. NOTE
+   To simply adjust the amplitude of a Potential instance, you can multiply the instance with a number. For example, ``pot= 2.*LogarithmicHaloPotential(amp=1.)`` is equivalent to ``pot= LogarithmicHaloPotential(amp=2.)``. This is useful if you want to, for instance, quickly adjust the mass of a potential.
 
 Close-to-circular orbits and orbital frequencies
 -------------------------------------------------

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -13,6 +13,8 @@ Use as ``Potential-instance.method(...)``
 .. toctree::
    :maxdepth: 2
 
+   __add__ <potentialadd.rst>
+   __mul__ <potentialmul.rst>
    __call__ <potentialcall.rst>
    dens <potentialdens.rst>
    dvcircdR <potentialdvcircdr.rst>
@@ -285,6 +287,8 @@ Use as ``Potential-instance.method(...)``
 .. toctree::
    :maxdepth: 2
 
+   __add__ <potential2dadd.rst>
+   __mul__ <potential2dmul.rst>
    __call__ <potential2dcall.rst>
    phiforce <potential2dphiforce.rst>
    Rforce <potential2drforce.rst>
@@ -367,6 +371,8 @@ Use as ``Potential-instance.method(...)``
 .. toctree::
    :maxdepth: 2
 
+   __add__ <potential1dadd.rst>
+   __mul__ <potential1dmul.rst>
    __call__ <potential1dcall.rst>
    force <potential1dforce.rst>
    plot <potential1dplot.rst>

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -229,35 +229,42 @@ potential was fit. This potential is defined as
 >>> bp= PowerSphericalPotentialwCutoff(alpha=1.8,rc=1.9/8.,normalize=0.05)
 >>> mp= MiyamotoNagaiPotential(a=3./8.,b=0.28/8.,normalize=.6)
 >>> np= NFWPotential(a=16/8.,normalize=.35)
->>> MWPotential2014= [bp,mp,np]
+>>> MWPotential2014= bp+mp+np
 
-and can thus be used like any list of ``Potentials``. If one wants to
-add the supermassive black hole at the Galactic center, this can be
-done by
+and can thus be used like any list of ``Potentials``. The mass of the
+dark-matter halo in ``MWPotential2014`` is on the low side of
+estimates of the Milky Way's halo mass; if you want to adjust it, for
+example making it 50% larger, you can simply multiply the halo part of
+``MWPotential2014`` by 1.5 as (this type of multiplication works for
+*any* potential in galpy)
+
+>>> MWPotential2014[2]*= 1.5
+
+If one wants to add the supermassive black hole at the Galactic
+center, this can be done by
 
 >>> from galpy.potential import KeplerPotential
 >>> from galpy.util import bovy_conversion
->>> MWPotential2014wBH= [MWPotential2014,KeplerPotential(amp=4*10**6./bovy_conversion.mass_in_msol(220.,8.))]
+>>> MWPotential2014wBH= MWPotential2014+KeplerPotential(amp=4*10**6./bovy_conversion.mass_in_msol(220.,8.))
 
-for a black hole with a mass of :math:`4\times10^6\,M_{\odot}` (this
-works because a list of Potential instances can contain a nested list
-of Potential instances in versions>=1.4). If you want to take into
-account dynamical friction for, say, an object of mass
-:math:`5\times 10^{10}\,M_\odot` and a half-mass radius of 5 kpc, do
+for a black hole with a mass of :math:`4\times10^6\,M_{\odot}`. If you
+want to take into account dynamical friction for, say, an object of
+mass :math:`5\times 10^{10}\,M_\odot` and a half-mass radius of 5 kpc,
+do
 
 >>> from galpy.potential import ChandrasekharDynamicalFrictionForce
 >>> from astropy import units
 >>> cdf= ChandrasekharDynamicalFrictionForce(GMs=5.*10.**10.*units.Msun,
 					     rhm=5.*units.kpc,
 					     dens=MWPotential2014)
->>> MWPotential2014wDF= [MWPotential2014,cdf]
+>>> MWPotential2014wDF= MWPotential2014+cdf
 
 where we have specified the parameters of the dynamical friction with units; alternatively, convert them directly to ``galpy`` natural units  as
 
 >>> cdf= ChandrasekharDynamicalFrictionForce(GMs=5.*10.**10./bovy_conversion.mass_in_msol(220.,8.),
 					     rhm=5./8.,
 					     dens=MWPotential2014)
->>> MWPotential2014wDF= [MWPotential2014,cdf]
+>>> MWPotential2014wDF= MWPotential2014+cdf
 
 As explained in :ref:`this section <nemopot>`, *without* this black
 hole or dynamical friction, ``MWPotential2014`` can be used with
@@ -271,7 +278,7 @@ potential that was *not* fit to data on the Milky Way is defined as
 >>> mp= MiyamotoNagaiPotential(a=0.5,b=0.0375,normalize=.6)
 >>> np= NFWPotential(a=4.5,normalize=.35)
 >>> hp= HernquistPotential(a=0.6/8,normalize=0.05)
->>> MWPotential= [mp,np,hp]
+>>> MWPotential= mp+np+hp
 
 ``galpy.potential.MWPotential2014`` supersedes
 ``galpy.potential.MWPotential``.

--- a/doc/source/reference/potential1dadd.rst
+++ b/doc/source/reference/potential1dadd.rst
@@ -1,0 +1,4 @@
+galpy.potential.linearPotential.__add__
+=========================================
+
+.. automethod:: galpy.potential.linearPotential.__add__

--- a/doc/source/reference/potential1dmul.rst
+++ b/doc/source/reference/potential1dmul.rst
@@ -1,0 +1,4 @@
+galpy.potential.linearPotential.__mul__
+=========================================
+
+.. automethod:: galpy.potential.linearPotential.__mul__

--- a/doc/source/reference/potential2dadd.rst
+++ b/doc/source/reference/potential2dadd.rst
@@ -1,0 +1,4 @@
+galpy.potential.planarPotential.__add__
+=========================================
+
+.. automethod:: galpy.potential.planarPotential.__add__

--- a/doc/source/reference/potential2dmul.rst
+++ b/doc/source/reference/potential2dmul.rst
@@ -1,0 +1,4 @@
+galpy.potential.planarPotential.__mul__
+=========================================
+
+.. automethod:: galpy.potential.planarPotential.__mul__

--- a/doc/source/reference/potentialadd.rst
+++ b/doc/source/reference/potentialadd.rst
@@ -1,0 +1,4 @@
+galpy.potential.Potential.__add__
+==================================
+
+.. automethod:: galpy.potential.Potential.__add__

--- a/doc/source/reference/potentialmul.rst
+++ b/doc/source/reference/potentialmul.rst
@@ -1,0 +1,6 @@
+galpy.potential.Potential.__mul__
+==================================
+
+.. automethod:: galpy.potential.Potential.__mul__
+
+

--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -47,7 +47,7 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
 
            amp - amplitude to be applied to the potential (default: 1)
 
-           GMs - satellite mass; can be a Quantity with units of mass or Gxmass; can be adjusted after initialization by setting obj.GMs= where obj is your ChandrasekharDynamicalFrictionForce instance
+           GMs - satellite mass; can be a Quantity with units of mass or Gxmass; can be adjusted after initialization by setting obj.GMs= where obj is your ChandrasekharDynamicalFrictionForce instance (note that the mass of the satellite can *not* be changed simply by multiplying the instance by a number, because he mass is not only used as an amplitude)
 
            rhm - half-mass radius of the satellite (set to zero for a black hole; can be a Quantity); can be adjusted after initialization by setting obj.rhm= where obj is your ChandrasekharDynamicalFrictionForce instance
 

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -211,7 +211,7 @@ class Force(object):
         if isinstance(b,list):
             return b+[self]
         else:
-            return [b,self]
+            raise TypeError("Can only add a Force or Potential instance to another instance or to a list of such instances")
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -180,6 +180,28 @@ class Force(object):
     __truediv__= __div__
 
     def __add__(self,b):
+        """
+        NAME:
+
+           __add__
+
+        PURPOSE:
+
+           Add Force or Potential instances together to create a multi-component potential (e.g., pot= pot1+pot2+pot3)
+
+        INPUT:
+
+           b - Force or Potential instance or a list thereof
+
+        OUTPUT:
+
+           List of Force or Potential instances that represents the combined potential
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
         if isinstance(b,list):
             return [self]+b
         else:

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -3,6 +3,7 @@
 #             not (DissipativeForce)
 #
 ###############################################################################
+import copy
 import numpy
 from galpy.util import config
 from galpy.util import bovy_conversion
@@ -144,6 +145,39 @@ class Force(object):
                 self._roSet= True
                 self._voSet= True
         return None
+
+    def __mul__(self,b):
+        """
+        NAME:
+
+           __mul__
+
+        PURPOSE:
+
+           Multiply a Force or Potential's amplitude by a number
+
+        INPUT:
+
+           b - number
+
+        OUTPUT:
+
+           New instance with amplitude = (old amplitude) x b
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
+        if not isinstance(b,(int,float)):
+            raise TypeError("Can only multiply a Force or Potential instance with a number")
+        out= copy.deepcopy(self)
+        out._amp*= b
+        return out
+    # Similar functions
+    __rmul__= __mul__
+    def __div__(self,b): return self.__mul__(1./b)
+    __truediv__= __div__
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -179,6 +179,18 @@ class Force(object):
     def __div__(self,b): return self.__mul__(1./b)
     __truediv__= __div__
 
+    def __add__(self,b):
+        if isinstance(b,list):
+            return [self]+b
+        else:
+            return [self,b]
+    # Define separately to keep order
+    def __radd__(self,b):
+        if isinstance(b,list):
+            return b+[self]
+        else:
+            return [b,self]
+
     def turn_physical_off(self):
         """
         NAME:

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -105,7 +105,7 @@ class linearPotential(object):
         if isinstance(b,list):
             return b+[self]
         else:
-            return [b,self]
+            raise TypeError("Can only add a Force or Potential instance to another instance or to a list of such instances")
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 import os, os.path
+import copy
 import pickle
 import numpy as nu
 import galpy.util.bovy_plot as plot
@@ -38,6 +39,51 @@ class linearPotential(object):
             self._vo= vo
             self._voSet= True
         return None
+
+    def __mul__(self,b):
+        """
+        NAME:
+
+           __mul__
+
+        PURPOSE:
+
+           Multiply a planarPotential's amplitude by a number
+
+        INPUT:
+
+           b - number
+
+        OUTPUT:
+
+           New instance with amplitude = (old amplitude) x b
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
+        if not isinstance(b,(int,float)):
+            raise TypeError("Can only multiply a planarPotential instance with a number")
+        out= copy.deepcopy(self)
+        out._amp*= b
+        return out
+    # Similar functions
+    __rmul__= __mul__
+    def __div__(self,b): return self.__mul__(1./b)
+    __truediv__= __div__
+
+    def __add__(self,b):
+        if isinstance(b,list):
+            return [self]+b
+        else:
+            return [self,b]
+    # Define separately to keep order
+    def __radd__(self,b):
+        if isinstance(b,list):
+            return b+[self]
+        else:
+            return [b,self]
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -48,7 +48,7 @@ class linearPotential(object):
 
         PURPOSE:
 
-           Multiply a planarPotential's amplitude by a number
+           Multiply a linearPotential's amplitude by a number
 
         INPUT:
 
@@ -74,6 +74,28 @@ class linearPotential(object):
     __truediv__= __div__
 
     def __add__(self,b):
+        """
+        NAME:
+
+           __add__
+
+        PURPOSE:
+
+           Add linearPotential instances together to create a multi-component potential (e.g., pot= pot1+pot2+pot3)
+
+        INPUT:
+
+           b - linearPotential instance or a list thereof
+
+        OUTPUT:
+
+           List of linearPotential instances that represents the combined potential
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
         if isinstance(b,list):
             return [self]+b
         else:

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -110,7 +110,7 @@ class planarPotential(object):
         if isinstance(b,list):
             return b+[self]
         else:
-            return [b,self]
+            raise TypeError("Can only add a Force or Potential instance to another instance or to a list of such instances")
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 import os
+import copy
 import pickle
 import numpy as nu
 from scipy import integrate
@@ -43,6 +44,51 @@ class planarPotential(object):
             self._vo= vo
             self._voSet= True
         return None
+
+    def __mul__(self,b):
+        """
+        NAME:
+
+           __mul__
+
+        PURPOSE:
+
+           Multiply a planarPotential's amplitude by a number
+
+        INPUT:
+
+           b - number
+
+        OUTPUT:
+
+           New instance with amplitude = (old amplitude) x b
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
+        if not isinstance(b,(int,float)):
+            raise TypeError("Can only multiply a planarPotential instance with a number")
+        out= copy.deepcopy(self)
+        out._amp*= b
+        return out
+    # Similar functions
+    __rmul__= __mul__
+    def __div__(self,b): return self.__mul__(1./b)
+    __truediv__= __div__
+
+    def __add__(self,b):
+        if isinstance(b,list):
+            return [self]+b
+        else:
+            return [self,b]
+    # Define separately to keep order
+    def __radd__(self,b):
+        if isinstance(b,list):
+            return b+[self]
+        else:
+            return [b,self]
 
     def turn_physical_off(self):
         """

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -79,6 +79,28 @@ class planarPotential(object):
     __truediv__= __div__
 
     def __add__(self,b):
+        """
+        NAME:
+
+           __add__
+
+        PURPOSE:
+
+           Add planarPotential instances together to create a multi-component potential (e.g., pot= pot1+pot2+pot3)
+
+        INPUT:
+
+           b - planarPotential instance or a list thereof
+
+        OUTPUT:
+
+           List of planarPotential instances that represents the combined potential
+
+        HISTORY:
+
+           2019-01-27 - Written - Bovy (UofT)
+
+        """
         if isinstance(b,list):
             return [self]+b
         else:

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -903,6 +903,122 @@ def test_evaluateAndDerivs_potential():
 "Calculation of mixed radial,vertical derivative through _evaluate and z2deriv inconsistent for the %s potential" % p
     return None
 
+#Test that potentials can be multiplied or divided by a number
+def test_amp_mult_divide():
+    #Grab all of the potentials
+    pots= [p for p in dir(potential) 
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+               and not 'FullTo' in p and not 'toPlanar' in p
+               and not 'evaluate' in p and not 'Wrapper' in p
+               and not 'toVertical' in p)]
+    pots.append('mockTwoPowerIntegerSphericalPotential')
+    pots.append('specialTwoPowerSphericalPotential')
+    pots.append('HernquistTwoPowerIntegerSphericalPotential')
+    pots.append('JaffeTwoPowerIntegerSphericalPotential')
+    pots.append('NFWTwoPowerIntegerSphericalPotential')
+    pots.append('specialMiyamotoNagaiPotential')
+    pots.append('specialMN3ExponentialDiskPotentialPD')
+    pots.append('specialMN3ExponentialDiskPotentialSECH')
+    pots.append('specialPowerSphericalPotential')
+    pots.append('specialFlattenedPowerPotential')
+    pots.append('testMWPotential')
+    pots.append('testplanarMWPotential')
+    pots.append('testlinearMWPotential')
+    pots.append('mockInterpRZPotential')
+    if _PYNBODY_LOADED:
+        pots.append('mockSnapshotRZPotential')
+        pots.append('mockInterpSnapshotRZPotential')
+    pots.append('mockCosmphiDiskPotentialnegcp')
+    pots.append('mockCosmphiDiskPotentialnegp')
+    pots.append('mockDehnenBarPotentialT1')
+    pots.append('mockDehnenBarPotentialTm1')
+    pots.append('mockDehnenBarPotentialTm5')
+    pots.append('mockEllipticalDiskPotentialT1')
+    pots.append('mockEllipticalDiskPotentialTm1')
+    pots.append('mockEllipticalDiskPotentialTm5')
+    pots.append('mockSteadyLogSpiralPotentialT1')
+    pots.append('mockSteadyLogSpiralPotentialTm1')
+    pots.append('mockSteadyLogSpiralPotentialTm5')
+    pots.append('mockTransientLogSpiralPotential')
+    pots.append('mockFlatEllipticalDiskPotential') #for evaluate w/ nonaxi lists
+    pots.append('mockMovingObjectPotential')
+    pots.append('mockMovingObjectPotentialExplPlummer')
+    pots.append('oblateHernquistPotential')
+    pots.append('oblateNFWPotential')
+    pots.append('oblatenoGLNFWPotential')
+    pots.append('oblateJaffePotential')
+    pots.append('prolateHernquistPotential')
+    pots.append('prolateNFWPotential')
+    pots.append('prolateJaffePotential')
+    pots.append('triaxialHernquistPotential')
+    pots.append('triaxialNFWPotential')
+    pots.append('triaxialJaffePotential')
+    pots.append('zRotatedTriaxialNFWPotential')
+    pots.append('yRotatedTriaxialNFWPotential')
+    pots.append('fullyRotatedTriaxialNFWPotential')
+    pots.append('fullyRotatednoGLTriaxialNFWPotential')
+    pots.append('HernquistTwoPowerTriaxialPotential')
+    pots.append('NFWTwoPowerTriaxialPotential')
+    pots.append('JaffeTwoPowerTriaxialPotential')
+    pots.append('mockSCFZeeuwPotential')
+    pots.append('mockSCFNFWPotential')
+    pots.append('mockSCFAxiDensity1Potential')
+    pots.append('mockSCFAxiDensity2Potential')
+    pots.append('mockSCFDensityPotential')
+    pots.append('mockAxisymmetricFerrersPotential')
+    pots.append('sech2DiskSCFPotential')
+    pots.append('expwholeDiskSCFPotential')
+    pots.append('nonaxiDiskSCFPotential')
+    pots.append('rotatingSpiralArmsPotential')
+    pots.append('specialSpiralArmsPotential')
+    pots.append('DehnenSmoothDehnenBarPotential')
+    pots.append('mockDehnenSmoothBarPotentialT1')
+    pots.append('mockDehnenSmoothBarPotentialTm1')
+    pots.append('mockDehnenSmoothBarPotentialTm5')
+    pots.append('mockDehnenSmoothBarPotentialDecay')
+    pots.append('SolidBodyRotationSpiralArmsPotential')
+    pots.append('triaxialLogarithmicHaloPotential')
+    pots.append('CorotatingRotationSpiralArmsPotential')
+    pots.append('GaussianAmplitudeDehnenBarPotential')
+    pots.append('nestedListPotential')
+    rmpots= ['Potential','MWPotential','MWPotential2014',
+             'MovingObjectPotential',
+             'interpRZPotential', 'linearPotential', 'planarAxiPotential',
+             'planarPotential', 'verticalPotential','PotentialError',
+             'SnapshotRZPotential','InterpSnapshotRZPotential',
+             'EllipsoidalPotential']
+    if False: #_TRAVIS: #travis CI
+        rmpots.append('DoubleExponentialDiskPotential')
+        rmpots.append('RazorThinExponentialDiskPotential')
+    for p in rmpots:
+        pots.remove(p)
+    R,Z,phi= 0.75,0.2,1.76
+    nums= numpy.random.uniform(size=len(pots)) # random set of amp changes
+    for num,p in zip(nums,pots):
+        #Setup instance of potential
+        try:
+            tclass= getattr(potential,p)
+        except AttributeError:
+            tclass= getattr(sys.modules[__name__],p)
+        tp= tclass()
+        if hasattr(tp,'normalize'): tp.normalize(1.)
+        if isinstance(tp,potential.linearPotential): 
+            assert numpy.fabs(tp(R)*num-(num*tp)(R)) < 1e-10, "Multiplying a linearPotential with a number does not behave as expected"
+            # Other way...
+            assert numpy.fabs(tp(R)*num-(tp*num)(R)) < 1e-10, "Multiplying a linearPotential with a number does not behave as expected"
+            assert numpy.fabs(tp(R)/num-(tp/num)(R)) < 1e-10, "Dividing a linearPotential with a number does not behave as expected"
+        elif isinstance(tp,potential.planarPotential):
+            assert numpy.fabs(tp(R,phi=phi)*num-(num*tp)(R,phi=phi)) < 1e-10, "Multiplying a planarPotential with a number does not behave as expected"
+            # Other way...
+            assert numpy.fabs(tp(R,phi=phi)*num-(tp*num)(R,phi=phi)) < 1e-10, "Multiplying a planarPotential with a number does not behave as expected"
+            assert numpy.fabs(tp(R,phi=phi)/num-(tp/num)(R,phi=phi)) < 1e-10, "Dividing a planarPotential with a number does not behave as expected"
+        else:
+            assert numpy.fabs(tp(R,Z,phi=phi)*num-(num*tp)(R,Z,phi=phi)) < 1e-10, "Multiplying a Potential with a number does not behave as expected"
+            # Other way...
+            assert numpy.fabs(tp(R,Z,phi=phi)*num-(tp*num)(R,Z,phi=phi)) < 1e-10, "Multiplying a Potential with a number does not behave as expected"
+            assert numpy.fabs(tp(R,Z,phi=phi)/num-(tp/num)(R,Z,phi=phi)) < 1e-10, "Dividing a Potential with a number does not behave as expected"
+    return None
+
 # Test that the amplitude for potentials with a finite mass and amp=mass is 
 # correct through the relation -r^2 F_r =~ GM at large r
 def test_finitemass_amp():

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -2653,6 +2653,34 @@ def test_scf_tupleindexwarning():
         p.Rforce(1.,0.)
     return None   
 
+# Test that attempting to multiply or divide a potential by something other than a number raises an error
+def test_mult_divide_error():
+    # 3D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9)
+    with pytest.raises(TypeError) as excinfo:
+        pot*[1.,2.]
+    with pytest.raises(TypeError) as excinfo:
+        [1.,2.]*pot
+    with pytest.raises(TypeError) as excinfo:
+        pot/[1.,2.]
+    # 2D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toPlanar()
+    with pytest.raises(TypeError) as excinfo:
+        pot*[1.,2.]
+    with pytest.raises(TypeError) as excinfo:
+        [1.,2.]*pot
+    with pytest.raises(TypeError) as excinfo:
+        pot/[1.,2.]
+    # 1D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toVertical(1.1)
+    with pytest.raises(TypeError) as excinfo:
+        pot*[1.,2.]
+    with pytest.raises(TypeError) as excinfo:
+        [1.,2.]*pot
+    with pytest.raises(TypeError) as excinfo:
+        pot/[1.,2.]
+    return None
+
 def test_plotting():
     import tempfile
     #Some tests of the plotting routines, to make sure they don't fail

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -2710,6 +2710,22 @@ def test_add_potentials():
     assert pot1+(pot2+pot3) == [pot1,pot2,pot3]
     return None
 
+# Test that attempting to multiply or divide a potential by something other than a number raises an error
+def test_add_potentials_error():
+    # 3D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9)
+    with pytest.raises(TypeError) as excinfo:
+        3+pot
+    # 2D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toPlanar()
+    with pytest.raises(TypeError) as excinfo:
+        3+pot
+    # 1D
+    pot= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toVertical(1.1)
+    with pytest.raises(TypeError) as excinfo:
+        3+pot
+    return None
+
 def test_plotting():
     import tempfile
     #Some tests of the plotting routines, to make sure they don't fail

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -2681,6 +2681,35 @@ def test_mult_divide_error():
         pot/[1.,2.]
     return None
 
+# Test that arithmetically adding potentials returns lists of potentials
+def test_add_potentials():
+    assert potential.MWPotential2014 == potential.MWPotential2014[0]+potential.MWPotential2014[1]+potential.MWPotential2014[2], 'Potential addition of components of MWPotential2014 does not give MWPotential2014'
+    # 3D
+    pot1= potential.LogarithmicHaloPotential(normalize=1.,q=0.9)
+    pot2= potential.MiyamotoNagaiPotential(normalize=0.2,a=0.4,b=0.1)
+    pot3= potential.HernquistPotential(normalize=0.4,a=0.1)
+    assert pot1+pot2 == [pot1,pot2]
+    assert pot1+pot2+pot3 == [pot1,pot2,pot3]
+    assert (pot1+pot2)+pot3 == [pot1,pot2,pot3]
+    assert pot1+(pot2+pot3) == [pot1,pot2,pot3]
+    # 2D
+    pot1= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toPlanar()
+    pot2= potential.MiyamotoNagaiPotential(normalize=0.2,a=0.4,b=0.1).toPlanar()
+    pot3= potential.HernquistPotential(normalize=0.4,a=0.1).toPlanar()
+    assert pot1+pot2 == [pot1,pot2]
+    assert pot1+pot2+pot3 == [pot1,pot2,pot3]
+    assert (pot1+pot2)+pot3 == [pot1,pot2,pot3]
+    assert pot1+(pot2+pot3) == [pot1,pot2,pot3]
+    # 1D
+    pot1= potential.LogarithmicHaloPotential(normalize=1.,q=0.9).toVertical(1.1)
+    pot2= potential.MiyamotoNagaiPotential(normalize=0.2,a=0.4,b=0.1).toVertical(1.1)
+    pot3= potential.HernquistPotential(normalize=0.4,a=0.1).toVertical(1.1)
+    assert pot1+pot2 == [pot1,pot2]
+    assert pot1+pot2+pot3 == [pot1,pot2,pot3]
+    assert (pot1+pot2)+pot3 == [pot1,pot2,pot3]
+    assert pot1+(pot2+pot3) == [pot1,pot2,pot3]
+    return None
+
 def test_plotting():
     import tempfile
     #Some tests of the plotting routines, to make sure they don't fail


### PR DESCRIPTION
This PR adds the ability to combine Forces/Potentials/planarPotentials/linearPotentials by using the addition operator ``+``, e.g.,
```
from galpy.potential import PowerSphericalPotentialwCutoff, MiyamotoNagaiPotential, NFWPotential
bp= PowerSphericalPotentialwCutoff(alpha=1.8,rc=1.9/8.,normalize=0.05)
mp= MiyamotoNagaiPotential(a=3./8.,b=0.28/8.,normalize=.6)
np= NFWPotential(a=16/8.,normalize=.35)
MWPotential2014= bp+mp+np
```
to define ``MWPotential2014``. The addition operator simply creates lists of the input Potentials.

This PR also adds the ability to change a Force/Potential/planarPotential/linearPotential's amplitude by simply multiplying the instance by a number. So for instance:
```
MWPotential2014[2]*= 1.5
```
increases the mass of the NFW dark-matter halo by a factor of 1.5. Division by a number also works. Multiplication only works for individual Force/Potential/planarPotential/linearPotential instances not for combinations (so you cannot do ``2*(pot1+pot2)``, although ``pot1+ 2*pot2`` works). 
