### PR TITLE
Reproducible doc-notebook re-renders + Claude diff summary in PR body

### DIFF
--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -207,6 +207,19 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Apply pre-commit autofixes to changed notebooks
+        # Run repo pre-commit hooks (trailing-whitespace, end-of-file-fixer, ...)
+        # against the freshly re-rendered notebooks so the committed result matches
+        # what `pre-commit` would enforce locally and the CI hook won't fail later.
+        # Autofix-on-find leaves files modified and the hook exits non-zero — that's
+        # expected, so swallow it; the staged content will reflect the fixed files.
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          pip install --quiet pre-commit
+          git diff --name-only -- doc/source/tutorials \
+            | grep -E '\.ipynb$' \
+            | xargs --no-run-if-empty pre-commit run --files \
+            || true
       - name: Upload updated notebooks as artifact (dry run)
         if: >-
           steps.check-changes.outputs.changed == 'true' &&
@@ -216,6 +229,108 @@ jobs:
         with:
           name: updated-doc-notebooks
           path: doc/source/tutorials/**/*.ipynb
+      - name: Claude diff analysis
+        # Have Claude summarize the re-render diff so the PR body tells the
+        # reviewer at a glance whether anything substantive changed. Output is
+        # written to /tmp/nb_analysis.md by Claude and merged into the PR body
+        # in the next step. Failure is non-fatal — we fall back to the generic
+        # blurb if Claude can't run (missing key, API error, ...).
+        id: claude-analysis
+        if: steps.check-changes.outputs.changed == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model sonnet
+            --allowed-tools "Bash,Read,Write"
+            --max-turns 40
+          prompt: |
+            You are reviewing an automated re-render of galpy's tutorial notebooks
+            against the upstream `main` branch. The current working tree contains
+            the new outputs; `HEAD` is the unchanged main. All edits live under
+            `doc/source/tutorials/**/*.ipynb`.
+
+            **Deliverable**: write `/tmp/nb_analysis.md` — a brief markdown summary
+            that will be appended verbatim to the PR body so reviewers can decide
+            at a glance whether the rerun is routine noise or needs attention.
+
+            ## Method
+
+            1. `pip install --quiet Pillow numpy` so PIL/numpy are available for
+               decoding embedded images.
+
+            2. List changed notebooks:
+               `git diff --name-only HEAD -- 'doc/source/tutorials/**/*.ipynb'`.
+
+            3. For each one, verify cell SOURCE is unchanged (only outputs should
+               differ). Compare:
+                   diff <(git show "HEAD:$f" | jq -r '.cells[] | (.source|join(""))') \
+                        <(jq -r '.cells[] | (.source|join(""))' "$f")
+               Loudly flag any source change — that would be unexpected and
+               worth investigating.
+
+            4. Classify remaining diffs.
+
+               NOISE — ignore, do NOT list individually:
+                 - papermill timestamps, durations, execution_counts
+                 - memory addresses inside `<...object at 0x...>` repr strings
+                 - Python kernel version metadata bumps
+                 - papermill `input_path`/`output_path` switching between absolute
+                   and relative paths
+                 - image base64 bytes that decode to visually-identical pixels
+                 - ≤1e-9 relative floating-point roundoff in printed numbers
+                 - cache-hit prints like `"Loaded N stars from local cache: …"`
+                 - jaxlib/CUDA stderr lines about no GPU
+                 - a galpyWarning disappearing because Python's default warnings
+                   filter deduplicates a second emission
+
+               SUBSTANTIVE — list these:
+                 - text output diffs with >1e-6 relative change in printed numbers
+                 - image diffs where >1% of pixels differ by >2 channel steps
+                   after PIL decode (treat ≤2-step diffs as compression noise)
+                 - cells that gained or lost outputs (excluding the
+                   warning-dedup case above)
+                 - any cell-source change at all
+
+            5. For images: extract each `image/png` from both versions via jq +
+               base64, decode with PIL, convert to numpy array, compare.
+
+            ## Output format
+
+            Write to `/tmp/nb_analysis.md`, structured exactly like this — keep the
+            top half under 250 words; everything else goes inside `<details>`:
+
+            ```markdown
+            ### Re-run diff summary
+
+            **Verdict**: <one short sentence — e.g. "no substantive changes" or
+            "N concerns flagged below">
+
+            <if there are concerns, include this table; otherwise omit it>
+
+            | Notebook | Cell | Change | Likely cause |
+            |---|---|---|---|
+            | … | … | … | … |
+
+            <details><summary>Image comparison (X image pairs)</summary>
+
+            - Byte-identical: …
+            - Visually identical (sub-perceptual): …
+            - Pixel-differing (>1%): … (list notebook + %)
+
+            </details>
+
+            <details><summary>Text output diffs (filtered)</summary>
+
+            <bullet list of substantive text diffs, or "none beyond floating-point
+            roundoff and unseeded MC samples (if any cells remain unseeded)">
+
+            </details>
+            ```
+
+            Be concise. Do not narrate steps in the output — the reader wants
+            findings, not your process.
       - name: Open pull request with updated notebooks
         if: >-
           steps.check-changes.outputs.changed == 'true' &&
