### PR TITLE
Allow vector inputs of solar parameters to `Orbit` initialization: `ro`, `zo`, `vo`, and `solarmotion`

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,9 @@
 v1.9.1 (expected around 2023-11-01)
 ===================
 
+- Allow vector inputs of solar parameters to Orbit initialization: ro, zo, vo,
+  and solarmotion (#595). Useful when sampling over the uncertainty in the solar
+  parameters.
 
 v1.9.0 (2023-07-02)
 ===================

--- a/doc/source/orbit.rst
+++ b/doc/source/orbit.rst
@@ -221,6 +221,8 @@ multiple objects. Specifically, the initial conditions can be:
    * None: assumed to be the Sun; if None occurs in a list it is assumed to be the Sun *and all other items in the list are assumed to be [ra,dec,...]*; cannot be combined with Quantity lists
    * lists of scalar phase-space coordinates arranged as in the first bullet above (so things like [R,vR,...] where R,vR are scalars in internal units
 
+The solar parameters ``ro``, ``zo``, ``vo``, and ``solarmotion`` can also be specified as arrays with the same shape as the resulting ``Orbit`` instance. This can be useful, for example, when sampling over the uncertainty in the Sun's position and velocity in the Milky Way.
+
 .. TIP::
    For multiple object initialization using an array or SkyCoord, arbitrary input shapes are supported.
 
@@ -252,6 +254,18 @@ and with a SkyCoord:
 
 As before, you can use the ``SkyCoord`` Galactocentric frame
 specification here.
+
+An example initialization with array input for ``ro`` is:
+
+>>> vxvvs= numpy.array([[1.,0.1,1.,0.1,-0.2,1.5] for ii in range(2)])
+>>> orbits= Orbit(vxvvs,ro=numpy.array([8.,8.5]))
+>>> print(orbits.R())
+# [ 8.   8.5]
+
+Array inputs can also be used for ``zo``, ``vo``, and ``solarmotion``. When using arrays,
+their shapes need to agree with the shape of the resulting ``Orbit`` instance (for
+``solarmotion``, the shape needs to be ``[3,*shape_orbit]``).
+
 
 ``Orbit`` instances containing multiple objects act like numpy arrays
 in many ways, but have some subtly different behaviors for some

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -1073,7 +1073,12 @@ def physical_conversion(quantity, pop=False):
                 if _apy_units:
                     return units.Quantity(out * fac, unit=u)
                 else:
-                    return out * fac
+                    # complicated logic for dealing with ro and vo arrays
+                    return out * (
+                        fac[:, numpy.newaxis]
+                        if isinstance(fac, numpy.ndarray) and len(out.shape) > 1
+                        else fac
+                    )
             else:
                 if use_physical_explicitly_set:
                     warnings.warn(

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -765,6 +765,27 @@ def test_XYZ_to_galcenrect_negXsun():
     ), "XYZ_to_galcenrect conversion did not work as expected for negative Xsun"
 
 
+def test_XYZ_to_galcenrect_vecSun():
+    X, Y, Z = (
+        numpy.array([1.0, 2.0]),
+        numpy.array([3.0, 3.0]),
+        numpy.array([-2.0, -2.0]),
+    )
+    gcXYZ = coords.XYZ_to_galcenrect(
+        X, Y, Z, Xsun=numpy.array([1.0, -2.0]), Zsun=numpy.array([0.0, 0.0])
+    )
+    assert numpy.all(
+        numpy.fabs(gcXYZ[:, 0]) < 10.0**-5.0
+    ), "XYZ_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(gcXYZ[:, 1] - 3.0) < 10.0**-5.0
+    ), "XYZ_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(gcXYZ[:, 2] + 2.0) < 10.0**-5.0
+    ), "XYZ_to_galcenrect conversion did not work as expected"
+    return None
+
+
 def test_lbd_to_galcenrect_galpyvsastropy():
     # Test that galpy's transformations agree with astropy's
     import astropy.units as u
@@ -990,6 +1011,27 @@ def test_XYZ_to_galcencyl():
     return None
 
 
