### PR TITLE
Including a wrapper to allow the z-axis vector of a potential to be adjusted (e.g. inclined discs, tilted bar)

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -58,10 +58,18 @@ v1.7 (XXXX-XX-XX)
 - Added AnySphericalPotential, the potential of an arbitrary spherical
   density distribution.
 
+- Added RotateAndTiltWrapperPotential, a wrapper potential to
+  re-orient a potential arbitrarily in three dimensions using three
+  angles.
+
 - Updated the definition of a Potential's mass to always return the
   mass within a spherical shell if only one argument is
   specified. Also implemented faster implementations of the masses of
   SCF and diskSCF potentials.
+
+- Added mixed azimuthal,vertical second derivative for all
+  non-axisymmetric potentials: potential function evaluatephizderivs
+  and Potential method phizderiv.
 
 - Added inverse action-angle transformations for the isochrone
   potential (actionAngleIsochroneInverse) and for a one-dimensional

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -577,4 +577,4 @@ Specific wrappers
    potentialdehnensmoothwrapper.rst
    potentialgaussampwrapper.rst
    potentialsolidbodyrotationwrapper.rst
-
+   potentialrotateandtiltwrapper.rst

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -26,6 +26,7 @@ Use as ``Potential-instance.method(...)``
    nemo_accpars <potentialnemoaccpars.rst>
    omegac <potentialomegac.rst>
    phiforce <potentialphiforce.rst>
+   phizderiv <potentialphizderiv.rst>
    phi2deriv <potentialphi2deriv.rst>
    plot <potentialplot.rst>
    plotDensity <potentialplotdensity.rst>
@@ -81,6 +82,7 @@ Use as ``method(...)``
    evaluateDensities <potentialdensities.rst>
    evaluatephiforces <potentialphiforces.rst>
    evaluatePotentials <potentialevaluate.rst>
+   evaluatephizderivs <potentialphizderivs.rst>
    evaluatephi2derivs <potentialphi2derivs.rst>
    evaluateRphiderivs <potentialrphiderivs.rst>
    evaluateR2derivs <potentialr2derivs.rst>

--- a/doc/source/reference/potentialphizderiv.rst
+++ b/doc/source/reference/potentialphizderiv.rst
@@ -1,0 +1,6 @@
+galpy.potential.Potential.phizderiv
+=====================================
+
+.. automethod:: galpy.potential.Potential.phizderiv
+
+

--- a/doc/source/reference/potentialphizderivs.rst
+++ b/doc/source/reference/potentialphizderivs.rst
@@ -1,0 +1,5 @@
+galpy.potential.evaluatephizderivs
+======================================
+
+.. autofunction:: galpy.potential.evaluatephizderivs
+

--- a/doc/source/reference/potentialrotateandtiltwrapper.rst
+++ b/doc/source/reference/potentialrotateandtiltwrapper.rst
@@ -1,0 +1,5 @@
+Rotate-and-tilt wrapper potential
+=====================================
+
+.. autoclass:: galpy.potential.RotateAndTiltWrapperPotential
+   :members: __init__

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -294,6 +294,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_type.extend(wrap_pot_type)
             pot_args.extend(wrap_pot_args)
             pot_args.extend([p._amp])
+            pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -284,7 +284,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
                              p._minr**2.])
             pot_args.extend([p._sigmar_rs_4interp[0],
                              p._sigmar_rs_4interp[-1]]) #r_0, r_f
-        elif isinstance(p,potential.zvecAdjustmentWrapperPotential):
+        elif isinstance(p,potential.RotateAndTiltWrapperPotential):
             pot_type.append(-8)
             # Not sure how to easily avoid this duplication
             wrap_npot, wrap_pot_type, wrap_pot_args= \

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -284,6 +284,17 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
                              p._minr**2.])
             pot_args.extend([p._sigmar_rs_4interp[0],
                              p._sigmar_rs_4interp[-1]]) #r_0, r_f
+        elif isinstance(p,potential.zvecAdjustmentWrapperPotential):
+            pot_type.append(-8)
+            # Not sure how to easily avoid this duplication
+            wrap_npot, wrap_pot_type, wrap_pot_args= \
+                _parse_pot(p._pot,
+                           potforactions=potforactions,potfortorus=potfortorus)
+            pot_args.append(wrap_npot)
+            pot_type.extend(wrap_pot_type)
+            pot_args.extend(wrap_pot_args)
+            pot_args.extend([p._amp])
+            pot_args.extend(list(p._rot.flatten()))
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')
     return (npot,pot_type,pot_args)
@@ -295,8 +306,8 @@ def _parse_scf_pot(p,extra_amp=1.):
     pot_args.extend(p._Acos.shape)
     pot_args.extend(extra_amp*p._amp*p._Acos.flatten(order='C'))
     if isNonAxi:
-        pot_args.extend(extra_amp*p._amp*p._Asin.flatten(order='C'))   
-    pot_args.extend([-1.,0,0,0,0,0,0])    
+        pot_args.extend(extra_amp*p._amp*p._Asin.flatten(order='C'))
+    pot_args.extend([-1.,0,0,0,0,0,0])
     return (24,pot_args)
 
 def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
@@ -329,7 +340,7 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
     rtol, atol= _parse_tol(rtol,atol)
     npot, pot_type, pot_args= _parse_pot(pot)
     int_method_c= _parse_integrator(int_method)
-    if dt is None: 
+    if dt is None:
         dt= -9999.99
 
     #Set up result array
@@ -341,7 +352,7 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
     integrationFunc= _lib.integrateFullOrbit
     integrationFunc.argtypes= [ctypes.c_int,
                                ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
-                               ctypes.c_int,                             
+                               ctypes.c_int,
                                ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
                                ctypes.c_int,
                                ndpointer(dtype=numpy.int32,flags=ndarrayFlags),
@@ -375,7 +386,7 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
                     result,
                     err,
                     ctypes.c_int(int_method_c))
-    
+
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")
 
@@ -421,7 +432,7 @@ def integrateFullOrbit_dxdv_c(pot,yo,dyo,t,int_method,rtol=None,atol=None): #pra
     ndarrayFlags= ('C_CONTIGUOUS','WRITEABLE')
     integrationFunc= _lib.integrateFullOrbit_dxdv
     integrationFunc.argtypes= [ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
-                               ctypes.c_int,                             
+                               ctypes.c_int,
                                ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
                                ctypes.c_int,
                                ndpointer(dtype=numpy.int32,flags=ndarrayFlags),
@@ -578,7 +589,7 @@ def _RZEOM(y,t,pot,l2):
     NAME:
        _RZEOM
     PURPOSE:
-       implements the EOM, i.e., the right-hand side of the differential 
+       implements the EOM, i.e., the right-hand side of the differential
        equation, for a 3D orbit assuming conservation of angular momentum
     INPUT:
        y - current phase-space position
@@ -600,7 +611,7 @@ def _EOM(y,t,pot):
     NAME:
        _EOM
     PURPOSE:
-       implements the EOM, i.e., the right-hand side of the differential 
+       implements the EOM, i.e., the right-hand side of the differential
        equation, for a 3D orbit
     INPUT:
        y - current phase-space position
@@ -650,4 +661,3 @@ def _rectForce(x,pot,t=0.):
     return numpy.array([cosphi*Rforce-1./R*sinphi*phiforce,
                      sinphi*Rforce+1./R*cosphi*phiforce,
                      _evaluatezforces(pot,R,x[2],phi=phi,t=t)])
-

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -322,9 +322,9 @@ def _parse_pot(pot):
             pot_args.extend([p._amp])
             pot_args.extend([p._orb.t[0],p._orb.t[-1]]) #t_0, t_f
         elif ((isinstance(p,planarPotentialFromFullPotential) or isinstance(p,planarPotentialFromRZPotential)) \
-              and isinstance(p._Pot,potential.zvecAdjustmentWrapperPotential)) \
-              or isinstance(p,potential.zvecAdjustmentWrapperPotential):
-            if not isinstance(p,potential.zvecAdjustmentWrapperPotential):
+              and isinstance(p._Pot,potential.RotateAndTiltWrapperPotential)) \
+              or isinstance(p,potential.RotateAndTiltWrapperPotential):
+            if not isinstance(p,potential.RotateAndTiltWrapperPotential):
                 p= p._Pot
             pot_type.append(-8)
             # wrap_pot_type, args, and npot obtained before this horrible if

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -323,18 +323,9 @@ def _parse_pot(pot):
             pot_args.extend([p._orb.t[0],p._orb.t[-1]]) #t_0, t_f
         elif ((isinstance(p,planarPotentialFromFullPotential) or isinstance(p,planarPotentialFromRZPotential)) \
               and isinstance(p._Pot,potential.RotateAndTiltWrapperPotential)) \
-              or isinstance(p,potential.RotateAndTiltWrapperPotential):
+              or isinstance(p,potential.RotateAndTiltWrapperPotential): # pragma: no cover
             raise NotImplementedError('Planar orbit integration in C for RotateAndTiltWrapperPotential not implemented; please integrate an orbit with (z,vz) = (0,0) instead')
-            if not isinstance(p,potential.RotateAndTiltWrapperPotential):
-                p= p._Pot
-            pot_type.append(-8)
-            # wrap_pot_type, args, and npot obtained before this horrible if
-            pot_args.append(wrap_npot)
-            pot_type.extend(wrap_pot_type)
-            pot_args.extend(wrap_pot_args)
-            pot_args.extend([p._amp])
-            pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
-            pot_args.extend(list(p._rot.flatten()))
+            # Note that potential.RotateAndTiltWrapperPotential would be -8
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')
     return (npot,pot_type,pot_args)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -324,6 +324,7 @@ def _parse_pot(pot):
         elif ((isinstance(p,planarPotentialFromFullPotential) or isinstance(p,planarPotentialFromRZPotential)) \
               and isinstance(p._Pot,potential.RotateAndTiltWrapperPotential)) \
               or isinstance(p,potential.RotateAndTiltWrapperPotential):
+            raise NotImplementedError('Planar orbit integration in C for RotateAndTiltWrapperPotential not implemented; please integrate an orbit with (z,vz) = (0,0) instead')
             if not isinstance(p,potential.RotateAndTiltWrapperPotential):
                 p= p._Pot
             pot_type.append(-8)
@@ -332,6 +333,7 @@ def _parse_pot(pot):
             pot_type.extend(wrap_pot_type)
             pot_args.extend(wrap_pot_args)
             pot_args.extend([p._amp])
+            pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -507,7 +507,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
-      potentialArgs->nargs= (int) 10;
+      potentialArgs->nargs= (int) 16;
       potentialArgs->requiresVelocity= false;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -184,7 +184,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->accx= gsl_interp_accel_alloc ();
       potentialArgs->accy= gsl_interp_accel_alloc ();
       for (kk=0; kk < nR; kk++)
-	put_row(potGrid_splinecoeffs,kk,*pot_args+kk*nz,nz); 
+	put_row(potGrid_splinecoeffs,kk,*pot_args+kk*nz,nz);
       *pot_args+= nR*nz;
       potentialArgs->i2drforce= interp_2d_alloc(nR,nz);
       interp_2d_init(potentialArgs->i2drforce,Rgrid,zgrid,potGrid_splinecoeffs,
@@ -192,8 +192,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->accxrforce= gsl_interp_accel_alloc ();
       potentialArgs->accyrforce= gsl_interp_accel_alloc ();
       for (kk=0; kk < nR; kk++)
-	put_row(potGrid_splinecoeffs,kk,*pot_args+kk*nz,nz); 
-      *pot_args+= nR*nz;    
+	put_row(potGrid_splinecoeffs,kk,*pot_args+kk*nz,nz);
+      *pot_args+= nR*nz;
       potentialArgs->i2dzforce= interp_2d_alloc(nR,nz);
       interp_2d_init(potentialArgs->i2dzforce,Rgrid,zgrid,potGrid_splinecoeffs,
 		     INTERP_2D_LINEAR); //latter bc we already calculated the coeffs
@@ -287,7 +287,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->psi= &TriaxialHernquistPotentialpsi;
       potentialArgs->mdens= &TriaxialHernquistPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialHernquistPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
@@ -301,7 +301,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->psi= &TriaxialNFWPotentialpsi;
       potentialArgs->mdens= &TriaxialNFWPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialNFWPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
@@ -315,7 +315,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->psi= &TriaxialJaffePotentialpsi;
       potentialArgs->mdens= &TriaxialJaffePotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialJaffePotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
@@ -335,7 +335,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->phiforce= &SoftenedNeedleBarPotentialphiforce;
       potentialArgs->nargs= (int) 13;
       potentialArgs->requiresVelocity= false;
-      break;      
+      break;
     case 26: //DiskSCFPotential, nsigma+3 arguments
       potentialArgs->potentialEval= &DiskSCFPotentialEval;
       potentialArgs->Rforce= &DiskSCFPotentialRforce;
@@ -356,7 +356,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rphideriv = &SpiralArmsPotentialRphideriv;
       potentialArgs->nargs = (int) 10 + **pot_args;
       potentialArgs->requiresVelocity= false;
-      break;    
+      break;
     case 30: // PerfectEllipsoidPotential, lots of arguments
       potentialArgs->potentialEval= &EllipsoidalPotentialEval;
       potentialArgs->Rforce = &EllipsoidalPotentialRforce;
@@ -372,7 +372,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->psi= &PerfectEllipsoidPotentialpsi;
       potentialArgs->mdens= &PerfectEllipsoidPotentialmdens;
       potentialArgs->mdensDeriv= &PerfectEllipsoidPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
@@ -454,7 +454,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->psi= &TriaxialGaussianPotentialpsi;
       potentialArgs->mdens= &TriaxialGaussianPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialGaussianPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
@@ -503,6 +503,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->nargs= (int) 16;
       potentialArgs->requiresVelocity= true;
       break;
+    case -8: //zvecAdjustmentWrapperPotential
+      potentialArgs->Rforce= &zvecAdjustmentWrapperPotentialRforce;
+      potentialArgs->zforce= &zvecAdjustmentWrapperPotentialzforce;
+      potentialArgs->phiforce= &zvecAdjustmentWrapperPotentialphiforce;
+      potentialArgs->nargs= (int) 2;
+      potentialArgs->requiresVelocity= false;
+      break;
     }
     int setupMovingObjectSplines = *(*pot_type-1) == -6 ? 1 : 0;
     int setupChandrasekharDynamicalFrictionSplines = *(*pot_type-1) == -7 ? 1 : 0;
