### PR TITLE
Correct behaviour of the potential in KingPotential

### DIFF
--- a/galpy/df/kingdf.py
+++ b/galpy/df/kingdf.py
@@ -81,7 +81,7 @@ class kingdf(isotropicsphericaldf):
         self._icmf = interpolate.InterpolatedUnivariateSpline(
             self._mass_scale * self._scalefree_kdf._cumul_mass / self.M,
             self._radius_scale * self._scalefree_kdf._r,
-            k=3,
+            k=1,
         )
         # Setup velocity DF interpolator for velocity sampling here
         self._rmin_sampling = 0.0

--- a/galpy/df/kingdf.py
+++ b/galpy/df/kingdf.py
@@ -138,7 +138,7 @@ class _scalefreekingdf:
             ],
             [0.0, rbreak],
             [self.W0, 0.0],
-            method="LSODA",
+            method="DOP853",
             t_eval=r[: npt // 2],
         )
         W[: npt // 2] = sol.y[0]
@@ -155,7 +155,7 @@ class _scalefreekingdf:
             ],
             [sol.y[0, -1], 0.0],
             [rbreak, sol.y[1, -1]],
-            method="LSODA",
+            method="DOP853",
             t_eval=W[npt // 2 - 1 :],
         )
         r[npt // 2 - 1 :] = sol.y[0]
@@ -171,18 +171,7 @@ class _scalefreekingdf:
         # Interpolate solution
         self._W_from_r = interpolate.InterpolatedUnivariateSpline(self._r, self._W, k=3)
         # Compute the cumulative mass and store the total mass
-        mass_shells = numpy.array(
-            [
-                integrate.quad(lambda r: _FOURPI * r**2 * self.dens(r), rlo, rhi)[0]
-                for rlo, rhi in zip(r[:-1], r[1:])
-            ]
-        )
-        self._cumul_mass = numpy.hstack(
-            (
-                integrate.quad(lambda r: _FOURPI * r**2 * self.dens(r), 0.0, r[0])[0],
-                numpy.cumsum(mass_shells),
-            )
-        )
+        self._cumul_mass = -self._dWdr * self._r**2.0
         self.mass = self._cumul_mass[-1]
         return None
 

--- a/galpy/df/kingdf.py
+++ b/galpy/df/kingdf.py
@@ -170,8 +170,13 @@ class _scalefreekingdf:
         self.c = numpy.log10(self.rt / self.r0)
         # Interpolate solution
         self._W_from_r = interpolate.InterpolatedUnivariateSpline(self._r, self._W, k=3)
-        # Compute the cumulative mass and store the total mass
+        # Compute the cumulative mass and store the total mass, adjust small decreases to zero
         self._cumul_mass = -self._dWdr * self._r**2.0
+        for ii in range(1, npt):
+            if self._cumul_mass[ii] < self._cumul_mass[ii - 1]:
+                self._cumul_mass[ii] = (
+                    self._cumul_mass[ii - 1] + 2.0 * numpy.finfo(float).eps
+                )
         self.mass = self._cumul_mass[-1]
         return None
 

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -454,7 +454,7 @@ class sphericaldf(df):
         if numpy.isinf(self._rmax):
             xis = numpy.append(xis, 1)
             ms = numpy.append(ms, 1)
-        return scipy.interpolate.InterpolatedUnivariateSpline(ms, xis, k=3)
+        return scipy.interpolate.InterpolatedUnivariateSpline(ms, xis, k=1)
 
     def _sample_position_angles(self, n=1):
         """Generate spherical angle samples"""

--- a/galpy/potential/KingPotential.py
+++ b/galpy/potential/KingPotential.py
@@ -68,7 +68,7 @@ class KingPotential(interpSphericalPotential):
             / radius_scale**2.0
             * numpy.interp(r / radius_scale, sfkdf._r, sfkdf._dWdr),
             rgrid=sfkdf._r * radius_scale,
-            Phi0=-W0 * mass_scale / radius_scale,
+            Phi0=-W0 * mass_scale / radius_scale - M / rt,
             ro=ro,
             vo=vo,
         )

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -7734,6 +7734,19 @@ def test_InterpSnapshotRZPotential_pickling():
     return None
 
 
+# Test that the King potential goes as -GM/r at r > rt
+def test_king_potential_beyond_tidal():
+    mass = 3.0
+    kp = potential.KingPotential(W0=6.0, rt=2.0, M=mass)
+    r = numpy.linspace(2.1, 10.0, 1001)
+    # Accuracy is limited because of the numerical solution of the King ODE and
+    # the fact that interpSphericalPotential doesn't directly use the solved W potential
+    assert numpy.all(
+        numpy.fabs(kp(r, 0.0) / mass * r + 1.0) < 1e-3
+    ), "King potential does not go as GM/r at r > rt"
+    return None
+
+
 # Test that trying to plot a potential with xy=True and effective=True raises a RuntimeError
 def test_plotting_xy_effective_error():
     # First a single potential

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -851,7 +851,7 @@ def test_osipkovmerritt_nfw_dens_massprofile():
         dfh = osipkovmerrittNFWdf(pot=pot, ra=ra)
         numpy.random.seed(10)
         samp = dfh.sample(n=100000)
-        tol = 5 * 1e-3
+        tol = 7 * 1e-3
         check_spherical_massprofile(
             samp, lambda r: pot.mass(r) / pot.mass(numpy.amax(samp.r())), tol, skip=1000
         )
@@ -1133,7 +1133,7 @@ def test_isotropic_nfw_dens_massprofile():
     dfp = isotropicNFWdf(pot=pot)
     numpy.random.seed(10)
     samp = dfp.sample(n=100000)
-    tol = 5 * 1e-3
+    tol = 7 * 1e-3
     check_spherical_massprofile(
         samp, lambda r: pot.mass(r) / pot.mass(numpy.amax(samp.r())), tol, skip=1000
     )


### PR DESCRIPTION
Fixes the fact that KingPotential was missing a constant offset to make the potential exactly Keplerian -GM/r outside the tidal radius. Also updates how the cumulative mass profile is calculated and how it is interpolated in general for spherical adds. And also updates the silver for the King profile slightly. 