@@ -262,8 +377,17 @@ jobs:
             : > pr_body.md
           fi
           {
-            echo "Automated re-execution of the tutorial notebooks under \`doc/source/tutorials/\` against the current \`main\` branch, produced by the \`Update documentation notebooks\` workflow ([run \`${{ github.run_id }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})) on ${date_tag}. Review the rendered diffs before merging."
+            echo "Automated re-execution of the tutorial notebooks under \`doc/source/tutorials/\` against the current \`main\` branch, produced by the \`Update documentation notebooks\` workflow ([run \`${{ github.run_id }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})) on ${date_tag}."
+            echo ""
           } >> pr_body.md
+
+          # Append the Claude-generated diff analysis (if the analysis step
+          # produced one — non-fatal if Claude failed or wasn't configured).
+          if [ -s /tmp/nb_analysis.md ]; then
+            cat /tmp/nb_analysis.md >> pr_body.md
+          else
+            echo "_Diff analysis not available — review the rendered notebook diffs manually._" >> pr_body.md
+          fi
 
           gh pr create \
             --base main \

--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -24,6 +24,9 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
+  # Required by anthropics/claude-code-action for the OIDC token exchange
+  # that validates the OAuth-token auth flow.
+  id-token: write
 
 jobs:
   update-notebooks:

--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -284,6 +284,21 @@ jobs:
                  - jaxlib/CUDA stderr lines about no GPU
                  - a galpyWarning disappearing because Python's default warnings
                    filter deduplicates a second emission
