### PR TITLE
Ignore Pillow 'mode' parameter deprecation warning

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -272,5 +272,6 @@ jobs:
         pip install pytest-cov
         # Turn astropy deprecation warnings into errors as well if astropy
         if $REQUIRES_ASTROPY; then export PYTEST_ADDOPTS="-W error::astropy.utils.exceptions.AstropyDeprecationWarning"; else export PYTEST_ADDOPTS=""; fi
+        export PILLOW_DEPRECATION="-W ignore:\"'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)\":DeprecationWarning"
         # eval necessary for -k 'not ...' in TEST_FILES
-        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"
+        eval "pytest -W error::DeprecationWarning -W error::FutureWarning $PYTEST_ADDOPTS $PILLOW_DEPRECATION -v $TEST_FILES --cov galpy --cov-config .coveragerc --disable-pytest-warnings --durations=0"


### PR DESCRIPTION
This warning is encountered somewhere in matplotlib, so is not our problem to deal with.