@@ -531,7 +538,7 @@ void parse_leapFuncArgs_Full(int npot,
 }
 EXPORT void integrateFullOrbit(int nobj,
 			       double *yo,
-			       int nt, 
+			       int nt,
 			       double *t,
 			       int npot,
 			       int * pot_type,
@@ -551,7 +558,7 @@ EXPORT void integrateFullOrbit(int nobj,
   max_threads= ( nobj < omp_get_max_threads() ) ? nobj : omp_get_max_threads();
   // Because potentialArgs may cache, safest to have one / thread
   struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( max_threads * npot * sizeof (struct potentialArg) );
-#pragma omp parallel for schedule(static,1) private(ii,thread_pot_type,thread_pot_args) num_threads(max_threads) 
+#pragma omp parallel for schedule(static,1) private(ii,thread_pot_type,thread_pot_args) num_threads(max_threads)
   for (ii=0; ii < max_threads; ii++) {
     thread_pot_type= pot_type; // need to make thread-private pointers, bc
     thread_pot_args= pot_args; // these pointers are changed in parse_...
@@ -624,7 +631,7 @@ EXPORT void integrateFullOrbit(int nobj,
 }
 // LCOV_EXCL_START
 void integrateOrbit_dxdv(double *yo,
-			 int nt, 
+			 int nt,
 			 double *t,
 			 int npot,
 			 int * pot_type,

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -503,10 +503,10 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->nargs= (int) 16;
       potentialArgs->requiresVelocity= true;
       break;
-    case -8: //zvecAdjustmentWrapperPotential
-      potentialArgs->Rforce= &zvecAdjustmentWrapperPotentialRforce;
-      potentialArgs->zforce= &zvecAdjustmentWrapperPotentialzforce;
-      potentialArgs->phiforce= &zvecAdjustmentWrapperPotentialphiforce;
+    case -8: //RotateAndTiltWrapperPotential
+      potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
+      potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
+      potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
       potentialArgs->nargs= (int) 2;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -507,7 +507,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
-      potentialArgs->nargs= (int) 2;
+      potentialArgs->nargs= (int) 10;
       potentialArgs->requiresVelocity= false;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -424,11 +424,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarphiforce= &MovingObjectPotentialPlanarphiforce;
       potentialArgs->nargs= (int) 3;
       break;
-    case -8: //RotateAndTiltWrapperPotential
-      potentialArgs->planarRforce= &RotateAndTiltWrapperPotentialPlanarRforce;
-      potentialArgs->planarphiforce= &RotateAndTiltWrapperPotentialPlanarphiforce;
-      potentialArgs->nargs= (int) 16;
-      break;
+    //RotateAndTiltWrapperPotential omitted, bc no planar version
     }
     int setupSplines = *(*pot_type-1) == -6 ? 1 : 0;
     if ( *(*pot_type-1) < 0) { // Parse wrapped potential for wrappers

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -424,10 +424,10 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarphiforce= &MovingObjectPotentialPlanarphiforce;
       potentialArgs->nargs= (int) 3;
       break;
-		case -8: //RotateAndTiltWrapperPotential
+    case -8: //RotateAndTiltWrapperPotential
       potentialArgs->planarRforce= &RotateAndTiltWrapperPotentialPlanarRforce;
       potentialArgs->planarphiforce= &RotateAndTiltWrapperPotentialPlanarphiforce;
-      potentialArgs->nargs= (int) 10;
+      potentialArgs->nargs= (int) 16;
       break;
     }
     int setupSplines = *(*pot_type-1) == -6 ? 1 : 0;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -424,12 +424,12 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarphiforce= &MovingObjectPotentialPlanarphiforce;
       potentialArgs->nargs= (int) 3;
       break;
-		case -8: //zvecAdjustmentWrapperPotential
-      potentialArgs->planarRforce= &zvecAdjustmentWrapperPotentialPlanarRforce;
-      potentialArgs->planarphiforce= &zvecAdjustmentWrapperPotentialPlanarphiforce;
-      potentialArgs->planarR2deriv= &zvecAdjustmentWrapperPotentialPlanarR2deriv;
-      potentialArgs->planarphi2deriv= &zvecAdjustmentWrapperPotentialPlanarphi2deriv;
-      potentialArgs->planarRphideriv= &zvecAdjustmentWrapperPotentialPlanarRphideriv;
+		case -8: //RotateAndTiltWrapperPotential
+      potentialArgs->planarRforce= &RotateAndTiltWrapperPotentialPlanarRforce;
+      potentialArgs->planarphiforce= &RotateAndTiltWrapperPotentialPlanarphiforce;
+      potentialArgs->planarR2deriv= &RotateAndTiltWrapperPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &RotateAndTiltWrapperPotentialPlanarphi2deriv;
+      potentialArgs->planarRphideriv= &RotateAndTiltWrapperPotentialPlanarRphideriv;
       potentialArgs->nargs= (int) 2;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -228,9 +228,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->psi= &TriaxialHernquistPotentialpsi;
       potentialArgs->mdens= &TriaxialHernquistPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialHernquistPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
-      break;    
+      break;
     case 22: // TriaxialNFWPotential, lots of arguments
       potentialArgs->planarRforce = &EllipsoidalPotentialPlanarRforce;
       potentialArgs->planarphiforce = &EllipsoidalPotentialPlanarphiforce;
@@ -241,9 +241,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->psi= &TriaxialNFWPotentialpsi;
       potentialArgs->mdens= &TriaxialNFWPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialNFWPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
-      break;    
+      break;
     case 23: // TriaxialJaffePotential, lots of arguments
       potentialArgs->planarRforce = &EllipsoidalPotentialPlanarRforce;
       potentialArgs->planarphiforce = &EllipsoidalPotentialPlanarphiforce;
@@ -254,9 +254,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->psi= &TriaxialJaffePotentialpsi;
       potentialArgs->mdens= &TriaxialJaffePotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialJaffePotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
-      break;    
+      break;
     case 24: //SCFPotential, many arguments
       potentialArgs->potentialEval= &SCFPotentialEval;
       potentialArgs->planarRforce= &SCFPotentialPlanarRforce;
@@ -271,7 +271,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarRforce= &SoftenedNeedleBarPotentialPlanarRforce;
       potentialArgs->planarphiforce= &SoftenedNeedleBarPotentialPlanarphiforce;
       potentialArgs->nargs= (int) 13;
-      break;    
+      break;
     case 26: //DiskSCFPotential, nsigma+3 arguments
       potentialArgs->potentialEval= &DiskSCFPotentialEval;
       potentialArgs->planarRforce= &DiskSCFPotentialPlanarRforce;
@@ -312,7 +312,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->psi= &PerfectEllipsoidPotentialpsi;
       potentialArgs->mdens= &PerfectEllipsoidPotentialmdens;
       potentialArgs->mdensDeriv= &PerfectEllipsoidPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       break;
     // 31: KGPotential
@@ -382,7 +382,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->psi= &TriaxialGaussianPotentialpsi;
       potentialArgs->mdens= &TriaxialGaussianPotentialmdens;
       potentialArgs->mdensDeriv= &TriaxialGaussianPotentialmdensDeriv;
-      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args 
+      potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       break;
 //////////////////////////////// WRAPPERS /////////////////////////////////////
@@ -424,6 +424,14 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarphiforce= &MovingObjectPotentialPlanarphiforce;
       potentialArgs->nargs= (int) 3;
       break;
+		case -8: //zvecAdjustmentWrapperPotential
+      potentialArgs->planarRforce= &zvecAdjustmentWrapperPotentialPlanarRforce;
+      potentialArgs->planarphiforce= &zvecAdjustmentWrapperPotentialPlanarphiforce;
+      potentialArgs->planarR2deriv= &zvecAdjustmentWrapperPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &zvecAdjustmentWrapperPotentialPlanarphi2deriv;
+      potentialArgs->planarRphideriv= &zvecAdjustmentWrapperPotentialPlanarRphideriv;
+      potentialArgs->nargs= (int) 2;
+      break;
     }
     int setupSplines = *(*pot_type-1) == -6 ? 1 : 0;
     if ( *(*pot_type-1) < 0) { // Parse wrapped potential for wrappers
@@ -448,7 +456,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
 }
 EXPORT void integratePlanarOrbit(int nobj,
 				 double *yo,
-				 int nt, 
+				 int nt,
 				 double *t,
 				 int npot,
 				 int * pot_type,
@@ -468,7 +476,7 @@ EXPORT void integratePlanarOrbit(int nobj,
   max_threads= ( nobj < omp_get_max_threads() ) ? nobj : omp_get_max_threads();
   // Because potentialArgs may cache, safest to have one / thread
   struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( max_threads * npot * sizeof (struct potentialArg) );
-#pragma omp parallel for schedule(static,1) private(ii,thread_pot_type,thread_pot_args) num_threads(max_threads) 
+#pragma omp parallel for schedule(static,1) private(ii,thread_pot_type,thread_pot_args) num_threads(max_threads)
   for (ii=0; ii < max_threads; ii++) {
     thread_pot_type= pot_type; // need to make thread-private pointers, bc
     thread_pot_args= pot_args; // these pointers are changed in parse_...
@@ -541,7 +549,7 @@ EXPORT void integratePlanarOrbit(int nobj,
 }
 
 EXPORT void integratePlanarOrbit_dxdv(double *yo,
-				      int nt, 
+				      int nt,
 				      double *t,
 				      int npot,
 				      int * pot_type,

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -427,10 +427,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
 		case -8: //RotateAndTiltWrapperPotential
       potentialArgs->planarRforce= &RotateAndTiltWrapperPotentialPlanarRforce;
       potentialArgs->planarphiforce= &RotateAndTiltWrapperPotentialPlanarphiforce;
-      potentialArgs->planarR2deriv= &RotateAndTiltWrapperPotentialPlanarR2deriv;
-      potentialArgs->planarphi2deriv= &RotateAndTiltWrapperPotentialPlanarphi2deriv;
-      potentialArgs->planarRphideriv= &RotateAndTiltWrapperPotentialPlanarRphideriv;
-      potentialArgs->nargs= (int) 2;
+      potentialArgs->nargs= (int) 10;
       break;
     }
     int setupSplines = *(*pot_type-1) == -6 ? 1 : 0;

--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -468,6 +468,48 @@ class DehnenBarPotential(Potential):
                                                       self._barphi))\
                         *(self._rb/r)**3.*R*z/r**6.*(2.*r**2.-7.*R**2.)
 
+    def _phizderiv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _phizderiv
+        PURPOSE:
+           evaluate the mixed azimuthal, vertical derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the mixed azimuthal, vertical derivative
+        HISTORY:
+           2021-04-30 - Written - Bovy (UofT)
+        """
+        #Calculate relevant time
+        smooth=self._smooth(t)
+        r= numpy.sqrt(R**2.+z**2.)
+        if isinstance(r,numpy.ndarray):
+            if not isinstance(R,numpy.ndarray):
+                R=numpy.repeat(R,len(r))
+            if not isinstance(z,numpy.ndarray):
+                z=numpy.repeat(z,len(r))
+            out=numpy.empty(len(r))
+            indx= r <= self._rb  
+            out[indx]= -((r[indx]/self._rb)**3.+4.)*R[indx]**2.*z[indx]/r[indx]**4.
+            indx=numpy.invert(indx)
+            out[indx]= -5.*(self._rb/r[indx])**3.*R[indx]**2.*z[indx]/r[indx]**4.
+
+            out*=self._af*smooth*numpy.sin(2.*(phi-self._omegab*t-self._barphi))
+            return 2.*out
+        else:
+            if r <= self._rb:
+                return -2*self._af*smooth*numpy.sin(2.*(phi-self._omegab*t
+                                                      -self._barphi))\
+                       *((r/self._rb)**3.+4.)*R**2.*z/r**4.
+            else:
+                return -10.*self._af*smooth*numpy.sin(2.*(phi-self._omegab*t-
+                                                      self._barphi))\
+                                *(self._rb/r)**3.*R**2.*z/r**4.
+
     def tform(self): #pragma: no cover
         """
         NAME:

--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -316,7 +316,7 @@ class EllipsoidalPotential(Potential):
             phi= 0.
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if not self._aligned:
-            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa)")
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa); use RotateAndTiltWrapperPotential for this functionality instead")
         phixx= self._2ndderiv_xyz(x,y,z,0,0)
         phixy= self._2ndderiv_xyz(x,y,z,0,1)
         phiyy= self._2ndderiv_xyz(x,y,z,1,1)
@@ -344,7 +344,7 @@ class EllipsoidalPotential(Potential):
             phi= 0.
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if not self._aligned:
-            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa)")
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa; use RotateAndTiltWrapperPotential for this functionality instead)")
         phixz= self._2ndderiv_xyz(x,y,z,0,2)
         phiyz= self._2ndderiv_xyz(x,y,z,1,2)
         return numpy.cos(phi)*phixz+numpy.sin(phi)*phiyz
@@ -370,7 +370,7 @@ class EllipsoidalPotential(Potential):
             phi= 0.
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if not self._aligned:
-            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa)")
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa; use RotateAndTiltWrapperPotential for this functionality instead)")
         return self._2ndderiv_xyz(x,y,z,2,2)
 
     @check_potential_inputs_not_arrays
@@ -394,7 +394,7 @@ class EllipsoidalPotential(Potential):
             phi= 0.
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if not self._aligned:
-            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa)")
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa; use RotateAndTiltWrapperPotential for this functionality instead)")
         Fx= self._force_xyz(x,y,z,0)
         Fy= self._force_xyz(x,y,z,1)
         phixx= self._2ndderiv_xyz(x,y,z,0,0)
@@ -425,7 +425,7 @@ class EllipsoidalPotential(Potential):
             phi= 0.
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if not self._aligned:
-            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa)")
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa; use RotateAndTiltWrapperPotential for this functionality instead)")
         Fx= self._force_xyz(x,y,z,0)
         Fy= self._force_xyz(x,y,z,1)
         phixx= self._2ndderiv_xyz(x,y,z,0,0)
@@ -434,6 +434,32 @@ class EllipsoidalPotential(Potential):
         return R*numpy.cos(phi)*numpy.sin(phi)*\
             (phiyy-phixx)+R*numpy.cos(2.*phi)*phixy\
             +numpy.sin(phi)*Fx-numpy.cos(phi)*Fy
+
+    @check_potential_inputs_not_arrays
+    def _phizderiv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _phizderiv
+        PURPOSE:
+           evaluate the mixed azimuthal, vertical derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the mixed radial, azimuthal derivative
+        HISTORY:
+           2021-04-30 - Written - Bovy (UofT)
+        """
+        if not self.isNonAxi:
+            phi= 0.
+        x,y,z= coords.cyl_to_rect(R,phi,z)
+        if not self._aligned:
+            raise NotImplementedError("2nd potential derivatives of TwoPowerTriaxialPotential not implemented for rotated coordinated frames (non-trivial zvec and pa; use RotateAndTiltWrapperPotential for this functionality instead)")
+        phixz= self._2ndderiv_xyz(x,y,z,0,2)
+        phiyz= self._2ndderiv_xyz(x,y,z,1,2)
+        return R*(numpy.cos(phi)*phiyz-numpy.sin(phi)*phixz)
 
     def _2ndderiv_xyz(self,x,y,z,i,j):
         """General 2nd derivative of the potential as a function of (x,y,z)

--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -358,6 +358,31 @@ class FerrersPotential(Potential):
             (phiyy-phixx)+R*numpy.cos(2.*(phi))*phixy\
             +numpy.sin(phi)*Fx-numpy.cos(phi)*Fy
 
+    def _phizderiv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _phizderiv
+        PURPOSE:
+           evaluate the mixed azimuthal, vertical derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the mixed azimuthal, vertical derivative
+        HISTORY:
+           2021-04-30 - Written - Bovy (UofT)
+        """
+        if not self.isNonAxi:
+            phi= 0.
+        x,y,z= self._compute_xyz(R,phi,z,t)
+        phixza= self._2ndderiv_xyz(x,y,z,0,2)
+        phiyza= self._2ndderiv_xyz(x,y,z,1,2)
+        phixz, phiyz= numpy.dot(self.rot(t,transposed=True),
+                                numpy.array([phixza,phiyza]))
+        return R*(numpy.cos(phi)*phiyz-numpy.sin(phi)*phixz)
+
     def _2ndderiv_xyz(self,x,y,z,i,j):
         """General 2nd derivative of the potential as a function of (x,y,z)
         in the aligned coordinate frame, d^2\Phi/dx_i/dx_j"""

--- a/galpy/potential/LogarithmicHaloPotential.py
+++ b/galpy/potential/LogarithmicHaloPotential.py
@@ -312,6 +312,30 @@ class LogarithmicHaloPotential(Potential):
         else:
             return 0.
 
+    def _phizderiv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _phizderiv
+        PURPOSE:
+           evaluate the mixed phi,z derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           d2Phi/dz/dphi
+        HISTORY:
+           2021-04-30 - Written - Bovy (UofT)
+        """
+        if self.isNonAxi:
+            Rt2= R**2.*(1.-self._1m1overb2*numpy.sin(phi)**2.)
+            denom= 1./(Rt2+(z/self._q)**2.+self._core2)
+            return 2*R**2*z*numpy.sin(phi)*numpy.cos(phi)*self._1m1overb2\
+                *denom**2/self._q**2
+        else:
+            return 0.
+
     @kms_to_kpcGyrDecorator
     def _nemo_accpars(self,vo,ro):
         """

--- a/galpy/potential/NumericalPotentialDerivativesMixin.py
+++ b/galpy/potential/NumericalPotentialDerivativesMixin.py
@@ -119,3 +119,18 @@ class NumericalPotentialDerivativesMixin(object):
                    +0.5*self._evaluate(Rplus2dR,z,phi=phiminusdphi,t=t))\
                    /dR/dphi
 
+    def _phizderiv(self,R,z,phi=0.,t=0.):
+        if not self.isNonAxi: return 0.
+        # Central derivative
+        phiplusdphi= phi+self._dphi2
+        phiminusdphi= phi-self._dphi2
+        dphi= (phiplusdphi-phiminusdphi)/2.
+        zplusdz= z+self._dz2
+        zminusdz= z-self._dz2
+        dz= zplusdz-zminusdz
+        return (self._evaluate(R,zplusdz,phi=phiplusdphi,t=t)
+                -self._evaluate(R,zplusdz,phi=phiminusdphi,t=t)
+                -self._evaluate(R,zminusdz,phi=phiplusdphi,t=t)
+                +self._evaluate(R,zminusdz,phi=phiminusdphi,t=t))\
+                /dz/dphi/2.
+    

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -709,7 +709,7 @@ class Potential(Force):
             return 0.
 
     @potential_physical_input
-    @physical_conversion('forcederivative',pop=True)
+    @physical_conversion('energy',pop=True)
     def phi2deriv(self,R,Z,phi=0.,t=0.):
         """
         NAME:
@@ -747,7 +747,7 @@ class Potential(Force):
             return 0.
 
     @potential_physical_input
-    @physical_conversion('forcederivative',pop=True)
+    @physical_conversion('force',pop=True)
     def Rphideriv(self,R,Z,phi=0.,t=0.):
         """
         NAME:
@@ -785,7 +785,7 @@ class Potential(Force):
             return 0.
 
     @potential_physical_input
-    @physical_conversion('forcederivative',pop=True)
+    @physical_conversion('force',pop=True)
     def phizderiv(self,R,Z,phi=0.,t=0.):
         """
         NAME:
@@ -2406,7 +2406,7 @@ def evaluateRzderivs(Pot,R,z,phi=None,t=0.):
         raise PotentialError("Input to 'evaluateRzderivs' is neither a Potential-instance or a list of such instances")
 
 @potential_physical_input
-@physical_conversion('forcederivative',pop=True)
+@physical_conversion('energy',pop=True)
 def evaluatephi2derivs(Pot,R,z,phi=None,t=0.):
     """
     NAME:
@@ -2454,7 +2454,7 @@ def evaluatephi2derivs(Pot,R,z,phi=None,t=0.):
         raise PotentialError("Input to 'evaluatephi2derivs' is neither a Potential-instance or a list of such instances")
 
 @potential_physical_input
-@physical_conversion('forcederivative',pop=True)
+@physical_conversion('force',pop=True)
 def evaluateRphiderivs(Pot,R,z,phi=None,t=0.):
     """
     NAME:
@@ -2502,7 +2502,7 @@ def evaluateRphiderivs(Pot,R,z,phi=None,t=0.):
         raise PotentialError("Input to 'evaluateRphiderivs' is neither a Potential-instance or a list of such instances")
 
 @potential_physical_input
-@physical_conversion('forcederivative',pop=True)
+@physical_conversion('force',pop=True)
 def evaluatephizderivs(Pot,R,z,phi=None,t=0.):
     """
     NAME:

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -961,7 +961,7 @@ class Potential(Force):
                     rmin=0.,rmax=1.5,nrs=21,zmin=-0.5,zmax=0.5,nzs=21,
                     phi=None,xy=False,
                     ncontours=21,savefilename=None,aspect=None,log=False,
-                    justcontours=False):
+                    justcontours=False,**kwargs):
         """
         NAME:
 
@@ -1012,12 +1012,12 @@ class Potential(Force):
                              zmin=zmin,zmax=zmax,nzs=nzs,phi=phi,xy=xy,t=t,
                              ncontours=ncontours,savefilename=savefilename,
                              justcontours=justcontours,
-                             aspect=aspect,log=log)
+                             aspect=aspect,log=log,**kwargs)
 
     def plotSurfaceDensity(self,t=0.,z=numpy.inf,
                            xmin=0.,xmax=1.5,nxs=21,ymin=-0.5,ymax=0.5,nys=21,
                            ncontours=21,savefilename=None,aspect=None,
-                           log=False,justcontours=False):
+                           log=False,justcontours=False,**kwargs):
         """
         NAME:
 
@@ -1067,7 +1067,7 @@ class Potential(Force):
                                     ncontours=ncontours,
                                     savefilename=savefilename,
                                     justcontours=justcontours,
-                                    aspect=aspect,log=log)
+                                    aspect=aspect,log=log,**kwargs)
     
     @potential_physical_input
     @physical_conversion('velocity',pop=True)
@@ -2624,7 +2624,7 @@ def plotPotentials(Pot,rmin=0.,rmax=1.5,nrs=21,zmin=-0.5,zmax=0.5,nzs=21,
 def plotDensities(Pot,rmin=0.,rmax=1.5,nrs=21,zmin=-0.5,zmax=0.5,nzs=21,
                   phi=None,xy=False,t=0.,
                   ncontours=21,savefilename=None,aspect=None,log=False,
-                  justcontours=False):
+                  justcontours=False,**kwargs):
         """
         NAME:
 
@@ -2721,16 +2721,17 @@ def plotDensities(Pot,rmin=0.,rmax=1.5,nrs=21,zmin=-0.5,zmax=0.5,nzs=21,
                            aspect=aspect,
                            xrange=[rmin,rmax],
                            yrange=[zmin,zmax],
-                           cntrls='-',
+                           cntrls=kwargs.pop('cntrls','-'),
                            justcontours=justcontours,
                            levels=numpy.linspace(numpy.nanmin(potRz),numpy.nanmax(potRz),
-                                                 ncontours))
+                                                 ncontours),
+                           **kwargs)
 
 def plotSurfaceDensities(Pot,
                          xmin=-1.5,xmax=1.5,nxs=21,ymin=-1.5,ymax=1.5,nys=21,
                          z=numpy.inf,t=0.,
                          ncontours=21,savefilename=None,aspect=None,
-                         log=False,justcontours=False):
+                         log=False,justcontours=False,**kwargs):
         """
         NAME:
 
@@ -2820,11 +2821,12 @@ def plotSurfaceDensities(Pot,
                            aspect=aspect,
                            xrange=[xmin,xmax],
                            yrange=[ymin,ymax],
-                           cntrls='-',
+                           cntrls=kwargs.pop('cntrls','-'),
                            justcontours=justcontours,
                            levels=numpy.linspace(numpy.nanmin(surfxy),
                                                  numpy.nanmax(surfxy),
-                                                 ncontours))
+                                                 ncontours),
+                           **kwargs)
     
 @potential_physical_input
 @physical_conversion('frequency',pop=True)

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -327,6 +327,8 @@ class Potential(Force):
 
            2018-08-19 - Written - Bovy (UofT)
 
+           2021-04-19 - Adjusted for non-z-symmetric densities - Bovy (UofT)
+
         """
         try:
             if forcepoisson: raise AttributeError #Hack!
@@ -334,11 +336,12 @@ class Potential(Force):
         except AttributeError:
             #Use the Poisson equation to get the surface density
             return (-self.zforce(R,numpy.fabs(z),phi=phi,t=t,use_physical=False)
+                    +self.zforce(R,-numpy.fabs(z),phi=phi,t=t,use_physical=False)
                     +integrate.quad(\
                 lambda x: -self.Rforce(R,x,phi=phi,t=t,use_physical=False)/R
                 +self.R2deriv(R,x,phi=phi,t=t,use_physical=False)
                 +self.phi2deriv(R,x,phi=phi,t=t,use_physical=False)/R**2.,
-                0.,numpy.fabs(z))[0])/2./numpy.pi
+                -numpy.fabs(z),numpy.fabs(z))[0])/4./numpy.pi
 
     def _surfdens(self,R,z,phi=0.,t=0.):
         """
@@ -355,8 +358,10 @@ class Potential(Force):
            the surface density
         HISTORY:
            2018-08-19 - Written - Bovy (UofT)
+           2021-04-19 - Adjusted for non-z-symmetric densities - Bovy (UofT)
         """
-        return 2.*integrate.quad(lambda x: self._dens(R,x,phi=phi,t=t),0,z)[0]
+        return integrate.quad(lambda x: self._dens(R,x,phi=phi,t=t),
+                              -numpy.fabs(z),numpy.fabs(z))[0]
 
     @potential_physical_input
     @physical_conversion('mass',pop=True)

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -51,7 +51,7 @@ class RotateAndTiltWrapperPotential(parentWrapperPotential):
 
     def _parse_inclination(self,inclination,sky_pa,zvec,galaxy_pa):
         if inclination is None:
