### PR TITLE
minor astropy units + mass calc fixes

### DIFF
--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -477,16 +477,11 @@ class sphericaldf(df):
         ximax = _RToxi(self._rmax, a=self._scale)
         xis = numpy.arange(ximin, ximax, 1e-4)
         rs = _xiToR(xis, a=self._scale)
-        # try/except necessary when mass doesn't take arrays, also need to
-        # switch to a more general mass method at some point...
-        try:
-            ms = mass(self._denspot, rs, use_physical=False)
-        except (ValueError, TypeError):
-            ms = numpy.array([mass(self._denspot, r, use_physical=False) for r in rs])
+        ms = mass(self._denspot, rs, use_physical=False)
         mnorm = mass(self._denspot, self._rmax, use_physical=False)
         if self._rmin_sampling > 0:
             ms -= mass(self._denspot, self._rmin_sampling, use_physical=False)
-            mnorm -= mass(self._denspot, self._rmin_sampling, use_phycial=False)
+            mnorm -= mass(self._denspot, self._rmin_sampling, use_physical=False)
         ms /= mnorm
         # Add total mass point
         if numpy.isinf(self._rmax):

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -477,7 +477,12 @@ class sphericaldf(df):
         ximax = _RToxi(self._rmax, a=self._scale)
         xis = numpy.arange(ximin, ximax, 1e-4)
         rs = _xiToR(xis, a=self._scale)
-        ms = mass(self._denspot, rs, use_physical=False)
+        # try/except necessary when mass doesn't take arrays, also need to
+        # switch to a more general mass method at some point...
+        try:
+            ms = mass(self._denspot, rs, use_physical=False)
+        except (ValueError, TypeError):
+            ms = numpy.array([mass(self._denspot, r, use_physical=False) for r in rs])
         mnorm = mass(self._denspot, self._rmax, use_physical=False)
         if self._rmin_sampling > 0:
             ms -= mass(self._denspot, self._rmin_sampling, use_physical=False)

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -386,6 +386,7 @@ class sphericaldf(df):
             2020-07-22 - Written - Lane (UofT)
 
         """
+        rmin = conversion.parse_length(rmin, ro=self._ro)
         if hasattr(self, "_rmin_sampling") and rmin != self._rmin_sampling:
             # Build new grids, easiest
             if hasattr(self, "_xi_cmf_interpolator"):
@@ -478,14 +479,14 @@ class sphericaldf(df):
         rs = _xiToR(xis, a=self._scale)
         # try/except necessary when mass doesn't take arrays, also need to
         # switch to a more general mass method at some point...
-        # try:
-        ms = mass(self._denspot, rs, use_physical=False)
-        # except ValueError:
-        #    ms= numpy.array([mass(self._denspot,r,use_physical=False) for r in rs])
+        try:
+            ms = mass(self._denspot, rs, use_physical=False)
+        except (ValueError, TypeError):
+            ms = numpy.array([mass(self._denspot, r, use_physical=False) for r in rs])
         mnorm = mass(self._denspot, self._rmax, use_physical=False)
         if self._rmin_sampling > 0:
-            ms -= mass(self._denspot, self._rmin_sampling)
-            mnorm -= mass(self._denspot, self._rmin_sampling)
+            ms -= mass(self._denspot, self._rmin_sampling, use_physical=False)
+            mnorm -= mass(self._denspot, self._rmin_sampling, use_phycial=False)
         ms /= mnorm
         # Add total mass point
         if numpy.isinf(self._rmax):

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -1495,6 +1495,26 @@ def test_isotropic_eddington_dehnencore_in_nfw_energyoutofbounds():
     return None
 
 
+# For the following test use the PowerSphericalPotential to make sure that
+# sampling works properly for potentials which do not have vectorized masses
+def test_eddington_powerspherical_massprofile():
+    rmin = 0.1  # PowerSphericalPotential behaves best w/ rmin
+    rmax = 5.0  # Mass profile divergent
+    pot = potential.PowerSphericalPotential(amp=1.3, alpha=1.4)
+    dfp = eddingtondf(pot=pot, rmax=rmax)
+    numpy.random.seed(10)
+    samp = dfp.sample(n=100000, rmin=rmin)
+    tol = 5 * 1e-3
+    check_spherical_massprofile(
+        samp,
+        lambda r: (pot.mass(r) - pot.mass(rmin))
+        / (pot.mass(numpy.amax(samp.r())) - pot.mass(rmin)),
+        tol,
+        skip=1000,
+    )
+    return None
+
+
 ############# TEST OF dMdE AGAINST KNOWN HERNQUIST FORMULA ############
 def test_eddington_hernquist_dMdE():
     # Test that dMdE for an isotropic Hernquist model is correct by comparing to the exact solution in isotropicHernquist


### PR DESCRIPTION
- Passing `rmin` as astropy quantity to `sphericaldf.sample()` always fails the comparison with `self._rmin_sampling`, so parse to internal units first.
- Uncomment the try-except sequence in `_make_cmf_interpolator()` to allow galpy potentials that don't have vectorized mass calculations to work properly.
- Add `use_physical=False` to the mass normalization for `self._rmin_sampling > 0` so it works properly when denspot has ro,vo set.