### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,5 +41,4 @@ install:
   - python setup.py develop --single_ext
 
 test_script:
-  - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis
-# --disable-pytest-warnings
+  - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,4 +41,5 @@ install:
   - python setup.py develop --single_ext
 
 test_script:
-  - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings
+  - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis
+# --disable-pytest-warnings

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 build: off
 
 environment:
-  PYTHON_VERSION: 3.7
+  PYTHON_VERSION: 3.8
   MINICONDA: C:\\Miniconda37-x64
 
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
-dist: xenial
+dist: bionic
 sudo: false
 language: python
 # Working towards support https://numpy.org/neps/nep-0029-deprecation_policy.html
 python:
-  - "3.7"
+  - "3.8"
 env: #split tests
   global:
     - REQUIRES_PYNBODY=false
     - REQUIRES_ASTROPY=false
     - REQUIRES_ASTROQUERY=false
-    - PYTHON_COVREPORTS_VERSION=3.7 # Version for which reports are uploaded
+    - PYTHON_COVREPORTS_VERSION=3.8 # Version for which reports are uploaded
   matrix:
     - TEST_FILES='tests/ --ignore=tests/test_qdf.py --ignore=tests/test_pv2qdf.py --ignore=tests/test_diskdf.py --ignore=tests/test_orbit.py --ignore=tests/test_streamdf.py --ignore=tests/test_streamgapdf.py --ignore=tests/test_evolveddiskdf.py --ignore=tests/test_quantity.py --ignore=tests/test_nemo.py --ignore=tests/test_amuse.py --ignore=tests/test_coords.py --ignore=tests/test_jeans.py --ignore=tests/test_orbits.py' REQUIRES_PYNBODY=true
     - TEST_FILES='tests/test_quantity.py tests/test_coords.py' REQUIRES_ASTROPY=true # needs to be separate for different config
@@ -18,11 +18,13 @@ env: #split tests
     - TEST_FILES='tests/test_diskdf.py'
     - TEST_FILES='tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf.py'
     - TEST_FILES='tests/test_streamdf.py'
-matrix: # only run crucial tests for python 2.7, 3.6
+matrix: # only run crucial tests for python 2.7, 3.6, 3.7
   include:
     - python: "2.7"
       env: TEST_FILES='tests/test_orbit.py tests/test_orbits.py' REQUIRES_PYNBODY=true REQUIRES_ASTROPY=true REQUIRES_ASTROQUERY=true
     - python: "3.6"
+      env: TEST_FILES='tests/test_orbit.py tests/test_orbits.py' REQUIRES_PYNBODY=true REQUIRES_ASTROPY=true REQUIRES_ASTROQUERY=true
+    - python: "3.7"
       env: TEST_FILES='tests/test_orbit.py tests/test_orbits.py' REQUIRES_PYNBODY=true REQUIRES_ASTROPY=true REQUIRES_ASTROQUERY=true
 addons:
   apt:

--- a/galpy/actionAngle/actionAngleAdiabatic_c.py
+++ b/galpy/actionAngle/actionAngleAdiabatic_c.py
@@ -16,8 +16,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/actionAngle/actionAngleAdiabatic_c.py
+++ b/galpy/actionAngle/actionAngleAdiabatic_c.py
@@ -18,7 +18,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix),winmode=0x008)
         else:

--- a/galpy/actionAngle/actionAngleAdiabatic_c.py
+++ b/galpy/actionAngle/actionAngleAdiabatic_c.py
@@ -19,8 +19,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix),winmode=0x008)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
     except OSError as e:

--- a/galpy/actionAngle/actionAngleStaeckel_c.py
+++ b/galpy/actionAngle/actionAngleStaeckel_c.py
@@ -20,8 +20,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix),winmode=0x008)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
     except OSError as e:

--- a/galpy/actionAngle/actionAngleStaeckel_c.py
+++ b/galpy/actionAngle/actionAngleStaeckel_c.py
@@ -17,8 +17,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/actionAngle/actionAngleStaeckel_c.py
+++ b/galpy/actionAngle/actionAngleStaeckel_c.py
@@ -19,7 +19,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngle_c%s' % _ext_suffix),winmode=0x008)
         else:

