### PR TITLE
Fix function pointer disagreement

### DIFF
--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -436,7 +436,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->ntfuncs= 0;
       break;
     case 40: //NullPotential, no arguments (only supported for orbit int)
-      potentialArgs->potentialEval= &ZeroPlanarForce;
+      potentialArgs->potentialEval= &ZeroForce;
       potentialArgs->planarRforce= &ZeroPlanarForce;
       potentialArgs->planarphitorque= &ZeroPlanarForce;
       potentialArgs->planarR2deriv= &ZeroPlanarForce;


### PR DESCRIPTION
This fixes the error:
```
galpy/orbit/orbit_c_ext/integratePlanarOrbit.c:439:35: error: incompatible function pointer types assigning to 'double (*)(double, double, double, double, struct potentialArg *)' from 'double (*)(double, double, double, struct potentialArg *)' [-Wincompatible-function-pointer-types]
      potentialArgs->potentialEval= &ZeroPlanarForce;
```

https://app.circleci.com/pipelines/github/hoodmane/pyodide/3785/workflows/deda3693-7508-459d-a8e1-2f576f821532/jobs/45989