### PR TITLE
Better handling of error in orbits function

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -247,11 +247,29 @@ class Orbits(object):
         """
         attribute = getattr(Orbit(), name)
         if callable(attribute):
-            return lambda *args, **kwargs: [
-                getattr(orbit, name)(*args, **kwargs) for orbit in self._orbits
-            ]
+            def __lambda(*args, **kwargs):
+                idx = 0  # use to keep track of indices
+                listt = []
+                for orbit in self._orbits:
+                    try:
+                        listt.append(getattr(orbit, name)(*args, **kwargs))
+                        idx += 1
+                    except Exception as e:
+                        # show informative error on which orbit is problematic
+                        warnings.warn(str(e) + ' at index %s' % idx)
+                return listt
+            return __lambda
         else:
-            return [getattr(orbit, name) for orbit in self.orbits]
+            idx = 0  # use to keep track of indices
+            listt = []
+            for orbit in self.orbits:
+                try:
+                    listt.append(getattr(orbit, name))
+                    idx += 1
+                except Exception as e:
+                    # show informative error on which orbit is problematic
+                    warnings.warn(str(e) + ' at index %s' % idx)
+            return listt
 
     def __getitem__(self,key):
         """

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -1075,3 +1075,23 @@ def test_ChandrasekharDynamicalFrictionForce_constLambda():
     assert numpy.all(numpy.fabs(r_pred-numpy.array(o.r(ts[-1]))) < 0.015), 'ChandrasekharDynamicalFrictionForce with constant lnLambda for circular orbits does not agree with analytical prediction'
     return None
 
+def test_error_handling():
+    # Only run this for astropy>3
+    if not _APY3: return None
+    from galpy.orbit import Orbits
+    ras = numpy.array([1., 2., 3.]) * u.deg
+    decs = numpy.array([1., 2., 3.]) * u.deg
+    dists = numpy.array([1., 2., 3.]) * u.kpc
+    pmras = numpy.array([1., 2000., 3.]) * u.mas / u.yr  # second one high velocity unbound orbit
+    pmdecs = numpy.array([1., 2000., 3.]) * u.mas / u.yr  # second one high velocity unbound orbit
+    vloss = numpy.array([1., 2., 3.]) * u.km / u.s
+    # Without any custom coordinate-transformation parameters
+    co = apycoords.SkyCoord(ra=ras, dec=decs, distance=dists,
+                            pm_ra_cosdec=pmras, pm_dec=pmdecs,
+                            radial_velocity=vloss,
+                            frame='icrs')
+    os = Orbits(co)
+
+    e = os.e(analytic=True, type='staeckel', pot=potential.MWPotential2014)
+    # assert all orbits e estimation are finished and the second high velocity one is NaN
+    assert numpy.isnan(e[1])


### PR DESCRIPTION
It just came up to me that I try to estimate eccentricity for the whole APOGEE DR14 with the new `Orbits` class, I get stuck in a orbit which is unbound. And it is very uninformative with just an error msg which orbit is unbound so user cannot debug.

So I modified to:
#. add which index the error msg is thrown so user know which orbit in `Orbits` is causing problem
#. instead of raising error, print warning so the whole operation can be finished
#. have done performance test, the new loops are as fast as the loop `Orbits` currently using (approx 4:29 to 4:31 minutes timed with hands on 140000 APOGEE stars eccentricity estimation on my laptop)
#. added a test to make sure an operation can be done to all orbit even some of them are problematic