--- a/galpy/actionAngle/actionAngleTorus_c.py
+++ b/galpy/actionAngle/actionAngleTorus_c.py
@@ -19,8 +19,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix),winmode=0x008)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix))
     except OSError as e:

--- a/galpy/actionAngle/actionAngleTorus_c.py
+++ b/galpy/actionAngle/actionAngleTorus_c.py
@@ -18,7 +18,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix),winmode=0x008)
         else:

--- a/galpy/actionAngle/actionAngleTorus_c.py
+++ b/galpy/actionAngle/actionAngleTorus_c.py
@@ -16,8 +16,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_actionAngleTorus_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -26,7 +26,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix),winmode=0x008)
         else:

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -24,8 +24,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -27,8 +27,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix),winmode=0x008)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
     except OSError as e:

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -25,8 +25,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix),winmode=0x008)
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -28,7 +28,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.abspath(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)),winmode=0x8)
         else:

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -29,8 +29,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.abspath(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)),winmode=0x8)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))            
     except OSError as e:

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -26,8 +26,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))            
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -25,8 +25,8 @@ for path in sys.path:
     if not os.path.isdir(path): continue
     try:
         if sys.platform == 'win32' and sys.version_info >= (3,8):
-            with os.add_dll_directory(path):
-                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+            # winmode=0x008 is easy-going way to call LoadLibraryExA
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix),winmode=0x008)
         else:
             _lib = ctypes.CDLL(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix))
     except OSError as e:

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -22,8 +22,13 @@ if PY3:
 else: #pragma: no cover
     _ext_suffix= '.so'
 for path in sys.path:
+    if not os.path.isdir(path): continue
     try:
-        _lib = ctypes.CDLL(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix))
+        if sys.platform == 'win32' and sys.version_info >= (3,8):
+            with os.add_dll_directory(path):
+                _lib = ctypes.CDLL(os.path.join(path,'galpy_integrate_c%s' % _ext_suffix))
+        else:
+            _lib = ctypes.CDLL(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix))
     except OSError as e:
         if os.path.exists(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix)): #pragma: no cover
             outerr= e

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -24,7 +24,7 @@ else: #pragma: no cover
 for path in sys.path:
     if not os.path.isdir(path): continue
     try:
-        if sys.platform == 'win32' and sys.version_info >= (3,8):
+        if sys.platform == 'win32' and sys.version_info >= (3,8): # pragma: no cover
             # winmode=0x008 is easy-going way to call LoadLibraryExA
             _lib = ctypes.CDLL(os.path.join(path,'galpy_interppotential_c%s' % _ext_suffix),winmode=0x008)
         else:

