### PR TITLE
Use emscripten-core/setup-emsdk action

### DIFF
--- a/.github/workflows/build_pyodide_wheels.yml
+++ b/.github/workflows/build_pyodide_wheels.yml
@@ -53,7 +53,7 @@ jobs:
       - run: |
           pip install pyodide-build
           echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
-      - uses: mymindstorm/setup-emsdk@v16
+      - uses: emscripten-core/setup-emsdk@v16
         with:
           version: ${{ env.EMSCRIPTEN_VERSION }}
       - name: Cache GSL build


### PR DESCRIPTION
## Summary

- Switch `build_pyodide_wheels.yml` from `mymindstorm/setup-emsdk@v16` to `emscripten-core/setup-emsdk@v16`.
- The action's source repository was migrated from `mymindstorm` to the `emscripten-core` organization. The `v16` release on the old repo is documented as a no-op release created purely to document the move, so the `v16` tag on the new location is the canonical source going forward.
- No behavior change expected; this is a rename to track the action at its new home.

## Test plan

- [ ] `build_pyodide_wheels.yml` runs successfully (emsdk install step still resolves the requested `EMSCRIPTEN_VERSION` and GSL build + wheel build still succeed).