-            return zvec
+            return (zvec,galaxy_pa)
         if sky_pa is None:
             sky_pa= 0.
         zvec_rot= numpy.dot(\

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -95,13 +95,8 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         return None
 
     def __getattr__(self,attribute):
-        if attribute == '_R2deriv' or attribute == '_z2deriv' \
-           or attribute == '_Rzderiv' or attribute == '_phi2deriv' \
-           or attribute == '_Rphideriv':
-            raise AttributeError
-        else:
-            return super(RotateAndTiltWrapperPotential,self)\
-                .__getattr__(attribute)
+        return super(RotateAndTiltWrapperPotential,self)\
+            .__getattr__(attribute)
 
     @check_potential_inputs_not_arrays
     def _evaluate(self,R,z,phi=0.,t=0.):

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -1,5 +1,6 @@
 ###############################################################################
-#   RotateAndTiltWrapperPotential.py: Wrapper to tilt the z-axis of a potential
+#   RotateAndTiltWrapperPotential.py: Wrapper to rotate and tilt the z-axis
+#   of a potential
 ###############################################################################
 import numpy
 from .WrapperPotential import parentWrapperPotential
@@ -7,7 +8,9 @@ from ..util import conversion
 from ..util import _rotate_to_arbitrary_vector
 from ..util import coords
 class RotateAndTiltWrapperPotential(parentWrapperPotential):
-    """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
+    """ Potential wrapper class that implements an adjustment to the rotation
+        and z-axis vector (tilt) of a given Potential. This can be used,
+        for example, to tilt a disc to a desired inclination angle
     """
     def __init__(self,amp=1.,zvec=None,pa=None,pot=None,
                  ro=None,vo=None):
@@ -33,7 +36,8 @@ class RotateAndTiltWrapperPotential(parentWrapperPotential):
            2020-03-29 - Started - Mackereth (UofT)
 
         """
-        self._setup_zvec_pa(zvec)
+        self._setup_zvec_pa(zvec, pa)
+        self._inv_rot = numpy.linalg.inv(self._rot)
         self.hasC= True
         self.hasC_dxdv= True
         self.isNonAxi = True
@@ -70,3 +74,45 @@ class RotateAndTiltWrapperPotential(parentWrapperPotential):
         args = (R, z)
         kwargs['phi'] = phi
         return self._wrap_pot_func(attribute)(self._pot,*args,**kwargs)
+
+    def _force_xyz(self,*args,**kwargs):
+        """ get the rectangular forces in the transformed frame """
+        #first figure out the R,phi,z force in the aligned frame...
+        o_R,o_phi,o_z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
+        if o_phi is None:
+            o_phi = 0.
+        x,y,z= coords.cyl_to_rect(o_R, o_phi, o_z)
+        #apply rotation matrix
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        #back to R,phi,z
+        t_R, t_phi, t_z = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
+        args = (t_R, t_z)
+        kwargs['phi'] = t_phi
+        #get the forces
+        Rforce_a = self._wrap_pot_func('_Rforce')(self._pot,*args,**kwargs)
+        phiforce_a = self._wrap_pot_func('_phiforce')(self._pot,*args,**kwargs)
+        zforce_a = self._wrap_pot_func('_zforce')(self._pot,*args,**kwargs)
+        #get the forces in x,y
+        xforce_a = numpy.cos(t_phi)*Rforce_a - numpy.sin(t_phi)*phiforce_a
+        yforce_a = numpy.sin(t_phi)*Rforce_a + numpy.cos(t_phi)*phiforce_a
+        #rotate back
+        Fxyz = numpy.dot(self._inv_rot, numpy.array([xforce_a,yforce_a,zforce_a]))
+        return Fxyz
+
+    def _Rforce(self,*args,**kwargs):
+        Fxyz = self._force_xyz(*args,**kwargs)
+        o_R,o_phi,o_z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
+        if o_phi is None:
+            o_phi = 0.
+        return numpy.cos(o_phi)*Fxyz[0] + numpy.sin(o_phi)*Fxyz[1]
+
+    def _phiforce(self,*args,**kwargs):
+        Fxyz = self._force_xyz(*args,**kwargs)
+        o_R,o_phi,o_z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
+        if o_phi is None:
+            o_phi = 0.
+        return -numpy.sin(o_phi)*Fxyz[0] + numpy.cos(o_phi)*Fxyz[1]
+
+    def _zforce(self,*args,**kwargs):
+        Fxyz = self._force_xyz(*args,**kwargs)
+        return Fxyz[2]

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -9,7 +9,7 @@ from ..util import coords
 class RotateAndTiltWrapperPotential(parentWrapperPotential):
     """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
     """
-    def __init__(self,amp=1.,zvec=None,pot=None,
+    def __init__(self,amp=1.,zvec=None,pa=None,pot=None,
                  ro=None,vo=None):
         """
         NAME:
@@ -33,23 +33,28 @@ class RotateAndTiltWrapperPotential(parentWrapperPotential):
            2020-03-29 - Started - Mackereth (UofT)
 
         """
-        self._setup_zvec(zvec)
+        self._setup_zvec_pa(zvec)
         self.hasC= True
         self.hasC_dxdv= True
         self.isNonAxi = True
 
-    def _setup_zvec(self,zvec):
+    def _setup_zvec_pa(self,zvec,pa):
         """ taken from EllipsoidalPotential """
+        if not pa is None:
+            pa_rot= numpy.array([[numpy.cos(pa),numpy.sin(pa),0.],
+                                 [-numpy.sin(pa),numpy.cos(pa),0.],
+                                 [0.,0.,1.]])
+        else:
+            pa_rot = numpy.eye(3)
         if not zvec is None:
             if not isinstance(zvec,numpy.ndarray):
                 zvec= numpy.array(zvec)
             zvec/= numpy.sqrt(numpy.sum(zvec**2.))
             zvec_rot= _rotate_to_arbitrary_vector(\
                 numpy.array([[0.,0.,1.]]),zvec,inv=True)[0]
-            self._rot = zvec_rot
         else:
-            self._rot = numpy.eye(3)
-
+            zvec_rot = numpy.eye(3)
+        self._rot = numpy.dot(pa_rot,zvec_rot)
         return None
 
     def _wrap(self,attribute,*args,**kwargs):

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -93,25 +93,25 @@ class RotateAndTiltWrapperPotential(parentWrapperPotential):
         phiforce_a = self._wrap_pot_func('_phiforce')(self._pot,*args,**kwargs)
         zforce_a = self._wrap_pot_func('_zforce')(self._pot,*args,**kwargs)
         #get the forces in x,y
-        xforce_a = numpy.cos(t_phi)*Rforce_a - numpy.sin(t_phi)*phiforce_a
-        yforce_a = numpy.sin(t_phi)*Rforce_a + numpy.cos(t_phi)*phiforce_a
+        xforce_a = numpy.cos(t_phi)*Rforce_a - numpy.sin(t_phi)*phiforce_a/t_R
+        yforce_a = numpy.sin(t_phi)*Rforce_a + numpy.cos(t_phi)*phiforce_a/t_R
         #rotate back
         Fxyz = numpy.dot(self._inv_rot, numpy.array([xforce_a,yforce_a,zforce_a]))
         return Fxyz
 
     def _Rforce(self,*args,**kwargs):
         Fxyz = self._force_xyz(*args,**kwargs)
-        o_R,o_phi,o_z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
-        if o_phi is None:
-            o_phi = 0.
-        return numpy.cos(o_phi)*Fxyz[0] + numpy.sin(o_phi)*Fxyz[1]
+        phi= kwargs.get('phi',0.)
+        if phi is None:
+            phi= 0.
+        return numpy.cos(phi)*Fxyz[0] + numpy.sin(phi)*Fxyz[1]
 
     def _phiforce(self,*args,**kwargs):
         Fxyz = self._force_xyz(*args,**kwargs)
-        o_R,o_phi,o_z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
-        if o_phi is None:
-            o_phi = 0.
-        return -numpy.sin(o_phi)*Fxyz[0] + numpy.cos(o_phi)*Fxyz[1]
+        R,phi= args[0],kwargs.get('phi',0.)
+        if phi is None:
+            phi= 0.
+        return R*(-numpy.sin(phi)*Fxyz[0] + numpy.cos(phi)*Fxyz[1])
 
     def _zforce(self,*args,**kwargs):
         Fxyz = self._force_xyz(*args,**kwargs)

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -14,10 +14,15 @@ from ..util import _rotate_to_arbitrary_vector
 from ..util import coords
 # Only implement 3D wrapper
 class RotateAndTiltWrapperPotential(WrapperPotential):
-    """ Potential wrapper class that implements an adjustment to the rotation
-        and z-axis vector (tilt) of a given Potential. This can be used,
-        for example, to tilt a disc to a desired inclination angle
-    """
+    """Potential wrapper that allows a potential to be rotated in 3D
+according to three orientation angles. These angles can either be
+specified using:
+
+* A rotation around the original z-axis (`galaxy_pa`) and the new direction of the z-axis (`zvec`) or
+
+* A rotation around the original z-axis (`galaxy_pa`), the `inclination`, and a rotation around the new z axis (`sky_pa`).
+
+The second option allows one to specify the inclination and sky position angle (measured from North) in the usual manner in extragalactic observations."""
     def __init__(self,amp=1.,inclination=None,galaxy_pa=None,sky_pa=None,
                  zvec=None,pot=None,
                  ro=None,vo=None):
@@ -32,7 +37,22 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
 
         INPUT:
 
-           zvec - the vector along the required final z-axis
+           amp= (1.) overall amplitude to apply to the potential
+
+           pot= Potential instance or list thereof for the potential to rotate and tilt
+
+           Orientation angles as
+        
+              galaxy_pa= rotation angle of the original potential around the original z axis (can be a Quantity)
+
+           and either
+
+
+              1) zvec= 3D vector specifying the direction of the rotated z axis
+
+              2) inclination= usual inclination angle (with the line-of-sight being the z axis)
+
+                 sky_pa= rotation angle around the inclined z axis (usual sky position angle measured from North)
 
         OUTPUT:
 

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -1,12 +1,12 @@
 ###############################################################################
-#   zvecAdjustmentWrapperPotential.py: Wrapper to tilt the z-axis of a potential
+#   RotateAndTiltWrapperPotential.py: Wrapper to tilt the z-axis of a potential
 ###############################################################################
 import numpy
 from .WrapperPotential import parentWrapperPotential
 from ..util import conversion
 from ..util import _rotate_to_arbitrary_vector
 from ..util import coords
-class zvecAdjustmentWrapperPotential(parentWrapperPotential):
+class RotateAndTiltWrapperPotential(parentWrapperPotential):
     """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
     """
     def __init__(self,amp=1.,zvec=None,pot=None,
@@ -18,7 +18,7 @@ class zvecAdjustmentWrapperPotential(parentWrapperPotential):
 
         PURPOSE:
 
-           initialize a zvecAdjustmentWrapper Potential
+           initialize a RotateAndTiltWrapper Potential
 
         INPUT:
 

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -213,7 +213,6 @@ class SpiralArmsPotential(Potential):
                * numpy.sum(self._Cs / Ds * numpy.cos(self._ns * self._gamma(R, phi - self._omega * t))
                         * numpy.tanh(zK_B) / numpy.cosh(zK_B)**Bs,axis=0)
 
-    
     def _phiforce(self, R, z, phi=0, t=0):
         """
         NAME:
@@ -538,6 +537,41 @@ class SpiralArmsPotential(Potential):
                                                     + 1 / self._Rs))),axis=0)
 
     
+    def _phizderiv(self, R, z, phi=0, t=0):
+        """
+        NAME:
+            _phizderiv
+        PURPOSE:
+            Evaluate the mixed azimuthal, vertical derivative for this potential at the given coordinates. (-dPhi/dz)
+        INPUT:
+            :param R: galactocentric cylindrical radius
+            :param z: vertical height
+            :param phi: azimuth
+            :param t: time
+        OUTPUT:
+            :return: mixed azimuthal, vertical derivative
+        HISTORY:
+            2021-04-30 - Jo Bovy (UofT) 
+        """
+        if isinstance(R,numpy.ndarray) or isinstance(z,numpy.ndarray):
+            nR= len(R) if isinstance(R,numpy.ndarray) else len(z)
+            self._Cs=numpy.transpose(numpy.array([self._Cs0,]*nR))
+            self._ns=numpy.transpose(numpy.array([self._ns0,]*nR))
+            self._HNn=numpy.transpose(numpy.array([self._HNn0,]*nR))
+        else:
+            self._Cs=self._Cs0
+            self._ns=self._ns0
+            self._HNn=self._HNn0
+
+        Ks = self._K(R)
+        Bs = self._B(R)
+        Ds = self._D(R)
+        zK_B = z * Ks / Bs
+
+        return -self._H * numpy.exp(-(R-self._r_ref) / self._Rs) \
+               * numpy.sum(self._Cs / Ds * self._ns * self._N * numpy.sin(self._ns * self._gamma(R, phi - self._omega * t))
+                        * numpy.tanh(zK_B) / numpy.cosh(zK_B)**Bs,axis=0)
+
     def _dens(self, R, z, phi=0, t=0):
         """
         NAME:

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -41,6 +41,7 @@ from . import DehnenSmoothWrapperPotential
 from . import SolidBodyRotationWrapperPotential
 from . import CorotatingRotationWrapperPotential
 from . import GaussianAmplitudeWrapperPotential
+from . import zvecAdjustmentWrapperPotential
 from . import ChandrasekharDynamicalFrictionForce
 from . import SphericalShellPotential
 from . import RingPotential
@@ -188,6 +189,7 @@ DehnenSmoothWrapperPotential= DehnenSmoothWrapperPotential.DehnenSmoothWrapperPo
 SolidBodyRotationWrapperPotential= SolidBodyRotationWrapperPotential.SolidBodyRotationWrapperPotential
 CorotatingRotationWrapperPotential= CorotatingRotationWrapperPotential.CorotatingRotationWrapperPotential
 GaussianAmplitudeWrapperPotential= GaussianAmplitudeWrapperPotential.GaussianAmplitudeWrapperPotential
+zvecAdjustmentWrapperPotential = zvecAdjustmentWrapperPotential.zvecAdjustmentWrapperPotential
 
 # MW potential models, now in galpy.potential.mwpotentials, but keep these two
 # for tests, backwards compatibility, and convenience

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -41,7 +41,7 @@ from . import DehnenSmoothWrapperPotential
 from . import SolidBodyRotationWrapperPotential
 from . import CorotatingRotationWrapperPotential
 from . import GaussianAmplitudeWrapperPotential
-from . import zvecAdjustmentWrapperPotential
+from . import RotateAndTiltWrapperPotential
 from . import ChandrasekharDynamicalFrictionForce
 from . import SphericalShellPotential
 from . import RingPotential
@@ -189,7 +189,7 @@ DehnenSmoothWrapperPotential= DehnenSmoothWrapperPotential.DehnenSmoothWrapperPo
 SolidBodyRotationWrapperPotential= SolidBodyRotationWrapperPotential.SolidBodyRotationWrapperPotential
 CorotatingRotationWrapperPotential= CorotatingRotationWrapperPotential.CorotatingRotationWrapperPotential
 GaussianAmplitudeWrapperPotential= GaussianAmplitudeWrapperPotential.GaussianAmplitudeWrapperPotential
-zvecAdjustmentWrapperPotential = zvecAdjustmentWrapperPotential.zvecAdjustmentWrapperPotential
+RotateAndTiltWrapperPotential = RotateAndTiltWrapperPotential.RotateAndTiltWrapperPotential
 
 # MW potential models, now in galpy.potential.mwpotentials, but keep these two
 # for tests, backwards compatibility, and convenience

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -71,6 +71,7 @@ evaluatez2derivs= Potential.evaluatez2derivs
 evaluateRzderivs= Potential.evaluateRzderivs
 evaluatephi2derivs= Potential.evaluatephi2derivs
 evaluateRphiderivs= Potential.evaluateRphiderivs
+evaluatephizderivs= Potential.evaluatephizderivs
 evaluater2derivs= Potential.evaluater2derivs
 RZToplanarPotential= planarPotential.RZToplanarPotential
 toPlanarPotential= planarPotential.toPlanarPotential

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -341,7 +341,7 @@ class planarPotential(object):
             raise PotentialError("'_R2deriv' function not implemented for this potential")      
 
     @potential_physical_input
-    @physical_conversion('forcederivative',pop=True)
+    @physical_conversion('energy',pop=True)
     def phi2deriv(self,R,phi=0.,t=0.):
         """
         NAME:
@@ -375,7 +375,7 @@ class planarPotential(object):
             raise PotentialError("'_phi2deriv' function not implemented for this potential")      
 
     @potential_physical_input
-    @physical_conversion('forcederivative',pop=True)
+    @physical_conversion('force',pop=True)
     def Rphideriv(self,R,phi=0.,t=0.):
         """
         NAME:

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -93,8 +93,10 @@ double RotateAndTiltWrapperPotentialphiforce(double R, double z, double phi,
      Fz = *(args + 6);
     }
     else
+    // LCOV_EXCL_START
      RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
                                             potentialArgs);
+    // LCOV_EXCL_STOP
     return *args * R * ( -sin ( phi ) * Fx + cos ( phi ) * Fy );
 }
 double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
@@ -115,17 +117,9 @@ double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
      Fz = *(args + 6);
     }
     else
+    // LCOV_EXCL_START
      RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
                                             potentialArgs);
+    // LCOV_EXCL_STOP
     return *args * Fz;
-}
-double RotateAndTiltWrapperPotentialPlanarRforce(double R, double phi,
-        double t,
-        struct potentialArg * potentialArgs){
-  return RotateAndTiltWrapperPotentialRforce(R, 0., phi, t, potentialArgs);
-}
-double RotateAndTiltWrapperPotentialPlanarphiforce(double R, double phi,
-        double t,
-        struct potentialArg * potentialArgs){
-  return RotateAndTiltWrapperPotentialphiforce(R, 0., phi, t, potentialArgs);
 }

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -25,50 +25,50 @@ static inline void rotate_force(double *Fx, double *Fy, double *Fz,
 void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  double t, double * Fx, double * Fy, double * Fz,
                  struct potentialArg * potentialArgs){
-    double * args = potentialArgs->args;
-    double * rot = args+1;
+    double * args= potentialArgs->args;
+    double * rot= args+7;
     double x, y;
+    double Rforce, phiforce;
     cyl_to_rect(R, phi, &x, &y);
     //caching
-    *(args + 11) = x;
-    *(args + 12) = y;
-    *(args + 13) = z;
+    *(args + 1)= x;
+    *(args + 2)= y;
+    *(args + 3)= z;
+    //now get the forces in R, phi, z in the aligned frame
     rotate(&x,&y,&z,rot);
     rect_to_cyl(x,y,&R,&phi);
-    //now get the forces in R, phi, z
-    double Rforce, phiforce;
-    Rforce = calcRforce(R, z, phi, t, potentialArgs->nwrapped,
-                        potentialArgs->wrappedPotentialArg);
-    phiforce = calcPhiforce(R, z, phi, t, potentialArgs->nwrapped,
-                        potentialArgs->wrappedPotentialArg);
-    *Fz = calczforce(R, z, phi, t, potentialArgs->nwrapped,
-                        potentialArgs->wrappedPotentialArg);
+    Rforce= calcRforce(R, z, phi, t, potentialArgs->nwrapped,
+		       potentialArgs->wrappedPotentialArg);
+    phiforce= calcPhiforce(R, z, phi, t, potentialArgs->nwrapped,
+			   potentialArgs->wrappedPotentialArg);
+    *Fz= calczforce(R, z, phi, t, potentialArgs->nwrapped,
+		    potentialArgs->wrappedPotentialArg);
     //back to rectangular
-    *Fx = cos( phi )*Rforce - sin( phi )*phiforce;
-    *Fy = sin( phi )*Rforce + cos( phi )*phiforce;
+    *Fx= cos( phi )*Rforce - sin( phi )*phiforce / R;
+    *Fy= sin( phi )*Rforce + cos( phi )*phiforce / R;
     //rotate back
     rotate_force(Fx,Fy,Fz,rot);
     //cache
-    *(args + 14) = *Fx;
-    *(args + 15) = *Fy;
-    *(args + 16) = *Fz;
+    *(args + 4)= *Fx;
+    *(args + 5)= *Fy;
+    *(args + 6)= *Fz;
 }
 double RotateAndTiltWrapperPotentialRforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
    double * args = potentialArgs->args;
    //get cached xyz
-   double cached_x = *(args + 11);
-   double cached_y = *(args + 12);
-   double cached_z = *(args + 13);
+   double cached_x = *(args + 1);
+   double cached_y = *(args + 2);
+   double cached_z = *(args + 3);
    // change the zvector, calculate Rforce
    double Fx, Fy, Fz;
    double x, y;
    cyl_to_rect(R, phi, &x, &y);
    if ( x == cached_x && y == cached_y && z == cached_z ){
-    Fx = *(args + 14);
-    Fy = *(args + 15);
-    Fz = *(args + 16);
+    Fx = *(args + 4);
+    Fy = *(args + 5);
+    Fz = *(args + 6);
    }
    else
     RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
