### PR TITLE
fixed amuse compatibility with Potentials instantiated with astropy quantities

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -25,7 +25,7 @@ Mathew Bub (from_name class method of Orbit)
 Samuel Wong (sampleV_interpolate method of quasiisothermaldf)
 James Lane (General mass distributions in MovingObjectPotential)
 Henry Leung (addition of Python and C implementation of Dormand-Prince 8(5,3) integrator)
-Nathaniel Starkman (custom coordinates in bovy_coords)
+Nathaniel Starkman (custom coordinates in bovy_coords, amuse-astropy Potential compatibility)
 
 General help:
 ==============

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -6,7 +6,7 @@
 
 - [ ] Remove previous version’s **NEW IN vX.X**
 
-- [ ] Update the version number in ``galpy/__init__.py``, ``setup.py``, and ``doc/source/conf.py``
+- [ ] Update the version number in ``galpy/__init__.py``, ``setup.py``, and ``doc/source/conf.py``; format the version number as X.X.X
 
 - [ ] Check whether any new files need to go in MANIFEST.in (check which files are added with ``git diff --name-status PREV_RELEASE_HASH | grep ^A``)
 

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -102,7 +102,6 @@ class galpy_profile(LiteratureReferencesMixIn):
         R= numpy.sqrt(x.value_in(units.kpc)**2.+y.value_in(units.kpc)**2.)
         zed= z.value_in(units.kpc)
         phi= numpy.arctan2(y.value_in(units.kpc),x.value_in(units.kpc))
-
         res= potential.evaluatePotentials(self.pot,R/self.ro,zed/self.ro,
                                           phi=phi,t=self.tgalpy,
                                           ro=self.ro,vo=self.vo,
@@ -174,7 +173,7 @@ class galpy_profile(LiteratureReferencesMixIn):
                                           ro=self.ro,vo=self.vo,
                                           use_physical=False) *
               bovy_conversion.dens_in_msolpc3(self.vo,self.ro))
-        return res | units.MSun / units.parsec**3.
+        return res | units.MSun / units.parsec**3
 
     def circular_velocity(self,r):
         """
@@ -212,7 +211,8 @@ class galpy_profile(LiteratureReferencesMixIn):
         vc= potential.vcirc(self.pot,r.value_in(units.kpc)/self.ro,phi=0,
                             t=self.tgalpy,ro=self.ro,vo=self.vo,
                             use_physical=False) * self.vo
-        return (vc**2.)*r.value_in(units.parsec)/bovy_conversion._G | units.MSun
+        return (vc**2.)*r.value_in(units.parsec)/bovy_conversion._G \
+            | units.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -119,18 +119,22 @@ class galpy_profile(LiteratureReferencesMixIn):
            ax,ay,az
         HISTORY:
            2019-08-12 - Written - Webb (UofT)
+           2019-11-06 - added physical compatibility - Starkman (UofT)
         """
         R= numpy.sqrt(x.value_in(units.kpc)**2.+y.value_in(units.kpc)**2.)
         zed= z.value_in(units.kpc)
         phi= numpy.arctan2(y.value_in(units.kpc),x.value_in(units.kpc))
         # Cylindrical force
         Rforce= potential.evaluateRforces(self.pot,R/self.ro,zed/self.ro,
-                                          phi=phi,t=self.tgalpy)
+                                          phi=phi,t=self.tgalpy,
+                                          use_physical=False)
         phiforce= potential.evaluatephiforces(self.pot,R/self.ro,zed/self.ro,
-                                              phi=phi,t=self.tgalpy)\
+                                              phi=phi,t=self.tgalpy,
+                                              use_physical=False)\
                                               /(R/self.ro)
         zforce=potential.evaluatezforces(self.pot,R/self.ro,zed/self.ro,
-                                         phi=phi,t=self.tgalpy)
+                                         phi=phi,t=self.tgalpy,
+                                         use_physical=False)
         # Convert cylindrical force --> rectangular
         cp, sp= numpy.cos(phi), numpy.sin(phi)
         ax= (Rforce*cp - phiforce*sp)\
@@ -181,7 +185,7 @@ class galpy_profile(LiteratureReferencesMixIn):
         """
         return potential.vcirc(self.pot,r.value_in(units.kpc)/self.ro,phi=0,
                                t=self.tgalpy,ro=self.ro,vo=self.vo) | units.kms
-        
+
     def enclosed_mass(self,r):
         """
         NAME:

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -212,8 +212,10 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        return (self.circular_velocity(r)**2. *
-                r.value_in(u.pc) / bovy_conversion._G) | u.MSun
+        vc= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
+                            t=self.tgalpy,ro=self.ro,vo=self.vo,
+                            use_physical=False) * self.vo
+        return (vc**2.)*r.value_in(u.pc)/bovy_conversion._G | u.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -1,13 +1,10 @@
 # galpy.potential.amuse: AMUSE representation of galpy potentials
 import numpy
-from amuse.units import units as u
+from amuse.units import units
 from amuse.units.quantities import ScalarQuantity
 from amuse.support.literature import LiteratureReferencesMixIn
 from .. import potential
 from ..util import bovy_conversion
