### PR TITLE
Add Python 3.14 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,6 +41,7 @@ jobs:
         - ["cp311","3.11"]
         - ["cp312","3.12"]
         - ["cp313","3.13"]
+        - ["cp314","3.14"]
     steps:
       - uses: actions/checkout@v5
       - name: Install GSL (Windows / Mac OS x86_64)
@@ -104,6 +105,7 @@ jobs:
             - ["cp311","3.11"]
             - ["cp312","3.12"]
             - ["cp313","3.13"]
+            - ["cp314","3.14"]
     steps:
       - uses: actions/checkout@v5
       - run: mkdir wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Environment :: WebAssembly :: Emscripten",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
Because Python 3.14 seems to be working (see https://github.com/jobovy/galpy/pull/750), this PR adds wheels for Python 3.14.