### PR TITLE
Allow TwoPowerSphericalPotental to be evaluated at r=0

### DIFF
--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -108,7 +108,9 @@ class TwoPowerSphericalPotential(Potential):
                 / (self.alpha - 2.0)
             )
         else:
-            r = numpy.sqrt(R**2.0 + z**2.0) + 1e-11  # avoid division by zero and numerical instability of the hyp2f1 function
+            r = (
+                numpy.sqrt(R**2.0 + z**2.0) + 1e-11
+            )  # avoid division by zero and numerical instability of the hyp2f1 function
             return (
                 special.gamma(self.beta - 3.0)
                 * (

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -40,7 +40,7 @@ def test_normalize_potential():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialPowerSphericalPotential")
     pots.append("specialFlattenedPowerPotential")
@@ -140,7 +140,7 @@ def test_forceAsDeriv_potential():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -394,7 +394,7 @@ def test_2ndDeriv_potential():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -788,7 +788,7 @@ def test_poisson_potential():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -1097,7 +1097,7 @@ def test_evaluateAndDerivs_potential():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -1356,7 +1356,7 @@ def test_amp_mult_divide():
     pots.append("HernquistTwoPowerSphericalPotential")
     pots.append("JaffeTwoPowerSphericalPotential")
     pots.append("NFWTwoPowerSphericalPotential")
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -1812,13 +1812,13 @@ def test_potential_at_zero():
             and not "toVertical" in p
         )
     ]
-    pots.append('specialTwoPowerSphericalPotential')
-    pots.append('DehnenTwoPowerSphericalPotential')
-    pots.append('DehnenCoreTwoPowerSphericalPotential')
-    pots.append('HernquistTwoPowerSphericalPotential')
-    pots.append('JaffeTwoPowerSphericalPotential')
-    pots.append('NFWTwoPowerSphericalPotential')
-    pots.append('CoreNFWTwoPowerSphericalPotential')
+    pots.append("specialTwoPowerSphericalPotential")
+    pots.append("DehnenTwoPowerSphericalPotential")
+    pots.append("DehnenCoreTwoPowerSphericalPotential")
+    pots.append("HernquistTwoPowerSphericalPotential")
+    pots.append("JaffeTwoPowerSphericalPotential")
+    pots.append("NFWTwoPowerSphericalPotential")
+    pots.append("CoreNFWTwoPowerSphericalPotential")
     pots.append("specialMiyamotoNagaiPotential")
     pots.append("specialMN3ExponentialDiskPotentialPD")
     pots.append("specialMN3ExponentialDiskPotentialSECH")
@@ -8315,6 +8315,7 @@ class NFWTwoPowerSphericalPotential(TwoPowerSphericalPotential):
     def __init__(self):
         TwoPowerSphericalPotential.__init__(self, amp=1.0, a=5.0, alpha=1.0, beta=3.0)
         return None
+
 
 class CoreNFWTwoPowerSphericalPotential(TwoPowerSphericalPotential):
     def __init__(self):


### PR DESCRIPTION
 For general values of alpha and beta; fixes #728.