### PR TITLE
Implement caching of the mass for the PowerSphericalPotentialwCutoff potential

### DIFF
--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -138,6 +138,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False):
         elif isinstance(p, potential.PowerSphericalPotentialwCutoff):
             pot_type.append(15)
             pot_args.extend([p._amp, p.alpha, p.rc])
+            pot_args.extend([0.0, 0.0])  # for caching
         elif isinstance(p, potential.MN3ExponentialDiskPotential):
             # Three Miyamoto-Nagai disks
             npot += 2

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -234,7 +234,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
-    case 15: //PowerSphericalwCutoffPotential, 3 arguments
+    case 15: //PowerSphericalwCutoffPotential, 5 arguments
       potentialArgs->potentialEval= &PowerSphericalPotentialwCutoffEval;
       potentialArgs->Rforce= &PowerSphericalPotentialwCutoffRforce;
       potentialArgs->zforce= &PowerSphericalPotentialwCutoffzforce;
@@ -243,7 +243,7 @@ void parse_leapFuncArgs_Full(int npot,
       //potentialArgs->R2deriv= &PowerSphericalPotentialR2deriv;
       //potentialArgs->planarphi2deriv= &ZeroForce;
       //potentialArgs->planarRphideriv= &ZeroForce;
-      potentialArgs->nargs= 3;
+      potentialArgs->nargs= 5;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/potential/potential_c_ext/PowerSphericalPotentialwCutoff.c
+++ b/galpy/potential/potential_c_ext/PowerSphericalPotentialwCutoff.c
@@ -5,7 +5,7 @@
 #define M_PI 3.14159265358979323846
 #endif
 //PowerSphericalPotentialwCutoff
-//3  arguments: amp, alpha, rc
+//5  arguments: amp, alpha, rc, cached_r2, cached_force
 double mass(double r2,double alpha, double rc){
   return 2. * M_PI * pow ( rc , 3. - alpha ) * ( gsl_sf_gamma ( 1.5 - 0.5 * alpha ) * gsl_sf_gamma_inc_P ( 1.5 - 0.5 * alpha , r2 / rc / rc ) );
 }
@@ -27,13 +27,22 @@ double PowerSphericalPotentialwCutoffRforce(double R,double Z, double phi,
 					    struct potentialArg * potentialArgs){
   double * args= potentialArgs->args;
   //Get args
-  double amp= *args++;
-  double alpha= *args++;
-  double rc= *args;
+  double amp= *args;
+  double alpha= *(args + 1);
+  double rc= *(args + 2);
   //Radius
   double r2= R*R+Z*Z;
+  double force;
+  if ( r2 == *(args + 3) ) {
+      force= *(args + 4);
+  } else {
+      force= -amp * mass(r2, alpha, rc) / pow(r2,1.5);
+      //Setup caching
+      *(args + 3)= r2;
+      *(args + 4)= force;
+  }
   //Calculate Rforce
-  return - amp * mass (r2,alpha,rc) * R / pow(r2,1.5);
+  return force * R;
 }
 double PowerSphericalPotentialwCutoffPlanarRforce(double R,double phi,
 						  double t,
@@ -53,13 +62,22 @@ double PowerSphericalPotentialwCutoffzforce(double R,double Z,double phi,
 					    struct potentialArg * potentialArgs){
   double * args= potentialArgs->args;
   //Get args
-  double amp= *args++;
-  double alpha= *args++;
-  double rc= *args;
+  double amp= *args;
+  double alpha= *(args + 1);
+  double rc= *(args + 2);
   //Radius
   double r2= R*R+Z*Z;
-  //Calculate Rforce
-  return - amp * mass (r2,alpha,rc) * Z / pow(r2,1.5);
+  double force;
+  if ( r2 == *(args + 3) ) {
+      force= *(args + 4);
+  } else {
+      force= -amp * mass(r2, alpha, rc) / pow(r2,1.5);
+      //Setup caching
+      *(args + 3)= r2;
+      *(args + 4)= force;
+  }
+  //Calculate zforce
+  return force * Z;
 }
 double PowerSphericalPotentialwCutoffPlanarR2deriv(double R,double phi,
 						   double t,


### PR DESCRIPTION
Hi @jobovy, here are the second set of changes to close off https://github.com/jobovy/galpy/issues/701.

I've taken two different approaches in two commits, happy to rebase this branch to contain whichever you prefer.

In https://github.com/jobovy/galpy/commit/020eb773eb2ad2b7b7e277cf55f331927cee1827 I've implemented the caching of the mass in the `Rforce` and `zforce` functions. I left the Planar functions as-is (including the nargs/potentialArgs) because I don't think there would be any performance benefit from caching in the Planar case, but just let me know if you'd prefer the caching to be included for the Planar functions as well for consistency (or if I'm mistaken about the lack of benefit).

In https://github.com/jobovy/galpy/commit/84da14b4bd885465f86f16bf8e988729650928ff I instead implemented the caching inside of the mass function itself. This requires that the potentialArgs be passed to the mass function, but reduces the duplicate code in each of the calling functions. In this case the caching needs to be set up for any situation that the mass function going to be called, i.e. including the Planar case.

I guess the tradeoff is that first option is potentially more flexible, whereas the second option is a bit tidier and reduces some repetition in the code.

In terms of performance both commits are the same; compared to the `main` branch I see a 25% performance improvement. E.g., using this simple test case;

```
    ts = np.linspace(0,1000,100001)*u.Gyr
    sun = Orbit()
    t = time.time()
    sun.integrate(ts, MWPotential2014, method="symplec4_c")
    print(f"Duration: {time.time() - t}")
```

With the current `main` branch I get
```
Duration: 7.169827222824097
```
and with this change I get
```
Duration: 5.4198899269104
```

Finally I haven't implemented any caching for the Python integrator, but am happy to include that here if you like (on that front, [functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) is an interesting option).