### PR TITLE
Enable galpy to be compiled with Intel Compiler

### DIFF
--- a/__intelcompiler.py
+++ b/__intelcompiler.py
@@ -16,6 +16,7 @@ else:
 class Intel64CompilerW(MSVCCompiler):
     """
     A modified Intel compiler compatible with an MSVC-built Python.
+    Only need to define the Windows one because Linux one is imported from distutils
     """
     compiler_type = 'intel64w'
     compiler_cxx = 'icl'
@@ -34,7 +35,7 @@ class Intel64CompilerW(MSVCCompiler):
                                       '/Qstd=c99', '/Z7', '/D_DEBUG']
 
 
-compiler_class['intel64w'] = ('intelcompiler', 'Intel64CompilerW',
+compiler_class['intel64w'] = ('__intelcompiler', 'Intel64CompilerW',
                               "Intel C Compiler for 64-bit applications on Windows")
 
 ccompiler._default_compilers += ('nt', 'intel64w')

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -418,6 +418,19 @@ The following is a list of publications using ``galpy``; please let me (bovy at 
 
 #. *The Journey Counts: The Importance of Including Orbits when Simulating Ram Pressure Stripping*, Stephanie Tonnesen (2019) *Astrophys. J.*, in press (`arXiv/1903.08178 <http://arxiv.org/abs/1903.08178>`_)
 
+#. *The moving groups as the origin of the vertical phase space spiral*, Tatiana A. Michtchenko, Douglas A. Barros, Angeles Pérez-Villegas, & Jacques R. D. Lépine (2019) *Astrophys. J.*, in press (`arXiv/1903.08325 <http://arxiv.org/abs/1903.08325>`_)
+
+#. *Origin of the excess of high-energy retrograde stars in the Galactic halo*, Tadafumi Matsuno, Wako Aoki, & Takuma Suda (2019) *Astrophys. J. Lett.*, in press (`arXiv/1903.09456 <http://arxiv.org/abs/1903.09456>`_)
+
+#. *Gaia DR2 orbital properties for field stars with globular cluster-like CN band strengths*, A. Savino & L. Posti (2019) *Astron. & Astrophys. Lett.*, in press (`arXiv/1904.01021 <http://arxiv.org/abs/1904.01021>`_)
+
+#. *Dissecting the Phase Space Snail Shell*, Zhao-Yu Li & Juntai Shen (2019) *Astrophys. J.*, submitted (`arXiv/1904.03314 <http://arxiv.org/abs/1904.03314>`_)
+
+#. *Exploring the age dependent properties of M and L dwarfs using Gaia and SDSS*, Rocio Kiman, Sarah J. Schmidt, Ruth Angus, Kelle L. Cruz, Jacqueline K. Faherty, Emily Rice (2019) *Astron. J.*, in press (`arXiv/1904.05911 <http://arxiv.org/abs/1904.05911>`_)
+
+#. *Signatures of resonance and phase mixing in the Galactic disc*, Jason A. S. Hunt, Mathew W. Bub, Jo Bovy, J. Ted Mackereth, Wilma H. Trick, & Daisuke Kawata (2019) *Mon. Not. Roy. Astron. Soc.*, submitted (`arXiv/1904.10968 <http://arxiv.org/abs/1904.10968>`_)
+
+
 
 Indices and tables
 ==================

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -120,18 +120,27 @@ If you encounter any issue related to OpenMP during compilation, you can do::
 Installing from source with Intel Compiler
 -------------------------------------------
 
-To compile galpy with Intel Compiler in Intel Parallel Studio XE for significant out of the box performance
-improvement on Intel CPUs with 64bit system. Moreover students can obtain a free copy of Intel Compiler at https://software.intel.com/en-us/qualify-for-free-software/student
+Compiling galpy with an Intel Compiler can give significant
+performance improvements on 64-bit Intel CPUs. Moreover students can
+obtain a free copy of an Intel Compiler at `this link
+<https://software.intel.com/en-us/qualify-for-free-software/student>`__.
 
-To compile galpy C extension with Intel Compiler on 64bit MaxOS/Linux::
+To compile the galpy C extensions with the Intel Compiler on 64bit
+MaxOS/Linux do::
 
     python setup.py build_ext --inplace --compiler=intelem
 
-To compile galpy C extension with Intel Compiler on 64bit Windows::
+and to compile the galpy C extensions with the Intel Compiler on 64bit
+Windows do::
 
     python setup.py build_ext --inplace --compiler=intel64w
 
-and then you can simply install or build your own wheels with::
+Then you can simply install with::
+
+     python setup.py install
+
+or other similar installation commands, or you can build your own
+wheels with::
 
     python setup.py sdist bdist_wheel
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -123,26 +123,17 @@ Installing from source with Intel Compiler
 To compile galpy with Intel Compiler in Intel Parallel Studio XE for significant out of the box performance
 improvement on Intel CPUs with 64bit system. Moreover students can obtain a free copy of Intel Compiler at https://software.intel.com/en-us/qualify-for-free-software/student
 
-To compile galpy C extension with Intel Compiler on 64bit MaxOS/Linux, add the following line at the beginning of ``setup.py``::
-
-    import numpy.distutils.intelccompiler
-
-and then in terminal type::
+To compile galpy C extension with Intel Compiler on 64bit MaxOS/Linux::
 
     python setup.py build_ext --inplace --compiler=intelem
 
-To compile galpy C extension with Intel Compiler on 64bit Windows, add the following line at the beginning of ``setup.py``::
-
-    import __intelcompiler
-
-and then in terminal type::
+To compile galpy C extension with Intel Compiler on 64bit Windows::
 
     python setup.py build_ext --inplace --compiler=intel64w
 
 and then you can simply install or build your own wheels with::
 
     python setup.py sdist bdist_wheel
-
 
 Installing the TorusMapper code
 --------------------------------

--- a/galpy/potential/DehnenSmoothWrapperPotential.py
+++ b/galpy/potential/DehnenSmoothWrapperPotential.py
@@ -18,7 +18,7 @@ class DehnenSmoothWrapperPotential(parentWrapperPotential):
     .. math::
 
         \\xi = \\begin{cases}
-        0 & t < t_\\mathrm{form}\\\\
+        -1 & t < t_\\mathrm{form}\\\\
         2\\left(\\frac{t-t_\\mathrm{form}}{t_\mathrm{steady}}\\right)-1\\,, &  t_\\mathrm{form} \\leq t \\leq t_\\mathrm{form}+t_\\mathrm{steady}\\\\
         1 & t > t_\\mathrm{form}+t_\\mathrm{steady}
         \\end{cases}

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,20 @@ else:
     del sys.argv[interppotential_ext_pos]
     interppotential_ext= True
 
+#Option to use Intel compilers
+try:
+    compiler_option_pos = ['--compiler=' in opt for opt in sys.argv]\
+        .index(True)
+except ValueError:
+    use_intel_compiler= False
+else:
+    use_intel_compiler= 'intel' in sys.argv[compiler_option_pos].split('=')[1]
+
+if use_intel_compiler and not WIN32:
+    import numpy.distutils.intelccompiler
+elif use_intel_compiler and WIN32:
+    import __intelcompiler
+
 #code to check the GSL version; list cmd w/ shell=True only works on Windows 
 # (https://docs.python.org/3/library/subprocess.html#converting-argument-sequence)
 cmd= ['gsl-config',


### PR DESCRIPTION
Last night I was just curious to compile galpy with Intel Compiler as I can get a free copy of Intel Compiler for personal educational use and googled some ways to compiled galpy with Intel Compiler. Moreover, as per free Intel Compiler license, I don't think I can distribute anything compiled with my free Intel Compiler but I guess it will be nice if anyone with the compiler can compile ``galpy`` to run faster.

**Don't merge it yet** as I will test it on the server later to see if the compilation command will work on Linux but at least it works on Windows. I just make this PR first to keep track the performance comparison I did on Windows. And I guess on Linux/MacOS one can specify `LDSHARED` and `CC` variable to compile with Intel Compiler? But it does not seems to work on Windows anyway for such method.

Also I don't know what performance comparison you would like to see  how fast/slow Intel compiled galpy can be. I only simply did three tests below and it seems intel compiled galpy run pretty fast without changing any C code.

Here are some performance comparison on my **Win10 v1809 x64 py37 (Intel 4 cores 8 threads 4.2GHz)**
```python3
from galpy.potential import MWPotential2014
from galpy.orbit import Orbit
import numpy

ts = numpy.linspace(0., 1000., 100001)

def orbit_int():
    o = Orbit([1., 0.1, 1.1, 0., 0.05])
    o.integrate(ts, MWPotential2014)

%timeit orbit_int()
```
Compiled  with Intel Compiler 2019.3: 359 ms ± 1.13 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
Compiled with MSVC2019:  551 ms ± 4.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Another test below:
```python3
from galpy.potential import MWPotential2014
from galpy.actionAngle import actionAngleAdiabatic
from galpy.orbit import Orbit
import numpy

aAA = actionAngleAdiabatic(pot=MWPotential2014, c=True)
ts = numpy.linspace(0., 100., 10001)
o = Orbit([1., 0.1, 1.1, 0., 0.05])
o.integrate(ts, MWPotential2014)
%timeit aAA(o.R(ts), o.vR(ts), o.vT(ts), o.z(ts), o.vz(ts))
```
Compiled  with Intel Compiler 2019.3: 102 ms ± 1.18 ms per loop(mean ± std. dev. of 7 runs, 10 loops each)
Compiled with MSVC2019: 155 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

Another test below:
```python3
from galpy.potential import MWPotential2014
from galpy.actionAngle import actionAngleStaeckel, estimateDeltaStaeckel
from galpy.orbit import Orbit
import numpy

ts = numpy.linspace(0., 100., 100000)
o= Orbit(vxvv=[1.,0.1,1.1,0.,0.1,0.])
o.integrate(ts, MWPotential2014)

aAS = actionAngleStaeckel(pot=MWPotential2014, delta=0.3)
R, vR, vT, z, vz, phi = o.getOrbit().T
delta = estimateDeltaStaeckel(MWPotential2014, R, z, no_median=True)

%timeit -n 10 es, zms, rps, ras = aAS.EccZmaxRperiRap(R,vR,vT,z,vz,phi,delta=delta)
```
Compiled  with Intel Compiler 2019.3: 600 ms ± 4.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
Compiled with MSVC2019: 780 ms ± 1.99 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

