### PR TITLE
Enable interpSphericalPotential as pot= in spherical DFs

### DIFF
--- a/doc/source/reference/df.rst
+++ b/doc/source/reference/df.rst
@@ -63,7 +63,12 @@ Various spherical DFs are explicitly implemented (e.g., Hernquist, NFW
 using a new approximation, King, Plummer) in isotropic and various
 anisotropic forms. General methods for computing isotropic,
 constant-beta anisotropic, and Osipkov-Merritt anisotropic for any
-potential/density pair are also included.
+potential/density pair are also included. Use of interpolated spherical 
+potentials (``galpy.potential.interpSphericalPotential``) is also supported 
+with DFs, however numerical issues can arise during sampling or calculation 
+of moments of the DF, and so caution is recommended when using these potentials. 
+It is adviseable to use a very finely spaced radial grid, and ensure that it 
+spans a range of radii much larger than the radii of interest for the DF.
 
 General instance routines
 +++++++++++++++++++++++++

--- a/doc/source/reference/df.rst
+++ b/doc/source/reference/df.rst
@@ -63,11 +63,11 @@ Various spherical DFs are explicitly implemented (e.g., Hernquist, NFW
 using a new approximation, King, Plummer) in isotropic and various
 anisotropic forms. General methods for computing isotropic,
 constant-beta anisotropic, and Osipkov-Merritt anisotropic for any
-potential/density pair are also included. Use of interpolated spherical 
-potentials (``galpy.potential.interpSphericalPotential``) is also supported 
-with DFs, however numerical issues can arise during sampling or calculation 
-of moments of the DF, and so caution is recommended when using these potentials. 
-It is adviseable to use a very finely spaced radial grid, and ensure that it 
+potential/density pair are also included. Use of interpolated spherical
+potentials (``galpy.potential.interpSphericalPotential``) is also supported
+with DFs, however numerical issues can arise during sampling or calculation
+of moments of the DF, and so caution is recommended when using these potentials.
+It is adviseable to use a very finely spaced radial grid, and ensure that it
 spans a range of radii much larger than the radii of interest for the DF.
 
 General instance routines

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -1068,6 +1068,12 @@ def estimateDeltaStaeckel(pot,R,z,no_median=False,delta0=1e-6):
                   for p in pot]) \
         if isinstance(pot,list) \
         else isinstance(pot,SCFPotential) or isinstance(pot,DiskSCFPotential)
