### PR TITLE
Automatically build windows wheels using AppVeyor for different Python versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,10 +48,10 @@ test_script:
   - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings
 
 after_test:
+  - conda deactivate
   - ps: |
       if ($env:BUILD_WHEELS -eq "true") {
         # Build wheels for different python versions
-        conda deactivate
         # Python 3.8
         conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
         conda activate py38

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,17 +5,20 @@ environment:
   MINICONDA: C:\\Miniconda37-x64
 
   matrix:
+    - TEST_FILES: tests\test_orbit.py tests\test_orbits.py
+      ADDL_CONDA_PKGS: astropy astroquery
+      COMPILE_NOOPENMP: 
+      BUILD_WHEELS: "true"
+
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
-
-    - TEST_FILES: tests\test_orbit.py tests\test_orbits.py
-      ADDL_CONDA_PKGS: astropy astroquery
-      COMPILE_NOOPENMP: "--no-openmp"
+      BUILD_WHEELS: "false"
 
     - TEST_FILES: tests\test_quantity.py tests\test_coords.py
       ADDL_CONDA_PKGS: astropy
       COMPILE_NOOPENMP: "--no-openmp"
+      BUILD_WHEELS: "false"
 
 platform:
     - x64
@@ -42,3 +45,26 @@ install:
 
 test_script:
   - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings
+
+after_test:
+  - ps: |
+      if ($env:BUILD_WHEELS -eq "true") {
+        # Build wheels for different python versions
+        # Python 3.8
+        conda create -n p38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
+        activate py38
+        pip install wheel
+        python setup.py bdist_wheel
+        # Python 3.7
+        conda create -n p37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
+        activate py37
+        pip install wheel
+        python setup.py bdist_wheel
+        # Python 3.6
+        conda create -n p36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
+        activate py36
+        pip install wheel
+        python setup.py bdist_wheel
+        # Done! Save as artifacts
+        Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+      }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ after_test:
         $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
         $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
-	conda deactivate
+        conda deactivate
         # Python 3.7
         conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
         activate py37

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ environment:
       ADDL_CONDA_PKGS: astropy astroquery
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "true"
+      APPVEYOR_JOB_NAME : "wheels"
 
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
@@ -51,18 +52,23 @@ after_test:
       if ($env:BUILD_WHEELS -eq "true") {
         # Build wheels for different python versions
         # Python 3.8
-        conda create -n p38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
+        conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
         activate py38
         pip install wheel
         python setup.py bdist_wheel
         # Python 3.7
-        conda create -n p37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
+        conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
         activate py37
         pip install wheel
         python setup.py bdist_wheel
         # Python 3.6
-        conda create -n p36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
+        conda create -n py36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
         activate py36
+        pip install wheel
+        python setup.py bdist_wheel
+        # Python 2.7
+        conda create -n py27 python=2.7 numpy scipy matplotlib setuptools pip pytest gsl
+        activate py27
         pip install wheel
         python setup.py bdist_wheel
         # Done! Save as artifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,22 +54,42 @@ after_test:
         # Python 3.8
         conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
         activate py38
+        conda remove --name test-environment --all
         pip install wheel
+        rm -rf build/
+        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
+        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
+        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
         # Python 3.7
         conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
         activate py37
+        conda remove --name py38 --all
         pip install wheel
+        rm -rf build/
+        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
+        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
+        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
         # Python 3.6
         conda create -n py36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
         activate py36
+        conda remove --name py37 --all
         pip install wheel
+        rm -rf build/
+        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
+        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
+        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
         # Python 2.7
         conda create -n py27 python=2.7 numpy scipy matplotlib setuptools pip pytest gsl
         activate py27
+        conda remove --name py36 --all
         pip install wheel
+        rm -rf build/
+        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
+        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
+        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
         # Done! Save as artifacts
         Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
   MINICONDA: C:\\Miniconda37-x64
 
   matrix:
-    - TEST_FILES: tests\test_orbit.py tests\test_orbits.py
+    - TEST_FILES: tests\test_orbits.py #tests\test_orbit.py 
       ADDL_CONDA_PKGS: astropy astroquery
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "true"
@@ -51,22 +51,22 @@ after_test:
   - ps: |
       if ($env:BUILD_WHEELS -eq "true") {
         # Build wheels for different python versions
+	conda deactivate
         # Python 3.8
         conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
-        activate py38
+        conda activate py38
         conda remove --name test-environment --all
         pip install wheel
-        rm -rf build/
         $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
         $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
         $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
         python setup.py bdist_wheel
+	conda deactivate
         # Python 3.7
         conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
         activate py37
         conda remove --name py38 --all
         pip install wheel
-        rm -rf build/
         $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
         $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
         $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
@@ -76,7 +76,6 @@ after_test:
         activate py36
         conda remove --name py37 --all
         pip install wheel
-        rm -rf build/
         $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
         $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
         $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
@@ -86,7 +85,6 @@ after_test:
         activate py27
         conda remove --name py36 --all
         pip install wheel
-        rm -rf build/
         $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
         $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
         $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,18 +8,17 @@ environment:
     - TEST_FILES: tests\test_orbits.py #tests\test_orbit.py 
       ADDL_CONDA_PKGS: astropy astroquery
       COMPILE_NOOPENMP: 
-      ARTIFACT_WHEELS: "true"
-      APPVEYOR_JOB_NAME : "wheels"
+      BUILD_WHEELS: "true"
 
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
-      ARTIFACT_WHEELS: "false"
+      BUILD_WHEELS: "false"
 
     - TEST_FILES: tests\test_quantity.py tests\test_coords.py
       ADDL_CONDA_PKGS: astropy
       COMPILE_NOOPENMP: "--no-openmp"
-      ARTIFACT_WHEELS: "false"
+      BUILD_WHEELS: "false"
 
 platform:
     - x64
@@ -48,7 +47,11 @@ test_script:
   - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings
 
 after_test:
-  # Build wheels for different python versions
+  # Build wheels for different python versions of BUILD_WHEELS, otherwise done
+  - ps: |
+      if ($env:BUILD_WHEELS -eq "false") {
+        Exit-AppVeyorBuild
+      }
   - conda deactivate
   - conda remove --name test-environment --all
   # Python 3.8
@@ -80,18 +83,8 @@ after_test:
   - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
   - python setup.py bdist_wheel
   - conda deactivate
-  # Python 2.7
-  - conda create -n py27 python=2.7 numpy scipy matplotlib setuptools pip pytest gsl
-  - conda activate py27
-  - conda remove --name py36 --all
-  - pip install wheel
-  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
-  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
-  - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
-  - python setup.py bdist_wheel
-  - conda deactivate
   # Upload as artifacts
   - ps: |
-      if ($env:ARTIFACT_WHEELS -eq "true") {
+      if ($env:BUILD_WHEELS -eq "true") {
         Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,7 @@ after_test:
   - ps: |
       if ($env:BUILD_WHEELS -eq "true") {
         # Build wheels for different python versions
-	conda deactivate
+        conda deactivate
         # Python 3.8
         conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
         conda activate py38

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,18 +8,18 @@ environment:
     - TEST_FILES: tests\test_orbits.py #tests\test_orbit.py 
       ADDL_CONDA_PKGS: astropy astroquery
       COMPILE_NOOPENMP: 
-      BUILD_WHEELS: "true"
+      ARTIFACT_WHEELS: "true"
       APPVEYOR_JOB_NAME : "wheels"
 
     - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
-      BUILD_WHEELS: "false"
+      ARTIFACT_WHEELS: "false"
 
     - TEST_FILES: tests\test_quantity.py tests\test_coords.py
       ADDL_CONDA_PKGS: astropy
       COMPILE_NOOPENMP: "--no-openmp"
-      BUILD_WHEELS: "false"
+      ARTIFACT_WHEELS: "false"
 
 platform:
     - x64
@@ -48,47 +48,50 @@ test_script:
   - pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc_travis --disable-pytest-warnings
 
 after_test:
+  # Build wheels for different python versions
   - conda deactivate
+  - conda remove --name test-environment --all
+  # Python 3.8
+  - conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
+  - conda activate py38
+  - pip install wheel
+  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+  - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+  - python setup.py bdist_wheel
+  - conda deactivate
+  # Python 3.7
+  - conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
+  - conda activate py37
+  - conda remove --name py38 --all
+  - pip install wheel
+  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+  - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+  - python setup.py bdist_wheel
+  - conda deactivate
+  # Python 3.6
+  - conda create -n py36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
+  - conda activate py36
+  - conda remove --name py37 --all
+  - pip install wheel
+  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+  - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+  - python setup.py bdist_wheel
+  - conda deactivate
+  # Python 2.7
+  - conda create -n py27 python=2.7 numpy scipy matplotlib setuptools pip pytest gsl
+  - conda activate py27
+  - conda remove --name py36 --all
+  - pip install wheel
+  - set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%
+  - set LIB=%CONDA_PREFIX%\Library\lib;%LIB%
+  - set LIBPATH=%CONDA_PREFIX%\Library\lib;%LIBPATH%
+  - python setup.py bdist_wheel
+  - conda deactivate
+  # Upload as artifacts
   - ps: |
-      if ($env:BUILD_WHEELS -eq "true") {
-        # Build wheels for different python versions
-        # Python 3.8
-        conda create -n py38 python=3.8 numpy scipy matplotlib setuptools pip pytest gsl
-        conda activate py38
-        conda remove --name test-environment --all
-        pip install wheel
-        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
-        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
-        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
-        python setup.py bdist_wheel
-        conda deactivate
-        # Python 3.7
-        conda create -n py37 python=3.7 numpy scipy matplotlib setuptools pip pytest gsl
-        activate py37
-        conda remove --name py38 --all
-        pip install wheel
-        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
-        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
-        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
-        python setup.py bdist_wheel
-        # Python 3.6
-        conda create -n py36 python=3.6 numpy scipy matplotlib setuptools pip pytest gsl
-        activate py36
-        conda remove --name py37 --all
-        pip install wheel
-        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
-        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
-        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
-        python setup.py bdist_wheel
-        # Python 2.7
-        conda create -n py27 python=2.7 numpy scipy matplotlib setuptools pip pytest gsl
-        activate py27
-        conda remove --name py36 --all
-        pip install wheel
-        $env:INCLUDE="$env:CONDA_PREFIX\Library\include;$env:INCLUDE"
-        $env:LIB="$env:CONDA_PREFIX\Library\lib;$env:LIB"
-        $env:LIBPATH="$env:CONDA_PREFIX\Library\lib;$env:LIBPATH"
-        python setup.py bdist_wheel
-        # Done! Save as artifacts
+      if ($env:ARTIFACT_WHEELS -eq "true") {
         Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
   MINICONDA: C:\\Miniconda37-x64
 
   matrix:
-    - TEST_FILES: tests\test_orbits.py #tests\test_orbit.py 
+    - TEST_FILES: tests\test_orbit.py tests\test_orbits.py
       ADDL_CONDA_PKGS: astropy astroquery
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "true"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -24,11 +24,11 @@
 
 - [ ] Push to testpypi: ``twine upload -r pypitest dist/*`` and can test with ``pip install -i https://testpypi.python.org/pypi galpy``
 
+- [ ] Download Windows wheels from AppVeyor from tagged build and put in ``dist/``.
+
+- [ ] Build Mac wheels for different python versions and put in ``dist/``. (note that Linux wheels are not supported)
+
 - [ ] Push to pypi: ``twine upload -r pypi dist/*``
-
-- [ ] Build wheels for different python versions: ``python setup.py bdist_wheel`` and upload with ``twine upload -r pypi dist/*.whl``
-
-- [ ] Create wheels for different python versions on other platforms and upload with ``twine upload dist/*.whl`` (note that Linux wheels are not supported)
 
 - [ ] Create the new conda builds at conda-forge —> now done automatically by bot, but still need to check that builds run correctly (should start within about half an hour from pushing the new release to PyPI)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,9 +47,9 @@ copyright = u'2010 - {}, Jo Bovy'.format(datetime.datetime.now().year)
 # built documents.
 #
 # The short X.Y version.
-version = '2.0'
+version = '1.6.0'
 # The full version, including alpha/beta/rc tags.
-release = '2.0.dev'
+release = '1.6.0.dev'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     version= 'v'+version

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -88,6 +88,9 @@ to, for example, install the ``dev`` branch.
 Installing from source on Windows
 ---------------------------------
 
+.. TIP::
+   You can install a pre-compiled Windows "wheel" of the latest ``master`` version that is automatically built on ``AppVeyor`` for all recent Python versions. Navigate to `the latest master build <http://ci.appveyor.com/project/jobovy/galpy?branch=master>`__, click on the first job and then on "Artifacts", download the wheel for your version of Python, and install with ``pip install WHEEL_FILE.whl``.
+
 Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows, using the CDM commandline, this is done as::
 
     set INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%

--- a/galpy/__init__.py
+++ b/galpy/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.dev"
+__version__ = "1.6.0.dev"

--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,7 @@ else:
     actionAngleTorus_c_incl= False
     
 setup(name='galpy',
-      version='2.0.dev',
+      version='1.6.0.dev',
       description='Galactic Dynamics in python',
       author='Jo Bovy',
       author_email='bovy@astro.utoronto.ca',


### PR DESCRIPTION
This PR adds to the AppVeyor ``.appveyor`` configuration file to build wheels for different Python versions for Windows each time the AppVeyor build runs. All wheels are built as part of the first job, so they can be accessed from that job's "Artifacts" page. At release, these wheels could be downloaded into the ``dist/`` directory and uploaded to PyPI.