### PR TITLE
Swap gsl_gamma_inc with gsl_gamma_inc_P for mass calculation

### DIFF
--- a/galpy/potential/potential_c_ext/PowerSphericalPotentialwCutoff.c
+++ b/galpy/potential/potential_c_ext/PowerSphericalPotentialwCutoff.c
@@ -7,7 +7,7 @@
 //PowerSphericalPotentialwCutoff
 //3  arguments: amp, alpha, rc
 double mass(double r2,double alpha, double rc){
-  return 2. * M_PI * pow ( rc , 3. - alpha ) * ( gsl_sf_gamma ( 1.5 - 0.5 * alpha ) - gsl_sf_gamma_inc ( 1.5 - 0.5 * alpha , r2 / rc / rc ) );
+  return 2. * M_PI * pow ( rc , 3. - alpha ) * ( gsl_sf_gamma ( 1.5 - 0.5 * alpha ) * gsl_sf_gamma_inc_P ( 1.5 - 0.5 * alpha , r2 / rc / rc ) );
 }
 double PowerSphericalPotentialwCutoffEval(double R,double Z, double phi,
 					  double t,


### PR DESCRIPTION
Hi @jobovy, here is the change that we discussed in (i) of #701 

For test cases, I've used integrations of the Sun over 1000Gyr (in order to get a decent sample size for profiling) and MW Globular clusters over 10Gyr;

```
        ts = np.linspace(0,1000,100001)*u.Gyr
        sun = Orbit()
        t = time.time()
        sun.integrate(ts, mw_pot, method="symplec4_c")
        print(f"Duration Sun: {time.time() - t}")

        ts = np.linspace(0,10,1001)*u.Gyr
        o = Orbit.from_name('MW globular clusters')
        t = time.time()
        o.integrate(ts, mw_pot, method="symplec4_c")
        print(f"Duration MW globular clusters: {time.time() - t}")
```

With the current `main` branch (using `gsl_sf_gamma_inc`), I find
```
    Duration Sun: 9.844529867172241
    Duration MW globular clusters: 6.79642391204834
```

and with this change (using `gsl_sf_gamma_inc_P`), I find
```
    Duration Sun: 7.059226989746094
    Duration MW globular clusters: 1.4422881603240967
```

So, just less than a 30% improvement for the Sun, and 80% for the collection of MW Globular Clusters, on my machine.

I also took a look at trying out `gsl_sf_gamma * (1 - gsl_sf_gamma_inc_Q)`, but found very similar runtime to with current `main`;
```
    Duration Sun: 9.121899127960205
    Duration MW globular clusters: 6.627019882202148
```

It looks like many of the calls to the gsl P function are diverted to a variation of the Q function (`gamma_inc_Q_large_x`), but if I call the `gsl_sf_gamma_inc_Q` directly we mostly end up in `gamma_inc_Q_CF => gamma_inc_F_CF` (the same place we end up via `gsl_sf_gamma_inc`), which is interesting... Looking at the gsl code, to filter between `gamma_inc_Q_CF` and `gamma_inc_Q_large_x`, the P function considers "large_x" as `x => 5*a`, whereas the Q function uses `x > 1.0e+06`. Anyway, it looks like we end up in the most efficient function for typical orbits by calling the P function.
For reference, I've included some of the callmaps obtained by running with `gperftools` profiler below.

### gsl_sf_gamma - gsl_sf_gamma_inc
<img width="915" alt="original2_sun" src="https://github.com/user-attachments/assets/70458158-0a1b-46c6-acc7-03e254d214fd" />


### gsl_sf_gamma * gsl_sf_gamma_inc_P
<img width="1368" alt="gsl_P_sun" src="https://github.com/user-attachments/assets/f5f28a00-d040-451c-9c88-5b06fec5338f" />


### gsl_sf_gamma * (1 - gsl_sf_gamma_inc_Q)
<img width="1090" alt="gsl_Q_sun" src="https://github.com/user-attachments/assets/3598ed5e-c02f-4b0f-a87f-eb52a5320d2e" />




