### PR TITLE
CI: update-doc-notebooks workflow should only stage .ipynb files

### DIFF
--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -229,7 +229,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
-          git add doc/source/tutorials
+          # Only stage notebook files. Other paths under doc/source/tutorials
+          # (e.g. the pynbody gasoline_ahf snapshot, Gaia/Dierickx query caches)
+          # are downloaded at runtime and must not end up in the PR.
+          find doc/source/tutorials -name '*.ipynb' -print0 | xargs -0 git add --
           git commit -m "Update documentation notebook outputs (${date_tag})"
           git push --set-upstream origin "$branch"
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ doc/source/tutorials/action_angle/gaia_dr3_solar_neighborhood.fits
 # Dierickx 2010 catalog cached by doc/source/tutorials/orbits/examples.ipynb
 doc/source/tutorials/orbits/dierickx_2010_thick_disk.fits
 
+# pynbody gasoline snapshot downloaded by doc/source/tutorials/potentials/nbody_snapshots.ipynb
+doc/source/tutorials/potentials/gasoline_ahf/
+
 
 # Build directories #
 #####################


### PR DESCRIPTION
## Summary
- The `Update documentation notebooks` workflow ran `git add doc/source/tutorials`, which swept in the pynbody gasoline snapshot data downloaded at runtime by `nbody_snapshots.ipynb` — see e.g. #883, which added ~1.4k lines of `g15784.lr.01024.z0.000.AHF_fpos` and other data files.
- Restrict the staging step to `*.ipynb` files only via `find … -print0 | xargs -0 git add --`, so the auto-PR contains only re-executed notebooks.
- Add `doc/source/tutorials/potentials/gasoline_ahf/` to `.gitignore` as a second line of defense, consistent with the existing entries for the Gaia DR3 and Dierickx 2010 query caches.

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` (dry run) and confirm the auto-PR — once enabled — would no longer include `gasoline_ahf/` files.
- [ ] Verify `git status` after running the notebooks locally shows `gasoline_ahf/` as ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)