### PR TITLE
P2.1 Spherical potentials: backend-agnostic namespace-swap

### DIFF
--- a/galpy/potential/BurkertPotential.py
+++ b/galpy/potential/BurkertPotential.py
@@ -1,9 +1,12 @@
 ###############################################################################
 #   BurkertPotential.py: Potential with a Burkert density
 ###############################################################################
+import math
+
 import numpy
 from scipy import special
 
+from ..backend import get_namespace
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
 
@@ -76,23 +79,24 @@ class BurkertPotential(SphericalPotential):
     #                                +(1.-x)*numpy.log(1.+x**2.))
 
     def _rforce(self, r, t=0.0):
+        xp = get_namespace(r)
         x = r / self.a
         return (
             self.a
-            * numpy.pi
+            * math.pi
             / x**2.0
             * (
-                numpy.pi
-                - 2.0 * numpy.arctan(1.0 / x)
-                - 2.0 * numpy.log(1.0 + x)
-                - numpy.log(1.0 + x**2.0)
+                math.pi
+                - 2.0 * xp.arctan(1.0 / x)
+                - 2.0 * xp.log(1.0 + x)
+                - xp.log(1.0 + x**2.0)
             )
         )
 
     def _r2deriv(self, r, t=0.0):
         x = r / self.a
         return (
-            4.0 * numpy.pi / (1.0 + x**2.0) / (1.0 + x)
+            4.0 * math.pi / (1.0 + x**2.0) / (1.0 + x)
             + 2.0 * self._rforce(r) / x / self.a
         )
 

--- a/galpy/potential/BurkertPotential.py
+++ b/galpy/potential/BurkertPotential.py
@@ -3,9 +3,6 @@
 ###############################################################################
 import math
 
-import numpy
-from scipy import special
-
 from ..backend import get_namespace
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
@@ -61,15 +58,28 @@ class BurkertPotential(SphericalPotential):
 
     def _revaluate(self, r, t=0.0):
         """Potential as a function of r and time"""
+        xp = get_namespace(r)
         x = r / self.a
+        # special.xlogy(2/x, 1+x**2) == (2/x)*log(1+x**2), but with the convention
+        # that it is 0 where the prefactor is 0 (i.e. as x -> infty, where the bare
+        # product would be 0*inf = NaN). Reproduce that backend-agnostically: the
+        # prefactor 2/x only vanishes at x == infty, so guard exactly that point.
+        pref = 2.0 / x
+        # safe argument so the (dead) finite branch cannot make log(inf) at x==inf
+        safe_x2 = xp.where(xp.isinf(x), xp.ones_like(x * 1.0), x**2.0)
+        xlogy_term = xp.where(
+            xp.isinf(x),
+            xp.zeros_like(x * 1.0),
+            pref * xp.log(1.0 + safe_x2),
+        )
         return (
             -(self.a**2.0)
-            * numpy.pi
+            * math.pi
             * (
-                -numpy.pi / x
-                + 2.0 * (1.0 / x + 1) * numpy.arctan(1 / x)
-                + (1.0 / x + 1) * numpy.log((1.0 + 1.0 / x) ** 2.0 / (1.0 + 1 / x**2.0))
-                + special.xlogy(2.0 / x, 1.0 + x**2.0)
+                -math.pi / x
+                + 2.0 * (1.0 / x + 1) * xp.arctan(1 / x)
+                + (1.0 / x + 1) * xp.log((1.0 + 1.0 / x) ** 2.0 / (1.0 + 1 / x**2.0))
+                + xlogy_term
             )
         )
 
@@ -105,34 +115,41 @@ class BurkertPotential(SphericalPotential):
         return 1.0 / (1.0 + x) / (1.0 + x**2.0)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         x = r / self.a
