### PR TITLE
add time dependences to Potential and related functions

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -25,7 +25,7 @@ Mathew Bub (from_name class method of Orbit)
 Samuel Wong (sampleV_interpolate method of quasiisothermaldf)
 James Lane (General mass distributions in MovingObjectPotential)
 Henry Leung (addition of Python and C implementation of Dormand-Prince 8(5,3) integrator)
-Nathaniel Starkman (custom coordinates in bovy_coords)
+Nathaniel Starkman (custom coordinates in bovy_coords, time dependences in Potential)
 
 General help:
 ==============

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -1023,7 +1023,7 @@ class NFWPotential(TwoPowerIntegerSphericalPotential):
         return numpy.log(1+r/self.a)-r/self.a/(1.+r/self.a)
 
     @bovy_conversion.physical_conversion('position',pop=False)
-    def rvir(self,H=70.,Om=0.3,overdens=200.,wrtcrit=False,ro=None,vo=None,
+    def rvir(self,H=70.,Om=0.3,t=0.,overdens=200.,wrtcrit=False,ro=None,vo=None,
              use_physical=False): # use_physical necessary bc of pop=False, does nothing inside
         """
         NAME:
@@ -1064,7 +1064,7 @@ class NFWPotential(TwoPowerIntegerSphericalPotential):
         else:
             od= overdens/bovy_conversion.dens_in_meanmatterdens(vo,ro,
                                                                 H=H,Om=Om)
-        dc= 12.*self.dens(self.a,0.,use_physical=False)/od
+        dc= 12.*self.dens(self.a,0.,t=t,use_physical=False)/od
         x= optimize.brentq(lambda y: (numpy.log(1.+y)-y/(1.+y))/y**3.-1./dc,
                            0.01,100.)
         return x*self.a

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -471,7 +471,7 @@ class planarAxiPotential(planarPotential):
 
     @potential_physical_input
     @physical_conversion('velocity',pop=True)
-    def vcirc(self,R,phi=None):
+    def vcirc(self,R,phi=None,t=0.):
         """
         
         NAME:
@@ -490,6 +490,8 @@ class planarAxiPotential(planarPotential):
         
             phi= (None) azimuth to use for non-axisymmetric potentials
 
+            t - time (optional; can be Quantity)
+
         OUTPUT:
         
             circular rotation velocity
@@ -501,11 +503,11 @@ class planarAxiPotential(planarPotential):
             2016-06-15 - Added phi= keyword for non-axisymmetric potential - Bovy (UofT)
 
         """
-        return nu.sqrt(R*-self.Rforce(R,phi=phi,use_physical=False))
+        return nu.sqrt(R*-self.Rforce(R,phi=phi,t=t,use_physical=False))
 
     @potential_physical_input
     @physical_conversion('frequency',pop=True)
-    def omegac(self,R):
+    def omegac(self,R,t=0.):
         """
         
         NAME:
@@ -521,6 +523,8 @@ class planarAxiPotential(planarPotential):
             Pot - Potential instance or list of such instances
         
             R - Galactocentric radius (can be Quantity)
+
+            t - time (optional; can be Quantity)
         
         OUTPUT:
         
@@ -531,11 +535,11 @@ class planarAxiPotential(planarPotential):
             2011-10-09 - Written - Bovy (IAS)
         
         """
-        return nu.sqrt(-self.Rforce(R,use_physical=False)/R)       
+        return nu.sqrt(-self.Rforce(R,t=t,use_physical=False)/R)       
 
     @potential_physical_input
     @physical_conversion('frequency',pop=True)
-    def epifreq(self,R):
+    def epifreq(self,R,t=0.):
         """
         
         NAME:
@@ -549,6 +553,8 @@ class planarAxiPotential(planarPotential):
         INPUT:
         
            R - Galactocentric radius (can be Quantity)
+
+           t - time (optional; can be Quantity)
         
         OUTPUT:
         
@@ -559,11 +565,11 @@ class planarAxiPotential(planarPotential):
            2011-10-09 - Written - Bovy (IAS)
         
         """
-        return nu.sqrt(self.R2deriv(R,use_physical=False)
-                       -3./R*self.Rforce(R,use_physical=False))
+        return nu.sqrt(self.R2deriv(R,t=t,use_physical=False)
+                       -3./R*self.Rforce(R,t=t,use_physical=False))
 
     @physical_conversion('position',pop=True)
-    def lindbladR(self,OmegaP,m=2,**kwargs):
+    def lindbladR(self,OmegaP,m=2,t=0.,**kwargs):
         """
         
         NAME:
@@ -581,6 +587,8 @@ class planarAxiPotential(planarPotential):
            m= order of the resonance (as in m(O-Op)=kappa (negative m for outer)
               use m='corotation' for corotation
               +scipy.optimize.brentq xtol,rtol,maxiter kwargs
+
+           t - time (optional; can be Quantity)
         
         OUTPUT:
         
@@ -593,11 +601,11 @@ class planarAxiPotential(planarPotential):
         """
         if _APY_LOADED and isinstance(OmegaP,units.Quantity):
             OmegaP= OmegaP.to(1/units.Gyr).value/freq_in_Gyr(self._vo,self._ro)
-        return lindbladR(self,OmegaP,m=m,use_physical=False,**kwargs)
+        return lindbladR(self,OmegaP,m=m,t=t,use_physical=False,**kwargs)
 
     @potential_physical_input
     @physical_conversion('velocity',pop=True)
-    def vesc(self,R):
+    def vesc(self,R,t=0.):
         """
 
         NAME:
@@ -614,6 +622,8 @@ class planarAxiPotential(planarPotential):
 
             R - Galactocentric radius (can be Quantity)
 
+            t - time (optional; can be Quantity)
+
         OUTPUT:
 
             escape velocity
@@ -623,8 +633,8 @@ class planarAxiPotential(planarPotential):
             2011-10-09 - Written - Bovy (IAS)
 
         """
-        return nu.sqrt(2.*(self(_INF,use_physical=False)
-                           -self(R,use_physical=False)))
+        return nu.sqrt(2.*(self(_INF,t=t,use_physical=False)
+                           -self(R,t=t,use_physical=False)))
         
     def plotRotcurve(self,*args,**kwargs):
         """

--- a/galpy/potential/plotEscapecurve.py
+++ b/galpy/potential/plotEscapecurve.py
@@ -120,7 +120,7 @@ def plotEscapecurve(Pot,*args,**kwargs):
     return plot.bovy_plot(Rs,esccurve,*args,
                           **kwargs)
 
-def calcEscapecurve(Pot,Rs):
+def calcEscapecurve(Pot,Rs,t=0.):
     """
     NAME:
        calcEscapecurve
@@ -131,6 +131,9 @@ def calcEscapecurve(Pot,Rs):
        Pot - Potential or list of Potential instances
 
        Rs - (array of) radius(i)
+
+       t - instantaneous time (optional)
+
     OUTPUT:
        array of v_esc
     HISTORY:
@@ -147,12 +150,12 @@ def calcEscapecurve(Pot,Rs):
         Rs= nu.array([Rs])
     esccurve= nu.zeros(grid)
     for ii in range(grid):
-        esccurve[ii]= vesc(Pot,Rs[ii],use_physical=False)
+        esccurve[ii]= vesc(Pot,Rs[ii],t=t,use_physical=False)
     return esccurve
 
 @potential_physical_input
 @physical_conversion('velocity',pop=True)
-def vesc(Pot,R):
+def vesc(Pot,R,t=0.):
     """
 
     NAME:
@@ -169,6 +172,8 @@ def vesc(Pot,R):
 
        R - Galactocentric radius (can be Quantity)
 
+       t - time (optional; can be Quantity)
+
     OUTPUT:
 
        escape velocity
@@ -181,9 +186,9 @@ def vesc(Pot,R):
     from galpy.potential import evaluateplanarPotentials
     from galpy.potential import PotentialError
     try:
-        return nu.sqrt(2.*(evaluateplanarPotentials(Pot,_INF,use_physical=False)-evaluateplanarPotentials(Pot,R,use_physical=False)))
+        return nu.sqrt(2.*(evaluateplanarPotentials(Pot,_INF,t=t,use_physical=False)-evaluateplanarPotentials(Pot,R,t=t,use_physical=False)))
     except PotentialError:
         from galpy.potential import RZToplanarPotential
         Pot= RZToplanarPotential(Pot)
-        return nu.sqrt(2.*(evaluateplanarPotentials(Pot,_INF,use_physical=False)-evaluateplanarPotentials(Pot,R,use_physical=False)))
+        return nu.sqrt(2.*(evaluateplanarPotentials(Pot,_INF,t=t,use_physical=False)-evaluateplanarPotentials(Pot,R,t=t,use_physical=False)))
         

--- a/galpy/potential/plotRotcurve.py
+++ b/galpy/potential/plotRotcurve.py
@@ -123,7 +123,7 @@ def plotRotcurve(Pot,*args,**kwargs):
     return plot.bovy_plot(Rs,rotcurve,*args,
                           **kwargs)
 
-def calcRotcurve(Pot,Rs,phi=None):
+def calcRotcurve(Pot,Rs,phi=None,t=0.):
     """
     NAME:
 
@@ -141,6 +141,8 @@ def calcRotcurve(Pot,Rs,phi=None):
        Rs - (array of) radius(i)
 
        phi= (None) azimuth to use for non-axisymmetric potentials
+
+       ts - instantaneous time (optional)
 
     OUTPUT:
 
@@ -160,12 +162,12 @@ def calcRotcurve(Pot,Rs,phi=None):
         Rs= nu.array([Rs])
     rotcurve= nu.zeros(grid)
     for ii in range(grid):
-        rotcurve[ii]= vcirc(Pot,Rs[ii],phi=phi,use_physical=False)
+        rotcurve[ii]= vcirc(Pot,Rs[ii],phi=phi,t=t,use_physical=False)
     return rotcurve
 
 @potential_physical_input
 @physical_conversion('velocity',pop=True)
-def vcirc(Pot,R,phi=None):
+def vcirc(Pot,R,phi=None,t=0.):
     """
 
     NAME:
@@ -184,6 +186,8 @@ def vcirc(Pot,R,phi=None):
 
        phi= (None) azimuth to use for non-axisymmetric potentials
 
+       t= time (optional; can be Quantity)
+
     OUTPUT:
 
        circular rotation velocity
@@ -198,17 +202,17 @@ def vcirc(Pot,R,phi=None):
     from galpy.potential import evaluateplanarRforces
     from galpy.potential import PotentialError
     try:
-        return nu.sqrt(-R*evaluateplanarRforces(Pot,R,phi=phi,
+        return nu.sqrt(-R*evaluateplanarRforces(Pot,R,phi=phi,t=t,
                                                 use_physical=False))
     except PotentialError:
         from galpy.potential import toPlanarPotential
         Pot= toPlanarPotential(Pot)
-        return nu.sqrt(-R*evaluateplanarRforces(Pot,R,phi=phi,
+        return nu.sqrt(-R*evaluateplanarRforces(Pot,R,phi=phi,t=t,
                                                 use_physical=False))
 
 @potential_physical_input
 @physical_conversion('frequency',pop=True)
-def dvcircdR(Pot,R,phi=None):
+def dvcircdR(Pot,R,phi=None,t=0.):
     """
 
     NAME:
@@ -227,6 +231,8 @@ def dvcircdR(Pot,R,phi=None):
 
        phi= (None) azimuth to use for non-axisymmetric potentials
 
+       t= time (optional; can be Quantity)
+
     OUTPUT:
 
        derivative of the circular rotation velocity wrt R
@@ -240,11 +246,11 @@ def dvcircdR(Pot,R,phi=None):
     """
     from galpy.potential import evaluateplanarRforces, evaluateplanarR2derivs
     from galpy.potential import PotentialError
-    tvc= vcirc(Pot,R,phi=phi,use_physical=False)
+    tvc= vcirc(Pot,R,phi=phi,t=t,use_physical=False)
     try:
-        return 0.5*(-evaluateplanarRforces(Pot,R,phi=phi,use_physical=False)+R*evaluateplanarR2derivs(Pot,R,phi=phi,use_physical=False))/tvc
+        return 0.5*(-evaluateplanarRforces(Pot,R,phi=phi,t=t,use_physical=False)+R*evaluateplanarR2derivs(Pot,R,phi=phi,t=t,use_physical=False))/tvc
     except PotentialError:
         from galpy.potential import RZToplanarPotential
         Pot= RZToplanarPotential(Pot)
-        return 0.5*(-evaluateplanarRforces(Pot,R,phi=phi,use_physical=False)+R*evaluateplanarR2derivs(Pot,R,phi=phi,use_physical=False))/tvc
+        return 0.5*(-evaluateplanarRforces(Pot,R,phi=phi,t=t,use_physical=False)+R*evaluateplanarR2derivs(Pot,R,phi=phi,t=t,use_physical=False))/tvc
 


### PR DESCRIPTION
there are a lot of functions, like vcirc, that call time-dependent functions but do not themselves have a time parameter. I just went and found as many time-dependent functions as I could. in `galpy.potential` (and all functions that called those functions) and gave them time parameters.