### PR TITLE
Improve Python leapfrog integration performance

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,7 +1,14 @@
 v1.10.2 (expected around 2025-03-01)
 ====================
 
-Nothing yet!
+ - Combine the drift calculations in the Python leapfrog integrator (#365).
+
+ - Move the checks for non-axisymmetric and dissipative potentials from internal to
+   public potential/force evaluation functions (e.g., from _evaluate[Potentials,
+   Rforces, phitorques, zforces] to evaluate[Potentials, Rforces, phitorques, zforces])
+   for performance improvements.
+
+ - Add an isDissipative attribute to force classes.
 
 v1.10.1 (2024-11-01)
 ====================

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -28,10 +28,12 @@ from ..potential import (
     verticalfreq,
 )
 from ..potential.Potential import (
+    PotentialError,
     _check_c,
     _evaluatePotentials,
     _evaluateRforces,
     _evaluatezforces,
+    _isNonAxi,
 )
 from ..potential.Potential import flatten as flatten_potential
 from ..util import coords  # for prolate confocal transforms
@@ -1511,7 +1513,12 @@ def estimateDeltaStaeckel(pot, R, z, no_median=False, delta0=1e-6):
     - 2022-09-14 - Deal with numerical issues with SCF/DiskSCFPotentials - Bovy (UofT)
     - 2022-09-15 - Add delta0 - Bovy (UofT)
     """
+
     pot = flatten_potential(pot)
+    if _isNonAxi(pot):
+        raise PotentialError(
+            "Calling estimateDeltaStaeckel with non-axisymmetric potentials is not supported"
+        )
     # We'll special-case delta<0 when the potential includes SCF/DiskSCF components
     pot_includes_scf = (
         numpy.any(

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -20,6 +20,7 @@ class linearPotential:
     def __init__(self, amp=1.0, ro=None, vo=None):
         self._amp = amp
         self.dim = 1
+        self.isDissipative = False
         self.isRZ = False
         self.hasC = False
         self.hasC_dxdv = False

--- a/galpy/potential/planarDissipativeForce.py
+++ b/galpy/potential/planarDissipativeForce.py
@@ -30,6 +30,7 @@ class planarDissipativeForce(planarForce):
         - 2023-05-29 - Started - Bovy (UofT)
         """
         planarForce.__init__(self, amp=amp, ro=ro, vo=vo)
+        self.isDissipative = True
 
     @potential_physical_input
     @physical_conversion("force", pop=True)

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -136,15 +136,15 @@ def RZToverticalPotential(RZPot, R):
 
     """
     RZPot = flatten(RZPot)
-    if _isDissipative(RZPot):
-        raise NotImplementedError(
-            "Converting dissipative forces to 1D vertical potentials is currently not supported"
-        )
     try:
         conversion.get_physical(RZPot)
     except:
         raise PotentialError(
             "Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances"
+        )
+    if _isDissipative(RZPot):
+        raise NotImplementedError(
+            "Converting dissipative forces to 1D vertical potentials is currently not supported"
         )
     R = conversion.parse_length(R, **conversion.get_physical(RZPot))
     if isinstance(RZPot, list):
@@ -158,7 +158,7 @@ def RZToverticalPotential(RZPot, R):
                 raise PotentialError(
                     "Input to 'RZToverticalPotential' cannot be a planarPotential"
                 )
-            else:
+            else:  # pragma: no cover
                 raise PotentialError(
                     "Input to 'RZToverticalPotential' is neither an RZPotential-instance or a list of such instances"
                 )
@@ -205,15 +205,15 @@ def toVerticalPotential(Pot, R, phi=None, t0=0.0):
 
     """
     Pot = flatten(Pot)
-    if _isDissipative(Pot):
-        raise NotImplementedError(
-            "Converting dissipative forces to 1D vertical potentials is currently not supported"
-        )
     try:
         conversion.get_physical(Pot)
     except:
         raise PotentialError(
             "Input to 'toVerticalPotential' is neither an Potential-instance or a list of such instances"
+        )
+    if _isDissipative(Pot):
+        raise NotImplementedError(
+            "Converting dissipative forces to 1D vertical potentials is currently not supported"
         )
     R = conversion.parse_length(R, **conversion.get_physical(Pot))
     phi = conversion.parse_angle(phi)

--- a/galpy/util/symplecticode.py
+++ b/galpy/util/symplecticode.py
@@ -76,17 +76,22 @@ def leapfrog(func, yo, t, args=(), rtol=1.49012e-12, atol=1.49012e-12):
     # Integrate
     to = t[0]
     for ii in range(1, len(t)):
-        for jj in range(ndt):  # loop over number of sub-intervals
-            # This could be made faster by combining the drifts
-            # drift
-            q12 = leapfrog_leapq(qo, po, dt / 2.0)
+        # initial half drift
+        q12 = leapfrog_leapq(qo, po, dt / 2.0)
+        for jj in range(ndt - 1):  # loop over number of sub-intervals
             # kick
             force = func(q12, *args, t=to + dt / 2)
             po = leapfrog_leapp(po, dt, force)
-            # drift
-            qo = leapfrog_leapq(q12, po, dt / 2.0)
+            # full drift to next half step
+            q12 = leapfrog_leapq(q12, po, dt)
             # Get ready for next
             to += dt
+        # last kick and half drift to arrive at final step
+        force = func(q12, *args, t=to + dt / 2)
+        po = leapfrog_leapp(po, dt, force)
+        qo = leapfrog_leapq(q12, po, dt / 2)
+        to += dt
+
         out[ii, 0 : len(yo) // 2] = qo
         out[ii, len(yo) // 2 : len(yo)] = po
     return out

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -5299,6 +5299,7 @@ def test_orbitfit():
 
 def test_orbitfit_potinput():
     from galpy.orbit import Orbit
+    from galpy.potential import PotentialError
 
     lp = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9)
     o = Orbit([0.8, 0.3, 1.3, 0.4, 0.2, 2.0])
@@ -5310,10 +5311,10 @@ def test_orbitfit_potinput():
     of = o()
     try:
         Orbit.from_fit(o.vxvv[0], vxvv, pot=None, tintJ=1.5)
-    except AttributeError:
+    except PotentialError:
         pass
     else:
-        raise AssertionError("Orbit fit w/o potential does not raise AttributeError")
+        raise AssertionError("Orbit fit w/o potential does not raise PotentialError")
     # Now give a potential to of
     of = Orbit.from_fit(o.vxvv[0], vxvv, pot=lp, tintJ=1.5)
     assert numpy.all(

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -5303,6 +5303,23 @@ def test_nonaxierror_function():
     return None
 
 
+# Test that _isNonAxi raises a PotentialError if input is missing an isNonAxi attribute
+def test_nonaxi_missingattr():
+    # Check that giving an object that is not a list or Potential instance produces an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        _ = _isNonAxi("something else")
+    # Check that given a list of objects that are not a Potential instances gives an error
+    with pytest.raises(potential.PotentialError) as excinfo:
+        _ = _isNonAxi([3, 4, 45])
+    # Check that using an a actual potential w/o nonaxi attribute gives an error
+    pot = potential.Potential()
+    del pot.isNonAxi
+    with pytest.raises(potential.PotentialError) as excinfo:
+        _ = _isNonAxi(pot)
+    with pytest.raises(potential.PotentialError) as excinfo:
+        _ = _isNonAxi([pot, pot, pot])
+
+
 def test_SoftenedNeedleBarPotential_density():
     # Some simple tests of the density of the SoftenedNeedleBarPotential
     # For a spherical softening kernel, density should be symmetric to y/z


### PR DESCRIPTION
See discussions in #365

This change aligns the Python implementation of the leapfrog integrator with the C code by combining the drift calculations to reduce computations in the inner integration loop.

Also, the checks for non-axisymmetric and dissipative Potentials are moved from the internal (e.g., _evaluateRforces) to public (e.g., evaluateRforces) methods in order to avoid calling the checks at every loop iteration.

Provides a ~50% reduction in computation time.

Profiling `main` using [this script](https://gist.github.com/jamesgrimmett/0efa7638a13ffcfbc9dea424c5220e75)
```
         55743016 function calls (49982710 primitive calls) in 27.938 seconds

   Ordered by: cumulative time
   List reduced from 99 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   27.938   27.938 Orbits.py:1338(integrate)
        1    0.000    0.000   27.938   27.938 integrateFullOrbit.py:714(integrateFullOrbit)
        1    0.001    0.001   27.938   27.938 integrateFullOrbit.py:766(integrate_for_map)
        1    0.415    0.415   27.937   27.937 symplecticode.py:38(leapfrog)
   320015    1.003    0.000   26.539    0.000 integrateFullOrbit.py:1236(_rectForce)
   320015    0.467    0.000   10.233    0.000 Potential.py:2257(_evaluatezforces)
   320015    0.477    0.000   10.107    0.000 Potential.py:2123(_evaluateRforces)
```

Profiling this branch;
```
         15121126 function calls (15121090 primitive calls) in 13.951 seconds

   Ordered by: cumulative time
   List reduced from 98 to 50 due to restriction <50>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   13.951   13.951 Orbits.py:1338(integrate)
        1    0.000    0.000   13.951   13.951 integrateFullOrbit.py:714(integrateFullOrbit)
        1    0.001    0.001   13.951   13.951 integrateFullOrbit.py:766(integrate_for_map)
        1    0.296    0.296   13.950   13.950 symplecticode.py:38(leapfrog)
   320015    0.937    0.000   12.978    0.000 integrateFullOrbit.py:1236(_rectForce)
   640030    6.469    0.000    7.289    0.000 PowerSphericalPotentialwCutoff.py:205(_mass)
   320015    0.313    0.000    5.725    0.000 Potential.py:2267(_evaluatezforces)
   320015    0.304    0.000    5.458    0.000 Potential.py:2133(_evaluateRforces)
```