### PR TITLE
Fix units of the phase-space density for spherical DFs

### DIFF
--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -102,7 +102,7 @@ class sphericaldf(df):
             )
 
     ############################## EVALUATING THE DF###############################
-    @physical_conversion("phasespacedensity", pop=True)
+    @physical_conversion("massphasespacedensity", pop=True)
     def __call__(self, *args, **kwargs):
         """
         Evaluate the DF
@@ -123,6 +123,7 @@ class sphericaldf(df):
         Notes
         -----
         - 2020-07-22 - Written - Lane (UofT)
+        - 2024-10-29 - Fixed to return mass/phase-space volume units for physical-unit output - Bovy (UofT)
         """
         # Get E,L,Lz
         if len(args) == 1:
@@ -160,7 +161,7 @@ class sphericaldf(df):
             )
         )
 
-    @physical_conversion("energydensity", pop=True)
+    @physical_conversion("massenergydensity", pop=True)
     def dMdE(self, E):
         """
         Compute the differential energy distribution dM/dE: the amount of mass per unit energy
@@ -216,10 +217,10 @@ class sphericaldf(df):
         if vo is None and hasattr(self, "_voSet") and self._voSet:
             vo = self._vo
         vo = conversion.parse_velocity_kms(vo)
-        if use_physical and not vo is None and not ro is None:
-            fac = vo ** (n + m) / ro**3
+        if use_physical and vo is not None and ro is not None:
+            fac = conversion.mass_in_msol(vo, ro) * vo ** (n + m) / ro**3
             if _optional_deps._APY_UNITS:
-                u = 1 / units.kpc**3 * (units.km / units.s) ** (n + m)
+                u = units.Msun / units.kpc**3 * (units.km / units.s) ** (n + m)
             out = self._vmomentdensity(r, n, m)
             if _optional_deps._APY_UNITS:
                 return units.Quantity(out * fac, unit=u)

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -766,7 +766,8 @@ _roNecessary = {
     "phasespacedensity2d": True,
     "phasespacedensityvelocity": True,
     "phasespacedensityvelocity2": True,
-    "energydensity": False,
+    "massphasespacedensity": True,
+    "massenergydensity": False,
     "dimensionless": False,
 }
 _voNecessary = copy.copy(_roNecessary)
@@ -778,7 +779,7 @@ _voNecessary["velocity"] = True
 _voNecessary["velocity2"] = True
 _voNecessary["velocity_kms"] = True
 _voNecessary["energy"] = True
-_voNecessary["energydensity"] = True
+_voNecessary["massenergydensity"] = True
 
 
 # Determine whether or not outputs will be physical or not
@@ -980,10 +981,14 @@ def physical_conversion(quantity, pop=False):
                     fac = 1.0 / vo / ro**3.0
                     if _apy_units:
                         u = 1 / (units.km / units.s) / units.kpc**3
-                elif quantity.lower() == "energydensity":
-                    fac = 1.0 / vo**2.0
+                elif quantity.lower() == "massphasespacedensity":
+                    fac = mass_in_msol(vo, ro) / vo**3.0 / ro**3.0
                     if _apy_units:
-                        u = 1 / (units.km / units.s) ** 2
+                        u = units.Msun / (units.km / units.s) ** 3 / units.kpc**3
+                elif quantity.lower() == "massenergydensity":
+                    fac = mass_in_msol(vo, ro) / vo**2.0
+                    if _apy_units:
+                        u = units.Msun / (units.km / units.s) ** 2
                 elif quantity.lower() == "dimensionless":
                     fac = 1.0
                     if _apy_units:

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -16038,63 +16038,67 @@ def test_sphericaldf_method_returnunit():
     dfa = constantbetaHernquistdf(pot=pot, beta=-0.2)
     o = Orbit([1.1, 0.1, 1.1, 0.1, 0.03, 0.4])
     try:
-        dfh(o).to(1 / units.kpc**3 / (units.km / units.s) ** 3)
+        dfh(o).to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method __call__ does not return Quantity with the right units"
         )
     try:
-        dfh((o.E(pot=pot),)).to(1 / units.kpc**3 / (units.km / units.s) ** 3)
+        dfh((o.E(pot=pot),)).to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method __call__ does not return Quantity with the right units"
         )
     try:
         dfh(o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi()).to(
-            1 / units.kpc**3 / (units.km / units.s) ** 3
+            units.Msun / units.kpc**3 / (units.km / units.s) ** 3
         )
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method __call__ does not return Quantity with the right units"
         )
     try:
-        dfh.dMdE(o.E(pot=pot)).to(1 / (units.km / units.s) ** 2)
+        dfh.dMdE(o.E(pot=pot)).to(units.Msun / (units.km / units.s) ** 2)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method dMdE does not return Quantity with the right units"
         )
     try:
-        dfh.vmomentdensity(1.1, 0, 0).to(1 / units.kpc**3)
+        dfh.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
         )
     try:
-        dfa.vmomentdensity(1.1, 0, 0).to(1 / units.kpc**3)
+        dfa.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
         )
     try:
-        dfh.vmomentdensity(1.1, 1, 0).to(1 / units.kpc**3 * units.km / units.s)
+        dfh.vmomentdensity(1.1, 1, 0).to(units.Msun / units.kpc**3 * units.km / units.s)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
         )
     try:
-        dfa.vmomentdensity(1.1, 1, 0).to(1 / units.kpc**3 * units.km / units.s)
+        dfa.vmomentdensity(1.1, 1, 0).to(units.Msun / units.kpc**3 * units.km / units.s)
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
         )
     try:
-        dfh.vmomentdensity(1.1, 0, 2).to(1 / units.kpc**3 * units.km**2 / units.s**2)
+        dfh.vmomentdensity(1.1, 0, 2).to(
+            units.Msun / units.kpc**3 * units.km**2 / units.s**2
+        )
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
         )
     try:
-        dfa.vmomentdensity(1.1, 0, 2).to(1 / units.kpc**3 * units.km**2 / units.s**2)
+        dfa.vmomentdensity(1.1, 0, 2).to(
+            units.Msun / units.kpc**3 * units.km**2 / units.s**2
+        )
     except units.UnitConversionError:
         raise AssertionError(
             "sphericaldf method vmomentdensity does not return Quantity with the right units"
@@ -16118,6 +16122,7 @@ def test_sphericaldf_method_value():
     from galpy import potential
     from galpy.df import constantbetaHernquistdf, isotropicHernquistdf
     from galpy.orbit import Orbit
+    from galpy.util import conversion
 
     ro, vo = 8.0, 220.0
     pot = potential.HernquistPotential(amp=2.0, a=1.3)
@@ -16128,63 +16133,78 @@ def test_sphericaldf_method_value():
     o = Orbit([1.1, 0.1, 1.1, 0.1, 0.03, 0.4])
     assert (
         numpy.fabs(
-            dfh(o).to(1 / units.kpc**3 / (units.km / units.s) ** 3).value
-            - dfh_nou(o) / ro**3 / vo**3
+            dfh(o).to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3).value
+            - dfh_nou(o) * conversion.mass_in_msol(vo, ro) / ro**3 / vo**3
         )
         < 10.0**-8.0
     ), "sphericaldf method __call__ does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfh((o.E(pot=pot),)).to(1 / units.kpc**3 / (units.km / units.s) ** 3).value
-            - dfh_nou((o.E(pot=pot),)) / ro**3 / vo**3
+            dfh((o.E(pot=pot),))
+            .to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
+            .value
+            - dfh_nou((o.E(pot=pot),)) * conversion.mass_in_msol(vo, ro) / ro**3 / vo**3
         )
         < 10.0**-8.0
     ), "sphericaldf method __call__ does not return correct Quantity"
     assert (
         numpy.fabs(
             dfh(o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi())
-            .to(1 / units.kpc**3 / (units.km / units.s) ** 3)
+            .to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
             .value
-            - dfh_nou(o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi()) / ro**3 / vo**3
+            - dfh_nou(o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi())
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
+            / vo**3
         )
         < 10.0**-8.0
     ), "sphericaldf method __call__ does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfh.dMdE(o.E(pot=pot)).to(1 / (units.km / units.s) ** 2).value
-            - dfh_nou.dMdE(o.E(pot=pot)) / vo**2
+            dfh.dMdE(o.E(pot=pot)).to(units.Msun / (units.km / units.s) ** 2).value
+            - dfh_nou.dMdE(o.E(pot=pot)) * conversion.mass_in_msol(vo, ro) / vo**2
         )
         < 10.0**-8.0
     ), "sphericaldf method dMdE does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfh.vmomentdensity(1.1, 0, 0).to(1 / units.kpc**3).value
-            - dfh_nou.vmomentdensity(1.1, 0, 0) / ro**3
+            dfh.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value
+            - dfh_nou.vmomentdensity(1.1, 0, 0)
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfa.vmomentdensity(1.1, 0, 0).to(1 / units.kpc**3).value
-            - dfa_nou.vmomentdensity(1.1, 0, 0) / ro**3
+            dfa.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value
+            - dfa_nou.vmomentdensity(1.1, 0, 0)
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfh.vmomentdensity(1.1, 1, 0)
-            .to(1 / units.kpc**3 * units.km / units.s)
+            .to(units.Msun / units.kpc**3 * units.km / units.s)
             .value
-            - dfh_nou.vmomentdensity(1.1, 1, 0) * vo / ro**3
+            - dfh_nou.vmomentdensity(1.1, 1, 0)
+            * conversion.mass_in_msol(vo, ro)
+            * vo
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfa.vmomentdensity(1.1, 1, 0)
-            .to(1 / units.kpc**3 * units.km / units.s)
+            .to(units.Msun / units.kpc**3 * units.km / units.s)
             .value
-            - dfa_nou.vmomentdensity(1.1, 1, 0) * vo / ro**3
+            - dfa_nou.vmomentdensity(1.1, 1, 0)
+            * conversion.mass_in_msol(vo, ro)
+            * vo
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
@@ -16195,7 +16215,10 @@ def test_sphericaldf_method_value():
     assert (
         numpy.fabs(
             dfh.vmomentdensity(1.1, 0, 2)
-            - dfh_nou.vmomentdensity(1.1, 0, 2) * vo**2 / ro**3
+            - dfh_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
@@ -16203,18 +16226,24 @@ def test_sphericaldf_method_value():
     assert (
         numpy.fabs(
             dfh.vmomentdensity(1.1, 0, 2)
-            .to(1 / units.kpc**3 * units.km**2 / units.s**2)
+            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
             .value
-            - dfh_nou.vmomentdensity(1.1, 0, 2) * vo**2 / ro**3
+            - dfh_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfa.vmomentdensity(1.1, 0, 2)
-            .to(1 / units.kpc**3 * units.km**2 / units.s**2)
+            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
             .value
-            - dfa_nou.vmomentdensity(1.1, 0, 2) * vo**2 / ro**3
+            - dfa_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
@@ -16237,6 +16266,7 @@ def test_sphericaldf_method_inputAsQuantity():
     from galpy import potential
     from galpy.df import constantbetaHernquistdf, isotropicHernquistdf
     from galpy.orbit import Orbit
+    from galpy.util import conversion
 
     ro, vo = 8.0, 220.0
     pot = potential.HernquistPotential(amp=2.0, a=1.3)
@@ -16247,15 +16277,20 @@ def test_sphericaldf_method_inputAsQuantity():
     o = Orbit([1.1, 0.1, 1.1, 0.1, 0.03, 0.4], ro=ro, vo=vo)
     assert (
         numpy.fabs(
-            dfh((o.E(pot=pot),)).to(1 / units.kpc**3 / (units.km / units.s) ** 3).value
-            - dfh_nou((o.E(pot=pot, use_physical=False),)) / ro**3 / vo**3
+            dfh((o.E(pot=pot),))
+            .to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
+            .value
+            - dfh_nou((o.E(pot=pot, use_physical=False),))
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
+            / vo**3
         )
         < 10.0**-8.0
     ), "sphericaldf method __call__ does not return correct Quantity"
     assert (
         numpy.fabs(
             dfh(o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi())
-            .to(1 / units.kpc**3 / (units.km / units.s) ** 3)
+            .to(units.Msun / units.kpc**3 / (units.km / units.s) ** 3)
             .value
             - dfh_nou(
                 o.R(use_physical=False),
@@ -16265,6 +16300,7 @@ def test_sphericaldf_method_inputAsQuantity():
                 o.vz(use_physical=False),
                 o.phi(use_physical=False),
             )
+            * conversion.mass_in_msol(vo, ro)
             / ro**3
             / vo**3
         )
@@ -16272,24 +16308,32 @@ def test_sphericaldf_method_inputAsQuantity():
     ), "sphericaldf method __call__ does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfh.dMdE(o.E(pot=pot)).to(1 / (units.km / units.s) ** 2).value
-            - dfh_nou.dMdE(o.E(pot=pot, use_physical=False)) / vo**2
+            dfh.dMdE(o.E(pot=pot)).to(units.Msun / (units.km / units.s) ** 2).value
+            - dfh_nou.dMdE(o.E(pot=pot, use_physical=False))
+            * conversion.mass_in_msol(vo, ro)
+            / vo**2
         )
         < 10.0**-8.0
     ), "sphericaldf method dMdE does not return correct Quantity"
     assert (
         numpy.fabs(
-            dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 0).to(1 / units.kpc**3).value
-            - dfh_nou.vmomentdensity(1.1, 0, 0) / ro**3
+            dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 0)
+            .to(units.Msun / units.kpc**3)
+            .value
+            - dfh_nou.vmomentdensity(1.1, 0, 0)
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 0, ro=ro * units.kpc)
-            .to(1 / units.kpc**3)
+            .to(units.Msun / units.kpc**3)
             .value
-            - dfa_nou.vmomentdensity(1.1, 0, 0) / ro**3
+            - dfa_nou.vmomentdensity(1.1, 0, 0)
+            * conversion.mass_in_msol(vo, ro)
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
@@ -16298,36 +16342,48 @@ def test_sphericaldf_method_inputAsQuantity():
             dfh.vmomentdensity(
                 1.1 * ro * units.kpc, 1, 0, ro=ro, vo=vo * units.km / units.s
             )
-            .to(1 / units.kpc**3 * units.km / units.s)
+            .to(units.Msun / units.kpc**3 * units.km / units.s)
             .value
-            - dfh_nou.vmomentdensity(1.1, 1, 0) * vo / ro**3
+            - dfh_nou.vmomentdensity(1.1, 1, 0)
+            * conversion.mass_in_msol(vo, ro)
+            * vo
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfa.vmomentdensity(1.1 * ro * units.kpc, 1, 0, vo=vo * units.km / units.s)
-            .to(1 / units.kpc**3 * units.km / units.s)
+            .to(units.Msun / units.kpc**3 * units.km / units.s)
             .value
-            - dfa_nou.vmomentdensity(1.1, 1, 0) * vo / ro**3
+            - dfa_nou.vmomentdensity(1.1, 1, 0)
+            * conversion.mass_in_msol(vo, ro)
+            * vo
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
-            .to(1 / units.kpc**3 * units.km**2 / units.s**2)
+            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
             .value
-            - dfh_nou.vmomentdensity(1.1, 0, 2) * vo**2 / ro**3
+            - dfh_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"
     assert (
         numpy.fabs(
             dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
-            .to(1 / units.kpc**3 * units.km**2 / units.s**2)
+            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
             .value
-            - dfa_nou.vmomentdensity(1.1, 0, 2) * vo**2 / ro**3
+            - dfa_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3
         )
         < 10.0**-8.0
     ), "sphericaldf method vmomentdensity does not return correct Quantity"

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -16516,6 +16516,35 @@ def test_kingdf_setup_wunits():
     return None
 
 
+def test_sphericaldf_densitymatch_issue677():
+    from astropy import units
+
+    from galpy.df import isotropicPlummerdf
+    from galpy.potential import PlummerPotential
+    from galpy.util import conversion
+
+    # First check that when not using unit-full output, the density of the
+    # PlummerPotential matches that of the Plummer DF
+    potential = PlummerPotential(amp=1e5, b=10.0)
+    df = isotropicPlummerdf(pot=potential)
+    assert (
+        numpy.fabs(
+            potential.dens(0.0, 0.0, 0.0) / df.vmomentdensity(0.0, 0.0, 0.0) - 1.0
+        )
+        < 1e-8
+    ), "Density of PlummerPotential does not match that of isotropicPlummerdf"
+    # Then check that they continue to match when using unit-full output
+    potential = PlummerPotential(amp=1e5 * units.Msun, b=10.0)
+    df = isotropicPlummerdf(pot=potential)
+    assert (
+        numpy.fabs(
+            potential.dens(0.0, 0.0, 0.0) / df.vmomentdensity(0.0, 0.0, 0.0) - 1.0
+        )
+        < 1e-8
+    ), "Density of PlummerPotential does not match that of isotropicPlummerdf when returning Quantities"
+    return None
+
+
 def test_streamdf_method_returntype():
     # Imports
     from galpy.actionAngle import actionAngleIsochroneApprox


### PR DESCRIPTION
As reported in #677. Fix here assumes that _all_ spherical DFs are normalized to have phase-space density units of mass/phase-space-volume, because they are all computed from a mass density rather than a number density.