### PR TITLE
Correctly record SCF potential type for handling its data in C

### DIFF
--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -670,6 +670,7 @@ void parse_leapFuncArgs_Full(int npot,
     int setupMovingObjectSplines = *(*pot_type-1) == -6 ? 1 : 0;
     // Need to set up the same sigma_r spline for both Chandrasekhar and FDM dynamical friction
     int setupChandrasekharDynamicalFrictionSplines = (*(*pot_type-1) == -7 || *(*pot_type-1) == -11) ? 1 : 0;
+    int initSCFData = *(*pot_type-1) == 24 ? 1 : 0;
     if ( *(*pot_type-1) < 0 ) { // Parse wrapped potential for wrappers
       potentialArgs->nwrapped= (int) *(*pot_args)++;
       potentialArgs->wrappedPotentialArg= \
@@ -696,7 +697,7 @@ void parse_leapFuncArgs_Full(int npot,
       (*pot_tfuncs)+= potentialArgs->ntfuncs;
     }
     // Initialize potential-specific pre-computed data
-    if ( *(*pot_type-1) == 24 ) // SCFPotential
+    if ( initSCFData )
       initSCFPotentialArgs(potentialArgs);
     potentialArgs++;
   }

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -621,6 +621,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
 
     }
     int setupSplines = *(*pot_type-1) == -6 ? 1 : 0;
+    int initSCFData = *(*pot_type-1) == 24 ? 1 : 0;
     if ( *(*pot_type-1) < 0) { // Parse wrapped potential for wrappers
       potentialArgs->nwrapped= (int) *(*pot_args)++;
       potentialArgs->wrappedPotentialArg= \
@@ -644,7 +645,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       (*pot_tfuncs)+= potentialArgs->ntfuncs;
     }
     // Initialize potential-specific pre-computed data
-    if ( *(*pot_type-1) == 24 ) // SCFPotential
+    if ( initSCFData )
       initSCFPotentialArgs(potentialArgs);
     potentialArgs++;
   }


### PR DESCRIPTION
Small tweak to make sure the code is as robust as possible. No real bug here, as ``SCFPotential`` isn't a wrapper, so its ``pot_type`` is never incremented before the end of the potential-argument-initialization function, but this change just to be sure that the potential type is correctly used.