-        Rpa = numpy.sqrt(R**2.0 + self.a**2.0)
-        Rma = numpy.sqrt(R**2.0 - self.a**2.0 + 0j)
-        if Rma == 0:
-            za = z / self.a
-            return (
-                self.a**2.0
-                / 2.0
-                * (
-                    (
-                        2.0
-                        - 2.0 * numpy.sqrt(za**2.0 + 1)
-                        + numpy.sqrt(2.0) * za * numpy.arctan(za / numpy.sqrt(2.0))
-                    )
-                    / z
-                    + numpy.sqrt(2 * za**2.0 + 2.0)
-                    * numpy.arctanh(za / numpy.sqrt(2.0 * (za**2.0 + 1)))
-                    / numpy.sqrt(self.a**2.0 + z**2.0)
+        Rpa = xp.sqrt(R**2.0 + self.a**2.0)
+        # R == a is a removable singularity of the generic (Rma != 0) branch:
+        # there Rma -> 0 and the arctan/Rma terms blow up, so we use a separate
+        # closed-form limit. xp.where evaluates BOTH branches, so the generic
+        # branch must stay NaN-free at the edge: build Rma from a safe argument
+        # that is never zero there (so 1/Rma, arctan(z/x/Rma) etc. stay finite).
+        at_edge = R == self.a
+        d2 = R**2.0 - self.a**2.0
+        safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
+        Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
+        # Edge (R == a) branch
+        za = z / self.a
+        edge = (
+            self.a**2.0
+            / 2.0
+            * (
+                (
+                    2.0
+                    - 2.0 * xp.sqrt(za**2.0 + 1)
+                    + 2.0**0.5 * za * xp.arctan(za / 2.0**0.5)
                 )
+                / z
+                + xp.sqrt(2 * za**2.0 + 2.0)
+                * xp.arctanh(za / xp.sqrt(2.0 * (za**2.0 + 1)))
+                / xp.sqrt(self.a**2.0 + z**2.0)
             )
-        else:
-            return (
-                self.a**2.0
-                * (
-                    numpy.arctan(z / x / Rma) / Rma
-                    + numpy.arctanh(z / x / Rpa) / Rpa
-                    - numpy.arctan(z / Rma) / Rma
-                    + numpy.arctan(z / Rpa) / Rpa
-                ).real
-            )
+        )
+        # Generic (R != a) branch; .real of the complex combination
+        generic = self.a**2.0 * xp.real(
+            xp.arctan(z / x / Rma) / Rma
+            + xp.arctanh(z / x / Rpa) / Rpa
+            - xp.arctan(z / Rma) / Rma
+            + xp.arctan(z / Rpa) / Rpa
+        )
+        return xp.where(at_edge, edge, generic)

--- a/galpy/potential/HomogeneousSpherePotential.py
+++ b/galpy/potential/HomogeneousSpherePotential.py
@@ -1,8 +1,9 @@
 ###############################################################################
 #   HomogeneousSpherePotential.py: The potential of a homogeneous sphere
 ###############################################################################
-import numpy
+import math
 
+from ..backend import get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -55,50 +56,65 @@ class HomogeneousSpherePotential(Potential):
         self.hasC_dens = True
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return r2 - 3.0 * self._R2
-        else:
-            return -2.0 * self._R3 / numpy.sqrt(r2)
+        inside = r2 < self._R2
+        # safe denominator so the (dead) outside branch cannot produce a
+        # 0/0 NaN at r2 == 0 that would poison reverse-mode gradients
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(inside, r2 - 3.0 * self._R2, -2.0 * self._R3 / xp.sqrt(safe))
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return -2.0 * R
-        else:
-            return -2.0 * self._R3 * R / r2**1.5
+        inside = r2 < self._R2
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(inside, -2.0 * R, -2.0 * self._R3 * R / safe**1.5)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return -2.0 * z
-        else:
-            return -2.0 * self._R3 * z / r2**1.5
+        inside = r2 < self._R2
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(inside, -2.0 * z, -2.0 * self._R3 * z / safe**1.5)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return 2.0
-        else:
-            return 2.0 * self._R3 / r2**1.5 - 6.0 * self._R3 * R**2.0 / r2**2.5
+        inside = r2 < self._R2
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(
+            inside,
+            2.0 * xp.ones_like(r2 * 1.0),
+            2.0 * self._R3 / safe**1.5 - 6.0 * self._R3 * R**2.0 / safe**2.5,
+        )
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return 2.0
-        else:
-            return 2.0 * self._R3 / r2**1.5 - 6.0 * self._R3 * z**2.0 / r2**2.5
+        inside = r2 < self._R2
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(
+            inside,
+            2.0 * xp.ones_like(r2 * 1.0),
+            2.0 * self._R3 / safe**1.5 - 6.0 * self._R3 * z**2.0 / safe**2.5,
+        )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return 0.0
-        else:
-            return -6.0 * self._R3 * R * z / r2**2.5
+        inside = r2 < self._R2
+        safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
+        return xp.where(
+            inside,
+            xp.zeros_like(r2 * 1.0),
+            -6.0 * self._R3 * R * z / safe**2.5,
+        )
 
     def _dens(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
-        if r2 < self._R2:
-            return 1.5 / numpy.pi
-        else:
-            return 0.0
+        inside = r2 < self._R2
+        return xp.where(
+            inside, 1.5 / math.pi * xp.ones_like(r2 * 1.0), xp.zeros_like(r2 * 1.0)
+        )

--- a/galpy/potential/PowerSphericalPotential.py
+++ b/galpy/potential/PowerSphericalPotential.py
@@ -6,9 +6,12 @@
 #                          rho(r)= ---------
 #                                   r^\alpha
 ###############################################################################
+import math
+
 import numpy
 from scipy import special
 
+from ..backend import get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -83,16 +86,20 @@ class PowerSphericalPotential(Potential):
         -----
         - Started: 2010-07-10 by Bovy (NYU)
         """
+        xp = get_namespace(R, z)
         r2 = R**2.0 + z**2.0
         if self.alpha == 2.0:
-            return numpy.log(r2) / 2.0
-        elif isinstance(r2, (float, int)) and r2 == 0 and self.alpha > 2:
-            return -numpy.inf
+            return xp.log(r2) / 2.0
+        elif self.alpha > 2:
+            # potential -> -inf at the center; use a safe r2 so the singular
+            # branch (0**negative) cannot produce a NaN/inf that poisons
+            # reverse-mode gradients, then patch in -inf where r2 == 0.
+            bad = r2 == 0.0
+            safe = xp.where(bad, xp.ones_like(r2 * 1.0), r2)
+            out = -(safe ** (1.0 - self.alpha / 2.0)) / (self.alpha - 2.0)
+            return xp.where(bad, -math.inf, out)
         else:
-            out = -(r2 ** (1.0 - self.alpha / 2.0)) / (self.alpha - 2.0)
-            if isinstance(r2, numpy.ndarray) and self.alpha > 2:
-                out[r2 == 0] = -numpy.inf
-            return out
+            return -(r2 ** (1.0 - self.alpha / 2.0)) / (self.alpha - 2.0)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         """
@@ -271,8 +278,9 @@ class PowerSphericalPotential(Potential):
         -----
         - 2013-01-09 - Written - Bovy (IAS)
         """
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        return (3.0 - self.alpha) / 4.0 / numpy.pi / r**self.alpha
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        return (3.0 - self.alpha) / 4.0 / math.pi / r**self.alpha
 
     def _ddensdr(self, r, t=0.0):
         """

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -8,6 +8,7 @@
 import numpy
 from scipy import special
 
+from ..backend import get_namespace
 from ..util import conversion
 from ..util._optional_deps import _JAX_LOADED
 from .Potential import Potential, kms_to_kpcGyrDecorator
@@ -146,18 +147,20 @@ class PowerSphericalPotentialwCutoff(Potential):
         )
 
     def _ddensdr(self, r, t=0.0):
+        xp = get_namespace(r)
         return (
             -self._amp
             * r ** (-1.0 - self.alpha)
-            * numpy.exp(-((r / self.rc) ** 2.0))
+            * xp.exp(-((r / self.rc) ** 2.0))
             * (2.0 * r**2.0 / self.rc**2.0 + self.alpha)
         )
 
     def _d2densdr2(self, r, t=0.0):
+        xp = get_namespace(r)
         return (
             self._amp
             * r ** (-2.0 - self.alpha)
-            * numpy.exp(-((r / self.rc) ** 2))
+            * xp.exp(-((r / self.rc) ** 2))
             * (
                 self.alpha**2.0
                 + self.alpha
@@ -199,8 +202,9 @@ class PowerSphericalPotentialwCutoff(Potential):
         )
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        return 1.0 / r**self.alpha * numpy.exp(-((r / self.rc) ** 2.0))
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        return 1.0 / r**self.alpha * xp.exp(-((r / self.rc) ** 2.0))
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:

--- a/galpy/potential/SphericalPotential.py
+++ b/galpy/potential/SphericalPotential.py
@@ -4,9 +4,6 @@
 ###############################################################################
 import math
 
-import numpy
-from scipy import integrate
-
 from ..backend import get_namespace
 from .Potential import Potential
 
@@ -99,5 +96,9 @@ class SphericalPotential(Potential):
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
             raise AttributeError  # use general implementation
-        R = numpy.float64(R)  # Avoid indexing issues
+        xp = get_namespace(R)
+        # asarray (not float64) avoids the original indexing issues for
+        # array-like input while preserving the backend (so a jax/torch R
+        # stays a tracked array rather than being coerced to numpy).
+        R = xp.asarray(R)
         return -(R**2.0) * self._rforce(R, t=t)

--- a/galpy/potential/SphericalPotential.py
+++ b/galpy/potential/SphericalPotential.py
@@ -2,9 +2,12 @@
 #   SphericalPotential.py: base class for potentials corresponding to
 #                          spherical density profiles
 ###############################################################################
+import math
+
 import numpy
 from scipy import integrate
 
+from ..backend import get_namespace
 from .Potential import Potential
 
 
@@ -47,43 +50,50 @@ class SphericalPotential(Potential):
 
     def _rdens(self, r, t=0.0):
         """Implement using the Poisson equation in case this isn't implemented"""
-        return (self._r2deriv(r, t=t) - 2.0 * self._rforce(r, t=t) / r) / 4.0 / numpy.pi
+        return (self._r2deriv(r, t=t) - 2.0 * self._rforce(r, t=t) / r) / 4.0 / math.pi
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return self._revaluate(r, t=t)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * R / r
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * z / r
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R**2.0 / r**2.0
             - self._rforce(r, t=t) * z**2.0 / r**3.0
         )
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * z**2.0 / r**2.0
             - self._rforce(r, t=t) * R**2.0 / r**3.0
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R * z / r**2.0
             + self._rforce(r, t=t) * R * z / r**3.0
         )
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return self._rdens(r, t=t)
 
     def _mass(self, R, z=None, t=0.0):

--- a/galpy/potential/SphericalShellPotential.py
+++ b/galpy/potential/SphericalShellPotential.py
@@ -93,8 +93,13 @@ class SphericalShellPotential(SphericalPotential):
         outside = R > self.a
         safe_arg = xp.where(outside, xp.ones_like(R * 1.0), self.a2 - R**2)
         h = xp.sqrt(safe_arg)
-        safe_h = xp.where(h == 0.0, xp.ones_like(h), h)
-        val = 1.0 / (2.0 * math.pi * self.a * safe_h)
+        # Do NOT mask h at the shell edge R == a (h == 0): the projected surface
+        # density genuinely diverges there (the 1/sqrt(a^2-R^2) limb singularity),
+        # so 1/(2 pi a h) -> inf is the correct value and matches the original numpy
+        # behavior. (Only the gradient at the exact edge is singular, which is real.)
+        # The R > a branch is still NaN-safe via safe_arg (h = sqrt(1) = 1 there,
+        # then masked to zero below).
+        val = 1.0 / (2.0 * math.pi * self.a * h)
         zero = xp.zeros_like((R + z) * 1.0)
         # zero for R > a or z < h, else val
         return xp.where(outside | (z < h), zero, val)

--- a/galpy/potential/SphericalShellPotential.py
+++ b/galpy/potential/SphericalShellPotential.py
@@ -2,8 +2,9 @@
 #   SphericalShellPotential.py: The gravitational potential of a thin,
 #                               spherical shell
 ###############################################################################
-import numpy
+import math
 
+from ..backend import get_namespace
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
 
@@ -58,37 +59,42 @@ class SphericalShellPotential(SphericalPotential):
 
     def _revaluate(self, r, t=0.0):
         """The potential as a function of r"""
-        if r <= self.a:
-            return -1.0 / self.a
-        else:
-            return -1.0 / r
+        xp = get_namespace(r)
+        inside = r <= self.a
+        # safe r so the (dead) outside branch cannot produce -1/0 at r == 0
+        safe = xp.where(inside, xp.ones_like(r * 1.0), r)
+        return xp.where(inside, -1.0 / self.a * xp.ones_like(r * 1.0), -1.0 / safe)
 
     def _rforce(self, r, t=0.0):
         """The force as a function of r"""
-        if r <= self.a:
-            return 0.0
-        else:
-            return -1 / r**2.0
+        xp = get_namespace(r)
+        inside = r <= self.a
+        safe = xp.where(inside, xp.ones_like(r * 1.0), r)
+        return xp.where(inside, xp.zeros_like(r * 1.0), -1 / safe**2.0)
 
     def _r2deriv(self, r, t=0.0):
         """The second radial derivative as a function of r"""
-        if r <= self.a:
-            return 0.0
-        else:
-            return -2.0 / r**3.0
+        xp = get_namespace(r)
+        inside = r <= self.a
+        safe = xp.where(inside, xp.ones_like(r * 1.0), r)
+        return xp.where(inside, xp.zeros_like(r * 1.0), -2.0 / safe**3.0)
 
     def _rdens(self, r, t=0.0):
         """The density as a function of r"""
-        if r != self.a:
-            return 0.0
-        else:  # pragma: no cover
-            return numpy.infty
+        xp = get_namespace(r)
+        return xp.where(
+            r != self.a, xp.zeros_like(r * 1.0), math.inf * xp.ones_like(r * 1.0)
+        )
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
-        if R > self.a:
-            return 0.0
-        h = numpy.sqrt(self.a2 - R**2)
-        if z < h:
-            return 0.0
-        else:
-            return 1.0 / (2.0 * numpy.pi * self.a * h)
+        xp = get_namespace(R, z)
+        # h is real only where R <= a; use a safe argument so the dead
+        # (R > a) branch cannot produce sqrt(negative) = NaN
+        outside = R > self.a
+        safe_arg = xp.where(outside, xp.ones_like(R * 1.0), self.a2 - R**2)
+        h = xp.sqrt(safe_arg)
+        safe_h = xp.where(h == 0.0, xp.ones_like(h), h)
+        val = 1.0 / (2.0 * math.pi * self.a * safe_h)
+        zero = xp.zeros_like((R + z) * 1.0)
+        # zero for R > a or z < h, else val
+        return xp.where(outside | (z < h), zero, val)

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -604,41 +604,51 @@ class HernquistPotential(DehnenSphericalPotential):
         )
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        Rma = numpy.sqrt(R**2.0 - self.a**2.0 + 0j)
-        if Rma == 0.0:
-            return (
-                (
-                    -12.0 * self.a**3
-                    - 5.0 * self.a * z**2
-                    + numpy.sqrt(1.0 + z**2 / self.a**2)
-                    * (12.0 * self.a**3 - self.a * z**2 + 2 / self.a * z**4)
-                )
-                / 30.0
-                / numpy.pi
-                * z**-5.0
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        # R == a is a removable singularity of the generic branch (Rma -> 0,
+        # (a^2-R^2) -> 0, (r^2-a^2) -> 0): use the closed-form limit there. Both
+        # xp.where branches are evaluated, so guard the generic branch's zero
+        # denominators with a safe R^2-a^2 that is never zero at the edge.
+        at_edge = R == self.a
+        d2 = R**2.0 - self.a**2.0
+        safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
+        Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
+        # also guard (r^2 - a^2), which vanishes at the edge when z == 0
+        d2r = r**2.0 - self.a**2.0
+        safe_d2r = xp.where(at_edge, xp.ones_like(d2r * 1.0), d2r)
+        edge = (
+            (
+                -12.0 * self.a**3
+                - 5.0 * self.a * z**2
+                + xp.sqrt(1.0 + z**2 / self.a**2)
+                * (12.0 * self.a**3 - self.a * z**2 + 2 / self.a * z**4)
             )
-        else:
-            return (
-                self.a
+            / 30.0
+            / math.pi
+            * z**-5.0
+        )
+        generic = (
+            self.a
+            * xp.real(
+                (2.0 * self.a**2.0 + R**2.0)
+                * Rma**-5
+                * (xp.arctan(z / Rma) - xp.arctan(self.a * z / r / Rma))
+                + z
                 * (
-                    (2.0 * self.a**2.0 + R**2.0)
-                    * Rma**-5
-                    * (numpy.arctan(z / Rma) - numpy.arctan(self.a * z / r / Rma))
-                    + z
-                    * (
-                        5.0 * self.a**3.0 * r
-                        - 4.0 * self.a**4
-                        + self.a**2 * (2.0 * r**2.0 + R**2)
-                        - self.a * r * (5.0 * R**2.0 + 3.0 * z**2.0)
-                        + R**2.0 * r**2.0
-                    )
-                    / (self.a**2.0 - R**2.0) ** 2.0
-                    / (r**2 - self.a**2.0) ** 2.0
-                ).real
-                / 4.0
-                / numpy.pi
+                    5.0 * self.a**3.0 * r
+                    - 4.0 * self.a**4
+                    + self.a**2 * (2.0 * r**2.0 + R**2)
+                    - self.a * r * (5.0 * R**2.0 + 3.0 * z**2.0)
+                    + R**2.0 * r**2.0
+                )
+                / safe_d2**2.0
+                / safe_d2r**2.0
             )
+            / 4.0
+            / math.pi
+        )
+        return xp.where(at_edge, edge, generic)
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
@@ -753,36 +763,42 @@ class JaffePotential(DehnenSphericalPotential):
         )
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        Rma = numpy.sqrt(R**2.0 - self.a**2.0 + 0j)
-        if Rma == 0.0:
-            return (
-                (
-                    3.0 * z**2.0
-                    - 2.0 * self.a**2.0
-                    + 2.0
-                    * numpy.sqrt(1.0 + (z / self.a) ** 2.0)
-                    * (self.a**2.0 - 2.0 * z**2.0)
-                    + 3.0 * z**3.0 / self.a * numpy.arctan(z / self.a)
-                )
-                / self.a
-                / z**3.0
-                / 6.0
-                / numpy.pi
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        # R == a is a removable singularity of the generic branch (Rma -> 0,
+        # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches
+        # are evaluated, so guard the generic branch's zero denominators.
+        at_edge = R == self.a
+        d2 = R**2.0 - self.a**2.0
+        safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
+        Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
+        edge = (
+            (
+                3.0 * z**2.0
+                - 2.0 * self.a**2.0
+                + 2.0
+                * xp.sqrt(1.0 + (z / self.a) ** 2.0)
+                * (self.a**2.0 - 2.0 * z**2.0)
+                + 3.0 * z**3.0 / self.a * xp.arctan(z / self.a)
             )
-        else:
-            return (
-                (
-                    (2.0 * self.a**2.0 - R**2.0)
-                    * Rma**-3
-                    * (numpy.arctan(z / Rma) - numpy.arctan(self.a * z / r / Rma))
-                    + numpy.arctan(z / R) / R
-                    - self.a * z / (R**2 - self.a**2) / (r + self.a)
-                ).real
-                / self.a
-                / 2.0
-                / numpy.pi
+            / self.a
+            / z**3.0
+            / 6.0
+            / math.pi
+        )
+        generic = (
+            xp.real(
+                (2.0 * self.a**2.0 - R**2.0)
+                * Rma**-3
+                * (xp.arctan(z / Rma) - xp.arctan(self.a * z / r / Rma))
+                + xp.arctan(z / R) / R
+                - self.a * z / safe_d2 / (r + self.a)
             )
+            / self.a
+            / 2.0
+            / math.pi
+        )
+        return xp.where(at_edge, edge, generic)
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
@@ -899,15 +915,20 @@ class NFWPotential(TwoPowerSphericalPotential):
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        if isinstance(r, (float, int)) and r == 0:
-            return -1.0 / self.a
-        elif isinstance(r, (float, int)):
-            return -special.xlogy(1.0 / r, 1.0 + r / self.a)  # stable as r -> infty
-        else:
-            out = -special.xlogy(1.0 / r, 1.0 + r / self.a)  # stable as r -> infty
-            out[r == 0] = -1.0 / self.a
-            return out
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        # -special.xlogy(1/r, 1+r/a) == -(1/r)*log(1+r/a), with xlogy's
+        # convention that the result is 0 where the prefactor 1/r is 0 (i.e.
+        # at r -> infty, where the bare product is 0*inf = NaN; this is the
+        # "stable as r -> infty" behavior). Additionally Phi(0) = -1/a. Both
+        # r == 0 and r == infty are handled with NaN-safe xp.where branches.
+        at0 = r == 0.0
+        atinf = xp.isinf(r)
+        # safe r so neither dead branch divides by 0 or takes log(inf)
+        safe = xp.where(at0 | atinf, xp.ones_like(r * 1.0), r)
+        bulk = -(1.0 / safe) * xp.log(1.0 + safe / self.a)
+        out = xp.where(atinf, xp.zeros_like(r * 1.0), bulk)
+        return xp.where(at0, -1.0 / self.a * xp.ones_like(r * 1.0), out)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
@@ -968,33 +989,34 @@ class NFWPotential(TwoPowerSphericalPotential):
         )
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        Rma = numpy.sqrt(R**2.0 - self.a**2.0 + 0j)
-        if Rma == 0.0:
-            za2 = (z / self.a) ** 2
-            return (
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        # R == a is a removable singularity of the generic branch (Rma -> 0,
+        # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches
+        # are evaluated, so guard the generic branch's zero denominators.
+        at_edge = R == self.a
+        d2 = R**2.0 - self.a**2.0
+        safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
+        Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
+        za2 = (z / self.a) ** 2
+        edge = self.a * (2.0 + xp.sqrt(za2 + 1.0) * (za2 - 2.0)) / 6.0 / math.pi / z**3
+        generic = (
+            xp.real(
                 self.a
-                * (2.0 + numpy.sqrt(za2 + 1.0) * (za2 - 2.0))
-                / 6.0
-                / numpy.pi
-                / z**3
+                * Rma**-3
+                * (xp.arctan(self.a * z / r / Rma) - xp.arctan(z / Rma))
+                + z / (r + self.a) / safe_d2
             )
-        else:
-            return (
-                (
-                    self.a
-                    * Rma**-3
-                    * (numpy.arctan(self.a * z / r / Rma) - numpy.arctan(z / Rma))
-                    + z / (r + self.a) / (R**2.0 - self.a**2.0)
-                ).real
-                / 2.0
-                / numpy.pi
-            )
+            / 2.0
+            / math.pi
+        )
+        return xp.where(at_edge, edge, generic)
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
             raise AttributeError  # use general implementation
-        return numpy.log(1 + R / self.a) - R / self.a / (1.0 + R / self.a)
+        xp = get_namespace(R)
+        return xp.log(1 + R / self.a) - R / self.a / (1.0 + R / self.a)
 
     @conversion.physical_conversion("position", pop=False)
     def rvir(

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -6,9 +6,12 @@
 #                             rho(r)= ------------------------------------
 #                                      (r/a)^\alpha (1+r/a)^(\beta-\alpha)
 ###############################################################################
+import math
+
 import numpy
 from scipy import optimize, special
 
+from ..backend import get_namespace
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED, _JAX_LOADED
 from .Potential import Potential, kms_to_kpcGyrDecorator
@@ -168,12 +171,13 @@ class TwoPowerSphericalPotential(Potential):
             )
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
             / (1.0 + r / self.a) ** (self.beta - self.alpha)
             / 4.0
-            / numpy.pi
+            / math.pi
             / self.a**3.0
         )
 
@@ -283,7 +287,8 @@ class TwoPowerSphericalPotential(Potential):
         return term1 + term2
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        return self._R2deriv(numpy.fabs(z), R)  # Spherical potential
+        xp = get_namespace(R, z)
+        return self._R2deriv(xp.abs(z), R)  # Spherical potential
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
@@ -355,7 +360,8 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
         if self._specialSelf is not None:
             return self._specialSelf._evaluate(R, z, phi=phi, t=t)
         else:  # valid for alpha != 2, 3
-            r = numpy.sqrt(R**2.0 + z**2.0)
+            xp = get_namespace(R, z)
+            r = xp.sqrt(R**2.0 + z**2.0)
             return -(1.0 - 1.0 / (1.0 + self.a / r) ** (2.0 - self.alpha)) / (
                 self.a * (2.0 - self.alpha) * (3.0 - self.alpha)
             )
@@ -364,7 +370,8 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
         if self._specialSelf is not None:
             return self._specialSelf._Rforce(R, z, phi=phi, t=t)
         else:
-            r = numpy.sqrt(R**2.0 + z**2.0)
+            xp = get_namespace(R, z)
+            r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -R
                 / r**self.alpha
@@ -375,12 +382,13 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         if self._specialSelf is not None:
             return self._specialSelf._R2deriv(R, z, phi=phi, t=t)
+        xp = get_namespace(R, z)
         a, alpha = self.a, self.alpha
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        r = xp.sqrt(R**2.0 + z**2.0)
         # formula not valid for alpha=2,3, (integers?)
         return (
-            numpy.power(r, -2.0 - alpha)
-            * numpy.power(r + a, alpha - 4.0)
+            r ** (-2.0 - alpha)
+            * (r + a) ** (alpha - 4.0)
             * (-a * r**2.0 + (2.0 * R**2.0 - z**2.0) * r + a * alpha * R**2.0)
             / (alpha - 3.0)
         )
@@ -389,7 +397,8 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
         if self._specialSelf is not None:
             return self._specialSelf._zforce(R, z, phi=phi, t=t)
         else:
-            r = numpy.sqrt(R**2.0 + z**2.0)
+            xp = get_namespace(R, z)
+            r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -z
                 / r**self.alpha
@@ -403,23 +412,21 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         if self._specialSelf is not None:
             return self._specialSelf._Rzderiv(R, z, phi=phi, t=t)
+        xp = get_namespace(R, z)
         a, alpha = self.a, self.alpha
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
-            R
-            * z
-            * numpy.power(r, -2.0 - alpha)
-            * numpy.power(a + r, alpha - 4.0)
-            * (3 * r + a * alpha)
+            R * z * r ** (-2.0 - alpha) * (a + r) ** (alpha - 4.0) * (3 * r + a * alpha)
         ) / (alpha - 3)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
             / (1.0 + r / self.a) ** (4.0 - self.alpha)
             / 4.0
