### PR TITLE
Don't use conda for windows tests

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -219,10 +219,11 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
-      shell: bash
+      shell: bash -l {0}
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
+        deactivate # deactivate environment, bc we don't want to use it
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --durations=0" # --disable-pytest-warnings

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -144,7 +144,10 @@ jobs:
             REQUIRES_JAX: false
     steps:
     - uses: actions/checkout@v3
-    # Windows installation: Install Micromamba, as specified by this repository's environment.yml for Windows
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
     # Cache both conda and pip, conda done by provision-with-micromamba
     - uses: actions/cache@v3
       with:
@@ -204,6 +207,7 @@ jobs:
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
     - name: Print debug info
+      shell: cmd
       env:
          REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
          REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,7 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
-        echo "PATH=$PATH:'$CONDA_PREFIX\\Library\\lib'" >> $GITHUB_ENV
+        echo "$CONDA_PREFIX\\Library\\lib" >> $GITHUB_PATH
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron: '0 20 * * 2'
 
+defaults:
+    run:
+        shell: wsl-bash {0}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -143,6 +147,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
     steps:
+    - uses: Vampire/setup-wsl@v1
     - uses: actions/checkout@v3
     # Windows installation: Install Micromamba, as specified by this repository's environment.yml for Windows
     # Cache both conda and pip, conda done by provision-with-micromamba
@@ -157,7 +162,7 @@ jobs:
         cd gsl-2.7
         ./configure
         make
-        sudo make install
+        make install
     - uses: mamba-org/provision-with-micromamba@v13
       with:
          environment-name: galpywheels

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -219,7 +219,7 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
-      shell: bash -l {0}
+      shell: bash
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,7 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
-        echo "PATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
+        echo "PATH=$PATH:$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -148,6 +148,8 @@ jobs:
             REQUIRES_JAX: false
     steps:
     - uses: Vampire/setup-wsl@v1
+      with:
+        distribution: Ubuntu-22.04
     - uses: actions/checkout@v3
     # Windows installation: Install Micromamba, as specified by this repository's environment.yml for Windows
     # Cache both conda and pip, conda done by provision-with-micromamba

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -219,8 +219,10 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
+      shell: bash
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
         pip install pytest-cov
-        pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0
+        # eval necessary for -k 'not ...' in TEST_FILES
+        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -223,7 +223,7 @@ jobs:
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
-        conda deactivate # Need env variables, but not the environment itself
+        mamba deactivate # Need env variables, but not the environment itself
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -207,7 +207,6 @@ jobs:
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
     - name: Print debug info
-      shell: cmd
       env:
          REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
          REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
@@ -216,9 +215,9 @@ jobs:
          python -c "import numpy; print('numpy: {}'.format(numpy.__version__))"
          python -c "import scipy; print('scipy: {}'.format(scipy.__version__))"
          python -c "import matplotlib; print('matplotlib: {}'.format(matplotlib.__version__))"
