### PR TITLE
fix keyword para issue in galpy.orbit.Orbits.Orbit._call_internal

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -5481,6 +5481,8 @@ class Orbit:
            2019-02-01 - Started - Bovy (UofT)
            2019-02-18 - Written interpolation part - Bovy (UofT)
         """
+        if len(args) == 0 and 't' in kwargs:
+            args = [kwargs.pop('t')]
         if len(args) == 0 or (not hasattr(self, "t") and args[0] == 0.0):
             return numpy.array(self.vxvv).T
         elif not hasattr(self, "t"):

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -9475,3 +9475,16 @@ def test_integrate_backwards():
             numpy.std(o.Jacobi(times)) / numpy.fabs(numpy.mean(o.Jacobi(times))) < 1e-4
         ), f"Orbit integration with method {method} does not conserve energy when integrating from a negative time to a positive time"
     return None
+
+# Test that Orbit._call_internal(t0) and Orbit._call_internal(t=t0) return the same results
+def test_call_internal_kwargs():
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    o = Orbit([1.0, 0.1, 1.2, 0.3, 0.2, 2.0])
+    times = numpy.array([0.0, 10.0])
+    o.integrate(times, lp)
+    assert numpy.array_equal(o._call_internal(10.0), o._call_internal(
+        t=10.0)), "Orbit._call_internal(t0) and Orbit._call_internal(t=t0) return different results"
+    return None


### PR DESCRIPTION
fix #565 , add a new test `test_call_internal_kwargs` in tests/test_orbit.py to test the results are the same when use/not use keyword parameter `t`.