### PR TITLE
Allow Orbits to be subclassed 

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -325,7 +325,7 @@ class Orbits(object):
                     copy.deepcopy(self.orbit[flat_indx_array])
                 integrate_kwargs['_pot']= self._pot
             else: integrate_kwargs= None
-            return Orbits._from_slice(orbits_list,integrate_kwargs,
+            return self._from_slice(orbits_list,integrate_kwargs,
                                       shape_kwargs)
 
     @classmethod


### PR DESCRIPTION
small change to Orbits such that Orbits may be fully subclassed.
Now __getitem__ will return an instance of child, not parent, class.