### PR TITLE
Update TwoPowerSphericalPotential.py

### DIFF
--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -191,6 +191,39 @@ class TwoPowerSphericalPotential(Potential):
         r= numpy.sqrt(R**2.+z**2.)
         return (self.a/r)**self.alpha/(1.+r/self.a)**(self.beta-self.alpha)/4./numpy.pi/self.a**3.
 
+    def _R2deriv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _R2deriv
+        PURPOSE:
+           evaluate the second cylindrically radial derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t- time
+        OUTPUT:
+           the second cylindrically radial derivative
+        HISTORY:
+           2020-11-23 - Written - Beane (CfA)
+        """
+        r = numpy.sqrt(R**2.+z**2.)
+        A = self.a**(self.alpha-3.)/(3.-self.alpha)
+        hyper = special.hyp2f1(3.-self.alpha,
+                                self.beta-self.alpha,
+                                4.-self.alpha,
+                                -r/self.a)
+        hyper_deriv = (3.-self.alpha) * (self.beta - self.alpha) / (4.-self.alpha) \
+               * special.hyp2f1(4.-self.alpha,
+                                1.+self.beta-self.alpha,
+                                5.-self.alpha,
+                                -r/self.a)
+        
+        term1 = A * r**(-self.alpha) * hyper
+        term2 = -self.alpha * A * R**2. * r**(-self.alpha-2.) * hyper
+        term3 = -A * R**2 * r**(-self.alpha-1.) / self.a * hyper_deriv
+        return term1 + term2 + term3
+
     def _z2deriv(self,R,z,phi=0.,t=0.):
         """
         NAME:

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2650,22 +2650,24 @@ def test_orbit_interface_staeckel_PotentialErrors():
     from galpy.potential import PotentialError
     from galpy.orbit import Orbit
     obs= Orbit([1.05, 0.02, 1.05, 0.03,0.,2.])
-    # Currently doesn't have second derivs
-    tp= TwoPowerSphericalPotential(normalize=1.,alpha=1.2,beta=2.5)
+    # Version of TwoPowerSphericalPotential that does not have R2deriv
+    class TwoPowerSphericalPotentialNoR2deriv(TwoPowerSphericalPotential):
+        _R2deriv= property() # turns it off!
+    tp= TwoPowerSphericalPotentialNoR2deriv(normalize=1.,alpha=1.2,beta=2.5)
     # Check that this potential indeed does not have second derivs
     with pytest.raises(PotentialError) as excinfo:
         dummy= tp.R2deriv(1.,0.1)
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('TwoPowerSphericalPotentialNoR2deriv appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     # Now check that estimating delta fails
     with pytest.raises(PotentialError) as excinfo:
         obs.jr(pot=tp,type='staeckel')
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('TwoPowerSphericalPotentialNoR2deriv appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     assert 'second derivatives' in str(excinfo.value), 'Estimating delta for potential lacking second derivatives should have failed with a message about the lack of second derivatives'
     # Generic non-axi
     sp= SpiralArmsPotential()
     with pytest.raises(PotentialError) as excinfo:
         obs.jr(pot=sp,type='staeckel')
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('TwoPowerSphericalPotentialNoR2deriv appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     assert 'not axisymmetric' in str(excinfo.value), 'Estimating delta for a non-axi potential should have failed with a message about the fact that the potential is non-axisymmetric'
     return None
 
@@ -2676,22 +2678,24 @@ def test_orbits_interface_staeckel_PotentialErrors():
     from galpy.orbit import Orbit
     obs= Orbit([[1.05, 0.02, 1.05, 0.03,0.,2.],
                 [1.15, -0.02, 1.02, -0.03,0.,2.]])
-    # Currently doesn't have second derivs
-    tp= TwoPowerSphericalPotential(normalize=1.,alpha=1.2,beta=2.5)
+    # Version of TwoPowerSphericalPotential that does not have R2deriv
+    class TwoPowerSphericalPotentialNoR2deriv(TwoPowerSphericalPotential):
+        _R2deriv= property() # turns it off!
+    tp= TwoPowerSphericalPotentialNoR2deriv(normalize=1.,alpha=1.2,beta=2.5)
     # Check that this potential indeed does not have second derivs
     with pytest.raises(PotentialError) as excinfo:
         dummy= tp.R2deriv(1.,0.1)
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('TwoPowerSphericalPotentialNoR2deriv appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     # Now check that estimating delta fails
     with pytest.raises(PotentialError) as excinfo:
         obs.jr(pot=tp,type='staeckel')
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('TwoPowerSphericalPotentialNoR2deriv appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     assert 'second derivatives' in str(excinfo.value), 'Estimating delta for potential lacking second derivatives should have failed with a message about the lack of second derivatives'
     # Generic non-axi
     sp= SpiralArmsPotential()
     with pytest.raises(PotentialError) as excinfo:
         obs.jr(pot=sp,type='staeckel')
-        pytest.fail('TwoPowerSphericalPotential appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
+        pytest.fail('SpiralArms appears to now have second derivatives, means that it cannot be used to test exceptions based on not having the second derivatives any longer')
     assert 'not axisymmetric' in str(excinfo.value), 'Estimating delta for a non-axi potential should have failed with a message about the fact that the potential is non-axisymmetric'
     return None
 


### PR DESCRIPTION
Adds R2 deriv function for TwoPowerSphericalPotential

I tested against the Rforce function using some numerical derivatives, test suite should work. sample code below:

```
from galpy.potential import TwoPowerSphericalPotential
pot = TwoPowerSphericalPotential() 
assert (pot.R2deriv(1, 0.5) + (pot.Rforce(1+1E-8, 0.5) - pot.Rforce(1-1E-8, 0.5)) / 2E-8 ) < 1E-8
assert (pot.R2deriv(3, 0) + (pot.Rforce(3+1E-8, 0) - pot.Rforce(3-1E-8, 0)) / 2E-8 ) < 1E-8 
```