### PR TITLE
Fix use of relative tolerance parameter in some of the C integrators

### DIFF
--- a/galpy/util/bovy_rk.c
+++ b/galpy/util/bovy_rk.c
@@ -345,13 +345,13 @@ double rk4_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
   double *scale= (double *) malloc ( dim * sizeof(double) );
   int ii;
   //find maximum values
-  max_val= fabs(*yo);
+  max_val= log(fabs(*yo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(yo+ii)) > max_val )
-      max_val= fabs(*(yo+ii));
+    if ( log(fabs(*(yo+ii))) > max_val )
+      max_val= log(fabs(*(yo+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val);
-  double s= log(exp(atol-c)+exp(rtol*max_val-c))+c;
+  double c= fmax(atol, rtol + max_val);
+  double s= log(exp(atol-c)+exp(rtol + max_val-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii)= s;
   //find good dt
   //dt*= 2.;
@@ -418,13 +418,13 @@ double rk6_estimate_step(void (*func)(double t, double *y, double *a,int nargs, 
   double *scale= (double *) malloc ( dim * sizeof(double) );
   int ii;
   //find maximum values
-  max_val= fabs(*yo);
+  max_val= log(fabs(*yo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(yo+ii)) > max_val )
-      max_val= fabs(*(yo+ii));
+    if ( log(fabs(*(yo+ii))) > max_val )
+      max_val= log(fabs(*(yo+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val);
-  double s= log(exp(atol-c)+exp(rtol*max_val-c))+c;
+  double c= fmax(atol, rtol + max_val);
+  double s= log(exp(atol-c)+exp(rtol + max_val-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii)= s;
   //find good dt
   //dt*= 2.;
@@ -725,13 +725,13 @@ double bovy_dopr54_actualstep(void (*func)(double t, double *y, double *a,int na
   for (ii=0; ii < dim; ii++) *(yerr+ii) += be7 * dt * *(a+ii);
   //yn1 is proposed new value
   //find maximum values
-  double max_val= fabs(*yo);
+  double max_val= log(fabs(*yo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(yo+ii)) > max_val )
-      max_val= fabs(*(yo+ii));
+    if ( log(fabs(*(yo+ii))) > max_val )
+      max_val= log(fabs(*(yo+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val);
-  double s= log(exp(atol-c)+exp(rtol*max_val-c))+c;
+  double c= fmax(atol, rtol + max_val);
+  double s= log(exp(atol-c)+exp(rtol + max_val-c))+c;
   //Norm
   double err= 0.;
   for (ii=0; ii < dim; ii++)

--- a/galpy/util/bovy_symplecticode.c
+++ b/galpy/util/bovy_symplecticode.c
@@ -578,20 +578,20 @@ double leapfrog_estimate_step(void (*func)(double t, double *q, double *a,int na
   double *scale= (double *) malloc ( 2 * dim * sizeof(double) );
   int ii;
   //find maximum values
-  max_val_q= fabs(*qo);
+  max_val_q= log(fabs(*qo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(qo+ii)) > max_val_q )
-      max_val_q= fabs(*(qo+ii));
-  max_val_p= fabs(*po);
+    if ( log(fabs(*(qo+ii))) > max_val_q )
+      max_val_q= log(fabs(*(qo+ii)));
+  max_val_p= log(fabs(*po));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(po+ii)) > max_val_p )
-      max_val_p= fabs(*(po+ii));
+    if ( log(fabs(*(po+ii))) > max_val_p )
+      max_val_p= log(fabs(*(po+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val_q);
-  double s= log(exp(atol-c)+exp(rtol*max_val_q-c))+c;
+  double c= fmax(atol, rtol + max_val_q);
+  double s= log(exp(atol-c)+exp(rtol + max_val_q-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii)= s;
-  c= fmax(atol, rtol * max_val_p);
-  s= log(exp(atol-c)+exp(rtol*max_val_p-c))+c;
+  c= fmax(atol, rtol + max_val_p);
+  s= log(exp(atol-c)+exp(rtol + max_val_p-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii+dim)= s;
   //find good dt
   dt*= 2.;
@@ -663,20 +663,20 @@ double symplec4_estimate_step(void (*func)(double t, double *q, double *a,int na
   double *scale= (double *) malloc ( 2 * dim * sizeof(double) );
   int ii;
   //find maximum values
-  max_val_q= fabs(*qo);
+  max_val_q= log(fabs(*qo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(qo+ii)) > max_val_q )
-      max_val_q= fabs(*(qo+ii));
-  max_val_p= fabs(*po);
+    if ( log(fabs(*(qo+ii))) > max_val_q )
+      max_val_q= log(fabs(*(qo+ii)));
+  max_val_p= log(fabs(*po));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(po+ii)) > max_val_p )
-      max_val_p= fabs(*(po+ii));
+    if ( log(fabs(*(po+ii))) > max_val_p )
+      max_val_p= log(fabs(*(po+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val_q);
-  double s= log(exp(atol-c)+exp(rtol*max_val_q-c))+c;
+  double c= fmax(atol, rtol + max_val_q);
+  double s= log(exp(atol-c)+exp(rtol + max_val_q-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii)= s;
-  c= fmax(atol, rtol * max_val_p);
-  s= log(exp(atol-c)+exp(rtol*max_val_p-c))+c;
+  c= fmax(atol, rtol + max_val_p);
+  s= log(exp(atol-c)+exp(rtol + max_val_p-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii+dim)= s;
   //find good dt
   dt*= 2.;
@@ -816,20 +816,20 @@ double symplec6_estimate_step(void (*func)(double t, double *q, double *a,int na
   double *scale= (double *) malloc ( 2 * dim * sizeof(double) );
   int ii;
   //find maximum values
-  max_val_q= fabs(*qo);
+  max_val_q= log(fabs(*qo));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(qo+ii)) > max_val_q )
-      max_val_q= fabs(*(qo+ii));
-  max_val_p= fabs(*po);
+    if ( log(fabs(*(qo+ii))) > max_val_q )
+      max_val_q= log(fabs(*(qo+ii)));
+  max_val_p= log(fabs(*po));
   for (ii=1; ii < dim; ii++)
-    if ( fabs(*(po+ii)) > max_val_p )
-      max_val_p= fabs(*(po+ii));
+    if ( log(fabs(*(po+ii))) > max_val_p )
+      max_val_p= log(fabs(*(po+ii)));
   //set up scale
-  double c= fmax(atol, rtol * max_val_q);
-  double s= log(exp(atol-c)+exp(rtol*max_val_q-c))+c;
+  double c= fmax(atol, rtol + max_val_q);
+  double s= log(exp(atol-c)+exp(rtol + max_val_q-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii)= s;
-  c= fmax(atol, rtol * max_val_p);
-  s= log(exp(atol-c)+exp(rtol*max_val_p-c))+c;
+  c= fmax(atol, rtol + max_val_p);
+  s= log(exp(atol-c)+exp(rtol + max_val_p-c))+c;
   for (ii=0; ii < dim; ii++) *(scale+ii+dim)= s;
   //find good dt
   dt*= 2.;

--- a/tests/test_evolveddiskdf.py
+++ b/tests/test_evolveddiskdf.py
@@ -1290,7 +1290,7 @@ def test_call_marginalizevlos():
                 nsigma=4,
             )
         )
-        < 10.0**-3.5
+        < 10.0**-2.5
     ), "diskdf call w/ marginalizeVlos does not work"
     return None
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -765,7 +765,8 @@ def test_liouville_planar():
     # tolerances in log10
     tol = {}
     tol["default"] = -8.0
-    tol["KeplerPotential"] = -7.0  # more difficult
+    tol["KeplerPotential"] = -6.5  # more difficult
+    tol["MN3ExponentialDiskPotential"] = -7.0  # more difficult
     tol["NFWPotential"] = -6.0  # more difficult for rk4_c, only one that does this
     tol["TriaxialNFWPotential"] = -4.0  # more difficult
     tol["triaxialLogarithmicHaloPotential"] = -7.0  # more difficult


### PR DESCRIPTION
`rtol` is passed to C as log(rtol), but wasn't entirely correctly used as such in the C code (but it was overall correct and the impact of this bug was very small)