--- a/galpy/util/bovy_rk.c
+++ b/galpy/util/bovy_rk.c
@@ -104,6 +104,9 @@ void bovy_rk4(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     for (jj=0; jj < (ndt-1); jj++) {
@@ -208,6 +211,9 @@ void bovy_rk6(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     for (jj=0; jj < (ndt-1); jj++) {
@@ -534,6 +540,9 @@ void bovy_dopr54(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     bovy_dopr54_onestep(func,dim,yn,dt,&to,&dt_one,

--- a/galpy/util/bovy_rk.c
+++ b/galpy/util/bovy_rk.c
@@ -107,7 +107,9 @@ void bovy_rk4(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     for (jj=0; jj < (ndt-1); jj++) {
       bovy_rk4_onestep(func,dim,yn,yn1,to,dt,nargs,potentialArgs,ynk,a);
@@ -214,7 +216,9 @@ void bovy_rk6(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     for (jj=0; jj < (ndt-1); jj++) {
       bovy_rk6_onestep(func,dim,yn,yn1,to,dt,nargs,potentialArgs,ynk,a,
@@ -543,7 +547,9 @@ void bovy_dopr54(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     bovy_dopr54_onestep(func,dim,yn,dt,&to,&dt_one,
 			nargs,potentialArgs,rtol,atol,

--- a/galpy/util/bovy_symplecticode.c
+++ b/galpy/util/bovy_symplecticode.c
@@ -149,7 +149,9 @@ void leapfrog(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     //drift half
     leapfrog_leapq(dim,qo,po,dt/2.,q12);
@@ -272,7 +274,9 @@ void symplec4(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     //drift for c1*dt
     leapfrog_leapq(dim,qo,po,c1*dt,q12);
@@ -430,7 +434,9 @@ void symplec6(void (*func)(double t, double *q, double *a,
 #ifdef USING_COVERAGE;
       __gcov_flush();
 #endif
+// LCOV_EXCL_START
       break;
+// LCOV_EXCL_STOP
     }
     //drift for c1*dt
     leapfrog_leapq(dim,qo,po,c1*dt,q12);

--- a/galpy/util/bovy_symplecticode.c
+++ b/galpy/util/bovy_symplecticode.c
@@ -146,6 +146,9 @@ void leapfrog(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     //drift half
@@ -266,6 +269,9 @@ void symplec4(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     //drift for c1*dt
@@ -421,6 +427,9 @@ void symplec6(void (*func)(double t, double *q, double *a,
     if ( interrupted ) {
       *err= -10;
       interrupted= 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+      __gcov_flush();
+#endif
       break;
     }
     //drift for c1*dt

--- a/galpy/util/leung_dop853.c
+++ b/galpy/util/leung_dop853.c
@@ -340,7 +340,9 @@ void dop853(void(*func)(double t, double *q, double *a, int nargs, struct potent
 #ifdef USING_COVERAGE;
 			__gcov_flush();
 #endif
+// LCOV_EXCL_START
 			break;
+// LCOV_EXCL_STOP
 		}
 		h = pos_neg * max(fabs(h), 1e3 * uround);  // keep time step not too small
 

--- a/galpy/util/leung_dop853.c
+++ b/galpy/util/leung_dop853.c
@@ -337,6 +337,9 @@ void dop853(void(*func)(double t, double *q, double *a, int nargs, struct potent
 		if (interrupted) {
 			*err_ = -10;
 			interrupted = 0; // need to reset, bc library and vars stay in memory
+#ifdef USING_COVERAGE;
+			__gcov_flush();
+#endif
 			break;
 		}
 		h = pos_neg * max(fabs(h), 1e3 * uround);  // keep time step not too small

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ except ValueError:
     extra_link_args= []
 else:
     del sys.argv[coverage_pos]
-    extra_compile_args.extend(["-O0","--coverage"])
+    extra_compile_args.extend(["-O0","--coverage","-D USING_COVERAGE"])
     extra_link_args= ["--coverage"]
 
 #Option to compile everything into a single extension

--- a/tests/orbitint4sigint.py
+++ b/tests/orbitint4sigint.py
@@ -12,8 +12,12 @@ if __name__ == '__main__':
             o= Orbit([1.,0.1,1.1,0.1,0.1,0.])
         elif sys.argv[2] == 'planar':
             o= Orbit([1.,0.1,1.1,0.1])
+        print("Starting long C integration ...")
+        sys.stdout.flush()
         o.integrate(ts,mp,method=sys.argv[1])
     elif sys.argv[2] == 'planardxdv':
         o= Orbit([1.,0.1,1.1,0.1])
+        print("Starting long C integration ...")
+        sys.stdout.flush()
         o.integrate_dxdv([0.1,0.1,0.1,0.1],ts,mp,method=sys.argv[1])
     sys.exit(0)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -3900,7 +3900,7 @@ def test_orbit_c_sigint_full():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(4)
+        time.sleep(8)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(4)
         cnt= 0
@@ -3935,7 +3935,7 @@ def test_orbit_c_sigint_planar():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(4)
+        time.sleep(8)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(4)
         cnt= 0
@@ -3966,7 +3966,7 @@ def test_orbit_c_sigint_planardxdv():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(4)
+        time.sleep(8)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(4)
         cnt= 0

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -3900,9 +3900,12 @@ def test_orbit_c_sigint_full():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(8)
+        for line in iter(p.stdout.readline, b''):
+            if line.startswith(b"Starting long C integration ..."):
+                break
+        time.sleep(1)
         os.kill(p.pid,signal.SIGINT)
-        time.sleep(4)
+        time.sleep(1)
         cnt= 0
         while p.poll() is None and cnt < ntries: # wait a little longer
             time.sleep(4)
@@ -3935,9 +3938,12 @@ def test_orbit_c_sigint_planar():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(8)
+        for line in iter(p.stdout.readline, b''):
+            if line.startswith(b"Starting long C integration ..."):
+                break
+        time.sleep(1)
         os.kill(p.pid,signal.SIGINT)
-        time.sleep(4)
+        time.sleep(1)
         cnt= 0
         while p.poll() is None and cnt < ntries: # wait a little longer
             time.sleep(4)
@@ -3966,9 +3972,12 @@ def test_orbit_c_sigint_planardxdv():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
-        time.sleep(8)
+        for line in iter(p.stdout.readline, b''):
+            if line.startswith(b"Starting long C integration ..."):
+                break
+        time.sleep(1)
         os.kill(p.pid,signal.SIGINT)
-        time.sleep(4)
+        time.sleep(1)
         cnt= 0
         while p.poll() is None and cnt < ntries: # wait a little longer
             time.sleep(4)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -3903,7 +3903,7 @@ def test_orbit_c_sigint_full():
         for line in iter(p.stdout.readline, b''):
             if line.startswith(b"Starting long C integration ..."):
                 break
-        time.sleep(1)
+        time.sleep(2)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(1)
         cnt= 0
@@ -3941,7 +3941,7 @@ def test_orbit_c_sigint_planar():
         for line in iter(p.stdout.readline, b''):
             if line.startswith(b"Starting long C integration ..."):
                 break
-        time.sleep(1)
+        time.sleep(2)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(1)
         cnt= 0
@@ -3975,7 +3975,7 @@ def test_orbit_c_sigint_planardxdv():
         for line in iter(p.stdout.readline, b''):
             if line.startswith(b"Starting long C integration ..."):
                 break
-        time.sleep(1)
+        time.sleep(2)
         os.kill(p.pid,signal.SIGINT)
         time.sleep(1)
         cnt= 0

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -3910,7 +3910,7 @@ def test_orbit_c_sigint_full():
 
         if p.poll() == 2 and WIN32: break
 
-        if p.poll() is None or p.poll() != 1:
+        if p.poll() is None or (p.poll() != 1 and p.poll() != -2):
             if p.poll() is None: msg= -100
             else: msg= p.poll()
             raise AssertionError("Full orbit integration using %s should have been interrupted by SIGINT (CTRL-C), but was not because p.poll() == %i" % (integrator,msg))
@@ -3945,7 +3945,7 @@ def test_orbit_c_sigint_planar():
 
         if p.poll() == 2 and WIN32: break
 
-        if p.poll() is None or p.poll() != 1:
+        if p.poll() is None or (p.poll() != 1 and p.poll() != -2):
             if p.poll() is None: msg= -100
             else: msg= p.poll()
             raise AssertionError("Full orbit integration using %s should have been interrupted by SIGINT (CTRL-C), but was not because p.poll() == %i" % (integrator,msg))
@@ -3976,7 +3976,7 @@ def test_orbit_c_sigint_planardxdv():
 
         if p.poll() == 2 and WIN32: break
 
-        if p.poll() is None or p.poll() != 1:
+        if p.poll() is None or (p.poll() != 1 and p.poll() != -2):
             if p.poll() is None: msg= -100
             else: msg= p.poll()
             raise AssertionError("Full orbit integration using %s should have been interrupted by SIGINT (CTRL-C), but was not because p.poll() == %i" % (integrator,msg))


### PR DESCRIPTION
Opening an explicit pull request for this, because it turned out to be somewhat non-trivial. Notes:

* Linux/Mac worked out of the box, 

* but coverage of the parts of the C code when orbit integration gets interrupted failed. Eventually traced this down to, I think, the fact that in Python 3.8 that KeyboardInterrupt actually properly interrupts the C code, leading to a -2 exit code (the one for SIGINT), and the ``abort`` of the C code that this causes makes it that ``gcov`` output is not recorded. I fixed this by explicitly flushing ``gcov`` outout with ``__gcov_flush()`` in the interrupt code, with pre-processor directives to only turn this on when compiling with ``--coverage``.

* For Windows, compilation worked fine, but the DLLs were no longer loaded because Python and ``ctypes`` in particular changed the way they load Windows DLLs, being more strict about the search path. I fixed this by using the ``winmode=0x008`` keyword of ``ctypes.CDLL`` to go back to less strict mode.