+def test_XYZ_to_galcencyl_vecSun():
+    X, Y, Z = (
+        numpy.array([5.0, 4.0]),
+        numpy.array([4.0, 4.0]),
+        numpy.array([-2.0, -2.0]),
+    )
+    gcRpZ = coords.XYZ_to_galcencyl(
+        X, Y, Z, Xsun=numpy.array([8.0, 7.0]), Zsun=numpy.array([0.0, 0.0])
+    )
+    assert numpy.all(
+        numpy.fabs(gcRpZ[:, 0] - 5.0) < 10.0**-5.0
+    ), "XYZ_to_galcencyl conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(gcRpZ[:, 1] - numpy.arctan(4.0 / 3.0)) < 10.0**-5.0
+    ), "XYZ_to_galcencyl conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(gcRpZ[:, 2] + 2.0) < 10.0**-4.8
+    ), "XYZ_to_galcencyl conversion did not work as expected"
+    return None
+
+
 def test_galcencyl_to_XYZ():
     gcR, gcp, gcZ = 5.0, numpy.arctan(4.0 / 3.0), 2.0
     XYZ = coords.galcencyl_to_XYZ(gcR, gcp, gcZ, Xsun=8.0, Zsun=0.0)
@@ -1135,6 +1177,79 @@ def test_vxvyvz_to_galcenrect_negXsun():
     assert (
         numpy.fabs(vgc[2] - vgcn[2]) < 10.0**-4.0
     ), "vxvyvz_to_galcenrect conversion did not work as expected for negative Xsun"
+    return None
+
+
+def test_vxvyvz_to_galcenrect_vecXsun():
+    vx, vy, vz = (
+        numpy.array([10.0, 10.0]),
+        numpy.array([-20.0, -20.0]),
+        numpy.array([30.0, 30.0]),
+    )
+    vgc = coords.vxvyvz_to_galcenrect(
+        vx,
+        vy,
+        vz,
+        vsun=[-5.0, 10.0, 5.0],
+        Xsun=numpy.array([1.1, 1.0]),
+        Zsun=numpy.array([0.0, 0.0]),
+    )
+    assert numpy.all(
+        numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 1] + 10.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 2] - 35.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    return None
+
+
+def test_vxvyvz_to_galcenrect_vecvsun():
+    vx, vy, vz = (
+        numpy.array([10.0, 5.0]),
+        numpy.array([-20.0, -10.0]),
+        numpy.array([30.0, 25.0]),
+    )
+    vgc = coords.vxvyvz_to_galcenrect(
+        vx, vy, vz, vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T
+    )
+    assert numpy.all(
+        numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 1] + 10.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 2] - 35.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    return None
+
+
+def test_vxvyvz_to_galcenrect_vecXsunvsun():
+    vx, vy, vz = (
+        numpy.array([10.0, 5.0]),
+        numpy.array([-20.0, -10.0]),
+        numpy.array([30.0, 25.0]),
+    )
+    vgc = coords.vxvyvz_to_galcenrect(
+        vx,
+        vy,
+        vz,
+        Xsun=numpy.array([1.1, 1.0]),
+        Zsun=numpy.array([0.0, 0.0]),
+        vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T,
+    )
+    assert numpy.all(
+        numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 1] + 10.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vgc[:, 2] - 35.0) < 10.0**-4.0
+    ), "vxvyvz_to_galcenrect conversion did not work as expected"
     return None
 
 
@@ -1435,6 +1550,79 @@ def test_galcenrect_to_vxvyvz_asInverse():
     assert numpy.all(
         numpy.fabs(vxyzt[:, 2] - vz * os) < 10.0**-10.0
     ), "galcenrect_to_vxvyvz is not the inverse of vxvyvz_to_galcenrect"
+    return None
+
+
+def test_galcenrect_to_vxvyvz_vecXsun():
+    vxg, vyg, vzg = (
+        numpy.array([-15.0, -15.0]),
+        numpy.array([-10.0, -10.0]),
+        numpy.array([35.0, 35.0]),
+    )
+    vxyz = coords.galcenrect_to_vxvyvz(
+        vxg,
+        vyg,
+        vzg,
+        vsun=[-5.0, 10.0, 5.0],
+        Xsun=numpy.array([1.1, 1.0]),
+        Zsun=numpy.array([0.0, 0.0]),
+    )
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 1] + 20.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 2] - 30.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    return None
+
+
+def test_galcenrect_to_vxvyvz_vecvsun():
+    vxg, vyg, vzg = (
+        numpy.array([-15.0, -5.0]),
+        numpy.array([-10.0, -20.0]),
+        numpy.array([35.0, 32.5]),
+    )
+    vxyz = coords.galcenrect_to_vxvyvz(
+        vxg, vyg, vzg, vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T
+    )
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 1] + 20.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 2] - 30.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    return None
+
+
+def test_galcenrect_to_vxvyvz_vecXsunvsun():
+    vxg, vyg, vzg = (
+        numpy.array([-15.0, -5.0]),
+        numpy.array([-10.0, -20.0]),
+        numpy.array([35.0, 32.5]),
+    )
+    vxyz = coords.galcenrect_to_vxvyvz(
+        vxg,
+        vyg,
+        vzg,
+        vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T,
+        Xsun=numpy.array([1.1, 1.0]),
+        Zsun=numpy.array([0.0, 0.0]),
+    )
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 1] + 20.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
+    assert numpy.all(
+        numpy.fabs(vxyz[:, 2] - 30.0) < 10.0**-4.0
+    ), "galcenrect_to_vxvyvz conversion did not work as expected"
     return None
 
 

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -368,6 +368,410 @@ def test_initialization_list_of_arrays():
     return None
 
 