-         if $REQUIRES_ASTROPY; then python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"; fi
-         if $REQUIRES_ASTROQUERY; then python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"; fi
-         if $REQUIRES_PYNBODY; then python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"; fi
+         if ( $REQUIRES_ASTROPY ) { python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"}
+         if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
+         if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -223,5 +223,4 @@ jobs:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
         pip install pytest-cov
-        # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"
+        pytest -v %TEST_FILES% --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,6 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
+        echo "PATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,6 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
+        echo "$CONDA_PREFIX\\Library\\bin" >> $GITHUB_PATH
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
@@ -220,11 +221,9 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
-      shell: bash -l {0}
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
-        micromamba deactivate
         python -c "from galpy.orbit import Orbit" # Try to see why extension doesn't load
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -223,7 +223,7 @@ jobs:
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
-        deactivate # deactivate environment, bc we don't want to use it
+        python -c "from galpy.orbit import Orbit" # Try to see why extension doesn't load
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --durations=0" # --disable-pytest-warnings
+        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -219,10 +219,11 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
-      shell: bash
+      shell: bash -l {0}
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
+        conda deactivate # Need env variables, but not the environment itself
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -13,10 +13,6 @@ on:
   schedule:
     - cron: '0 20 * * 2'
 
-defaults:
-    run:
-        shell: wsl-bash {0}
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -147,9 +143,6 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
     steps:
-    - uses: Vampire/setup-wsl@v1
-      with:
-        distribution: Ubuntu-22.04
     - uses: actions/checkout@v3
     # Windows installation: Install Micromamba, as specified by this repository's environment.yml for Windows
     # Cache both conda and pip, conda done by provision-with-micromamba
@@ -165,66 +158,59 @@ jobs:
         ./configure
         make
         make install
+    # Install just the GSL using conda
     - uses: mamba-org/provision-with-micromamba@v13
       with:
-         environment-name: galpywheels
-         environment-file: .github/conda-build-environment-${{ matrix.os }}.yml
-         extra-specs: python=${{ matrix.python-version }}
+         environment-name: installgsl
+         environment-file: false
+         extra-specs: |
+           python=3.10
+           gsl
          cache-downloads: true
          cache-env: true
-         cache-env-key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build_windows.yml') }}-${{ hashFiles('.github/conda-build-environment-windows-latest.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
-    - name: Set environment variables on Windows
+         cache-env-key: ${{ runner.os }}-${{ hashFiles('.github/workflows/build_windows.yml') }}
+    - name: Set GSL environment variables
       shell: bash -l {0}
       run: |
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
-      shell: bash -l {0}
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
-      shell: bash -l {0}
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY && matrix.python-version != 4.0 }}
-      shell: bash -l {0}
       run: |
          pip install astropy pyerfa
     - name: Install astropy (Python 4.0; doesn't exist of course, placeholder for new python v)
       if: ${{ matrix.REQUIRES_ASTROPY && matrix.python-version == 4.0 }}
-      shell: bash -l {0}
       run: |
          pip install pyerfa
          pip install --extra-index-url=https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple/ --pre astropy
     - name: Install astroquery
       if: ${{ matrix.REQUIRES_ASTROQUERY }}
-      shell: bash -l {0}
       run: pip install astroquery
     - name: Install numba
       if: ${{ matrix.REQUIRES_NUMBA }}
-      shell: bash -l {0}
       run: pip install numba
     - name: Install JAX
       if: ${{ matrix.REQUIRES_JAX }}
-      shell: bash -l {0}
       run: pip install jax jaxlib
     - name: Download dfcorrections
-      shell: bash -l {0}
       run: |
          curl -O https://github.s3.amazonaws.com/downloads/jobovy/galpy/galpy-dfcorrections.tar.gz
          tar xvzf galpy-dfcorrections.tar.gz -C ./galpy/df/data/
     - name: Install package
-      shell: bash -l {0}
       run: |
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
     - name: Print debug info
-      shell: bash -l {0}
       env:
          REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
          REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
@@ -237,7 +223,6 @@ jobs:
          if $REQUIRES_ASTROQUERY; then python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"; fi
          if $REQUIRES_PYNBODY; then python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"; fi
     - name: Test with pytest
-      shell: bash -l {0}
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -210,6 +210,7 @@ jobs:
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
     - name: Print debug info
+      shell: pwsh
       env:
          REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
          REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -150,6 +150,14 @@ jobs:
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build_windows.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
+    - name: Install the GSL
+      run: |
+        curl -O https://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz
+        tar -xvzf gsl-2.7.tar.gz
+        cd gsl-2.7
+        ./configure
+        make
+        sudo make install
     - uses: mamba-org/provision-with-micromamba@v13
       with:
          environment-name: galpywheels

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,7 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
-        echo "PATH=$PATH:$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
+        echo "PATH=$PATH:'$CONDA_PREFIX\\Library\\lib'" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -150,19 +150,12 @@ jobs:
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build_windows.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
-    - name: Install the GSL
-      run: |
-        curl -O https://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz
-        tar -xvzf gsl-2.7.tar.gz
-        cd gsl-2.7
-        ./configure
-        make
-        make install
     # Install just the GSL using conda
     - uses: mamba-org/provision-with-micromamba@v13
       with:
          environment-name: installgsl
          environment-file: false
+         channels: conda-forge,anaconda
          extra-specs: |
            python=3.10
            gsl

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -223,7 +223,6 @@ jobs:
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
-        mamba deactivate # Need env variables, but not the environment itself
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"
+        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --durations=0" # --disable-pytest-warnings

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   build:
+    defaults:
+      run:
+        shell: bash
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
@@ -171,7 +174,6 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
-        echo "$CONDA_PREFIX\\Library\\lib" >> $GITHUB_PATH
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
@@ -220,11 +222,10 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
-      shell: bash
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
         python -c "from galpy.orbit import Orbit" # Try to see why extension doesn't load
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0
+        eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -209,19 +209,19 @@ jobs:
       run: |
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
-    - name: Print debug info
-      shell: pwsh
-      env:
-         REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
-         REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
-         REQUIRES_PYNBODY : ${{ matrix.REQUIRES_PYNBODY }}
-      run: |
-         python -c "import numpy; print('numpy: {}'.format(numpy.__version__))"
-         python -c "import scipy; print('scipy: {}'.format(scipy.__version__))"
-         python -c "import matplotlib; print('matplotlib: {}'.format(matplotlib.__version__))"
-         if ( $REQUIRES_ASTROPY ) { python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"}
-         if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
-         if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
+#    - name: Print debug info
+#      shell: pwsh
+#      env:
+#         REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
+#         REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
+#         REQUIRES_PYNBODY : ${{ matrix.REQUIRES_PYNBODY }}
+#      run: |
+#         python -c "import numpy; print('numpy: {}'.format(numpy.__version__))"
+#         python -c "import scipy; print('scipy: {}'.format(scipy.__version__))"
+#         python -c "import matplotlib; print('matplotlib: {}'.format(matplotlib.__version__))"
+#         if ( $REQUIRES_ASTROPY ) { python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"}
+#         if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
+#         if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -171,7 +171,7 @@ jobs:
         echo "INCLUDE=$CONDA_PREFIX\\Library\\include" >> $GITHUB_ENV
         echo "LIB=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
-        echo "$CONDA_PREFIX\\Library\\bin" >> $GITHUB_PATH
+        echo "$CONDA_PREFIX\\Library\\bin" >> $GITHUB_PATH # necessary when we don't activate the environment
     - name: Install Python dependencies
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
@@ -221,10 +221,10 @@ jobs:
          if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
          if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
+      shell: bash
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
-        python -c "from galpy.orbit import Orbit" # Try to see why extension doesn't load
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -176,6 +176,8 @@ jobs:
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
+         cat ~/.profile
+         cat ~/.bashrc
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
@@ -210,7 +210,6 @@ jobs:
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
     - name: Print debug info
-      shell: pwsh
       env:
          REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
          REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -176,7 +176,7 @@ jobs:
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
-         cat ~/.bashrc
+         micromamba deactivate
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -176,7 +176,6 @@ jobs:
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
-         cat ~/.profile
          cat ~/.bashrc
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -15,9 +15,6 @@ on:
 
 jobs:
   build:
-    defaults:
-      run:
-        shell: bash -l {0}
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
@@ -176,7 +173,6 @@ jobs:
         echo "LIBPATH=$CONDA_PREFIX\\Library\\lib" >> $GITHUB_ENV
     - name: Install Python dependencies
       run: |
-         micromamba deactivate
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
@@ -210,23 +206,25 @@ jobs:
       run: |
         python setup.py build_ext --no-openmp --single_ext --inplace
         python setup.py develop --single_ext
-#    - name: Print debug info
-#      shell: pwsh
-#      env:
-#         REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
-#         REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
-#         REQUIRES_PYNBODY : ${{ matrix.REQUIRES_PYNBODY }}
-#      run: |
-#         python -c "import numpy; print('numpy: {}'.format(numpy.__version__))"
-#         python -c "import scipy; print('scipy: {}'.format(scipy.__version__))"
-#         python -c "import matplotlib; print('matplotlib: {}'.format(matplotlib.__version__))"
-#         if ( $REQUIRES_ASTROPY ) { python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"}
-#         if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
-#         if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
+    - name: Print debug info
+      shell: pwsh
+      env:
+         REQUIRES_ASTROPY : ${{ matrix.REQUIRES_ASTROPY }}
+         REQUIRES_ASTROQUERY : ${{ matrix.REQUIRES_ASTROQUERY }}
+         REQUIRES_PYNBODY : ${{ matrix.REQUIRES_PYNBODY }}
+      run: |
+         python -c "import numpy; print('numpy: {}'.format(numpy.__version__))"
+         python -c "import scipy; print('scipy: {}'.format(scipy.__version__))"
+         python -c "import matplotlib; print('matplotlib: {}'.format(matplotlib.__version__))"
+         if ( $REQUIRES_ASTROPY ) { python -c "import astropy; print('astropy: {}'.format(astropy.__version__))"}
+         if ( $REQUIRES_ASTROQUERY ) { python -c "import astroquery; print('astroquery: {}'.format(astroquery.__version__))"}
+         if ( $REQUIRES_PYNBODY ) {python -c "import pynbody; print('pynbody: {}'.format(pynbody.__version__))"}
     - name: Test with pytest
+      shell: bash -l {0}
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}
       run: |
+        micromamba deactivate
         python -c "from galpy.orbit import Orbit" # Try to see why extension doesn't load
         pip install pytest-cov
         # eval necessary for -k 'not ...' in TEST_FILES


### PR DESCRIPTION
But we still need it to install the GSL. But no conda for anything else, so we can decouple the conda Python version and the test Python version. This has many advantages