### PR TITLE
Add Python 3.13 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - python-3.13-wheels
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - python-3.13-wheels
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,6 +41,7 @@ jobs:
         - ["cp310","3.10"]
         - ["cp311","3.11"]
         - ["cp312","3.12"]
+        - ["cp313","3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install GSL (Windows / Mac OS x86_64)
@@ -114,6 +115,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python[1] }}
+          allow-prereleases: true
       - name: Install GSL (Windows)
         uses: mamba-org/setup-micromamba@v1
         if: matrix.buildplat[1] == 'win'

--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Environment :: WebAssembly :: Emscripten",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
Because Python 3.13 seems to be working (see #673), this PR adds wheels for Python 3.13.