### PR TITLE
Add align_to_orbit helper to coords + Orbit

### DIFF
--- a/doc/source/reference/orbit.rst
+++ b/doc/source/reference/orbit.rst
@@ -52,6 +52,7 @@ Methods
 
    __call__ <orbitcall.rst>
    __getitem__ <orbitgetitem.rst>
+   align_to_orbit <orbitaligntoorbit.rst>
    bb <orbitbb.rst>
    bruteSOS <orbitbrutesos.rst>
    dec <orbitdec.rst>
@@ -83,9 +84,13 @@ Methods
    Oz <orbitoz.rst>
    phasedim <orbitphasedim.rst>
    phi <orbitphi.rst>
+   phi1 <orbitphi1.rst>
+   phi2 <orbitphi2.rst>
    pmbb <orbitpmbb.rst>
    pmdec <orbitpmdec.rst>
    pmll <orbitpmll.rst>
+   pmphi1 <orbitpmphi1.rst>
+   pmphi2 <orbitpmphi2.rst>
    pmra <orbitpmra.rst>
    r <orbitsphr.rst>
    R <orbitr.rst>

--- a/doc/source/reference/orbitaligntoorbit.rst
+++ b/doc/source/reference/orbitaligntoorbit.rst
@@ -1,0 +1,4 @@
+galpy.orbit.Orbit.align_to_orbit
+================================
+
+.. automethod:: galpy.orbit.Orbit.align_to_orbit

--- a/doc/source/reference/orbitphi1.rst
+++ b/doc/source/reference/orbitphi1.rst
@@ -1,0 +1,4 @@
+galpy.orbit.Orbit.phi1
+======================
+
+.. automethod:: galpy.orbit.Orbit.phi1

--- a/doc/source/reference/orbitphi2.rst
+++ b/doc/source/reference/orbitphi2.rst
@@ -1,0 +1,4 @@
+galpy.orbit.Orbit.phi2
+======================
+
+.. automethod:: galpy.orbit.Orbit.phi2

--- a/doc/source/reference/orbitpmphi1.rst
+++ b/doc/source/reference/orbitpmphi1.rst
@@ -1,0 +1,4 @@
+galpy.orbit.Orbit.pmphi1
+========================
+
+.. automethod:: galpy.orbit.Orbit.pmphi1

--- a/doc/source/reference/orbitpmphi2.rst
+++ b/doc/source/reference/orbitpmphi2.rst
@@ -1,0 +1,4 @@
+galpy.orbit.Orbit.pmphi2
+========================
+
+.. automethod:: galpy.orbit.Orbit.pmphi2

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -4749,8 +4749,6 @@ class Orbit:
         -----
         - 2026-04-23: Written by Bovy (UofT).
         """
-        from ..util import coords
-
         # Use internal units (Sun at Xsun=1, Zsun=zo/ro). The rotation
         # matrix is scale-invariant since L = r x v only matters up to
         # overall magnitude.
@@ -5066,8 +5064,6 @@ class Orbit:
         -----
         - 2026-05-01: Written by Bovy (UofT).
         """
-        from ..util import coords
-
         _check_roSet(self, kwargs, "phi1")
         T = self._resolve_custom_transform(kwargs, "phi1")
         thiso = self._call_internal(*args, **kwargs)
@@ -5109,8 +5105,6 @@ class Orbit:
         -----
         - 2026-05-01: Written by Bovy (UofT).
         """
-        from ..util import coords
-
         _check_roSet(self, kwargs, "phi2")
         T = self._resolve_custom_transform(kwargs, "phi2")
         thiso = self._call_internal(*args, **kwargs)
@@ -5154,8 +5148,6 @@ class Orbit:
         -----
         - 2026-05-01: Written by Bovy (UofT).
         """
-        from ..util import coords
-
         _check_roSet(self, kwargs, "pmphi1")
         _check_voSet(self, kwargs, "pmphi1")
         T = self._resolve_custom_transform(kwargs, "pmphi1")
@@ -5203,8 +5195,6 @@ class Orbit:
         -----
         - 2026-05-01: Written by Bovy (UofT).
         """
-        from ..util import coords
-
         _check_roSet(self, kwargs, "pmphi2")
         _check_voSet(self, kwargs, "pmphi2")
         T = self._resolve_custom_transform(kwargs, "pmphi2")

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -160,11 +160,15 @@ _labeldict_radec = {
     "dec": r"$\delta\ (\mathrm{deg})$",
     "ll": r"$l\ (\mathrm{deg})$",
     "bb": r"$b\ (\mathrm{deg})$",
+    "phi1": r"$\phi_1\ (\mathrm{deg})$",
+    "phi2": r"$\phi_2\ (\mathrm{deg})$",
     "dist": r"$d\ (\mathrm{kpc})$",
     "pmra": r"$\mu_\alpha\ (\mathrm{mas\,yr}^{-1})$",
     "pmdec": r"$\mu_\delta\ (\mathrm{mas\,yr}^{-1})$",
     "pmll": r"$\mu_l\ (\mathrm{mas\,yr}^{-1})$",
     "pmbb": r"$\mu_b\ (\mathrm{mas\,yr}^{-1})$",
+    "pmphi1": r"$\mu_{\phi_1}\ (\mathrm{mas\,yr}^{-1})$",
+    "pmphi2": r"$\mu_{\phi_2}\ (\mathrm{mas\,yr}^{-1})$",
     "vlos": r"$v_\mathrm{los}\ (\mathrm{km\,s}^{-1})$",
     "helioX": r"$X\ (\mathrm{kpc})$",
     "helioY": r"$Y\ (\mathrm{kpc})$",
@@ -4725,6 +4729,12 @@ class Orbit:
         r"""
         Return a sky rotation matrix that places this orbit's orbital plane at ``phi2=0`` and the orbit itself at ``(phi1, phi2) = (center_phi1, 0)``.
 
