### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_actionAngle.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -32,7 +32,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_sphericaldf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -40,7 +40,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: true
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_actionAngleTorus.py tests/test_conversion.py tests/test_galpypaper.py tests/test_import.py tests/test_interp_potential.py tests/test_kuzminkutuzov.py  tests/test_util.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -48,7 +48,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_SpiralArmsPotential.py tests/test_potential.py tests/test_scf.py tests/test_snapshotpotential.py
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: false
@@ -56,7 +56,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_quantity.py tests/test_coords.py
             REQUIRES_PYNBODY: false
             # needs to be separate for different config
@@ -65,7 +65,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_orbit.py -k 'test_energy_jacobi_conservation or from_name'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -73,7 +73,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -81,7 +81,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_evolveddiskdf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -89,7 +89,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -97,7 +97,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -105,7 +105,7 @@ jobs:
             REQUIRES_NUMBA: true
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_streamgapdf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -113,7 +113,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_diskdf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -121,7 +121,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -129,6 +129,22 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py -k 'test_energy_jacobi_conservation or from_name'
+            REQUIRES_PYNBODY: true
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
+            REQUIRES_PYNBODY: true
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: ubuntu-latest
             python-version: "3.11"
             TEST_FILES: tests/test_orbit.py -k 'test_energy_jacobi_conservation or from_name'
             REQUIRES_PYNBODY: true
@@ -193,7 +209,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: macos-13
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_orbit.py -k 'test_energy_jacobi_conservation or from_name'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -201,7 +217,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: macos-13
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
@@ -209,7 +225,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
     env:
-      PYTHON_COVREPORTS_VERSION: "3.12"
+      PYTHON_COVREPORTS_VERSION: "3.13"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_actionAngle.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -32,7 +32,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_sphericaldf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -40,7 +40,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_conversion.py tests/test_galpypaper.py tests/test_import.py tests/test_interp_potential.py tests/test_kuzminkutuzov.py  tests/test_util.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -48,7 +48,7 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_SpiralArmsPotential.py tests/test_potential.py tests/test_scf.py
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: false
@@ -56,11 +56,75 @@ jobs:
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             TEST_FILES: tests/test_quantity.py tests/test_coords.py
             REQUIRES_PYNBODY: false
             # needs to be separate for different config
             REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_orbit.py -k test_energy_jacobi_conservation
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: true
+            REQUIRES_ASTROQUERY: true
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_evolveddiskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: true
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_streamgapdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_diskdf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
+            REQUIRES_ASTROQUERY: false
+            REQUIRES_NUMBA: false
+            REQUIRES_JAX: false
+          - os: windows-latest
+            python-version: "3.13"
+            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
+            REQUIRES_PYNBODY: false
+            REQUIRES_ASTROPY: false
             REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
@@ -78,54 +142,6 @@ jobs:
             REQUIRES_PYNBODY: false
             REQUIRES_ASTROPY: true
             REQUIRES_ASTROQUERY: true
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_evolveddiskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_jeans.py tests/test_dynamfric.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_qdf.py tests/test_pv2qdf.py tests/test_streamgapdf_impulse.py tests/test_noninertial.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: true
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_streamgapdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_diskdf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
-            REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
-          - os: windows-latest
-            python-version: "3.12"
-            TEST_FILES: tests/test_streamdf.py tests/test_streamspraydf.py
-            REQUIRES_PYNBODY: false
-            REQUIRES_ASTROPY: false
-            REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
             REQUIRES_JAX: false
           - os: windows-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,6 +105,7 @@ jobs:
             - ["cp310","3.10"]
             - ["cp311","3.11"]
             - ["cp312","3.12"]
+            - ["cp313","3.13"]
     steps:
       - uses: actions/checkout@v4
       - run: mkdir wheelhouse

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ FAQ](http://docs.galpy.org/en/latest/installation.html#installation-faq).
 PYTHON VERSIONS AND DEPENDENCIES
 ================================
 
-`galpy` supports Python 3. Specifically, galpy supports Python 3.8, 3.9, 3.10, 3.11,
-and 3.12. GitHub Actions CI builds regularly check support for
-Python 3.12 (and of 3.8, 3.9, 3.10, and 3.11 using a more limited, core set of tests)
-on Linux and Windows (and 3.12 on Mac OS). Python 2.7 is no longer supported.
+`galpy` supports Python 3. Specifically, galpy supports Python 3.8, 3.9, 3.10, 3.11, 3.12
+and 3.13. GitHub Actions CI builds regularly check support for
+Python 3.13 (and of 3.8, 3.9, 3.10, 3.11, and 3.12 using a more limited, core set of tests)
+on Linux and Windows (and 3.13 on Mac OS). Python 2.7 is no longer supported.
 
 This package requires [Numpy](https://numpy.org/),
 [Scipy](http://www.scipy.org/), and

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -7463,7 +7463,7 @@ def _from_name_oneobject(name, obs):
         "pmdec",
         "rvz_radvel" if _AQ_GT_47 else "rv_value",
     )
-    if not _AQ_GT_47:
+    if not _AQ_GT_47:  # pragma: no cover
         simbad.add_votable_fields("plx", "distance")
     # query SIMBAD for the named object
     try:
@@ -7501,7 +7501,7 @@ def _from_name_oneobject(name, obs):
             dist = simbad_table["mesdistance.dist"][0]
         else:
             dist = 1.0 / simbad_table["plx_value"][0]
-    else:
+    else:  # pragma: no cover
         # check that the necessary coordinates have been found
         missing = simbad_table.mask
         if any(missing["RA_d", "DEC_d", "PMRA", "PMDEC", "RV_VALUE"][0]) or all(


### PR DESCRIPTION
**This issue just tracks progress to fully changing the build/test infrastructure to Python 3.13. Python 3.13 wheels were already added in #674 and are part of the latest version (since the 1.10.1 release).**

**Ready to be merged as soon as ``numba`` releases 0.61.**

This PR tracks progress towards fully supporting Python 3.13. Any necessary fixes will be done separately outside of this PR, so actual Python 3.13 support can be achieved for many platforms before achieving it for all. We believe, in fact, that galpy fully works, but it is hard to fully test until all dependencies support Python 3.13. 

Current status:

- Linux works almost 100%, but can't run tests dependent on ``JAX`` or ``numba``, because they do not support Python 3.13 yet. This affects only the spherical DFs (for ``JAX``) and the non-inertial-frame force tests. There appears to be an issue with use of ``pynbody`` in ``SnapshotRZPotential``
  - [x] Fix ``SnapshotRZPotential`` ``pynbody`` issue
  - [x] Test ``JAX``-dependent code
  - [x] Test ``numba``-dependent code
- Mac does not work because of an issue with installing pynbody from source, but we believe it's status is the same as Linux.
  - [x] run Mac tests --> require RC pynbody, but that's fine
- Windows works, but numba can't be installed currently. But should work.
- Wheels:
  - [x] Build Python 3.13 wheels for all platforms