### PR TITLE
Replace archived jakejarvis/s3-sync-action with AWS CLI

### DIFF
--- a/.github/workflows/build_pyodide_wheels.yml
+++ b/.github/workflows/build_pyodide_wheels.yml
@@ -112,13 +112,15 @@ jobs:
           path: tmp_wheelhouse/
       # Flatten directory structure into wheelhouse/
       - run: find tmp_wheelhouse/ -mindepth 2 -type f -exec mv -i '{}' wheelhouse/ ';'
-      - uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          args: --acl public-read --follow-symlinks
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Upload to AWS S3
+        run: |
+          aws s3 sync wheelhouse "s3://${AWS_S3_BUCKET}/wheelhouse" \
+            --acl public-read --follow-symlinks
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-2'
-          SOURCE_DIR: wheelhouse
-          DEST_DIR: wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -287,14 +287,16 @@ jobs:
             with open("index.html", "w") as f:
                 f.write("<html><body>\n" + "\n".join(links) + "\n</body></html>\n")
             EOF
-      - name: Upload to AWS S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          args: --acl public-read --follow-symlinks --delete --exclude "*emscripten*" --exclude "*pyodide*"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Upload to AWS S3
+        run: |
+          aws s3 sync wheelhouse "s3://${AWS_S3_BUCKET}/wheelhouse/simple/galpy" \
+            --acl public-read --follow-symlinks --delete \
+            --exclude "*emscripten*" --exclude "*pyodide*"
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-2'
-          SOURCE_DIR: wheelhouse
-          DEST_DIR: wheelhouse/simple/galpy


### PR DESCRIPTION
## Summary

- `jakejarvis/s3-sync-action@v0.5.1` was [archived on Jan 18, 2025](https://github.com/jakejarvis/s3-sync-action) and is no longer maintained.
- Replace both usages (`wheels.yml` deploy step and `build_pyodide_wheels.yml` deploy step) with the official `aws-actions/configure-aws-credentials@v6` action plus a plain `aws s3 sync` invocation — which is essentially what the archived action wrapped internally.
- Auth remains **keys-based** using the existing `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_S3_BUCKET` secrets, so no secrets need rotating.
- Preserves the exact same sync arguments per call site:
  - `wheels.yml`: `--acl public-read --follow-symlinks --delete --exclude "*emscripten*" --exclude "*pyodide*"` to `s3://$BUCKET/wheelhouse/simple/galpy`
  - `build_pyodide_wheels.yml`: `--acl public-read --follow-symlinks` to `s3://$BUCKET/wheelhouse`
- Switching to OIDC-based auth (via `role-to-assume`) is left as a separate follow-up, since it requires setting up an IAM role with a trust policy for this repo.

## Test plan

- [ ] Verify a main-branch push of `wheels.yml` still successfully uploads wheels to `s3://$BUCKET/wheelhouse/simple/galpy/`, with the same `--exclude` filters applied.
- [ ] Verify a main-branch push of `build_pyodide_wheels.yml` still successfully uploads pyodide wheels to `s3://$BUCKET/wheelhouse/`.
- [ ] Confirm the existing `AWS_*` repository secrets are still referenced correctly (no rename needed).
