### PR TITLE
Switch to controlling compilation options through environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,9 +295,13 @@ jobs:
          fi
     - name: Install package
       if: matrix.os == 'ubuntu-latest'
+      env:
+        GALPY_COMPILE_NO_OPENMP: 1
+        GALPY_COMPILE_COVERAGE: 1
+        GALPY_COMPILE_SINGLE_EXT: 1
       run: |
-        python setup.py build_ext --no-openmp --coverage --single_ext --inplace
-        python setup.py develop --single_ext
+        python -m pip install --no-build-isolation -ve .
+        python setup.py build_ext --inplace
     - name: Install package
       if: matrix.os == 'macos-13'
       run: |

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -536,14 +536,14 @@ I'm having issues with OpenMP
 
 galpy uses `OpenMP <http://www.openmp.org/>`_ to parallelize various
 of the computations done in C. galpy can be installed without OpenMP
-by specifying the option ``--no-openmp`` when running the installation
-commands above::
+by setting the environment variable ``GALPY_COMPILE_NO_OPENMP=1`` before
+running the installation commands above::
 
-	   pip install . --install-option="--no-openmp"
+	   export GALPY_COMPILE_NO_OPENMP=1 && pip install .
 
 or when using pip as follows::
 
-    pip install -U --no-deps --install-option="--no-openmp" git+https://github.com/jobovy/galpy.git#egg=galpy
+    export GALPY_COMPILE_NO_OPENMP=1 && pip install -U --no-deps git+https://github.com/jobovy/galpy.git#egg=galpy
 
 This might be useful if one is using the
 ``clang`` compiler, which is the new default on macs with OS X (>=
@@ -558,7 +558,7 @@ If you get these errors, you can use the commands given above to
 install without OpenMP, or specify to use ``gcc`` by specifying the
 ``CC`` and ``LDSHARED`` environment variables to use ``gcc``. Note that recent
 versions of ``galpy`` attempt to automatically detect OpenMP support, so using
-``--no-openmp`` should not typically be necessary even on Macs.
+``GALPY_COMPILE_NO_OPENMP`` should not typically be necessary even on Macs.
 
 .. _configfile:
 


### PR DESCRIPTION
This is more compatible with modern pip/setup.py. Build/test infrastructure still need ``python setup.py build_ext --inplace`` for C coverage.