-from .Force import _APY_LOADED
-if _APY_LOADED:
-    from astropy import units as apy_u
 class galpy_profile(LiteratureReferencesMixIn):
     """
     User-defined potential from galpy
@@ -57,10 +54,10 @@ class galpy_profile(LiteratureReferencesMixIn):
         else:
             self.model_time= \
                 t*bovy_conversion.time_in_Gyr(ro=self.ro,vo=self.vo) \
-                | u.Gyr
+                | units.Gyr
         #Initialize galpy time
         if isinstance(tgalpy,ScalarQuantity):
-            self.tgalpy= tgalpy.value_in(u.Gyr)\
+            self.tgalpy= tgalpy.value_in(units.Gyr)\
                 /bovy_conversion.time_in_Gyr(ro=self.ro,vo=self.vo)
         else:
             self.tgalpy= tgalpy
@@ -81,10 +78,10 @@ class galpy_profile(LiteratureReferencesMixIn):
         dt= time-self.model_time
         self.model_time= time  
         if self.reverse:
-            self.tgalpy-= dt.value_in(u.Gyr)\
+            self.tgalpy-= dt.value_in(units.Gyr)\
                 /bovy_conversion.time_in_Gyr(ro=self.ro,vo=self.vo)
         else:
-            self.tgalpy+= dt.value_in(u.Gyr)\
+            self.tgalpy+= dt.value_in(units.Gyr)\
                 /bovy_conversion.time_in_Gyr(ro=self.ro,vo=self.vo)
 
     def get_potential_at_point(self,eps,x,y,z):
@@ -102,15 +99,15 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
-        zed= z.value_in(u.kpc)
-        phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
+        R= numpy.sqrt(x.value_in(units.kpc)**2.+y.value_in(units.kpc)**2.)
+        zed= z.value_in(units.kpc)
+        phi= numpy.arctan2(y.value_in(units.kpc),x.value_in(units.kpc))
 
         res= potential.evaluatePotentials(self.pot,R/self.ro,zed/self.ro,
                                           phi=phi,t=self.tgalpy,
                                           ro=self.ro,vo=self.vo,
                                           use_physical=False)
-        return res * self.vo**2 | u.kms**2
+        return res * self.vo**2 | units.kms**2
 
     def get_gravity_at_point(self,eps,x,y,z):
         """
@@ -127,9 +124,9 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
-        zed= z.value_in(u.kpc)
-        phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
+        R= numpy.sqrt(x.value_in(units.kpc)**2.+y.value_in(units.kpc)**2.)
+        zed= z.value_in(units.kpc)
+        phi= numpy.arctan2(y.value_in(units.kpc),x.value_in(units.kpc))
         # Cylindrical force
         Rforce= potential.evaluateRforces(self.pot,R/self.ro,zed/self.ro,
                                           phi=phi,t=self.tgalpy,
@@ -145,13 +142,13 @@ class galpy_profile(LiteratureReferencesMixIn):
         cp, sp= numpy.cos(phi), numpy.sin(phi)
         ax= (Rforce*cp - phiforce*sp)\
             *bovy_conversion.force_in_kmsMyr(ro=self.ro,vo=self.vo) \
-            | u.kms * u.myr**-1
+            | units.kms / units.Myr
         ay= (Rforce*sp + phiforce*cp)\
             *bovy_conversion.force_in_kmsMyr(ro=self.ro,vo=self.vo) \
-            | u.kms * u.myr**-1
+            | units.kms / units.Myr
         az= zforce\
             *bovy_conversion.force_in_kmsMyr(ro=self.ro,vo=self.vo) \
-            | u.kms * u.myr**-1
+            | units.kms / units.Myr
         return ax,ay,az
 
     def mass_density(self,x,y,z):
@@ -169,15 +166,15 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
-        zed= z.value_in(u.kpc)
-        phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
+        R= numpy.sqrt(x.value_in(units.kpc)**2.+y.value_in(units.kpc)**2.)
+        zed= z.value_in(units.kpc)
+        phi= numpy.arctan2(y.value_in(units.kpc),x.value_in(units.kpc))
         res= (potential.evaluateDensities(self.pot,R/self.ro,zed/self.ro,
                                           phi=phi,t=self.tgalpy,
                                           ro=self.ro,vo=self.vo,
                                           use_physical=False) *
               bovy_conversion.dens_in_msolpc3(self.vo,self.ro))
-        return res | u.MSun / u.parsec**3.
+        return res | units.MSun / units.parsec**3.
 
     def circular_velocity(self,r):
         """
@@ -193,10 +190,10 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        res= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
+        res= potential.vcirc(self.pot,r.value_in(units.kpc)/self.ro,phi=0,
                              t=self.tgalpy,ro=self.ro,vo=self.vo,
                              use_physical=False)
-        return res * self.vo | u.kms
+        return res * self.vo | units.kms
 
     def enclosed_mass(self,r):
         """
@@ -212,10 +209,10 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        vc= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
+        vc= potential.vcirc(self.pot,r.value_in(units.kpc)/self.ro,phi=0,
                             t=self.tgalpy,ro=self.ro,vo=self.vo,
                             use_physical=False) * self.vo
-        return (vc**2.)*r.value_in(u.pc)/bovy_conversion._G | u.MSun
+        return (vc**2.)*r.value_in(units.pc)/bovy_conversion._G | units.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -177,7 +177,7 @@ class galpy_profile(LiteratureReferencesMixIn):
                                           ro=self.ro,vo=self.vo,
                                           use_physical=False) *
               bovy_conversion.dens_in_msolpc3(self.vo,self.ro))
