### PR TITLE
Adds starting index to range of cml_pvr used to make interpolator

### DIFF
--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -20,6 +20,7 @@
 #  Note that we may have to re-think the implementation of anisotropic DFs to
 #  allow more general forms such as Osipkov-Merritt...
 #
+import warnings
 import numpy
 import scipy.interpolate
 from scipy import integrate, special
@@ -27,7 +28,7 @@ from .df import df
 from ..potential import evaluatePotentials, vesc
 from ..potential.SCFPotential import _xiToR
 from ..orbit import Orbit
-from ..util import conversion
+from ..util import conversion, galpyWarning
 from ..util.conversion import physical_conversion
 if conversion._APY_LOADED:
     from astropy import units
@@ -415,6 +416,8 @@ class sphericaldf(df):
         icdf_v_vesc_grid_reg = numpy.zeros((n_new_pvr,len(r_a_values)))
         for i in range(pvr_grid_cml_norm.shape[1]):
             cml_pvr = pvr_grid_cml_norm[:,i]
+            if numpy.any(cml_pvr < 0):
+                warnings.warn("The DF appears to have negative regions; we'll try to ignore these for sampling the DF, but this may adversely affect the generated samples. Proceed with care!",galpyWarning)
             cml_pvr[cml_pvr < 0] = 0.
             start_indx= numpy.amax(numpy.arange(len(cml_pvr))[cml_pvr == numpy.amin(cml_pvr)])
             end_indx= numpy.amin(numpy.arange(len(cml_pvr))[cml_pvr == numpy.amax(cml_pvr)])+1

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -415,9 +415,11 @@ class sphericaldf(df):
         icdf_v_vesc_grid_reg = numpy.zeros((n_new_pvr,len(r_a_values)))
         for i in range(pvr_grid_cml_norm.shape[1]):
             cml_pvr = pvr_grid_cml_norm[:,i]
+            cml_pvr[cml_pvr < 0] = 0.
+            start_indx= numpy.amax(numpy.arange(len(cml_pvr))[cml_pvr == numpy.amin(cml_pvr)])
             end_indx= numpy.amin(numpy.arange(len(cml_pvr))[cml_pvr == numpy.amax(cml_pvr)])+1
-            cml_pvr_inv_interp = scipy.interpolate.InterpolatedUnivariateSpline(cml_pvr[:end_indx], 
-                v_vesc_values[:end_indx],k=3)
+            cml_pvr_inv_interp = scipy.interpolate.InterpolatedUnivariateSpline(
+                cml_pvr[start_indx:end_indx], v_vesc_values[start_indx:end_indx],k=3)
             pvr_samples_reg = numpy.linspace(0,1,n_new_pvr)
             v_vesc_samples_reg = cml_pvr_inv_interp(pvr_samples_reg)
             icdf_pvr_grid_reg[:,i] = pvr_samples_reg

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -438,7 +438,7 @@ def test_king_beta_directint():
                          rmin=dfk._scale/10.,rmax=dfk.rt*0.7,bins=31)
     return None
 
-################################ TESTS OF ERRORS###############################
+########################### TESTS OF ERRORS AND WARNINGS#######################
 
 def test_isotropic_hernquist_nopot():
     with pytest.raises(AssertionError)  as excinfo:
@@ -466,6 +466,18 @@ def test_anisotropic_hernquist_wrongpot():
     assert str(excinfo.value) == 'pot= must be potential.HernquistPotential', 'Error message when not supplying the potential is incorrect'
     return None
 
+def test_anisotropic_hernquist_negdf():
+    pot= potential.HernquistPotential(amp=2.3,a=1.3)
+    # beta > 0.5 has negative DF parts
+    dfh= constantbetaHernquistdf(pot=pot,beta=0.7)
+    with pytest.warns(None) as record:
+        samp= dfh.sample(n=100)
+    raisedWarning= False
+    for rec in record:
+        # check that the message matches
+        raisedWarning+= (str(rec.message.args[0]) == "The DF appears to have negative regions; we'll try to ignore these for sampling the DF, but this may adversely affect the generated samples. Proceed with care!")
+    assert raisedWarning, "Using an anisotropic Hernquist DF that has negative parts should have raised a warning, but didn't"
+    
 ############################# TESTS OF UNIT HANDLING###########################
 
 # Test that setting up a DF with unit conversion parameters that are


### PR DESCRIPTION
Uses start_indx to set minimum value of cml_pvr used to make 1D cumulative p(v|r) -> v_vesc interpolators. Ensures when the DF is negative or 0 for a non-zero v_vesc that the interpolator can properly initialize and be used to sample v_vesc.