### PR TITLE
Allow ``DehnenBarPotential`` to work with zero pattern speed

### DIFF
--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -46,6 +46,8 @@ class DehnenBarPotential(Potential):
 
        \\alpha = 3\\,\\frac{A_f}{v_0^2}\\,\\left(\\frac{R_b}{r_0}\\right)^3\\,.
 
+    If the bar's pattern speed is zero, :math:`t_\\mathrm{form}` and :math:`t_\\mathrm{steady}` are straight times, not times divided by the bar period.
+
     """
 
     normalize = property()  # turn off normalize
@@ -142,7 +144,7 @@ class DehnenBarPotential(Potential):
             self._omegab = omegab
             self._rb = rb
             self._af = Af
-        self._tb = 2.0 * numpy.pi / self._omegab
+        self._tb = 2.0 * numpy.pi / self._omegab if self._omegab != 0.0 else 1.0
         self._tform = tform * self._tb
         if tsteady is None:
             self._tsteady = self._tform / 2.0

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -155,6 +155,7 @@ def test_forceAsDeriv_potential():
     pots.append("mockCosmphiDiskPotentialnegp")
     pots.append("mockDehnenBarPotentialT1")
     pots.append("mockDehnenBarPotentialTm1")
+    pots.append("mockDehnenBarPotentialTm1Omega0")
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
@@ -402,6 +403,7 @@ def test_2ndDeriv_potential():
     pots.append("mockCosmphiDiskPotentialnegp")
     pots.append("mockDehnenBarPotentialT1")
     pots.append("mockDehnenBarPotentialTm1")
+    pots.append("mockDehnenBarPotentialTm1Omega0")
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
@@ -1077,6 +1079,7 @@ def test_evaluateAndDerivs_potential():
     pots.append("mockCosmphiDiskPotentialnegp")
     pots.append("mockDehnenBarPotentialT1")
     pots.append("mockDehnenBarPotentialTm1")
+    pots.append("mockDehnenBarPotentialTm1Omega0")
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
@@ -1343,6 +1346,7 @@ def test_amp_mult_divide():
     pots.append("mockCosmphiDiskPotentialnegp")
     pots.append("mockDehnenBarPotentialT1")
     pots.append("mockDehnenBarPotentialTm1")
+    pots.append("mockDehnenBarPotentialTm1Omega0")
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
@@ -8339,6 +8343,22 @@ class mockDehnenBarPotentialTm1(DehnenBarPotential):
         DehnenBarPotential.__init__(
             self,
             omegab=1.9,
+            rb=0.6,
+            barphi=25.0 * numpy.pi / 180.0,
+            beta=0.0,
+            tform=-1.0,
+            tsteady=1.01,
+            alpha=0.01,
+            Af=0.04,
+        )
+
+
+# Also one with omegab=0. to test that that works
+class mockDehnenBarPotentialTm1Omega0(DehnenBarPotential):
+    def __init__(self):
+        DehnenBarPotential.__init__(
+            self,
+            omegab=0.0,
             rb=0.6,
             barphi=25.0 * numpy.pi / 180.0,
             beta=0.0,


### PR DESCRIPTION
This currently didn't work, because the formation and steady-state times were always specified in terms of the bar period, which is infinite for zero pattern speed. Fixed by making them actual times when the pattern speed is zero.