### PR TITLE
Fixed indx in smooth so bar does not grow for t < t_form

### DIFF
--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -142,7 +142,7 @@ class DehnenBarPotential(Potential):
             indx=(t < self._tform)
             smooth[indx]=0.
 
-            indx=(t < self._tsteady)
+            indx=(t < self._tsteady) * (t >= self._tform)
             deltat=t[indx]-self._tform
             xi= 2.*deltat/(self._tsteady-self._tform)-1.
             smooth[indx]= (3./16.*xi**5.-5./8*xi**3.+15./16.*xi+.5)


### PR DESCRIPTION
The calculation of smooth when t is an array is incorrect. indx=(t < self._tform) set smooth=0 for t < tform, but those values were being overwritten by indx=(t < self._tsteady). So the bar was growing before and after self._tform.

This edit should do the trick