### PR TITLE
Remove specific gcc version for installing ``pynbody``

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,9 +242,6 @@ jobs:
          pip install --upgrade --upgrade-strategy eager numpy scipy matplotlib numexpr setuptools cython pytest tqdm
     - name: Install pynbody
       if: ${{ matrix.REQUIRES_PYNBODY }}
-      env:
-        CC: gcc-11
-        CXX: g++-11
       run: |
          pip install --upgrade --upgrade-strategy eager h5py pandas pytz
          pip install --upgrade --upgrade-strategy eager wheel


### PR DESCRIPTION
Doesn't seem to be necessary currently because we are back to installing `pynbody` wheels and when building `pynbody` becomes necessary again, might have to do GCC13 anyway..