### PR TITLE
Simplify pynbody installation in tests again 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,17 +225,11 @@ jobs:
       run: |
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
-      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version != '3.8' }}
+      if: ${{ matrix.REQUIRES_PYNBODY }}
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel
          pip install --upgrade --upgrade-strategy eager pynbody
-    - name: Install pynbody (Python 3.8)
-      if: ${{ matrix.REQUIRES_PYNBODY && matrix.python-version == '3.8' }}
-      run: |
-         pip install --upgrade --upgrade-strategy eager h5py pandas pytz
-         pip install --upgrade --upgrade-strategy eager wheel
-         pip install --upgrade --upgrade-strategy eager pynbody==1.4.2
     - name: Install astropy
       if: ${{ matrix.REQUIRES_ASTROPY }}
       run: pip install astropy pyerfa


### PR DESCRIPTION
Now that the offending Python 3.8 versions were yanked from PyPI, so just pip installing pynbody again installs a Python 3.8-compatible version.