### PR TITLE
Set runners used in wheels workflow explicitly

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         # Following numpy's setup
         buildplat:
-        - [ubuntu-latest, manylinux, x86_64]
-        - [macos-latest, macosx, x86_64]
+        - [ubuntu-22.04, manylinux, x86_64]
+        - [macos-12, macosx, x86_64]
         - [macos-14, macosx, arm64]
         - [windows-2019, win, amd64]
         python: ["cp38", "cp39", "cp310", "cp311", "cp312"]


### PR DESCRIPTION
Among other things, , to make sure to create the 64bit mac wheel now that [macos-latest is becoming M1](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/)