-            / numpy.pi
+            / math.pi
             / self.a**3.0
         )
 
@@ -470,38 +477,43 @@ class DehnenCoreSphericalPotential(DehnenSphericalPotential):
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return -(1.0 - 1.0 / (1.0 + self.a / r) ** 2.0) / (6.0 * self.a)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        return -R / numpy.power(numpy.sqrt(R**2.0 + z**2.0) + self.a, 3.0) / 3.0
+        xp = get_namespace(R, z)
+        return -R / (xp.sqrt(R**2.0 + z**2.0) + self.a) ** 3.0 / 3.0
 
     def _rforce_jax(self, r):
         # No need for actual JAX!
         return -self._amp * r / (r + self.a) ** 3.0 / 3.0
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         return -(
-            ((2.0 * R**2.0 - z**2.0) - self.a * r)
-            / (3.0 * r * numpy.power(r + self.a, 4.0))
+            ((2.0 * R**2.0 - z**2.0) - self.a * r) / (3.0 * r * (r + self.a) ** 4.0)
         )
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        return -z / numpy.power(self.a + r, 3.0) / 3.0
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        return -z / (self.a + r) ** 3.0 / 3.0
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         return self._R2deriv(z, R, phi=phi, t=t)
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         a = self.a
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        return -(R * z / r / numpy.power(a + r, 4.0))
+        r = xp.sqrt(R**2.0 + z**2.0)
+        return -(R * z / r / (a + r) ** 4.0)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
-        return 1.0 / (1.0 + r / self.a) ** 4.0 / 4.0 / numpy.pi / self.a**3.0
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        return 1.0 / (1.0 + r / self.a) ** 4.0 / 4.0 / math.pi / self.a**3.0
 
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
@@ -553,14 +565,17 @@ class HernquistPotential(DehnenSphericalPotential):
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        return -1.0 / (1.0 + numpy.sqrt(R**2.0 + z**2.0) / self.a) / 2.0 / self.a
+        xp = get_namespace(R, z)
+        return -1.0 / (1.0 + xp.sqrt(R**2.0 + z**2.0) / self.a) / 2.0 / self.a
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
     def _rforce_jax(self, r):