+        The returned matrix is also stashed on this Orbit as
+        ``self._custom_transform``, so subsequent ``self.phi1()`` /
+        ``self.phi2()`` / ``self.pmphi1()`` / ``self.pmphi2()`` calls
+        (and ``self.plot(d1='phi1', d2='phi2')``) work without having
+        to pass ``T=`` explicitly.
+
         Parameters
         ----------
         center_phi1 : float, optional
@@ -4745,7 +4755,7 @@ class Orbit:
         # Use internal units (Sun at Xsun=1, Zsun=zo/ro). The rotation
         # matrix is scale-invariant since L = r x v only matters up to
         # overall magnitude.
-        return coords.align_to_orbit(
+        T = coords.align_to_orbit(
             float(self.x(use_physical=False)),
             float(self.y(use_physical=False)),
             float(self.z(use_physical=False)),
@@ -4756,6 +4766,8 @@ class Orbit:
             Zsun=self._zo / self._ro,
             center_phi1=center_phi1,
         )
+        self._custom_transform = T
+        return T
 
     @physical_conversion("angle_deg")
     @shapeDecorator
@@ -5007,6 +5019,205 @@ class Orbit:
         thiso_shape = thiso.shape
         thiso = thiso.reshape((thiso_shape[0], -1))
         return _pmrapmdec(self, thiso, *args, **kwargs).T[1].reshape(thiso_shape[1:]).T
+
+    def _resolve_custom_transform(self, kwargs, name):
+        """Pop ``T=`` off ``kwargs`` and fall back to ``self._custom_transform``.
+        Raises ``RuntimeError`` if neither is available — both phi1/phi2 and
+        their proper-motion counterparts share the same lookup."""
+        T = kwargs.pop("T", None)
+        if T is None:
+            T = getattr(self, "_custom_transform", None)
+        if T is None:
+            raise RuntimeError(
+                f"{name}() needs a custom-frame rotation matrix; either "
+                "call self.align_to_orbit() first to stash one, or pass "
+                "T=<3x3 matrix> explicitly."
+            )
+        return numpy.asarray(T)
+
+    @physical_conversion("angle_deg")
+    @shapeDecorator
+    def phi1(self, *args, **kwargs):
+        r"""
+        Return the longitude in the custom sky frame defined by this orbit's :meth:`align_to_orbit` rotation matrix (or one passed via ``T=``).
+
+        Parameters
+        ----------
+        t : numeric, numpy.ndarray or Quantity, optional
+            Time at which to get phi1. Default is the initial time.
+        T : numpy.ndarray, optional
+            3x3 rotation matrix from (ra, dec) to (phi1, phi2). Default
+            is the matrix stored by a previous call to
+            :meth:`align_to_orbit`. Required if no such call was made.
+        obs : numpy.ndarray, Quantity or Orbit, optional
+            Position of observer (in kpc, arranged as [X,Y,Z]; default=object-wide default).
+        ro : float or Quantity, optional
+            Physical scale in kpc for distances to use to convert. Default is object-wide default.
+        use_physical : bool, optional
+            Use to override object-wide default for using a physical scale for output.
+        quantity : bool, optional
+            If True, return an Astropy Quantity object. Default from configuration file.
+
+        Returns
+        -------
+        float, numpy.ndarray or Quantity [\*input_shape,nt]
+            Longitude in the custom sky frame in degrees.
+
+        Notes
+        -----
+        - 2026-05-01: Written by Bovy (UofT).
+        """
+        from ..util import coords
+
+        _check_roSet(self, kwargs, "phi1")
+        T = self._resolve_custom_transform(kwargs, "phi1")
+        thiso = self._call_internal(*args, **kwargs)
+        thiso_shape = thiso.shape
+        thiso = thiso.reshape((thiso_shape[0], -1))
+        radec = _radec(self, thiso, *args, **kwargs)
+        p12 = coords.radec_to_custom(radec[:, 0], radec[:, 1], T=T, degree=True)
+        return p12[:, 0].reshape(thiso_shape[1:]).T
+
+    @physical_conversion("angle_deg")
+    @shapeDecorator
+    def phi2(self, *args, **kwargs):
+        r"""
+        Return the latitude in the custom sky frame defined by this orbit's :meth:`align_to_orbit` rotation matrix (or one passed via ``T=``).
+
+        Parameters
+        ----------
+        t : numeric, numpy.ndarray or Quantity, optional
+            Time at which to get phi2. Default is the initial time.
+        T : numpy.ndarray, optional
+            3x3 rotation matrix from (ra, dec) to (phi1, phi2). Default
+            is the matrix stored by a previous call to
+            :meth:`align_to_orbit`. Required if no such call was made.
+        obs : numpy.ndarray, Quantity or Orbit, optional
+            Position of observer (in kpc, arranged as [X,Y,Z]; default=object-wide default).
+        ro : float or Quantity, optional
+            Physical scale in kpc for distances to use to convert. Default is object-wide default.
+        use_physical : bool, optional
+            Use to override object-wide default for using a physical scale for output.
+        quantity : bool, optional
+            If True, return an Astropy Quantity object. Default from configuration file.
+
+        Returns
+        -------
+        float, numpy.ndarray or Quantity [\*input_shape,nt]
+            Latitude in the custom sky frame in degrees.
+
+        Notes
+        -----
+        - 2026-05-01: Written by Bovy (UofT).
+        """
+        from ..util import coords
+
+        _check_roSet(self, kwargs, "phi2")
+        T = self._resolve_custom_transform(kwargs, "phi2")
+        thiso = self._call_internal(*args, **kwargs)
+        thiso_shape = thiso.shape
+        thiso = thiso.reshape((thiso_shape[0], -1))
+        radec = _radec(self, thiso, *args, **kwargs)
+        p12 = coords.radec_to_custom(radec[:, 0], radec[:, 1], T=T, degree=True)
+        return p12[:, 1].reshape(thiso_shape[1:]).T
+
+    @physical_conversion("proper-motion_masyr")
+    @shapeDecorator
+    def pmphi1(self, *args, **kwargs):
+        r"""
+        Return the proper motion in phi1 (mas/yr, includes ``cos(phi2)``) in the custom sky frame defined by :meth:`align_to_orbit`.
+
+        Parameters
+        ----------
+        t : numeric, numpy.ndarray or Quantity, optional
+            Time at which to get pmphi1. Default is the initial time.
+        T : numpy.ndarray, optional
+            3x3 rotation matrix from (ra, dec) to (phi1, phi2). Default
+            is the matrix stored by a previous call to
+            :meth:`align_to_orbit`. Required if no such call was made.
+        obs : numpy.ndarray, Quantity or Orbit, optional
+            Position and velocity of observer (in kpc and km/s, arranged as [X,Y,Z,vx,vy,vz]; default=object-wide default).
+        ro : float or Quantity, optional
+            Physical scale in kpc for distances to use to convert. Default is object-wide default.
+        vo : float or Quantity, optional
+            Physical scale for velocities in km/s to use to convert. Default is object-wide default.
+        use_physical : bool, optional
+            Use to override object-wide default for using a physical scale for output.
+        quantity : bool, optional
+            If True, return an Astropy Quantity object. Default from configuration file.
+
+        Returns
+        -------
+        float, numpy.ndarray or Quantity [\*input_shape,nt]
+            Proper motion in phi1 in mas/yr.
+
+        Notes
+        -----
+        - 2026-05-01: Written by Bovy (UofT).
+        """
+        from ..util import coords
+
+        _check_roSet(self, kwargs, "pmphi1")
+        _check_voSet(self, kwargs, "pmphi1")
+        T = self._resolve_custom_transform(kwargs, "pmphi1")
+        thiso = self._call_internal(*args, **kwargs)
+        thiso_shape = thiso.shape
+        thiso = thiso.reshape((thiso_shape[0], -1))
+        radec = _radec(self, thiso, *args, **kwargs)
+        pmrapmdec = _pmrapmdec(self, thiso, *args, **kwargs)
+        pm12 = coords.pmrapmdec_to_custom(
+            pmrapmdec[:, 0], pmrapmdec[:, 1], radec[:, 0], radec[:, 1], T=T, degree=True
+        )
+        return pm12[:, 0].reshape(thiso_shape[1:]).T
+
+    @physical_conversion("proper-motion_masyr")
+    @shapeDecorator
+    def pmphi2(self, *args, **kwargs):
+        r"""
+        Return the proper motion in phi2 (mas/yr) in the custom sky frame defined by :meth:`align_to_orbit`.
+
+        Parameters
+        ----------
+        t : numeric, numpy.ndarray or Quantity, optional
+            Time at which to get pmphi2. Default is the initial time.
+        T : numpy.ndarray, optional
+            3x3 rotation matrix from (ra, dec) to (phi1, phi2). Default
+            is the matrix stored by a previous call to
+            :meth:`align_to_orbit`. Required if no such call was made.
+        obs : numpy.ndarray, Quantity or Orbit, optional
+            Position and velocity of observer (in kpc and km/s, arranged as [X,Y,Z,vx,vy,vz]; default=object-wide default).
+        ro : float or Quantity, optional
+            Physical scale in kpc for distances to use to convert. Default is object-wide default.
+        vo : float or Quantity, optional
+            Physical scale for velocities in km/s to use to convert. Default is object-wide default.
+        use_physical : bool, optional
+            Use to override object-wide default for using a physical scale for output.
+        quantity : bool, optional
+            If True, return an Astropy Quantity object. Default from configuration file.
+
+        Returns
+        -------
+        float, numpy.ndarray or Quantity [\*input_shape,nt]
+            Proper motion in phi2 in mas/yr.
+
+        Notes
+        -----
+        - 2026-05-01: Written by Bovy (UofT).
+        """
+        from ..util import coords
+
+        _check_roSet(self, kwargs, "pmphi2")
+        _check_voSet(self, kwargs, "pmphi2")
+        T = self._resolve_custom_transform(kwargs, "pmphi2")
+        thiso = self._call_internal(*args, **kwargs)
+        thiso_shape = thiso.shape
+        thiso = thiso.reshape((thiso_shape[0], -1))
+        radec = _radec(self, thiso, *args, **kwargs)
+        pmrapmdec = _pmrapmdec(self, thiso, *args, **kwargs)
+        pm12 = coords.pmrapmdec_to_custom(
+            pmrapmdec[:, 0], pmrapmdec[:, 1], radec[:, 0], radec[:, 1], T=T, degree=True
+        )
+        return pm12[:, 1].reshape(thiso_shape[1:]).T
 
     @physical_conversion("proper-motion_masyr")
     @shapeDecorator

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -4721,6 +4721,42 @@ class Orbit:
         else:
             return numpy.arctan2(thiso[0], thiso[3]).T
 
+    def align_to_orbit(self, center_phi1=180.0):
+        r"""
+        Return a sky rotation matrix that places this orbit's orbital plane at ``phi2=0`` and the orbit itself at ``(phi1, phi2) = (center_phi1, 0)``.
+
+        Parameters
+        ----------
+        center_phi1 : float, optional
+            Longitude at which to place the orbit in the custom frame,
+            in degrees. Default 180.0.
+
+        Returns
+        -------
+        numpy.ndarray
+            3x3 rotation matrix.
+
+        Notes
+        -----
+        - 2026-04-23: Written by Bovy (UofT).
+        """
+        from ..util import coords
+
+        # Use internal units (Sun at Xsun=1, Zsun=zo/ro). The rotation
+        # matrix is scale-invariant since L = r x v only matters up to
+        # overall magnitude.
+        return coords.align_to_orbit(
+            float(self.x(use_physical=False)),
+            float(self.y(use_physical=False)),
+            float(self.z(use_physical=False)),
+            float(self.vx(use_physical=False)),
+            float(self.vy(use_physical=False)),
+            float(self.vz(use_physical=False)),
+            Xsun=1.0,
+            Zsun=self._zo / self._ro,
+            center_phi1=center_phi1,
+        )
+
     @physical_conversion("angle_deg")
     @shapeDecorator
     def ra(self, *args, **kwargs):

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -4727,13 +4727,12 @@ class Orbit:
 
     def align_to_orbit(self, center_phi1=180.0):
         r"""
-        Return a sky rotation matrix that places this orbit's orbital plane at ``phi2=0`` and the orbit itself at ``(phi1, phi2) = (center_phi1, 0)``.
+        Return a sky rotation matrix aligned with this orbit's orbital plane.
 
-        The returned matrix is also stashed on this Orbit as
-        ``self._custom_transform``, so subsequent ``self.phi1()`` /
-        ``self.phi2()`` / ``self.pmphi1()`` / ``self.pmphi2()`` calls
-        (and ``self.plot(d1='phi1', d2='phi2')``) work without having
-        to pass ``T=`` explicitly.
+        The matrix is also stashed on this Orbit as
+        ``self._custom_transform`` so that ``self.phi1()``,
+        ``self.phi2()``, ``self.pmphi1()``, ``self.pmphi2()`` (and
+        ``self.plot(d1='phi1', d2='phi2')``) work without ``T=``.
 
         Parameters
         ----------
@@ -5039,7 +5038,7 @@ class Orbit:
     @shapeDecorator
     def phi1(self, *args, **kwargs):
         r"""
-        Return the longitude in the custom sky frame defined by this orbit's :meth:`align_to_orbit` rotation matrix (or one passed via ``T=``).
+        Return the longitude in a custom sky frame (in deg).
 
         Parameters
         ----------
@@ -5082,7 +5081,7 @@ class Orbit:
     @shapeDecorator
     def phi2(self, *args, **kwargs):
         r"""
-        Return the latitude in the custom sky frame defined by this orbit's :meth:`align_to_orbit` rotation matrix (or one passed via ``T=``).
+        Return the latitude in a custom sky frame (in deg).
 
         Parameters
         ----------
@@ -5125,7 +5124,7 @@ class Orbit:
     @shapeDecorator
     def pmphi1(self, *args, **kwargs):
         r"""
-        Return the proper motion in phi1 (mas/yr, includes ``cos(phi2)``) in the custom sky frame defined by :meth:`align_to_orbit`.
+        Return proper motion in custom-frame longitude (in mas/yr, includes ``cos(phi2)``).
 
         Parameters
         ----------
@@ -5174,7 +5173,7 @@ class Orbit:
     @shapeDecorator
     def pmphi2(self, *args, **kwargs):
         r"""
-        Return the proper motion in phi2 (mas/yr) in the custom sky frame defined by :meth:`align_to_orbit`.
+        Return proper motion in custom-frame latitude (in mas/yr).
 
         Parameters
         ----------

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2548,12 +2548,16 @@ def align_to_orbit(x, y, z, vx, vy, vz, Xsun=1.0, Zsun=0.0, center_phi1=180.0):
     Lx = dy * vz - dz * vy
     Ly = dz * vx - dx * vz
     Lz = dx * vy - dy * vx
-    # L in galactocentric basis → Galactic (l, b). Galactic ``X`` points
-    # toward the GC, opposite of galpy's galactocentric ``x``, hence the
-    # ``-Lx``; Galactic ``Y``/``Z`` match galactocentric ``y``/``z``
-    # (ignoring the tiny Zsun tilt).
-    l_pole = numpy.degrees(numpy.arctan2(Ly, -Lx))
-    b_pole = numpy.degrees(numpy.arctan2(Lz, numpy.sqrt(Lx**2 + Ly**2)))
+    # Rotate L from the galactocentric basis to the heliocentric Galactic
+    # basis. ``galcenrect_to_vxvyvz`` is the rotation-only sibling of
+    # ``galcenrect_to_XYZ`` (no translation, since L is a free vector);
+    # with ``vsun=0`` it accounts for the Zsun tilt and the astropy-
+    # alignment ``galcen_extra_rot``.
+    Lh = numpy.atleast_2d(
+        galcenrect_to_vxvyvz(Lx, Ly, Lz, vsun=[0.0, 0.0, 0.0], Xsun=Xsun, Zsun=Zsun)
+    )[0]
+    l_pole = numpy.degrees(numpy.arctan2(Lh[1], Lh[0]))
+    b_pole = numpy.degrees(numpy.arctan2(Lh[2], numpy.sqrt(Lh[0] ** 2 + Lh[1] ** 2)))
     radec = numpy.atleast_2d(lb_to_radec(l_pole, b_pole, degree=True))
     ra_pole = float(radec[0, 0])
     dec_pole = float(radec[0, 1])

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2487,6 +2487,104 @@ def custom_to_pmrapmdec(pmphi1, pmphi2, phi1, phi2, T=None, degree=False):
     )
 
 
+def align_to_orbit(x, y, z, vx, vy, vz, Xsun=1.0, Zsun=0.0, center_phi1=180.0):
+    """Build a 3x3 sky rotation aligning a stream-generating orbit.
+
+    Given the progenitor's galactocentric Cartesian phase-space
+    coordinates (galpy convention: ``+x`` toward the Sun, ``+y`` in the
+    direction of Galactic rotation, ``+z`` toward the North Galactic
+    Pole), returns the ``T`` matrix that :func:`radec_to_custom`
+    consumes, chosen so that in the resulting ``(phi1, phi2)`` frame:
+
+    - the progenitor's orbital plane lies at ``phi2 ≈ 0`` (so a stream
+      generated from it runs approximately horizontally);
+    - the progenitor itself sits at ``(phi1, phi2) = (center_phi1, 0)``
+      — by default ``center_phi1 = 180°`` so the stream wraps naturally
+      across the ``0/360°`` boundary rather than through the centre of
+      the plot.
+
+    Parameters
+    ----------
+    x, y, z : float
+        Galactocentric Cartesian position of the progenitor (galpy
+        convention: ``+x`` toward the Sun).
+    vx, vy, vz : float
+        Galactocentric Cartesian velocity of the progenitor (same
+        convention). The angular-momentum direction is scale-invariant,
+        so any consistent pair of position/velocity units works.
+    Xsun : float, optional
+        Galactocentric x-coordinate of the Sun in the same units as
+        ``x`` (default 1.0 — galpy internal units).
+    Zsun : float, optional
+        Galactocentric z-coordinate of the Sun in the same units as
+        ``z`` (default 0.0).
+    center_phi1 : float, optional
+        Longitude at which to place the progenitor, in degrees
+        (default 180.0).
+
+    Returns
+    -------
+    numpy.ndarray
+        3x3 rotation matrix ``T``. Use as
+        ``coords.radec_to_custom(ra, dec, T=T, degree=True)`` or pass to
+        :class:`galpy.df.streamTrack.StreamTrack` as
+        ``custom_transform=T``. Inverse of a rotation is its transpose —
+        use ``T.T`` to rotate back to equatorial sky.
+
+    Notes
+    -----
+    The alignment uses the angular momentum of the progenitor about the
+    Sun, ``L = (r_prog − r_sun) × v_prog``, with the Sun treated as at
+    rest in the Galactocentric frame. This is the quantity that defines
+    a great circle on the observer's sky closest to the apparent orbit
+    trajectory (heliocentric ``L`` with Sun-motion subtracted gives a
+    slightly different plane and a less horizontal stream).
+    """
+    from . import _rotate_to_arbitrary_vector
+
+    dx = x - Xsun
+    dy = y
+    dz = z - Zsun
+    Lx = dy * vz - dz * vy
+    Ly = dz * vx - dx * vz
+    Lz = dx * vy - dy * vx
+    # L in galactocentric basis → Galactic (l, b). Galactic ``X`` points
+    # toward the GC, opposite of galpy's galactocentric ``x``, hence the
+    # ``-Lx``; Galactic ``Y``/``Z`` match galactocentric ``y``/``z``
+    # (ignoring the tiny Zsun tilt).
+    l_pole = numpy.degrees(numpy.arctan2(Ly, -Lx))
+    b_pole = numpy.degrees(numpy.arctan2(Lz, numpy.sqrt(Lx**2 + Ly**2)))
+    radec = numpy.atleast_2d(lb_to_radec(l_pole, b_pole, degree=True))
+    ra_pole = float(radec[0, 0])
+    dec_pole = float(radec[0, 1])
+    L_eq = numpy.array(
+        [
+            numpy.cos(numpy.radians(dec_pole)) * numpy.cos(numpy.radians(ra_pole)),
+            numpy.cos(numpy.radians(dec_pole)) * numpy.sin(numpy.radians(ra_pole)),
+            numpy.sin(numpy.radians(dec_pole)),
+        ]
+    )
+    R_base = _rotate_to_arbitrary_vector(numpy.atleast_2d(L_eq), [0.0, 0.0, 1.0])[0]
+
+    # Progenitor heliocentric Galactic (X, Y, Z) → (l, b) → (ra, dec).
+    XYZ_h = galcenrect_to_XYZ(x, y, z, Xsun=Xsun, Zsun=Zsun)
+    lbd = XYZ_to_lbd(float(XYZ_h[0]), float(XYZ_h[1]), float(XYZ_h[2]), degree=True)
+    radec_p = numpy.atleast_2d(lb_to_radec(float(lbd[0]), float(lbd[1]), degree=True))
+    ra_p = float(radec_p[0, 0])
+    dec_p = float(radec_p[0, 1])
+    phi12 = radec_to_custom(
+        numpy.atleast_1d(ra_p),
+        numpy.atleast_1d(dec_p),
+        T=R_base,
+        degree=True,
+    )
+    phi1_prog = float(phi12[0, 0])
+    dphi = numpy.radians(center_phi1 - phi1_prog)
+    c, s = numpy.cos(dphi), numpy.sin(dphi)
+    R_z = numpy.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+    return R_z @ R_base
+
+
 def get_epoch_angles(epoch=2000.0):
     """
     Get the angles relevant for the transformation from ra, dec to l,b for the given epoch.

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2540,8 +2540,6 @@ def align_to_orbit(x, y, z, vx, vy, vz, Xsun=1.0, Zsun=0.0, center_phi1=180.0):
     trajectory (heliocentric ``L`` with Sun-motion subtracted gives a
     slightly different plane and a less horizontal stream).
     """
-    from . import _rotate_to_arbitrary_vector
-
     dx = x - Xsun
     dy = y
     dz = z - Zsun

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -3405,7 +3405,7 @@ def test_align_to_orbit():
         degree=True,
     )
     assert abs(p12[0, 0] - 180.0) < 1e-4, "progenitor not at phi1=180 (default)"
-    assert abs(p12[0, 1]) < 0.5, "progenitor not on the great circle phi2=0"
+    assert abs(p12[0, 1]) < 1e-4, "progenitor not on the great circle phi2=0"
     # center_phi1=0 override
     T0 = coords.align_to_orbit(
         x, y, z, vx, vy, vz, Xsun=Xsun, Zsun=Zsun, center_phi1=0.0

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -3377,3 +3377,45 @@ def _turn_off_apy(keep_loaded=False):
 def _turn_on_apy():
     coords._APY_COORDS = coords._APY_COORDS_ORIG
     coords._APY_LOADED = True
+
+
+def test_align_to_orbit():
+    # coords.align_to_orbit takes 6D galactocentric Cartesian kinematics
+    # (no Orbit dependency) and returns a sky-rotation matrix that places
+    # the orbit's plane at phi2≈0 with center_phi1 at the input position.
+    # Use a fixed test point in internal units (Sun at Xsun=1, Zsun≈0.0026).
+    Xsun = 1.0
+    Zsun = 0.0208 / 8.0
+    x, y, z = 1.56148083, 0.35081535, -1.15481504
+    vx, vy, vz = 0.88719443, -0.47713334, 0.12019596
+    T = coords.align_to_orbit(x, y, z, vx, vy, vz, Xsun=Xsun, Zsun=Zsun)
+    assert T.shape == (3, 3), "align_to_orbit should return a 3x3 matrix"
+    # Orthogonal: T.T == T^{-1}
+    assert numpy.allclose(T @ T.T, numpy.eye(3), atol=1e-10), (
+        "align_to_orbit rotation matrix is not orthogonal"
+    )
+    # The orbit point should land at phi1=180, phi2≈0 (default center_phi1)
+    XYZ = coords.galcenrect_to_XYZ(x, y, z, Xsun=Xsun, Zsun=Zsun)
+    lbd = coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=True)
+    radec = coords.lb_to_radec(lbd[0], lbd[1], degree=True)
+    p12 = coords.radec_to_custom(
+        numpy.atleast_1d(radec[0]),
+        numpy.atleast_1d(radec[1]),
+        T=T,
+        degree=True,
+    )
+    assert abs(p12[0, 0] - 180.0) < 1e-4, "progenitor not at phi1=180 (default)"
+    assert abs(p12[0, 1]) < 0.5, "progenitor not on the great circle phi2=0"
+    # center_phi1=0 override
+    T0 = coords.align_to_orbit(
+        x, y, z, vx, vy, vz, Xsun=Xsun, Zsun=Zsun, center_phi1=0.0
+    )
+    p12_0 = coords.radec_to_custom(
+        numpy.atleast_1d(radec[0]),
+        numpy.atleast_1d(radec[1]),
+        T=T0,
+        degree=True,
+    )
+    assert abs(p12_0[0, 0]) < 1e-4 or abs(p12_0[0, 0] - 360.0) < 1e-4, (
+        "center_phi1=0 override does not place the progenitor at phi1=0"
+    )

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -11731,3 +11731,45 @@ def test_integrate_auto_vcirc_filtering_consistency_2D():
         f"Integration times differ: {o1.t[-1]} vs {o2.t[-1]}"
     )
     return None
+
+
+def test_orbit_align_to_orbit():
+    # Orbit.align_to_orbit() is a thin method wrapper around
+    # galpy.util.coords.align_to_orbit — must forward this orbit's
+    # galactocentric Cartesian kinematics plus Xsun/Zsun and produce
+    # the same rotation matrix as the coords function.
+    from galpy.orbit import Orbit
+    from galpy.util import coords as gcoords
+
+    prog = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+        ro=8.0,
+        vo=220.0,
+    )
+    T_method = prog.align_to_orbit()
+    T_func = gcoords.align_to_orbit(
+        float(prog.x(use_physical=False)),
+        float(prog.y(use_physical=False)),
+        float(prog.z(use_physical=False)),
+        float(prog.vx(use_physical=False)),
+        float(prog.vy(use_physical=False)),
+        float(prog.vz(use_physical=False)),
+        Xsun=1.0,
+        Zsun=prog._zo / prog._ro,
+    )
+    assert T_method.shape == (3, 3)
+    assert numpy.allclose(T_method, T_func)
+    # center_phi1 kwarg threads through
+    T0_method = prog.align_to_orbit(center_phi1=0.0)
+    T0_func = gcoords.align_to_orbit(
+        float(prog.x(use_physical=False)),
+        float(prog.y(use_physical=False)),
+        float(prog.z(use_physical=False)),
+        float(prog.vx(use_physical=False)),
+        float(prog.vy(use_physical=False)),
+        float(prog.vz(use_physical=False)),
+        Xsun=1.0,
+        Zsun=prog._zo / prog._ro,
+        center_phi1=0.0,
+    )
+    assert numpy.allclose(T0_method, T0_func)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -11773,3 +11773,133 @@ def test_orbit_align_to_orbit():
         center_phi1=0.0,
     )
     assert numpy.allclose(T0_method, T0_func)
+
+
+def test_orbit_phi1phi2_after_align_to_orbit():
+    # After Orbit.align_to_orbit() stashes a custom_transform, the
+    # phi1/phi2/pmphi1/pmphi2 accessors should work without further setup
+    # and reproduce coords.radec_to_custom / pmrapmdec_to_custom directly.
+    from galpy.orbit import Orbit
+    from galpy.util import coords as gcoords
+
+    prog = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+        ro=8.0,
+        vo=220.0,
+    )
+    T = prog.align_to_orbit()
+    # The orbit's own phi1/phi2 should land at (180, ~0) by the
+    # default center_phi1=180 alignment, matching the analytical
+    # round-trip via radec_to_custom.
+    p12 = gcoords.radec_to_custom(
+        numpy.atleast_1d(prog.ra()),
+        numpy.atleast_1d(prog.dec()),
+        T=T,
+        degree=True,
+    )
+    assert abs(float(prog.phi1()) - p12[0, 0]) < 1e-8
+    assert abs(float(prog.phi2()) - p12[0, 1]) < 1e-8
+    pm12 = gcoords.pmrapmdec_to_custom(
+        numpy.atleast_1d(prog.pmra()),
+        numpy.atleast_1d(prog.pmdec()),
+        numpy.atleast_1d(prog.ra()),
+        numpy.atleast_1d(prog.dec()),
+        T=T,
+        degree=True,
+    )
+    assert abs(float(prog.pmphi1()) - pm12[0, 0]) < 1e-8
+    assert abs(float(prog.pmphi2()) - pm12[0, 1]) < 1e-8
+
+
+def test_orbit_phi1phi2_T_kwarg_override():
+    # Without calling align_to_orbit, an explicit T= still works (and
+    # overrides any stashed matrix).
+    from galpy.orbit import Orbit
+
+    prog = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+        ro=8.0,
+        vo=220.0,
+    )
+    # Identity T means phi1=ra, phi2=dec (modulo wrap on the equator)
+    val = float(prog.phi1(T=numpy.eye(3)))
+    assert abs(val - float(prog.ra())) < 1e-8
+
+
+def test_orbit_phi1_no_transform_raises():
+    # Without align_to_orbit and without an explicit T=, the accessors
+    # raise so the user knows to set up the rotation matrix.
+    from galpy.orbit import Orbit
+
+    prog = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+        ro=8.0,
+        vo=220.0,
+    )
+    import pytest
+
+    for name in ("phi1", "phi2", "pmphi1", "pmphi2"):
+        with pytest.raises(RuntimeError):
+            getattr(prog, name)()
+
+
+def test_orbit_plot_phi1phi2():
+    # Orbit.plot dispatches d1='phi1', d2='phi2' through the new
+    # accessors; smoke-test that the call returns successfully and
+    # picks up the labeldict_radec entries.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from galpy.orbit import Orbit
+    from galpy.potential import MWPotential2014
+
+    prog = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+        ro=8.0,
+        vo=220.0,
+    )
+    prog.align_to_orbit()
+    prog.integrate(numpy.linspace(0, 1, 11), MWPotential2014)
+    line = prog.plot(d1="phi1", d2="phi2")
+    assert line and len(line) >= 1
+    line2 = prog.plot(d1="phi1", d2="pmphi2")
+    assert line2 and len(line2) >= 1
+
+
+def test_orbit_phi1phi2_multi_shape_and_time():
+    # phi1/phi2/pmphi1/pmphi2 must broadcast correctly over (N orbits,
+    # M times): shape (N, M) on the input vxvv shape (N,), and each
+    # row should match the per-orbit single-Orbit accessor result.
+    from galpy.orbit import Orbit
+    from galpy.potential import MWPotential2014
+
+    vxvv = numpy.array(
+        [
+            [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596],
+            [1.20, 0.10, -0.95, 0.50, -0.20, 0.30],
+            [1.40, 0.20, -1.00, 0.70, -0.30, 0.20],
+        ]
+    )
+    multi = Orbit(vxvv, ro=8.0, vo=220.0)
+    assert multi.shape == (3,)
+    ts = numpy.linspace(0, 1, 4)
+    multi.integrate(ts, MWPotential2014)
+    # Build a custom transform from the first orbit, share across all
+    T = multi[0].align_to_orbit()
+    multi._custom_transform = T
+    out = multi.phi1(ts)
+    assert out.shape == (3, 4), f"phi1 shape {out.shape} (expected (3, 4))"
+    # Each row should agree with a per-orbit call (which we have to set
+    # up the transform on separately because Orbit getitem yields a
+    # fresh instance without the parent's _custom_transform)
+    for i in range(3):
+        single = multi[i]
+        single._custom_transform = T
+        single_out = single.phi1(ts)
+        assert single_out.shape == (4,), f"single[{i}] phi1 shape {single_out.shape}"
+        assert numpy.allclose(out[i], single_out), (
+            f"orbit {i} phi1 differs between multi and single: {out[i]} vs {single_out}"
+        )
+        assert numpy.allclose(multi.phi2(ts)[i], single.phi2(ts))
+        assert numpy.allclose(multi.pmphi1(ts)[i], single.pmphi1(ts))
+        assert numpy.allclose(multi.pmphi2(ts)[i], single.pmphi2(ts))


### PR DESCRIPTION
## Summary

Adds `galpy.util.coords.align_to_orbit` and a thin `Orbit.align_to_orbit()` wrapper. Returns a 3×3 rotation matrix from `(ra, dec)` to a custom `(phi1, phi2)` sky frame aligned with a progenitor orbit's plane:

- `phi2 = 0` traces the great circle closest to the apparent orbit on the observer's sky
- `phi1 = center_phi1` (default 180°) at the progenitor location, so the stream wraps across 0°/360° rather than through the centre of the plot

The alignment uses `L = (r_prog - r_sun) × v_prog` — the angular momentum about the Sun (not the heliocentric momentum).

Extracted ahead of #861 since `align_to_orbit` is generally useful (any consumer that wants a per-stream sky frame), and #861's `streamTrack(custom_transform=T, ...)` already takes any 3×3 rotation matrix and doesn't strictly need this helper to land alongside.

## Commits

- `coords.align_to_orbit`: heliocentric-Cartesian 6D entry point, returning the rotation matrix
- `Orbit.align_to_orbit`: thin method wrapper that forwards the progenitor's galactocentric coords + Xsun/Zsun
- L-about-the-Sun (not heliocentric): noticeably tighter residual `phi2` spread on tests
- Drop dead 2-D guards in the progenitor `(l, b)` extraction (the function is scalar-only)

## Test plan

- [x] `test_align_to_orbit` covers the coords function: orthogonal rotation, progenitor at `(180°, ~0°)`, `center_phi1=0` override
- [x] `test_orbit_align_to_orbit` covers the `Orbit` method: same matrix as the coords function, `center_phi1` threading through
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)