### PR TITLE
PowerShell script in docs for Windows

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -88,9 +88,17 @@ Installing from source on Windows
 
 Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows this is done as::
 
-     set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
-     set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
-     set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+For CMD::
+
+    set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+    set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+    set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+
+For PowerShell which newer Anaconda prompt might be set as default::
+
+    $env:INCLUDE="$env:CONDA_PREFIX\Library\include"
+    $env:LIB="$env:CONDA_PREFIX\Library\lib"
+    $env:LIBPATH="$env:CONDA_PREFIX\Library\lib"
 
 where in this example ``CONDA_PREFIX`` is the path of your current conda environment (the path that ends in ``\ENV_NAME``). If you have installed the GSL somewhere else, adjust these paths (but do not use ``YOUR_PATH\include\gsl`` or ``YOUR_PATH\lib\gsl`` as the paths, simply use ``YOUR_PATH\include`` and ``YOUR_PATH\lib``).
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -86,15 +86,14 @@ to, for example, install the ``dev`` branch.
 Installing from source on Windows
 ---------------------------------
 
-Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows this is done as::
-
-For CMD::
+Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows, using the CDM commandline, this is done as::
 
     set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
     set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
     set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
 
-For PowerShell which newer Anaconda prompt might be set as default::
+If you are using the Windows PowerShell (which newer versions of the
+Anaconda prompt might set as the default), do::
 
     $env:INCLUDE="$env:CONDA_PREFIX\Library\include"
     $env:LIB="$env:CONDA_PREFIX\Library\lib"


### PR DESCRIPTION
I just realized the newer Anaconda for Windows migrated to PowerShell from CMD now so the compiling on Windows guide is not working straightforward. I have added an equivalent script for PowerShell so people can just copy and paste if using PowerShell.

I also tested to compile galpy with the new MSVC 2019 compiler and things seem fine.