+def test_initialization_diffro():
+    # Test that supplying an array of ro values works as expected
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], ro=ros, radec=True)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            radec=True,
+        )
+        assert (
+            numpy.fabs((all_orbs.R()[ii] - orb.R()) / orb.R()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vR()[ii] - orb.vR()) / orb.vR()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vT()[ii] - orb.vT()) / orb.vT()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.z()[ii] - orb.z()) / orb.z()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vz()[ii] - orb.vz()) / orb.vz()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs(
+                ((all_orbs.phi()[ii] - orb.phi() + numpy.pi) % (2.0 * numpy.pi))
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert (
+            numpy.fabs((all_orbs.ra()[ii] - orb.ra()) / orb.ra()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dec()[ii] - orb.dec()) / orb.dec()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dist()[ii] - orb.dist()) / orb.dist()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmra()[ii] - orb.pmra()) / orb.pmra()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmdec()[ii] - orb.pmdec()) / orb.pmdec()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vlos()[ii] - orb.vlos()) / orb.vlos()) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+    return None
+
+
+def test_initialization_diffzo():
+    # Test that supplying an array of zo values works as expected
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    zos = (-1.0 + numpy.random.uniform(size=nrand) * 2.0) * 50.0 * u.pc
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], zo=zos, radec=True)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            zo=zos[ii],
+            radec=True,
+        )
+        assert (
+            numpy.fabs((all_orbs.R()[ii] - orb.R()) / orb.R()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vR()[ii] - orb.vR()) / orb.vR()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vT()[ii] - orb.vT()) / orb.vT()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.z()[ii] - orb.z()) / orb.z()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vz()[ii] - orb.vz()) / orb.vz()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs(
+                ((all_orbs.phi()[ii] - orb.phi() + numpy.pi) % (2.0 * numpy.pi))
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert (
+            numpy.fabs((all_orbs.ra()[ii] - orb.ra()) / orb.ra()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dec()[ii] - orb.dec()) / orb.dec()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dist()[ii] - orb.dist()) / orb.dist()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmra()[ii] - orb.pmra()) / orb.pmra()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmdec()[ii] - orb.pmdec()) / orb.pmdec()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vlos()[ii] - orb.vlos()) / orb.vlos()) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+    return None
+
+
+def test_initialization_diffvo():
+    # Test that supplying a single vo value works as expected
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], vo=vos, radec=True)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            vo=vos[ii],
+            radec=True,
+        )
+        assert (
+            numpy.fabs((all_orbs.R()[ii] - orb.R()) / orb.R()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vR()[ii] - orb.vR()) / orb.vR()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vT()[ii] - orb.vT()) / orb.vT()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.z()[ii] - orb.z()) / orb.z()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vz()[ii] - orb.vz()) / orb.vz()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs(
+                ((all_orbs.phi()[ii] - orb.phi() + numpy.pi) % (2.0 * numpy.pi))
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert (
+            numpy.fabs((all_orbs.ra()[ii] - orb.ra()) / orb.ra()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dec()[ii] - orb.dec()) / orb.dec()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dist()[ii] - orb.dist()) / orb.dist()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmra()[ii] - orb.pmra()) / orb.pmra()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmdec()[ii] - orb.pmdec()) / orb.pmdec()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vlos()[ii] - orb.vlos()) / orb.vlos()) < 1e-7
+        ), "Orbits initialization with single vo does not work as expected"
+    return None
+
+
+def test_initialization_diffsolarmotion():
+    # Test that supplying an array of solarmotion values works as expected
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss], solarmotion=solarmotions, radec=True
+    )
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        )
+        assert (
+            numpy.fabs((all_orbs.R()[ii] - orb.R()) / orb.R()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vR()[ii] - orb.vR()) / orb.vR()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vT()[ii] - orb.vT()) / orb.vT()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.z()[ii] - orb.z()) / orb.z()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vz()[ii] - orb.vz()) / orb.vz()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs(
+                ((all_orbs.phi()[ii] - orb.phi() + numpy.pi) % (2.0 * numpy.pi))
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert (
+            numpy.fabs((all_orbs.ra()[ii] - orb.ra()) / orb.ra()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dec()[ii] - orb.dec()) / orb.dec()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dist()[ii] - orb.dist()) / orb.dist()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmra()[ii] - orb.pmra()) / orb.pmra()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmdec()[ii] - orb.pmdec()) / orb.pmdec()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vlos()[ii] - orb.vlos()) / orb.vlos()) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+    return None
+
+
+def test_initialization_allsolarparams():
+    # Test that supplying all parameters works as expected
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+    zos = (-1.0 + numpy.random.uniform(size=nrand) * 2.0) * 50.0 * u.pc
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss],
+        ro=ros,
+        zo=zos,
+        vo=vos,
+        solarmotion=solarmotions,
+        radec=True,
+    )
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            zo=zos[ii],
+            vo=vos[ii],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        )
+        assert (
+            numpy.fabs((all_orbs.R()[ii] - orb.R()) / orb.R()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vR()[ii] - orb.vR()) / orb.vR()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vT()[ii] - orb.vT()) / orb.vT()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.z()[ii] - orb.z()) / orb.z()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vz()[ii] - orb.vz()) / orb.vz()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs(
+                ((all_orbs.phi()[ii] - orb.phi() + numpy.pi) % (2.0 * numpy.pi))
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert (
+            numpy.fabs((all_orbs.ra()[ii] - orb.ra()) / orb.ra()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dec()[ii] - orb.dec()) / orb.dec()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.dist()[ii] - orb.dist()) / orb.dist()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmra()[ii] - orb.pmra()) / orb.pmra()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.pmdec()[ii] - orb.pmdec()) / orb.pmdec()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+        assert (
+            numpy.fabs((all_orbs.vlos()[ii] - orb.vlos()) / orb.vlos()) < 1e-7
+        ), "Orbits initialization with all parameters does not work as expected"
+    return None
+
+
+def test_initialization_diffsolarparams_shape_error():
+    # Test that we get the correct error when providing the wrong shape for array
+    # ro/zo/vo/solarmotion inputs
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 30
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand * 2) * 2.0) * u.kpc
+    with pytest.raises(RuntimeError) as excinfo:
+        Orbit([ras, decs, dists, pmras, pmdecs, vloss], ro=ros, radec=True)
+    assert (
+        excinfo.value.args[0]
+        == "ro must have the same shape as the input orbits for an array of orbits"
+    ), "Orbits initialization with wrong shape for ro does not raise correct error"
+
+    zos = (-1.0 + numpy.random.uniform(size=2 * nrand) * 2.0) * 50.0 * u.pc
+    with pytest.raises(RuntimeError) as excinfo:
+        Orbit([ras, decs, dists, pmras, pmdecs, vloss], zo=zos, radec=True)
+    assert (
+        excinfo.value.args[0]
+        == "zo must have the same shape as the input orbits for an array of orbits"
+    ), "Orbits initialization with wrong shape for zo does not raise correct error"
+
+    vos = (200.0 + numpy.random.uniform(size=2 * nrand) * 40.0) * u.km / u.s
+    with pytest.raises(RuntimeError) as excinfo:
+        Orbit([ras, decs, dists, pmras, pmdecs, vloss], vo=vos, radec=True)
+    assert (
+        excinfo.value.args[0]
+        == "vo must have the same shape as the input orbits for an array of orbits"
+    ), "Orbits initialization with wrong shape for vo does not raise correct error"
+
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, 2 * nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        Orbit(
+            [ras, decs, dists, pmras, pmdecs, vloss],
+            solarmotion=solarmotions,
+            radec=True,
+        )
+    assert (
+        excinfo.value.args[0]
+        == "solarmotion must have the shape [3,...] where the ... matches the shape of the input orbits for an array of orbits"
+    ), "Orbits initialization with wrong shape for solarmotion does not raise correct error"
+
+    return None
+
+
 # Tests that integrating Orbits agrees with integrating multiple Orbit
 # instances
 def test_integration_1d():