-        return res | u.MSun/(u.parsec**3.)
+        return res | u.MSun / u.parsec**3.
 
     def circular_velocity(self,r):
         """
@@ -212,12 +212,8 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-08-12 - Written - Webb (UofT)
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        vc= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
-                            t=self.tgalpy,ro=self.ro,vo=self.vo,
-                            use_physical=False) * self.vo
-        # if hasattr(vc, 'unit'):
-        #     vc= vc.to_value(apy_u.km / apy_u.s)
-        return (vc**2.)*r.value_in(u.pc)/bovy_conversion._G|u.MSun
+        return (self.circular_velocity(r)**2. *
+                r.value_in(u.pc) / bovy_conversion._G) | u.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -212,7 +212,7 @@ class galpy_profile(LiteratureReferencesMixIn):
         vc= potential.vcirc(self.pot,r.value_in(units.kpc)/self.ro,phi=0,
                             t=self.tgalpy,ro=self.ro,vo=self.vo,
                             use_physical=False) * self.vo
-        return (vc**2.)*r.value_in(units.pc)/bovy_conversion._G | units.MSun
+        return (vc**2.)*r.value_in(units.parsec)/bovy_conversion._G | units.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -108,10 +108,9 @@ class galpy_profile(LiteratureReferencesMixIn):
 
         res= potential.evaluatePotentials(self.pot,R/self.ro,zed/self.ro,
                                           phi=phi,t=self.tgalpy,
-                                          ro=self.ro,vo=self.vo)
-        if hasattr(res, 'unit'):
-            res= res.to_value(apy_u.km**2 / apy_u.s**2)
-        return res | u.kms**2
+                                          ro=self.ro,vo=self.vo,
+                                          use_physical=False)
+        return res * self.vo**2 | u.kms**2
 
     def get_gravity_at_point(self,eps,x,y,z):
         """
@@ -173,11 +172,11 @@ class galpy_profile(LiteratureReferencesMixIn):
         R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
         zed= z.value_in(u.kpc)
         phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
-        res= potential.evaluateDensities(self.pot,R/self.ro,zed/self.ro,
-                                         phi=phi,t=self.tgalpy,
-                                         ro=self.ro,vo=self.vo)
-        if hasattr(res, 'unit'):
-            res= res.to_value(apy_u.solMass/(apy_u.pc**3))
+        res= (potential.evaluateDensities(self.pot,R/self.ro,zed/self.ro,
+                                          phi=phi,t=self.tgalpy,
+                                          ro=self.ro,vo=self.vo,
+                                          use_physical=False) *
+              bovy_conversion.dens_in_msolpc3(self.vo,self.ro))
         return res | u.MSun/(u.parsec**3.)
 
     def circular_velocity(self,r):
@@ -195,10 +194,9 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
         res= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
-                             t=self.tgalpy,ro=self.ro,vo=self.vo)
-        if hasattr(res, 'unit'):
-            res= res.to_value(apy_u.km / apy_u.s)
-        return res | u.kms
+                             t=self.tgalpy,ro=self.ro,vo=self.vo,
+                             use_physical=False)
+        return res * self.vo | u.kms
 
     def enclosed_mass(self,r):
         """
@@ -215,10 +213,11 @@ class galpy_profile(LiteratureReferencesMixIn):
            2019-11-06 - added physical compatibility - Starkman (UofT)
         """
         vc= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
-                            t=self.tgalpy,ro=self.ro,vo=self.vo)
-        if hasattr(vc, 'unit'):
-            vc= vc.to_value(apy_u.km / apy_u.s)
-        return (vc**2.)*r.value_in(u.kpc)/bovy_conversion._G*1000.|u.MSun
+                            t=self.tgalpy,ro=self.ro,vo=self.vo,
+                            use_physical=False) * self.vo
+        # if hasattr(vc, 'unit'):
+        #     vc= vc.to_value(apy_u.km / apy_u.s)
+        return (vc**2.)*r.value_in(u.pc)/bovy_conversion._G|u.MSun
 
     def stop(self):
         """

--- a/galpy/potential/amuse.py
+++ b/galpy/potential/amuse.py
@@ -100,15 +100,18 @@ class galpy_profile(LiteratureReferencesMixIn):
            Phi(x,y,z)
         HISTORY:
            2019-08-12 - Written - Webb (UofT)
+           2019-11-06 - added physical compatibility - Starkman (UofT)
         """
         R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
         zed= z.value_in(u.kpc)
         phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
-        return potential.evaluatePotentials(self.pot,R/self.ro,zed/self.ro,
-                                            phi=phi,t=self.tgalpy,
-                                            ro=self.ro,vo=self.vo,
-                                            use_physical=False
-                                            ) | u.km**2*u.s**-2
+
+        res= potential.evaluatePotentials(self.pot,R/self.ro,zed/self.ro,
+                                          phi=phi,t=self.tgalpy,
+                                          ro=self.ro,vo=self.vo)
+        if hasattr(res, 'unit'):
+            res= res.to_value(apy_u.km**2 / apy_u.s**2)
+        return res | u.kms**2
 
     def get_gravity_at_point(self,eps,x,y,z):
         """
@@ -165,15 +168,17 @@ class galpy_profile(LiteratureReferencesMixIn):
            the density
         HISTORY:
            2019-08-12 - Written - Webb (UofT)
+           2019-11-06 - added physical compatibility - Starkman (UofT)
         """
         R= numpy.sqrt(x.value_in(u.kpc)**2.+y.value_in(u.kpc)**2.)
         zed= z.value_in(u.kpc)
         phi= numpy.arctan2(y.value_in(u.kpc),x.value_in(u.kpc))