@@ -80,39 +80,39 @@ double RotateAndTiltWrapperPotentialphiforce(double R, double z, double phi,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
     //get cached xyz
-    double cached_x = *(args + 11);
-    double cached_y = *(args + 12);
-    double cached_z = *(args + 13);
+    double cached_x = *(args + 1);
+    double cached_y = *(args + 2);
+    double cached_z = *(args + 3);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
     double x, y;
     cyl_to_rect(R, phi, &x, &y);
     if ( x == cached_x && y == cached_y && z == cached_z ){
-     Fx = *(args + 14);
-     Fy = *(args + 15);
-     Fz = *(args + 16);
+     Fx = *(args + 4);
+     Fy = *(args + 5);
+     Fz = *(args + 6);
     }
     else
      RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
                                             potentialArgs);
-    return *args * ( -sin ( phi ) * Fx + cos ( phi ) * Fy );
+    return *args * R * ( -sin ( phi ) * Fx + cos ( phi ) * Fy );
 }
 double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
     //get cached xyz
-    double cached_x = *(args + 11);
-    double cached_y = *(args + 12);
-    double cached_z = *(args + 13);
+    double cached_x = *(args + 1);
+    double cached_y = *(args + 2);
+    double cached_z = *(args + 3);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
     double x, y;
     cyl_to_rect(R, phi, &x, &y);
     if ( x == cached_x && y == cached_y && z == cached_z ){
-     Fx = *(args + 14);
-     Fy = *(args + 15);
-     Fz = *(args + 16);
+     Fx = *(args + 4);
+     Fy = *(args + 5);
+     Fz = *(args + 6);
     }
     else
      RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
@@ -122,10 +122,10 @@ double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
 double RotateAndTiltWrapperPotentialPlanarRforce(double R, double phi,
         double t,
         struct potentialArg * potentialArgs){
-    return EllipsoidalPotentialRforce(R, 0., phi, t, potentialArgs);
+  return RotateAndTiltWrapperPotentialRforce(R, 0., phi, t, potentialArgs);
 }
 double RotateAndTiltWrapperPotentialPlanarphiforce(double R, double phi,
         double t,
         struct potentialArg * potentialArgs){
-    return EllipsoidalPotentialphiforce(R, 0., phi, t, potentialArgs);
+  return RotateAndTiltWrapperPotentialphiforce(R, 0., phi, t, potentialArgs);
 }

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -27,53 +27,96 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
     double * rot = args+1;
-    double x, y, t_z;
-    double t_R, t_phi;
+    double x, y;
     cyl_to_rect(R, phi, &x, &y);
-    rotate(&x,&y,&t_z,rot);
-    rect_to_cyl(x,y,&t_R,&t_phi);
+    //caching
+    *(args + 11) = x;
+    *(args + 12) = y;
+    *(args + 13) = z;
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R,&phi);
     //now get the forces in R, phi, z
     double Rforce, phiforce;
-    Rforce = calcRforce(t_R, t_z, t_phi, t, potentialArgs->nwrapped,
+    Rforce = calcRforce(R, z, phi, t, potentialArgs->nwrapped,
                         potentialArgs->wrappedPotentialArg);
-    phiforce = calcPhiforce(t_R, t_z, t_phi, t, potentialArgs->nwrapped,
+    phiforce = calcPhiforce(R, z, phi, t, potentialArgs->nwrapped,
                         potentialArgs->wrappedPotentialArg);
-    *Fz = calczforce(t_R, t_z, t_phi, t, potentialArgs->nwrapped,
+    *Fz = calczforce(R, z, phi, t, potentialArgs->nwrapped,
                         potentialArgs->wrappedPotentialArg);
     //back to rectangular
-    *Fx = cos( t_phi )*Rforce - sin( t_phi )*phiforce;
-    *Fy = sin( t_phi )*Rforce + cos( t_phi )*phiforce;
+    *Fx = cos( phi )*Rforce - sin( phi )*phiforce;
+    *Fy = sin( phi )*Rforce + cos( phi )*phiforce;
     //rotate back
     rotate_force(Fx,Fy,Fz,rot);
+    //cache
+    *(args + 14) = *Fx;
+    *(args + 15) = *Fy;
+    *(args + 16) = *Fz;
 }
 double RotateAndTiltWrapperPotentialRforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
    double * args = potentialArgs->args;
+   //get cached xyz
+   double cached_x = *(args + 11);
+   double cached_y = *(args + 12);
+   double cached_z = *(args + 13);
    // change the zvector, calculate Rforce
    double Fx, Fy, Fz;
-   RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
-                                          potentialArgs);
+   double x, y;
+   cyl_to_rect(R, phi, &x, &y);
+   if ( x == cached_x && y == cached_y && z == cached_z ){
+    Fx = *(args + 14);
+    Fy = *(args + 15);
+    Fz = *(args + 16);
+   }
+   else
+    RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
+                                           potentialArgs);
    return *args * ( cos ( phi ) * Fx + sin ( phi ) * Fy );
 }
 double RotateAndTiltWrapperPotentialphiforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
+    //get cached xyz
+    double cached_x = *(args + 11);
+    double cached_y = *(args + 12);
+    double cached_z = *(args + 13);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
-    RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
-                                           potentialArgs);
+    double x, y;
+    cyl_to_rect(R, phi, &x, &y);
+    if ( x == cached_x && y == cached_y && z == cached_z ){
+     Fx = *(args + 14);
+     Fy = *(args + 15);
+     Fz = *(args + 16);
+    }
+    else
+     RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
+                                            potentialArgs);
     return *args * ( -sin ( phi ) * Fx + cos ( phi ) * Fy );
 }
 double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