+    if numpy.any(z==0.): # pragma: no cover
+        warnings.warn("z=0 encountered in estimateDeltaStaeckel, for which delta is undefined. Setting instances of z=0 to z=1e-4",galpyWarning)
+        if isinstance(z,numpy.ndarray):
+            z[z==0.]= 1e-4
+        else:
+            z= 1e-4
     if isinstance(R,numpy.ndarray):
         delta2= numpy.array([(z[ii]**2.-R[ii]**2. #eqn. (9) has a sign error
                            +(3.*R[ii]*_evaluatezforces(pot,R[ii],z[ii])

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -196,9 +196,16 @@ class constantbetadf(_constantbetadf):
         r_a_values= numpy.concatenate(\
                         (numpy.array([0.]),
                          numpy.geomspace(1e-6,1e6,10001)))
-        self._rphi= interpolate.InterpolatedUnivariateSpline(\
-                        [_evaluatePotentials(self._pot,r*self._scale,0)
-                         for r in r_a_values],r_a_values*self._scale,k=3)
+        phis = numpy.array([_evaluatePotentials(self._pot,r*self._scale,0)
+                           for r in r_a_values])
+        # Ensure phi is monotonic
+        if numpy.any(numpy.diff(phis) <= 0):
+            phim = numpy.maximum.accumulate(phis)
+            indx_rm = numpy.where(numpy.diff(phim)==0)[0]
+            phis = numpy.delete(phim,indx_rm)
+            r_a_values = numpy.delete(r_a_values,indx_rm)
+        self._rphi= interpolate.InterpolatedUnivariateSpline(phis,
+            r_a_values*self._scale,k=3)
         # Build interpolator for the lower limit of the integration (near the
         # 1/(Phi-E)^alpha divergence; at the end, we slightly adjust it up
         # to be sure to be above the point where things go haywire...

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -63,9 +63,16 @@ class eddingtondf(isotropicsphericaldf):
         r_a_values= numpy.concatenate(\
                         (numpy.array([0.]),
                          numpy.geomspace(1e-6,1e6,10001)))
-        self._rphi= interpolate.InterpolatedUnivariateSpline(\
-                        [_evaluatePotentials(self._pot,r*self._scale,0)
-                         for r in r_a_values],r_a_values*self._scale,k=3)
+        phis = numpy.array([_evaluatePotentials(self._pot,r*self._scale,0)
+                           for r in r_a_values])
+        # Ensure phi is monotonic
+        if numpy.any(numpy.diff(phis) <= 0):
+            phim = numpy.maximum.accumulate(phis)
+            indx_rm = numpy.where(numpy.diff(phim)==0)[0]
+            phis = numpy.delete(phim,indx_rm)
+            r_a_values = numpy.delete(r_a_values,indx_rm)
+        self._rphi= interpolate.InterpolatedUnivariateSpline(phis,
+            r_a_values*self._scale,k=3)
 
     def sample(self,R=None,z=None,phi=None,n=1,return_orbit=True,rmin=0.):
         # Slight over-write of superclass method to first build f(E) interp

--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -5,9 +5,12 @@ import numpy
 from scipy import interpolate
 
 from ..util.conversion import get_physical, physical_compatible
+from ..util._optional_deps import _JAX_LOADED
 from .Potential import _evaluatePotentials, _evaluateRforces
 from .SphericalPotential import SphericalPotential
 
+if _JAX_LOADED:
+    import jax.numpy as jnp
 
 class interpSphericalPotential(SphericalPotential):
     """__init__(self,rforce=None,rgrid=numpy.geomspace(0.01,20,101),Phi0=None,ro=None,vo=None)
@@ -46,6 +49,7 @@ Class that interpolates a spherical potential on a grid"""
         """
         SphericalPotential.__init__(self,amp=1.,ro=ro,vo=vo)
         self._rgrid= rgrid
+        self._rforce_jax_rgrid= rgrid if len(rgrid)>10000 else numpy.geomspace(0.01,100.,10001)
         # Determine whether rforce is a galpy Potential or list thereof
         try:
             _evaluateRforces(rforce,1.,0.)
@@ -68,6 +72,7 @@ Class that interpolates a spherical potential on a grid"""
         self._rforce_grid= numpy.array([_rforce(r) for r in rgrid])
         self._force_spline= interpolate.InterpolatedUnivariateSpline(
             self._rgrid,self._rforce_grid,k=3,ext=0)
+        self._rforce_jax_grid= numpy.array([_rforce(r) for r in self._rforce_jax_rgrid])
         # Get potential and r2deriv as splines for the integral and derivative
         self._pot_spline= self._force_spline.antiderivative()
         self._Phi0= Phi0+self._pot_spline(self._rgrid[0])
@@ -94,6 +99,24 @@ Class that interpolates a spherical potential on a grid"""
         out[r >= self._rmax]= -self._total_mass/r[r >= self._rmax]**2.
         out[r < self._rmax]= self._force_spline(r[r < self._rmax])
         return out
+
+    def _rforce_jax(self,r):
+        """
+        NAME:
+           _rforce_jax
+        PURPOSE:
+           evaluate the spherical radial force for this potential using JAX, 
+           which doesn't support splines, only linear interpolation.
+        INPUT:
+           r - Galactocentric spherical radius
+        OUTPUT:
+           the radial force
+        HISTORY:
+           2023-02-10 - Written - Lane (UofT)
+        """
+        if not _JAX_LOADED: # pragma: no cover
+            raise ImportError("Making use of _rforce_jax function requires the google/jax library")
+        return jnp.interp(r,self._rforce_jax_rgrid,self._rforce_jax_grid)
 
     def _r2deriv(self,r,t=0.):
         out= numpy.empty_like(r)

--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -4,8 +4,8 @@
 import numpy
 from scipy import interpolate
 
-from ..util.conversion import get_physical, physical_compatible
 from ..util._optional_deps import _JAX_LOADED
+from ..util.conversion import get_physical, physical_compatible
 from .Potential import _evaluatePotentials, _evaluateRforces
 from .SphericalPotential import SphericalPotential
 
@@ -105,7 +105,7 @@ Class that interpolates a spherical potential on a grid"""
         NAME:
            _rforce_jax
         PURPOSE:
-           evaluate the spherical radial force for this potential using JAX, 
+           evaluate the spherical radial force for this potential using JAX,
            which doesn't support splines, only linear interpolation.
         INPUT:
            r - Galactocentric spherical radius

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -1722,6 +1722,175 @@ def test_constantbeta_differentpotentials_dens_directint():
                              bins=11)
     return None
 
+################# INTERPOLATED POTENTIALS IN DFS ##############################
+
+# Eddington DFs with interpolated potentials
+def test_eddington_interpolatedpotentials_dens_directint():
+    # Some potentials
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    tols= [1e-3 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        print(pot)
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))
+        # Make sure to use the actual galpy potential for denspot
+        dfh= eddingtondf(pot=ipot,denspot=pot)
+        check_dens_directint(dfh,pot,tol,lambda r: pot.dens(r,0),
+                             rmin=rmin,rmax=10.,bins=5)
+    return None
+
+def test_eddington_interpolatedpotentials_meanvr_directint():
+    # Some potentials
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    tols= [1e-3 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        print(pot)
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))
+        # Make sure to use the actual galpy potential for denspot
+        dfh= eddingtondf(pot=ipot,denspot=pot)
+        check_meanvr_directint(dfh,pot,tol,rmin=rmin,rmax=10.,bins=5)
+    return None
+
+def test_eddington_interpolatedpotentials_sigmar():
+    # Some potentials, make sure to use something stable for denspot
+    denspot = potential.HernquistPotential(amp=1.3,a=0.8)
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    tols = [5e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))   
+        # Make sure to use the actual galpy potential for denspot
+        dfh= eddingtondf(pot=ipot,denspot=denspot)
+        numpy.random.seed(10)
+        samp= dfh.sample(n=1000000)
+        # rmin larger than usual to avoid low number sampling
+        check_sigmar_against_jeans(samp,pot,tol,dens=lambda r: denspot.dens(r,0),
+                                   rmin=rmin,rmax=10.,bins=31)
+    return None
+
+def test_eddington_interpolatedpotentials_beta():
+    # Some potentials, make sure to use something stable for denspot
+    denspot = potential.HernquistPotential(amp=1.3,a=0.8)
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    tols = [5e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))   
+        # Make sure to use the actual galpy potential for denspot
+        dfh= eddingtondf(pot=ipot,denspot=denspot)
+        numpy.random.seed(10)
+        samp= dfh.sample(n=2000000)
+        # rmin larger than usual to avoid low number sampling
+        check_beta(samp,pot,tol,rmin=rmin,rmax=10.,bins=31)
+    return None
+
+# Constant beta DFs with interpolated potentials
+def test_constantbeta_interpolatedpotentials_dens_directint():
+    if WIN32: return None # skip on Windows, because no JAX
+    # Combinations of potentials and betas
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    twobetas= [-1,1]
+    tols= [1e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    # Also test interpolated spherical potentials as source potential
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        # Important for rgrid to extend far beyond the test range
+        ipot= potential.interpSphericalPotential(rforce=pot,
+                rgrid=numpy.geomspace(0.01,100.,10001))
+        for twobeta in twobetas:
+            # Make sure to use the actual galpy potential for denspot
+            dfh= constantbetadf(pot=ipot,denspot=pot,twobeta=twobeta)
+            check_dens_directint(dfh,pot,tol,lambda r: pot.dens(r,0),
+                                 rmin=rmin,rmax=10.,bins=5)
+    return None
+
+def test_constantbeta_interpolatedpotentials_sigmar_directint():
+    if WIN32: return None # skip on Windows, because no JAX
+    # Combinations of potentials and betas
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    twobetas= [-1,1]
+    tols= [1e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    # Also test interpolated spherical potentials as source potential
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        # Important for rgrid to extend far beyond the test range
+        ipot= potential.interpSphericalPotential(rforce=pot,
+                rgrid=numpy.geomspace(0.01,100.,10001))
+        for twobeta in twobetas:
+            # Make sure to use the actual galpy potential for denspot
+            dfh= constantbetadf(pot=ipot,denspot=pot,twobeta=twobeta)
+            check_meanvr_directint(dfh,pot,tol,rmin=rmin,rmax=10.,bins=5)
+    return None
+
+def test_constantbeta_interpolatedpotentials_sigmar():
+    if WIN32: return None # skip on Windows, because no JAX
+    # Combinations of potentials and betas, make sure to use something stable for denspot
+    denspot = potential.HernquistPotential(amp=1.3,a=0.8)
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    twobetas= [-1,1]
+    tols = [5e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))   
+        for twobeta in twobetas:
+            # Make sure to use the actual galpy potential for denspot
+            dfh= constantbetadf(pot=ipot,denspot=denspot,twobeta=twobeta)
+            numpy.random.seed(10)
+            samp= dfh.sample(n=1000000)
+            check_sigmar_against_jeans(samp,pot,tol,
+                dens=lambda r: denspot.dens(r,0),beta=twobeta/2,rmin=rmin,
+                rmax=10.,bins=21)
+    return None
+
+def test_constantbeta_interpolatedpotentials_beta():
+    if WIN32: return None # skip on Windows, because no JAX
+    # Combinations of potentials and betas, make sure to use something stable for denspot
+    denspot = potential.HernquistPotential(amp=1.3,a=0.8)
+    pots= [potential.HernquistPotential(amp=1.3,a=0.8),
+           potential.PlummerPotential(amp=2.3,b=1.3),
+           potential.NFWPotential(amp=1.3,a=1.5),
+           ]
+    twobetas= [-1,1]
+    tols = [5e-2 for pot in pots]
+    rmins = [0.1,0.2,0.2]
+    for pot,tol,rmin in zip(pots,tols,rmins):
+        ipot= potential.interpSphericalPotential(rforce=pot,
+            rgrid=numpy.geomspace(0.01,100.,10001))   
+        for twobeta in twobetas:
+            # Make sure to use the actual galpy potential for denspot
+            dfh= constantbetadf(pot=ipot,denspot=denspot,twobeta=twobeta)
+            numpy.random.seed(10)
+            samp= dfh.sample(n=2000000)
+            check_beta(samp,pot,tol,beta=twobeta/2,rmin=rmin,rmax=10.,bins=31)
+    return None
+
 ########################### TESTS OF ERRORS AND WARNINGS#######################
 
 def test_isotropic_hernquist_nopot():

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -1771,7 +1771,7 @@ def test_eddington_interpolatedpotentials_sigmar():
     rmins = [0.1,0.2,0.2]
     for pot,tol,rmin in zip(pots,tols,rmins):
         ipot= potential.interpSphericalPotential(rforce=pot,
-            rgrid=numpy.geomspace(0.01,100.,10001))   
+            rgrid=numpy.geomspace(0.01,100.,10001))
         # Make sure to use the actual galpy potential for denspot
         dfh= eddingtondf(pot=ipot,denspot=denspot)
         numpy.random.seed(10)