-        return potential.evaluateDensities(self.pot,R/self.ro,zed/self.ro,
-                                           phi=phi,t=self.tgalpy,
-                                           ro=self.ro,vo=self.vo,
-                                           use_physical=False
-                                           ) | u.MSun/(u.parsec**3.)
+        res= potential.evaluateDensities(self.pot,R/self.ro,zed/self.ro,
+                                         phi=phi,t=self.tgalpy,
+                                         ro=self.ro,vo=self.vo)
+        if hasattr(res, 'unit'):
+            res= res.to_value(apy_u.solMass/(apy_u.pc**3))
+        return res | u.MSun/(u.parsec**3.)
 
     def circular_velocity(self,r):
         """
@@ -187,10 +192,13 @@ class galpy_profile(LiteratureReferencesMixIn):
            the circular velocity
         HISTORY:
            2019-08-12 - Written - Webb (UofT)
+           2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        return potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
-                               t=self.tgalpy,ro=self.ro,vo=self.vo,
-                               use_physical=False) | u.kms
+        res= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
+                             t=self.tgalpy,ro=self.ro,vo=self.vo)
+        if hasattr(res, 'unit'):
+            res= res.to_value(apy_u.km / apy_u.s)
+        return res | u.kms
 
     def enclosed_mass(self,r):
         """
@@ -204,11 +212,13 @@ class galpy_profile(LiteratureReferencesMixIn):
            the mass enclosed
         HISTORY:
            2019-08-12 - Written - Webb (UofT)
+           2019-11-06 - added physical compatibility - Starkman (UofT)
         """
-        vc2= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
-                            t=self.tgalpy,ro=self.ro,vo=self.vo,
-                            use_physical=False)**2.
-        return vc2*r.value_in(u.kpc)/bovy_conversion._G*1000.|u.MSun
+        vc= potential.vcirc(self.pot,r.value_in(u.kpc)/self.ro,phi=0,
+                            t=self.tgalpy,ro=self.ro,vo=self.vo)
+        if hasattr(vc, 'unit'):
+            vc= vc.to_value(apy_u.km / apy_u.s)
+        return (vc**2.)*r.value_in(u.kpc)/bovy_conversion._G*1000.|u.MSun
 
     def stop(self):
         """

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -24,62 +24,100 @@ def test_amuse_potential_with_physical():
     a_u= 0.8 * apy_u.kpc
     ro_u, vo_u= 8.* apy_u.kpc, 220.* apy_u.km / apy_u.s
 
+    # ------------------------------------
     # get_potential_at_point
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    gg1 = pot1(5/ro, 2/ro)
+    gg1 = gg1.to_value(apy_u.km**2 / apy_u.s**2) if hasattr(gg1, 'unit') else gg1
     amuse_pot1= to_amuse(pot1)
