### PR TITLE
Fix ActionAngle eval fail for (R,vR,vT) array input

### DIFF
--- a/galpy/actionAngle/actionAngle.py
+++ b/galpy/actionAngle/actionAngle.py
@@ -140,13 +140,13 @@ class actionAngle(with_metaclass(MetaActionAngle,object)):
         HISTORY:
            2010-07-11 - Written - Bovy (NYU)
         """
-        if len(args) == 3: #R,vR.vT
+        if len(args) == 3: #R, vR, vT
             R,vR,vT= args
             self._eval_R= R
             self._eval_vR= vR
             self._eval_vT= vT
-            self._eval_z= 0.
-            self._eval_vz= 0.
+            self._eval_z= numpy.zeros_like(R)
+            self._eval_vz= numpy.zeros_like(R)
         elif len(args) == 5: #R,vR.vT, z, vz
             R,vR,vT, z, vz= args
             self._eval_R= R

--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -572,7 +572,7 @@ class actionAngleIsochroneApprox(actionAngle):
                 R,vR,vT, z, vz, phi= args
             else:
                 R,vR,vT, phi= args
-                z, vz= 0., 0.
+                z, vz= numpy.zeros_like(R), numpy.zeros_like(R)
             if isinstance(R,float):
                 os= [Orbit([R,vR,vT,z,vz,phi])]
                 RasOrbit= True


### PR DESCRIPTION
I think this issue affects both `actionAngleAdiabatic` and `actionAngleIsochroneApprox`
This works fine:
```python
from galpy.potential import MWPotential2014
from galpy.actionAngle import actionAngleAdiabatic
from galpy.orbit import Orbit
import numpy

aAA= actionAngleAdiabatic(pot=MWPotential2014)
ts=numpy.linspace(0.,100.,1001)
o= Orbit([1.,0.1,1.1,0.,0.05])
o.integrate(ts,MWPotential2014)
js= aAA(o.R(ts),o.vR(ts),o.vT(ts),o.z(ts),o.vz(ts))
```

This also works fine without `z` and `vz` if only one
```python
js= aAA(o.R(ts)[0],o.vR(ts)[0],o.vT(ts)[0])
```

But not this without specifying `z` and `vz`. This PR will fix the issue
```python
js= aAA(o.R(ts),o.vR(ts),o.vT(ts))
```