### PR TITLE
Add Python 3.12 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - py312-wheels
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - py312-wheels
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
         - [macos-latest, macosx, x86_64]
         - [macos-latest, macosx, arm64]
         - [windows-2019, win, amd64]
-        python: ["cp38", "cp39", "cp310", "cp311"]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
     steps:
       - uses: actions/checkout@v3
       - name: Install GSL (Windows / Mac OS x86_64)


### PR DESCRIPTION
Because Python 3.12 seems to be working (see `py312` branch), this PR adds wheels for Python 3.12.