-    g1= amuse_pot1.get_potential_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+    ag1= amuse_pot1.get_potential_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
+
+    assert np.abs(gg1 - ag1.value_in(u.kms**2)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    gg2 = pot1(5*apy_u.kpc, 2*apy_u.kpc)
+    gg2 = gg2.to_value(apy_u.km**2 / apy_u.s**2) if hasattr(gg2, 'unit') else gg2
     amuse_pot2= to_amuse(pot2)
-    g2= amuse_pot2.get_potential_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+    ag2= amuse_pot2.get_potential_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
 
-    assert np.abs(g1 - g2) < 1e-10|u.kms**2
+    assert np.abs(gg2 - ag2.value_in(u.kms**2)) < 1e-10
 
+    assert np.abs(ag1 - ag2) < 1e-10|u.kms**2
+
+    # ------------------------------------
     # test get_gravity_at_point
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
     amuse_pot1= to_amuse(pot1)
-    ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+    ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     amuse_pot2= to_amuse(pot2)
-    ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+    ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
 
     assert np.abs(ax1 - ax2) < 1e-10|u.kms/u.Myr
     assert np.abs(ay1 - ay2) < 1e-10|u.kms/u.Myr
     assert np.abs(az1 - az2) < 1e-10|u.kms/u.Myr
 
+    # ------------------------------------
     # test mass_density
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    grho1 = pot1.dens(5/ro, 2/ro)
+    grho1 = grho1.to_value(apy_u.solMass/apy_u.pc**3) if hasattr(grho1, 'unit') else grho1
     amuse_pot1= to_amuse(pot1)
-    rho1= amuse_pot1.mass_density(1|units.kpc, .2|units.kpc, 3|units.kpc)
+    arho1= amuse_pot1.mass_density(3|u.kpc, 4|u.kpc, 2|u.kpc)
+
+    assert np.abs(grho1 - arho1.value_in(u.MSun/u.pc**3)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    grho2= pot2.dens(5*apy_u.kpc, 2*apy_u.kpc)
+    grho2= grho2.to_value(apy_u.solMass/apy_u.pc**3) if hasattr(grho2, 'unit') else grho2
     amuse_pot2= to_amuse(pot2)
-    rho2= amuse_pot2.mass_density(1|units.kpc, .2|units.kpc, 3|units.kpc)
+    arho2= amuse_pot2.mass_density(3|u.kpc, 4|u.kpc, 2|u.kpc)
 
-    assert np.abs(rho1 - rho2) < 1e-10|u.MSun/u.pc**3
+    assert np.abs(grho2 - arho2.value_in(u.MSun/u.pc**3)) < 1e-10
 
+    assert np.abs(arho1 - arho2) < 1e-10|u.MSun/u.pc**3
+
+    # ------------------------------------
     # test circular_velocity
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    gv1= pot1.vcirc(1/ro)
+    gv1=  gv1.to_value(apy_u.km/apy_u.s) if hasattr(gv1, 'unit') else gv1
     amuse_pot1= to_amuse(pot1)
-    v1= amuse_pot1.circular_velocity(1|units.kpc)
+    av1= amuse_pot1.circular_velocity(1|u.kpc)
+
+    assert np.abs(gv1 - av1.value_in(u.kms)) < 1e10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    gv2= pot2.vcirc(1*apy_u.kpc)
+    gv2=  gv2.to_value(apy_u.km/apy_u.s) if hasattr(gv2, 'unit') else gv2
     amuse_pot2= to_amuse(pot2)
-    v2= amuse_pot2.circular_velocity(1|units.kpc)
+    av2= amuse_pot2.circular_velocity(1|u.kpc)
 
-    assert np.abs(v1 - v2) < 1e-10|u.kms
+    assert np.abs(gv2 - av2.value_in(u.kms)) < 1e10
 
+    assert np.abs(av1 - av2) < 1e-10|u.kms
+
+    # ------------------------------------
     # test enclosed_mass
+
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    gm1= pot1.mass(1/ro)
+    gm1= gm1.to_value(apy_u.solMass) if hasattr(gm1, 'unit') else gm1
     amuse_pot1= to_amuse(pot1)
-    m1= amuse_pot1.enclosed_mass(1|units.kpc)
+    am1= amuse_pot1.enclosed_mass(1|u.kpc)    
+
+    assert np.abs(gm1 - am1.value_in(u.MSun)) < 1e10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    gm2= pot2.mass(1*apy_u.kpc)
+    gm2= gm2.to_value(apy_u.solMass) if hasattr(gm2, 'unit') else gm2
     amuse_pot2= to_amuse(pot2)
-    m2= amuse_pot2.enclosed_mass(1|units.kpc)
+    am2= amuse_pot2.enclosed_mass(1|u.kpc)
 
-    assert np.abs(m1 - m2) < 1e-10|u.MSun
+    assert np.abs(gm2 - am2.value_in(u.MSun)) < 1e10
+
+    assert np.abs(am1 - am2) < 1e-10|u.MSun
 
     return None
 

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -22,7 +22,10 @@ def test_amuse_potential_with_physical():
 
     amp_u= 1e8 * apy_u.solMass
     a_u= 0.8 * apy_u.kpc
-    ro_u, vo_u= 8.* apy_u.kpc, 220.* apy_u.km / apy_u.s
+    ro_u, vo_u= 8.*apy_u.kpc, 220.*apy_u.km/apy_u.s
+
+    x, y, z = 3|u.kpc, 4|u.kpc, 2|u.kpc
+    r = 5|u.kpc
 
     # ------------------------------------
     # get_potential_at_point
@@ -30,7 +33,7 @@ def test_amuse_potential_with_physical():
     gg1 = pot1(5/ro, 2/ro)
     gg1 = gg1.to_value(apy_u.km**2 / apy_u.s**2) if hasattr(gg1, 'unit') else gg1
     amuse_pot1= to_amuse(pot1)
-    ag1= amuse_pot1.get_potential_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
+    ag1= amuse_pot1.get_potential_at_point(0, )
 
     assert np.abs(gg1 - ag1.value_in(u.kms**2)) < 1e-10
 
@@ -38,7 +41,7 @@ def test_amuse_potential_with_physical():
     gg2 = pot1(5*apy_u.kpc, 2*apy_u.kpc)
     gg2 = gg2.to_value(apy_u.km**2 / apy_u.s**2) if hasattr(gg2, 'unit') else gg2
     amuse_pot2= to_amuse(pot2)
-    ag2= amuse_pot2.get_potential_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
+    ag2= amuse_pot2.get_potential_at_point(0, x, y, z)
 
     assert np.abs(gg2 - ag2.value_in(u.kms**2)) < 1e-10
 
@@ -48,11 +51,11 @@ def test_amuse_potential_with_physical():
     # test get_gravity_at_point
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
     amuse_pot1= to_amuse(pot1)
-    ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
-    
+    ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, x, y, z)
+
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     amuse_pot2= to_amuse(pot2)
-    ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
+    ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, x, y, z)
 
     assert np.abs(ax1 - ax2) < 1e-10|u.kms/u.Myr
     assert np.abs(ay1 - ay2) < 1e-10|u.kms/u.Myr
@@ -64,7 +67,7 @@ def test_amuse_potential_with_physical():
     grho1 = pot1.dens(5/ro, 2/ro)
     grho1 = grho1.to_value(apy_u.solMass/apy_u.pc**3) if hasattr(grho1, 'unit') else grho1
     amuse_pot1= to_amuse(pot1)
-    arho1= amuse_pot1.mass_density(3|u.kpc, 4|u.kpc, 2|u.kpc)
+    arho1= amuse_pot1.mass_density(x, y, z)
 
     assert np.abs(grho1 - arho1.value_in(u.MSun/u.pc**3)) < 1e-10
 
@@ -72,12 +75,12 @@ def test_amuse_potential_with_physical():
     grho2= pot2.dens(5*apy_u.kpc, 2*apy_u.kpc)
     grho2= grho2.to_value(apy_u.solMass/apy_u.pc**3) if hasattr(grho2, 'unit') else grho2
     amuse_pot2= to_amuse(pot2)
-    arho2= amuse_pot2.mass_density(3|u.kpc, 4|u.kpc, 2|u.kpc)
+    arho2= amuse_pot2.mass_density(x, y, z)
 
     assert np.abs(grho2 - arho2.value_in(u.MSun/u.pc**3)) < 1e-10
 
     assert np.abs(arho1 - arho2) < 1e-10|u.MSun/u.pc**3
-    
+
     # ------------------------------------
     # test circular_velocity
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
@@ -97,7 +100,7 @@ def test_amuse_potential_with_physical():
     assert np.abs(gv2 - av2.value_in(u.kms)) < 1e-10
 
     assert np.abs(av1 - av2) < 1e-10|u.kms
-    
+
     # ------------------------------------
     # test enclosed_mass
 
@@ -106,19 +109,19 @@ def test_amuse_potential_with_physical():
     gm1= gm1.to_value(apy_u.solMass) if hasattr(gm1, 'unit') else gm1
     amuse_pot1= to_amuse(pot1)
     am1= amuse_pot1.enclosed_mass(1|u.kpc)