@@ -1792,7 +1792,7 @@ def test_eddington_interpolatedpotentials_beta():
     rmins = [0.1,0.2,0.2]
     for pot,tol,rmin in zip(pots,tols,rmins):
         ipot= potential.interpSphericalPotential(rforce=pot,
-            rgrid=numpy.geomspace(0.01,100.,10001))   
+            rgrid=numpy.geomspace(0.01,100.,10001))
         # Make sure to use the actual galpy potential for denspot
         dfh= eddingtondf(pot=ipot,denspot=denspot)
         numpy.random.seed(10)
@@ -1858,7 +1858,7 @@ def test_constantbeta_interpolatedpotentials_sigmar():
     rmins = [0.1,0.2,0.2]
     for pot,tol,rmin in zip(pots,tols,rmins):
         ipot= potential.interpSphericalPotential(rforce=pot,
-            rgrid=numpy.geomspace(0.01,100.,10001))   
+            rgrid=numpy.geomspace(0.01,100.,10001))
         for twobeta in twobetas:
             # Make sure to use the actual galpy potential for denspot
             dfh= constantbetadf(pot=ipot,denspot=denspot,twobeta=twobeta)
@@ -1882,7 +1882,7 @@ def test_constantbeta_interpolatedpotentials_beta():
     rmins = [0.1,0.2,0.2]
     for pot,tol,rmin in zip(pots,tols,rmins):
         ipot= potential.interpSphericalPotential(rforce=pot,
-            rgrid=numpy.geomspace(0.01,100.,10001))   
+            rgrid=numpy.geomspace(0.01,100.,10001))
         for twobeta in twobetas:
             # Make sure to use the actual galpy potential for denspot
             dfh= constantbetadf(pot=ipot,denspot=denspot,twobeta=twobeta)


### PR DESCRIPTION
Adds _rforce_jax to `interpSphericalPotential` and a check for `phi` during the creation of the `rphi` interpolator for spherical DFs. Tests are implemented for `eddingtondf` and `constantbetadf`. There are concerns about numerical stability, particularly while integrating the moments of the DF. Tests are done for `beta` as low as -0.5, but lower will probably not pass. Add brief note in docs about use of interpolated potentials in spherical DFs.