### PR TITLE
Allow ``SteadyLogSpiralPotential`` to work with zero pattern speed

### DIFF
--- a/galpy/potential/SteadyLogSpiralPotential.py
+++ b/galpy/potential/SteadyLogSpiralPotential.py
@@ -89,7 +89,7 @@ class SteadyLogSpiralPotential(planarPotential):
             self._alpha = self._m / numpy.tan(p)
         else:
             self._alpha = alpha
-        self._ts = 2.0 * numpy.pi / self._omegas
+        self._ts = 2.0 * numpy.pi / self._omegas if self._omegas != 0.0 else 1.0
         if not tform is None:
             self._tform = tform * self._ts
         else:

--- a/galpy/potential/SteadyLogSpiralPotential.py
+++ b/galpy/potential/SteadyLogSpiralPotential.py
@@ -17,7 +17,7 @@ class SteadyLogSpiralPotential(planarPotential):
         \\Phi(R,\\phi) = \\frac{\\mathrm{amp}\\times A}{\\alpha}\\,\\cos\\left(\\alpha\\,\\ln R - m\\,(\\phi-\\Omega_s\\,t-\\gamma)\\right)
 
 
-    Can be grown in a similar way as the DehnenBarPotential, but using :math:`T_s = 2\\pi/\\Omega_s` to normalize :math:`t_{\\mathrm{form}}` and :math:`T_{\\mathrm{steady}}`.
+    Can be grown in a similar way as the DehnenBarPotential, but using :math:`T_s = 2\\pi/\\Omega_s` to normalize :math:`t_{\\mathrm{form}}` and :math:`t_{\\mathrm{steady}}`. If the pattern speed is zero, :math:`t_\\mathrm{form}` and :math:`t_\\mathrm{steady}` are straight times, not times divided by the spiral period.
 
     """
 

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -162,6 +162,7 @@ def test_forceAsDeriv_potential():
     pots.append("mockEllipticalDiskPotentialTm5")
     pots.append("mockSteadyLogSpiralPotentialT1")
     pots.append("mockSteadyLogSpiralPotentialTm1")
+    pots.append("mockSteadyLogSpiralPotentialTm1Omega0")
     pots.append("mockSteadyLogSpiralPotentialTm5")
     pots.append("mockTransientLogSpiralPotential")
     pots.append("mockFlatEllipticalDiskPotential")  # for evaluate w/ nonaxi lists
@@ -410,6 +411,7 @@ def test_2ndDeriv_potential():
     pots.append("mockEllipticalDiskPotentialTm5")
     pots.append("mockSteadyLogSpiralPotentialT1")
     pots.append("mockSteadyLogSpiralPotentialTm1")
+    pots.append("mockSteadyLogSpiralPotentialTm1Omega0")
     pots.append("mockSteadyLogSpiralPotentialTm5")
     pots.append("mockTransientLogSpiralPotential")
     pots.append("mockFlatEllipticalDiskPotential")  # for evaluate w/ nonaxi lists
@@ -1083,6 +1085,7 @@ def test_evaluateAndDerivs_potential():
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
+    pots.append("mockSteadyLogSpiralPotentialTm1Omega0")
     pots.append("mockEllipticalDiskPotentialTm5")
     pots.append("mockSteadyLogSpiralPotentialT1")
     pots.append("mockSteadyLogSpiralPotentialTm1")
@@ -1350,6 +1353,7 @@ def test_amp_mult_divide():
     pots.append("mockDehnenBarPotentialTm5")
     pots.append("mockEllipticalDiskPotentialT1")
     pots.append("mockEllipticalDiskPotentialTm1")
+    pots.append("mockSteadyLogSpiralPotentialTm1Omega0")
     pots.append("mockEllipticalDiskPotentialTm5")
     pots.append("mockSteadyLogSpiralPotentialT1")
     pots.append("mockSteadyLogSpiralPotentialTm1")
@@ -8498,6 +8502,22 @@ class mockSteadyLogSpiralPotentialTm1(SteadyLogSpiralPotential):
             self,
             amp=1.0,
             omegas=0.65,
+            A=-0.035,
+            m=2,
+            gamma=numpy.pi / 4.0,
+            p=-0.3,
+            tform=-1.0,
+            tsteady=None,
+        )
+
+
+# Also one with omegab=0. to test that that works
+class mockSteadyLogSpiralPotentialTm1Omega0(SteadyLogSpiralPotential):
+    def __init__(self):
+        SteadyLogSpiralPotential.__init__(
+            self,
+            amp=1.0,
+            omegas=0.0,
             A=-0.035,
             m=2,
             gamma=numpy.pi / 4.0,


### PR DESCRIPTION
This currently didn't work, because the formation and steady-state times were always specified in terms of the spiral period, which is infinite for zero pattern speed. Fixed by making them actual times when the pattern speed is zero. Equivalent of #584 but for the ``SteadyLogSpiralPotential``.