+    //get cached xyz
+    double cached_x = *(args + 11);
+    double cached_y = *(args + 12);
+    double cached_z = *(args + 13);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
-    RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
-                                           potentialArgs);
+    double x, y;
+    cyl_to_rect(R, phi, &x, &y);
+    if ( x == cached_x && y == cached_y && z == cached_z ){
+     Fx = *(args + 14);
+     Fy = *(args + 15);
+     Fz = *(args + 16);
+    }
+    else
+     RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
+                                            potentialArgs);
     return *args * Fz;
 }
 double RotateAndTiltWrapperPotentialPlanarRforce(double R, double phi,

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -2,7 +2,7 @@
 #include <math.h>
 #include <bovy_coords.h>
 #include <galpy_potentials.h>
-//zvecAdjustmentWrapperPotential
+//RotateAndTiltWrapperPotential
 static inline void rotate(double *x, double *y, double *z, double *rot){
   double xp,yp,zp;
   xp= *(rot)   * *x + *(rot+1) * *y + *(rot+2) * *z;
@@ -22,7 +22,7 @@ static inline void rotate_force(double *Fx, double *Fy, double *Fz,
   *Fy= Fyp;
   *Fz= Fzp;
 }
-double zvecAdjustmentWrapperPotentialRforce(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialRforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
    double * args = potentialArgs->args;
@@ -36,7 +36,7 @@ double zvecAdjustmentWrapperPotentialRforce(double R, double z, double phi,
    return *args * calcRforce(R,z,phi,t, potentialArgs->nwrapped,
       potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialphiforce(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialphiforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -49,7 +49,7 @@ double zvecAdjustmentWrapperPotentialphiforce(double R, double z, double phi,
     return *args * calcPhiforce(R,z,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialzforce(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -62,7 +62,7 @@ double zvecAdjustmentWrapperPotentialzforce(double R, double z, double phi,
     return *args * calczforce(R,z,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialPlanarRforce(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialPlanarRforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -75,7 +75,7 @@ double zvecAdjustmentWrapperPotentialPlanarRforce(double R, double z, double phi
     return *args * calcPlanarRforce(R,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialPlanarphiforce(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialPlanarphiforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -88,7 +88,7 @@ double zvecAdjustmentWrapperPotentialPlanarphiforce(double R, double z, double p
     return *args * calcPlanarphiforce(R,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialPlanarR2deriv(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialPlanarR2deriv(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -101,7 +101,7 @@ double zvecAdjustmentWrapperPotentialPlanarR2deriv(double R, double z, double ph
     return *args * calcPlanarR2deriv(R,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialPlanarphi2deriv(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
@@ -114,7 +114,7 @@ double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double R, double z, double 
     return *args * calcPlanarphi2deriv(R,phi,t, potentialArgs->nwrapped,
        potentialArgs->wrappedPotentialArg);
 }
-double zvecAdjustmentWrapperPotentialPlanarRphideriv(double R, double z, double phi,
+double RotateAndTiltWrapperPotentialPlanarRphideriv(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -689,18 +689,10 @@ double RotateAndTiltWrapperPotentialphiforce(double,double,double,double,
 					    struct potentialArg *);
 double RotateAndTiltWrapperPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarRforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialPlanarRforce(double,double,double,
 						struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarphiforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialPlanarphiforce(double,double,double,
 						  struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarR2deriv(double,double,double,double,
-						 struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarphi2deriv(double,double,double,
-               double,
-						   struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarRphideriv(double,double,double,
-               double,
-						   struct potentialArg *);
 //ChandrasekharDynamicalFrictionForce, takes vR,vT,vZ
 double ChandrasekharDynamicalFrictionForceRforce(double,double,double,double,
 						 struct potentialArg *,

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -689,10 +689,6 @@ double RotateAndTiltWrapperPotentialphiforce(double,double,double,double,
 					    struct potentialArg *);
 double RotateAndTiltWrapperPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarRforce(double,double,double,
-						struct potentialArg *);
-double RotateAndTiltWrapperPotentialPlanarphiforce(double,double,double,
-						  struct potentialArg *);
 //ChandrasekharDynamicalFrictionForce, takes vR,vT,vZ
 double ChandrasekharDynamicalFrictionForceRforce(double,double,double,double,
 						 struct potentialArg *,

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -689,15 +689,17 @@ double zvecAdjustmentWrapperPotentialphiforce(double,double,double,double,
 					    struct potentialArg *);
 double zvecAdjustmentWrapperPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarRforce(double,double,double,
+double zvecAdjustmentWrapperPotentialPlanarRforce(double,double,double,double,
 						struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarphiforce(double,double,double,
+double zvecAdjustmentWrapperPotentialPlanarphiforce(double,double,double,double,
 						  struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarR2deriv(double,double,double,
+double zvecAdjustmentWrapperPotentialPlanarR2deriv(double,double,double,double,
 						 struct potentialArg *);
 double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double,double,double,
+               double,
 						   struct potentialArg *);
 double zvecAdjustmentWrapperPotentialPlanarRphideriv(double,double,double,
+               double,
 						   struct potentialArg *);
 //ChandrasekharDynamicalFrictionForce, takes vR,vT,vZ
 double ChandrasekharDynamicalFrictionForceRforce(double,double,double,double,

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -114,25 +114,25 @@ double (calcRforce)(double,double,double,double,int,struct potentialArg *,
 		    double,double,double);
 double (calczforce)(double,double,double,double,int,struct potentialArg *,
 		      double,double,double);
-double (calcPhiforce)(double, double,double, double, 
+double (calcPhiforce)(double, double,double, double,
 		      int, struct potentialArg *,
 		      double,double,double);
 // end hack
-double calcR2deriv(double, double, double,double, 
+double calcR2deriv(double, double, double,double,
 			 int, struct potentialArg *);
-double calcphi2deriv(double, double, double,double, 
+double calcphi2deriv(double, double, double,double,
 			   int, struct potentialArg *);
-double calcRphideriv(double, double, double,double, 
+double calcRphideriv(double, double, double,double,
 			   int, struct potentialArg *);
-double calcPlanarRforce(double, double, double, 
+double calcPlanarRforce(double, double, double,
 			int, struct potentialArg *);
-double calcPlanarphiforce(double, double, double, 
+double calcPlanarphiforce(double, double, double,
 			int, struct potentialArg *);
-double calcPlanarR2deriv(double, double, double, 
+double calcPlanarR2deriv(double, double, double,
 			 int, struct potentialArg *);
-double calcPlanarphi2deriv(double, double, double, 
+double calcPlanarphi2deriv(double, double, double,
 			   int, struct potentialArg *);
-double calcPlanarRphideriv(double, double, double, 
+double calcPlanarRphideriv(double, double, double,
 			   int, struct potentialArg *);
 double calcLinearForce(double, double, int, struct potentialArg *);
 double calcDensity(double, double, double,double, int, struct potentialArg *);
@@ -356,7 +356,7 @@ double KuzminDiskPotentialPlanarRforce(double,double,double,
 						struct potentialArg *);
 double KuzminDiskPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
-double KuzminDiskPotentialPlanarR2deriv(double,double,double, 
+double KuzminDiskPotentialPlanarR2deriv(double,double,double,
 					    struct potentialArg *);
 //PlummerPotential
 double PlummerPotentialEval(double,double,double,double,
@@ -433,7 +433,7 @@ double SCFPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
 double SCFPotentialphiforce(double,double,double,double,
 				        struct potentialArg *);
-				        
+
 double SCFPotentialPlanarRforce(double,double,double,
                         struct potentialArg *);
 double SCFPotentialPlanarphiforce(double,double,double,
@@ -570,7 +570,7 @@ double interpSphericalPotentialrevaluate(double,double,struct potentialArg *);
 double interpSphericalPotentialrforce(double,double,struct potentialArg *);
 double interpSphericalPotentialr2deriv(double,double,struct potentialArg *);
 double interpSphericalPotentialrdens(double,double,struct potentialArg *);
-  
+
 //TriaxialGaussian: uses EllipsoidalPotential, only need psi, dens, densDeriv
 double TriaxialGaussianPotentialpsi(double,double *);
 double TriaxialGaussianPotentialmdens(double,double *);
@@ -682,6 +682,23 @@ double MovingObjectPotentialPlanarRforce(double,double,double,
 					struct potentialArg *);
 double MovingObjectPotentialPlanarphiforce(double,double,double,
 					    struct potentialArg *);
+//zvecAdjustmentWrapperPotential
+double zvecAdjustmentWrapperPotentialRforce(double,double,double,double,
+					struct potentialArg *);
+double zvecAdjustmentWrapperPotentialphiforce(double,double,double,double,
+					    struct potentialArg *);
+double zvecAdjustmentWrapperPotentialzforce(double,double,double,double,
+				        struct potentialArg *);
+double zvecAdjustmentWrapperPotentialPlanarRforce(double,double,double,
+						struct potentialArg *);
+double zvecAdjustmentWrapperPotentialPlanarphiforce(double,double,double,
+						  struct potentialArg *);
+double zvecAdjustmentWrapperPotentialPlanarR2deriv(double,double,double,
+						 struct potentialArg *);
+double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double,double,double,
+						   struct potentialArg *);
+double zvecAdjustmentWrapperPotentialPlanarRphideriv(double,double,double,
+						   struct potentialArg *);
 //ChandrasekharDynamicalFrictionForce, takes vR,vT,vZ
 double ChandrasekharDynamicalFrictionForceRforce(double,double,double,double,
 						 struct potentialArg *,

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -682,23 +682,23 @@ double MovingObjectPotentialPlanarRforce(double,double,double,
 					struct potentialArg *);
 double MovingObjectPotentialPlanarphiforce(double,double,double,
 					    struct potentialArg *);
-//zvecAdjustmentWrapperPotential
-double zvecAdjustmentWrapperPotentialRforce(double,double,double,double,
+//RotateAndTiltWrapperPotential
+double RotateAndTiltWrapperPotentialRforce(double,double,double,double,
 					struct potentialArg *);
-double zvecAdjustmentWrapperPotentialphiforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialphiforce(double,double,double,double,
 					    struct potentialArg *);
-double zvecAdjustmentWrapperPotentialzforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarRforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialPlanarRforce(double,double,double,double,
 						struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarphiforce(double,double,double,double,
+double RotateAndTiltWrapperPotentialPlanarphiforce(double,double,double,double,
 						  struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarR2deriv(double,double,double,double,
+double RotateAndTiltWrapperPotentialPlanarR2deriv(double,double,double,double,
 						 struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double,double,double,
+double RotateAndTiltWrapperPotentialPlanarphi2deriv(double,double,double,
                double,
 						   struct potentialArg *);
-double zvecAdjustmentWrapperPotentialPlanarRphideriv(double,double,double,
+double RotateAndTiltWrapperPotentialPlanarRphideriv(double,double,double,
                double,
 						   struct potentialArg *);
 //ChandrasekharDynamicalFrictionForce, takes vR,vT,vZ

--- a/galpy/potential/potential_c_ext/zvecAdjustmentWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/zvecAdjustmentWrapperPotential.c
@@ -1,0 +1,129 @@
+#include <stdbool.h>
+#include <math.h>
+#include <bovy_coords.h>
+#include <galpy_potentials.h>
+//zvecAdjustmentWrapperPotential
+static inline void rotate(double *x, double *y, double *z, double *rot){
+  double xp,yp,zp;
+  xp= *(rot)   * *x + *(rot+1) * *y + *(rot+2) * *z;
+  yp= *(rot+3) * *x + *(rot+4) * *y + *(rot+5) * *z;
+  zp= *(rot+6) * *x + *(rot+7) * *y + *(rot+8) * *z;
+  *x= xp;
+  *y= yp;
+  *z= zp;
+}
+static inline void rotate_force(double *Fx, double *Fy, double *Fz,
+				double *rot){
+  double Fxp,Fyp,Fzp;
+  Fxp= *(rot)   * *Fx + *(rot+3) * *Fy + *(rot+6) * *Fz;
+  Fyp= *(rot+1) * *Fx + *(rot+4) * *Fy + *(rot+7) * *Fz;
+  Fzp= *(rot+2) * *Fx + *(rot+5) * *Fy + *(rot+8) * *Fz;
+  *Fx= Fxp;
+  *Fy= Fyp;
+  *Fz= Fzp;
+}
+double zvecAdjustmentWrapperPotentialRforce(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+   double * args = potentialArgs->args;
+   // change the zvector, calculate Rforce
+
+   double * rot = args+1;
+   double x, y;
+   cyl_to_rect(R,phi,&x, &y);
+   rotate(&x,&y,&z,rot);
+   rect_to_cyl(x,y,&R, &phi);
+   return *args * calcRforce(R,z,phi,t, potentialArgs->nwrapped,
+      potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialphiforce(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate phiforce
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPhiforce(R,z,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialzforce(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate zforce
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calczforce(R,z,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialPlanarRforce(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate Rforce
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPlanarRforce(R,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialPlanarphiforce(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate phiforce
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPlanarphiforce(R,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialPlanarR2deriv(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate R2deriv
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPlanarR2deriv(R,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialPlanarphi2deriv(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate phi2deriv
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPlanarphi2deriv(R,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}
+double zvecAdjustmentWrapperPotentialPlanarRphideriv(double R, double z, double phi,
+        double t,
+        struct potentialArg * potentialArgs){
+    double * args= potentialArgs->args;
+    //calculate Rphideriv
+    double * rot = args+1;
+    double x, y;
+    cyl_to_rect(R,phi,&x, &y);
+    rotate(&x,&y,&z,rot);
+    rect_to_cyl(x,y,&R, &phi);
+    return *args * calcPlanarRphideriv(R,phi,t, potentialArgs->nwrapped,
+       potentialArgs->wrappedPotentialArg);
+}

--- a/galpy/potential/zvecAdjustmentWrapperPotential.py
+++ b/galpy/potential/zvecAdjustmentWrapperPotential.py
@@ -1,0 +1,60 @@
+###############################################################################
+#   zvecAdjustmentWrapperPotential.py: Wrapper to tilt the z-axis of a potential
+###############################################################################
+import numpy
+from .WrapperPotential import parentWrapperPotential
+from ..util import conversion
+from ..util import _rotate_to_arbitrary_vector
+class zvecAdjustmentWrapperPotential(parentWrapperPotential):
+    """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
+    """
+    def __init__(self,zvec=None,pot=None,
+                 ro=None,vo=None):
+        """
+        NAME:
+
+           __init__
+
+        PURPOSE:
+
+           initialize a zvecAdjustmentWrapper Potential
+
+        INPUT:
+
+           zvec - the vector along the required final z-axis
+
+        OUTPUT:
+
+           (none)
+
+        HISTORY:
+
+           2020-03-29 - Started - Mackereth (UofT)
+
+        """
+    self._setup_zvec(zvec)
+    self.hasC= False
+    self.hasC_dxdv= False
+
+    def _setup_zvec(self,zvec):
+        """ taken from EllipsoidalPotential """
+        if not zvec is None:
+            if not isinstance(zvec,numpy.ndarray):
+                zvec= numpy.array(zvec)
+            zvec/= numpy.sqrt(numpy.sum(zvec**2.))
+            zvec_rot= _rotate_to_arbitrary_vector(\
+                numpy.array([[0.,0.,1.]]),zvec,inv=True)[0]
+            self._rot = zvec_rot
+        else:
+            self._rot = numpy.eye(3)
+
+        return None
+
+    def _wrap(self,attribute,*args,**kwargs):
+        x,y,z= coords.cyl_to_rect(args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1])
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        R, phi, z = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
+        args[0] = R
+        args[1] = z
+        kwargs['phi'] = phi
+        return self._wrap_pot_func(attribute)(self._pot,*args,**kwargs)

--- a/galpy/potential/zvecAdjustmentWrapperPotential.py
+++ b/galpy/potential/zvecAdjustmentWrapperPotential.py
@@ -9,7 +9,7 @@ from ..util import coords
 class zvecAdjustmentWrapperPotential(parentWrapperPotential):
     """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
     """
-    def __init__(self,zvec=None,pot=None,
+    def __init__(self,amp=1.,zvec=None,pot=None,
                  ro=None,vo=None):
         """
         NAME:
@@ -34,8 +34,8 @@ class zvecAdjustmentWrapperPotential(parentWrapperPotential):
 
         """
         self._setup_zvec(zvec)
-        self.hasC= False
-        self.hasC_dxdv= False
+        self.hasC= True
+        self.hasC_dxdv= True
         self.isNonAxi = True
 
     def _setup_zvec(self,zvec):

--- a/galpy/potential/zvecAdjustmentWrapperPotential.py
+++ b/galpy/potential/zvecAdjustmentWrapperPotential.py
@@ -5,6 +5,7 @@ import numpy
 from .WrapperPotential import parentWrapperPotential
 from ..util import conversion
 from ..util import _rotate_to_arbitrary_vector
+from ..util import coords
 class zvecAdjustmentWrapperPotential(parentWrapperPotential):
     """ Potential wrapper class that implements an adjustment to the z-axis vector of a given Potential. This can be used, for example, to tilt a disc to a desired inclination angle
     """
@@ -32,9 +33,10 @@ class zvecAdjustmentWrapperPotential(parentWrapperPotential):
            2020-03-29 - Started - Mackereth (UofT)
 
         """
-    self._setup_zvec(zvec)
-    self.hasC= False
-    self.hasC_dxdv= False
+        self._setup_zvec(zvec)
+        self.hasC= False
+        self.hasC_dxdv= False
+        self.isNonAxi = True
 
     def _setup_zvec(self,zvec):
         """ taken from EllipsoidalPotential """
@@ -51,10 +53,15 @@ class zvecAdjustmentWrapperPotential(parentWrapperPotential):
         return None
 
     def _wrap(self,attribute,*args,**kwargs):
-        x,y,z= coords.cyl_to_rect(args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1])
+        #need to convert input R,phi,z to x,y,z for rotation
+        R,phi,z = args[0],kwargs.get('phi',0.),0 if len(args) == 1 else args[1]
+        if phi is None:
+            phi = 0.
+        x,y,z= coords.cyl_to_rect(R, phi, z)
+        #apply rotation matrix
         xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        #back to R,phi,z
         R, phi, z = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
-        args[0] = R
-        args[1] = z
+        args = (R, z)
         kwargs['phi'] = phi
         return self._wrap_pot_func(attribute)(self._pot,*args,**kwargs)

--- a/galpy/util/bovy_coords.c
+++ b/galpy/util/bovy_coords.c
@@ -14,6 +14,16 @@ void cyl_to_rect(double R, double phi,double *x, double *y){
   *x= R * cos ( phi );
   *y= R * sin ( phi );
 }
+/*
+NAME: rect_to_cyl
+PURPOSE: convert 2D (x,y) to (R,phi) [mainly used in the context of cylindrical coordinates, hence the name)
+INPUT:
+   double x - x
+   double y - y
+OUTPUT (as arguments):
+   double *R - cylindrical radius
+   double *phi - azimuth (rad)
+ */
 void rect_to_cyl(double x, double y,double *R, double *phi){
   *R = sqrt (x*x+y*y);
   *phi = atan2 ( y , x );

--- a/galpy/util/bovy_coords.c
+++ b/galpy/util/bovy_coords.c
@@ -14,6 +14,10 @@ void cyl_to_rect(double R, double phi,double *x, double *y){
   *x= R * cos ( phi );
   *y= R * sin ( phi );
 }
+void rect_to_cyl(double x, double y,double *R, double *phi){
+  *R = sqrt (x*x+y*y);
+  *phi = atan2 ( y , x );
+}
 /*
 NAME: polar_to_rect_galpy
 PURPOSE: convert (R,vR,vT,phi) to (x,y,vx,vy)

--- a/galpy/util/bovy_coords.h
+++ b/galpy/util/bovy_coords.h
@@ -5,15 +5,15 @@ Some coordinate transformations for use in galpy's C code
 Copyright (c) 2018, Jo Bovy
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-   Redistributions of source code must retain the above copyright notice, 
+   Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-   Redistributions in binary form must reproduce the above copyright notice, 
-      this list of conditions and the following disclaimer in the 
+   Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-   The name of the author may not be used to endorse or promote products 
+   The name of the author may not be used to endorse or promote products
       derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -41,6 +41,7 @@ extern "C" {
   Function declarations
 */
 void cyl_to_rect(double,double,double *,double *);
+void rect_to_cyl(double,double,double *,double *);
 void polar_to_rect_galpy(double *);
 void rect_to_polar_galpy(double *);
 void cyl_to_rect_galpy(double *);

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -195,6 +195,7 @@ def test_energy_jacobi_conservation():
             ptp= tp.toPlanar()
         else:
             ptp= None
+        print(p)
         for integrator in integrators:
             if integrator == 'dopr54_c' \
                     and ('Spiral' in p or 'Lopsided' in p \
@@ -226,6 +227,7 @@ def test_energy_jacobi_conservation():
                     or 'GaussianAmplitudeBar' in p  \
                     or p == 'mockMovingObjectLongIntPotential' \
                     or 'Cosmphi' in p or 'triaxialLog' in p \
+                    or 'RotatedAndTilted' in p \
                     or 'Henon' in p:
                 tJacobis= o.Jacobi(ttimes,pot=tp)
             else:
@@ -323,6 +325,7 @@ def test_energy_jacobi_conservation():
                                            or ('Burkert' in p and not tp.hasC)): break
                 else: continue
             #Same for a planarPotential
+            if p == 'mockRotatedAndTiltedMWP14WrapperPotential': break
 #            print integrator
             if not ptp is None and not ptp.isNonAxi:
                 o= setup_orbit_energy(ptp,axi=True)
@@ -514,6 +517,7 @@ def test_energy_conservation_linear():
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -682,7 +686,6 @@ def test_liouville_planar():
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
-    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -69,7 +69,8 @@ from test_potential import testplanarMWPotential, testMWPotential, \
     testorbitHenonHeilesPotential, \
     nestedListPotential, \
     mockInterpSphericalPotential, \
-    mockAdiabaticContractionMWP14WrapperPotential
+    mockAdiabaticContractionMWP14WrapperPotential, \
+    mockRotatedAndTiltedMWP14WrapperPotential
 _TRAVIS= bool(os.getenv('TRAVIS'))
 if not _TRAVIS:
     _QUICKTEST= True #Run a more limited set of tests
@@ -94,9 +95,9 @@ def test_energy_jacobi_conservation():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
-               and not 'FullTo' in p and not 'toPlanar' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
+               and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
     pots.append('mockFlatEllipticalDiskPotential')
@@ -138,13 +139,14 @@ def test_energy_jacobi_conservation():
     pots.append('mockSlowFlatDecayingDehnenSmoothBarPotential')
     pots.append('mockFlatSolidBodyRotationSpiralArmsPotential')
     pots.append('mockFlatSolidBodyRotationPlanarSpiralArmsPotential')
-    pots.append('triaxialLogarithmicHaloPotential')   
-    pots.append('testorbitHenonHeilesPotential')   
+    pots.append('triaxialLogarithmicHaloPotential')
+    pots.append('testorbitHenonHeilesPotential')
     pots.append('mockFlatCorotatingRotationSpiralArmsPotential')
     pots.append('mockFlatGaussianAmplitudeBarPotential')
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
-    pots.append('mockAdiabaticContractionMWP14WrapperPotential')   
+    pots.append('mockAdiabaticContractionMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -483,9 +485,9 @@ def test_energy_conservation_linear():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
-               and not 'FullTo' in p and not 'toPlanar' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
+               and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
     pots.append('specialMiyamotoNagaiPotential')
@@ -508,7 +510,7 @@ def test_energy_conservation_linear():
     pots.append('sech2DiskSCFPotential')
     pots.append('expwholeDiskSCFPotential')
     pots.append('altExpwholeDiskSCFPotential')
-    pots.append('triaxialLogarithmicHaloPotential')   
+    pots.append('triaxialLogarithmicHaloPotential')
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
@@ -605,7 +607,7 @@ def test_energy_symplec_longterm():
     #tolerances in log10
     tol= {}
     tol['default']= -20.
-    tol['leapfrog_c']= -16. 
+    tol['leapfrog_c']= -16.
     tol['leapfrog']= -16.
     for p in pots:
         #Setup instance of potential
@@ -633,7 +635,7 @@ def test_energy_symplec_longterm():
                 "Absence of secular trend in energy conservation fails for potential %s and symplectic integrator %s" %(p,integrator)
     #raise AssertionError
     return None
-   
+
 def test_liouville_planar():
     if _NOLONGINTEGRATIONS: return None
     #Basic parameters for the test
@@ -643,8 +645,8 @@ def test_liouville_planar():
                   'odeint', #direct python solver
                   'rk4_c','rk6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -670,16 +672,17 @@ def test_liouville_planar():
     #pots.append('mockFlatSteadyLogSpiralPotential')
     #pots.append('mockFlatTransientLogSpiralPotential')
     pots.append('mockFlatDehnenSmoothBarPotential')
-    pots.append('mockSlowFlatDehnenSmoothBarPotential') 
-    pots.append('mockSlowFlatDecayingDehnenSmoothBarPotential') 
+    pots.append('mockSlowFlatDehnenSmoothBarPotential')
+    pots.append('mockSlowFlatDecayingDehnenSmoothBarPotential')
     pots.append('mockFlatSolidBodyRotationSpiralArmsPotential')
-    pots.append('triaxialLogarithmicHaloPotential')   
-    pots.append('testorbitHenonHeilesPotential')   
+    pots.append('triaxialLogarithmicHaloPotential')
+    pots.append('testorbitHenonHeilesPotential')
     pots.append('mockFlatTrulyCorotatingRotationSpiralArmsPotential')
     pots.append('mockFlatTrulyGaussianAmplitudeBarPotential')
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -809,8 +812,8 @@ def test_eccentricity():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -923,7 +926,7 @@ def test_eccentricity():
             if _QUICKTEST and (not 'NFW' in p or tp.isNonAxi): break
     #raise AssertionError
     return None
-    
+
 # Test that the pericenter of orbits launched with vR=0 and vT > vc is the starting radius
 def test_pericenter():
     #return None
@@ -936,8 +939,8 @@ def test_pericenter():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1189,8 +1192,8 @@ def test_zmax():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1303,8 +1306,8 @@ def test_analytic_ecc_rperi_rap():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1572,7 +1575,7 @@ def test_analytic_ecc_rperi_rap():
             if _QUICKTEST and (not 'NFW' in p or tp.isNonAxi): break
     #raise AssertionError
     return None
-    
+
 def test_orbit_rguiding():
     from galpy.potential import LogarithmicHaloPotential, MWPotential2014, \
         TriaxialNFWPotential, rl
@@ -1630,8 +1633,8 @@ def test_analytic_zmax():
                   'rk4_c','rk6_c',
                   'symplec4_c','symplec6_c']
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1915,7 +1918,7 @@ def test_angularmomentum():
     o= Orbit([1.,0.1,1.1])
     assert numpy.ndim(o.L()) == 0, "planarOrbit's angular momentum isn't 1D"
     assert o.L() == 1.1, "planarOrbit's angular momentum isn't correct"
-    if False: 
+    if False:
         #JB 5/23/2019 isn'tn sure why he ever implemented the Omega
         # keyword for L, so decided not to support this in new Orbits
         # If Omega is given, then it should be subtracted
@@ -4403,7 +4406,7 @@ def test_orbit_sun_setup():
 def test_integrate_dxdv_errors():
     from galpy.orbit import Orbit
     ts= numpy.linspace(0.,10.,1001)
-    # Test that attempting to use integrate_dxdv with a non-phasedim==4 orbit 
+    # Test that attempting to use integrate_dxdv with a non-phasedim==4 orbit
     # raises error
     o= Orbit([1.,0.1])
     with pytest.raises(AttributeError) as excinfo:
@@ -4868,10 +4871,10 @@ def test_from_name_named():
             else:
                 assert numpy.isclose(getattr(o,'{:s}'.format(attr))(),
                                      named_data[obj][attr])
-    return None    
+    return None
 
 def test_from_name_collections():
-    # Test that the values from the JSON file are correctly transferred, 
+    # Test that the values from the JSON file are correctly transferred,
     # for collections of objects
     from galpy.orbit import Orbit
     from galpy.orbit.Orbits import _known_objects_collections_original_keys
@@ -4897,7 +4900,7 @@ def test_from_name_collections():
                 else:
                     assert numpy.isclose(getattr(o,'{:s}'.format(attr))()[ii],
                                          named_data[individual_obj][attr])
-    return None    
+    return None
 
 def test_from_name_solarsystem():
     # Test that the solar system matches Bovy et al. (2010)'s input data
@@ -4937,7 +4940,7 @@ def test_rguiding_errors():
     return None
 
 def test_phi_range():
-    # Test that the range returned by Orbit.phi is [-pi,pi], 
+    # Test that the range returned by Orbit.phi is [-pi,pi],
     # example from Jeremy Webb
     from galpy.orbit import Orbit
     from galpy.potential import MWPotential2014
@@ -5049,7 +5052,7 @@ def test_SkyCoord_init_with_radecisTrue():
     assert numpy.fabs(o_sky.vlos()-o_radec.vlos()) < 1e-8, 'Orbit setup with SkyCoord and lb=True does not agree with Orbit setup directly with lb'
     return None
 
-# Test related to issue #415: calling an Orbit with a single int time does not 
+# Test related to issue #415: calling an Orbit with a single int time does not
 # work properly
 # Test from @jamesmlane
 def test_orbit_call_single_time_as_int():
@@ -5067,7 +5070,7 @@ def test_orbit_call_single_time_as_int():
     assert numpy.fabs(o.x(times[0])-o.x()) < 1e-10
     return None
 
-# Test related to issue #415: calling an Orbit with a single Quantity time 
+# Test related to issue #415: calling an Orbit with a single Quantity time
 # does not work properly
 # Test from @jamesmlane
 def test_orbit_call_single_time_as_Quantity():
@@ -5355,4 +5358,3 @@ def test_MovingObjectPotential_planar_orbit():
     assert numpy.fabs(oc.vx(tmax)-op.vx(tmax)) < 10.**-3.,  'Final orbit velocity between C and Python integration in a planar MovingObjectPotential is too large'
     assert numpy.fabs(oc.vy(tmax)-op.vy(tmax)) < 10.**-3.,  'Final orbit velocity between C and Python integration in a planar MovingObjectPotential is too large'
     return None
-

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -3571,17 +3571,20 @@ def test_RotateAndTiltWrapper():
     #test against the transformed potential and a MWPotential evaluated at the transformed coords
     assert (evaluatePotentials(testpot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(potential.MWPotential2014, tRphiz_test[0], tRphiz_test[2], phi=tRphiz_test[1])) < 1e-6, 'Evaluating potential at same relative position in a Rotated and tilted MWPotential2014 and non-Rotated does not give same result'
     # Also a triaxial NFW
-    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
-    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa)
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa,b=0.7,c=0.5)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
     # Try not specifying galaxy_pa, shouldn be =0
-    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec,pot=potential.TriaxialNFWPotential(amp=1.))
-    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec,pa=0.)
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec,pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec,pa=0.,b=0.7,c=0.5)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
     # Try not specifying zvec, should be =[0,0,1]
-    NFW_wrapped= potential.RotateAndTiltWrapperPotential(galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
-    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=[0.,0.,1.],pa=galaxy_pa)
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=[0.,0.,1.],pa=galaxy_pa,b=0.7,c=0.5)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
+    # Quickly test attributeerror for non-axi 2nd derivs
+    with pytest.raises(potential.PotentialError) as excinfo:
+        NFW_wrapped.R2deriv(1.,0.1,phi=0.3)
     return None
 
 def test_vtermnegl_issue314():

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -168,7 +168,6 @@ def test_forceAsDeriv_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
-    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -342,7 +341,6 @@ def test_2ndDeriv_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
-    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -571,7 +569,6 @@ def test_poisson_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
-    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -3555,23 +3555,32 @@ def test_AdiabaticContractionWrapper():
 
 def test_RotateAndTiltWrapper():
     # some tests of the rotate and tilt wrapper
-    zvec = numpy.array([numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)])
+    zvec= numpy.array([numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)])
     zvec/= numpy.sqrt(numpy.sum(zvec**2))
-    rot = _rotate_to_arbitrary_vector(numpy.array([[0.,0.,1.]]), zvec, inv=True)[0]
-    galaxy_pa = 0.3
+    rot= _rotate_to_arbitrary_vector(numpy.array([[0.,0.,1.]]), zvec, inv=True)[0]
+    galaxy_pa= 0.3
     pa_rot= numpy.array([[numpy.cos(galaxy_pa),numpy.sin(galaxy_pa),0.],
                          [-numpy.sin(galaxy_pa),numpy.cos(galaxy_pa),0.],
                          [0.,0.,1.]])
-    rot = numpy.dot(pa_rot, rot)
+    rot= numpy.dot(pa_rot, rot)
     xyz_test= numpy.array([0.5,0.5,0.5])
-    Rphiz_test = coords.rect_to_cyl(xyz_test[0], xyz_test[1], xyz_test[2])
-    txyz_test = numpy.dot(rot, xyz_test)
-    tRphiz_test = coords.rect_to_cyl(txyz_test[0], txyz_test[1], txyz_test[2])
-    testpot = potential.RotateAndTiltWrapperPotential(zvec=zvec,galaxy_pa=galaxy_pa,pot=potential.MWPotential2014)
+    Rphiz_test= coords.rect_to_cyl(xyz_test[0], xyz_test[1], xyz_test[2])
+    txyz_test= numpy.dot(rot, xyz_test)
+    tRphiz_test= coords.rect_to_cyl(txyz_test[0], txyz_test[1], txyz_test[2])
+    testpot= potential.RotateAndTiltWrapperPotential(zvec=zvec,galaxy_pa=galaxy_pa,pot=potential.MWPotential2014)
     #test against the transformed potential and a MWPotential evaluated at the transformed coords
     assert (evaluatePotentials(testpot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(potential.MWPotential2014, tRphiz_test[0], tRphiz_test[2], phi=tRphiz_test[1])) < 1e-6, 'Evaluating potential at same relative position in a Rotated and tilted MWPotential2014 and non-Rotated does not give same result'
-    NFW_wrapped = potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
-    NFW_rot = potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa)
+    # Also a triaxial NFW
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa)
+    assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
+    # Try not specifying galaxy_pa, shouldn be =0
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec,pot=potential.TriaxialNFWPotential(amp=1.))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec,pa=0.)
+    assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
+    # Try not specifying zvec, should be =[0,0,1]
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=[0.,0.,1.],pa=galaxy_pa)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
     return None
 
@@ -5138,6 +5147,6 @@ class mockRotatedAndTiltedMWP14WrapperPotentialwInclination(testMWPotential):
                 RotateAndTiltWrapperPotential(pot=potential.MWPotential2014,
                                               inclination=2.,
                                               galaxy_pa=0.3,
-                                              sky_pa=-3.)])
+                                              sky_pa=None)])
     def OmegaP(self):
         return 0.

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -168,6 +168,7 @@ def test_forceAsDeriv_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -341,6 +342,7 @@ def test_2ndDeriv_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -569,6 +571,7 @@ def test_poisson_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -807,6 +810,7 @@ def test_evaluateAndDerivs_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1019,6 +1023,7 @@ def test_amp_mult_divide():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1285,6 +1290,7 @@ def test_potential_at_zero():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -4877,7 +4883,8 @@ class mockMovingObjectLongIntPotential(mockMovingObjectPotential):
 # Classes to test wrappers
 from galpy.potential import DehnenSmoothWrapperPotential, \
     SolidBodyRotationWrapperPotential, CorotatingRotationWrapperPotential, \
-    GaussianAmplitudeWrapperPotential, AdiabaticContractionWrapperPotential
+    GaussianAmplitudeWrapperPotential, AdiabaticContractionWrapperPotential, \
+    RotateAndTiltWrapperPotential
 from galpy.potential.WrapperPotential import parentWrapperPotential
 class DehnenSmoothDehnenBarPotential(DehnenSmoothWrapperPotential):
     # This wrapped potential should be the same as the default DehnenBar
@@ -5100,3 +5107,13 @@ class mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential(AdiabaticContrac
                                 pot=potential.MWPotential2014[2],
                                 baryonpot=potential.MWPotential2014[:2],
                                 f_bar=0.1)
+
+class mockRotatedAndTiltedMWP14WrapperPotential(RotateAndTiltWrapperPotential):
+    def __new__(cls,*args,**kwargs):
+        if kwargs.get('_init',False):
+            return parentWrapperPotential.__new__(cls,*args,**kwargs)
+        mwpot = potential.MWPotential2014
+        return RotateAndTiltWrapperPotential.__new__(cls,\
+                                                     pot=mwpot,
+                                                     zvec=[numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)],
+                                                     pa=0.4)

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -341,6 +341,8 @@ def test_2ndDeriv_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -569,6 +571,8 @@ def test_poisson_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -678,6 +682,8 @@ def test_poisson_surfdens_potential():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -808,6 +814,7 @@ def test_evaluateAndDerivs_potential():
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1021,6 +1028,7 @@ def test_amp_mult_divide():
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1288,6 +1296,7 @@ def test_potential_at_zero():
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1334,6 +1343,7 @@ def test_potential_at_zero():
            or p == 'AnyAxisymmetricRazorThinDiskPotential' \
            or p == 'AnySphericalPotential' \
            or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
+           or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
            or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -1398,6 +1408,7 @@ def test_potential_at_infinity():
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1441,6 +1452,7 @@ def test_potential_at_infinity():
            or p == 'AnyAxisymmetricRazorThinDiskPotential' \
            or p == 'AnySphericalPotential' \
            or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
+           or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
           or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -5118,5 +5130,14 @@ class mockRotatedAndTiltedMWP14WrapperPotential(testMWPotential):
                                                     numpy.sqrt(1/3.),
                                                     numpy.sqrt(1/3.)],
                                               galaxy_pa=0.4)])
+    def OmegaP(self):
+        return 0.
+class mockRotatedAndTiltedMWP14WrapperPotentialwInclination(testMWPotential):
+    def __init__(self):
+        testMWPotential.__init__(self,potlist=[\
+                RotateAndTiltWrapperPotential(pot=potential.MWPotential2014,
+                                              inclination=2.,
+                                              galaxy_pa=0.3,
+                                              sky_pa=-3.)])
     def OmegaP(self):
         return 0.

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -13,13 +13,14 @@ except ImportError:
     _PYNBODY_LOADED= False
 from galpy import potential
 from galpy.util import coords
+from galpy.util import _rotate_to_arbitrary_vector
 _TRAVIS= bool(os.getenv('TRAVIS'))
 
 #Test whether the normalization of the potential works
 def test_normalize_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -87,8 +88,8 @@ def test_normalize_potential():
 #Test whether the derivative of the potential is minus the force
 def test_forceAsDeriv_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -210,7 +211,7 @@ def test_forceAsDeriv_potential():
                 dr= 10.**-8.
                 newR= Rs[ii]+dr
                 dr= newR-Rs[ii] #Representable number
-                if isinstance(tp,potential.linearPotential): 
+                if isinstance(tp,potential.linearPotential):
                     mpotderivR= (potential.evaluatelinearPotentials(tp,Rs[ii])
                                  -potential.evaluatelinearPotentials(tp,Rs[ii]+dr))/dr
                     tRforce= potential.evaluatelinearForces(tp,Rs[ii])
@@ -277,8 +278,8 @@ def test_forceAsDeriv_potential():
 #Test whether the second derivative of the potential is minus the derivative of the force
 def test_2ndDeriv_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -339,7 +340,7 @@ def test_2ndDeriv_potential():
     pots.append('mockInterpSphericalPotential')
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
-    pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')   
+    pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -385,10 +386,10 @@ def test_2ndDeriv_potential():
                     dr= 10.**-8.
                     newR= Rs[ii]+dr
                     dr= newR-Rs[ii] #Representable number
-                    if isinstance(tp,potential.linearPotential): 
+                    if isinstance(tp,potential.linearPotential):
                         mRforcederivR= (tp.Rforce(Rs[ii])-tp.Rforce(Rs[ii]+dr))/dr
                         tR2deriv= tp.R2deriv(Rs[ii])
-                    elif isinstance(tp,potential.planarPotential): 
+                    elif isinstance(tp,potential.planarPotential):
                         mRforcederivR= (tp.Rforce(Rs[ii],Zs[jj])-tp.Rforce(Rs[ii]+dr,Zs[jj]))/dr
                         tR2deriv= potential.evaluateplanarR2derivs(tp,Rs[ii],
                                                                    phi=Zs[jj])
@@ -464,7 +465,7 @@ def test_2ndDeriv_potential():
                     if p == 'JaffeTwoPowerSphericalPotential': continue #Not implemented, or badly defined
                     if p == 'NFWTwoPowerSphericalPotential': continue #Not implemented, or badly defined
                     #Excluding KuzminDiskPotential at z = 0
-                    if p == 'KuzminDiskPotential' and Zs[jj] == 0: continue  
+                    if p == 'KuzminDiskPotential' and Zs[jj] == 0: continue
                     dz= 10.**-8.
                     newz= Zs[jj]+dz
                     dz= newz-Zs[jj] #Representable number
@@ -479,11 +480,11 @@ def test_2ndDeriv_potential():
         #mixed radial vertical
         if not isinstance(tp,potential.planarPotential) \
                 and not isinstance(tp,potential.linearPotential) \
-                and hasattr(tp,'_Rzderiv'):             
+                and hasattr(tp,'_Rzderiv'):
             for ii in range(len(Rs)):
                 for jj in range(len(Zs)):
                     #Excluding KuzminDiskPotential at z = 0
-                    if p == 'KuzminDiskPotential' and Zs[jj] == 0: continue 
+                    if p == 'KuzminDiskPotential' and Zs[jj] == 0: continue
 #                    if p == 'RazorThinExponentialDiskPotential': continue #Not implemented, or badly defined
                     dz= 10.**-8.
                     newz= Zs[jj]+dz
@@ -495,7 +496,7 @@ def test_2ndDeriv_potential():
                             "Calculation of the mixed radial vertical derivative of the potential as the vertical derivative of the %s radial force fails at (R,Z) = (%.3f,%.3f); diff = %e, rel. diff = %e" % (p,Rs[ii],Zs[jj],numpy.fabs(tRzderiv-mRforcederivz), numpy.fabs((tRzderiv-mRforcederivz)/tRzderiv))
                     else:
                         assert (tRzderiv-mRforcederivz)**2./tRzderiv**2. < 10.**ttol, \
-"Calculation of the mixed radial vertical derivative of the potential as the vertical derivative of the %s radial force fails at (R,Z) = (%.3f,%.3f); diff = %e, rel. diff = %e" % (p,Rs[ii],Zs[jj],numpy.fabs(tRzderiv-mRforcederivz), numpy.fabs((tRzderiv-mRforcederivz)/tRzderiv))                        
+"Calculation of the mixed radial vertical derivative of the potential as the vertical derivative of the %s radial force fails at (R,Z) = (%.3f,%.3f); diff = %e, rel. diff = %e" % (p,Rs[ii],Zs[jj],numpy.fabs(tRzderiv-mRforcederivz), numpy.fabs((tRzderiv-mRforcederivz)/tRzderiv))
         #mixed radial, azimuthal
         if not isinstance(tp,potential.linearPotential) \
                 and hasattr(tp,'_Rphideriv'):
@@ -525,8 +526,8 @@ def test_2ndDeriv_potential():
 #Test whether the Poisson equation is satisfied if _dens and the relevant second derivatives are implemented
 def test_poisson_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -567,7 +568,7 @@ def test_poisson_potential():
     pots.append('mockInterpSphericalPotential')
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
-    pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')   
+    pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -628,12 +629,12 @@ def test_poisson_potential():
                         assert (tpoissondens-tdens)**2./tdens**2. < 10.**ttol, \
                             "Poisson equation relation between the derivatives of the potential and the implemented density is not satisfied for the %s potential at (R,Z,phi) = (%.3f,%.3f,%.3f); diff = %e, rel. diff = %e" % (p,Rs[ii],Zs[jj],phis[kk],numpy.fabs(tdens-tpoissondens), numpy.fabs((tdens-tpoissondens)/tdens))
     return None
-                        
+
 #Test whether the (integrated) Poisson equation is satisfied if _surfdens and the relevant second derivatives are implemented
 def test_poisson_surfdens_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -740,12 +741,12 @@ def test_poisson_surfdens_potential():
                         assert (tpoissondens-tdens)**2./tdens**2. < 10.**ttol, \
                             "Poisson equation relation between the derivatives of the potential and the implemented surface density is not satisfied for the %s potential at (R,Z,phi) = (%.3f,%.3f,%.3f); diff = %e, rel. diff = %e" % (p,Rs[ii],Zs[jj],phis[kk],numpy.fabs(tdens-tpoissondens), numpy.fabs((tdens-tpoissondens)/tdens))
     return None
-                        
+
 #Test whether the _evaluate function is correctly implemented in specifying derivatives
 def test_evaluateAndDerivs_potential():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -836,9 +837,9 @@ def test_evaluateAndDerivs_potential():
         if p in list(tol.keys()): ttol= tol[p]
         else: ttol= tol['default']
         #1st radial
-        if isinstance(tp,potential.linearPotential): 
+        if isinstance(tp,potential.linearPotential):
             continue
-        elif isinstance(tp,potential.planarPotential): 
+        elif isinstance(tp,potential.planarPotential):
             tevaldr= tp(1.2,phi=0.1,dR=1)
             trforce= tp.Rforce(1.2,phi=0.1)
         else:
@@ -850,21 +851,21 @@ def test_evaluateAndDerivs_potential():
 "Calculation of radial derivative through _evaluate and Rforce inconsistent for the %s potential" % p
             else:
                 assert (tevaldr+trforce)**2./tevaldr**2. < 10.**ttol, \
-                    "Calculation of radial derivative through _evaluate and Rforce inconsistent for the %s potential" % p                
+                    "Calculation of radial derivative through _evaluate and Rforce inconsistent for the %s potential" % p
         #2nd radial
         hasR2= True
         from galpy.potential import PotentialError
         if 'RazorThin' in p: R2z= 0.
         else: R2z= 0.1
         try:
-            if isinstance(tp,potential.planarPotential): 
+            if isinstance(tp,potential.planarPotential):
                 tp.R2deriv(1.2)
             else:
                 tp.R2deriv(1.2,R2z)
         except PotentialError:
             hasR2= False
         if hasR2:
-            if isinstance(tp,potential.planarPotential): 
+            if isinstance(tp,potential.planarPotential):
                 tevaldr2= tp(1.2,phi=0.1,dR=2)
                 tr2deriv= tp.R2deriv(1.2,phi=0.1)
             else:
@@ -876,9 +877,9 @@ def test_evaluateAndDerivs_potential():
                         "Calculation of 2nd radial derivative through _evaluate and R2deriv inconsistent for the %s potential" % p
                 else:
                     assert (tevaldr2-tr2deriv)**2./tevaldr2**2. < 10.**ttol, \
-                        "Calculation of 2nd radial derivative through _evaluate and R2deriv inconsistent for the %s potential" % p                    
+                        "Calculation of 2nd radial derivative through _evaluate and R2deriv inconsistent for the %s potential" % p
         #1st phi
-        if isinstance(tp,potential.planarPotential): 
+        if isinstance(tp,potential.planarPotential):
             tevaldphi= tp(1.2,phi=0.1,dphi=1)
             tphiforce= tp.phiforce(1.2,phi=0.1)
         else:
@@ -894,14 +895,14 @@ def test_evaluateAndDerivs_potential():
         #2nd phi
         hasphi2= True
         try:
-            if isinstance(tp,potential.planarPotential): 
+            if isinstance(tp,potential.planarPotential):
                 tp.phi2deriv(1.2,phi=0.1)
             else:
                 tp.phi2deriv(1.2,0.1,phi=0.1)
         except (PotentialError,AttributeError):
             hasphi2= False
         if hasphi2 and hasattr(tp,'_phi2deriv'):
-            if isinstance(tp,potential.planarPotential): 
+            if isinstance(tp,potential.planarPotential):
                 tevaldphi2= tp(1.2,phi=0.1,dphi=2)
                 tphi2deriv= tp.phi2deriv(1.2,phi=0.1)
             else:
@@ -920,7 +921,7 @@ def test_evaluateAndDerivs_potential():
         else: raise AssertionError('Higher-order derivative request in potential __call__ does not raise NotImplementedError for %s' % p)
         continue
         #mixed radial,vertical
-        if isinstance(tp,potential.planarPotential): 
+        if isinstance(tp,potential.planarPotential):
             tevaldrz= tp(1.2,0.1,phi=0.1,dR=1,dz=1)
             trzderiv= tp.Rzderiv(1.2,0.1,phi=0.1)
         else:
@@ -938,8 +939,8 @@ def test_evaluateAndDerivs_potential():
 #Test that potentials can be multiplied or divided by a number
 def test_amp_mult_divide():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1040,7 +1041,7 @@ def test_amp_mult_divide():
             tclass= getattr(sys.modules[__name__],p)
         tp= tclass()
         if hasattr(tp,'normalize'): tp.normalize(1.)
-        if isinstance(tp,potential.linearPotential): 
+        if isinstance(tp,potential.linearPotential):
             assert numpy.fabs(tp(R)*num-(num*tp)(R)) < 1e-10, "Multiplying a linearPotential with a number does not behave as expected"
             # Other way...
             assert numpy.fabs(tp(R)*num-(tp*num)(R)) < 1e-10, "Multiplying a linearPotential with a number does not behave as expected"
@@ -1060,8 +1061,8 @@ def test_amp_mult_divide():
 #Test whether potentials that support array input do so correctly
 def test_potential_array_input():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1167,8 +1168,8 @@ def test_potential_array_input():
 # their 3D versions can
 def test_toVertical_array():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1234,8 +1235,8 @@ def test_toVertical_array():
 #Test that all potentials can be evaluated at zero
 def test_potential_at_zero():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1342,8 +1343,8 @@ def test_potential_at_infinity():
     # which uses the potential at infinity. Import what vesc uses for infinity
     from galpy.potential.plotEscapecurve import _INF
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1442,7 +1443,7 @@ def test_potential_at_infinity():
         assert not numpy.any(numpy.isnan(potential.evaluatePotentials(tp,_INF*numpy.ones(4),numpy.zeros(4),phi=0.,t=0.))), 'Potential {} evaluated at vesc _INF gave NaN'.format(p)
     return None
 
-# Test that the amplitude for potentials with a finite mass and amp=mass is 
+# Test that the amplitude for potentials with a finite mass and amp=mass is
 # correct through the relation -r^2 F_r =~ GM at large r
 def test_finitemass_amp():
     r_large= 10000.
@@ -1489,7 +1490,7 @@ def test_rforce():
     assert numpy.fabs(pp.Rforce(R,z)*r/R-pp.rforce(R,z)) < 10.**-10., 'rforce does not behave as expected for spherical potentials'
     assert numpy.fabs(potential.evaluateRforces(pp,R,z)*r/R-potential.evaluaterforces(pp,R,z)) < 10.**-10., 'evaluaterforces does not behave as expected for spherical potentials'
     return None
-    
+
 def test_rforce_dissipative():
     # Use dynamical friction along a radial orbit at z=0 --> spherical
     pp= potential.PlummerPotential(amp=1.12,b=2.)
@@ -1520,7 +1521,7 @@ def test_r2deriv():
     assert numpy.fabs(potential.evaluatez2derivs([pp],R,z)-potential.evaluater2derivs([pp],R,z)*(z/r)**2.+potential.evaluaterforces([pp],R,z)*R**2./r**3.) < 10.**-10., 'r2deriv does not behave as expected for spherical potentials'
     assert numpy.fabs(potential.evaluateRzderivs([pp],R,z)-potential.evaluater2derivs([pp],R,z)*R*z/r**2.-potential.evaluaterforces([pp],R,z)*R*z/r**3.) < 10.**-10., 'r2deriv does not behave as expected for spherical potentials'
     return None
-    
+
 # Check that the masses are calculated correctly for spherical potentials
 def test_mass_spher():
     #PowerPotential close to Kepler should be very steep
@@ -1535,7 +1536,7 @@ def test_mass_spher():
     assert numpy.fabs(potential.mass([pp],tR,forceint=True)-pp._amp*tR**(3.-pp.alpha)) < 10.**-10., 'Mass for PowerSphericalPotential not as expected'
     tR= 20.
     assert numpy.fabs(pp.mass(tR,forceint=True)-pp._amp*tR**(3.-pp.alpha)) < 10.**-9., 'Mass for PowerSphericalPotential not as expected'
-    #Test that for a cut-off potential, the mass far beyond the cut-off is 
+    #Test that for a cut-off potential, the mass far beyond the cut-off is
     # 2pi rc^(3-alpha) gamma(1.5-alpha/2)
     pp= potential.PowerSphericalPotentialwCutoff(amp=2.)
     from scipy import special
@@ -1598,7 +1599,7 @@ def test_mass_axi():
     assert numpy.fabs(mp.mass(200.,20.)-1.) < 0.01, 'Total mass of Miyamoto-Nagai potential w/ amp=1 is not equal to 1'
     # Also spherical
     assert numpy.fabs(mp.mass(200.)-1.) < 0.01, 'Total mass of Miyamoto-Nagai potential w/ amp=1 is not equal to 1'
-    #For a double-exponential disk potential, the 
+    #For a double-exponential disk potential, the
     # mass(R,z) = amp x hR^2 x hz x (1-(1+R/hR)xe^(-R/hR)) x (1-e^(-Z/hz)
     dp= potential.DoubleExponentialDiskPotential(amp=2.)
     def dblexpmass(r,z,dp):
@@ -1699,12 +1700,12 @@ def test_mass_spheroidal():
     r= 3.9
     assert numpy.fabs(dp.mass(r)/b/c-4.*numpy.pi*2.*r) < 1e-6, 'General potential.EllipsoidalPotential mass incorrect'
     return None
-    
+
 # Check that toVertical and toPlanar work
 def test_toVertical_toPlanar():
     #Grab all of the potentials
-    pots= [p for p in dir(potential) 
-           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p 
+    pots= [p for p in dir(potential)
+           if ('Potential' in p and not 'plot' in p and not 'RZTo' in p
                and not 'FullTo' in p and not 'toPlanar' in p
                and not 'evaluate' in p and not 'Wrapper' in p
                and not 'toVertical' in p)]
@@ -1827,10 +1828,10 @@ def test_RZToverticalPotential():
         plp= potential.RZToverticalPotential([lp,3,4,45],1.2)
     # Check that giving a planarPotential gives an error
     with pytest.raises(potential.PotentialError) as excinfo:
-        plp= potential.RZToverticalPotential(lp.toPlanar(),1.2)       
+        plp= potential.RZToverticalPotential(lp.toPlanar(),1.2)
     # Check that giving a list of planarPotential gives an error
     with pytest.raises(potential.PotentialError) as excinfo:
-        plp= potential.RZToverticalPotential([lp.toPlanar()],1.2)       
+        plp= potential.RZToverticalPotential([lp.toPlanar()],1.2)
     # Check that using a non-axisymmetric potential gives an error
     lpna= potential.LogarithmicHaloPotential(normalize=1.,q=0.9,b=0.8)
     with pytest.raises(potential.PotentialError) as excinfo:
@@ -1871,10 +1872,10 @@ def test_toVerticalPotential():
         raise AssertionError('Using toVerticalPotential with a string rather than an Potential or a linearPotential did not raise PotentialError')
     # Check that giving a planarPotential gives an error
     with pytest.raises(potential.PotentialError) as excinfo:
-        plp= potential.toVerticalPotential(tnp.toPlanar(),1.2,phi=0.8)       
+        plp= potential.toVerticalPotential(tnp.toPlanar(),1.2,phi=0.8)
     # Check that giving a list of planarPotential gives an error
     with pytest.raises(potential.PotentialError) as excinfo:
-        plp= potential.toVerticalPotential([tnp.toPlanar()],1.2,phi=0.8)       
+        plp= potential.toVerticalPotential([tnp.toPlanar()],1.2,phi=0.8)
     # Check that giving a list of non-potentials gives error
     with pytest.raises(potential.PotentialError) as excinfo:
         plp= potential.toVerticalPotential([3,4,45],1.2)
@@ -2029,7 +2030,7 @@ def test_vcirc_vesc_special():
     lp= potential.LogarithmicHaloPotential(normalize=1.)
     assert numpy.fabs(potential.calcRotcurve(lp,0.8)-lp.vcirc(0.8)) < 10.**-16., 'Circular velocity calculated with calcRotcurve not the same as that calculated with vcirc'
     assert numpy.fabs(potential.calcEscapecurve(lp,0.8)-lp.vesc(0.8)) < 10.**-16., 'Escape velocity calculated with calcEscapecurve not the same as that calculated with vcirc'
-    return None        
+    return None
 
 def test_lindbladR():
     lp= potential.LogarithmicHaloPotential(normalize=1.)
@@ -2495,7 +2496,7 @@ def test_Cautun20():
     assert numpy.fabs(potential.evaluateDensities(Cautun20[0],1.,0.,use_physical=False)
                       *conversion.dens_in_msolpc3(vo,ro)*1.e3-8.8) < 5e-2, 'Halo density at the Sun in Cautun20 does not agree with what it should be'
     return None
-    
+
 # Test that the Irrgang13 potentials are what they are supposed to be
 def test_Irrgang13():
     from galpy.potential.mwpotentials import Irrgang13I, Irrgang13II, \
@@ -2587,8 +2588,8 @@ def check_DehnenBinney98_model(pot,model='model 1'):
                  'A':13.8,
                  'B':-13.6}
             }
-    phys_kwargs= conversion.get_physical(pot) 
-    ro= phys_kwargs.get('ro') 
+    phys_kwargs= conversion.get_physical(pot)
+    ro= phys_kwargs.get('ro')
     vo= phys_kwargs.get('vo')
     assert numpy.fabs(pot[1].surfdens(1.,10./ro)-truth[model]['SigmaR0']) < 0.2, 'Surface density at R0 in Dehnen & Binney (1998) {} does not agree with paper value'.format(model)
     assert numpy.fabs(potential.vcirc(pot,1.)-truth[model]['vc']) < 0.5, 'Circular velocity at R0 in Dehnen & Binney (1998) {} does not agree with paper value'.format(model)
@@ -2596,7 +2597,7 @@ def check_DehnenBinney98_model(pot,model='model 1'):
     assert numpy.fabs(0.5*(potential.vcirc(pot,1.,use_physical=False)-potential.dvcircdR(pot,1.,use_physical=False))*vo/ro-truth[model]['A']) < 0.05, 'Oort A in Dehnen & Binney (1998) {} does not agree with paper value'.format(model)
     assert numpy.fabs(-0.5*(potential.vcirc(pot,1.,use_physical=False)+potential.dvcircdR(pot,1.,use_physical=False))*vo/ro-truth[model]['B']) < 0.05, 'Oort A in Dehnen & Binney (1998) {} does not agree with paper value'.format(model)
     return None
-    
+
 # Test that the virial setup of NFW works
 def test_NFW_virialsetup_wrtmeanmatter():
     H, Om, overdens, wrtcrit= 71., 0.32, 201., False
@@ -2725,7 +2726,7 @@ def test_LinShuReductionFactor():
     from galpy.potential import LinShuReductionFactor, \
         LogarithmicHaloPotential, omegac, epifreq
     lp= LogarithmicHaloPotential(normalize=1.) #work in flat rotation curve
-    #nu^2 = 0.2, x=4 for m=2,sigmar=0.1 
+    #nu^2 = 0.2, x=4 for m=2,sigmar=0.1
     # w/ nu = m(OmegaP-omegac)/epifreq, x=sr^2*k^2/epifreq^2
     R,m,sr = 0.9,2.,0.1
     tepi, tomegac= epifreq(lp,R), omegac(lp,R)
@@ -2735,11 +2736,11 @@ def test_LinShuReductionFactor():
     #nu^2 = 0.8, x=10
     OmegaP= tepi*numpy.sqrt(0.8)/m+tomegac #leads to nu^2 = 0.8
     k= numpy.sqrt(10.)*tepi/sr
-    assert numpy.fabs(LinShuReductionFactor(lp,R,sr,m=m,k=k,OmegaP=OmegaP)-0.04) < 0.01, 'LinShuReductionFactor does not agree w/ Figure 1 from Lin & Shu (1966)'   
+    assert numpy.fabs(LinShuReductionFactor(lp,R,sr,m=m,k=k,OmegaP=OmegaP)-0.04) < 0.01, 'LinShuReductionFactor does not agree w/ Figure 1 from Lin & Shu (1966)'
     #Similar test, but using a nonaxiPot= input
     from galpy.potential import SteadyLogSpiralPotential
     sp= SteadyLogSpiralPotential(m=2.,omegas=OmegaP,alpha=k*R)
-    assert numpy.fabs(LinShuReductionFactor(lp,R,sr,nonaxiPot=sp)-0.04) < 0.01, 'LinShuReductionFactor does not agree w/ Figure 1 from Lin & Shu (1966)'   
+    assert numpy.fabs(LinShuReductionFactor(lp,R,sr,nonaxiPot=sp)-0.04) < 0.01, 'LinShuReductionFactor does not agree w/ Figure 1 from Lin & Shu (1966)'
     #Test exception
     try:
         LinShuReductionFactor(lp,R,sr)
@@ -2749,7 +2750,7 @@ def test_LinShuReductionFactor():
 
 def test_nemoaccname():
     #There is no real good way to test this (I think), so I'm just testing to
-    #what I think is the correct output now to make sure this isn't 
+    #what I think is the correct output now to make sure this isn't
     #accidentally changed
     # Log
     lp= potential.LogarithmicHaloPotential(normalize=1.)
@@ -2913,7 +2914,7 @@ def test_MN3ExponentialDiskPotential_inputs():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always",galpyWarning)
         mn= MN3ExponentialDiskPotential(normalize=1.,hz=1.438,hr=1.)
-        # Should raise warning bc of MN3ExponentialDiskPotential, 
+        # Should raise warning bc of MN3ExponentialDiskPotential,
         # might raise others
         raisedWarning= False
         for wa in w:
@@ -3155,7 +3156,7 @@ def test_zaxisRotatedNFWPotential():
     return None
 
 def test_nonaxierror_function():
-    # Test that the code throws an exception when calling a non-axisymmetric 
+    # Test that the code throws an exception when calling a non-axisymmetric
     # potential without phi
     tnp= potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.9)
     with pytest.raises(potential.PotentialError) as excinfo:
@@ -3201,7 +3202,7 @@ def test_SoftenedNeedleBarPotential_density():
     # Another one
     assert sbp.dens(4.,0.,phi=numpy.pi/4.) > sbp.dens(2.*numpy.sqrt(2.),2.*numpy.sqrt(2.),phi=0.), 'SoftenedNeedleBarPotential with flattened softening kernel does not appear to have a consistent'
     return None
-    
+
 def test_DiskSCFPotential_SigmaDerivs():
     # Test that the derivatives of Sigma are correctly implemented in DiskSCF
     # Very rough finite difference checks
@@ -3301,7 +3302,7 @@ def test_DiskSCFPotential_againstDoubleExp_dens():
     return None
 
 def test_WrapperPotential_dims():
-    # Test that WrapperPotentials get assigned to Potential/planarPotential 
+    # Test that WrapperPotentials get assigned to Potential/planarPotential
     # correctly, based on input pot=
     from galpy.potential.WrapperPotential import parentWrapperPotential, \
         WrapperPotential, planarWrapperPotential
@@ -3320,17 +3321,17 @@ def test_WrapperPotential_dims():
     assert isinstance(dwp,parentWrapperPotential), 'WrapperPotential for 3D pot= is not an instance of parentWrapperPotential'
     assert isinstance(dwp,planarWrapperPotential), 'WrapperPotential for 3D pot= is not an instance of planarWrapperPotential'
     assert not isinstance(dwp,WrapperPotential), 'WrapperPotential for 3D pot= is an instance of WrapperPotential'
-    return None    
+    return None
 
 def test_Wrapper_potinputerror():
-    # Test that setting up a WrapperPotential with anything other than a 
+    # Test that setting up a WrapperPotential with anything other than a
     # (list of) planar/Potentials raises an error
     with pytest.raises(ValueError) as excinfo:
         potential.DehnenSmoothWrapperPotential(pot=1)
     return None
 
 def test_Wrapper_incompatibleunitserror():
-    # Test that setting up a WrapperPotential with a potential with 
+    # Test that setting up a WrapperPotential with a potential with
     # incompatible units to the wrapper itself raises an error
     # 3D
     ro,vo= 8., 220.
@@ -3468,7 +3469,7 @@ def test_dissipative_noVelocityError():
     return None
 
 def test_RingPotential_correctPotentialIntegral():
-    # Test that the RingPotential's potential is correct, by comparing it to a 
+    # Test that the RingPotential's potential is correct, by comparing it to a
     # direct integral solution of the Poisson equation
     from scipy import special, integrate
     # Direct solution
@@ -3534,6 +3535,28 @@ def test_AdiabaticContractionWrapper():
     assert numpy.fabs(dm4.mass(r)/potential.MWPotential2014[2].mass(r)-1.43) < 1e-2, '"gnedin" adiabatic contraction does not agree at R ~ 10 kpc'
     return None
 
+def test_RotateAndTiltWrapper():
+    # some tests of the rotate and tilt wrapper
+    zvec = numpy.array([numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)])
+    zvec/= numpy.sqrt(numpy.sum(zvec**2))
+    rot = _rotate_to_arbitrary_vector(numpy.array([[0.,0.,1.]]), zvec, inv=True)[0]
+    pa = 0.3
+    pa_rot= numpy.array([[numpy.cos(pa),numpy.sin(pa),0.],
+                                     [-numpy.sin(pa),numpy.cos(pa),0.],
+                                     [0.,0.,1.]])
+    rot = numpy.dot(pa_rot, rot)
+    xyz_test= numpy.array([0.5,0.5,0.5])
+    Rphiz_test = coords.rect_to_cyl(xyz_test[0], xyz_test[1], xyz_test[2])
+    txyz_test = numpy.dot(rot, xyz_test)
+    tRphiz_test = coords.rect_to_cyl(txyz_test[0], txyz_test[1], txyz_test[2])
+    testpot = potential.RotateAndTiltWrapperPotential(zvec=zvec, pa=pa, pot=potential.MWPotential2014)
+    #test against the transformed potential and a MWPotential evaluated at the transformed coords
+    assert (evaluatePotentials(testpot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(potential.MWPotential2014, tRphiz_test[0], tRphiz_test[2], phi=tRphiz_test[1])) < 1e-6, 'Evaluating potential at same relative position in a Rotated and tilted MWPotential2014 and non-Rotated does not give same result'
+    NFW_wrapped = potential.RotateAndTiltWrapperPotential(zvec=zvec, pa=pa, pot=potential.TriaxialNFWPotential(amp=1.))
+    NFW_rot = potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=pa)
+    assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
+    return None
+
 def test_vtermnegl_issue314():
     # Test related to issue 314: vterm for negative l
     rp= potential.RazorThinExponentialDiskPotential(normalize=1.,hr=3./8.)
@@ -3592,7 +3615,7 @@ def test_ttensor():
     assert numpy.all(numpy.fabs(tij[0][2]-tij[2][0]) < 1e-10), "Calculation of tidal tensor in point-mass potential fails"
     assert numpy.all(numpy.fabs(tij[1][2]-tij[2][1]) < 1e-10), "Calculation of tidal tensor in point-mass potential fails"
     return None
-    
+
 def test_ttensor_trace():
     # Test that the trace of the tidal tensor == 4piG density for a bunch of
     # potentials
@@ -3644,7 +3667,7 @@ def test_zvc_range():
     R_a_little_less= Rmin-1e-4
     assert potential.evaluatePotentials(pot,R_a_little_less,0.)+Lz**2./2./R_a_little_less**2. > E, 'zvc_range does not give the minimum R for which Phi_eff(R,0) < E'
     R_a_little_more= Rmax+1e-4
-    assert potential.evaluatePotentials(pot,R_a_little_more,0.)+Lz**2./2./R_a_little_more**2. > E, 'zvc_range does not give the maximum R for which Phi_eff(R,0) < E'   
+    assert potential.evaluatePotentials(pot,R_a_little_more,0.)+Lz**2./2./R_a_little_more**2. > E, 'zvc_range does not give the maximum R for which Phi_eff(R,0) < E'
     return None
 
 # Test that we get [NaN,NaN] when there are no orbits for this combination of E and Lz
@@ -3733,7 +3756,7 @@ def test_zvc_valueerror():
     with pytest.raises(ValueError) as excinfo:
         potential.zvc(potential.MWPotential2014,0.7,E+100,Lz)
     return None
-        
+
 def test_rhalf():
     # Test some known cases
     a= numpy.pi
@@ -3833,7 +3856,7 @@ def test_scf_tupleindexwarning():
         warnings.simplefilter("error",FutureWarning)
         p= mockSCFZeeuwPotential()
         p.Rforce(numpy.atleast_1d(1.),numpy.atleast_1d(0.))
-    return None   
+    return None
 
 # Test that attempting to multiply or divide a potential by something other than a number raises an error
 def test_mult_divide_error():
@@ -3892,7 +3915,7 @@ def test_add_potentials():
     assert pot1+(pot2+pot3) == [pot1,pot2,pot3]
     return None
 
-# Test that attempting to multiply or divide a potential by something other 
+# Test that attempting to multiply or divide a potential by something other
 # than a number raises a TypeError (test both left and right)
 def test_add_potentials_error():
     # 3D
@@ -4011,7 +4034,7 @@ def test_plotting():
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         kp.plotRotcurve(Rrange=[0.01,10.],
@@ -4036,7 +4059,7 @@ def test_plotting():
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         kp.plotEscapecurve(Rrange=[0.01,10.],
@@ -4050,24 +4073,24 @@ def test_plotting():
         os.remove(tmp_savefilename)
     #Plot the potential itself
     kp.plot()
-    kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11, 
+    kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11,
             effective=False,Lz=None,xy=True,
             xrange=[0.01,1.8],yrange=[-0.55,0.55],justcontours=True,
             ncontours=11,savefilename=None)
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
-        kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11, 
-                effective=False,Lz=None, 
-                xrange=[0.01,1.8],yrange=[-0.55,0.55], 
+        kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11,
+                effective=False,Lz=None,
+                xrange=[0.01,1.8],yrange=[-0.55,0.55],
                 ncontours=11,savefilename=tmp_savefilename)
         #Then plot using the saved file
-        kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11, 
-                effective=False,Lz=None, 
-                xrange=[0.01,1.8],yrange=[-0.55,0.55], 
+        kp.plot(t=1.,rmin=0.01,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11,
+                effective=False,Lz=None,
+                xrange=[0.01,1.8],yrange=[-0.55,0.55],
                 ncontours=11,savefilename=tmp_savefilename)
     finally:
         os.remove(tmp_savefilename)
@@ -4075,18 +4098,18 @@ def test_plotting():
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         potential.plotPotentials([kp],
                                  rmin=0.01,rmax=1.8,nrs=11,
-                                 zmin=-0.55,zmax=0.55,nzs=11, 
+                                 zmin=-0.55,zmax=0.55,nzs=11,
                                  justcontours=True,xy=True,
                                  ncontours=11,savefilename=tmp_savefilename)
         #Then plot using the saved file
         potential.plotPotentials([kp],t=1.,
                                  rmin=0.01,rmax=1.8,nrs=11,
-                                 zmin=-0.55,zmax=0.55,nzs=11, 
+                                 zmin=-0.55,zmax=0.55,nzs=11,
                                  ncontours=11,savefilename=tmp_savefilename)
     finally:
         os.remove(tmp_savefilename)
@@ -4110,13 +4133,13 @@ def test_plotting():
     #Plot the density of a LogarithmicHaloPotential
     lp= potential.LogarithmicHaloPotential(normalize=1.)
     lp.plotDensity()
-    lp.plotDensity(t=1.,rmin=0.05,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11, 
+    lp.plotDensity(t=1.,rmin=0.05,rmax=1.8,nrs=11,zmin=-0.55,zmax=0.55,nzs=11,
                    aspect=1.,log=True,justcontours=True,xy=True,
                    ncontours=11,savefilename=None)
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         lp.plotDensity(savefilename=tmp_savefilename)
@@ -4127,7 +4150,7 @@ def test_plotting():
     potential.plotDensities([lp])
     potential.plotDensities([lp],t=1.,
                             rmin=0.05,rmax=1.8,nrs=11,
-                            zmin=-0.55,zmax=0.55,nzs=11, 
+                            zmin=-0.55,zmax=0.55,nzs=11,
                             aspect=1.,log=True,xy=True,
                             justcontours=True,
                             ncontours=11,savefilename=None)
@@ -4135,13 +4158,13 @@ def test_plotting():
     lp= potential.LogarithmicHaloPotential(normalize=1.)
     lp.plotSurfaceDensity()
     lp.plotSurfaceDensity(t=1.,z=2.,xmin=0.05,xmax=1.8,nxs=11,
-                          ymin=-0.55,ymax=0.55,nys=11, 
+                          ymin=-0.55,ymax=0.55,nys=11,
                           aspect=1.,log=True,justcontours=True,
                           ncontours=11,savefilename=None)
     #Also while saving the result
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         lp.plotSurfaceDensity(savefilename=tmp_savefilename)
@@ -4152,7 +4175,7 @@ def test_plotting():
     potential.plotSurfaceDensities([lp])
     potential.plotSurfaceDensities([lp],t=1.,z=2.,
                                    xmin=0.05,xmax=1.8,nxs=11,
-                                   ymin=-0.55,ymax=0.55,nys=11, 
+                                   ymin=-0.55,ymax=0.55,nys=11,
                                    aspect=1.,log=True,
                                    justcontours=True,
                                    ncontours=11,savefilename=None)
@@ -4160,7 +4183,7 @@ def test_plotting():
     kp.toPlanar().plot()
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         kp.toPlanar().plot(Rrange=[0.01,1.8],grid=11,
@@ -4173,7 +4196,7 @@ def test_plotting():
     dp= potential.EllipticalDiskPotential()
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         dp.plot(xrange=[0.01,1.8],yrange=[0.01,1.8],gridx=11,gridy=11,
@@ -4189,7 +4212,7 @@ def test_plotting():
     lip.plot()
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         lip.plot(t=0.,min=-15.,max=15,ns=21,savefilename=tmp_savefilename)
@@ -4199,7 +4222,7 @@ def test_plotting():
         os.remove(tmp_savefilename)
     savefile, tmp_savefilename= tempfile.mkstemp()
     try:
-        os.close(savefile) #Easier this way 
+        os.close(savefile) #Easier this way
         os.remove(tmp_savefilename)
         #First save
         potential.plotlinearPotentials(lip,t=0.,min=-15.,max=15,ns=21,
@@ -4388,7 +4411,7 @@ class sech2DiskSCFPotential(DiskSCFPotential):
         return None
 class expwholeDiskSCFPotential(DiskSCFPotential):
     def __init__(self):
-        # Add a Hernquist potential because otherwise the density near the 
+        # Add a Hernquist potential because otherwise the density near the
         # center is zero
         from galpy.potential import HernquistPotential
         hp= HernquistPotential(normalize=0.5)
@@ -4406,7 +4429,7 @@ class expwholeDiskSCFPotential(DiskSCFPotential):
 # case is handled correctly
 class altExpwholeDiskSCFPotential(DiskSCFPotential):
     def __init__(self):
-        # Add a Hernquist potential because otherwise the density near the 
+        # Add a Hernquist potential because otherwise the density near the
         # center is zero
         from galpy.potential import HernquistPotential
         hp= HernquistPotential(normalize=0.5)
@@ -4511,7 +4534,7 @@ class mockCosmphiDiskPotentialnegp(CosmphiDiskPotential):
 class mockEllipticalDiskPotentialT1(EllipticalDiskPotential):
     def __init__(self):
         EllipticalDiskPotential.__init__(self,amp=1.,phib=25.*numpy.pi/180.,
-                                         p=1.,twophio=0.02, 
+                                         p=1.,twophio=0.02,
                                          tform=0.5,tsteady=1.,
                                          cp=0.05,sp=0.05)
 class mockEllipticalDiskPotentialTm1(EllipticalDiskPotential):
@@ -4528,25 +4551,25 @@ class mockEllipticalDiskPotentialTm5(EllipticalDiskPotential):
                                          cp=-0.05,sp=0.05)
 class mockSteadyLogSpiralPotentialT1(SteadyLogSpiralPotential):
     def __init__(self):
-        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035, 
+        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035,
                                           m=2,gamma=numpy.pi/4.,
-                                          p=-0.3, 
+                                          p=-0.3,
                                           tform=0.5,tsteady=1.)
 class mockSteadyLogSpiralPotentialTm1(SteadyLogSpiralPotential):
     def __init__(self):
-        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035, 
+        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035,
                                           m=2,gamma=numpy.pi/4.,
-                                          p=-0.3, 
+                                          p=-0.3,
                                           tform=-1.,tsteady=None)
 class mockSteadyLogSpiralPotentialTm5(SteadyLogSpiralPotential):
     def __init__(self):
-        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035, 
+        SteadyLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035,
                                           m=2,gamma=numpy.pi/4.,
-                                          p=-0.3, 
+                                          p=-0.3,
                                           tform=-1.,tsteady=-5.)
 class mockTransientLogSpiralPotential(TransientLogSpiralPotential):
     def __init__(self):
-        TransientLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035, 
+        TransientLogSpiralPotential.__init__(self,amp=1.,omegas=0.65,A=-0.035,
                                              m=2,gamma=numpy.pi/4.,
                                              p=-0.3)
 
@@ -4554,50 +4577,50 @@ class mockTransientLogSpiralPotential(TransientLogSpiralPotential):
 def rho_Zeeuw(R, z=0., phi=0., a=1.):
     r, theta, phi = coords.cyl_to_spher(R,z, phi)
     return 3./(4*numpy.pi) * numpy.power((a + r),-4.) * a
-   
-    
+
+
 def axi_density1(R, z=0, phi=0.):
     r, theta, phi = coords.cyl_to_spher(R,z, phi)
     h = potential.HernquistPotential()
     return h.dens(R, z, phi)*(1 + numpy.cos(theta) + numpy.cos(theta)**2.)
-    
+
 def axi_density2(R, z=0, phi=0.):
     r, theta, phi = coords.cyl_to_spher(R,z, phi)
     return rho_Zeeuw(R,z,phi)*(1 +numpy.cos(theta) + numpy.cos(theta)**2)
-    
+
 def scf_density(R, z=0, phi=0.):
     eps = .1
     return axi_density2(R,z,phi)*(1 + eps*(numpy.cos(phi) + numpy.sin(phi)))
 
-##Mock SCF class                                                         
+##Mock SCF class
 class mockSCFZeeuwPotential(potential.SCFPotential):
     def __init__(self):
         Acos, Asin = potential.scf_compute_coeffs_spherical(rho_Zeeuw,2)
         potential.SCFPotential.__init__(self,amp=1.,Acos=Acos, Asin=Asin)
-        
+
 
 class mockSCFNFWPotential(potential.SCFPotential):
     def __init__(self):
         nfw = potential.NFWPotential()
         Acos, Asin = potential.scf_compute_coeffs_spherical(nfw.dens,10)
         potential.SCFPotential.__init__(self,amp=1.,Acos=Acos, Asin=Asin)
-        
+
 class mockSCFAxiDensity1Potential(potential.SCFPotential):
     def __init__(self):
         Acos, Asin = potential.scf_compute_coeffs_axi(axi_density1,10,2)
         potential.SCFPotential.__init__(self,amp=1.,Acos=Acos, Asin=Asin)
-              
-              
+
+
 class mockSCFAxiDensity2Potential(potential.SCFPotential):
     def __init__(self):
         Acos, Asin = potential.scf_compute_coeffs_axi(axi_density2,10,2)
         potential.SCFPotential.__init__(self,amp=1.,Acos=Acos, Asin=Asin)
-        
+
 class mockSCFDensityPotential(potential.SCFPotential):
     def __init__(self):
         Acos, Asin = potential.scf_compute_coeffs(scf_density,10,10,phi_order=30)
         potential.SCFPotential.__init__(self,amp=1.,Acos=Acos, Asin=Asin)
-        
+
 # Test interpSphericalPotential
 class mockInterpSphericalPotential(potential.interpSphericalPotential):
     def __init__(self):
@@ -4980,7 +5003,7 @@ class mockFlatSolidBodyRotationPlanarSpiralArmsPotential(testplanarMWPotential):
     def OmegaP(self):
         return self._potlist[1].OmegaP()
 class testorbitHenonHeilesPotential(testplanarMWPotential):
-    # Need this class, bc orbit tests skip potentials that do not have 
+    # Need this class, bc orbit tests skip potentials that do not have
     # .normalize, and HenonHeiles as a non-axi planarPotential instance
     # does not
     def __init__(self):
@@ -5077,4 +5100,3 @@ class mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential(AdiabaticContrac
                                 pot=potential.MWPotential2014[2],
                                 baryonpot=potential.MWPotential2014[:2],
                                 f_bar=0.1)
-        

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1333,6 +1333,7 @@ def test_potential_at_zero():
            or p == 'SphericalShellPotential' \
            or p == 'AnyAxisymmetricRazorThinDiskPotential' \
            or p == 'AnySphericalPotential' \
+           or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
            or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -1396,6 +1397,7 @@ def test_potential_at_infinity():
     pots.append('mockInterpSphericalPotentialwForce')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential')
+    pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1438,6 +1440,7 @@ def test_potential_at_infinity():
            or p == 'SphericalShellPotential' \
            or p == 'AnyAxisymmetricRazorThinDiskPotential' \
            or p == 'AnySphericalPotential' \
+           or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
           or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -5105,12 +5105,15 @@ class mockAdiabaticContractionMWP14ExplicitfbarWrapperPotential(AdiabaticContrac
                                 baryonpot=potential.MWPotential2014[:2],
                                 f_bar=0.1)
 
-class mockRotatedAndTiltedMWP14WrapperPotential(RotateAndTiltWrapperPotential):
-    def __new__(cls,*args,**kwargs):
-        if kwargs.get('_init',False):
-            return parentWrapperPotential.__new__(cls,*args,**kwargs)
-        mwpot = potential.MWPotential2014
-        return RotateAndTiltWrapperPotential.__new__(cls,\
-                                                     pot=mwpot,
-                                                     zvec=[numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)],
-                                                     pa=0.4)
+    def normalize(self,norm):
+        self._amp*= norm/numpy.fabs(self.Rforce(1.,0.,use_physical=False))
+class mockRotatedAndTiltedMWP14WrapperPotential(testMWPotential):
+    def __init__(self):
+        testMWPotential.__init__(self,potlist=[\
+                RotateAndTiltWrapperPotential(pot=potential.MWPotential2014,
+                                              zvec=[numpy.sqrt(1/3.),
+                                                    numpy.sqrt(1/3.),
+                                                    numpy.sqrt(1/3.)],
+                                              pa=0.4)])
+    def OmegaP(self):
+        return 0.

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -3543,20 +3543,20 @@ def test_RotateAndTiltWrapper():
     zvec = numpy.array([numpy.sqrt(1/3.),numpy.sqrt(1/3.),numpy.sqrt(1/3.)])
     zvec/= numpy.sqrt(numpy.sum(zvec**2))
     rot = _rotate_to_arbitrary_vector(numpy.array([[0.,0.,1.]]), zvec, inv=True)[0]
-    pa = 0.3
-    pa_rot= numpy.array([[numpy.cos(pa),numpy.sin(pa),0.],
-                                     [-numpy.sin(pa),numpy.cos(pa),0.],
-                                     [0.,0.,1.]])
+    galaxy_pa = 0.3
+    pa_rot= numpy.array([[numpy.cos(galaxy_pa),numpy.sin(galaxy_pa),0.],
+                         [-numpy.sin(galaxy_pa),numpy.cos(galaxy_pa),0.],
+                         [0.,0.,1.]])
     rot = numpy.dot(pa_rot, rot)
     xyz_test= numpy.array([0.5,0.5,0.5])
     Rphiz_test = coords.rect_to_cyl(xyz_test[0], xyz_test[1], xyz_test[2])
     txyz_test = numpy.dot(rot, xyz_test)
     tRphiz_test = coords.rect_to_cyl(txyz_test[0], txyz_test[1], txyz_test[2])
-    testpot = potential.RotateAndTiltWrapperPotential(zvec=zvec, pa=pa, pot=potential.MWPotential2014)
+    testpot = potential.RotateAndTiltWrapperPotential(zvec=zvec,galaxy_pa=galaxy_pa,pot=potential.MWPotential2014)
     #test against the transformed potential and a MWPotential evaluated at the transformed coords
     assert (evaluatePotentials(testpot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(potential.MWPotential2014, tRphiz_test[0], tRphiz_test[2], phi=tRphiz_test[1])) < 1e-6, 'Evaluating potential at same relative position in a Rotated and tilted MWPotential2014 and non-Rotated does not give same result'
-    NFW_wrapped = potential.RotateAndTiltWrapperPotential(zvec=zvec, pa=pa, pot=potential.TriaxialNFWPotential(amp=1.))
-    NFW_rot = potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=pa)
+    NFW_wrapped = potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.))
+    NFW_rot = potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
     return None
 
@@ -5114,6 +5114,6 @@ class mockRotatedAndTiltedMWP14WrapperPotential(testMWPotential):
                                               zvec=[numpy.sqrt(1/3.),
                                                     numpy.sqrt(1/3.),
                                                     numpy.sqrt(1/3.)],
-                                              pa=0.4)])
+                                              galaxy_pa=0.4)])
     def OmegaP(self):
         return 0.

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1540,6 +1540,7 @@ def test_potential_method_returntype():
     assert isinstance(pot.Rzderiv(1.1,0.1),units.Quantity), 'Potential method Rzderiv does not return Quantity when it should'
     assert isinstance(pot.Rphideriv(1.1,0.1),units.Quantity), 'Potential method Rphideriv does not return Quantity when it should'
     assert isinstance(pot.phi2deriv(1.1,0.1),units.Quantity), 'Potential method phi2deriv does not return Quantity when it should'
+    assert isinstance(pot.phizderiv(1.1,0.1),units.Quantity), 'Potential method phizderiv does not return Quantity when it should'
     assert isinstance(pot.flattening(1.1,0.1),units.Quantity), 'Potential method flattening does not return Quantity when it should'
     assert isinstance(pot.vcirc(1.1),units.Quantity), 'Potential method vcirc does not return Quantity when it should'
     assert isinstance(pot.dvcircdR(1.1),units.Quantity), 'Potential method dvcircdR does not return Quantity when it should'
@@ -1641,13 +1642,17 @@ def test_potential_method_returnunit():
     except units.UnitConversionError:
         raise AssertionError('Potential method Rzderiv does not return Quantity with the right units')
     try:
-        pot.phi2deriv(1.1,0.1).to(1/units.s**2)
+        pot.phi2deriv(1.1,0.1).to(units.km**2/units.s**2)
     except units.UnitConversionError:
         raise AssertionError('Potential method phi2deriv does not return Quantity with the right units')
     try:
-        pot.Rphideriv(1.1,0.1).to(1/units.s**2)
+        pot.Rphideriv(1.1,0.1).to(units.km/units.s**2)
     except units.UnitConversionError:
         raise AssertionError('Potential method Rphideriv does not return Quantity with the right units')
+    try:
+        pot.phizderiv(1.1,0.1).to(units.km/units.s**2)
+    except units.UnitConversionError:
+        raise AssertionError('Potential method phizderiv does not return Quantity with the right units')
     try:
         pot.flattening(1.1,0.1).to(units.dimensionless_unscaled)
     except units.UnitConversionError:
@@ -1738,11 +1743,11 @@ def test_planarPotential_method_returnunit():
     except units.UnitConversionError:
         raise AssertionError('Potential method R2deriv does not return Quantity with the right units')
     try:
-        pot.phi2deriv(1.1).to(1/units.s**2)
+        pot.phi2deriv(1.1).to(units.km**2/units.s**2)
     except units.UnitConversionError:
         raise AssertionError('Potential method phi2deriv does not return Quantity with the right units')
     try:
-        pot.Rphideriv(1.1).to(1/units.s**2)
+        pot.Rphideriv(1.1).to(units.km/units.s**2)
     except units.UnitConversionError:
         raise AssertionError('Potential method Rphideriv does not return Quantity with the right units')
     try:
@@ -1797,8 +1802,9 @@ def test_potential_method_value():
     assert numpy.fabs(pot.R2deriv(1.1,0.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.R2deriv(1.1,0.1)*vo**2./ro**2.) < 10.**-8., 'Potential method R2deriv does not return the correct value as Quantity'
     assert numpy.fabs(pot.z2deriv(1.1,0.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.z2deriv(1.1,0.1)*vo**2./ro**2.) < 10.**-8., 'Potential method z2deriv does not return the correct value as Quantity'
     assert numpy.fabs(pot.Rzderiv(1.1,0.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.Rzderiv(1.1,0.1)*vo**2./ro**2.) < 10.**-8., 'Potential method Rzderiv does not return the correct value as Quantity'
-    assert numpy.fabs(pot.Rphideriv(1.1,0.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.Rphideriv(1.1,0.1)*vo**2./ro**2.) < 10.**-8., 'Potential method Rphideriv does not return the correct value as Quantity'
-    assert numpy.fabs(pot.phi2deriv(1.1,0.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.phi2deriv(1.1,0.1)*vo**2./ro**2.) < 10.**-8., 'Potential method phi2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.Rphideriv(1.1,0.1).to(units.km**2/units.s**2./units.kpc).value-potu.Rphideriv(1.1,0.1)*vo**2./ro) < 10.**-8., 'Potential method Rphideriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.phi2deriv(1.1,0.1).to(units.km**2/units.s**2.).value-potu.phi2deriv(1.1,0.1)*vo**2.) < 10.**-8., 'Potential method phi2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.phizderiv(1.1,0.1).to(units.km**2/units.s**2./units.kpc).value-potu.phizderiv(1.1,0.1)*vo**2./ro) < 10.**-8., 'Potential method phizderiv does not return the correct value as Quantity'
     assert numpy.fabs(pot.flattening(1.1,0.1).value-potu.flattening(1.1,0.1)) < 10.**-8., 'Potential method flattening does not return the correct value as Quantity'
     assert numpy.fabs(pot.vcirc(1.1).to(units.km/units.s).value-potu.vcirc(1.1)*vo) < 10.**-8., 'Potential method vcirc does not return the correct value as Quantity'
     assert numpy.fabs(pot.dvcircdR(1.1).to(units.km/units.s/units.kpc).value-potu.dvcircdR(1.1)*vo/ro) < 10.**-8., 'Potential method dvcircdR does not return the correct value as Quantity'
@@ -1828,8 +1834,8 @@ def test_planarPotential_method_value():
     assert numpy.fabs(pot.Rforce(1.1).to(units.km/units.s**2).value*10.**13.-potu.Rforce(1.1)*conversion.force_in_10m13kms2(vo,ro)) < 10.**-4., 'Potential method Rforce does not return the correct value as Quantity'
     assert numpy.fabs(pot.phiforce(1.1).to(units.km**2/units.s**2).value-potu.phiforce(1.1)*vo**2) < 10.**-4., 'Potential method phiforce does not return the correct value as Quantity'
     assert numpy.fabs(pot.R2deriv(1.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.R2deriv(1.1)*vo**2./ro**2.) < 10.**-8., 'Potential method R2deriv does not return the correct value as Quantity'
-    assert numpy.fabs(pot.Rphideriv(1.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.Rphideriv(1.1)*vo**2./ro**2.) < 10.**-8., 'Potential method Rphideriv does not return the correct value as Quantity'
-    assert numpy.fabs(pot.phi2deriv(1.1).to(units.km**2/units.s**2./units.kpc**2).value-potu.phi2deriv(1.1)*vo**2./ro**2.) < 10.**-8., 'Potential method phi2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.Rphideriv(1.1).to(units.km**2/units.s**2./units.kpc).value-potu.Rphideriv(1.1)*vo**2./ro) < 10.**-8., 'Potential method Rphideriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.phi2deriv(1.1).to(units.km**2/units.s**2.).value-potu.phi2deriv(1.1)*vo**2.) < 10.**-8., 'Potential method phi2deriv does not return the correct value as Quantity'
     assert numpy.fabs(pot.vcirc(1.1).to(units.km/units.s).value-potu.vcirc(1.1)*vo) < 10.**-8., 'Potential method vcirc does not return the correct value as Quantity'
     assert numpy.fabs(pot.omegac(1.1).to(units.km/units.s/units.kpc).value-potu.omegac(1.1)*vo/ro) < 10.**-8., 'Potential method omegac does not return the correct value as Quantity'
     assert numpy.fabs(pot.epifreq(1.1).to(units.km/units.s/units.kpc).value-potu.epifreq(1.1)*vo/ro) < 10.**-8., 'Potential method epifreq does not return the correct value as Quantity'
@@ -2162,6 +2168,7 @@ def test_potential_method_inputAsQuantity():
     assert numpy.fabs(pot.Rzderiv(1.1*ro,0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.Rzderiv(1.1,0.1)) < 10.**-8., 'Potential method Rzderiv does not return the correct value when input is Quantity'
     assert numpy.fabs(pot.Rphideriv(1.1*ro,0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.Rphideriv(1.1,0.1)) < 10.**-8., 'Potential method Rphideriv does not return the correct value when input is Quantity'
     assert numpy.fabs(pot.phi2deriv(1.1*ro,0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.phi2deriv(1.1,0.1)) < 10.**-8., 'Potential method phi2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.phizderiv(1.1*ro,0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.phizderiv(1.1,0.1)) < 10.**-8., 'Potential method phizderiv does not return the correct value when input is Quantity'
     assert numpy.fabs(pot.flattening(1.1*ro,0.1*ro,use_physical=False)-potu.flattening(1.1,0.1)) < 10.**-8., 'Potential method flattening does not return the correct value when input is Quantity'
     assert numpy.fabs(pot.vcirc(1.1*ro,use_physical=False)-potu.vcirc(1.1)) < 10.**-8., 'Potential method vcirc does not return the correct value when input is Quantity'
     assert numpy.fabs(pot.dvcircdR(1.1*ro,use_physical=False)-potu.dvcircdR(1.1)) < 10.**-8., 'Potential method dvcircdR does not return the correct value when input is Quantity'

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -3379,6 +3379,25 @@ def test_potential_paramunits():
     # Check potential
     assert numpy.fabs(pot(4.,0.,phi=1.,use_physical=False)-pot_nounits(4.,0.,phi=1.,use_physical=False)) < 10.**-8., "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"   
     # If you add one here, don't base it on ChandrasekharDynamicalFrictionForce!!
+    # RotateAndTiltWrapperPotential, zvec, pa
+    wrappot= potential.TriaxialNFWPotential(amp=1.,a=3.,b=0.7,c=0.5)
+    pot= potential.RotateAndTiltWrapperPotential(pot=wrappot,zvec=[0,1.,0],galaxy_pa=30.*units.deg,
+                                                 ro=ro,vo=vo)
+    pot_nounits= potential.RotateAndTiltWrapperPotential(pot=wrappot,zvec=[0,1.,0],galaxy_pa=numpy.pi/6.,
+                                                         ro=ro,vo=vo)
+    # Check potential
+    assert numpy.fabs(pot(4.,0.,phi=1.,use_physical=False)-pot_nounits(4.,0.,phi=1.,use_physical=False)) < 10.**-8., "RotateAndTiltWrapperPotential w/ pa w/ units does not behave as expected"   
+    # RotateAndTiltWrapperPotential, inclination, galaxy_pa, sky_pa
+    wrappot= potential.TriaxialNFWPotential(amp=1.,a=3.,b=0.7,c=0.5)
+    pot= potential.RotateAndTiltWrapperPotential(pot=wrappot,galaxy_pa=30.*units.deg,
+                                                 inclination=60.*units.deg,sky_pa=-45.*units.deg,
+                                                 ro=ro,vo=vo)
+    pot_nounits= potential.RotateAndTiltWrapperPotential(pot=wrappot,galaxy_pa=numpy.pi/6.,
+                                                         inclination=numpy.pi/3.,sky_pa=-numpy.pi/4.,
+                                                         ro=ro,vo=vo)
+    # Check potential
+    assert numpy.fabs(pot(4.,0.,phi=1.,use_physical=False)-pot_nounits(4.,0.,phi=1.,use_physical=False)) < 10.**-8., "RotateAndTiltWrapperPotential w/ pa w/ units does not behave as expected"   
+    # If you add one here, don't base it on ChandrasekharDynamicalFrictionForce!!
     return None
 
 def test_potential_paramunits_2d():


### PR DESCRIPTION
I started having a go at implementing this wrapper potential which allows an adjustment to the z-axis of a potential. This will allow for potentials to be tilted around (in a similar way to the transformations currently allowed when using `EllipsoidalPotential` type potentials). Starting the PR to keep my momentum up!

The python implementation of the potential seems to be working as expected, but including the C code has given me some hiccups (which I think will cause the tests to fail!). I can't see why - but orbit integration in C doesn't seem to want to work. This is my first foray into C, so that might explain it.

I need to add testing of all the added things - once that's done, hopefully this should merge in easily... 