### PR TITLE
Vendor scipy.integrate.romberg due to impending deprecation within scipy

### DIFF
--- a/galpy/df/diskdf.py
+++ b/galpy/df/diskdf.py
@@ -32,7 +32,7 @@ from scipy import integrate, interpolate, optimize, stats
 from ..actionAngle import actionAngleAdiabatic
 from ..orbit import Orbit
 from ..potential import PowerSphericalPotential
-from ..util import conversion, save_pickles
+from ..util import conversion, quadpack, save_pickles
 from ..util.ars import ars
 from ..util.conversion import (
     _APY_LOADED,
@@ -2702,7 +2702,7 @@ def _oned_intFunc(x, twodfunc, gfun, hfun, tol, args):
     """Internal function for bovy_dblquad"""
     thisargs = copy.deepcopy(args)
     thisargs.insert(0, x)
-    return integrate.romberg(twodfunc, gfun(x), hfun(x), args=thisargs, tol=tol)
+    return quadpack.romberg(twodfunc, gfun(x), hfun(x), args=thisargs, tol=tol)
 
 
 def bovy_dblquad(func, a, b, gfun, hfun, args=(), tol=1.48e-08):

--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -1737,7 +1737,7 @@ def impulse_deltav_general_orbitintegration(
     acc = (numpy.reshape(evaluateRforces(pot, r.flatten(), 0.0), (nstar, nsamp)) / r)[
         :, :, numpy.newaxis
     ] * X
-    return integrate.simps(acc, x=times, axis=1)
+    return integrate.simpson(acc, x=times, axis=1)
 
 
 def impulse_deltav_general_fullplummerintegration(


### PR DESCRIPTION
Also use renamed `simpson` rather than `simps`.