@@ -607,6 +1011,753 @@ def test_integration_p5d():
             numpy.amax(numpy.fabs(orbits_list[ii].vT(times) - orbits.vT(times)[ii]))
             < 1e-10
         ), "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+    return None
+
+
+def test_integrate_3d_diffro():
+    # Test that supplying an array of ro values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], ro=ros, radec=True)
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            radec=True,
+        )
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+    return None
+
+
+def test_integrate_3d_diffzo():
+    # Test that supplying an array of zo values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    zos = (-1.0 + numpy.random.uniform(size=nrand) * 2.0) * 100.0 * u.pc
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], zo=zos, radec=True)
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            zo=zos[ii],
+            radec=True,
+        )
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+    return None
+
+
+def test_integrate_3d_diffvo():
+    # Test that supplying an array of zo values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+
+    all_orbs = Orbit([ras, decs, dists, pmras, pmdecs, vloss], vo=vos, radec=True)
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            vo=vos[ii],
+            radec=True,
+        )
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+    return None
+
+
+def test_integrate_3d_diffsolarmotion():
+    # Test that supplying an array of zo values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss], solarmotion=solarmotions, radec=True
+    )
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        )
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+    return None
+
+
+def test_integrate_3d_diffallsolarparams():
+    # Test that supplying an array of solar values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+    zos = (-1.0 + numpy.random.uniform(size=nrand) * 2.0) * 100.0 * u.pc
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss],
+        ro=ros,
+        zo=zos,
+        vo=vos,
+        solarmotion=solarmotions,
+        radec=True,
+    )
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            zo=zos[ii],
+            vo=vos[ii],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        )
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+    return None
+
+
+def test_integrate_2d_diffro():
+    # Test that supplying an array of ro values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss], ro=ros, radec=True
+    ).toPlanar()
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            radec=True,
+        ).toPlanar()
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+    return None
+
+
+def test_integrate_2d_diffvo():
+    # Test that supplying an array of zo values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss], vo=vos, radec=True
+    ).toPlanar()
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            vo=vos[ii],
+            radec=True,
+        ).toPlanar()
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+    return None
+
+
+def test_integrate_2d_diffsolarmotion():
+    # Test that supplying an array of zo values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss], solarmotion=solarmotions, radec=True
+    ).toPlanar()
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        ).toPlanar()
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+    return None
+
+
+def test_integrate_2d_diffallsolarparams():
+    # Test that supplying an array of solar values works as expected when integrating an orbit
+    from galpy.orbit import Orbit
+
+    numpy.random.seed(1)
+    nrand = 4
+    ras = numpy.random.uniform(size=nrand) * 360.0 * u.deg
+    decs = 90.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.deg
+    dists = numpy.random.uniform(size=nrand) * 10.0 * u.kpc
+    pmras = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    pmdecs = 20.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * 20.0 * u.mas / u.yr
+    vloss = 200.0 * (2.0 * numpy.random.uniform(size=nrand) - 1.0) * u.km / u.s
+
+    ros = (6.0 + numpy.random.uniform(size=nrand) * 2.0) * u.kpc
+    zos = (-1.0 + numpy.random.uniform(size=nrand) * 2.0) * 100.0 * u.pc
+    vos = (200.0 + numpy.random.uniform(size=nrand) * 40.0) * u.km / u.s
+    solarmotions = (
+        (2.0 * numpy.random.uniform(size=(3, nrand)) - 1.0) * 10.0 * u.km / u.s
+    )
+
+    all_orbs = Orbit(
+        [ras, decs, dists, pmras, pmdecs, vloss],
+        ro=ros,
+        zo=zos,
+        vo=vos,
+        solarmotion=solarmotions,
+        radec=True,
+    ).toPlanar()
+
+    times = numpy.linspace(0.0, 10.0, 1001)
+
+    all_orbs.integrate(times, potential.MWPotential2014)
+    for ii in range(nrand):
+        orb = Orbit(
+            [ras[ii], decs[ii], dists[ii], pmras[ii], pmdecs[ii], vloss[ii]],
+            ro=ros[ii],
+            zo=zos[ii],
+            vo=vos[ii],
+            solarmotion=solarmotions[:, ii],
+            radec=True,
+        ).toPlanar()
+        orb.integrate(times, potential.MWPotential2014)
+        assert numpy.all(
+            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (
+                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
+                - numpy.pi
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        # Also some observed values like ra, dec, ...
+        assert numpy.all(
+            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
     return None
 
 


### PR DESCRIPTION
In all cases except for lists of `Orbit` instances for now.