+                 - In `action_angle/staeckel.ipynb` and `action_angle/torus.ipynb`:
+                   printed actions/frequencies/angles drifting at the ~1e-5
+                   relative level, and corresponding scatter-plot point shifts
+                   in those notebooks. The `actionAngleStaeckel` and
+                   `actionAngleTorus` C extensions are not bitwise-reproducible
+                   across CI runners (compiler/libm differences), and we
+                   accept this as routine.
+                 - Coordinated output shifts across cells in
+                   `action_angle/staeckel.ipynb` (Gaia DR3 catalog) or
+                   `orbits/examples.ipynb` (Dierickx 2010 thick-disk catalog)
+                   when the data file itself changed. Those FITS files are
+                   refreshed monthly by the `test-doc-notebooks.yml` workflow,
+                   so a coordinated shift in those notebooks just reflects a
+                   newer snapshot — note it as a one-liner ("Gaia DR3 cache
+                   refreshed this cycle") instead of itemizing every diff.
 
                SUBSTANTIVE — list these:
                  - text output diffs with >1e-6 relative change in printed numbers

--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -220,21 +220,12 @@ jobs:
             | grep -E '\.ipynb$' \
             | xargs --no-run-if-empty pre-commit run --files \
             || true
-      - name: Upload updated notebooks as artifact (dry run)
-        if: >-
-          steps.check-changes.outputs.changed == 'true' &&
-          (github.event_name == 'pull_request' ||
-           (github.event_name == 'workflow_dispatch' && inputs.dry_run))
-        uses: actions/upload-artifact@v7
-        with:
-          name: updated-doc-notebooks
-          path: doc/source/tutorials/**/*.ipynb
       - name: Claude diff analysis
-        # Have Claude summarize the re-render diff so the PR body tells the
-        # reviewer at a glance whether anything substantive changed. Output is
-        # written to /tmp/nb_analysis.md by Claude and merged into the PR body
-        # in the next step. Failure is non-fatal — we fall back to the generic
-        # blurb if Claude can't run (missing key, API error, ...).
+        # Have Claude summarize the re-render diff so the PR body (and
+        # the dry-run artifact / Actions step summary) tell the reviewer
+        # at a glance whether anything substantive changed. Output is
+        # written to /tmp/nb_analysis.md. Failure is non-fatal — we fall
+        # back to a clear warning in the PR body and on the step summary.
         id: claude-analysis
         if: steps.check-changes.outputs.changed == 'true'
         continue-on-error: true
@@ -346,6 +337,54 @@ jobs:
 
             Be concise. Do not narrate steps in the output — the reader wants
             findings, not your process.
+      - name: Surface diff analysis to Actions step summary
+        # Visible in the GitHub Actions UI for any run (dry-run or scheduled),
+        # so dry-runs — which don't open a PR — still expose what Claude
+        # found. On real runs the same content is also merged into the PR
+        # body below.
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          if [ -s /tmp/nb_analysis.md ]; then
+            cat /tmp/nb_analysis.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.claude-analysis.outcome }}" = "failure" ]; then
+            {
+              echo "## :warning: Claude diff analysis failed"
+              echo ""
+              echo "Most likely the \`CLAUDE_CODE_OAUTH_TOKEN\` repository secret has expired or been revoked."
+              echo "Regenerate it locally with \`claude setup-token\` and update the secret at"
+              echo "[Settings → Secrets and variables → Actions](${{ github.server_url }}/${{ github.repository }}/settings/secrets/actions)."
+              echo ""
+              echo "See the \`Claude diff analysis\` step log above for the exact error."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "_Diff analysis was skipped (no relevant changes)._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Stage analysis file for dry-run artifact
+        # Copy /tmp/nb_analysis.md into the workspace so the next step can
+        # include it without absolute-path warnings from upload-artifact.
+        if: >-
+          steps.check-changes.outputs.changed == 'true' &&
+          (github.event_name == 'pull_request' ||
+           (github.event_name == 'workflow_dispatch' && inputs.dry_run))
+        run: |
+          mkdir -p artifact-staging
+          if [ -s /tmp/nb_analysis.md ]; then
+            cp /tmp/nb_analysis.md artifact-staging/nb_analysis.md
+          fi
+      - name: Upload updated notebooks as artifact (dry run)
+        # Bundles the re-rendered notebooks and (if produced) Claude's diff
+        # analysis so a dry-run reviewer can download both.
+        if: >-
+          steps.check-changes.outputs.changed == 'true' &&
+          (github.event_name == 'pull_request' ||
+           (github.event_name == 'workflow_dispatch' && inputs.dry_run))
+        uses: actions/upload-artifact@v7
+        with:
+          name: updated-doc-notebooks
+          path: |
+            doc/source/tutorials/**/*.ipynb
+            artifact-staging/nb_analysis.md
+          if-no-files-found: warn
       - name: Open pull request with updated notebooks
         if: >-
           steps.check-changes.outputs.changed == 'true' &&
@@ -396,12 +435,21 @@ jobs:
             echo ""
           } >> pr_body.md
 
-          # Append the Claude-generated diff analysis (if the analysis step
-          # produced one — non-fatal if Claude failed or wasn't configured).
+          # Append the Claude-generated diff analysis. If the analysis step
+          # failed (most commonly: expired CLAUDE_CODE_OAUTH_TOKEN), surface a
+          # clear warning + remediation instead of a generic fallback so the
+          # next person to look at the PR knows exactly what to do.
           if [ -s /tmp/nb_analysis.md ]; then
             cat /tmp/nb_analysis.md >> pr_body.md
+          elif [ "${{ steps.claude-analysis.outcome }}" = "failure" ]; then
+            {
+              echo "> [!WARNING]"
+              echo "> **Diff analysis step failed.** Most likely the \`CLAUDE_CODE_OAUTH_TOKEN\` repository secret has expired or been revoked. Regenerate it locally with \`claude setup-token\` and update it at [Settings → Secrets and variables → Actions](${{ github.server_url }}/${{ github.repository }}/settings/secrets/actions). See the [\`Claude diff analysis\` step log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the exact error."
+              echo ""
+              echo "_Review the rendered notebook diffs manually for this rerun._"
+            } >> pr_body.md
           else
