### PR TITLE
Add a progress bar when integrating multiple orbits at once

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,12 @@ environment:
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "true"
 
-    - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
+    - TEST_FILES: tests\test_potential.py tests\test_actionAngle.py
+      ADDL_CONDA_PKGS: 
+      COMPILE_NOOPENMP: 
+      BUILD_WHEELS: "false"
+
+    - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_potential.py --ignore=tests\\test_actionAngle.py--ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "false"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "false"
 
-    - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_potential.py --ignore=tests\\test_actionAngle.py--ignore=tests\\test_orbits.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
+    - TEST_FILES: "tests\\ --ignore=tests\\test_actionAngleTorus.py --ignore=tests\\test_snapshotpotential.py --ignore=tests\\test_qdf.py --ignore=tests\\test_pv2qdf.py --ignore=tests\\test_diskdf.py --ignore=tests\\test_orbit.py --ignore=tests\\test_orbits.py --ignore=tests\\test_potential.py --ignore=tests\\test_actionAngle.py --ignore=tests\\test_streamdf.py --ignore=tests\\test_streamgapdf.py --ignore=tests\\test_evolveddiskdf.py --ignore=tests\\test_quantity.py --ignore=tests\\test_nemo.py --ignore=tests\\test_amuse.py --ignore=tests\\test_coords.py"
       ADDL_CONDA_PKGS: 
       COMPILE_NOOPENMP: 
       BUILD_WHEELS: "false"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
     - name: Install Python dependencies
       run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != 4.0 }}
       run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -165,7 +165,7 @@ jobs:
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
       run: |

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -6,7 +6,7 @@ v1.8 (XXXX-XX-XX)
   and origin accelerations are supported (#471).
 
 - Added a progress bar when integrating multiple objects in a single 
-  orbit instance (requires tqdm). 
+  orbit instance (requires tqdm) (see #476). 
 
 - Turn on NFWPotential physical output when initializing using the 
   virial mass mvir (see #465)

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,6 +5,9 @@ v1.8 (XXXX-XX-XX)
   when integrating orbits in non-inertial frames. Arbitrary rotations 
   and origin accelerations are supported (#471).
 
+- Added a progress bar when integrating multiple objects in a single 
+  orbit instance (requires tqdm). 
+
 - Turn on NFWPotential physical output when initializing using the 
   virial mass mvir (see #465)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ requiring version 1.14 or higher. Other optional dependencies include:
 * Support for providing inputs and getting outputs as Quantities with units is provided through
 [`astropy`](http://www.astropy.org/).
 * Querying SIMBAD for the coordinates of an object in the `Orbit.from_name` initialization method requires [`astroquery`](https://astroquery.readthedocs.io/en/latest/).
+* Displaying a progress bar for certain operations (e.g., orbit integration of multiple objects at once) requires [`tqdm`](https://github.com/tqdm/tqdm).
 * Plotting arbitrary functions of Orbit attributes requires [`numexpr`](https://github.com/pydata/numexpr).
 * Speeding up the evaluation of certain functions in the C code requires [`numba`](https://numba.pydata.org/).
 * Constant-anisotropy DFs in `galpy.df.constantbetadf` require [`JAX`](https://github.com/google/jax).

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -15,6 +15,7 @@ Optional dependencies are:
 
   * ``astropy`` for `Quantity <http://docs.astropy.org/en/stable/api/astropy.units.Quantity.html>`__ support (used throughout galpy when installed),
   * ``astroquery`` for the ``Orbit.from_name`` initialization method (to initialize using a celestial object's name),
+  * ``tqdm`` for displaying a progress bar for certain operations (e.g., orbit integration of multiple objects at once)
   * ``numexpr`` for plotting arbitrary expressions of ``Orbit`` quantities,
   * ``numba`` for speeding up the evaluation of certain functions when using C orbit integration,
   * ``JAX`` for use of constant-anisotropy DFs in ``galpy.df.constantbetadf``, and

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1141,7 +1141,9 @@ class Orbit(object):
             if self.dim() == 1:
                 out, msg= integrateLinearOrbit_c(self._pot,
                                                  numpy.copy(self.vxvv),
-                                                 t,method,dt=dt)
+                                                 t,method,
+                                                 progressbar=progressbar,
+                                                 dt=dt)
             else:
                 if self.phasedim() == 3 \
                    or self.phasedim() == 5:
@@ -1152,10 +1154,14 @@ class Orbit(object):
                     vxvvs= numpy.copy(self.vxvv)
                 if self.dim() == 2:
                     out, msg= integratePlanarOrbit_c(self._pot,vxvvs,
-                                                     t,method,dt=dt)
+                                                     t,method,
+                                                     progressbar=progressbar,
+                                                     dt=dt)
                 else:
                     out, msg= integrateFullOrbit_c(self._pot,vxvvs,
-                                                   t,method,dt=dt)
+                                                   t,method,
+                                                   progressbar=progressbar,
+                                                   dt=dt)
 
                 if self.phasedim() == 3 \
                    or self.phasedim() == 5:

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1024,7 +1024,8 @@ class Orbit(object):
             self._vo= conversion.parse_velocity_kms(vo)
         return None
 
-    def integrate(self,t,pot,method='symplec4_c',dt=None,numcores=_NUMCORES,
+    def integrate(self,t,pot,method='symplec4_c',progressbar=True,
+                  dt=None,numcores=_NUMCORES,
                   force_map=False):
         """
         NAME:
@@ -1051,6 +1052,8 @@ class Orbit(object):
                      'dopr54_c' for a 5-4 Dormand-Prince integrator in C
                      'dop853' for a 8-5-3 Dormand-Prince integrator in Python
                      'dop853_c' for a 8-5-3 Dormand-Prince integrator in C
+                     
+            progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
 
             dt - if set, force the integrator to use this basic stepsize; must be an integer divisor of output stepsize (only works for the C integrators that use a fixed stepsize) (can be Quantity)
 
@@ -1121,14 +1124,17 @@ class Orbit(object):
         # Implementation with parallel_map in Python
         if not '_c' in method or not ext_loaded or force_map:
             if self.dim() == 1:
-                out, msg= integrateLinearOrbit(self._pot,self.vxvv,t,
-                                               method,numcores=numcores,dt=dt)
+                out, msg= integrateLinearOrbit(self._pot,self.vxvv,t,method,
+                                               progressbar=progressbar,
+                                               numcores=numcores,dt=dt)
             elif self.dim() == 2:
-                out, msg= integratePlanarOrbit(self._pot,self.vxvv,t,
-                                               method,numcores=numcores,dt=dt)
+                out, msg= integratePlanarOrbit(self._pot,self.vxvv,t,method,
+                                               progressbar=progressbar,
+                                               numcores=numcores,dt=dt)
             else:
-                out, msg= integrateFullOrbit(self._pot,self.vxvv,t,
-                                             method,numcores=numcores,dt=dt)
+                out, msg= integrateFullOrbit(self._pot,self.vxvv,t,method,
+                                             progressbar=progressbar,
+                                             numcores=numcores,dt=dt)
         else:
             warnings.warn("Using C implementation to integrate orbits",
                           galpyWarningVerbose)

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1213,7 +1213,8 @@ class Orbit(object):
                           galpyWarning)
         return None
 
-    def integrate_dxdv(self,dxdv,t,pot,method='dopr54_c',dt=None,
+    def integrate_dxdv(self,dxdv,t,pot,method='dopr54_c',
+                       progressbar=True,dt=None,
                        numcores=_NUMCORES,force_map=False,
                        rectIn=False,rectOut=False):
         """
@@ -1232,6 +1233,8 @@ class Orbit(object):
            t - list of times at which to output (0 has to be in this!) (can be Quantity)
 
            pot - potential instance or list of instances
+           
+           progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
 
            dt - if set, force the integrator to use this basic stepsize; must be an integer divisor of output stepsize (only works for the C integrators that use a fixed stepsize) (can be Quantity)
 
@@ -1309,6 +1312,7 @@ class Orbit(object):
             if self.dim() == 2:
                 out, msg= integratePlanarOrbit_dxdv(self._pot,self.vxvv,dxdv,
                                                     t,method,rectIn,rectOut,
+                                                    progressbar=progressbar,
                                                     numcores=numcores,dt=dt)
         # Store orbit internally
         self.orbit_dxdv= out

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -469,6 +469,9 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
                     err,
                     ctypes.c_int(int_method_c),
                     pbar_c)
+    
+    if nobj > 1 and progressbar:
+        pbar.close()
 
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -539,8 +539,8 @@ def integrateFullOrbit_dxdv_c(pot,yo,dyo,t,int_method,rtol=None,atol=None): #pra
 
     return (result,err.value)
 
-def integrateFullOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
-                       dt=None):
+def integrateFullOrbit(pot,yo,t,int_method,rtol=None,atol=None,
+                       numcores=1,progressbar=True,dt=None):
     """
     NAME:
        integrateFullOrbit
@@ -553,6 +553,7 @@ def integrateFullOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
        int_method= 'leapfrog', 'odeint', or 'dop853'
        rtol, atol= tolerances (not always used...)
        numcores= (1) number of cores to use for multi-processing
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one; only for C-based integrators)
     OUTPUT:
        (y,err)
@@ -647,7 +648,8 @@ def integrateFullOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
     if len(yo) == 1: # Can't map a single value...
         out= numpy.atleast_3d(integrate_for_map(yo[0]).T).T
     else:
-        out= numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores)))
+        out= numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores,
+                                       progressbar=progressbar)))
     if nophi:
         out= out[:,:,:5]
     return out, numpy.zeros(len(yo))

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -9,11 +9,15 @@ from ..util import galpyWarning
 from ..potential.Potential import _evaluateRforces, _evaluatezforces,\
     _evaluatephiforces
 from .integratePlanarOrbit import (_parse_integrator, _parse_tol,
-                                   _parse_scf_pot, _prep_tfuncs)
+                                   _parse_scf_pot, _prep_tfuncs,
+                                   _TQDM_LOADED)
 from ..util.multi import parallel_map
 from ..util.leung_dop853 import dop853
 from ..util import symplecticode
 from ..util import _load_extension_libs
+
+if _TQDM_LOADED:
+    import tqdm
 
 _lib, _ext_loaded= _load_extension_libs.load_libgalpy()
 
@@ -372,7 +376,8 @@ def _parse_pot(pot,potforactions=False,potfortorus=False):
     pot_args= numpy.array(pot_args,dtype=numpy.float64,order='C')
     return (npot,pot_type,pot_args,pot_tfuncs)
 
-def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
+def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
+                         progressbar=True,dt=None):
     """
     NAME:
        integrateFullOrbit_c
@@ -384,6 +389,7 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
        t - set of times at which one wants the result
        int_method= 'leapfrog_c', 'rk4_c', 'rk6_c', 'symplec4_c'
        rtol, atol
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one; only for C-based integrators)
     OUTPUT:
        (y,err)
@@ -394,6 +400,7 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
     HISTORY:
        2011-11-13 - Written - Bovy (IAS)
        2018-12-21 - Adapted to allow multiple objects - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     if len(yo.shape) == 1: single_obj= True
     else: single_obj= False
@@ -409,6 +416,15 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
     #Set up result array
     result= numpy.empty((nobj,len(t),6))
     err= numpy.zeros(nobj,dtype=numpy.int32)
+    
+    #Set up progressbar
+    progressbar*= _TQDM_LOADED
+    if nobj > 1 and progressbar:
+        pbar= tqdm.tqdm(total=nobj,leave=False)
+        pbar_func_ctype= ctypes.CFUNCTYPE(None)
+        pbar_c= pbar_func_ctype(pbar.update)
+    else: # pragma: no cover
+        pbar_c= None
 
     #Set up the C code
     ndarrayFlags= ('C_CONTIGUOUS','WRITEABLE')
@@ -426,7 +442,8 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
                                ctypes.c_double,
                                ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
                                ndpointer(dtype=numpy.int32,flags=ndarrayFlags),
-                               ctypes.c_int]
+                               ctypes.c_int,
+                               ctypes.c_void_p]
 
     #Array requirements, first store old order
     f_cont= [yo.flags['F_CONTIGUOUS'],
@@ -450,7 +467,8 @@ def integrateFullOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
                     ctypes.c_double(atol),
                     result,
                     err,
-                    ctypes.c_int(int_method_c))
+                    ctypes.c_int(int_method_c),
+                    pbar_c)
 
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -564,6 +564,7 @@ def integrateFullOrbit(pot,yo,t,int_method,rtol=None,atol=None,
     HISTORY:
        2010-08-01 - Written - Bovy (NYU)
        2019-04-09 - Adapted to allow multiple objects and parallel mapping - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     nophi= False
     if not int_method.lower() == 'dop853' and not int_method == 'odeint':

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -190,6 +190,9 @@ def integrateLinearOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
                     ctypes.c_int(int_method_c),
                     pbar_c)
     
+    if nobj > 1 and progressbar:
+        pbar.close()
+    
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")
 

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -185,7 +185,7 @@ def integrateLinearOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,dt=None):
 
 # Python integration functions
 def integrateLinearOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
-                         dt=None):
+                         progressbar=True,dt=None):
     """
     NAME:
        integrateLinearOrbit
@@ -198,6 +198,7 @@ def integrateLinearOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
        int_method= 'leapfrog', 'odeint', or 'dop853'
        rtol, atol= tolerances (not always used...)
        numcores= (1) number of cores to use for multi-processing
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one; only for C-based integrators)
     OUTPUT:
        (y,err)
@@ -231,7 +232,8 @@ def integrateLinearOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
     if len(yo) == 1: # Can't map a single value...
         return numpy.atleast_3d(integrate_for_map(yo[0]).T).T, 0
     else:
-        return (numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores))),
+        return (numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores,
+                                          progressbar=progressbar))),
                 numpy.zeros(len(yo)))
 
 def _linearEOM(y,t,pot):

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -209,6 +209,7 @@ def integrateLinearOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
     HISTORY:
        2010-07-13- Written - Bovy (NYU)
        2019-04-08 - Adapted to allow multiple orbits to be integrated at once and moved to integrateLinearOrbit.py - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     if int_method.lower() == 'leapfrog':
         if rtol is None: rtol= 1e-8

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -3,6 +3,11 @@ import ctypes.util
 from numpy.ctypeslib import ndpointer
 import numpy
 from scipy import integrate
+_TQDM_LOADED= True
+try:
+    import tqdm
+except ImportError: #pragma: no cover
+    _TQDM_LOADED= False
 _NUMBA_LOADED= True
 try:
     from numba import types, cfunc
@@ -427,7 +432,7 @@ def _prep_tfuncs(pot_tfuncs):
     return pot_tfuncs
 
 def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
-                           dt=None):
+                           progressbar=True,dt=None):
     """
     NAME:
        integratePlanarOrbit_c
@@ -439,6 +444,7 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
        t - set of times at which one wants the result
        int_method= 'leapfrog_c', 'rk4_c', 'rk6_c', 'symplec4_c', ...
        rtol, atol
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one)
    OUTPUT:
        (y,err)