@@ -568,7 +583,8 @@ class HernquistPotential(DehnenSphericalPotential):
         return -self._amp / 2.0 / (r + self.a) ** 2.0
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * z**2.0 + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
             / sqrtRz**3.0
@@ -577,7 +593,8 @@ class HernquistPotential(DehnenSphericalPotential):
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
             * z
@@ -702,18 +719,22 @@ class JaffePotential(DehnenSphericalPotential):
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        return -numpy.log(1.0 + self.a / numpy.sqrt(R**2.0 + z**2.0)) / self.a
+        xp = get_namespace(R, z)
+        return -xp.log(1.0 + self.a / xp.sqrt(R**2.0 + z**2.0)) / self.a
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * (z**2.0 - R**2.0) + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
             / sqrtRz**4.0
@@ -721,7 +742,8 @@ class JaffePotential(DehnenSphericalPotential):
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        sqrtRz = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
             * z
@@ -888,19 +910,19 @@ class NFWPotential(TwoPowerSphericalPotential):
             return out
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         Rz = R**2.0 + z**2.0
-        sqrtRz = numpy.sqrt(Rz)
+        sqrtRz = xp.sqrt(Rz)
         return R * (
-            1.0 / Rz / (self.a + sqrtRz)
-            - numpy.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
+            1.0 / Rz / (self.a + sqrtRz) - xp.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
         )
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         Rz = R**2.0 + z**2.0
-        sqrtRz = numpy.sqrt(Rz)
+        sqrtRz = xp.sqrt(Rz)
         return z * (
-            1.0 / Rz / (self.a + sqrtRz)
-            - numpy.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
+            1.0 / Rz / (self.a + sqrtRz) - xp.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
         )
 
     def _rforce_jax(self, r):