-            echo "_Diff analysis not available — review the rendered notebook diffs manually._" >> pr_body.md
+            echo "_Diff analysis was skipped — review the rendered notebook diffs manually._" >> pr_body.md
           fi
 
           gh pr create \

--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -240,7 +240,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model sonnet
             --allowed-tools "Bash,Read,Write"

--- a/.github/workflows/update-doc-notebooks.yml
+++ b/.github/workflows/update-doc-notebooks.yml
@@ -278,6 +278,29 @@ jobs:
                  - jaxlib/CUDA stderr lines about no GPU
                  - a galpyWarning disappearing because Python's default warnings
                    filter deduplicates a second emission
+                 - Consecutive `stdout` (or `stderr`) stream outputs inside a
+                   single cell merging into one (or splitting into more) when the
+                   concatenated text is byte-identical. This reflects
+                   IPython/papermill capture-buffering changes between runs, not
+                   a real output gain/loss — do NOT treat it as a "cell gained
+                   or lost outputs" event.
+                 - Monte-Carlo variance in printed numbers and scatter-plot point
+                   positions when the cell calls `numpy.random.*`,
+                   `df.sample(...)`, or `qdf.mean*(mc=True)` WITHOUT a preceding
+                   `numpy.random.seed(...)`. Expected run-to-run wobble. Note
+                   only the existence of any unseeded cell in a single bullet
+                   ("N cells still draw unseeded MC: <list>") so a follow-up
+                   can pin them; do not itemize the individual diffs.
+                 - When ONE notebook's Python kernel version differs from the
+                   rest (e.g. siblings all show 3.13.13 but one is still on
+                   3.12.x and just jumped), plot-pixel-dimension shifts and
+                   small layout drift in that outlier are an expected
+                   matplotlib-on-new-interpreter artifact. Note the version
+                   transition once; do not itemize the affected cells.
+                 - Image pairs whose dimensions differ by ≤24 px in one axis
+                   (matplotlib layout autosizing on a different environment).
+                   Compare the overlapping region; only flag as pixel-differing
+                   if the overlap also exceeds the >1% / >2-step rule below.
                  - In `action_angle/staeckel.ipynb` and `action_angle/torus.ipynb`:
                    printed actions/frequencies/angles drifting at the ~1e-5
                    relative level, and corresponding scatter-plot point shifts

--- a/doc/source/tutorials/action_angle/torus.ipynb
+++ b/doc/source/tutorials/action_angle/torus.ipynb
@@ -549,6 +549,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "nangles = 200001\n",
     "angler_rand = numpy.random.uniform(size=nangles) * 2.0 * numpy.pi\n",
     "anglep_rand = numpy.random.uniform(size=nangles) * 2.0 * numpy.pi\n",

--- a/doc/source/tutorials/distribution_functions/disk_df_2d.ipynb
+++ b/doc/source/tutorials/distribution_functions/disk_df_2d.ipynb
@@ -513,6 +513,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "samples = dfc.sample(n=500, returnOrbit=True, nphi=1)\n",
     "print(\"Number of sampled orbits:\", len(samples))\n",
     "print(\"First orbit R, vR, vT:\", samples[0].R(), samples[0].vR(), samples[0].vT())"
@@ -571,6 +572,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "vrvt = dfc.sampleVRVT(1.0, n=1000)\n",
     "plt.scatter(vrvt[:, 0], vrvt[:, 1], s=1, alpha=0.5, label=\"Samples\")\n",
     "\n",

--- a/doc/source/tutorials/distribution_functions/disk_df_3d.ipynb
+++ b/doc/source/tutorials/distribution_functions/disk_df_3d.ipynb
@@ -334,6 +334,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "print(\"<J_R> at (R=1, z=0):\", qdf.meanjr(1.0, 0.0, mc=True, nmc=10000))\n",
     "print(\"<L_z> at (R=1, z=0):\", qdf.meanlz(1.0, 0.0, mc=True, nmc=10000))\n",
     "print(\"<J_z> at (R=1, z=0):\", qdf.meanjz(1.0, 0.0, mc=True, nmc=10000))"