@@ -449,6 +455,7 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
     HISTORY:
        2011-10-03 - Written - Bovy (IAS)
        2018-12-20 - Adapted to allow multiple objects - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     if len(yo.shape) == 1: single_obj= True
     else: single_obj= False
@@ -464,6 +471,15 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
     #Set up result array
     result= numpy.empty((nobj,len(t),4))
     err= numpy.zeros(nobj,dtype=numpy.int32)
+    
+    #Set up progressbar
+    progressbar*= _TQDM_LOADED
+    if nobj > 1 and progressbar:
+        pbar= tqdm.tqdm(total=nobj,leave=False)
+        pbar_func_ctype= ctypes.CFUNCTYPE(None)
+        pbar_c= pbar_func_ctype(pbar.update)
+    else: # pragma: no cover
+        pbar_c= None
 
     #Set up the C code
     ndarrayFlags= ('C_CONTIGUOUS','WRITEABLE')
@@ -481,7 +497,8 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
                                ctypes.c_double,
                                ndpointer(dtype=numpy.float64,flags=ndarrayFlags),
                                ndpointer(dtype=numpy.int32,flags=ndarrayFlags),
-                               ctypes.c_int]
+                               ctypes.c_int,
+                               ctypes.c_void_p]
 
     #Array requirements, first store old order
     f_cont= [yo.flags['F_CONTIGUOUS'],
@@ -505,7 +522,8 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
                     ctypes.c_double(atol),
                     result,
                     err,
-                    ctypes.c_int(int_method_c))
+                    ctypes.c_int(int_method_c),
+                    pbar_c)
 
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -601,7 +601,7 @@ def integratePlanarOrbit_dxdv_c(pot,yo,dyo,t,int_method,rtol=None,atol=None,
     return (result,err.value)
 
 def integratePlanarOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
-                         dt=None):
+                         progressbar=True,dt=None):
     """
     NAME:
        integratePlanarOrbit
@@ -614,6 +614,7 @@ def integratePlanarOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
        int_method= 'leapfrog', 'odeint', or 'dop853'
        rtol, atol= tolerances (not always used...)
        numcores= (1) number of cores to use for multi-processing
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one; only for C-based integrators!)
     OUTPUT:
        (y,err)
@@ -702,7 +703,8 @@ def integratePlanarOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
     if len(yo) == 1: # Can't map a single value...
         out= numpy.atleast_3d(integrate_for_map(yo[0]).T).T
     else:
-        out= numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores)))
+        out= numpy.array((parallel_map(integrate_for_map,yo,numcores=numcores,
+                                       progressbar=progressbar)))
     if nophi:
         out= out[:,:,:3]
     return out, numpy.zeros(len(yo))

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -625,6 +625,7 @@ def integratePlanarOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
     HISTORY:
        2010-07-20 - Written - Bovy (NYU)
        2019-04-09 - Adapted to allow multiple objects and parallel mapping - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     nophi= False
     if not int_method.lower() == 'dop853' and not int_method == 'odeint':
@@ -712,7 +713,7 @@ def integratePlanarOrbit(pot,yo,t,int_method,rtol=None,atol=None,numcores=1,
 def integratePlanarOrbit_dxdv(pot,yo,dyo,t,int_method,
                               rectIn,rectOut,
                               rtol=None,atol=None,
-                              dt=None,numcores=1):
+                              progressbar=True,dt=None,numcores=1):
     """
     NAME:
        integratePlanarOrbit_dxdv
