### PR TITLE
Include an offset option in RotateAndTiltWrapperPotential

### DIFF
--- a/.github/workflows/build_macosx_windows_wheels.yml
+++ b/.github/workflows/build_macosx_windows_wheels.yml
@@ -91,13 +91,13 @@ jobs:
           password: ${{ secrets.pypi_token }}
           packages_dir: wheelhouse/
       - name: Rename wheel to 'latest' version for AWS S3
-        if: ( github.event_name != 'release' || github.event.action != 'created' )
+        if: github.event_name != 'release' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           GALPY_VERSION="$(awk '/^current_version/{print $NF}' .bumpversion.cfg)"
           for f in wheelhouse/*$GALPY_VERSION*; do mv -i -- "$f" "${f//$GALPY_VERSION/latest}"; done
       # Upload to AWS S3
       - name: Upload to AWS S3
-        if: github.event_name != 'release' || github.event.action != 'created'
+        if: github.event_name != 'release' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks --delete --exclude "*manylinux*" --exclude "*none-any*"

--- a/.github/workflows/build_manylinux_wheels.yml
+++ b/.github/workflows/build_manylinux_wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build manylinux2014_x86_64 wheels
         uses: ./.github/workflows/actions/manylinux2014_x86_64/
       - name: Rename wheels to 'latest' version
-        if: github.event_name != 'release' || github.event.action != 'created'
+        if: github.event_name != 'release' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           GALPY_VERSION="$(awk '/^current_version/{print $NF}' .bumpversion.cfg)"
           for f in wheelhouse/*$GALPY_VERSION*; do sudo mv -i -- "$f" "${f//$GALPY_VERSION/latest}"; done
@@ -41,7 +41,7 @@ jobs:
           packages_dir: wheelhouse/
       # Also create a pure Python wheel for the AWS S3 wheelhouse
       - name: Create pure Python wheel
-        if: github.event_name != 'release' || github.event.action != 'created'
+        if: github.event_name != 'release' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           sudo python setup.py bdist_wheel --no_ext
           sudo mv dist/*.whl wheelhouse
@@ -49,7 +49,7 @@ jobs:
           for f in wheelhouse/*$GALPY_VERSION*; do sudo mv -i -- "$f" "${f//$GALPY_VERSION/latest}"; done
       # Upload to AWS S3
       - name: Upload to AWS S3
-        if: github.event_name != 'release' || github.event.action != 'created'
+        if: github.event_name != 'release' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks --delete --exclude "*macos*" --exclude "*win*"

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ build/
 dist/
 galpy.egg-info/
 
+# Editors' dotfiles #
+#####################
+.vscode
+
 # Virtual environments / Codespaces #
 #####################################
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ galpy/df/data/dfcorrection*.sav
 build/
 dist/
 galpy.egg-info/
+
+# Virtual environments / Codespaces #
+#####################################
+.venv
+devcontainer.json
+Dockerfile

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -9,6 +9,9 @@ v1.8 (XXXX-XX-XX)
 - Allow actions to be computed for Orbit instances with actionAngle
   methods that don't compute frequencies.
 
+- Correctly parse potential method/function R/z/x inputs if they
+  are given as keyword arguments.
+
 v1.7.1 (2021-11-17)
 ===================
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,6 +4,8 @@ v1.8 (XXXX-XX-XX)
 - Turn on NFWPotential physical output when initializing using the 
   virial mass mvir (see #465)
 
+- Added NullPotential, a potential with a constant value.
+
 - Allow actions to be computed for Orbit instances with actionAngle
   methods that don't compute frequencies.
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -7,7 +7,9 @@ Dependencies
 ------------
 
 galpy requires the ``numpy``, ``scipy``, and ``matplotlib`` packages;
-these must be installed or the code will not be able to be imported.
+these must be installed or the code will not be able to be imported. 
+The installation methods described below will all automatically install
+these required dependencies.
 
 Optional dependencies are:
 
@@ -91,15 +93,15 @@ Note that these latest-version commands all install directly from the
 source code and thus require you to have the GSL and a C compiler
 installed to build the C extension(s). If you are having issues with
 this, you can also download a binary wheel for the latest ``main``
-version, which are available `here
-<https://github.com/jobovy/galpy/actions?query=workflow%3A%22Build+Mac+OS+X+%26+Windows+wheels+and+upload+to+PyPI+upon+release%22+branch%3Amain>`__
-for Mac/Windows wheels and `here
-<https://github.com/jobovy/galpy/actions?query=workflow%3A%22Build+manylinux+wheels%2C+upload+to+PyPI+upon+release%22+branch%3Amain>`__
-for Linux wheels (note that you need to be logged into GitHub to access the artifacts, which otherwise just show up as a gray non-link). To install these wheels, click on the latest run, download the "artifact" for the platform/Python version that you are using, unzip the file, and install the wheel with::
+version, which are available `here <http://www.galpy.org.s3-website.us-east-2.amazonaws.com/list.html>`__.
+To install these wheels, download the relevant version for your operating
+system and Python version and do::
 
     pip install WHEEL_FILE.whl
 
-
+Note that there is also a Pure Python wheel available there, but use of this is not recommended.
+These wheels have stable `...latest...` names, so you can embed them in workflows that should always
+be using the latest version of `galpy` (e.g., to test your code against the latest development version).
 
 Installing from a branch
 ------------------------
@@ -115,7 +117,8 @@ than ``main``. If you *really* wanted this, you could fork galpy,
 edit the GitHub Actions workflow file that generates the wheel to
 include the branch that you want to build (in the ``on:`` section),
 and push to GitHub; then the binary wheel will be built as part of
-your fork.
+your fork. Alternatively, you could do a pull request, which would also
+trigger the building of the wheels.
 
 .. _install_win:
 
@@ -123,7 +126,11 @@ Installing from source on Windows
 ---------------------------------
 
 .. TIP::
-   You can install a pre-compiled Windows "wheel" of the latest ``main`` version that is automatically built on ``AppVeyor`` for all recent Python versions. Navigate to `the latest main build <http://ci.appveyor.com/project/jobovy/galpy?branch=main>`__, click on the first job and then on "Artifacts", download the wheel for your version of Python, and install with ``pip install WHEEL_FILE.whl``. Similar wheels are also available `here <https://github.com/jobovy/galpy/actions?query=workflow%3A%22Build+Mac+OS+X+%26+Windows+wheels+and+upload+to+PyPI+upon+release%22+branch%3Amain>`__ (see above), but require you to be logged into GitHub.
+   You can install a pre-compiled Windows "wheel" of the latest ``main`` version that is 
+   automatically built using ``GitHub Actions`` for all recent Python versions 
+   `here <http://www.galpy.org.s3-website.us-east-2.amazonaws.com/list.html>`__. 
+   Download the wheel for your version of Python, and install with ``pip install WHEEL_FILE.whl`` 
+   (see above).
 
 Versions >1.3 should be able to be compiled on Windows systems using the Microsoft Visual Studio C compiler (>= 2015). For this you need to first install the GNU Scientific Library (GSL), for example using Anaconda (:ref:`see below <gsl_install>`). Similar to on a UNIX system, you need to set paths to the header and library files where the GSL is located. On Windows, using the CDM commandline, this is done as::
 

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -249,6 +249,7 @@ Spiral, bar, other triaxial, and miscellaneous potentials
    potentialferrers.rst
    potentialloghalo.rst
    potentialmovingobj.rst
+   potentialnull.rst
    potentialsoftenedneedle.rst
    potentialspiralarms.rst
 

--- a/doc/source/reference/potentialnull.rst
+++ b/doc/source/reference/potentialnull.rst
@@ -1,0 +1,7 @@
+.. _null_potential:
+
+Constant (null) potential
+==========================
+
+.. autoclass:: galpy.potential.NullPotential
+   :members: __init__

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -311,7 +311,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_args.extend([p._amp])
             pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
-            pot_args.append(not (p._rot == numpy.eye(3)).all())
+            pot_args.append(not p._norot)
             pot_args.append(not p._offset is None)
             pot_args.extend(list(p._offset) if not p._offset is None else [0.,0.,0.])
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -311,6 +311,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_args.extend([p._amp])
             pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
+            pot_args.append(not (p._rot == numpy.eye(3)).all())
             pot_args.append(not p._offset is None)
             pot_args.extend(list(p._offset) if not p._offset is None else [0.,0.,0.])
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -21,6 +21,14 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
     #Figure out what's in pot
     if not isinstance(pot,list):
         pot= [pot]
+    if (potforactions or potfortorus) \
+        and ( (len(pot) == 1 and isinstance(pot[0],potential.NullPotential)) 
+             or numpy.all([isinstance(p,potential.NullPotential) for p in pot]) ):
+        raise NotImplementedError("Evaluating actions using the C backend is not supported for NullPotential instances")
+    # Remove NullPotentials from list of Potentials containing other potentials
+    purged_pot= [p for p in pot if not isinstance(p,potential.NullPotential)]
+    if len(purged_pot) > 0:
+        pot= purged_pot
     #Initialize everything
     pot_type= []
     pot_args= []
@@ -216,6 +224,9 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
                              p._Phi0,p._Phimax])
         # 37: TriaxialGaussianPotential, done with others above
         # 38: PowerTriaxialPotential, done with others above
+        elif isinstance(p,potential.NullPotential):
+            pot_type.append(40)
+            # No arguments, zero forces
         ############################## WRAPPERS ###############################
         elif isinstance(p,potential.DehnenSmoothWrapperPotential):
             pot_type.append(-1)

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -300,6 +300,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_args.extend([p._amp])
             pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
+            pot_args.extend(list(p._offset))
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')
     return (npot,pot_type,pot_args)

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -301,7 +301,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
             pot_args.append(not p._offset is None)
-            pot_args.extend(list(p._offset))
+            pot_args.extend(list(p._offset) if not p._offset is None else [0.,0.,0.])
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')
     return (npot,pot_type,pot_args)

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -300,6 +300,7 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
             pot_args.extend([p._amp])
             pot_args.extend([0.,0.,0.,0.,0.,0.]) # for caching
             pot_args.extend(list(p._rot.flatten()))
+            pot_args.append(not p._offset is None)
             pot_args.extend(list(p._offset))
     pot_type= numpy.array(pot_type,dtype=numpy.int32,order='C')
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -22,6 +22,10 @@ def _parse_pot(pot):
     #Figure out what's in pot
     if not isinstance(pot,list):
         pot= [pot]
+    # Remove NullPotentials from list of Potentials containing other potentials
+    purged_pot= [p for p in pot if not isinstance(p,potential.NullPotential)]
+    if len(purged_pot) > 0:
+        pot= purged_pot
     #Initialize everything
     pot_type= []
     pot_args= []
@@ -263,6 +267,9 @@ def _parse_pot(pot):
                              p._Pot._total_mass,p._Pot._Phi0,p._Pot._Phimax])
         # 37: TriaxialGaussianPotential, done with other EllipsoidalPotentials above
         # 38: PowerTriaxialPotential, done with other EllipsoidalPotentials above
+        elif isinstance(p,planarPotentialFromRZPotential) \
+             and isinstance(p._Pot,potential.NullPotential):
+            pot_type.append(40)
         ############################## WRAPPERS ###############################
         elif ((isinstance(p,planarPotentialFromFullPotential) or isinstance(p,planarPotentialFromRZPotential)) \
               and isinstance(p._Pot,potential.DehnenSmoothWrapperPotential)) \

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -526,7 +526,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
-      potentialArgs->nargs= (int) 19;
+      potentialArgs->nargs= (int) 20;
       potentialArgs->requiresVelocity= false;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -534,7 +534,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
-      potentialArgs->nargs= (int) 20;
+      potentialArgs->nargs= (int) 21;
       potentialArgs->requiresVelocity= false;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -526,7 +526,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phiforce= &RotateAndTiltWrapperPotentialphiforce;
-      potentialArgs->nargs= (int) 16;
+      potentialArgs->nargs= (int) 19;
       potentialArgs->requiresVelocity= false;
       break;
     }

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -477,6 +477,14 @@ void parse_leapFuncArgs_Full(int npot,
 					    + (int) (*(*pot_args+7) + 20)));
       potentialArgs->requiresVelocity= false;
       break;
+    case 40: //NullPotential, no arguments (only supported for orbit int)
+      potentialArgs->Rforce= &ZeroForce;
+      potentialArgs->zforce= &ZeroForce;
+      potentialArgs->phiforce= &ZeroForce;
+      potentialArgs->dens= &ZeroForce;
+      potentialArgs->nargs= 0;
+      potentialArgs->requiresVelocity= false;
+      break;
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -398,6 +398,15 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->nargs = (int) (21 + *(*pot_args+7) + 2 * *(*pot_args
 					    + (int) (*(*pot_args+7) + 20)));
       break;
+    case 40: //NullPotential, no arguments (only supported for orbit int)
+      potentialArgs->potentialEval= &ZeroPlanarForce;
+      potentialArgs->planarRforce= &ZeroPlanarForce;
+      potentialArgs->planarphiforce= &ZeroPlanarForce;
+      potentialArgs->planarR2deriv= &ZeroPlanarForce;
+      potentialArgs->planarphi2deriv= &ZeroPlanarForce;
+      potentialArgs->planarRphideriv= &ZeroPlanarForce;
+      potentialArgs->nargs= 0;
+      break;
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -246,7 +246,7 @@ class Force(object):
 
     @potential_physical_input
     @physical_conversion('force',pop=True)
-    def rforce(self,*args,**kwargs):
+    def rforce(self,R,z,**kwargs):
         """
         NAME:
 
@@ -277,7 +277,6 @@ class Force(object):
            2016-06-20 - Written - Bovy (UofT)
 
         """
-        R,z= args
         r= numpy.sqrt(R**2.+z**2.)
         kwargs['use_physical']= False
-        return self.Rforce(*args,**kwargs)*R/r+self.zforce(*args,**kwargs)*z/r
+        return self.Rforce(R,z,**kwargs)*R/r+self.zforce(R,z,**kwargs)*z/r

--- a/galpy/potential/NullPotential.py
+++ b/galpy/potential/NullPotential.py
@@ -1,0 +1,163 @@
+###############################################################################
+#   NullPotential.py: class that implements a constant potential
+###############################################################################
+from .Potential import Potential
+class NullPotential(Potential):
+    """Class that implements a constant potential with, thus, zero forces. Can be used, for example, for integrating orbits in the absence of forces or for adjusting the value of the total gravitational potential, say, at infinity"""
+    normalize= property() # turn off normalize
+    def __init__(self,amp=1.,ro=None,vo=None):
+        """
+        NAME:
+
+           __init__
+
+        PURPOSE:
+
+           initialize a null potential: a constant potential with, thus, zero forces
+
+        INPUT:
+
+           amp - constant value of the potential (default: 1); can be a Quantity with units of velocity-squared
+
+           ro=, vo= distance and velocity scales for translation into internal units (default from configuration file)
+
+        OUTPUT:
+
+           (none)
+
+        HISTORY:
+
+           2022-03-18 - Written - Bovy (UofT)
+
+        """
+        Potential.__init__(self,amp=amp,ro=ro,vo=vo,amp_units='velocity2')
+        self.hasC= True
+        self.hasC_dxdv= True
+        self.hasC_dens= True
+        return None
+
+    def _evaluate(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _evaluate
+        PURPOSE:
+           evaluate the potential at R,z
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           Phi(R,z)
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 1.
+     
+    def _Rforce(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _Rforce
+        PURPOSE:
+           evaluate the radial force for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the radial force
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.
+
+    def _zforce(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _zforce
+        PURPOSE:
+           evaluate the vertical force for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the vertical force
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.
+
+    def _dens(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _dens
+        PURPOSE:
+           evaluate the density for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the density
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.
+     
+    def _R2deriv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _R2deriv
+        PURPOSE:
+           evaluate the second radial derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the second radial derivative
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.
+
+    def _z2deriv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _z2deriv
+        PURPOSE:
+           evaluate the second vertical derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           the second vertical derivative
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.
+
+    def _Rzderiv(self,R,z,phi=0.,t=0.):
+        """
+        NAME:
+           _Rzderiv
+        PURPOSE:
+           evaluate the mixed R,z derivative for this potential
+        INPUT:
+           R - Galactocentric cylindrical radius
+           z - vertical height
+           phi - azimuth
+           t - time
+        OUTPUT:
+           d2Phi/dR/dz
+        HISTORY:
+           2022-03-18 - Written - Bovy (UofT)
+        """
+        return 0.

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -533,7 +533,7 @@ class Potential(Force):
 
     @potential_physical_input
     @physical_conversion('forcederivative',pop=True)
-    def R2deriv(self,R,Z,phi=0.,t=0.):
+    def R2deriv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -547,7 +547,7 @@ class Potential(Force):
 
            R - Galactocentric radius (can be Quantity)
 
-           Z - vertical height (can be Quantity)
+           z - vertical height (can be Quantity)
 
            phi - Galactocentric azimuth (can be Quantity)
 
@@ -563,13 +563,13 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._R2deriv(R,Z,phi=phi,t=t)
+            return self._amp*self._R2deriv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             raise PotentialError("'_R2deriv' function not implemented for this potential")      
 
     @potential_physical_input
     @physical_conversion('forcederivative',pop=True)
-    def z2deriv(self,R,Z,phi=0.,t=0.):
+    def z2deriv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -583,7 +583,7 @@ class Potential(Force):
 
            R - Galactocentric radius (can be Quantity)
 
-           Z - vertical height (can be Quantity)
+           z - vertical height (can be Quantity)
 
            phi - Galactocentric azimuth (can be Quantity)
 
@@ -599,13 +599,13 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._z2deriv(R,Z,phi=phi,t=t)
+            return self._amp*self._z2deriv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             raise PotentialError("'_z2deriv' function not implemented for this potential")      
 
     @potential_physical_input
     @physical_conversion('forcederivative',pop=True)
-    def Rzderiv(self,R,Z,phi=0.,t=0.):
+    def Rzderiv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -635,7 +635,7 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._Rzderiv(R,Z,phi=phi,t=t)
+            return self._amp*self._Rzderiv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             raise PotentialError("'_Rzderiv' function not implemented for this potential")      
 
@@ -710,7 +710,7 @@ class Potential(Force):
 
     @potential_physical_input
     @physical_conversion('energy',pop=True)
-    def phi2deriv(self,R,Z,phi=0.,t=0.):
+    def phi2deriv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -740,7 +740,7 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._phi2deriv(R,Z,phi=phi,t=t)
+            return self._amp*self._phi2deriv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             if self.isNonAxi:
                 raise PotentialError("'_phi2deriv' function not implemented for this non-axisymmetric potential")
@@ -748,7 +748,7 @@ class Potential(Force):
 
     @potential_physical_input
     @physical_conversion('force',pop=True)
-    def Rphideriv(self,R,Z,phi=0.,t=0.):
+    def Rphideriv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -778,7 +778,7 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._Rphideriv(R,Z,phi=phi,t=t)
+            return self._amp*self._Rphideriv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             if self.isNonAxi:
                 raise PotentialError("'_Rphideriv' function not implemented for this non-axisymmetric potential")
@@ -786,7 +786,7 @@ class Potential(Force):
 
     @potential_physical_input
     @physical_conversion('force',pop=True)
-    def phizderiv(self,R,Z,phi=0.,t=0.):
+    def phizderiv(self,R,z,phi=0.,t=0.):
         """
         NAME:
 
@@ -816,7 +816,7 @@ class Potential(Force):
 
         """
         try:
-            return self._amp*self._phizderiv(R,Z,phi=phi,t=t)
+            return self._amp*self._phizderiv(R,z,phi=phi,t=t)
         except AttributeError: #pragma: no cover
             if self.isNonAxi:
                 raise PotentialError("'_phizderiv' function not implemented for this non-axisymmetric potential")

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -77,7 +77,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         galaxy_pa= conversion.parse_angle(galaxy_pa)
         zvec, galaxy_pa= self._parse_inclination(inclination,sky_pa,
                                                  zvec,galaxy_pa)
-        self._offset= offset
+        self._offset= self._setup_offset(offset)
         self._setup_zvec_pa(zvec,galaxy_pa)
         self.hasC= True
         self.hasC_dxdv= True
@@ -119,6 +119,12 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         self._rot = numpy.dot(pa_rot,zvec_rot)
         self._inv_rot = numpy.linalg.inv(self._rot)
         return None
+    
+    def _setup_offset(self, offset):
+        if not offset:
+            return numpy.array([0.,0.,0.])
+        else:
+            return numpy.array(offset)
 
     def __getattr__(self,attribute):
         return super(RotateAndTiltWrapperPotential,self)\
@@ -143,9 +149,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
-        if self._offset:
-            xyzp += self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return _evaluatePotentials(self._pot,Rp,zp,phi=phip,t=t)
 
@@ -211,9 +215,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _force_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
-        if self._offset:
-           xyzp += self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -353,9 +355,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _2ndderiv_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
-        if self._offset:
-           xyzp += self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -407,9 +407,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
-        if self._offset:
-           xyzp += self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return evaluateDensities(self._pot,Rp,zp,phi=phip,t=t,
                                  use_physical=False)

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -79,6 +79,9 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
                                                  zvec,galaxy_pa)
         self._offset= conversion.parse_length(offset,ro=self._ro)
         self._setup_zvec_pa(zvec,galaxy_pa)
+        self._norot = False
+        if (self._rot == numpy.eye(3)).all():
+            self._norot = True
         self.hasC= True
         self.hasC_dxdv= True
         self.isNonAxi= True
@@ -143,7 +146,10 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._norot:
+           xyzp = numpy.array([x,y,z])
+        else:
+           xyzp = numpy.dot(self._rot,numpy.array([x,y,z]))
         if self._offset:
             xyzp+= self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
@@ -211,7 +217,10 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _force_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._norot:
+           xyzp = numpy.array([x,y,z])
+        else:
+           xyzp = numpy.dot(self._rot,numpy.array([x,y,z]))
         if self._offset:
             xyzp+= self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
@@ -353,7 +362,10 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _2ndderiv_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._norot:
+           xyzp = numpy.array([x,y,z])
+        else:
+           xyzp = numpy.dot(self._rot,numpy.array([x,y,z]))
         if self._offset:
             xyzp+= self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
@@ -407,7 +419,10 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._norot:
+           xyzp = numpy.array([x,y,z])
+        else:
+           xyzp = numpy.dot(self._rot,numpy.array([x,y,z]))
         if self._offset:
             xyzp+= self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -55,7 +55,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
 
                  sky_pa= rotation angle around the inclined z axis (usual sky position angle measured from North)
 
-            offset= optional static offset in Cartesian coordinates
+            offset= optional static offset in Cartesian coordinates (can be a Quantity)
 
         OUTPUT:
 
@@ -77,7 +77,7 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         galaxy_pa= conversion.parse_angle(galaxy_pa)
         zvec, galaxy_pa= self._parse_inclination(inclination,sky_pa,
                                                  zvec,galaxy_pa)
-        self._offset= self._setup_offset(offset)
+        self._offset= conversion.parse_length(offset,ro=self._ro)
         self._setup_zvec_pa(zvec,galaxy_pa)
         self.hasC= True
         self.hasC_dxdv= True
@@ -119,12 +119,6 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         self._rot = numpy.dot(pa_rot,zvec_rot)
         self._inv_rot = numpy.linalg.inv(self._rot)
         return None
-    
-    def _setup_offset(self, offset):
-        if not offset:
-            return numpy.array([0.,0.,0.])
-        else:
-            return numpy.array(offset)
 
     def __getattr__(self,attribute):
         return super(RotateAndTiltWrapperPotential,self)\
@@ -149,7 +143,9 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+            xyzp+= self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return _evaluatePotentials(self._pot,Rp,zp,phi=phip,t=t)
 
@@ -215,7 +211,9 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _force_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+            xyzp+= self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -355,7 +353,9 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
     def _2ndderiv_xyz(self,R,z,phi=0.,t=0.):
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+            xyzp+= self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -407,7 +407,9 @@ A final `offset` option allows one to apply a static offset in Cartesian coordin
         """
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
-        xyzp= numpy.dot(self._rot,numpy.array([x,y,z])) + self._offset
+        xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+            xyzp+= self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return evaluateDensities(self._pot,Rp,zp,phi=phip,t=t,
                                  use_physical=False)

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -22,9 +22,10 @@ specified using:
 
 * A rotation around the original z-axis (`galaxy_pa`), the `inclination`, and a rotation around the new z axis (`sky_pa`).
 
-The second option allows one to specify the inclination and sky position angle (measured from North) in the usual manner in extragalactic observations."""
+The second option allows one to specify the inclination and sky position angle (measured from North) in the usual manner in extragalactic observations.
+A final `offset` option allows one to apply a static offset in Cartesian coordinate space to be applied to the potential following the rotation and tilt."""
     def __init__(self,amp=1.,inclination=None,galaxy_pa=None,sky_pa=None,
-                 zvec=None,pot=None,
+                 zvec=None,offset=None,pot=None,
                  ro=None,vo=None):
         """
         NAME:
@@ -54,6 +55,8 @@ The second option allows one to specify the inclination and sky position angle (
 
                  sky_pa= rotation angle around the inclined z axis (usual sky position angle measured from North)
 
+            offset= optional static offset in Cartesian coordinates
+
         OUTPUT:
 
            (none)
@@ -64,6 +67,8 @@ The second option allows one to specify the inclination and sky position angle (
 
            2021-04-18 - Added inclination, sky_pa, galaxy_pa setup - Bovy (UofT)
 
+           2022-03-14 - added offset kwarg - Mackereth (UofT)
+
         """
         WrapperPotential.__init__(self,amp=amp,pot=pot,ro=ro,vo=vo,
                                   _init=True)
@@ -72,6 +77,7 @@ The second option allows one to specify the inclination and sky position angle (
         galaxy_pa= conversion.parse_angle(galaxy_pa)
         zvec, galaxy_pa= self._parse_inclination(inclination,sky_pa,
                                                  zvec,galaxy_pa)
+        self._offset= offset
         self._setup_zvec_pa(zvec,galaxy_pa)
         self.hasC= True
         self.hasC_dxdv= True
@@ -138,6 +144,8 @@ The second option allows one to specify the inclination and sky position angle (
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
         xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+            xyzp += self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return _evaluatePotentials(self._pot,Rp,zp,phi=phip,t=t)
 
@@ -204,6 +212,8 @@ The second option allows one to specify the inclination and sky position angle (
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
         xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+           xyzp += self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -344,6 +354,8 @@ The second option allows one to specify the inclination and sky position angle (
         """Get the rectangular forces in the transformed frame"""
         x,y,z= coords.cyl_to_rect(R,phi,z)
         xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+           xyzp += self._offset
         Rp,phip,zp =coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         Rforcep= _evaluateRforces(self._pot,Rp,zp,phi=phip,t=t)
         phiforcep= _evaluatephiforces(self._pot,Rp,zp,phi=phip,t=t)
@@ -396,6 +408,8 @@ The second option allows one to specify the inclination and sky position angle (
         x,y,z= coords.cyl_to_rect(R,phi,z)
         if numpy.isinf(R): y= 0.
         xyzp= numpy.dot(self._rot,numpy.array([x,y,z]))
+        if self._offset:
+           xyzp += self._offset
         Rp,phip,zp = coords.rect_to_cyl(xyzp[0],xyzp[1],xyzp[2])
         return evaluateDensities(self._pot,Rp,zp,phi=phip,t=t,
                                  use_physical=False)

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -56,6 +56,7 @@ from . import AnyAxisymmetricRazorThinDiskPotential
 from . import AnySphericalPotential
 from . import AdiabaticContractionWrapperPotential
 from . import PowerTriaxialPotential
+from . import NullPotential
 #
 # Functions
 #
@@ -195,6 +196,7 @@ GaussianAmplitudeWrapperPotential= GaussianAmplitudeWrapperPotential.GaussianAmp
 RotateAndTiltWrapperPotential = RotateAndTiltWrapperPotential.RotateAndTiltWrapperPotential
 AdiabaticContractionWrapperPotential= AdiabaticContractionWrapperPotential.AdiabaticContractionWrapperPotential
 PowerTriaxialPotential= PowerTriaxialPotential.PowerTriaxialPotential
+NullPotential= NullPotential.NullPotential
 
 # MW potential models, now in galpy.potential.mwpotentials, but keep these two
 # for tests, backwards compatibility, and convenience

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -27,13 +27,14 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
     double * rot= args+7;
+    double * offset= args+16;
     double x, y;
     double Rforce, phiforce;
     cyl_to_rect(R, phi, &x, &y);
     //caching
-    *(args + 1)= x;
-    *(args + 2)= y;
-    *(args + 3)= z;
+    *(args + 1)= x + *(offset);
+    *(args + 2)= y + *(offset+1);
+    *(args + 3)= z + *(offset+2);
     //now get the forces in R, phi, z in the aligned frame
     rotate(&x,&y,&z,rot);
     rect_to_cyl(x,y,&R,&phi);

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -2,7 +2,7 @@
 #include <math.h>
 #include <bovy_coords.h>
 #include <galpy_potentials.h>
-#include <stdio.h>
+
 //RotateAndTiltWrapperPotential
 static inline void rotate(double *x, double *y, double *z, double *rot){
   double xp,yp,zp;

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -4,8 +4,7 @@
 #include <galpy_potentials.h>
 
 //RotateAndTiltWrapperPotential
-static inline void rotate(double *x, double *y, double *z, bool rotSet, double *rot){
-  if (rotSet) {
+static inline void rotate(double *x, double *y, double *z, double *rot){
   double xp,yp,zp;
   xp= *(rot)   * *x + *(rot+1) * *y + *(rot+2) * *z;
   yp= *(rot+3) * *x + *(rot+4) * *y + *(rot+5) * *z;
@@ -13,11 +12,8 @@ static inline void rotate(double *x, double *y, double *z, bool rotSet, double *
   *x= xp;
   *y= yp;
   *z= zp;
-  }
 }
-static inline void rotate_force(double *Fx, double *Fy, double *Fz,
-				bool rotSet, double *rot){
-  if (rotSet) {
+static inline void rotate_force(double *Fx, double *Fy, double *Fz, double *rot){
   double Fxp,Fyp,Fzp;
   Fxp= *(rot)   * *Fx + *(rot+3) * *Fy + *(rot+6) * *Fz;
   Fyp= *(rot+1) * *Fx + *(rot+4) * *Fy + *(rot+7) * *Fz;
@@ -25,19 +21,8 @@ static inline void rotate_force(double *Fx, double *Fy, double *Fz,
   *Fx= Fxp;
   *Fy= Fyp;
   *Fz= Fzp;
-  }
 }
-static inline void apply_offset(double *x, double *y, double *z, bool offsetSet, double *offset){
-  if (offsetSet) {
-    double xp,yp,zp;
-    xp = *x + *(offset);
-    yp = *y + *(offset+1);
-    zp = *z + *(offset+2);
-    *x = xp;
-    *y = yp;
-    *z = zp;
-  }
-}
+
 void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  double t, double * Fx, double * Fy, double * Fz,
                  struct potentialArg * potentialArgs){
@@ -54,8 +39,14 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     *(args + 2)= y;
     *(args + 3)= z;
     //now get the forces in R, phi, z in the aligned frame
-    rotate(&x,&y,&z,rotSet,rot);
-    apply_offset(&x,&y,&z,offsetSet,offset);
+    if (rotSet) {
+      rotate(&x,&y,&z,rot);
+    }
+    if (offsetSet) {
+      x += *(offset);
+      y += *(offset+1);
+      z += *(offset+2);
+    }
     rect_to_cyl(x,y,&R,&phi);
     Rforce= calcRforce(R, z, phi, t, potentialArgs->nwrapped,
 		       potentialArgs->wrappedPotentialArg);
@@ -67,7 +58,9 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     *Fx= cos( phi )*Rforce - sin( phi )*phiforce / R;
     *Fy= sin( phi )*Rforce + cos( phi )*phiforce / R;
     //rotate back
-    rotate_force(Fx,Fy,Fz,rotSet,rot);
+    if (rotSet) {
+      rotate_force(Fx,Fy,Fz,rot);
+    }
     //cache
     *(args + 4)= *Fx;
     *(args + 5)= *Fy;

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -4,7 +4,8 @@
 #include <galpy_potentials.h>
 
 //RotateAndTiltWrapperPotential
-static inline void rotate(double *x, double *y, double *z, double *rot){
+static inline void rotate(double *x, double *y, double *z, bool rotSet, double *rot){
+  if (rotSet) {
   double xp,yp,zp;
   xp= *(rot)   * *x + *(rot+1) * *y + *(rot+2) * *z;
   yp= *(rot+3) * *x + *(rot+4) * *y + *(rot+5) * *z;
@@ -12,9 +13,11 @@ static inline void rotate(double *x, double *y, double *z, double *rot){
   *x= xp;
   *y= yp;
   *z= zp;
+  }
 }
 static inline void rotate_force(double *Fx, double *Fy, double *Fz,
-				double *rot){
+				bool rotSet, double *rot){
+  if (rotSet) {
   double Fxp,Fyp,Fzp;
   Fxp= *(rot)   * *Fx + *(rot+3) * *Fy + *(rot+6) * *Fz;
   Fyp= *(rot+1) * *Fx + *(rot+4) * *Fy + *(rot+7) * *Fz;
@@ -22,24 +25,27 @@ static inline void rotate_force(double *Fx, double *Fy, double *Fz,
   *Fx= Fxp;
   *Fy= Fyp;
   *Fz= Fzp;
+  }
 }
 static inline void apply_offset(double *x, double *y, double *z, bool offsetSet, double *offset){
-  double xp,yp,zp;
-   xp = *x + *(offset);
-   yp = *y + *(offset+1);
-   zp = *z + *(offset+2);
-   *x = xp;
-   *y = yp;
-   *z = zp;
-  
+  if (offsetSet) {
+    double xp,yp,zp;
+    xp = *x + *(offset);
+    yp = *y + *(offset+1);
+    zp = *z + *(offset+2);
+    *x = xp;
+    *y = yp;
+    *z = zp;
+  }
 }
 void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  double t, double * Fx, double * Fy, double * Fz,
                  struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
     double * rot= args+7;
-    bool offsetSet= (bool) *(args+16);
-    double * offset= args+17;
+    bool rotSet= (bool) *(args+16);
+    bool offsetSet= (bool) *(args+17);
+    double * offset= args+18;
     double x, y;
     double Rforce, phiforce;
     cyl_to_rect(R, phi, &x, &y);
@@ -48,7 +54,7 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     *(args + 2)= y;
     *(args + 3)= z;
     //now get the forces in R, phi, z in the aligned frame
-    rotate(&x,&y,&z,rot);
+    rotate(&x,&y,&z,rotSet,rot);
     apply_offset(&x,&y,&z,offsetSet,offset);
     rect_to_cyl(x,y,&R,&phi);
     Rforce= calcRforce(R, z, phi, t, potentialArgs->nwrapped,
@@ -61,7 +67,7 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     *Fx= cos( phi )*Rforce - sin( phi )*phiforce / R;
     *Fy= sin( phi )*Rforce + cos( phi )*phiforce / R;
     //rotate back
-    rotate_force(Fx,Fy,Fz,rot);
+    rotate_force(Fx,Fy,Fz,rotSet,rot);
     //cache
     *(args + 4)= *Fx;
     *(args + 5)= *Fy;

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -27,7 +27,8 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
     double * rot= args+7;
-    double * offset= args+16;
+    bool offsetSet= (bool) *(args+16);
+    double * offset= args+17;
     double x, y;
     double Rforce, phiforce;
     cyl_to_rect(R, phi, &x, &y);

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <bovy_coords.h>
 #include <galpy_potentials.h>
+#include <stdio.h>
 //RotateAndTiltWrapperPotential
 static inline void rotate(double *x, double *y, double *z, double *rot){
   double xp,yp,zp;
@@ -22,6 +23,16 @@ static inline void rotate_force(double *Fx, double *Fy, double *Fz,
   *Fy= Fyp;
   *Fz= Fzp;
 }
+static inline void apply_offset(double *x, double *y, double *z, bool offsetSet, double *offset){
+  double xp,yp,zp;
+   xp = *x + *(offset);
+   yp = *y + *(offset+1);
+   zp = *z + *(offset+2);
+   *x = xp;
+   *y = yp;
+   *z = zp;
+  
+}
 void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  double t, double * Fx, double * Fy, double * Fz,
                  struct potentialArg * potentialArgs){
@@ -33,11 +44,12 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     double Rforce, phiforce;
     cyl_to_rect(R, phi, &x, &y);
     //caching
-    *(args + 1)= x + *(offset);
-    *(args + 2)= y + *(offset+1);
-    *(args + 3)= z + *(offset+2);
+    *(args + 1)= x;
+    *(args + 2)= y;
+    *(args + 3)= z;
     //now get the forces in R, phi, z in the aligned frame
     rotate(&x,&y,&z,rot);
+    apply_offset(&x,&y,&z,offsetSet,offset);
     rect_to_cyl(x,y,&R,&phi);
     Rforce= calcRforce(R, z, phi, t, potentialArgs->nwrapped,
 		       potentialArgs->wrappedPotentialArg);

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -866,7 +866,7 @@ def potential_physical_input(method):
             else:
                 newargs= newargs+(args[ii],)
         args= newargs
-        # phi and t kwargs
+        # phi and t kwargs, also do R, z, and x in case these are given as kwargs
         if 'phi' in kwargs and _APY_LOADED \
                 and isinstance(kwargs['phi'],units.Quantity):
             kwargs['phi']= kwargs['phi'].to(units.rad).value
@@ -874,6 +874,15 @@ def potential_physical_input(method):
                 and isinstance(kwargs['t'],units.Quantity):
             kwargs['t']= kwargs['t'].to(units.Gyr).value\
                 /time_in_Gyr(vo,ro)
+        if 'R' in kwargs and _APY_LOADED \
+                and isinstance(kwargs['R'],units.Quantity):
+            kwargs['R']= kwargs['R'].to(units.kpc).value/ro
+        if 'z' in kwargs and _APY_LOADED \
+                and isinstance(kwargs['z'],units.Quantity):
+            kwargs['z']= kwargs['z'].to(units.kpc).value/ro
+        if 'x' in kwargs and _APY_LOADED \
+                and isinstance(kwargs['x'],units.Quantity):
+            kwargs['x']= kwargs['x'].to(units.kpc).value/ro
         # v kwarg for dissipative forces
         if 'v' in kwargs and _APY_LOADED \
                 and isinstance(kwargs['v'],units.Quantity):
@@ -888,9 +897,7 @@ def potential_physical_input(method):
                 kwargs['M']= kwargs['M'].to(units.pc*units.km**2/units.s**2)\
                     .value/mass_in_msol(vo,ro)/_G
         # kwargs that come up in quasiisothermaldf    
-        if 'z' in kwargs and _APY_LOADED \
-                and isinstance(kwargs['z'],units.Quantity):
-            kwargs['z']= kwargs['z'].to(units.kpc).value/ro
+        # z done above
         if 'dz' in kwargs and _APY_LOADED \
                 and isinstance(kwargs['dz'],units.Quantity):
             kwargs['dz']= kwargs['dz'].to(units.kpc).value/ro

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -3224,6 +3224,17 @@ def test_physical_actionAngleIsochroneInverse():
         assert numpy.fabs(aAII.Freqs(0.1,1.1,0.1)[ii]-aAIInu.Freqs(0.1,1.1,0.1)[ii]*conversion.freq_in_Gyr(vo,ro)) < 10.**-8., 'actionAngleInverse function Freqs does not return Quantity with the right value'
     return None
 
+# Test that computing actionAngle coordinates in C for a NullPotential leads to an error
+def test_nullpotential_error():
+    from galpy.potential import NullPotential
+    from galpy.actionAngle import actionAngleStaeckel
+    np= NullPotential()
+    aAS= actionAngleStaeckel(pot=np,delta=1.)
+    with pytest.raises(NotImplementedError) as excinfo:
+        aAS(1.,0.,1.,0.1,0.)
+        pytest.fail('Calculating actionAngle coordinates in C for a NullPotential should have given a NotImplementedError, but did not')
+    return None
+
 def check_actionAngleIsochroneInverse_wrtIsochrone(pot,aAI,aAII,obs,
                                                    tol,ntimes=1001):
     times= numpy.linspace(0.,30.,ntimes)

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2752,14 +2752,14 @@ def test_orbit_interface_actionAngleIsochroneApprox():
                         obs.wp(pot=MWPotential,type=type,b=0.8),
                         obs.wz(pot=MWPotential,type=type,b=0.8)])
     maxdev= numpy.amax(numpy.abs(acfs-acfso))
-    assert maxdev < 10.**-16., 'Orbit interface for actionAngleIsochroneApprox does not return the same as actionAngle interface'
-    assert numpy.abs(obs.Tr(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[3]) < 10.**-16., \
+    assert maxdev < 10.**-13., 'Orbit interface for actionAngleIsochroneApprox does not return the same as actionAngle interface'
+    assert numpy.abs(obs.Tr(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[3]) < 10.**-13., \
         'Orbit.Tr does not agree with actionAngleIsochroneApprox frequency'
-    assert numpy.abs(obs.Tp(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[4]) < 10.**-16., \
+    assert numpy.abs(obs.Tp(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[4]) < 10.**-13., \
         'Orbit.Tp does not agree with actionAngleIsochroneApprox frequency'
-    assert numpy.abs(obs.Tz(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[5]) < 10.**-16., \
+    assert numpy.abs(obs.Tz(pot=MWPotential,type=type,b=0.8)-2.*numpy.pi/acfso[5]) < 10.**-13., \
         'Orbit.Tz does not agree with actionAngleIsochroneApprox frequency'
-    assert numpy.abs(obs.TrTp(pot=MWPotential,type=type,b=0.8)-acfso[4]/acfso[3]*numpy.pi) < 10.**-16., \
+    assert numpy.abs(obs.TrTp(pot=MWPotential,type=type,b=0.8)-acfso[4]/acfso[3]*numpy.pi) < 10.**-13., \
         'Orbit.TrTp does not agree with actionAngleIsochroneApprox frequency'
     return None
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -71,7 +71,8 @@ from test_potential import testplanarMWPotential, testMWPotential, \
     nestedListPotential, \
     mockInterpSphericalPotential, \
     mockAdiabaticContractionMWP14WrapperPotential, \
-    mockRotatedAndTiltedMWP14WrapperPotential
+    mockRotatedAndTiltedMWP14WrapperPotential, \
+    testNullPotential
 _GHACTIONS= bool(os.getenv('GITHUB_ACTIONS'))
 if not _GHACTIONS:
     _QUICKTEST= True #Run a more limited set of tests
@@ -148,6 +149,7 @@ def test_energy_jacobi_conservation():
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('testNullPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -522,6 +524,7 @@ def test_energy_conservation_linear():
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
+    pots.append('testNullPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -690,6 +693,7 @@ def test_liouville_planar():
     pots.append('nestedListPotential')
     pots.append('mockInterpSphericalPotential')
     pots.append('mockAdiabaticContractionMWP14WrapperPotential')
+    pots.append('testNullPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -4425,7 +4425,7 @@ from galpy.potential import TwoPowerSphericalPotential, \
     TriaxialHernquistPotential, TriaxialNFWPotential, TriaxialJaffePotential, \
     TwoPowerTriaxialPotential, BurkertPotential, SoftenedNeedleBarPotential, \
     FerrersPotential, DiskSCFPotential, SpiralArmsPotential, \
-    LogarithmicHaloPotential
+    LogarithmicHaloPotential, NullPotential
 class mockSphericalSoftenedNeedleBarPotential(SoftenedNeedleBarPotential):
     def __init__(self):
         SoftenedNeedleBarPotential.__init__(self,amp=1.,a=0.000001,b=0.,
@@ -4581,6 +4581,9 @@ class JaffeTwoPowerTriaxialPotential(TwoPowerTriaxialPotential):
         TwoPowerTriaxialPotential.__init__(self,amp=1.,a=5.,alpha=2.,beta=4.,
                                            b=1.3,c=1.8)
         return None
+class testNullPotential(NullPotential):
+    def normalize(self,norm):
+        pass
 # Other DiskSCFPotentials
 class sech2DiskSCFPotential(DiskSCFPotential):
     def __init__(self):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -173,6 +173,7 @@ def test_forceAsDeriv_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -350,6 +351,7 @@ def test_2ndDeriv_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -601,6 +603,7 @@ def test_poisson_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -714,6 +717,7 @@ def test_poisson_surfdens_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -848,6 +852,7 @@ def test_evaluateAndDerivs_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1064,6 +1069,7 @@ def test_amp_mult_divide():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1341,6 +1347,7 @@ def test_potential_at_zero():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1390,6 +1397,7 @@ def test_potential_at_zero():
            or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
            or p == 'mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination' \
            or p == 'mockRotatedTiltedOffsetMWP14WrapperPotential' \
+           or p == 'mockOffsetMWP14WrapperPotential' \
            or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -1457,6 +1465,7 @@ def test_potential_at_infinity():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
     pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
+    pots.append('mockOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1503,6 +1512,7 @@ def test_potential_at_infinity():
            or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
            or p == 'mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination' \
            or p == 'mockRotatedTiltedOffsetMWP14WrapperPotential' \
+           or p == 'mockOffsetMWP14WrapperPotential' \
           or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -5340,6 +5350,15 @@ class mockRotatedTiltedOffsetMWP14WrapperPotential(testMWPotential):
                                                     numpy.sqrt(1/3.),
                                                     numpy.sqrt(1/3.)],
                                               galaxy_pa=0.4,
+                                              offset=[1.,1.,1.]),])
+    def OmegaP(self):
+        return 0.
+class mockOffsetMWP14WrapperPotential(testMWPotential):
+    def __init__(self):
+        testMWPotential.__init__(self,potlist=[\
+                RotateAndTiltWrapperPotential(pot=potential.MWPotential2014,
+                                              zvec=None,
+                                              galaxy_pa=None,
                                               offset=[1.,1.,1.]),])
     def OmegaP(self):
         return 0.

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -172,6 +172,7 @@ def test_forceAsDeriv_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -348,6 +349,7 @@ def test_2ndDeriv_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -598,6 +600,7 @@ def test_poisson_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -710,6 +713,7 @@ def test_poisson_surfdens_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -843,6 +847,7 @@ def test_evaluateAndDerivs_potential():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1058,6 +1063,7 @@ def test_amp_mult_divide():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1334,6 +1340,7 @@ def test_potential_at_zero():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1382,6 +1389,7 @@ def test_potential_at_zero():
            or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
            or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
            or p == 'mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination' \
+           or p == 'mockRotatedTiltedOffsetMWP14WrapperPotential' \
            or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -1448,6 +1456,7 @@ def test_potential_at_infinity():
     pots.append('mockRotatedAndTiltedMWP14WrapperPotential')
     pots.append('mockRotatedAndTiltedMWP14WrapperPotentialwInclination')
     pots.append('mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination')
+    pots.append('mockRotatedTiltedOffsetMWP14WrapperPotential')
     rmpots= ['Potential','MWPotential','MWPotential2014',
              'MovingObjectPotential',
              'interpRZPotential', 'linearPotential', 'planarAxiPotential',
@@ -1493,6 +1502,7 @@ def test_potential_at_infinity():
            or p == 'mockRotatedAndTiltedMWP14WrapperPotential' \
            or p == 'mockRotatedAndTiltedMWP14WrapperPotentialwInclination' \
            or p == 'mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination' \
+           or p == 'mockRotatedTiltedOffsetMWP14WrapperPotential' \
           or 'riaxial' in p \
            or 'oblate' in p \
            or 'prolate' in p:
@@ -5320,5 +5330,16 @@ class mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination(testMWPotential):
                                               inclination=2.,
                                               galaxy_pa=0.3,
                                               sky_pa=None)])
+    def OmegaP(self):
+        return 0.
+class mockRotatedTiltedOffsetMWP14WrapperPotential(testMWPotential):
+    def __init__(self):
+        testMWPotential.__init__(self,potlist=[\
+                RotateAndTiltWrapperPotential(pot=potential.MWPotential2014,
+                                              zvec=[numpy.sqrt(1/3.),
+                                                    numpy.sqrt(1/3.),
+                                                    numpy.sqrt(1/3.)],
+                                              galaxy_pa=0.4,
+                                              offset=[1.,1.,1.]),])
     def OmegaP(self):
         return 0.

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -3646,7 +3646,10 @@ def test_RotateAndTiltWrapper():
     NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, offset=[20.,0.,3.], pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
     NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa,b=0.7,c=0.5)
     assert (evaluatePotentials(NFW_wrapped, 0., 0., phi=0.)-evaluatePotentials(NFW_rot, 20., - 3., phi=numpy.pi)) < 1e-6, 'Wrapped + Offset and Internally rotated NFW potentials do not match when evaluated at the same point'
-    #test a quick orbit integration to hit the C code (also test pure python)
+    
+
+def test_integration_RotateAndTiltWrapper():
+    ## test a quick orbit integration to hit the C code (also test pure python)
     #two potentials, one offset
     offset = [3.,2.,1.]
     mwpot = potential.MWPotential2014
@@ -3703,6 +3706,7 @@ def test_RotateAndTiltWrapper():
     Rphi_t = numpy.dstack([tR*ro,tz*ro])[0]
     assert numpy.all(numpy.fabs(Rphi-Rphi_t) < 10.**-10), 'C orbit integration in an offset potential does not work as expected'
     return None
+
 
 def test_vtermnegl_issue314():
     # Test related to issue 314: vterm for negative l

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -3640,6 +3640,11 @@ def test_RotateAndTiltWrapper():
     NFW_wrapped= potential.RotateAndTiltWrapperPotential(galaxy_pa=galaxy_pa, pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
     NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=[0.,0.,1.],pa=galaxy_pa,b=0.7,c=0.5)
     assert (evaluatePotentials(NFW_wrapped, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])-evaluatePotentials(NFW_rot, Rphiz_test[0], Rphiz_test[2], phi=Rphiz_test[1])) < 1e-6, 'Wrapped and Internally rotated NFW potentials do not match when evaluated at the same point'
+    #make sure the offset works as intended
+    # triaxial NFW at x,y,z = [20.,0.,3.]
+    NFW_wrapped= potential.RotateAndTiltWrapperPotential(zvec=zvec, galaxy_pa=galaxy_pa, offset=[20.,0.,3.], pot=potential.TriaxialNFWPotential(amp=1.,b=0.7,c=0.5))
+    NFW_rot= potential.TriaxialNFWPotential(amp=1., zvec=zvec, pa=galaxy_pa,b=0.7,c=0.5)
+    assert (evaluatePotentials(NFW_wrapped, 0., 0., phi=0.)-evaluatePotentials(NFW_rot, 20., - 3., phi=numpy.pi)) < 1e-6, 'Wrapped + Offset and Internally rotated NFW potentials do not match when evaluated at the same point'
     return None
 
 def test_vtermnegl_issue314():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -2603,6 +2603,12 @@ def test_potential_ampunits():
         b=1.3,c=0.4)
     # Check potential
     assert numpy.fabs(pot(4.,0.,phi=1.,use_physical=False)-pot_nounits(4.,0.,phi=1.,use_physical=False)) < 10.**-8., "TriaxialGaussianPotential w/ amp w/ units does not behave as expected"
+    # NullPotential
+    pot= potential.NullPotential(amp=(200.*units.km/units.s)**2,ro=ro,vo=vo)
+    pot_nounits= potential.NullPotential(\
+        amp=(200/vo)**2.,ro=ro,vo=vo)
+    # Check potential
+    assert numpy.fabs(pot(4.,0.,phi=1.,use_physical=False)-pot_nounits(4.,0.,phi=1.,use_physical=False)) < 10.**-8., "NullPotential w/ amp w/ units does not behave as expected"    
     return None
 
 def test_potential_ampunits_altunits():
@@ -2932,6 +2938,9 @@ def test_potential_ampunits_wrongunits():
         potential.TriaxialGaussianPotential(amp=40.*units.Msun/units.pc**2,
                                             sigma=2.,ro=ro,vo=vo,
                                             b=1.3,c=0.4)
+    # NullPotential
+    with pytest.raises(units.UnitConversionError) as excinfo:
+        potential.NullPotential(amp=40.*units.Msun,ro=ro,vo=vo)
     return None
 
 def test_potential_paramunits():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -2191,6 +2191,42 @@ def test_potential_method_inputAsQuantity():
     assert numpy.fabs(pot.tdyn(1.1*ro,use_physical=False)-potu.tdyn(1.1)) < 10.**-8., 'Potential method tdyn does not return the correct value when input is Quantity'
     return None
 
+def test_potential_method_inputAsQuantity_Rzaskwargs():
+    from galpy.potential import PlummerPotential
+    from galpy.util import conversion
+    ro, vo= 8.*units.kpc, 220.
+    pot= PlummerPotential(normalize=True,ro=ro,vo=vo)
+    potu= PlummerPotential(normalize=True)
+    assert numpy.fabs(pot(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu(1.1,0.1)) < 10.**-8., 'Potential method __call__ does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.Rforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.Rforce(1.1,0.1)) < 10.**-4., 'Potential method Rforce does not return the correct value when input is Quantity'
+    # Few more cases for Rforce
+    assert numpy.fabs(pot.Rforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,ro=9.,use_physical=False)-potu.Rforce(1.1*8./9.,0.1*8./9.)) < 10.**-4., 'Potential method Rforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.Rforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,vo=230.,use_physical=False)-potu.Rforce(1.1,0.1)) < 10.**-4., 'Potential method Rforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.rforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.rforce(1.1,0.1)) < 10.**-4., 'Potential method rforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.zforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.zforce(1.1,0.1)) < 10.**-4., 'Potential method zforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.phiforce(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.phiforce(1.1,0.1)) < 10.**-4., 'Potential method phiforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.dens(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.dens(1.1,0.1)) < 10.**-8., 'Potential method dens does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.surfdens(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.surfdens(1.1,0.1)) < 10.**-8., 'Potential method surfdens does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.mass(R=1.1*ro,z=0.1*ro,use_physical=False)-potu.mass(1.1,0.1)) < 10.**-8., 'Potential method mass does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.R2deriv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.R2deriv(1.1,0.1)) < 10.**-8., 'Potential method R2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.z2deriv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.z2deriv(1.1,0.1)) < 10.**-8., 'Potential method z2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.Rzderiv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.Rzderiv(1.1,0.1)) < 10.**-8., 'Potential method Rzderiv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.Rphideriv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.Rphideriv(1.1,0.1)) < 10.**-8., 'Potential method Rphideriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.phi2deriv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.phi2deriv(1.1,0.1)) < 10.**-8., 'Potential method phi2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.phizderiv(R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potu.phizderiv(1.1,0.1)) < 10.**-8., 'Potential method phizderiv does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.flattening(R=1.1*ro,z=0.1*ro,use_physical=False)-potu.flattening(1.1,0.1)) < 10.**-8., 'Potential method flattening does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.vcirc(R=1.1*ro,use_physical=False)-potu.vcirc(1.1)) < 10.**-8., 'Potential method vcirc does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.dvcircdR(R=1.1*ro,use_physical=False)-potu.dvcircdR(1.1)) < 10.**-8., 'Potential method dvcircdR does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.omegac(R=1.1*ro,use_physical=False)-potu.omegac(1.1)) < 10.**-8., 'Potential method omegac does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.epifreq(R=1.1*ro,use_physical=False)-potu.epifreq(1.1)) < 10.**-8., 'Potential method epifreq does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.verticalfreq(R=1.1*ro,use_physical=False)-potu.verticalfreq(1.1)) < 10.**-8., 'Potential method verticalfreq does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.vesc(R=1.1*ro,use_physical=False)-potu.vesc(1.1)) < 10.**-8., 'Potential method vesc does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.rtide(R=1.1*ro,z=0.1*ro,M=10.**9.*units.Msun,use_physical=False)-potu.rtide(1.1,0.1,M=10.**9./conversion.mass_in_msol(vo,ro.value))) < 10.**-8., 'Potential method rtide does not return the correct value when input is Quantity'
+    assert numpy.all(numpy.fabs(pot.ttensor(R=1.1*ro,z=0.1*ro,use_physical=False)-potu.ttensor(1.1,0.1)) < 10.**-8.), 'Potential method ttensor does not return the correct value when input is Quantity'
+    assert numpy.all(numpy.fabs(pot.ttensor(R=1.1*ro,z=0.1*ro,eigenval=True,use_physical=False)-potu.ttensor(1.1,0.1,eigenval=True)) < 10.**-8.), 'Potential method ttensor does not return the correct value when input is Quantity'
+    assert numpy.fabs(pot.tdyn(R=1.1*ro,use_physical=False)-potu.tdyn(1.1)) < 10.**-8., 'Potential method tdyn does not return the correct value when input is Quantity'
+    return None
+
 def test_planarPotential_method_inputAsQuantity():
     from galpy.potential import PlummerPotential
     from galpy.util import conversion
@@ -2214,6 +2250,30 @@ def test_planarPotential_method_inputAsQuantity():
     assert numpy.fabs(pot.epifreq(1.1*ro,use_physical=False)-potu.epifreq(1.1)) < 10.**-8., 'Potential method epifreq does not return the correct value as Quantity'
     assert numpy.fabs(pot.vesc(1.1*ro,use_physical=False)-potu.vesc(1.1)) < 10.**-8., 'Potential method vesc does not return the correct value as Quantity'
     assert numpy.fabs(pot.lindbladR(0.9*conversion.freq_in_Gyr(vo,ro.value)/units.Gyr,m='corot',use_physical=False)-potu.lindbladR(0.9,m='corot')) < 10.**-8., 'Potential method lindbladR does not return the correct value when input is Quantity'
+    return None
+
+def test_planarPotential_method_inputAsQuantity_Raskwarg():
+    from galpy.potential import PlummerPotential
+    from galpy.util import conversion
+    ro, vo= 8.*units.kpc, 220.
+    pot= PlummerPotential(normalize=True,ro=ro,vo=vo)
+    # Force planarPotential setup with default
+    pot._ro= None
+    pot._roSet= False
+    pot._vo= None
+    pot._voSet= False
+    pot= pot.toPlanar()
+    potu= PlummerPotential(normalize=True).toPlanar()
+    assert numpy.fabs(pot(R=1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(pot.Rforce(R=1.1*ro,use_physical=False)-potu.Rforce(1.1)) < 10.**-4., 'Potential method Rforce does not return the correct value as Quantity'
+    assert numpy.fabs(pot.phiforce(R=1.1*ro,use_physical=False)-potu.phiforce(1.1)) < 10.**-4., 'Potential method phiforce does not return the correct value as Quantity'
+    assert numpy.fabs(pot.R2deriv(R=1.1*ro,use_physical=False)-potu.R2deriv(1.1)) < 10.**-8., 'Potential method R2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.Rphideriv(R=1.1*ro,use_physical=False)-potu.Rphideriv(1.1)) < 10.**-8., 'Potential method Rphideriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.phi2deriv(R=1.1*ro,use_physical=False)-potu.phi2deriv(1.1)) < 10.**-8., 'Potential method phi2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(pot.vcirc(R=1.1*ro,use_physical=False)-potu.vcirc(1.1)) < 10.**-8., 'Potential method vcirc does not return the correct value as Quantity'
+    assert numpy.fabs(pot.omegac(R=1.1*ro,use_physical=False)-potu.omegac(1.1)) < 10.**-8., 'Potential method omegac does not return the correct value as Quantity'
+    assert numpy.fabs(pot.epifreq(R=1.1*ro,use_physical=False)-potu.epifreq(1.1)) < 10.**-8., 'Potential method epifreq does not return the correct value as Quantity'
+    assert numpy.fabs(pot.vesc(R=1.1*ro,use_physical=False)-potu.vesc(1.1)) < 10.**-8., 'Potential method vesc does not return the correct value as Quantity'
     return None
 
 def test_linearPotential_method_inputAsQuantity():
@@ -2246,6 +2306,38 @@ def test_linearPotential_method_inputAsQuantity():
                                         t0=1.*units.Gyr)
     assert numpy.fabs(pot(1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
     assert numpy.fabs(pot.force(1.1*ro,use_physical=False)-potu.force(1.1)) < 10.**-4., 'Potential method force does not return the correct value as Quantity'
+    return None
+
+def test_linearPotential_method_inputAsQuantity_xaskwarg():
+    from galpy.potential import PlummerPotential, SpiralArmsPotential
+    from galpy import potential
+    from galpy.util import conversion
+    ro, vo= 8.*units.kpc, 220.*units.km/units.s
+    pot= PlummerPotential(normalize=True,ro=ro,vo=vo)
+    # Force linearPotential setup with default
+    pot._ro= None
+    pot._roSet= False
+    pot._vo= None
+    pot._voSet= False
+    pot= pot.toVertical(1.1)
+    potu= potential.RZToverticalPotential(PlummerPotential(normalize=True),
+                                          1.1*ro)
+    assert numpy.fabs(pot(x=1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(pot.force(x=1.1*ro,use_physical=False)-potu.force(1.1)) < 10.**-4., 'Potential method force does not return the correct value as Quantity'
+    # also toVerticalPotential w/ non-axi
+    pot= SpiralArmsPotential(ro=ro,vo=vo)
+    # Force linearPotential setup with default
+    pot._ro= None
+    pot._roSet= False
+    pot._vo= None
+    pot._voSet= False
+    pot= pot.toVertical(1.1,10./180.*numpy.pi,
+                        t0=1./conversion.time_in_Gyr(vo.to(units.km/units.s).value,ro.to(units.kpc).value))
+    potu= potential.toVerticalPotential(SpiralArmsPotential(),
+                                        1.1*ro,phi=10*units.deg,
+                                        t0=1.*units.Gyr)
+    assert numpy.fabs(pot(x=1.1*ro,use_physical=False)-potu(1.1)) < 10.**-8., 'Potential method __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(pot.force(x=1.1*ro,use_physical=False)-potu.force(1.1)) < 10.**-4., 'Potential method force does not return the correct value as Quantity'
     return None
 
 def test_dissipativeforce_method_inputAsQuantity():
@@ -2300,6 +2392,38 @@ def test_potential_function_inputAsQuantity():
     assert numpy.fabs(potential.tdyn(pot,1.1*ro,use_physical=False)-potential.tdyn(potu,1.1)) < 10.**-8., 'Potential function tdyn does not return the correct value when input is Quantity'
     return None
 
+def test_potential_function_inputAsQuantity_Rzaskwargs():
+    from galpy.potential import PlummerPotential
+    from galpy.util import conversion
+    from galpy import potential
+    ro, vo= 8.*units.kpc, 220.
+    pot= [PlummerPotential(normalize=True,ro=ro,vo=vo)]
+    potu= [PlummerPotential(normalize=True)]
+    assert numpy.fabs(potential.evaluatePotentials(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluatePotentials(potu,1.1,0.1)) < 10.**-8., 'Potential function __call__ does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluateRforces(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,ro=8.*units.kpc,vo=220.*units.km/units.s,use_physical=False)-potential.evaluateRforces(potu,1.1,0.1)) < 10.**-4., 'Potential function Rforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluaterforces(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,ro=8.*units.kpc,vo=220.*units.km/units.s,use_physical=False)-potential.evaluaterforces(potu,1.1,0.1)) < 10.**-4., 'Potential function rforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluatezforces(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluatezforces(potu,1.1,0.1)) < 10.**-4., 'Potential function zforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluatephiforces(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluatephiforces(potu,1.1,0.1)) < 10.**-4., 'Potential function phiforce does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluateDensities(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluateDensities(potu,1.1,0.1)) < 10.**-8., 'Potential function dens does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluateSurfaceDensities(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluateSurfaceDensities(potu,1.1,0.1)) < 10.**-8., 'Potential function surfdens does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluateR2derivs(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluateR2derivs(potu,1.1,0.1)) < 10.**-8., 'Potential function R2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluatez2derivs(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluatez2derivs(potu,1.1,0.1)) < 10.**-8., 'Potential function z2deriv does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.evaluateRzderivs(pot,R=1.1*ro,z=0.1*ro,phi=10.*units.deg,t=10.*units.Gyr,use_physical=False)-potential.evaluateRzderivs(potu,1.1,0.1)) < 10.**-8., 'Potential function Rzderiv does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.flattening(pot,R=1.1*ro,z=0.1*ro,use_physical=False)-potential.flattening(potu,1.1,0.1)) < 10.**-8., 'Potential function flattening does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.vcirc(pot,R=1.1*ro,use_physical=False)-potential.vcirc(potu,1.1)) < 10.**-8., 'Potential function vcirc does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.dvcircdR(pot,R=1.1*ro,use_physical=False)-potential.dvcircdR(potu,1.1)) < 10.**-8., 'Potential function dvcircdR does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.omegac(pot,R=1.1*ro,use_physical=False)-potential.omegac(potu,1.1)) < 10.**-8., 'Potential function omegac does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.epifreq(pot,R=1.1*ro,use_physical=False)-potential.epifreq(potu,1.1)) < 10.**-8., 'Potential function epifreq does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.verticalfreq(pot,R=1.1*ro,use_physical=False)-potential.verticalfreq(potu,1.1)) < 10.**-8., 'Potential function verticalfreq does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.vesc(pot,R=1.1*ro,use_physical=False)-potential.vesc(potu,1.1)) < 10.**-8., 'Potential function vesc does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.rtide(pot,R=1.1*ro,z=0.1*ro,M=10.**9.*units.Msun,use_physical=False)-potential.rtide(potu,1.1,0.1,M=10.**9./conversion.mass_in_msol(vo,ro.value))) < 10.**-8., 'Potential function rtide does not return the correct value when input is Quantity'
+    # Test non-list for M as well, bc units done in rtide special, and do GM
+    assert numpy.fabs(potential.rtide(pot[0],R=1.1*ro,z=0.1*ro,M=constants.G*10.**9.*units.Msun,use_physical=False)-potential.rtide(potu,1.1,0.1,M=10.**9./conversion.mass_in_msol(vo,ro.value))) < 10.**-8., 'Potential function rtide does not return the correct value when input is Quantity'
+    assert numpy.all(numpy.fabs(potential.ttensor(pot,R=1.1*ro,z=0.1*ro,use_physical=False)-potential.ttensor(potu,1.1,0.1)) < 10.**-8.), 'Potential function ttensor does not return the correct value when input is Quantity'
+    assert numpy.all(numpy.fabs(potential.ttensor(pot,R=1.1*ro,z=0.1*ro,eigenval=True,use_physical=False)-potential.ttensor(potu,1.1,0.1,eigenval=True)) < 10.**-8.), 'Potential function ttensor does not return the correct value when input is Quantity'
+    assert numpy.fabs(potential.tdyn(pot,R=1.1*ro,use_physical=False)-potential.tdyn(potu,1.1)) < 10.**-8., 'Potential function tdyn does not return the correct value when input is Quantity'
+    return None
+
 def test_dissipativeforce_function_inputAsQuantity():
     from galpy.potential import ChandrasekharDynamicalFrictionForce
     from galpy.util import conversion
@@ -2330,6 +2454,22 @@ def test_planarPotential_function_inputAsQuantity():
     assert numpy.fabs(potential.vesc(pot,1.1*ro,use_physical=False)-potential.vesc(potu,1.1)) < 10.**-8., 'Potential function vesc does not return the correct value as Quantity'
     return None
 
+def test_planarPotential_function_inputAsQuantity_Raskwarg():
+    from galpy.potential import PlummerPotential
+    from galpy import potential
+    ro, vo= 8.*units.kpc, 220.
+    pot= [PlummerPotential(normalize=True,ro=ro,vo=vo).toPlanar()]
+    potu= [PlummerPotential(normalize=True).toPlanar()]
+    assert numpy.fabs(potential.evaluateplanarPotentials(pot,R=1.1*ro,use_physical=False)-potential.evaluateplanarPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluateplanarRforces(pot,R=1.1*ro,use_physical=False)-potential.evaluateplanarRforces(potu,1.1)) < 10.**-4., 'Potential function Rforce does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluateplanarphiforces(pot,R=1.1*ro,use_physical=False)-potential.evaluateplanarphiforces(potu,1.1)) < 10.**-4., 'Potential function phiforce does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluateplanarR2derivs(pot,R=1.1*ro,use_physical=False)-potential.evaluateplanarR2derivs(potu,1.1)) < 10.**-8., 'Potential function R2deriv does not return the correct value as Quantity'
+    assert numpy.fabs(potential.vcirc(pot,R=1.1*ro,use_physical=False)-potential.vcirc(potu,1.1)) < 10.**-8., 'Potential function vcirc does not return the correct value as Quantity'
+    assert numpy.fabs(potential.omegac(pot,R=1.1*ro,use_physical=False)-potential.omegac(potu,1.1)) < 10.**-8., 'Potential function omegac does not return the correct value as Quantity'
+    assert numpy.fabs(potential.epifreq(pot,R=1.1*ro,use_physical=False)-potential.epifreq(potu,1.1)) < 10.**-8., 'Potential function epifreq does not return the correct value as Quantity'
+    assert numpy.fabs(potential.vesc(pot,R=1.1*ro,use_physical=False)-potential.vesc(potu,1.1)) < 10.**-8., 'Potential function vesc does not return the correct value as Quantity'
+    return None
+
 def test_linearPotential_function_inputAsQuantity():
     from galpy.potential import PlummerPotential, SpiralArmsPotential
     from galpy import potential
@@ -2348,6 +2488,26 @@ def test_linearPotential_function_inputAsQuantity():
                                         t0=1.*units.Gyr)
     assert numpy.fabs(potential.evaluatelinearPotentials(pot,1.1*ro,use_physical=False)-potential.evaluatelinearPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
     assert numpy.fabs(potential.evaluatelinearForces(pot,1.1*ro,use_physical=False)-potential.evaluatelinearForces(potu,1.1)) < 10.**-4., 'Potential function force does not return the correct value as Quantity'
+    return None
+
+def test_linearPotential_function_inputAsQuantity_xaskwarg():
+    from galpy.potential import PlummerPotential, SpiralArmsPotential
+    from galpy import potential
+    ro, vo= 8.*units.kpc, 220.
+    pot= [PlummerPotential(normalize=True,ro=ro,vo=vo).toVertical(1.1*ro)]
+    potu= potential.RZToverticalPotential([PlummerPotential(normalize=True)],
+                                          1.1*ro)
+    assert numpy.fabs(potential.evaluatelinearPotentials(pot,x=1.1*ro,use_physical=False)-potential.evaluatelinearPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluatelinearForces(pot,x=1.1*ro,use_physical=False)-potential.evaluatelinearForces(potu,1.1)) < 10.**-4., 'Potential function force does not return the correct value as Quantity'
+    # Also toVerticalPotential, with non-axi
+    pot= [SpiralArmsPotential(ro=ro,vo=vo)\
+              .toVertical((1.1*ro).to(units.kpc).value/8.,phi=20.*units.deg,
+                          t0=1.*units.Gyr)]
+    potu= potential.toVerticalPotential([SpiralArmsPotential()],
+                                        1.1*ro,phi=20.*units.deg,
+                                        t0=1.*units.Gyr)
+    assert numpy.fabs(potential.evaluatelinearPotentials(pot,x=1.1*ro,use_physical=False)-potential.evaluatelinearPotentials(potu,1.1)) < 10.**-8., 'Potential function __call__ does not return the correct value as Quantity'
+    assert numpy.fabs(potential.evaluatelinearForces(pot,x=1.1*ro,use_physical=False)-potential.evaluatelinearForces(potu,1.1)) < 10.**-4., 'Potential function force does not return the correct value as Quantity'
     return None
 
 def test_plotting_inputAsQuantity():


### PR DESCRIPTION
adds an `offset` option that allows the RotateAndTiltWrapper potential to also be offset in Cartesian coordinates, after the rotation and tilt is applied. I think the test should cover all the added code - not sure if there is sufficient testing of the offset as added to the C code, though. Will add that if necessary!