@@ -926,6 +927,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "vs = qdfS.sampleV(1.0, 0.0, n=10000)\n",
     "# Compare sampled vT distribution to the marginalized pvT\n",
     "plt.hist(\n",

--- a/doc/source/tutorials/distribution_functions/spherical_dfs.ipynb
+++ b/doc/source/tutorials/distribution_functions/spherical_dfs.ipynb
@@ -224,6 +224,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "samples = dfh.sample(n=5000)\n",
     "print(\"Type:\", type(samples))\n",
     "print(\"Number of orbits:\", len(samples))"
@@ -532,6 +533,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "from galpy.df import kingdf\n",
     "\n",
     "kdf = kingdf(W0=3.0, M=1.0, rt=1.5)\n",
@@ -792,6 +794,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "from galpy.df import constantbetaHernquistdf\n",
     "\n",
     "hp = HernquistPotential(amp=2.0, a=1.3)\n",

--- a/doc/source/tutorials/orbits/integration_and_plotting.ipynb
+++ b/doc/source/tutorials/orbits/integration_and_plotting.ipynb
@@ -829,7 +829,11 @@
     }
    ],
    "source": [
-    "o.plot(d1=\"t\", d2=lambda t: o.R(t) * numpy.cos(o.phi(t)) * numpy.sin(o.phi(t)));"
+    "o.plot(\n",
+    "    d1=\"t\",\n",
+    "    d2=lambda t: o.R(t) * numpy.cos(o.phi(t)) * numpy.sin(o.phi(t)),\n",
+    "    ylabel=r\"$R\\,\\cos\\phi\\,\\sin\\phi$\",\n",
+    ");"
    ]
   },
   {

--- a/doc/source/tutorials/streams/streamdf.ipynb
+++ b/doc/source/tutorials/streams/streamdf.ipynb
@@ -558,6 +558,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "RvR = sdf.sample(n=1000)\n",
     "plt.figure(figsize=(8, 4))\n",
     "plt.subplot(1, 2, 1)\n",
@@ -778,6 +779,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "# Sample in (l, b, dist, pmll, pmbb, vlos) coordinates\n",
     "lb = sdf.sample(n=500, lb=True)\n",
     "plt.figure(figsize=(8, 4))\n",
@@ -845,6 +847,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "# Returns (frequencies [3,N], angles [3,N], stripping_time [N])\n",
     "mockaA = sdf.sample(n=500, returnaAdt=True)\n",
     "plt.plot(mockaA[0][0], mockaA[0][2], \"k.\", ms=2)\n",

--- a/doc/source/tutorials/streams/streamspraydf.ipynb
+++ b/doc/source/tutorials/streams/streamspraydf.ipynb
@@ -211,6 +211,7 @@
    },
    "outputs": [],
    "source": [
+    "numpy.random.seed(1)\n",
     "lead_stream = spdf_lead.sample(n=500)"
    ]
   },
