### PR TITLE
Fix for issue #506

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -1068,8 +1068,7 @@ def estimateDeltaStaeckel(pot,R,z,no_median=False,delta0=1e-6):
                   for p in pot]) \
         if isinstance(pot,list) \
         else isinstance(pot,SCFPotential) or isinstance(pot,DiskSCFPotential)
-    if numpy.any(z==0.): # pragma: no cover
-        warnings.warn("z=0 encountered in estimateDeltaStaeckel, for which delta is undefined. Setting instances of z=0 to z=1e-4",galpyWarning)
+    if numpy.any(z==0.):
         if isinstance(z,numpy.ndarray):
             z[z==0.]= 1e-4
         else:

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -1068,6 +1068,12 @@ def estimateDeltaStaeckel(pot,R,z,no_median=False,delta0=1e-6):
                   for p in pot]) \
         if isinstance(pot,list) \
         else isinstance(pot,SCFPotential) or isinstance(pot,DiskSCFPotential)
+    if numpy.any(z==0.): # pragma: no cover
+        warnings.warn("z=0 encountered in estimateDeltaStaeckel, for which delta is undefined. Setting instances of z=0 to z=1e-4",galpyWarning)
+        if isinstance(z,numpy.ndarray):
+            z[z==0.]= 1e-4
+        else:
+            z= 1e-4
     if isinstance(R,numpy.ndarray):
         delta2= numpy.array([(z[ii]**2.-R[ii]**2. #eqn. (9) has a sign error
                            +(3.*R[ii]*_evaluatezforces(pot,R[ii],z[ii])

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -1640,6 +1640,25 @@ def test_estimateDeltaStaeckel_no_median():
 	assert (numpy.fabs(nomed-indiv) < 1e-10).all(), 'no_median option returns different values to individual Delta estimation'
 	return None
 
+# Test that the replacement of z=0 with a small value works
+def test_estimateDeltaStaeckel_z_is_0():
+    from galpy.actionAngle import estimateDeltaStaeckel
+    from galpy.potential import MWPotential2014
+
+    # Test that z=0 works for a single value
+    n = 11
+    rs = numpy.linspace(0.1,10.,n)
+    for r in rs:
+        delta0= estimateDeltaStaeckel(MWPotential2014,r,0.)
+        deltasmall = estimateDeltaStaeckel(MWPotential2014,r,5e-4)
+        assert numpy.fabs(delta0-deltasmall) < 1e-3, 'Delta computed with z=0 does not agree with that computed for small z'
+    # And an array
+    delta0= estimateDeltaStaeckel(MWPotential2014,rs,numpy.zeros(n))
+    deltasmall = estimateDeltaStaeckel(MWPotential2014,rs,5e-4*numpy.ones(n))
+    assert numpy.all(numpy.fabs(delta0-deltasmall) < 1e-3), 'Delta computed with array of z=0 does not agree with that computed for array of small z'
+
+
+
 def test_actionAngleStaeckel_indivdelta_actions_c():
     from galpy.actionAngle import actionAngleStaeckel
     from galpy.orbit import Orbit


### PR DESCRIPTION
Adds a check for z=0 in estimateDeltaStaeckel and sets to 1e-4. This figure shows that delta approaches a constant value for z->0 and setting z=1e-4 returns an appropriate value (dashed lines)

![staeckel_delta_z0_fix](https://user-images.githubusercontent.com/20076217/219752000-78ddec6d-e971-4d1d-b8c5-84ccf836940b.png)
