### PR TITLE
Add ``DiskMultipoleExpansionPotential``

### DIFF
--- a/doc/source/potential.rst
+++ b/doc/source/potential.rst
@@ -590,7 +590,7 @@ To then initialize an ``SCFPotential`` from these coefficients, do
 
 >>> sp= SCFPotential(Acos=Acos,Asin=Asin,a=2.)
 
-To use the SCF method for disky potentials, we use the trick from
+To use the SCF or multipole methods for disky potentials, we use the trick from
 `Kuijken & Dubinski (1995)
 <http://adsabs.harvard.edu/abs/1995MNRAS.277.1341K>`__. This trick works by approximating the disk density as :math:`\rho_{\mathrm{disk}}(R,\phi,z) \approx \sum_i \Sigma_i(R)\,h_i(z)`, with :math:`h_i(z) = \mathrm{d}^2 H(z) / \mathrm{d} z^2` and searching for solutions of the form
 
@@ -598,7 +598,13 @@ To use the SCF method for disky potentials, we use the trick from
 
        \Phi(R,\phi,z = \Phi_{\mathrm{ME}}(R,\phi,z) + 4\pi G\sum_i \Sigma_i(r)\,H_i(z)\,,
 
-where :math:`r` is the spherical radius :math:`r^2 = R^2+z^2`. The density which gives rise to :math:`\Phi_{\mathrm{ME}}(R,\phi,z)` is not strongly confined to a plane when :math:`\rho_{\mathrm{disk}}(R,\phi,z) \approx \sum_i \Sigma_i(R)\,h_i(z)` and can be obtained using the SCF basis-function-expansion technique discussed above. See the documentation of the :ref:`DiskSCFPotential <disk_scf_potential>` class for more details on this procedure.
+where :math:`r` is the spherical radius :math:`r^2 = R^2+z^2`. The density which gives
+rise to :math:`\Phi_{\mathrm{ME}}(R,\phi,z)` is not strongly confined to a plane when
+:math:`\rho_{\mathrm{disk}}(R,\phi,z) \approx \sum_i \Sigma_i(R)\,h_i(z)` and can be
+obtained using either the SCF basis-function-expansion or multipole expansion techniques
+discussed above. See the documentation of the :ref:`DiskSCFPotential <disk_scf_potential>`
+and :ref:`DiskMultipolePotential <disk_multipole_potential>` classes for more details
+on this procedure.
 
 As an example, consider a double-exponential disk, which we can
 compare to the ``DoubleExponentialDiskPotential`` implementation
@@ -650,7 +656,7 @@ The orbits diverge slightly because the potentials are not quite the
 same, but have very similar properties otherwise (peri- and
 apogalacticons, eccentricity, ...). By increasing the order of the SCF
 approximation, the potential can be gotten closer to the target
-density. Note that orbit integration in the ``DiskSCFPotential`` is
+density. Note that orbit integration in the ``DiskSCFPotential`` (and ``DiskMultipoleExpansionPotential``) is
 much faster than that of the ``DoubleExponentialDisk`` potential
 
 >>> %%timeit
@@ -663,8 +669,10 @@ and
 o.integrate(ts,dscfp)
 # 57.2 ms ± 99.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
-The :ref:`SCFPotential <scf_potential>` and :ref:`DiskSCFPotential
-<disk_scf_potential>` can be used wherever general potentials can be
+The :ref:`SCFPotential <scf_potential>`, :ref:`DiskSCFPotential
+<disk_scf_potential>`, :ref:`MultipoleExpansionPotential <multipole_potential>`
+and :ref:`DiskMultipoleExpansionPotential
+<disk_multipole_potential>` can be used wherever general potentials can be
 used in galpy.
 
 The potential of N-body simulations

--- a/doc/source/reference/potential.rst
+++ b/doc/source/reference/potential.rst
@@ -267,6 +267,7 @@ General Poisson solvers for disks and halos
 .. toctree::
    :maxdepth: 1
 
+   potentialdiskmultipole.rst
    potentialmultipole.rst
    potentialdiskscf.rst
    potentialscf.rst

--- a/doc/source/reference/potentialdiskmultipole.rst
+++ b/doc/source/reference/potentialdiskmultipole.rst
@@ -1,0 +1,7 @@
+.. _disk_multipole_potential:
+
+Disk potential using multipole expansion
+========================================
+
+.. autoclass:: galpy.potential.DiskMultipoleExpansionPotential
+   :members: __init__

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -18,7 +18,9 @@ from ..util._optional_deps import _TQDM_LOADED
 from ..util.leung_dop853 import dop853
 from ..util.multi import parallel_map
 from .integratePlanarOrbit import (
+    _parse_disk_approx_pairs,
     _parse_integrator,
+    _parse_multipole_expansion_pot,
     _parse_scf_pot,
     _parse_tol,
     _prep_tfuncs,
@@ -258,43 +260,33 @@ def _parse_pot(pot, potforactions=False, potfortorus=False):
             pot_type.append(25)
             pot_args.extend([p._amp, p._a, p._b, p._c2, p._pa, p._omegab])
             pot_args.extend([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # for caching
+        elif isinstance(p, potential.DiskMultipoleExpansionPotential):
+            # Need to pull this apart into: (a) MultipoleExpansion part,
+            # (b) constituent [Sigma_i,h_i] parts
+            # (a) MultipoleExpansion, multiply in any add'l amp
+            pt, pa = _parse_multipole_expansion_pot(p._me, extra_amp=p._amp)
+            pot_type.append(pt)
+            pot_args.extend(pa)
+            # (b) constituent [Sigma_i,h_i] parts
+            dpts, dpa = _parse_disk_approx_pairs(p, extra_amp=p._amp)
+            for dpt in dpts:
+                npot += 1
+                pot_type.append(dpt)
+            pot_args.extend(dpa)
         elif isinstance(p, potential.DiskSCFPotential):
             # Need to pull this apart into: (a) SCF part, (b) constituent
             # [Sigma_i,h_i] parts
             # (a) SCF, multiply in any add'l amp
-            pt, pa, ptf = _parse_scf_pot(p._scf, extra_amp=p._amp)
+            pt, pa, ptf = _parse_scf_pot(p._me, extra_amp=p._amp)
             pot_type.append(pt)
             pot_args.extend(pa)
             pot_tfuncs.extend(ptf)
             # (b) constituent [Sigma_i,h_i] parts
-            for Sigma, hz in zip(p._Sigma_dict, p._hz_dict):
+            dpts, dpa = _parse_disk_approx_pairs(p, extra_amp=p._amp)
+            for dpt in dpts:
                 npot += 1
-                pot_type.append(26)
-                stype = Sigma.get("type", "exp")
-                if stype == "exp" and not "Rhole" in Sigma:
-                    pot_args.extend(
-                        [
-                            3,
-                            0,
-                            4.0 * numpy.pi * Sigma.get("amp", 1.0) * p._amp,
-                            Sigma.get("h", 1.0 / 3.0),
-                        ]
-                    )
-                elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
-                    pot_args.extend(
-                        [
-                            4,
-                            1,
-                            4.0 * numpy.pi * Sigma.get("amp", 1.0) * p._amp,
-                            Sigma.get("h", 1.0 / 3.0),
-                            Sigma.get("Rhole", 0.5),
-                        ]
-                    )
-                hztype = hz.get("type", "exp")
-                if hztype == "exp":
-                    pot_args.extend([0, hz.get("h", 0.0375)])
-                elif hztype == "sech2":
-                    pot_args.extend([1, hz.get("h", 0.0375)])
+                pot_type.append(dpt)
+            pot_args.extend(dpa)
         elif isinstance(p, potential.SpiralArmsPotential):
             pot_type.append(27)
             pot_args.extend(

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -346,43 +346,36 @@ def _parse_pot(pot):
         elif (
             isinstance(p, planarPotentialFromFullPotential)
             or isinstance(p, planarPotentialFromRZPotential)
+        ) and isinstance(p._Pot, potential.DiskMultipoleExpansionPotential):
+            # Need to pull this apart into: (a) MultipoleExpansion part,
+            # (b) constituent [Sigma_i,h_i] parts
+            # (a) MultipoleExpansion, multiply in any add'l amp
+            pt, pa = _parse_multipole_expansion_pot(p._Pot._me, extra_amp=p._Pot._amp)
+            pot_type.append(pt)
+            pot_args.extend(pa)
+            # (b) constituent [Sigma_i,h_i] parts
+            dpts, dpa = _parse_disk_approx_pairs(p._Pot, extra_amp=p._Pot._amp)
+            for dpt in dpts:
+                npot += 1
+                pot_type.append(dpt)
+            pot_args.extend(dpa)
+        elif (
+            isinstance(p, planarPotentialFromFullPotential)
+            or isinstance(p, planarPotentialFromRZPotential)
         ) and isinstance(p._Pot, potential.DiskSCFPotential):
             # Need to pull this apart into: (a) SCF part, (b) constituent
             # [Sigma_i,h_i] parts
             # (a) SCF, multiply in any add'l amp
-            pt, pa, ptf = _parse_scf_pot(p._Pot._scf, extra_amp=p._Pot._amp)
+            pt, pa, ptf = _parse_scf_pot(p._Pot._me, extra_amp=p._Pot._amp)
             pot_type.append(pt)
             pot_args.extend(pa)
             pot_tfuncs.extend(ptf)
             # (b) constituent [Sigma_i,h_i] parts
-            for Sigma, hz in zip(p._Pot._Sigma_dict, p._Pot._hz_dict):
+            dpts, dpa = _parse_disk_approx_pairs(p._Pot, extra_amp=p._Pot._amp)
+            for dpt in dpts:
                 npot += 1
-                pot_type.append(26)
-                stype = Sigma.get("type", "exp")
-                if stype == "exp" and not "Rhole" in Sigma:
-                    pot_args.extend(
-                        [
-                            3,
-                            0,
-                            4.0 * numpy.pi * Sigma.get("amp", 1.0) * p._Pot._amp,
-                            Sigma.get("h", 1.0 / 3.0),
-                        ]
-                    )
-                elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
-                    pot_args.extend(
-                        [
-                            4,
-                            1,
-                            4.0 * numpy.pi * Sigma.get("amp", 1.0) * p._Pot._amp,
-                            Sigma.get("h", 1.0 / 3.0),
-                            Sigma.get("Rhole", 0.5),
-                        ]
-                    )
-                hztype = hz.get("type", "exp")
-                if hztype == "exp":
-                    pot_args.extend([0, hz.get("h", 0.0375)])
-                elif hztype == "sech2":
-                    pot_args.extend([1, hz.get("h", 0.0375)])
+                pot_type.append(dpt)
+            pot_args.extend(dpa)
         elif isinstance(p, planarPotentialFromFullPotential) and isinstance(
             p._Pot, potential.SpiralArmsPotential
         ):
@@ -729,6 +722,54 @@ def _parse_scf_pot(p, extra_amp=1.0):
         pot_args.extend(extra_amp * p._amp * p._Asin.flatten(order="C"))
     pot_args.extend([-1.0, 0, 0, 0, 0, 0, 0])
     return (24, pot_args, [])  # latter is pot_tfuncs
+
+
+def _parse_multipole_expansion_pot(p, extra_amp=1.0):
+    # Stand-alone parser for MultipoleExpansionPotential, bc reused
+    # for DiskMultipoleExpansionPotential with extra_amp
+    pot_args = potential.MultipoleExpansionPotential._serialize_for_c(p)
+    if extra_amp != 1.0:
+        # amp is at index 4 + Nr (after Nr, L, M, isNonAxi, rgrid[Nr])
+        Nr = int(pot_args[0])
+        pot_args[4 + Nr] *= extra_amp
+    return (44, pot_args)
+
+
+def _parse_disk_approx_pairs(p, extra_amp=1.0, per_pair_suffix=None):
+    # Stand-alone parser for disk approximation [Sigma_i, h_i] pairs used
+    # in the KuijkenDubinskiDiskExpansionPotential-based potentials, bc reused
+    pot_types = []
+    pot_args = []
+    for Sigma, hz in zip(p._Sigma_dict, p._hz_dict):
+        pot_types.append(26)
+        stype = Sigma.get("type", "exp")
+        if stype == "exp" and not "Rhole" in Sigma:
+            pot_args.extend(
+                [
+                    3,
+                    0,
+                    4.0 * numpy.pi * Sigma.get("amp", 1.0) * extra_amp,
+                    Sigma.get("h", 1.0 / 3.0),
+                ]
+            )
+        elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
+            pot_args.extend(
+                [
+                    4,
+                    1,
+                    4.0 * numpy.pi * Sigma.get("amp", 1.0) * extra_amp,
+                    Sigma.get("h", 1.0 / 3.0),
+                    Sigma.get("Rhole", 0.5),
+                ]
+            )
+        hztype = hz.get("type", "exp")
+        if hztype == "exp":
+            pot_args.extend([0, hz.get("h", 0.0375)])
+        elif hztype == "sech2":
+            pot_args.extend([1, hz.get("h", 0.0375)])
+        if per_pair_suffix is not None:
+            pot_args.extend(per_pair_suffix)
+    return pot_types, pot_args
 
 
 def _prep_tfuncs(pot_tfuncs):

--- a/galpy/potential/DiskMultipoleExpansionPotential.py
+++ b/galpy/potential/DiskMultipoleExpansionPotential.py
@@ -1,16 +1,16 @@
 ###############################################################################
-#   DiskSCFPotential.py: Potential expansion for disk+halo potentials
+#   DiskMultipoleExpansionPotential.py: Potential expansion for disk+halo
+#   potentials using MultipoleExpansionPotential
 ###############################################################################
 import numpy
 
-from ..util import conversion
 from .KuijkenDubinskiDiskExpansionPotential import (
     KuijkenDubinskiDiskExpansionPotential,
 )
-from .SCFPotential import SCFPotential
+from .MultipoleExpansionPotential import MultipoleExpansionPotential
 
 
-class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
+class DiskMultipoleExpansionPotential(KuijkenDubinskiDiskExpansionPotential):
     """Class that implements a basis-function-expansion technique for solving the Poisson equation for disk (+halo) systems. We solve the Poisson equation for a given density :math:`\\rho(R,\\phi,z)` by introducing *K* helper function pairs :math:`[\\Sigma_i(R),h_i(z)]`, with :math:`h_i(z) = \\mathrm{d}^2 H(z) / \\mathrm{d} z^2` and search for solutions of the form
 
         .. math::
@@ -23,10 +23,9 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
 
            \\frac{\\Delta \\Phi_{\\mathrm{ME}}(R,\\phi,z)}{4\\pi G} = \\rho(R,\\phi,z) - \\sum_i\\left\\{ \\Sigma_i(r)\\,h_i(z) + \\frac{\\mathrm{d}^2 \\Sigma_i(r)}{\\mathrm{d} r^2}\\,H_i(z)+\\frac{2}{r}\\,\\frac{\\mathrm{d} \\Sigma_i(r)}{\\mathrm{d} r}\\left[H_i(z)+z\\,\\frac{\\mathrm{d}H_i(z)}{\\mathrm{d} z}\\right]\\right\\}\\,.
 
-    We solve this equation by using the :ref:`SCFPotential <scf_potential>` class and methods (:ref:`scf_compute_coeffs_axi <scf_compute_coeffs_axi>` or :ref:`scf_compute_coeffs <scf_compute_coeffs>` depending on whether :math:`\\rho(R,\\phi,z)` is axisymmetric or not). This technique works very well if the disk portion of the potential can be exactly written as :math:`\\rho_{\\mathrm{disk}} = \\sum_i \\Sigma_i(R)\\,h_i(z)`, because the effective density on the right-hand side of this new Poisson equation is then not 'disky' and can be well represented using spherical harmonics. But the technique is general and can be used to compute the potential of any disk+halo potential; the closer the disk is to :math:`\\rho_{\\mathrm{disk}} \\approx \\sum_i \\Sigma_i(R)\\,h_i(z)`, the better the technique works.
+    We solve this equation by using the :ref:`MultipoleExpansionPotential <multipole_expansion_potential>` class. This technique works very well if the disk portion of the potential can be exactly written as :math:`\\rho_{\\mathrm{disk}} = \\sum_i \\Sigma_i(R)\\,h_i(z)`, because the effective density on the right-hand side of this new Poisson equation is then not 'disky' and can be well represented using spherical harmonics. But the technique is general and can be used to compute the potential of any disk+halo potential; the closer the disk is to :math:`\\rho_{\\mathrm{disk}} \\approx \\sum_i \\Sigma_i(R)\\,h_i(z)`, the better the technique works.
 
-    This technique was introduced by `Kuijken & Dubinski (1995) <http://adsabs.harvard.edu/abs/1995MNRAS.277.1341K>`__ and was popularized by `Dehnen & Binney (1998) <http://adsabs.harvard.edu/abs/1998MNRAS.294..429D>`__. The current implementation is a slight generalization of the technique in those papers and uses the SCF approach of `Hernquist & Ostriker (1992)
-    <http://adsabs.harvard.edu/abs/1992ApJ...386..375H>`__ to solve the Poisson equation for :math:`\\Phi_{\\mathrm{ME}}(R,\\phi,z)` rather than solving it on a grid using spherical harmonics and interpolating the solution (as done in `Dehnen & Binney 1998 <http://adsabs.harvard.edu/abs/1998MNRAS.294..429D>`__).
+    This technique was introduced by `Kuijken & Dubinski (1995) <http://adsabs.harvard.edu/abs/1995MNRAS.277.1341K>`__ and was popularized by `Dehnen & Binney (1998) <http://adsabs.harvard.edu/abs/1998MNRAS.294..429D>`__. The current implementation is a slight generalization of the technique in those papers and uses the :ref:`MultipoleExpansionPotential <multipole_expansion_potential>` to solve the Poisson equation for :math:`\\Phi_{\\mathrm{ME}}(R,\\phi,z)`.
 
     """
 
@@ -42,17 +41,16 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
         d2SigmadR2=None,
         Hz=None,
         dHzdz=None,
-        N=10,
         L=10,
-        a=1.0,
-        radial_order=None,
+        rgrid=numpy.geomspace(1e-3, 30, 1001),
+        symmetry=None,
         costheta_order=None,
         phi_order=None,
         ro=None,
         vo=None,
     ):
         """
-        Initialize a DiskSCFPotential.
+        Initialize a DiskMultipoleExpansionPotential.
 
         Parameters
         ----------
@@ -62,18 +60,16 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
             If True, normalize such that vc(1.,0.)=1., or, if given as a number, such that the force is this fraction of the force necessary to make vc(1.,0.)=1.
         dens : callable
             Function of R,z[,phi optional] that gives the density [in natural units, cannot return a Quantity currently].
-        N : int, optional
-            Number of radial basis functions to use in the SCF expansion.
         L : int, optional
-            Number of angular basis functions to use in the SCF expansion.
-        a : float or Quantity, optional
-            Scale radius for the SCF expansion.
-        radial_order : int, optional
-            Order of the radial basis functions to use in the SCF expansion.
+            Maximum spherical harmonic degree + 1 (l goes from 0 to L-1).
+        rgrid : numpy.ndarray, optional
+            Radial grid points (1D array). Default: ``numpy.geomspace(1e-3, 30, 1001)``.
+        symmetry : str or None, optional
+            ``'spherical'``, ``'axisymmetric'``, or ``None`` (general). If None and the density is axisymmetric, ``'axisymmetric'`` is used automatically.
         costheta_order : int, optional
-            Order of the angular basis functions to use in the SCF expansion.
+            Gauss-Legendre quadrature order for theta.
         phi_order : int, optional
-            Order of the azimuthal basis functions to use in the SCF expansion.
+            Number of uniform phi points for trapezoidal rule.
         Sigma : dict or callable
             Either a dictionary of surface density (example: {'type':'exp','h':1./3.,'amp':1.,'Rhole':0.} for amp x exp(-Rhole/R-R/h) ) or a function of R that gives the surface density.
         hz : dict or callable
@@ -96,7 +92,7 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
         Notes
         -----
         - Either specify (Sigma,hz) or (Sigma_amp,Sigma,dSigmadR,d2SigmadR2,hz,Hz,dHzdz)
-        - Written - Bovy (UofT) - 2016-12-26
+        - 2026-02-22 - Written - Bovy (UofT)
 
         """
         KuijkenDubinskiDiskExpansionPotential.__init__(
@@ -113,18 +109,17 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
             ro=ro,
             vo=vo,
         )
-        a = conversion.parse_length(a, ro=self._ro)
         # Auto-detect symmetry if not specified
-        symmetry = "axisymmetric" if not self.isNonAxi else None
-        self._me = SCFPotential.from_density(
+        if symmetry is None and not self.isNonAxi:
+            symmetry = "axisymmetric"
+        self._me = MultipoleExpansionPotential.from_density(
             dens=self._phiME_dens_func,
-            N=N,
             L=L,
-            a=a,
+            rgrid=rgrid,
             symmetry=symmetry,
-            radial_order=radial_order,
             costheta_order=costheta_order,
             phi_order=phi_order,
+            amp=1.0,
             ro=None,
             vo=None,
         )

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -1,0 +1,364 @@
+###############################################################################
+#   KuijkenDubinskiDiskExpansionPotential.py: Base class for disk+halo
+#   potentials using the Kuijken & Dubinski (1995) technique
+###############################################################################
+import copy
+
+import numpy
+import scipy
+from packaging.version import parse as parse_version
+
+_SCIPY_VERSION = parse_version(scipy.__version__)
+if _SCIPY_VERSION < parse_version("0.10"):  # pragma: no cover
+    from scipy.maxentropy import logsumexp
+elif _SCIPY_VERSION < parse_version("0.19"):  # pragma: no cover
+    from scipy.misc import logsumexp
+else:
+    from scipy.special import logsumexp
+
+from scipy import integrate
+
+from .Potential import Potential
+
+
+class KuijkenDubinskiDiskExpansionPotential(Potential):
+    """Base class for disk+halo potentials using the Kuijken & Dubinski (1995)
+    technique. This class contains all shared logic for decomposing a potential
+    as Phi = Phi_ME + 4*pi*G * sum_i Sigma_i(r) * H_i(z), where Phi_ME is
+    solved via a multipole/basis-function expansion.
+
+    Subclasses (DiskSCFPotential, DiskMultipoleExpansionPotential) only differ
+    in how they create the expansion sub-potential (self._me).
+    """
+
+    def __init__(
+        self,
+        amp=1.0,
+        dens=lambda R, z: 13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z)),
+        Sigma={"type": "exp", "h": 1.0 / 3.0, "amp": 1.0},
+        hz={"type": "exp", "h": 1.0 / 27.0},
+        Sigma_amp=None,
+        dSigmadR=None,
+        d2SigmadR2=None,
+        Hz=None,
+        dHzdz=None,
+        ro=None,
+        vo=None,
+    ):
+        Potential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units=None)
+        # Parse and store given functions
+        self.isNonAxi = dens.__code__.co_argcount == 3
+        self._parse_Sigma(Sigma_amp, Sigma, dSigmadR, d2SigmadR2)
+        self._parse_hz(hz, Hz, dHzdz)
+        if self.isNonAxi:
+            self._inputdens = dens
+        else:
+            self._inputdens = lambda R, z, phi: dens(R, z)
+        # Compute phiME density function
+        if not self.isNonAxi:
+            self._phiME_dens_func = lambda R, z: phiME_dens(
+                R,
+                z,
+                0.0,
+                self._inputdens,
+                self._Sigma,
+                self._dSigmadR,
+                self._d2SigmadR2,
+                self._hz,
+                self._Hz,
+                self._dHzdz,
+                self._Sigma_amp,
+            )
+        else:
+            self._phiME_dens_func = lambda R, z, phi: phiME_dens(
+                R,
+                z,
+                phi,
+                self._inputdens,
+                self._Sigma,
+                self._dSigmadR,
+                self._d2SigmadR2,
+                self._hz,
+                self._Hz,
+                self._dHzdz,
+                self._Sigma_amp,
+            )
+
+    def _finish_init(self, normalize):
+        """Called by subclasses after setting self._me."""
+        if self._Sigma_dict is not None and self._hz_dict is not None:
+            self.hasC = True
+            self.hasC_dens = True
+        if normalize or (
+            isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
+        ):
+            self.normalize(normalize)
+
+    def _parse_Sigma(self, Sigma_amp, Sigma, dSigmadR, d2SigmadR2):
+        if isinstance(Sigma, dict):
+            Sigma = [Sigma]
+        try:
+            nsigma = len(Sigma)
+        except TypeError:
+            Sigma_amp = [Sigma_amp]
+            Sigma = [Sigma]
+            dSigmadR = [dSigmadR]
+            d2SigmadR2 = [d2SigmadR2]
+            nsigma = 1
+        self._nsigma = nsigma
+        self._Sigma_amp = Sigma_amp
+        self._Sigma = Sigma
+        self._dSigmadR = dSigmadR
+        self._d2SigmadR2 = d2SigmadR2
+        if isinstance(Sigma[0], dict):
+            self._Sigma_dict = copy.copy(Sigma)
+            self._parse_Sigma_dict()
+        else:
+            self._Sigma_dict = None
+        return None
+
+    def _parse_Sigma_dict(self):
+        Sigma_amp, Sigma, dSigmadR, d2SigmadR2 = [], [], [], []
+        for ii in range(self._nsigma):
+            ta, ts, tds, td2s = self._parse_Sigma_dict_indiv(self._Sigma[ii])
+            Sigma_amp.append(ta)
+            Sigma.append(ts)
+            dSigmadR.append(tds)
+            d2SigmadR2.append(td2s)
+        self._Sigma_amp = Sigma_amp
+        self._Sigma = Sigma
+        self._dSigmadR = dSigmadR
+        self._d2SigmadR2 = d2SigmadR2
+        return None
+
+    def _parse_Sigma_dict_indiv(self, Sigma):
+        stype = Sigma.get("type", "exp")
+        if stype == "exp" and not "Rhole" in Sigma:
+            rd = Sigma.get("h", 1.0 / 3.0)
+            ta = Sigma.get("amp", 1.0)
+            ts = lambda R, trd=rd: numpy.exp(-R / trd)
+            tds = lambda R, trd=rd: -numpy.exp(-R / trd) / trd
+            td2s = lambda R, trd=rd: numpy.exp(-R / trd) / trd**2.0
+        elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
+            rd = Sigma.get("h", 1.0 / 3.0)
+            rm = Sigma.get("Rhole", 0.5)
+            ta = Sigma.get("amp", 1.0)
+            ts = lambda R, trd=rd, trm=rm: numpy.exp(-trm / R - R / trd)
+            tds = lambda R, trd=rd, trm=rm: (
+                (trm / R**2.0 - 1.0 / trd) * numpy.exp(-trm / R - R / trd)
+            )
+            td2s = lambda R, trd=rd, trm=rm: (
+                ((trm / R**2.0 - 1.0 / trd) ** 2.0 - 2.0 * trm / R**3.0)
+                * numpy.exp(-trm / R - R / trd)
+            )
+        return (ta, ts, tds, td2s)
+
+    def _parse_hz(self, hz, Hz, dHzdz):
+        if isinstance(hz, dict):
+            hz = [hz]
+        try:
+            nhz = len(hz)
+        except TypeError:
+            hz = [hz]
+            Hz = [Hz]
+            dHzdz = [dHzdz]
+            nhz = 1
+        if nhz != self._nsigma and nhz != 1:
+            raise ValueError(
+                "Number of hz functions needs to be equal to the number of Sigma functions or to 1"
+            )
+        if nhz == 1 and self._nsigma > 1:
+            hz = [hz[0] for ii in range(self._nsigma)]
+            if not isinstance(hz[0], dict):
+                Hz = [Hz[0] for ii in range(self._nsigma)]
+                dHzdz = [dHzdz[0] for ii in range(self._nsigma)]
+        self._Hz = Hz
+        self._hz = hz
+        self._dHzdz = dHzdz
+        self._nhz = len(self._hz)
+        if isinstance(hz[0], dict):
+            self._hz_dict = copy.copy(hz)
+            self._parse_hz_dict()
+        else:
+            self._hz_dict = None
+        return None
+
+    def _parse_hz_dict(self):
+        hz, Hz, dHzdz = [], [], []
+        for ii in range(self._nhz):
+            th, tH, tdH = self._parse_hz_dict_indiv(self._hz[ii])
+            hz.append(th)
+            Hz.append(tH)
+            dHzdz.append(tdH)
+        self._hz = hz
+        self._Hz = Hz
+        self._dHzdz = dHzdz
+        return None
+
+    def _parse_hz_dict_indiv(self, hz):
+        htype = hz.get("type", "exp")
+        if htype == "exp":
+            zd = hz.get("h", 0.0375)
+            th = lambda z, tzd=zd: 1.0 / 2.0 / tzd * numpy.exp(-numpy.fabs(z) / tzd)
+            tH = lambda z, tzd=zd: (
+                (numpy.exp(-numpy.fabs(z) / tzd) - 1.0 + numpy.fabs(z) / tzd)
+                * tzd
+                / 2.0
+            )
+            tdH = lambda z, tzd=zd: (
+                0.5 * numpy.sign(z) * (1.0 - numpy.exp(-numpy.fabs(z) / tzd))
+            )
+        elif htype == "sech2":
+            zd = hz.get("h", 0.0375)
+            # th/tH written so as to avoid overflow in cosh
+            th = lambda z, tzd=zd: (
+                numpy.exp(
+                    -logsumexp(
+                        numpy.array(
+                            [z / tzd, -z / tzd, numpy.log(2.0) * numpy.ones_like(z)]
+                        ),
+                        axis=0,
+                    )
+                )
+                / tzd
+            )
+            tH = lambda z, tzd=zd: (
+                tzd
+                * (
+                    logsumexp(numpy.array([z / 2.0 / tzd, -z / 2.0 / tzd]), axis=0)
+                    - numpy.log(2.0)
+                )
+            )
+            tdH = lambda z, tzd=zd: numpy.tanh(z / 2.0 / tzd) / 2.0
+        return (th, tH, tdH)
+
+    def _evaluate(self, R, z, phi=0.0, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me(R, z, phi=phi, use_physical=False)
+        for a, s, H in zip(self._Sigma_amp, self._Sigma, self._Hz):
+            out += 4.0 * numpy.pi * a * s(r) * H(z)
+        return out
+
+    def _Rforce(self, R, z, phi=0, t=0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.Rforce(R, z, phi=phi, use_physical=False)
+        for a, ds, H in zip(self._Sigma_amp, self._dSigmadR, self._Hz):
+            out -= 4.0 * numpy.pi * a * ds(r) * H(z) * R / r
+        return out
+
+    def _zforce(self, R, z, phi=0, t=0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.zforce(R, z, phi=phi, use_physical=False)
+        for a, s, ds, H, dH in zip(
+            self._Sigma_amp, self._Sigma, self._dSigmadR, self._Hz, self._dHzdz
+        ):
+            out -= 4.0 * numpy.pi * a * (ds(r) * H(z) * z / r + s(r) * dH(z))
+        return out
+
+    def _phitorque(self, R, z, phi=0.0, t=0.0):
+        return self._me.phitorque(R, z, phi=phi, use_physical=False)
+
+    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.R2deriv(R, z, phi=phi, use_physical=False)
+        for a, ds, d2s, H in zip(
+            self._Sigma_amp, self._dSigmadR, self._d2SigmadR2, self._Hz
+        ):
+            out += (
+                4.0
+                * numpy.pi
+                * a
+                * H(z)
+                / r**2.0
+                * (d2s(r) * R**2.0 + z**2.0 / r * ds(r))
+            )
+        return out
+
+    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.z2deriv(R, z, phi=phi, use_physical=False)
+        for a, s, ds, d2s, h, H, dH in zip(
+            self._Sigma_amp,
+            self._Sigma,
+            self._dSigmadR,
+            self._d2SigmadR2,
+            self._hz,
+            self._Hz,
+            self._dHzdz,
+        ):
+            out += (
+                4.0
+                * numpy.pi
+                * a
+                * (
+                    H(z) / r**2.0 * (d2s(r) * z**2.0 + ds(r) * R**2.0 / r)
+                    + 2.0 * ds(r) * dH(z) * z / r
+                    + s(r) * h(z)
+                )
+            )
+        return out
+
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.Rzderiv(R, z, phi=phi, use_physical=False)
+        for a, ds, d2s, H, dH in zip(
+            self._Sigma_amp, self._dSigmadR, self._d2SigmadR2, self._Hz, self._dHzdz
+        ):
+            out += (
+                4.0
+                * numpy.pi
+                * a
+                * (H(z) * R * z / r**2.0 * (d2s(r) - ds(r) / r) + ds(r) * dH(z) * R / r)
+            )
+        return out
+
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
+        return self._me.phi2deriv(R, z, phi=phi, use_physical=False)
+
+    def _dens(self, R, z, phi=0.0, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        out = self._me.dens(R, z, phi=phi, use_physical=False)
+        for a, s, ds, d2s, h, H, dH in zip(
+            self._Sigma_amp,
+            self._Sigma,
+            self._dSigmadR,
+            self._d2SigmadR2,
+            self._hz,
+            self._Hz,
+            self._dHzdz,
+        ):
+            out += a * (
+                s(r) * h(z) + d2s(r) * H(z) + 2.0 / r * ds(r) * (H(z) + z * dH(z))
+            )
+        return out
+
+    def _mass(self, R, z=None, t=0.0):
+        if not z is None:  # pragma: no cover
+            raise AttributeError  # Hack to fall back to general
+        out = self._me.mass(R, z=None, use_physical=False)
+        r = R
+
+        def _integrand(theta):
+            # ~ rforce
+            tz = r * numpy.cos(theta)
+            tR = r * numpy.sin(theta)
+            out = 0.0
+            for a, s, ds, H, dH in zip(
+                self._Sigma_amp, self._Sigma, self._dSigmadR, self._Hz, self._dHzdz
+            ):
+                out += a * ds(r) * H(tz) * tR**2
+                out += a * (ds(r) * H(tz) * tz / r + s(r) * dH(tz)) * tz * r
+            return out * numpy.sin(theta)
+
+        return out + 2.0 * numpy.pi * integrate.quad(_integrand, 0.0, numpy.pi)[0]
+
+
+def phiME_dens(R, z, phi, dens, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz, Sigma_amp):
+    """The density corresponding to phi_ME"""
+    r = numpy.sqrt(R**2.0 + z**2.0)
+    out = dens(R, z, phi)
+    for a, s, ds, d2s, h, H, dH in zip(
+        Sigma_amp, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz
+    ):
+        out -= a * (s(r) * h(z) + d2s(r) * H(z) + 2.0 / r * ds(r) * (H(z) + z * dH(z)))
+    return out

--- a/galpy/potential/__init__.py
+++ b/galpy/potential/__init__.py
@@ -10,6 +10,7 @@ from . import (
     CylindricallySeparablePotentialWrapper,
     DehnenBarPotential,
     DehnenSmoothWrapperPotential,
+    DiskMultipoleExpansionPotential,
     DiskSCFPotential,
     DoubleExponentialDiskPotential,
     EinastoPotential,
@@ -201,6 +202,9 @@ TwoPowerTriaxialPotential = TwoPowerTriaxialPotential.TwoPowerTriaxialPotential
 FerrersPotential = FerrersPotential.FerrersPotential
 SCFPotential = SCFPotential.SCFPotential
 SoftenedNeedleBarPotential = SoftenedNeedleBarPotential.SoftenedNeedleBarPotential
+DiskMultipoleExpansionPotential = (
+    DiskMultipoleExpansionPotential.DiskMultipoleExpansionPotential
+)
 DiskSCFPotential = DiskSCFPotential.DiskSCFPotential
 SpiralArmsPotential = SpiralArmsPotential.SpiralArmsPotential
 HenonHeilesPotential = HenonHeilesPotential.HenonHeilesPotential

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,8 @@ def pytest_generate_tests(metafunc):
         pots.append("sech2DiskSCFPotential")
         pots.append("expwholeDiskSCFPotential")
         pots.append("altExpwholeDiskSCFPotential")
+        pots.append("sech2DiskMultipoleExpansionPotential")
+        pots.append("expwholeDiskMultipoleExpansionPotential")
         pots.append("mockFlatSpiralArmsPotential")
         pots.append("mockRotatingFlatSpiralArmsPotential")
         pots.append("mockSpecialRotatingFlatSpiralArmsPotential")
@@ -96,6 +98,7 @@ def pytest_generate_tests(metafunc):
             "CompositePotential",
             "planarCompositePotential",
             "baseCompositePotential",
+            "KuijkenDubinskiDiskExpansionPotential",
         ]
         rmpots.append("SphericalShellPotential")
         rmpots.append("RingPotential")
@@ -168,6 +171,8 @@ def pytest_generate_tests(metafunc):
         pots.append("sech2DiskSCFPotential")
         pots.append("expwholeDiskSCFPotential")
         pots.append("altExpwholeDiskSCFPotential")
+        pots.append("sech2DiskMultipoleExpansionPotential")
+        pots.append("expwholeDiskMultipoleExpansionPotential")
         pots.append("triaxialLogarithmicHaloPotential")
         pots.append("nestedListPotential")
         pots.append("mockInterpSphericalPotential")
@@ -199,6 +204,7 @@ def pytest_generate_tests(metafunc):
             "CompositePotential",
             "planarCompositePotential",
             "baseCompositePotential",
+            "KuijkenDubinskiDiskExpansionPotential",
         ]
         rmpots.append("SphericalShellPotential")
         rmpots.append("RingPotential")

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -24,6 +24,7 @@ from test_potential import (
     MWP14CylindricallySeparablePotentialWrapper,
     NFWTwoPowerTriaxialPotential,
     altExpwholeDiskSCFPotential,
+    expwholeDiskMultipoleExpansionPotential,
     expwholeDiskSCFPotential,
     fullyRotatedTriaxialNFWPotential,
     mockAdiabaticContractionMWP14WrapperPotential,
@@ -69,6 +70,7 @@ from test_potential import (
     oblateNFWPotential,
     prolateJaffePotential,
     prolateNFWPotential,
+    sech2DiskMultipoleExpansionPotential,
     sech2DiskSCFPotential,
     specialFlattenedPowerPotential,
     specialMiyamotoNagaiPotential,
@@ -766,6 +768,7 @@ def test_liouville_planar():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     # rmpots.append('BurkertPotential')
     # Don't have C implementations of the relevant 2nd derivatives
@@ -779,6 +782,7 @@ def test_liouville_planar():
     rmpots.append("DiskSCFPotential")
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
+    rmpots.append("DiskMultipoleExpansionPotential")
     for p in rmpots:
         pots.remove(p)
     # tolerances in log10
@@ -1225,6 +1229,7 @@ def test_eccentricity():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -1240,6 +1245,7 @@ def test_eccentricity():
     tol["NFWPotential"] = -12.0  # these are more difficult
     tol["TriaxialNFWPotential"] = -12.0  # these are more difficult
     tol["MultipoleExpansionPotential"] = -15.0  # slightly more difficult
+    tol["DiskMultipoleExpansionPotential"] = -6.0  # these are more difficult
     firstTest = True
     for p in pots:
         # Setup instance of potential
@@ -1405,6 +1411,7 @@ def test_pericenter():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -1583,6 +1590,7 @@ def test_apocenter():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -1761,6 +1769,7 @@ def test_zmax():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -1924,6 +1933,7 @@ def test_analytic_ecc_rperi_rap():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -1959,6 +1969,7 @@ def test_analytic_ecc_rperi_rap():
     tol["PseudoIsothermalPotential"] = -7.0  # these are more difficult
     tol["KuzminDiskPotential"] = -8.0  # these are more difficult
     tol["DiskSCFPotential"] = -8.0  # these are more difficult
+    tol["DiskMultipoleExpansionPotential"] = -8.0  # these are more difficult
     tol["PowerTriaxialPotential"] = -8.0  # these are more difficult
     for p in pots:
         # Setup instance of potential
@@ -2585,6 +2596,7 @@ def test_analytic_zmax():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
@@ -2625,6 +2637,7 @@ def test_analytic_zmax():
     tol["SCFPotential"] = -8.0  # these are more difficult
     tol["DiskSCFPotential"] = -6.0  # these are more difficult
     tol["MultipoleExpansionPotential"] = -8.0
+    tol["DiskMultipoleExpansionPotential"] = -6.0  # these are more difficult
     for p in pots:
         # Setup instance of potential
         if p in list(tol.keys()):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -68,6 +68,7 @@ def test_normalize_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -201,6 +202,9 @@ def test_forceAsDeriv_potential():
     pots.append("sech2DiskSCFPotential")
     pots.append("expwholeDiskSCFPotential")
     pots.append("nonaxiDiskSCFPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
@@ -251,6 +255,7 @@ def test_forceAsDeriv_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -454,6 +459,9 @@ def test_2ndDeriv_potential():
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("rotatingSpiralArmsPotential")
     pots.append("specialSpiralArmsPotential")
     pots.append("DehnenSmoothDehnenBarPotential")
@@ -501,6 +509,7 @@ def test_2ndDeriv_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -856,6 +865,9 @@ def test_poisson_potential():
     pots.append("mockOffsetMWP14WrapperPotential")
     pots.append("mockTimeDependentAmplitudeWrapperPotential")
     pots.append("mockKuzminLikeWrapperPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     rmpots = [
         "Potential",
         "MWPotential",
@@ -877,7 +889,12 @@ def test_poisson_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
+    # Default DiskMultipoleExpansionPotential uses exp(-27|z|) which has a
+    # derivative discontinuity at z=0 that the multipole expansion cannot
+    # resolve well; the sech2/expwhole/nonaxi test cases test Poisson properly
+    rmpots.append("DiskMultipoleExpansionPotential")
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
         rmpots.append("RazorThinExponentialDiskPotential")
@@ -897,6 +914,7 @@ def test_poisson_potential():
     tol["specialSpiralArmsPotential"] = -4
     tol["SolidBodyRotationSpiralArmsPotential"] = -2.9  # these are more difficult
     tol["nestedListPotential"] = -3  # these are more difficult
+    tol["nonaxiDiskMultipoleExpansionPotential"] = -6.0
     # tol['RazorThinExponentialDiskPotential']= -6.
     for p in pots:
         # if not 'NFW' in p: continue #For testing the test
@@ -1030,6 +1048,7 @@ def test_poisson_surfdens_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -1171,6 +1190,9 @@ def test_evaluateAndDerivs_potential():
     pots.append("sech2DiskSCFPotential")
     pots.append("expwholeDiskSCFPotential")
     pots.append("nonaxiDiskSCFPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
@@ -1221,6 +1243,7 @@ def test_evaluateAndDerivs_potential():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -1458,6 +1481,9 @@ def test_amp_mult_divide():
     pots.append("sech2DiskSCFPotential")
     pots.append("expwholeDiskSCFPotential")
     pots.append("nonaxiDiskSCFPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
@@ -1505,6 +1531,7 @@ def test_amp_mult_divide():
         "planarCompositePotential",
         "baseCompositePotential",
         "linearCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -1828,6 +1855,7 @@ def test_potential_array_input():
         "planarCompositePotential",
         "baseCompositePotential",
         "linearCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("FerrersPotential")
     rmpots.append("PerfectEllipsoidPotential")
@@ -2018,6 +2046,7 @@ def test_toVertical_array():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     rmpots.append("FerrersPotential")
     rmpots.append("PerfectEllipsoidPotential")
@@ -2147,6 +2176,9 @@ def test_potential_at_zero():
     pots.append("sech2DiskSCFPotential")
     pots.append("expwholeDiskSCFPotential")
     pots.append("nonaxiDiskSCFPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
@@ -2182,6 +2214,7 @@ def test_potential_at_zero():
         "planarCompositePotential",
         "baseCompositePotential",
         "linearCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     # Remove some more potentials that we don't support for now TO DO
     rmpots.append("BurkertPotential")  # Need to figure out...
@@ -2308,6 +2341,9 @@ def test_potential_at_infinity():
     pots.append("sech2DiskSCFPotential")
     pots.append("expwholeDiskSCFPotential")
     pots.append("nonaxiDiskSCFPotential")
+    pots.append("sech2DiskMultipoleExpansionPotential")
+    pots.append("expwholeDiskMultipoleExpansionPotential")
+    pots.append("nonaxiDiskMultipoleExpansionPotential")
     pots.append("mockMultipoleExpansionSphericalPotential")
     pots.append("mockMultipoleExpansionAxiPotential")
     pots.append("mockMultipoleExpansionPotential")
@@ -2343,6 +2379,7 @@ def test_potential_at_infinity():
         "planarCompositePotential",
         "baseCompositePotential",
         "linearCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     # Remove some more potentials that we don't support for now TO DO
     rmpots.append("FerrersPotential")  # Need to figure out...
@@ -3198,6 +3235,7 @@ def test_toVertical_toPlanar():
         "CompositePotential",
         "planarCompositePotential",
         "baseCompositePotential",
+        "KuijkenDubinskiDiskExpansionPotential",
     ]
     if False:
         rmpots.append("DoubleExponentialDiskPotential")
@@ -10286,6 +10324,7 @@ def test_linearPotential_len_iter():
 # cases of some other potentials
 from galpy.potential import (
     BurkertPotential,
+    DiskMultipoleExpansionPotential,
     DiskSCFPotential,
     FerrersPotential,
     FlattenedPowerPotential,
@@ -10660,6 +10699,77 @@ class nonaxiDiskSCFPotential(DiskSCFPotential):
                 0.5 * numpy.sign(z) * (1.0 - numpy.exp(-27.0 * numpy.fabs(z)))
             ),
             N=5,
+            L=5,
+        )
+        return None
+
+
+# DiskMultipoleExpansionPotentials
+class sech2DiskMultipoleExpansionPotential(DiskMultipoleExpansionPotential):
+    def __init__(self):
+        DiskMultipoleExpansionPotential.__init__(
+            self,
+            dens=lambda R, z: (
+                numpy.exp(-3.0 * R)
+                * 1.0
+                / numpy.cosh(z / 2.0 * 27.0) ** 2.0
+                / 4.0
+                * 27.0
+            ),
+            Sigma={"h": 1.0 / 3.0, "type": "exp", "amp": 1.0},
+            hz={"type": "sech2", "h": 1.0 / 27.0},
+            L=5,
+        )
+        return None
+
+
+class expwholeDiskMultipoleExpansionPotential(DiskMultipoleExpansionPotential):
+    def __init__(self):
+        # Add a Hernquist potential because otherwise the density near the
+        # center is zero
+        from galpy.potential import HernquistPotential
+
+        hp = HernquistPotential(normalize=0.5)
+        DiskMultipoleExpansionPotential.__init__(
+            self,
+            dens=lambda R, z: (
+                13.5
+                * numpy.exp(-0.5 / (R + 10.0**-10.0) - 3.0 * R - numpy.fabs(z) * 27.0)
+                + hp.dens(R, z)
+            ),
+            Sigma={"h": 1.0 / 3.0, "type": "expwhole", "amp": 1.0, "Rhole": 0.5},
+            hz={"type": "exp", "h": 1.0 / 27.0},
+            L=5,
+        )
+        return None
+
+
+class nonaxiDiskMultipoleExpansionPotential(DiskMultipoleExpansionPotential):
+    def __init__(self):
+        thp = triaxialHernquistPotential()
+        DiskMultipoleExpansionPotential.__init__(
+            self,
+            dens=lambda R, z, phi: (
+                13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
+                + thp.dens(R, z, phi=phi)
+            ),
+            Sigma_amp=[0.5, 0.5],
+            Sigma=[lambda R: numpy.exp(-3.0 * R), lambda R: numpy.exp(-3.0 * R)],
+            dSigmadR=[
+                lambda R: -3.0 * numpy.exp(-3.0 * R),
+                lambda R: -3.0 * numpy.exp(-3.0 * R),
+            ],
+            d2SigmadR2=[
+                lambda R: 9.0 * numpy.exp(-3.0 * R),
+                lambda R: 9.0 * numpy.exp(-3.0 * R),
+            ],
+            hz=lambda z: 13.5 * numpy.exp(-27.0 * numpy.fabs(z)),
+            Hz=lambda z: (
+                (numpy.exp(-27.0 * numpy.fabs(z)) - 1.0 + 27.0 * numpy.fabs(z)) / 54.0
+            ),
+            dHzdz=lambda z: (
+                0.5 * numpy.sign(z) * (1.0 - numpy.exp(-27.0 * numpy.fabs(z)))
+            ),
             L=5,
         )
         return None


### PR DESCRIPTION
Uses ``MultipoleExpansionPotential`` to solve Poisson equation for disk+halo systems, similar to how ``DiskSCFPotential`` uses ``SCFPotential``.

Introduces ``KuijkenDubinskiDiskExpansionPotential`` as a shared base class for ``DiskSCFPotential`` and ``DiskMultipoleExpansionPotential``, refactors ``DiskSCFPotential`` to inherit from it, adds C orbit integration support, and includes comprehensive tests and documentation