### PR TITLE
Constantbetadf

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -10,7 +10,7 @@ from .sphericaldf import anisotropicsphericaldf, sphericaldf
 # formula can be found following this class
 class _constantbetadf(anisotropicsphericaldf):
     """Class that implements DFs of the form f(E,L) = L^{-2\beta} f(E) with constant beta anisotropy parameter"""
-    def __init__(self,pot=None,denspot=None,beta=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,beta=None,rmin=None,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -27,6 +27,8 @@ class _constantbetadf(anisotropicsphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
             scale - Characteristic scale radius to aid sampling calculations. 
@@ -34,8 +36,8 @@ class _constantbetadf(anisotropicsphericaldf):
                 available.
 
         """
-        anisotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmax=rmax,
-                                        scale=scale,ro=ro,vo=vo)
+        anisotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmin=rmin,
+                                        rmax=rmax,scale=scale,ro=ro,vo=vo)
         self._beta= beta
 
     def _call_internal(self,*args):
@@ -101,8 +103,8 @@ class _constantbetadf(anisotropicsphericaldf):
 
 class constantbetadf(_constantbetadf):
     """Class that implements DFs of the form f(E,L) = L^{-2\beta} f(E) with constant beta anisotropy parameter for a given density profile"""
-    def __init__(self,pot=None,denspot=None,beta=0.,twobeta=None,rmax=None,
-                 scale=None,ro=None,vo=None):
+    def __init__(self,pot=None,denspot=None,beta=0.,twobeta=None,rmin=None,
+                 rmax=None,scale=None,ro=None,vo=None):
         """
         NAME:
 
@@ -121,6 +123,8 @@ class constantbetadf(_constantbetadf):
            beta= (0.) anisotropy parameter
 
            twobeta= (None) twice the anisotropy parameter (useful for \beta = half-integer, which is a special case); has priority over beta
+
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -146,7 +150,7 @@ class constantbetadf(_constantbetadf):
             beta= twobeta/2.
         else:
             twobeta= 2.*beta
-        _constantbetadf.__init__(self,pot=pot,denspot=denspot,beta=beta,
+        _constantbetadf.__init__(self,pot=pot,denspot=denspot,beta=beta,rmin=rmin,
                                  rmax=rmax,scale=scale,ro=ro,vo=vo)
         self._twobeta= twobeta
         self._halfint= False
@@ -188,7 +192,7 @@ class constantbetadf(_constantbetadf):
         self._gradfunc= vmap(func)
         # Min and max energy
         self._potInf= _evaluatePotentials(self._pot,self._rmax,0)
-        self._Emin= _evaluatePotentials(self._pot,0,0)
+        self._Emin= _evaluatePotentials(self._pot,self._rmin,0)
         # Build interpolator r(pot)
         r_a_values= numpy.concatenate(\
                         (numpy.array([0.]),

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -10,7 +10,7 @@ from .sphericaldf import anisotropicsphericaldf, sphericaldf
 # formula can be found following this class
 class _constantbetadf(anisotropicsphericaldf):
     """Class that implements DFs of the form f(E,L) = L^{-2\beta} f(E) with constant beta anisotropy parameter"""
-    def __init__(self,pot=None,denspot=None,beta=None,rmin=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,beta=None,rmin=0.,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -27,7 +27,7 @@ class _constantbetadf(anisotropicsphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -103,7 +103,7 @@ class _constantbetadf(anisotropicsphericaldf):
 
 class constantbetadf(_constantbetadf):
     """Class that implements DFs of the form f(E,L) = L^{-2\beta} f(E) with constant beta anisotropy parameter for a given density profile"""
-    def __init__(self,pot=None,denspot=None,beta=0.,twobeta=None,rmin=None,
+    def __init__(self,pot=None,denspot=None,beta=0.,twobeta=None,rmin=0.,
                  rmax=None,scale=None,ro=None,vo=None):
         """
         NAME:
@@ -124,7 +124,7 @@ class constantbetadf(_constantbetadf):
 
            twobeta= (None) twice the anisotropy parameter (useful for \beta = half-integer, which is a special case); has priority over beta
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0.) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -15,7 +15,7 @@ class eddingtondf(isotropicsphericaldf):
         f(\\mathcal{E}) = \\frac{1}{\\sqrt{8}\\,\\pi^2}\\,\\left[\\int_0^\\mathcal{E}\\mathrm{d}\\Psi\\,\\frac{1}{\\sqrt{\\mathcal{E}-\\Psi}}\\,\\frac{\\mathrm{d}^2\\rho}{\\mathrm{d}\\Psi^2} +\\frac{1}{\\sqrt{\\mathcal{E}}}\\,\\frac{\\mathrm{d}\\rho}{\\mathrm{d}\\Psi}\\Bigg|_{\\Psi=0}\\right]\\,,
 
     where :math:`\\Psi = -\\Phi+\\Phi(\\infty)` is the relative potential, :math:`\\mathcal{E} = \\Psi-v^2/2` is the relative (binding) energy, and :math:`\\rho` is the density of the tracer population (not necessarily the density corresponding to :math:`\\Psi` according to the Poisson equation). Note that the second term on the right-hand side is currently assumed to be zero in the code."""
-    def __init__(self,pot=None,denspot=None,rmin=None,rmax=1e4,
+    def __init__(self,pot=None,denspot=None,rmin=0.,rmax=1e4,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -32,7 +32,7 @@ class eddingtondf(isotropicsphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (1e4) when sampling, maximum radius to consider (can be Quantity)
 

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -15,7 +15,7 @@ class eddingtondf(isotropicsphericaldf):
         f(\\mathcal{E}) = \\frac{1}{\\sqrt{8}\\,\\pi^2}\\,\\left[\\int_0^\\mathcal{E}\\mathrm{d}\\Psi\\,\\frac{1}{\\sqrt{\\mathcal{E}-\\Psi}}\\,\\frac{\\mathrm{d}^2\\rho}{\\mathrm{d}\\Psi^2} +\\frac{1}{\\sqrt{\\mathcal{E}}}\\,\\frac{\\mathrm{d}\\rho}{\\mathrm{d}\\Psi}\\Bigg|_{\\Psi=0}\\right]\\,,
 
     where :math:`\\Psi = -\\Phi+\\Phi(\\infty)` is the relative potential, :math:`\\mathcal{E} = \\Psi-v^2/2` is the relative (binding) energy, and :math:`\\rho` is the density of the tracer population (not necessarily the density corresponding to :math:`\\Psi` according to the Poisson equation). Note that the second term on the right-hand side is currently assumed to be zero in the code."""
-    def __init__(self,pot=None,denspot=None,rmax=1e4,
+    def __init__(self,pot=None,denspot=None,rmin=None,rmax=1e4,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -32,6 +32,8 @@ class eddingtondf(isotropicsphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+
            rmax= (1e4) when sampling, maximum radius to consider (can be Quantity)
 
            scale - Characteristic scale radius to aid sampling calculations. Optionaland will also be overridden by value from pot if available.
@@ -47,8 +49,8 @@ class eddingtondf(isotropicsphericaldf):
             2021-02-04 - Written - Bovy (UofT)
 
         """
-        isotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmax=rmax,
-                                      scale=scale,ro=ro,vo=vo)
+        isotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmin=rmin,
+                                      rmax=rmax,scale=scale,ro=ro,vo=vo)
         self._dnudr= self._denspot._ddensdr \
             if not isinstance(self._denspot,list) \
             else lambda r: numpy.sum([p._ddensdr(r) for p in self._denspot])
@@ -56,7 +58,7 @@ class eddingtondf(isotropicsphericaldf):
             if not isinstance(self._denspot,list) \
             else lambda r: numpy.sum([p._d2densdr2(r) for p in self._denspot])
         self._potInf= _evaluatePotentials(pot,self._rmax,0)
-        self._Emin= _evaluatePotentials(pot,0,0)
+        self._Emin= _evaluatePotentials(pot,self._rmin,0)
         # Build interpolator r(pot)
         r_a_values= numpy.concatenate(\
                         (numpy.array([0.]),

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -11,7 +11,7 @@ from .eddingtondf import eddingtondf
 # formula can be found following this class
 class _osipkovmerrittdf(anisotropicsphericaldf):
     """General Osipkov-Merritt superclass with useful functions for any DF of the Osipkov-Merritt type."""
-    def __init__(self,pot=None,denspot=None,ra=1.4,rmax=None,
+    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=None,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -29,7 +29,11 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
             denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
             ra - anisotropy radius (can be a Quantity)
-          
+
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+
+           rmax= (None) when sampling, maximum radius to consider (can be Quantity)
+
             scale - Characteristic scale radius to aid sampling calculations. 
                 Not necessary, and will also be overridden by value from pot 
                 if available.
@@ -45,8 +49,8 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
             2020-11-12 - Written - Bovy (UofT)
 
         """
-        anisotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmax=rmax,
-                                        scale=scale,ro=ro,vo=vo)
+        anisotropicsphericaldf.__init__(self,pot=pot,denspot=denspot,rmin=rmin,
+                                        rmax=rmax,scale=scale,ro=ro,vo=vo)
         self._ra= conversion.parse_length(ra,ro=self._ro)
         self._ra2= self._ra**2.
 
@@ -126,7 +130,7 @@ class osipkovmerrittdf(_osipkovmerrittdf):
         \\beta(r) = \\frac{1}{1+r_a^2/r^2}
 
     with :math:`r_a` the anistropy radius for arbitrary combinations of potential and density profile."""
-    def __init__(self,pot=None,denspot=None,ra=1.4,rmax=1e4,
+    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=None,rmax=1e4,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -144,7 +148,9 @@ class osipkovmerrittdf(_osipkovmerrittdf):
             denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
             ra - anisotropy radius (can be a Quantity)
-          
+
+            rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+
            rmax= (1e4) when sampling, maximum radius to consider (can be Quantity)
 
            scale - Characteristic scale radius to aid sampling calculations. Optionaland will also be overridden by value from pot if available.
@@ -160,13 +166,13 @@ class osipkovmerrittdf(_osipkovmerrittdf):
             2021-02-07 - Written - Bovy (UofT)
 
         """
-        _osipkovmerrittdf.__init__(self,pot=pot,denspot=denspot,ra=ra,
+        _osipkovmerrittdf.__init__(self,pot=pot,denspot=denspot,ra=ra,rmin=rmin,
                                    rmax=rmax,scale=scale,ro=ro,vo=vo)
         # Because f(Q) is the same integral as the Eddington conversion, but
         # using the augmented density rawdensx(1+r^2/ra^2), we use a helper
         # eddingtondf to do this integral, hacked to use the augmented density
         self._edf= eddingtondf(pot=self._pot,denspot=self._denspot,scale=scale,
-                               rmax=rmax,ro=ro,vo=vo)
+                               rmin=rmin,rmax=rmax,ro=ro,vo=vo)
         self._edf._dnudr= \
            (lambda r: self._denspot._ddensdr(r)*(1.+r**2./self._ra2) \
                    +2.*self._denspot.dens(r,0,use_physical=False)*r/self._ra2)\

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -11,7 +11,7 @@ from .eddingtondf import eddingtondf
 # formula can be found following this class
 class _osipkovmerrittdf(anisotropicsphericaldf):
     """General Osipkov-Merritt superclass with useful functions for any DF of the Osipkov-Merritt type."""
-    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=0.,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -30,7 +30,7 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
 
             ra - anisotropy radius (can be a Quantity)
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -130,7 +130,7 @@ class osipkovmerrittdf(_osipkovmerrittdf):
         \\beta(r) = \\frac{1}{1+r_a^2/r^2}
 
     with :math:`r_a` the anistropy radius for arbitrary combinations of potential and density profile."""
-    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=None,rmax=1e4,
+    def __init__(self,pot=None,denspot=None,ra=1.4,rmin=0.,rmax=1e4,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -149,7 +149,7 @@ class osipkovmerrittdf(_osipkovmerrittdf):
 
             ra - anisotropy radius (can be a Quantity)
 
-            rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+            rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (1e4) when sampling, maximum radius to consider (can be Quantity)
 

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -81,7 +81,7 @@ class sphericaldf(df):
         self._denspot= self._pot if denspot is None else denspot
         if not conversion.physical_compatible(self._pot,self._denspot):
             raise RuntimeError("Unit-conversion parameters of input potential incompatible with those of the density potential")
-        rmin= conversion.parse_length(rmin,ro=self._ro)
+        self._rmin= conversion.parse_length(rmin,ro=self._ro)
         self._rmax= numpy.inf if rmax is None \
             else conversion.parse_length(rmax,ro=self._ro)            
         try:

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -33,7 +33,7 @@ if conversion._APY_LOADED:
 
 class sphericaldf(df):
     """Superclass for spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -49,6 +49,8 @@ class sphericaldf(df):
            pot= (None) Potential instance or list thereof
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
+
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -79,6 +81,8 @@ class sphericaldf(df):
         self._denspot= self._pot if denspot is None else denspot
         if not conversion.physical_compatible(self._pot,self._denspot):
             raise RuntimeError("Unit-conversion parameters of input potential incompatible with those of the density potential")
+        self._rmin= 0. if rmin is None \
+            else conversion.parse_length(rmin,ro=self._ro)
         self._rmax= numpy.inf if rmax is None \
             else conversion.parse_length(rmax,ro=self._ro)            
         try:
@@ -397,8 +401,9 @@ class sphericaldf(df):
         
         so that xi is in the range [-1,1], which corresponds to an r range of 
         [0,infinity)"""
+        ximin = (self._rmin-1.)/(self._rmin+1.)
         ximax= (1.-1./self._rmax)/(1.+1./self._rmax)
-        xis = numpy.arange(-1,ximax,1e-4)
+        xis = numpy.arange(ximin,ximax,1e-4)
         rs = _xiToR(xis,a=self._scale)
         # try/except necessary when mass doesn't take arrays, also need to
         # switch to a more general mass method at some point...
@@ -406,7 +411,11 @@ class sphericaldf(df):
         ms = mass(self._denspot,rs,use_physical=False)
         #except ValueError:
         #    ms= numpy.array([mass(self._denspot,r,use_physical=False) for r in rs])
-        ms/= mass(self._denspot,self._rmax,use_physical=False)
+        mnorm = mass(self._denspot,self._rmax,use_physical=False)
+        if self._rmin > 0:
+            ms-= mass(self._denspot,self._rmin)
+            mnorm-= mass(self._denspot,self._rmin)
+        ms/= mnorm
         # Add total mass point
         if numpy.isinf(self._rmax):
             xis = numpy.append(xis,1)
@@ -478,6 +487,7 @@ class sphericaldf(df):
             Written 2020-07-24 - James Lane (UofT)
         """
         # Make an array of r/a by v/vesc and then calculate p(v|r)
+        r_a_start = numpy.amax([numpy.log10((self._rmin+1e-8)/self._scale),r_a_start])
         r_a_end= numpy.amin([numpy.log10((self._rmax-1e-8)/self._scale),r_a_end])
         r_a_values = 10.**numpy.linspace(r_a_start,r_a_end,n_r_a)
         v_vesc_values = numpy.linspace(0,1,n_v_vesc)
@@ -515,7 +525,7 @@ class sphericaldf(df):
 
 class isotropicsphericaldf(sphericaldf):
     """Superclass for isotropic spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -532,6 +542,8 @@ class isotropicsphericaldf(sphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
+           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
            scale= scale parameter to be used internally
@@ -547,7 +559,7 @@ class isotropicsphericaldf(sphericaldf):
             2020-09-02 - Written - Bovy (UofT)
 
         """
-        sphericaldf.__init__(self,pot=pot,denspot=denspot,rmax=rmax,
+        sphericaldf.__init__(self,pot=pot,denspot=denspot,rmin=rmin,rmax=rmax,
                              scale=scale,ro=ro,vo=vo)
 
     def _call_internal(self,*args):
@@ -600,7 +612,7 @@ class isotropicsphericaldf(sphericaldf):
     
 class anisotropicsphericaldf(sphericaldf):
     """Superclass for anisotropic spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -617,6 +629,8 @@ class anisotropicsphericaldf(sphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
+           rmin= (None) minimum radius to consider (can be Quantity)
+
            rmax= (None) maximum radius to consider (can be Quantity)
 
            scale= (None) length-scale parameter to be used internally
@@ -632,5 +646,5 @@ class anisotropicsphericaldf(sphericaldf):
             2020-07-22 - Written - Lane (UofT)
 
         """
-        sphericaldf.__init__(self,pot=pot,denspot=denspot,rmax=rmax,
+        sphericaldf.__init__(self,pot=pot,denspot=denspot,rmin=rmin,rmax=rmax,
                              scale=scale,ro=ro,vo=vo)

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -33,7 +33,7 @@ if conversion._APY_LOADED:
 
 class sphericaldf(df):
     """Superclass for spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=0.,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -50,7 +50,7 @@ class sphericaldf(df):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -81,8 +81,7 @@ class sphericaldf(df):
         self._denspot= self._pot if denspot is None else denspot
         if not conversion.physical_compatible(self._pot,self._denspot):
             raise RuntimeError("Unit-conversion parameters of input potential incompatible with those of the density potential")
-        self._rmin= 0. if rmin is None \
-            else conversion.parse_length(rmin,ro=self._ro)
+        conversion.parse_length(rmin,ro=self._ro)
         self._rmax= numpy.inf if rmax is None \
             else conversion.parse_length(rmax,ro=self._ro)            
         try:
@@ -525,7 +524,7 @@ class sphericaldf(df):
 
 class isotropicsphericaldf(sphericaldf):
     """Superclass for isotropic spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=0.,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -542,7 +541,7 @@ class isotropicsphericaldf(sphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
-           rmin= (None) when sampling, minimum radius to consider (can be Quantity)
+           rmin= (0) when sampling, minimum radius to consider (can be Quantity)
 
            rmax= (None) when sampling, maximum radius to consider (can be Quantity)
 
@@ -612,7 +611,7 @@ class isotropicsphericaldf(sphericaldf):
     
 class anisotropicsphericaldf(sphericaldf):
     """Superclass for anisotropic spherical distribution functions"""
-    def __init__(self,pot=None,denspot=None,rmin=None,rmax=None,
+    def __init__(self,pot=None,denspot=None,rmin=0.,rmax=None,
                  scale=None,ro=None,vo=None):
         """
         NAME:
@@ -629,7 +628,7 @@ class anisotropicsphericaldf(sphericaldf):
 
            denspot= (None) Potential instance or list thereof that represent the density of the tracers (assumed to be spherical; if None, set equal to pot)
 
-           rmin= (None) minimum radius to consider (can be Quantity)
+           rmin= (0) minimum radius to consider (can be Quantity)
 
            rmax= (None) maximum radius to consider (can be Quantity)
 

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -81,7 +81,7 @@ class sphericaldf(df):
         self._denspot= self._pot if denspot is None else denspot
         if not conversion.physical_compatible(self._pot,self._denspot):
             raise RuntimeError("Unit-conversion parameters of input potential incompatible with those of the density potential")
-        conversion.parse_length(rmin,ro=self._ro)
+        rmin= conversion.parse_length(rmin,ro=self._ro)
         self._rmax= numpy.inf if rmax is None \
             else conversion.parse_length(rmax,ro=self._ro)            
         try:

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -1673,6 +1673,21 @@ def test_constantbeta_dehnencore_rmin_rmax_dens_massprofile():
                                     tol,skip=1000)
     return None
 
+def test_constantbeta_dehnencore_rmin_rmax_beta():
+    if WIN32: return None # skip on appveyor, because no JAX
+    # Use list
+    pot= [potential.DehnenCoreSphericalPotential(amp=2.5,a=1.15)]
+    twobetas= [0.5]
+    for twobeta,dfh in zip(twobetas,constantbeta_dfs_dehnencore_rmin_rmax):
+        numpy.random.seed(10)
+        samp= dfh.sample(n=1000000)
+        rmin,rmax = 0.5,5.
+        tol= 0.07
+        # rmin larger than usual to avoid low number sampling
+        check_beta(samp,pot,tol,beta=twobeta/2.,
+                   rmin=rmin,rmax=rmax,bins=31)
+    return None
+
 ########################### TESTS OF ERRORS AND WARNINGS#######################
 
 def test_isotropic_hernquist_nopot():

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -1641,6 +1641,38 @@ def test_constantbeta_dehnencore_in_nfw_sigmar_directint():
 #                             bins=3)
 #    return None
 
+# For the following tests, we use a DehnenCoreSphericalPotential with 
+# both rmin and rmax set
+constantbeta_dfs_dehnencore_rmin_rmax= None # re-use in other tests
+def test_constantbeta_dehnencore_rmin_rmax_inbounds():
+    if WIN32: return None # skip on appveyor, because no JAX
+    pot= potential.DehnenCoreSphericalPotential(amp=2.5,a=1.15)
+    twobetas= [0.5]
+    rmin,rmax = 0.5,5.
+    global constantbeta_dfs_dehnencore_rmin_rmax
+    constantbeta_dfs_dehnencore_rmin_rmax= []
+    for twobeta in twobetas:
+        dfh= constantbetadf(pot=pot,twobeta=twobeta,rmin=rmin,rmax=rmax)
+        constantbeta_dfs_dehnencore_rmin_rmax.append(dfh)
+        samp= dfh.sample(n=1000000)
+        assert numpy.max(samp.r()) <= rmax, 'Sample maximum r greater than rmax'
+        assert numpy.min(samp.r()) >= rmin, 'Sample minimum r less than rmin'
+        return None
+
+def test_constantbeta_dehnencore_rmin_rmax_dens_massprofile():
+    if WIN32: return None # skip on appveyor, because no JAX
+    pot= potential.DehnenCoreSphericalPotential(amp=2.5,a=1.15)
+    twobetas= [0.5]
+    rmin,rmax = 0.5,5.
+    for twobeta,dfh in zip(twobetas,constantbeta_dfs_dehnencore_rmin_rmax):
+        numpy.random.seed(10)
+        samp= dfh.sample(n=100000)
+        tol= 5*1e-3
+        check_spherical_massprofile(samp,lambda r: (pot.mass(r)-pot.mass(rmin))\
+                                    /(pot.mass(rmax)-pot.mass(rmin)),
+                                    tol,skip=1000)
+    return None
+
 ########################### TESTS OF ERRORS AND WARNINGS#######################
 
 def test_isotropic_hernquist_nopot():


### PR DESCRIPTION
Adds rmin to general spherical DFs, not potential-specific DFs (i.e. Hernquist or NFW variations). Also adds limited tests for rmin and rmax use in DFs.