-    
-    assert np.abs(gm1 - am1.value_in(u.MSun)) < 1e-10
-    
+
+    assert np.abs(gm1 - am1.value_in(u.MSun)) < 3e-8
+
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gm2= pot2.mass(1*apy_u.kpc)
     gm2= gm2.to_value(apy_u.solMass) if hasattr(gm2, 'unit') else gm2
     amuse_pot2= to_amuse(pot2)
     am2= amuse_pot2.enclosed_mass(1|u.kpc)
-    
-    assert np.abs(gm2 - am2.value_in(u.MSun)) < 1e-10
-    
+
+    assert np.abs(gm2 - am2.value_in(u.MSun)) < 3e-8
+
     assert np.abs(am1 - am2) < 1e-10|u.MSun
-    
+
     return None
 
 def test_amuse_MN3ExponentialDiskPotential():

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -69,7 +69,7 @@ def test_amuse_potential_with_physical():
     amuse_pot1= to_amuse(pot1)
     arho1= amuse_pot1.mass_density(x, y, z)
 
-    assert numpy.abs(grho1 - arho1.value_in(units.MSun/units.pc**3)) < 1e-10
+    assert numpy.abs(grho1 - arho1.value_in(units.MSun/units.parsec**3)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     grho2= pot2.dens(5*apy_u.kpc, 2*apy_u.kpc)
@@ -77,9 +77,9 @@ def test_amuse_potential_with_physical():
     amuse_pot2= to_amuse(pot2)
     arho2= amuse_pot2.mass_density(x, y, z)
 
-    assert numpy.abs(grho2 - arho2.value_in(units.MSun/units.pc**3)) < 1e-10
+    assert numpy.abs(grho2 - arho2.value_in(units.MSun/units.parsec**3)) < 1e-10
 
-    assert numpy.abs(arho1 - arho2) < 1e-10|units.MSun/units.pc**3
+    assert numpy.abs(arho1 - arho2) < 1e-10|units.MSun/units.parsec**3
 
     # ------------------------------------
     # test circular_velocity

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -13,6 +13,28 @@ from amuse.lab import *
 from amuse.couple import bridge
 from amuse.datamodel import Particles
 
+from astropy import units as apy_u
+
+def test_amuse_potential_with_physical():
+    ro, vo=8., 220.
+
+    amp= 1e8 / bovy_conversion.mass_in_msol(ro=ro, vo=vo)
+    a= 0.8 / ro
+    pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot1= to_amuse(pot1)
+    ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    amp= 1e8 * apy_u.solMass
+    a= 0.8 * apy_u.kpc
+    pot2= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot2= to_amuse(pot2)
+    ax1, ay2, az2= amuse_pot2.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    assert np.abs(ax1 - ax2) < 1e-10
+    assert np.abs(ay1 - ay2) < 1e-10
+    assert np.abs(az1 - az2) < 1e-10
+    return None
+
 def test_amuse_MN3ExponentialDiskPotential():
     mn= potential.MN3ExponentialDiskPotential(normalize=1.,hr=0.5,hz=0.1)
     tmax= 3.

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -24,8 +24,8 @@ def test_amuse_potential_with_physical():
     a_u= 0.8 * apy_u.kpc
     ro_u, vo_u= 8.*apy_u.kpc, 220.*apy_u.km/apy_u.s
 
-    x, y, z = 3|u.kpc, 4|u.kpc, 2|u.kpc
-    r = 5|u.kpc
+    x, y, z = 3|units.kpc, 4|units.kpc, 2|units.kpc
+    r = 5|units.kpc
 
     # ------------------------------------
     # get_potential_at_point
@@ -33,9 +33,9 @@ def test_amuse_potential_with_physical():
     gg1 = pot1(5/ro, 2/ro)
     gg1 = gg1.to_value(apy_u.km**2 / apy_u.s**2) if hasattr(gg1, 'unit') else gg1
     amuse_pot1= to_amuse(pot1)
-    ag1= amuse_pot1.get_potential_at_point(0, )
+    ag1= amuse_pot1.get_potential_at_point(0, x, y, z)
 
-    assert np.abs(gg1 - ag1.value_in(u.kms**2)) < 1e-10
+    assert numpy.abs(gg1 - ag1.value_in(units.kms**2)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gg2 = pot1(5*apy_u.kpc, 2*apy_u.kpc)
@@ -43,9 +43,9 @@ def test_amuse_potential_with_physical():
     amuse_pot2= to_amuse(pot2)
     ag2= amuse_pot2.get_potential_at_point(0, x, y, z)
 
-    assert np.abs(gg2 - ag2.value_in(u.kms**2)) < 1e-10
+    assert numpy.abs(gg2 - ag2.value_in(units.kms**2)) < 1e-10
 
-    assert np.abs(ag1 - ag2) < 1e-10|u.kms**2
+    assert numpy.abs(ag1 - ag2) < 1e-10|units.kms**2
 
     # ------------------------------------
     # test get_gravity_at_point
@@ -57,9 +57,9 @@ def test_amuse_potential_with_physical():
     amuse_pot2= to_amuse(pot2)
     ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, x, y, z)
 
-    assert np.abs(ax1 - ax2) < 1e-10|u.kms/u.Myr
-    assert np.abs(ay1 - ay2) < 1e-10|u.kms/u.Myr
-    assert np.abs(az1 - az2) < 1e-10|u.kms/u.Myr
+    assert numpy.abs(ax1 - ax2) < 1e-10|units.kms/units.Myr
+    assert numpy.abs(ay1 - ay2) < 1e-10|units.kms/units.Myr
+    assert numpy.abs(az1 - az2) < 1e-10|units.kms/units.Myr
 
     # ------------------------------------
     # test mass_density
@@ -69,7 +69,7 @@ def test_amuse_potential_with_physical():
     amuse_pot1= to_amuse(pot1)
     arho1= amuse_pot1.mass_density(x, y, z)
 
-    assert np.abs(grho1 - arho1.value_in(u.MSun/u.pc**3)) < 1e-10
+    assert numpy.abs(grho1 - arho1.value_in(units.MSun/units.pc**3)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     grho2= pot2.dens(5*apy_u.kpc, 2*apy_u.kpc)
@@ -77,9 +77,9 @@ def test_amuse_potential_with_physical():
     amuse_pot2= to_amuse(pot2)
     arho2= amuse_pot2.mass_density(x, y, z)
 
-    assert np.abs(grho2 - arho2.value_in(u.MSun/u.pc**3)) < 1e-10
+    assert numpy.abs(grho2 - arho2.value_in(units.MSun/units.pc**3)) < 1e-10
 
-    assert np.abs(arho1 - arho2) < 1e-10|u.MSun/u.pc**3
+    assert numpy.abs(arho1 - arho2) < 1e-10|units.MSun/units.pc**3
 
     # ------------------------------------
     # test circular_velocity
@@ -87,19 +87,19 @@ def test_amuse_potential_with_physical():
     gv1= pot1.vcirc(1*apy_u.kpc)
     gv1=  gv1.to_value(apy_u.km/apy_u.s) if hasattr(gv1, 'unit') else gv1
     amuse_pot1= to_amuse(pot1)
-    av1= amuse_pot1.circular_velocity(1|u.kpc)
+    av1= amuse_pot1.circular_velocity(1|units.kpc)
 
-    assert np.abs(gv1 - av1.value_in(u.kms)) < 1e-10
+    assert numpy.abs(gv1 - av1.value_in(units.kms)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gv2= pot2.vcirc(1*apy_u.kpc)
     gv2=  gv2.to_value(apy_u.km/apy_u.s) if hasattr(gv2, 'unit') else gv2
     amuse_pot2= to_amuse(pot2)
-    av2= amuse_pot2.circular_velocity(1|u.kpc)
+    av2= amuse_pot2.circular_velocity(1|units.kpc)
 
-    assert np.abs(gv2 - av2.value_in(u.kms)) < 1e-10
+    assert numpy.abs(gv2 - av2.value_in(units.kms)) < 1e-10
 
-    assert np.abs(av1 - av2) < 1e-10|u.kms
+    assert numpy.abs(av1 - av2) < 1e-10|units.kms
 
     # ------------------------------------
     # test enclosed_mass
@@ -108,19 +108,19 @@ def test_amuse_potential_with_physical():
     gm1= pot1.mass(1/ro)
     gm1= gm1.to_value(apy_u.solMass) if hasattr(gm1, 'unit') else gm1
     amuse_pot1= to_amuse(pot1)
-    am1= amuse_pot1.enclosed_mass(1|u.kpc)
+    am1= amuse_pot1.enclosed_mass(1|units.kpc)
 
-    assert np.abs(gm1 - am1.value_in(u.MSun)) < 3e-8
+    assert numpy.abs(gm1 - am1.value_in(units.MSun)) < 3e-8
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gm2= pot2.mass(1*apy_u.kpc)
     gm2= gm2.to_value(apy_u.solMass) if hasattr(gm2, 'unit') else gm2
     amuse_pot2= to_amuse(pot2)
-    am2= amuse_pot2.enclosed_mass(1|u.kpc)
+    am2= amuse_pot2.enclosed_mass(1|units.kpc)
 
-    assert np.abs(gm2 - am2.value_in(u.MSun)) < 3e-8
+    assert numpy.abs(gm2 - am2.value_in(units.MSun)) < 3e-8
 
-    assert np.abs(am1 - am2) < 1e-10|u.MSun
+    assert numpy.abs(am1 - am2) < 1e-10|units.MSun
 
     return None
 
@@ -267,6 +267,6 @@ class drift_without_gravity(object):
         return (0.5*self.particles.mass*self.particles.velocity.lengths()**2).sum()
     @property
     def angular_momenum(self):
-        return np.cross(self.particles.position,self.particles.velocity)
+        return numpy.cross(self.particles.position,self.particles.velocity)
     def stop(self):
         pass

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -49,7 +49,7 @@ def test_amuse_potential_with_physical():
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
     amuse_pot1= to_amuse(pot1)
     ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
-
+    
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     amuse_pot2= to_amuse(pot2)
     ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, 3|u.kpc, 4|u.kpc, 2|u.kpc)
@@ -77,16 +77,16 @@ def test_amuse_potential_with_physical():
     assert np.abs(grho2 - arho2.value_in(u.MSun/u.pc**3)) < 1e-10
 
     assert np.abs(arho1 - arho2) < 1e-10|u.MSun/u.pc**3
-
+    
     # ------------------------------------
     # test circular_velocity
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
-    gv1= pot1.vcirc(1/ro)
+    gv1= pot1.vcirc(1*apy_u.kpc)
     gv1=  gv1.to_value(apy_u.km/apy_u.s) if hasattr(gv1, 'unit') else gv1
     amuse_pot1= to_amuse(pot1)
     av1= amuse_pot1.circular_velocity(1|u.kpc)
 
-    assert np.abs(gv1 - av1.value_in(u.kms)) < 1e10
+    assert np.abs(gv1 - av1.value_in(u.kms)) < 1e-10
 
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gv2= pot2.vcirc(1*apy_u.kpc)
@@ -94,10 +94,10 @@ def test_amuse_potential_with_physical():
     amuse_pot2= to_amuse(pot2)
     av2= amuse_pot2.circular_velocity(1|u.kpc)
 
-    assert np.abs(gv2 - av2.value_in(u.kms)) < 1e10
+    assert np.abs(gv2 - av2.value_in(u.kms)) < 1e-10
 
     assert np.abs(av1 - av2) < 1e-10|u.kms
-
+    
     # ------------------------------------
     # test enclosed_mass
 
@@ -105,20 +105,20 @@ def test_amuse_potential_with_physical():
     gm1= pot1.mass(1/ro)
     gm1= gm1.to_value(apy_u.solMass) if hasattr(gm1, 'unit') else gm1
     amuse_pot1= to_amuse(pot1)
-    am1= amuse_pot1.enclosed_mass(1|u.kpc)    
-
-    assert np.abs(gm1 - am1.value_in(u.MSun)) < 1e10
-
+    am1= amuse_pot1.enclosed_mass(1|u.kpc)
+    
+    assert np.abs(gm1 - am1.value_in(u.MSun)) < 1e-10
+    
     pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     gm2= pot2.mass(1*apy_u.kpc)
     gm2= gm2.to_value(apy_u.solMass) if hasattr(gm2, 'unit') else gm2
     amuse_pot2= to_amuse(pot2)
     am2= amuse_pot2.enclosed_mass(1|u.kpc)
-
-    assert np.abs(gm2 - am2.value_in(u.MSun)) < 1e10
-
+    
+    assert np.abs(gm2 - am2.value_in(u.MSun)) < 1e-10
+    
     assert np.abs(am1 - am2) < 1e-10|u.MSun
-
+    
     return None
 
 def test_amuse_MN3ExponentialDiskPotential():

--- a/tests/test_amuse.py
+++ b/tests/test_amuse.py
@@ -17,22 +17,70 @@ from astropy import units as apy_u
 
 def test_amuse_potential_with_physical():
     ro, vo=8., 220.
-
     amp= 1e8 / bovy_conversion.mass_in_msol(ro=ro, vo=vo)
     a= 0.8 / ro
+
+    amp_u= 1e8 * apy_u.solMass
+    a_u= 0.8 * apy_u.kpc
+    ro_u, vo_u= 8.* apy_u.kpc, 220.* apy_u.km / apy_u.s
+
+    # get_potential_at_point
+    pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot1= to_amuse(pot1)
+    g1= amuse_pot1.get_potential_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    amuse_pot2= to_amuse(pot2)
+    g2= amuse_pot2.get_potential_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    assert np.abs(g1 - g2) < 1e-10|u.kms**2
+
+    # test get_gravity_at_point
     pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
     amuse_pot1= to_amuse(pot1)
     ax1, ay1, az1= amuse_pot1.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
 
-    amp= 1e8 * apy_u.solMass
-    a= 0.8 * apy_u.kpc
-    pot2= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
     amuse_pot2= to_amuse(pot2)
-    ax1, ay2, az2= amuse_pot2.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
+    ax2, ay2, az2= amuse_pot2.get_gravity_at_point(0, 1|units.kpc, .2|units.kpc, 3|units.kpc)
 
-    assert np.abs(ax1 - ax2) < 1e-10
-    assert np.abs(ay1 - ay2) < 1e-10
-    assert np.abs(az1 - az2) < 1e-10
+    assert np.abs(ax1 - ax2) < 1e-10|u.kms/u.Myr
+    assert np.abs(ay1 - ay2) < 1e-10|u.kms/u.Myr
+    assert np.abs(az1 - az2) < 1e-10|u.kms/u.Myr
+
+    # test mass_density
+    pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot1= to_amuse(pot1)
+    rho1= amuse_pot1.mass_density(1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    amuse_pot2= to_amuse(pot2)
+    rho2= amuse_pot2.mass_density(1|units.kpc, .2|units.kpc, 3|units.kpc)
+
+    assert np.abs(rho1 - rho2) < 1e-10|u.MSun/u.pc**3
+
+    # test circular_velocity
+    pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot1= to_amuse(pot1)
+    v1= amuse_pot1.circular_velocity(1|units.kpc)
+
+    pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    amuse_pot2= to_amuse(pot2)
+    v2= amuse_pot2.circular_velocity(1|units.kpc)
+
+    assert np.abs(v1 - v2) < 1e-10|u.kms
+
+    # test enclosed_mass
+    pot1= potential.TwoPowerSphericalPotential(amp=amp, a=a, ro=ro, vo=vo)
+    amuse_pot1= to_amuse(pot1)
+    m1= amuse_pot1.enclosed_mass(1|units.kpc)
+
+    pot2= potential.TwoPowerSphericalPotential(amp=amp_u, a=a_u, ro=ro_u, vo=vo_u)
+    amuse_pot2= to_amuse(pot2)
+    m2= amuse_pot2.enclosed_mass(1|units.kpc)
+
+    assert np.abs(m1 - m2) < 1e-10|u.MSun
+
     return None
 
 def test_amuse_MN3ExponentialDiskPotential():


### PR DESCRIPTION
A Potential instantiated with astropy quantitities has the `physical` flag set to true. The `galpy_profile` wrapper for amuse compatibility does all calculations without physical units. Normally this is not a problem as the galpy output is piped directly from galpy to. AMUSE,  but for `galpy_profile.get_gravity_at_point` the galpy output is first converted to cartesian coordinates and the units are adjusted. To prevent double conversion in the instances that galpy uses physical units, the `evaluateRforces`, `evaluatephiforces`, and `evaluatezforces` methods need to pass `use_physical=False`.