### PR TITLE
Fix OpenMP compilation on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,10 +226,10 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
          sudo apt-get install libgsl-dev
-    - name: Install the GSL
+    - name: Install the GSL and OpenMP
       if: matrix.os == 'macos-12'
       run: |
-         brew install gsl
+         brew install gsl libomp
          echo "CFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
          echo "LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
          echo "LD_LIBRARY_PATH=$(brew --prefix)/lib" >> $GITHUB_ENV

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,12 @@ WIN32 = platform.system() == "Windows"
 MACOS = platform.system() == "Darwin"
 # homebrew directory for MacOS is different on Intel and Apple Silicon
 try:
-    MACOS_BREW_PREFIX = subprocess.Popen(
-        ["brew", "--prefix"], stdout=subprocess.PIPE
-    ).communicate()[0].decode("utf-8").replace("\n", "")
+    MACOS_BREW_PREFIX = (
+        subprocess.Popen(["brew", "--prefix"], stdout=subprocess.PIPE)
+        .communicate()[0]
+        .decode("utf-8")
+        .replace("\n", "")
+    )
 except FileNotFoundError:
     # if not homebrew, set to empty string
     # the code should work without homebrew as well (users use conda or other package managers)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import distutils.ccompiler
 import glob
 import os
 import os.path
@@ -147,19 +146,6 @@ extra_compile_args.append("-D GSL_MAJOR_VERSION=%s" % (gsl_version[0]))
 
 # HACK for testing
 # gsl_version= ['0','0']
-
-# MSVC: inline does not exist (not C99!); default = not necessarily actual, but will have to do for now...
-# Note for the futureL could now get the actual compiler in the BuildExt class
-# below
-if distutils.ccompiler.get_default_compiler().lower() == "msvc":
-    extra_compile_args.append("-Dinline=__inline")
-    # only msvc compiler can be tested with initialize(), msvc is a default on windows
-    # check for 'msvc' not WIN32, user can use other compiler like 'mingw32', in such case compiler exists for them
-    try:
-        test_compiler = distutils.ccompiler.new_compiler()
-        test_compiler.initialize()  # try to initialize a test compiler to see if compiler presented
-    except PlatformError:  # this error will be raised if no compiler in the system
-        no_compiler = True
 
 # To properly export GSL symbols on Windows, need to defined GSL_DLL and WIN32
 if WIN32:


### PR DESCRIPTION
Currently galpy wheels for MacOS on PyPI are not compiled with OpenMP because `-fopenmp` is not supported by default clang in the OS but need to use `-Xclang=-fopenmp`. This PR provides a fix such that galpy can use OpenMP on MacOS too, also removes unneccessary code to define inline for Windows that use `distutils` which was removed in Python 3.12.

A quick sanity check with `nm -g libgalpy.cpython-312-darwin.so` using a galpy wheel on PyPI indeed show OpenMP is not used (missing symbols like `_omp_get_max_threads` since v1.8.1).

In `setup.py`, I have assumed homebrew is used and set the ibclude/lib path directly. Not sure what is the best way to do this since openmp does not have something like `gsl-config --prefix`.

The performance test is as follow

<img width="812" alt="Screenshot 2024-06-20 at 9 53 12 AM" src="https://github.com/jobovy/galpy/assets/28623434/e2db0d12-f81e-4cd6-9b3d-c199db6d23d8">