@@ -728,6 +729,7 @@ def integratePlanarOrbit_dxdv(pot,yo,dyo,t,int_method,
        rectOut= (False) if True, output dyo is in rectangular coordinates
        rtol, atol= tolerances (not always used...)
        numcores= (1) number of cores to use for multi-processing
+       progressbar= (True) if True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!)
        dt= (None) force integrator to use this stepsize (default is to automatically determine one; only for C-based integrators)
     OUTPUT:
        (y,err)
@@ -738,6 +740,7 @@ def integratePlanarOrbit_dxdv(pot,yo,dyo,t,int_method,
     HISTORY:
        2011-10-17 - Written - Bovy (IAS)
        2019-05-21 - Adapted to allow multiple objects and parallel mapping - Bovy (UofT)
+       2022-04-12 - Add progressbar - Bovy (UofT)
     """
     #go to the rectangular frame
     this_yo= numpy.array([yo[:,0]*numpy.cos(yo[:,3]),
@@ -783,7 +786,8 @@ def integratePlanarOrbit_dxdv(pot,yo,dyo,t,int_method,
         out= numpy.atleast_3d(integrate_for_map(this_yo[0]).T).T
     else:
         out= numpy.array((parallel_map(integrate_for_map,this_yo,
-                                    numcores=numcores)))
+                                       progressbar=progressbar,
+                                       numcores=numcores)))
     #go back to the cylindrical frame
     R= numpy.sqrt(out[...,0]**2.+out[...,1]**2.)
     phi= numpy.arccos(out[...,0]/R)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -525,6 +525,9 @@ def integratePlanarOrbit_c(pot,yo,t,int_method,rtol=None,atol=None,
                     ctypes.c_int(int_method_c),
                     pbar_c)
 
+    if nobj > 1 and progressbar:
+        pbar.close()
+
     if numpy.any(err == -10): #pragma: no cover
         raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")
 

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -640,7 +640,8 @@ EXPORT void integrateFullOrbit(int nobj,
 			       double atol,
 			       double *result,
 			       int * err,
-			       int odeint_type){
+			       int odeint_type,
+             orbint_callback_type cb){
   //Set up the forces, first count
   int ii,jj;
   int dim;
@@ -715,6 +716,8 @@ EXPORT void integrateFullOrbit(int nobj,
 		result+6*nt*ii,err+ii);
     for (jj=0; jj < nt; jj++)
       rect_to_cyl_galpy(result+6*jj+6*nt*ii);
+    if ( cb ) // Callback if not void
+      cb();
   }
   //Free allocated memory
 #pragma omp parallel for schedule(static,1) private(ii) num_threads(max_threads)

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.h
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.h
@@ -7,6 +7,7 @@ extern "C" {
 #include <Python.h>
 #endif
 #include <galpy_potentials.h>
+typedef void (*orbint_callback_type)(); // Callback function
 void parse_leapFuncArgs_Full(int, struct potentialArg *,int **,double **,tfuncs_type_arr *);
 #ifdef _WIN32
 // On Windows, *need* to define this function to allow the package to be imported

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -125,7 +125,8 @@ EXPORT void integrateLinearOrbit(int nobj,
 				 double atol,
 				 double *result,
 				 int * err,
-				 int odeint_type){
+				 int odeint_type,
+         orbint_callback_type cb){
   //Set up the forces, first count
   int dim;
   int ii;
@@ -193,10 +194,13 @@ EXPORT void integrateLinearOrbit(int nobj,
     break;
   }
 #pragma omp parallel for schedule(dynamic,ORBITS_CHUNKSIZE) private(ii) num_threads(max_threads)
-  for (ii=0; ii < nobj; ii++) 
+  for (ii=0; ii < nobj; ii++) {
     odeint_func(odeint_deriv_func,dim,yo+2*ii,nt,dt,t,
 		npot,potentialArgs+omp_get_thread_num()*npot,rtol,atol,
 		result+2*nt*ii,err+ii);
+    if ( cb ) // Callback if not void
+      cb();
+  }
   //Free allocated memory
 #pragma omp parallel for schedule(static,1) private(ii) num_threads(max_threads)
   for (ii=0; ii < max_threads; ii++)

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -542,7 +542,8 @@ EXPORT void integratePlanarOrbit(int nobj,
 				 double atol,
 				 double *result,
 				 int * err,
-				 int odeint_type){
+				 int odeint_type,
+         orbint_callback_type cb){
   //Set up the forces, first count
   int ii,jj;
   int dim;
@@ -617,6 +618,8 @@ EXPORT void integratePlanarOrbit(int nobj,
 		result+4*nt*ii,err+ii);
     for (jj= 0; jj < nt; jj++)
       rect_to_polar_galpy(result+4*jj+4*nt*ii);
+    if ( cb ) // Callback if not void
+      cb();
   }
   //Free allocated memory
 #pragma omp parallel for schedule(static,1) private(ii) num_threads(max_threads)
@@ -638,7 +641,8 @@ EXPORT void integratePlanarOrbit_dxdv(double *yo,
 				      double atol,
 				      double *result,
 				      int * err,
-				      int odeint_type){
+				      int odeint_type,
+              orbint_callback_type cb){
   //Set up the forces, first count
   int dim;
   struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -6432,7 +6432,7 @@ def test_streamdf_method_value():
     assert numpy.fabs(sdf_bovy14.estimateTdisrupt(0.1).to(units.Gyr).value-sdf_bovy14_nou.estimateTdisrupt(0.1)*conversion.time_in_Gyr(vo,ro)) < _NUMPY_1_22 * 1e-7 + (1-_NUMPY_1_22) * 1e-8, 'streamdf method estimateTdisrupt does not return correct Quantity'
     assert numpy.all(numpy.fabs(sdf_bovy14.meanOmega(0.1).to(1/units.Gyr).value-sdf_bovy14_nou.meanOmega(0.1)*conversion.freq_in_Gyr(vo,ro)) < 10.**-8.), 'streamdf method meanOmega does not return correct Quantity'
     assert numpy.fabs(sdf_bovy14.sigOmega(0.1).to(1/units.Gyr).value-sdf_bovy14_nou.sigOmega(0.1)*conversion.freq_in_Gyr(vo,ro)) < 10.**-8., 'streamdf method sigOmega does not return correct Quantity'
-    assert numpy.fabs(sdf_bovy14.meantdAngle(0.1).to(units.Gyr).value-sdf_bovy14_nou.meantdAngle(0.1)*conversion.time_in_Gyr(vo,ro)) < 10.**-8., 'streamdf method meantdAngle does not return correct Quantity'
+    assert numpy.fabs(sdf_bovy14.meantdAngle(0.1).to(units.Gyr).value-sdf_bovy14_nou.meantdAngle(0.1)*conversion.time_in_Gyr(vo,ro)) < 10.**-7., 'streamdf method meantdAngle does not return correct Quantity'
     assert numpy.fabs(sdf_bovy14.sigtdAngle(0.1).to(units.Gyr).value-sdf_bovy14_nou.sigtdAngle(0.1)*conversion.time_in_Gyr(vo,ro)) < 10.**-8., 'streamdf method sigtdAngle does not return correct Quantity'
     assert numpy.fabs(sdf_bovy14.meanangledAngle(0.1).to(units.rad).value-sdf_bovy14_nou.meanangledAngle(0.1)) < 10.**-8., 'streamdf method meanangledAngle does not return correct Quantity'
     assert numpy.fabs(sdf_bovy14.sigangledAngle(0.1).to(units.rad).value-sdf_bovy14_nou.sigangledAngle(0.1)) < 10.**-8., 'streamdf method sigangledAngle does not return correct Quantity'


### PR DESCRIPTION
As requested by @jmackereth _years ago_...

Example:

<img width="402" alt="Screen Shot 2022-04-13 at 12 08 15 AM" src="https://user-images.githubusercontent.com/1044876/163098336-4222e342-f510-44ff-85f8-47713ee52c7a.png">

Not adding a progress bar for action-angle calculations at this point, because the C calculation isn't structured as a loop of the full calculation over all objects (instead, various components of the calculation are done for all objects). So it's more difficult to define 'progress'. But when there is a metric of progress, the code in this PR should make it pretty easy to implement a progress bar for action-angle calculations as well.
.