### PR TITLE
Pin ``pynbody`` version to 1.4.2 for Python 3.8 tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager pynbody==1.5.0
+         pip install --upgrade --upgrade-strategy eager pynbody==1.4.2
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
       run: pip install astropy pyerfa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,11 +225,17 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
-      if: ${{ matrix.REQUIRES_PYNBODY }}
+      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.8' }}
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
+    - name: Install pynbody (Python 3.8)
+      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.8' }}
+      run: |
+         pip install --upgrade --upgrade-strategy eager h5py pandas pytz
+         pip install --upgrade --upgrade-strategy eager wheel
+         pip install --upgrade --upgrade-strategy eager pynbody==1.5.0
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
       run: pip install astropy pyerfa


### PR DESCRIPTION
Because of newer ``pynbody`` versions' incompatibility with Python 3.9 (see https://github.com/pynbody/pynbody/issues/753).