@@ -911,8 +933,9 @@ class NFWPotential(TwoPowerSphericalPotential):
         return self._amp * (1.0 / r / (self.a + r) - jnp.log(1.0 + r / self.a) / r**2.0)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         Rz = R**2.0 + z**2.0
-        sqrtRz = numpy.sqrt(Rz)
+        sqrtRz = xp.sqrt(Rz)
         return (
             (
                 3.0 * R**4.0
@@ -920,15 +943,16 @@ class NFWPotential(TwoPowerSphericalPotential):
                 - z**2.0 * (z**2.0 + self.a * sqrtRz)
                 - (2.0 * R**2.0 - z**2.0)
                 * (self.a**2.0 + R**2.0 + z**2.0 + 2.0 * self.a * sqrtRz)
-                * numpy.log(1.0 + sqrtRz / self.a)
+                * xp.log(1.0 + sqrtRz / self.a)
             )
             / Rz**2.5
             / (self.a + sqrtRz) ** 2.0
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         Rz = R**2.0 + z**2.0
-        sqrtRz = numpy.sqrt(Rz)
+        sqrtRz = xp.sqrt(Rz)
         return (
             -R
             * z
@@ -937,7 +961,7 @@ class NFWPotential(TwoPowerSphericalPotential):
                 - 3.0 * self.a * sqrtRz
                 + 3.0
                 * (self.a**2.0 + Rz + 2.0 * self.a * sqrtRz)
-                * numpy.log(1.0 + sqrtRz / self.a)
+                * xp.log(1.0 + sqrtRz / self.a)
             )
             * Rz**-2.5
             * (self.a + sqrtRz) ** -2.0

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -9,10 +9,13 @@
 #      gradient is consistent with the hand-coded force).
 #
 # Backends that are not installed self-skip, so this is green on numpy alone.
-# Methods that still call scipy.special / scipy.integrate (e.g. NFW._evaluate
-# via xlogy, TwoPower._evaluate via hyp2f1, the _surfdens of the cuspy
-# profiles) are intentionally NOT exercised here: they are deferred to the
-# later scipy-router PR.
+# Methods that genuinely require scipy.special with no backend-agnostic
+# replacement yet (e.g. the base TwoPower._evaluate/_Rforce via hyp2f1,
+# PowerSpherical._surfdens via hyp2f1, PowerSphericalPotentialwCutoff._mass via
+# hyp1f1) remain numpy-only and are NOT exercised here. The previously deferred
+# closed-form cases -- the xlogy-based NFW._evaluate and Burkert._revaluate, and
+# the complex-arithmetic _surfdens of Burkert/Hernquist/Jaffe/NFW -- are now
+# migrated and ARE covered below (incl. their R == a removable singularity).
 ###############################################################################
 import numpy
 import pytest
@@ -27,6 +30,7 @@ from galpy.potential import (
     KeplerPotential,
     NFWPotential,
     PowerSphericalPotential,
+    PowerSphericalPotentialwCutoff,
     SphericalShellPotential,
     TwoPowerSphericalPotential,
 )
@@ -100,12 +104,20 @@ CASES = [
         ],
         True,
     ),
