### PR TITLE
Fix scipy 1.15 deprecations: removal of ``vectorize1`` and ``lpmn`` --> ``assoc_legendre_p_all``

### DIFF
--- a/galpy/util/quadpack.py
+++ b/galpy/util/quadpack.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy
 from scipy.integrate import fixed_quad, quad
-from scipy.integrate._quadrature import vectorize1
 
 
 def _infunc(x, func, gfun, hfun, more_args, epsrel, epsabs):


### PR DESCRIPTION
We didn't need ``vectorize1`` anyway! Argh!