### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
     - name: Install Python dependencies
       if: matrix.python-version != '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython<1 pytest tqdm
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
          #pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
          #pip install --upgrade --upgrade-strategy eager h5py
          #pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager --no-deps pynbody
+         pip install --upgrade --upgrade-strategy eager --no-deps --pre pynbody
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,9 @@ jobs:
          pip install --upgrade --upgrade-strategy eager --pre numpy scipy "matplotlib<3.8" numexpr setuptools "cython<1" pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
+      env:
+        CC: gcc-11
+        CXX: g++-11
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,8 +267,8 @@ jobs:
          pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
          brew install hdf5
          export HDF5_DIR=$(brew --prefix hdf5)
-         pip install --upgrade --upgrade-strategy eager --pre --no-deps --no-build-isolation --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager --pre --no-deps --no-build-isolation --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
          #pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
          #pip install --upgrade --upgrade-strategy eager h5py
          #pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager --no-deps --pre pynbody
+         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/jobovy/pynbody.git@numpy-include
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: macos-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_orbit.py -k test_energy_jacobi_conservation
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -201,7 +201,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: macos-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -251,12 +251,21 @@ jobs:
          pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
-    - name: Install pynbody (3.12)
-      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
+    - name: Install pynbody (3.12; ubuntu)
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |
          pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+         pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
          sudo apt-get install libhdf5-dev