@@ -320,6 +321,7 @@
    },
    "outputs": [],
    "source": [
+    "numpy.random.seed(1)\n",
     "spdf_both = chen24spraydf(\n",
     "    progenitor_mass=2 * 10**4.0 * u.Msun,\n",
     "    progenitor=prog,\n",
@@ -431,6 +433,7 @@
    },
    "outputs": [],
    "source": [
+    "numpy.random.seed(1)\n",
     "spdf_fardal = fardal15spraydf(\n",
     "    progenitor_mass=2 * 10**4.0 * u.Msun,\n",
     "    progenitor=prog,\n",
@@ -560,6 +563,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "from galpy.potential import PlummerPotential\n",
     "\n",
     "progpot = PlummerPotential(2 * 10.0**4.0 * u.Msun, 4.0 * u.pc)\n",
@@ -724,6 +728,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "# Sample with integration and stripping times\n",
     "orbs_integrated, dt = spdf_both.sample(n=500, returndt=True, integrate=True)\n",
     "\n",
@@ -790,6 +795,7 @@
     }
    ],
    "source": [
+    "numpy.random.seed(1)\n",
     "# Sample with integration and stripping times\n",
     "orbs_not_integrated, dt = spdf_both.sample(n=500, returndt=True, integrate=False)\n",
     "\n",


### PR DESCRIPTION
## Motivation

The monthly `Update documentation notebooks` workflow re-renders all tutorial notebooks and opens a PR with the result (e.g. #885). Most of the resulting diff is unavoidable re-render noise — papermill timestamps, memory addresses, base64 PNG bytes that decode to the same image — but a real fraction is *avoidable*: several cells draw from `numpy.random` without a seed, and one cell's y-axis falls back to `repr(lambda …)` and bakes a memory address into the rendered plot.

This PR makes the re-renders reproducible where they can be, and adds a Claude-powered summary step so reviewers can see at a glance whether anything substantive changed.

## Notebook changes

- `numpy.random.seed(1)` inserted at the top of every cell that drives a `numpy.random` call, a galpy `df.sample(...)`, or `qdf.mean*(mc=True)`. (galpy's samplers use the numpy global RNG internally, so a per-cell seed is sufficient.) 17 cells across 6 notebooks:

  | Notebook | Cells seeded |
  |---|---|
  | `action_angle/torus.ipynb` | `e7f8a9b0c1d2` |
  | `distribution_functions/disk_df_2d.ipynb` | `c3933fab…`, `83098799…` |
  | `distribution_functions/disk_df_3d.ipynb` | `938c804e…`, `7a28786a` |
  | `distribution_functions/spherical_dfs.ipynb` | `8763a12b…`, `504fb2a4…`, `b43b363d…` |
  | `streams/streamdf.ipynb` | `a12`, `47a2ac43`, `34cf821c` |
  | `streams/streamspraydf.ipynb` | `b8`, `b11`, `b14`, `bc23e0d2`, `fc80e237`, `5a650fe8` |

- `orbits/integration_and_plotting.ipynb` cell `f73e762f` now passes `ylabel=r"$R\,\cos\phi\,\sin\phi$"` to `o.plot(...)` so the y-axis no longer renders as `<function <lambda> at 0x…>`.

The committed cell outputs are stale relative to the new seeded source — the next scheduled run of the workflow will re-render them and produce the first clean diff.

## Workflow changes (`.github/workflows/update-doc-notebooks.yml`)

- New step **Apply pre-commit autofixes to changed notebooks** — runs `pre-commit run --files <changed .ipynb>` between "Check for notebook changes" and the artifact upload, so `trailing-whitespace` / `end-of-file-fixer` autofixes land in the same commit and the PR can't fail pre-commit on merge.

- New step **Claude diff analysis** — invokes `anthropics/claude-code-action@v1` with a self-contained prompt that tells Claude to:
  1. verify zero cell-source changes,
  2. decode embedded PNGs with PIL and pixel-compare them,
  3. classify the rest as noise vs. substantive (the prompt enumerates the noise categories explicitly — papermill metadata, memory addresses, `~1e-5` C-extension drift in `actionAngleStaeckel` / `actionAngleTorus`, monthly Gaia/Dierickx cache refreshes, etc.),
  4. write a concise markdown summary to `/tmp/nb_analysis.md`.

  Authenticated via `claude_code_oauth_token` so usage counts against the Max-plan rate limits rather than billable API spend. `continue-on-error: true` — if Claude fails (token expired, rate limited, API error) the workflow falls back to the generic blurb.

- The **Open pull request** step assembles the PR body as: partial-update warning (if any) → existing run-link blurb → Claude's summary (or a fallback line if `/tmp/nb_analysis.md` is empty).

## Required repo setup

- Generate an OAuth token locally with `claude setup-token` (requires Claude Code installed and signed in to the Max-plan account).
- Add it as a `CLAUDE_CODE_OAUTH_TOKEN` repository secret. Until that's done the analysis step skips gracefully and the PR opens with only the generic blurb.

## Known remaining sources of small re-render drift (out of scope)

These are documented in the prompt's noise list so Claude won't flag them as substantive:

- `actionAngleStaeckel` and `actionAngleTorus` C extensions produce ~10⁻⁵-level differences across CI runners — affects `staeckel.ipynb` scatter plots and `torus.ipynb` printed frequencies.
- The Gaia DR3 and Dierickx 2010 caches are refreshed monthly by `test-doc-notebooks.yml`, so downstream cells in `staeckel.ipynb` / `examples.ipynb` can shift coherently when the catalog snapshot rolls over.