-    # NFW: forces/2nd-derivs/dens migrated; _evaluate uses scipy.special.xlogy
-    # (deferred) so it is excluded here and the AD-vs-FD check is skipped.
+    # NFW: forces/2nd-derivs/dens migrated; _evaluate now migrated (the xlogy
+    # was rewritten as the equivalent NaN-safe -(1/r) log(1+r/a)).
     (
         NFWPotential(amp=1.3, a=1.1),
-        ["_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv", "_dens"],
-        False,
+        [
+            "_evaluate",
+            "_Rforce",
+            "_zforce",
+            "_R2deriv",
+            "_z2deriv",
+            "_Rzderiv",
+            "_dens",
+        ],
+        True,
     ),
     # PowerSpherical / Kepler: all listed compute methods migrated (_surfdens
     # uses hyp2f1, deferred).
@@ -120,11 +132,20 @@ CASES = [
     # HomogeneousSphere: piecewise, all methods migrated via xp.where.
     (HomogeneousSpherePotential(amp=1.3, R=1.1), _THREE_D, True),
     # Burkert: _rforce/_r2deriv/_rdens migrated => 3D forces/derivs/dens work;
-    # _revaluate uses xlogy (deferred) so _evaluate is excluded.
+    # _revaluate now migrated (the xlogy was rewritten as the equivalent
+    # NaN-safe (2/x) log(1+x^2)), so _evaluate is included.
     (
         BurkertPotential(amp=1.3, a=1.1),
-        ["_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv", "_dens"],
-        False,
+        [
+            "_evaluate",
+            "_Rforce",
+            "_zforce",
+            "_R2deriv",
+            "_z2deriv",
+            "_Rzderiv",
+            "_dens",
+        ],
+        True,
     ),
     # SphericalShell: all 1D methods migrated via xp.where (+ surfdens).
     (
@@ -236,3 +257,109 @@ def test_grad_evaluate_matches_rforce(backend_name, pot, methods, ad_ok):
         pot._evaluate(R, torch.tensor(z0, dtype=torch.float64)).backward()
         g1 = float(R.grad)
     numpy.testing.assert_allclose(g1, ref_force, rtol=1e-9)
+
+
+###############################################################################
+# _surfdens for the cuspy / complex-arithmetic profiles.
+#
+# These were migrated from the numpy `sqrt(neg + 0j)` + `if Rma == 0` scalar
+# branch to a backend-agnostic xp form: a complex sqrt built from a NaN-safe
+# real argument, the generic-branch result via xp.real, and the removable
+# singularity at R == a handled with a NaN-safe xp.where. The grids below
+# deliberately *include* R == a so the safe-`where` guards are exercised.
+###############################################################################
+# (potential, scale-radius attribute)
+_SURFDENS_CASES = [
+    BurkertPotential(amp=1.3, a=1.1),
+    HernquistPotential(amp=1.3, a=1.1),
+    JaffePotential(amp=1.3, a=1.1),
+    NFWPotential(amp=1.3, a=1.1),
+]
+_SURFDENS_IDS = [type(p).__name__ for p in _SURFDENS_CASES]
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_surfdens_value_parity(backend_name, pot):
+    a = pot.a
+    # Grid spanning R < a, R == a (the removable singularity), and R > a.
+    Rs = [0.5, 0.9 * a, a, 1.3 * a, 2.0]
+    zs = [0.3, 0.2, 0.4, 0.2, 0.3]
+    ref = numpy.asarray(pot._surfdens(numpy.asarray(Rs), numpy.asarray(zs)))
+    got = _tonumpy(
+        pot._surfdens(_asarray(backend_name, Rs), _asarray(backend_name, zs))
+    )
+    numpy.testing.assert_allclose(
+        got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{type(pot).__name__}._surfdens"
+    )
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_surfdens_edge_finite(backend_name, pot):
+    # The R == a removable singularity must give the same finite value across
+    # backends (this is the branch the safe-`where` guards protect).
+    a = pot.a
+    ref = float(numpy.asarray(pot._surfdens(numpy.asarray(a), numpy.asarray(0.3))))
+    got = float(
+        _tonumpy(pot._surfdens(_asarray(backend_name, a), _asarray(backend_name, 0.3)))
+    )
+    assert numpy.isfinite(ref)
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+def _surfdens_grad(backend_name, pot, R0, z0):
+    if backend_name == "jax":
+        return float(
+            jax.grad(lambda R: pot._surfdens(R, jnp.asarray(z0)))(jnp.asarray(R0))
+        )
+    R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+    pot._surfdens(R, torch.tensor(z0, dtype=torch.float64)).backward()
+    return float(R.grad)
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_surfdens_grad_vs_finite_difference(backend_name, pot):
+    # Off-edge (R != a), the migrated generic branch must be differentiable and
+    # its gradient must match finite differences.
+    z0 = 0.3
+    R0 = 0.6
+    eps = 1e-6
+    fd = (
+        float(pot._surfdens(numpy.asarray(R0 + eps), numpy.asarray(z0)))
+        - float(pot._surfdens(numpy.asarray(R0 - eps), numpy.asarray(z0)))
+    ) / (2 * eps)
+    ad = _surfdens_grad(backend_name, pot, R0, z0)
+    assert numpy.isfinite(ad), f"{type(pot).__name__} grad NaN at R={R0}"
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_surfdens_grad_finite_at_edge(backend_name, pot):
+    # At the exact removable singularity R == a the dead generic branch's
+    # 1/Rma / 1/(R^2-a^2) terms would, without the safe-`where` guards, inject
+    # NaNs into reverse-mode autodiff. The guards must keep the gradient FINITE.
+    # (Its *value* at the measure-zero edge point is the R-independent edge
+    # branch's derivative, i.e. 0; we only require finiteness, not FD-match, at
+    # this single kink point.)
+    a = pot.a
+    ad = _surfdens_grad(backend_name, pot, float(a), 0.3)
+    assert numpy.isfinite(ad), f"{type(pot).__name__} grad NaN at edge R==a"
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_powerspherical_wcutoff_dens_parity(backend_name):
+    # PowerSphericalPotentialwCutoff._dens / _ddensdr / _d2densdr2 are the
+    # scipy-free (closed-form) methods of that potential and were migrated to xp.
+    pot = PowerSphericalPotentialwCutoff(amp=1.3, alpha=1.3, rc=1.2)
+    Rs = [0.5, 1.0, 2.0]
+    zs = [0.1, 0.2, 0.3]
+    ref = numpy.asarray(pot._dens(numpy.asarray(Rs), numpy.asarray(zs)))
+    got = _tonumpy(pot._dens(_asarray(backend_name, Rs), _asarray(backend_name, zs)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+    for method in ["_ddensdr", "_d2densdr2"]:
+        ref = numpy.asarray(getattr(pot, method)(numpy.asarray(Rs)))
+        got = _tonumpy(getattr(pot, method)(_asarray(backend_name, Rs)))
+        numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14, err_msg=method)

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -1,0 +1,238 @@
+###############################################################################
+# test_backend_spherical.py: multi-backend tests for the spherical-potential
+# family migrated to the galpy.backend namespace layer (P2.1).
+#
+# For every migrated potential and every migrated compute method this proves:
+#   1. numpy / jax / torch produce identical values at the existing tolerances,
+#   2. autodiff (jax.grad / torch.autograd) of _evaluate matches finite
+#      differences (so the migrated compute path is differentiable and its
+#      gradient is consistent with the hand-coded force).
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+# Methods that still call scipy.special / scipy.integrate (e.g. NFW._evaluate
+# via xlogy, TwoPower._evaluate via hyp2f1, the _surfdens of the cuspy
+# profiles) are intentionally NOT exercised here: they are deferred to the
+# later scipy-router PR.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.potential import (
+    BurkertPotential,
+    DehnenCoreSphericalPotential,
+    DehnenSphericalPotential,
+    HernquistPotential,
+    HomogeneousSpherePotential,
+    JaffePotential,
+    KeplerPotential,
+    NFWPotential,
+    PowerSphericalPotential,
+    SphericalShellPotential,
+    TwoPowerSphericalPotential,
+)
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# Each entry: (potential instance, list of migrated methods to check, list of
+# methods supporting the AD-vs-FD _evaluate check [empty if _evaluate deferred]).
+# Only methods whose compute path is fully namespace-swapped are listed.
+_THREE_D = [
+    "_evaluate",
+    "_Rforce",
+    "_zforce",
+    "_R2deriv",
+    "_z2deriv",
+    "_Rzderiv",
+    "_dens",
+]
+
+CASES = [
+    # Dehnen family: fully analytic, all 3D methods migrated.
+    (DehnenSphericalPotential(amp=1.3, a=1.1, alpha=1.5), _THREE_D, True),
+    (DehnenCoreSphericalPotential(amp=1.3, a=1.1), _THREE_D, True),
+    # Hernquist / Jaffe: _evaluate/_Rforce/_zforce/_R2deriv/_Rzderiv/_dens
+    # migrated; _z2deriv delegates to _R2deriv; _surfdens deferred (complex).
+    (
+        HernquistPotential(amp=1.3, a=1.1),
+        [
+            "_evaluate",
+            "_Rforce",
+            "_zforce",
+            "_R2deriv",
+            "_z2deriv",
+            "_Rzderiv",
+            "_dens",
+        ],
+        True,
+    ),
+    (
+        JaffePotential(amp=1.3, a=1.1),
+        [
+            "_evaluate",
+            "_Rforce",
+            "_zforce",
+            "_R2deriv",
+            "_z2deriv",
+            "_Rzderiv",
+            "_dens",
+        ],
+        True,
+    ),
+    # NFW: forces/2nd-derivs/dens migrated; _evaluate uses scipy.special.xlogy
+    # (deferred) so it is excluded here and the AD-vs-FD check is skipped.
+    (
+        NFWPotential(amp=1.3, a=1.1),
+        ["_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv", "_dens"],
+        False,
+    ),
+    # PowerSpherical / Kepler: all listed compute methods migrated (_surfdens
+    # uses hyp2f1, deferred).
+    (PowerSphericalPotential(amp=1.3, alpha=1.5), _THREE_D, True),
+    (KeplerPotential(amp=1.3), _THREE_D, True),
+    # TwoPower base (non-special): only _dens is scipy-free.
+    (
+        TwoPowerSphericalPotential(amp=1.3, a=1.1, alpha=1.5, beta=3.5),
+        ["_dens"],
+        False,
+    ),
+    # HomogeneousSphere: piecewise, all methods migrated via xp.where.
+    (HomogeneousSpherePotential(amp=1.3, R=1.1), _THREE_D, True),
+    # Burkert: _rforce/_r2deriv/_rdens migrated => 3D forces/derivs/dens work;
+    # _revaluate uses xlogy (deferred) so _evaluate is excluded.
+    (
+        BurkertPotential(amp=1.3, a=1.1),
+        ["_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv", "_dens"],
+        False,
+    ),
+    # SphericalShell: all 1D methods migrated via xp.where (+ surfdens).
+    (
+        SphericalShellPotential(amp=1.3, a=0.7),
+        [
+            "_evaluate",
+            "_Rforce",
+            "_zforce",
+            "_R2deriv",
+            "_z2deriv",
+            "_Rzderiv",
+            "_dens",
+        ],
+        True,
+    ),
+]
+
+CASE_IDS = [type(p).__name__ for p, _, _ in CASES]
+
+# Grid avoids r == a exact points (shell singularities) and r == 0.
+_RS = [0.5, 1.0, 2.0]
+_ZS = [0.1, 0.2, 0.3]
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    if backend_name == "torch":
+        return torch.tensor(x, dtype=torch.float64)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+@pytest.mark.parametrize("pot,methods,_ad", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, pot, methods, _ad):
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    for method in methods:
+        ref = numpy.asarray(
+            getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS))
+        )
+        got = _tonumpy(getattr(pot, method)(R, z))
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{type(pot).__name__}.{method}"
+        )
+
+
+@pytest.mark.parametrize("pot,methods,_ad", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_public_value_parity(backend_name, pot, methods, _ad):
+    # The public Rforce (through the unit decorators and _amp) must give
+    # identical values across backends. Only meaningful where _Rforce is
+    # actually migrated (the base TwoPower _Rforce is scipy-deferred).
+    if "_Rforce" not in methods:
+        pytest.skip("_Rforce deferred (scipy.special) for this potential")
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    ref = numpy.asarray(pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS)))
+    got = _tonumpy(pot.Rforce(R, z))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("pot,methods,ad_ok", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_vs_finite_difference(backend_name, pot, methods, ad_ok):
+    if not ad_ok:
+        pytest.skip("_evaluate deferred (scipy.special) for this potential")
+    R0, z0 = 1.3, 0.4
+    eps = 1e-6
+
+    def phi_np(R):
+        return float(pot._evaluate(numpy.asarray(R), numpy.asarray(z0)))
+
+    fd = (phi_np(R0 + eps) - phi_np(R0 - eps)) / (2 * eps)
+    if backend_name == "jax":
+        ad = float(
+            jax.grad(lambda R: pot._evaluate(R, jnp.asarray(z0)))(jnp.asarray(R0))
+        )
+    else:
+        R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+        y = pot._evaluate(R, torch.tensor(z0, dtype=torch.float64))
+        y.backward()
+        ad = float(R.grad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("pot,methods,ad_ok", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_matches_rforce(backend_name, pot, methods, ad_ok):
+    # d(_evaluate)/dR == -_Rforce (consistency of the migrated gradient with the
+    # hand-coded radial force). Only where _evaluate is migrated.
+    if not ad_ok:
+        pytest.skip("_evaluate deferred (scipy.special) for this potential")
+    R0, z0 = 1.3, 0.4
+    ref_force = -float(pot._Rforce(R0, z0))
+    if backend_name == "jax":
+        g1 = float(
+            jax.grad(lambda R: pot._evaluate(R, jnp.asarray(z0)))(jnp.asarray(R0))
+        )
+    else:
+        R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+        pot._evaluate(R, torch.tensor(z0, dtype=torch.float64)).backward()
+        g1 = float(R.grad)
+    numpy.testing.assert_allclose(g1, ref_force, rtol=1e-9)

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -3268,6 +3268,8 @@ def test_isotropic_powerlaw_energyoutofbounds():
     assert numpy.all(numpy.fabs(dfp((numpy.arange(0.1, 10.0, 0.1),))) < 1e-8), (
         "Evaluating the isotropic power-law DF at E > 0 does not give zero"
     )
+    # Also test scalar fE input (plain float, no .shape — covers the non-array return path)
+    assert dfp.fE(-1.0) > 0.0
 
 
 def test_isotropic_powerlaw_nonself_dens_directint():
@@ -3585,6 +3587,8 @@ def test_osipkovmerritt_powerlaw_Qoutofbounds():
     assert numpy.all(numpy.fabs(dfp((numpy.arange(0.1, 10.0, 0.1), 1.0))) < 1e-8), (
         "Evaluating the OM power-law DF at E > 0 does not give zero"
     )
+    # Also test scalar fQ input (plain float, no .shape — covers the non-array return path)
+    assert dfp.fQ(1.0) > 0.0
 
 
 def test_osipkovmerritt_powerlaw_large_ra_approaches_isotropic():


### PR DESCRIPTION
Part of the **P2.x potential namespace-swap** series (→ #892 integration branch).

Migrates the spherical family to backend-agnostic compute (numpy/jax/torch) via the PR0 convention (`xp = get_namespace(...)`; private compute layer only).

**Migrated:** `SphericalPotential` (the 3D→1D reduction layer — covers the whole family), Dehnen(Core)Spherical, Hernquist, Jaffe, NFW, TwoPowerSpherical (base dens/z2deriv), PowerSpherical/Kepler, HomogeneousSphere, SphericalShell, Burkert.
**Deferred to Pspecial** (scipy.special/interpolate): TwoPower `_evaluate` (hyp2f1/gamma), NFW `_evaluate` (xlogy), the `_surfdens` of Hernquist/Jaffe/NFW/Burkert (data-dependent complex-sqrt branch), Einasto, interpSpherical.
**Hazards fixed:** torch lacks `power`→`**`; in-place `out[r2==0]=-inf`→safe-denominator `xp.where`; piecewise `if r<a`→shape-polymorphic `xp.where`; `numpy.fabs`→`xp.abs` (a real cross-namespace bug caught by the test).
**Tests:** `tests/test_backend_spherical.py` — 95 passed, 15 skipped (numpy/jax/torch parity rtol 1e-12 + grad-vs-FD + grad==−Rforce). Numpy path byte-identical (max diff 0.0 on spot checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)