+         pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
+         pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
+    - name: Install pynbody (3.12; macos)
+      if: ${{ matrix.os == 'macos-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
+      run: |
+         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
+         pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+         brew install hdf5
          pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
-        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning"
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
     - name: Generate code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
     - name: Install pynbody (3.12)
-      if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version == '3.12'
+      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |
          pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
@@ -260,7 +260,7 @@ jobs:
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
     - name: Install pynbody
-      if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version != '3.12'
+      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
       if: matrix.python-version == '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager --pre numpy
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib==3.8.0.dev1960+gac376ea1a6
          pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager --pre numpy scipy matplotlib numexpr setuptools "cython<1" pytest tqdm
+         pip install --upgrade --upgrade-strategy eager --pre numpy scipy "matplotlib<3.8" numexpr setuptools "cython<1" pytest tqdm
     - name: Install pynbody (3.12; ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
          pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         brew install hdf5 --universal
+         brew install hdf5
          export HDF5_DIR=$(brew --prefix hdf5)
          pip install --upgrade --upgrade-strategy eager --pre --no-deps --no-build-isolation --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_actionAngle.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -32,7 +32,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_sphericaldf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -40,7 +40,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: true
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_actionAngleTorus.py tests/test_conversion.py tests/test_galpypaper.py tests/test_import.py tests/test_interp_potential.py tests/test_kuzminkutuzov.py  tests/test_util.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -48,7 +48,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_SpiralArmsPotential.py tests/test_potential.py tests/test_scf.py tests/test_snapshotpotential.py
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: false
@@ -56,11 +56,75 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_quantity.py tests/test_coords.py
             REQUIRES_PYNBODY: false
             # needs to be separate for different config
             REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py -k test_energy_jacobi_conservation
+            REQUIRES_PYNBODY: true
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
+            REQUIRES_PYNBODY: true
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_evolveddiskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: true
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_streamgapdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_diskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
             REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
@@ -78,54 +142,6 @@ jobs:
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
             REQUIRES_ASTROQUERY: true
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_evolveddiskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: true
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_streamgapdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_diskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: ubuntu-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
@@ -200,6 +216,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install lcov
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -222,8 +239,14 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
     - name: Install Python dependencies
+      if: matrix.python-version != '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
+    - name: Install Python dependencies (3.12)
+      if: matrix.python-version == '3.12'
+      run: |
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy matplotlib
+         pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,8 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager --pre numpy
          # matplotlib dependencies
-         pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing python-dateutil
+         pip install git+https://github.com/dateutil/dateutil.git
+         pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
     - name: Install pynbody

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,27 +246,8 @@ jobs:
       if: matrix.python-version == '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager --pre numpy scipy "matplotlib<3.8" numexpr setuptools "cython<1" pytest tqdm
-    - name: Install pynbody (3.12; ubuntu)
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
-      run: |
-         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
-         pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         sudo apt-get install libhdf5-dev
-         pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
-         pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
-    - name: Install pynbody (3.12; macos)
-      if: ${{ matrix.os == 'macos-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
-      run: |
-         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
-         pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         brew install hdf5
-         export HDF5_DIR=$(brew --prefix hdf5)
-         pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager --pre --no-deps --no-build-isolation --no-binary=h5py git+https://github.com/h5py/h5py.git
-         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
     - name: Install pynbody
-      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
+      if: ${{ matrix.REQUIRES_PYNBODY }}
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,11 +238,6 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/build.yml') }}-${{ matrix.REQUIRES_PYNBODY }}-${{ matrix.REQUIRES_ASTROPY }}-${{ matrix.REQUIRES_ASTROQUERY }}-${{ matrix.REQUIRES_NUMBA }}-${{ matrix.REQUIRES_JAX }}
     - name: Install Python dependencies
-      if: matrix.python-version != '3.12'
-      run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
-    - name: Install Python dependencies (3.12)
-      if: matrix.python-version == '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,14 +209,13 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
     env:
-      PYTHON_COVREPORTS_VERSION: "3.11"
+      PYTHON_COVREPORTS_VERSION: "3.12"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
     - name: Install lcov
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -245,7 +244,7 @@ jobs:
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager --pre numpy scipy "matplotlib<3.8" numexpr setuptools "cython<1" pytest tqdm
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
       env:
@@ -257,10 +256,10 @@ jobs:
          pip install --upgrade --upgrade-strategy eager pynbody
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
-      run: pip install --pre astropy pyerfa
+      run: pip install astropy pyerfa
     - name: Install astroquery
       if: ${{ matrix.REQUIRES_ASTROQUERY }}
-      run: pip install --pre astroquery
+      run: pip install astroquery
     - name: Install numba
       if: ${{ matrix.REQUIRES_NUMBA }}
       run: |
@@ -270,7 +269,7 @@ jobs:
         pip install --upgrade --force-reinstall setuptools
     - name: Install JAX
       if: ${{ matrix.REQUIRES_JAX }}
-      run: pip install --pre jax jaxlib
+      run: pip install jax jaxlib
     - name: Install torus code
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,12 +259,12 @@ jobs:
          pip install --upgrade --upgrade-strategy eager h5py
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
-         - name: Install pynbody
-         if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version != '3.12'
-         run: |
-            pip install --upgrade --upgrade-strategy eager h5py pandas pytz
-            pip install --upgrade --upgrade-strategy eager wheel
-            pip install --upgrade --upgrade-strategy eager pynbody
+    - name: Install pynbody
+      if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version != '3.12'
+      run: |
+         pip install --upgrade --upgrade-strategy eager h5py pandas pytz
+         pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager pynbody
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
       run: pip install --pre astropy pyerfa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,8 +338,9 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
+        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
     - name: Generate code coverage
       if: ${{ matrix.python-version == env.PYTHON_COVREPORTS_VERSION && matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,11 +254,12 @@ jobs:
     - name: Install pynbody (3.12)
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |
-         #pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
-         #pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         #pip install --upgrade --upgrade-strategy eager h5py
-         #pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/jobovy/pynbody.git@numpy-include
+         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+         sudo apt-get install libhdf5-dev
+         pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
+         pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
-        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\\: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
     - name: Generate code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,11 +254,11 @@ jobs:
     - name: Install pynbody (3.12)
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |
-         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         pip install --upgrade --upgrade-strategy eager h5py
-         pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager pynbody
+         #pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
+         #pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+         #pip install --upgrade --upgrade-strategy eager h5py
+         #pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager --no-deps pynbody
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
     - name: Install Python dependencies
       if: matrix.python-version != '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools "cython<1" pytest tqdm
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |
@@ -250,7 +250,7 @@ jobs:
          pip install git+https://github.com/dateutil/dateutil.git
          pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
-         pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
+         pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools "cython<1" pytest tqdm
     - name: Install pynbody (3.12; ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,8 @@ jobs:
       if: matrix.python-version == '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager --pre numpy
-         pip install --upgrade --upgrade-strategy eager contourpy
+         # matplotlib dependencies
+         pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing python-dateutil
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
     - name: Install pynbody

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
     - name: Install Python dependencies
       if: matrix.python-version != '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython<1 pytest tqdm
+         pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools "cython<1" pytest tqdm
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,12 +245,7 @@ jobs:
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager --pre numpy
-         # matplotlib dependencies
-         pip install git+https://github.com/dateutil/dateutil.git
-         pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
-         pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools "cython<1" pytest tqdm
+         pip install --upgrade --upgrade-strategy eager --pre numpy scipy matplotlib numexpr setuptools "cython<1" pytest tqdm
     - name: Install pynbody (3.12; ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' && matrix.REQUIRES_PYNBODY && matrix.python-version == '3.12' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,9 +265,9 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
          pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-         brew install hdf5
+         brew install hdf5 --universal
          export HDF5_DIR=$(brew --prefix hdf5)
-         pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
+         pip install --upgrade --upgrade-strategy eager --pre --no-deps --no-build-isolation --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git
     - name: Install pynbody

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
-        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\\: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
     - name: Generate code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,18 +251,26 @@ jobs:
          pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
-    - name: Install pynbody
-      if: ${{ matrix.REQUIRES_PYNBODY }}
+    - name: Install pynbody (3.12)
+      if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version == '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager h5py pandas pytz
+         pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+         pip install --upgrade --upgrade-strategy eager h5py
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
+         - name: Install pynbody
+         if: ${{ matrix.REQUIRES_PYNBODY }} && matrix.python-version != '3.12'
+         run: |
+            pip install --upgrade --upgrade-strategy eager h5py pandas pytz
+            pip install --upgrade --upgrade-strategy eager wheel
+            pip install --upgrade --upgrade-strategy eager pynbody
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
-      run: pip install astropy pyerfa
+      run: pip install --pre astropy pyerfa
     - name: Install astroquery
       if: ${{ matrix.REQUIRES_ASTROQUERY }}
-      run: pip install astroquery
+      run: pip install --pre astroquery
     - name: Install numba
       if: ${{ matrix.REQUIRES_NUMBA }}
       run: |
@@ -272,7 +280,7 @@ jobs:
         pip install --upgrade --force-reinstall setuptools
     - name: Install JAX
       if: ${{ matrix.REQUIRES_JAX }}
-      run: pip install jax jaxlib
+      run: pip install --pre jax jaxlib
     - name: Install torus code
       env:
           TEST_FILES: ${{ matrix.TEST_FILES }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,7 @@ jobs:
     - name: Install numba
       if: ${{ matrix.REQUIRES_NUMBA }}
       run: |
-        pip install numba
+        pip install numba==0.59.0rc1 llvmlite==0.42.0rc1
         # numba may force install an older version of setuptools,
         # but it isn't actually a *runtime* requirement numba/numba#8366
         pip install --upgrade --force-reinstall setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
-        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\: datetime.datetime.now(datetime.UTC).\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
         eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0 --cov-report=term --cov-report=xml"
     - name: Generate code coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
          # matplotlib dependencies
          pip install --upgrade --upgrade-strategy eager contourpy cycler fonttools kiwisolver packaging pillow pyparsing python-dateutil
          pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
-         pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
+         pip install --upgrade --upgrade-strategy eager --pre numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,8 @@ jobs:
     - name: Install Python dependencies (3.12)
       if: matrix.python-version == '3.12'
       run: |
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy matplotlib
+         pip install --upgrade --upgrade-strategy eager --pre numpy
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
     - name: Install numba
       if: ${{ matrix.REQUIRES_NUMBA }}
       run: |
-        pip install numba==0.59.0rc1 llvmlite==0.42.0rc1
+        pip install numba
         # numba may force install an older version of setuptools,
         # but it isn't actually a *runtime* requirement numba/numba#8366
         pip install --upgrade --force-reinstall setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,7 @@ jobs:
          pip install --upgrade --upgrade-strategy eager --pre pytz tzdata
          pip install --upgrade --upgrade-strategy eager --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
          brew install hdf5
+         export HDF5_DIR=$(brew --prefix hdf5)
          pip install --upgrade --upgrade-strategy eager --pre --no-binary=h5py git+https://github.com/h5py/h5py.git
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager --no-deps --pre git+https://github.com/pynbody/pynbody.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,8 @@ jobs:
       if: matrix.python-version == '3.12'
       run: |
          pip install --upgrade --upgrade-strategy eager --pre numpy
-         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib==3.8.0.dev1960+gac376ea1a6
+         pip install --upgrade --upgrade-strategy eager contourpy
+         pip install --upgrade --upgrade-strategy eager -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy matplotlib
          pip install --upgrade --upgrade-strategy eager numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_actionAngle.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -32,7 +32,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_sphericaldf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -40,7 +40,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_conversion.py tests/test_galpypaper.py tests/test_import.py tests/test_interp_potential.py tests/test_kuzminkutuzov.py  tests/test_util.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -48,7 +48,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_SpiralArmsPotential.py tests/test_potential.py tests/test_scf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -56,11 +56,75 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
             TEST_FILES: tests/test_quantity.py tests/test_coords.py
             REQUIRES_PYNBODY: false
             # needs to be separate for different config
             REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py -k test_energy_jacobi_conservation
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_evolveddiskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_streamgapdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_diskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
             REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
@@ -78,54 +142,6 @@ jobs:
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: true
             REQUIRES_ASTROQUERY: true
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_evolveddiskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_streamgapdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_diskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.11"
-            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -256,5 +256,6 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
+        export TQDM_DEPRECATION="-W ignore:\"datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version.\":DeprecationWarning -W ignore:\"datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"
+        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $TQDM_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"


### PR DESCRIPTION
**This issue just tracks progress to fully changing the build/test infrastructure to Python 3.12** Python 3.12 wheels are already being created successfully and are included in the latest release. 

This PR tracks progress towards fully supporting Python 3.12. Any necessary fixes will be done separately outside of this PR, so actual Python 3.12 support can be achieved for many platforms before achieving it for all. We believe, in fact, that galpy fully works, but it is hard to fully test until all dependencies support Python 3.12. 

Current status:

- Linux works, but can't run tests dependent on ``JAX`` or ``numba``, because they do not support Python 3.12 yet. This affects only the spherical DFs (for ``JAX``) and the non-inertial-frame force tests
  - [x] Test ``JAX``-dependent code
  - [x] Test ``numba``-dependent code
- Mac does not work because of an issue with installing h5py:
  - [x] run Mac tests
- Windows untested, because Windows tests use ``conda`` in the CI and ``conda`` does not support Python 3.12 yet.
  - [x] Run Windows tests
- Wheels:
  - [x] Build Python 3.12 wheels for all platforms