### PR TITLE
Pvar-rhs: 3D variational RHS + integrate_dxdv for phasedim==6 + validation

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -65,6 +65,7 @@ from ..util.coords import _K
 from .integrateFullOrbit import (
     integrateFullOrbit,
     integrateFullOrbit_c,
+    integrateFullOrbit_dxdv,
     integrateFullOrbit_sos,
     integrateFullOrbit_sos_c,
 )
@@ -2273,7 +2274,7 @@ class Orbit:
         Parameters
         ----------
         dxdv : numpy.ndarray
-            Initial conditions for the orbit in cylindrical or rectangular coordinates. The shape of the array should be (\*input_shape, 4).
+            Initial conditions for the phase-space deviation in cylindrical or rectangular coordinates. The shape of the array should be (\*input_shape, 4) for planar (4D) orbits and (\*input_shape, 6) for 3D (6D) orbits.
         t : list, numpy.ndarray or Quantity
             List of equispaced times at which to compute the orbit. The initial condition is t[0].  (note that for method='odeint', method='dop853', and method='dop853_c', the time array can be non-equispaced).
         pot : Potential, DissipativeForce, or a combined force/potential formed using addition (pot1+pot2+force3+…)
@@ -2318,9 +2319,9 @@ class Orbit:
         - 2019-05-21 - Parallelized and incorporated into new Orbits class - Bovy (UofT)
 
         """
-        if not self.phasedim() == 4:
+        if not (self.phasedim() == 4 or self.phasedim() == 6):
             raise AttributeError(
-                "integrate_dxdv is only implemented for 4D (planar) orbits"
+                "integrate_dxdv is only implemented for 4D (planar) and 6D (3D) orbits"
             )
         self.check_integrator(method, no_symplec=True)
         pot = _check_potential_list_and_deprecate(pot)
@@ -2350,6 +2351,8 @@ class Orbit:
             delattr(self, "_orbInterp")
         if self.dim() == 2:
             thispot = toPlanarPotential(pot)
+        else:
+            thispot = pot
         self.t = numpy.array(t)
         self._pot_dxdv = thispot
         self._pot = thispot
@@ -2388,9 +2391,24 @@ class Orbit:
                     rtol=rtol,
                     atol=atol,
                 )
+            else:
+                out, msg = integrateFullOrbit_dxdv(
+                    self._pot,
+                    self.vxvv,
+                    dxdv,
+                    t,
+                    method,
+                    rectIn,
+                    rectOut,
+                    progressbar=progressbar,
+                    numcores=numcores,
+                    dt=dt,
+                    rtol=rtol,
+                    atol=atol,
+                )
         # Store orbit internally
         self.orbit_dxdv = out
-        self.orbit = self.orbit_dxdv[..., :4]
+        self.orbit = self.orbit_dxdv[..., : self.phasedim()]
         return None
 
     def flip(self, inplace=False):
@@ -2522,7 +2540,7 @@ class Orbit:
         - 2019-05-21: Written by Bovy (UofT)
 
         """
-        return self.orbit_dxdv[..., 4:].copy()
+        return self.orbit_dxdv[..., self.phasedim() :].copy()
 
     @physical_conversion("energy")
     @shapeDecorator

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -11,9 +11,15 @@ from ..potential.Potential import (
     _evaluatephitorques,
     _evaluateRforces,
     _evaluatezforces,
+    evaluatephi2derivs,
+    evaluatephizderivs,
+    evaluateR2derivs,
+    evaluateRphiderivs,
+    evaluateRzderivs,
+    evaluatez2derivs,
     potential_list_of_potentials_input,
 )
-from ..util import _load_extension_libs, galpyWarning, symplecticode
+from ..util import _load_extension_libs, coords, galpyWarning, symplecticode
 from ..util._optional_deps import _TQDM_LOADED
 from ..util.leung_dop853 import dop853
 from ..util.multi import parallel_map
@@ -700,11 +706,14 @@ def integrateFullOrbit_c(
         return (result, err)
 
 
-def integrateFullOrbit_dxdv_c(
-    pot, yo, dyo, t, int_method, rtol=None, atol=None
-):  # pragma: no cover because not included in v1, uncover when included
+def integrateFullOrbit_dxdv_c(pot, yo, dyo, t, int_method, rtol=None, atol=None):
     """
-    Integrate an ode for a planarOrbit+phase space volume dxdv.
+    Integrate an ode for a fullOrbit+phase space volume dxdv in C.
+
+    Both the input state ``yo`` and deviation ``dyo`` as well as the output are
+    in the rectangular frame (x,y,z,vx,vy,vz | dx,dy,dz,dvx,dvy,dvz); the
+    cylindrical<->rectangular transforms are handled by the calling
+    ``integrateFullOrbit_dxdv``.
 
     Parameters
     ----------
@@ -796,6 +805,164 @@ def integrateFullOrbit_dxdv_c(
         t = numpy.asfortranarray(t)
 
     return (result, err.value)
+
+
+def integrateFullOrbit_dxdv(
+    pot,
+    yo,
+    dyo,
+    t,
+    int_method,
+    rectIn,
+    rectOut,
+    rtol=None,
+    atol=None,
+    progressbar=True,
+    dt=None,
+    numcores=1,
+):
+    """
+    Integrate an ode for a fullOrbit+phase space volume dxdv.
+
+    The 3D analog of ``integratePlanarOrbit_dxdv``: handles the
+    cylindrical<->rectangular transform of both the base state and the
+    phase-space deviation (via the chain rule, using the Jacobian of the
+    cyl->rect transform), then integrates the 12D rectangular variational
+    system in C (or, for the pure-Python ``dop853``/``odeint`` methods, via
+    ``_EOM_dxdv``).
+
+    Parameters
+    ----------
+    pot : Potential or a combined potential formed using addition (pot1+pot2+…)
+    yo : numpy.ndarray
+        Initial condition [q,p], shape [N,6] in cylindrical (R,vR,vT,z,vz,phi).
+    dyo : numpy.ndarray
+        Initial condition [dq,dp], shape [N,6]; cylindrical (dR,dvR,dvT,dz,dvz,dphi)
+        unless ``rectIn`` (then rectangular dx,dy,dz,dvx,dvy,dvz).
+    t : numpy.ndarray
+        Set of times at which one wants the result.
+    int_method : str
+        Integration method. One of 'dopr54_c', 'dop853_c', 'rk4_c', 'rk6_c',
+        'dop853', 'odeint'.
+    rectIn : bool
+        If True, input ``dyo`` is in rectangular coordinates.
+    rectOut : bool
+        If True, output deviation is in rectangular coordinates.
+    rtol : float, optional
+        Relative tolerance.
+    atol : float, optional
+        Absolute tolerance.
+    progressbar : bool, optional
+        If True, display a tqdm progress bar when integrating multiple orbits.
+    dt : float, optional
+        Force integrator to use this stepsize (default is to automatically determine one).
+    numcores : int, optional
+        Number of cores to use for multi-processing.
+
+    Returns
+    -------
+    tuple
+        (out,err)
+        out : array, shape (N,len(t),12)
+            base orbit (cylindrical R,vR,vT,z,vz,phi) in [...,:6] and the
+            deviation in [...,6:] (rectangular if ``rectOut`` else cylindrical).
+        err : array
+            Error message per orbit (0 unless maximum step reduction happened).
+
+    Notes
+    -----
+    - 2026-06-03 - Written based on integratePlanarOrbit_dxdv - Bovy (UofT)
+    """
+    # Go to the rectangular frame: base state (R,vR,vT,z,vz,phi) -> (x,y,z,vx,vy,vz)
+    R, vR, vT, z, vz, phi = (
+        yo[:, 0],
+        yo[:, 1],
+        yo[:, 2],
+        yo[:, 3],
+        yo[:, 4],
+        yo[:, 5],
+    )
+    X, Y, Z = coords.cyl_to_rect(R, phi, z)
+    vX, vY, vZ = coords.cyl_to_rect_vec(vR, vT, vz, phi)
+    this_yo = numpy.array([X, Y, Z, vX, vY, vZ]).T
+    if not rectIn:
+        # Chain rule: rect deviation = J . cyl deviation, with J the Jacobian
+        # of (x,y,z,vx,vy,vz) wrt (R,vR,vT,z,vz,phi).
+        this_dyo = numpy.empty_like(dyo)
+        for ii in range(len(yo)):
+            jac = coords.cyl_to_rect_jac(R[ii], vR[ii], vT[ii], z[ii], vz[ii], phi[ii])
+            this_dyo[ii] = numpy.dot(jac, dyo[ii])
+    else:
+        this_dyo = dyo
+    this_yo = numpy.hstack((this_yo, this_dyo))
+    if int_method.lower() == "dop853" or int_method.lower() == "odeint":
+        if int_method.lower() == "dop853":
+            if rtol is None:
+                rtol = 1e-12
+            if atol is None:
+                atol = 1e-12
+            integrator = dop853
+            extra_kwargs = {"rtol": rtol, "atol": atol}
+        else:
+            integrator = integrate.odeint
+            extra_kwargs = {"rtol": rtol, "atol": atol}
+
+        def integrate_for_map(vxvv):
+            return integrator(_EOM_dxdv, vxvv, t=t, args=(pot,), **extra_kwargs)
+
+    else:  # Assume we are forcing parallel_mapping of a C integrator...
+
+        def integrate_for_map(vxvv):
+            return integrateFullOrbit_dxdv_c(
+                pot,
+                numpy.copy(vxvv[:6]),
+                numpy.copy(vxvv[6:]),
+                t,
+                int_method,
+                rtol=rtol,
+                atol=atol,
+            )[0]
+
+    if len(this_yo) == 1:  # Can't map a single value...
+        out = numpy.atleast_3d(integrate_for_map(this_yo[0]).T).T
+    else:
+        out = numpy.array(
+            parallel_map(
+                integrate_for_map, this_yo, progressbar=progressbar, numcores=numcores
+            )
+        )
+    # Go back to the cylindrical frame: base state out[...,:6] is rectangular
+    # (x,y,z,vx,vy,vz); convert to (R,vR,vT,z,vz,phi) and (optionally) the
+    # deviation out[...,6:] from rectangular to cylindrical.
+    Rout, phiout, Zout = coords.rect_to_cyl(out[..., 0], out[..., 1], out[..., 2])
+    vRout, vTout, vzout = coords.rect_to_cyl_vec(
+        out[..., 3], out[..., 4], out[..., 5], out[..., 0], out[..., 1], out[..., 2]
+    )
+    out[..., 0] = Rout
+    out[..., 1] = vRout
+    out[..., 2] = vTout
+    out[..., 3] = Zout
+    out[..., 4] = vzout
+    out[..., 5] = phiout
+    if not rectOut:
+        # cyl deviation = J^{-1} . rect deviation, with J the cyl->rect Jacobian
+        # evaluated at each (R,vR,vT,z,vz,phi) along the orbit.
+        shp = Rout.shape
+        Rf = Rout.ravel()
+        vRf = vRout.ravel()
+        vTf = vTout.ravel()
+        Zf = Zout.ravel()
+        vzf = vzout.ravel()
+        phif = phiout.ravel()
+        dev_rect = out[..., 6:].reshape((-1, 6))
+        dev_cyl = numpy.empty_like(dev_rect)
+        for ii in range(dev_rect.shape[0]):
+            jac = coords.cyl_to_rect_jac(
+                Rf[ii], vRf[ii], vTf[ii], Zf[ii], vzf[ii], phif[ii]
+            )
+            dev_cyl[ii] = numpy.linalg.solve(jac, dev_rect[ii])
+        out[..., 6:] = dev_cyl.reshape(shp + (6,))
+    return out, numpy.zeros(len(yo))
 
 
 @potential_list_of_potentials_input
@@ -1394,5 +1561,95 @@ def _rectForce(x, pot, t=0.0, vx=None):
             cosphi * Rforce - 1.0 / R * sinphi * phitorque,
             sinphi * Rforce + 1.0 / R * cosphi * phitorque,
             _evaluatezforces(pot, R, x[2], phi=phi, t=t, v=vx),
+        ]
+    )
+
+
+def _EOM_dxdv(x, t, pot):
+    """
+    Implements the EOM, i.e., the right-hand side of the differential
+    equation, for integrating a 3D orbit + phase-space deviation, in the
+    rectangular frame.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Current 12D rectangular phase-space state
+        (x,y,z,vx,vy,vz | dx,dy,dz,dvx,dvy,dvz).
+    t : float
+        Current time.
+    pot : Potential instance or a combined potential formed using addition (pot1+pot2+…)
+
+    Returns
+    -------
+    numpy.ndarray
+        dx/dt (12D).
+
+    Notes
+    -----
+    - 2026-06-03 - Written, mirroring the C evalRectDeriv_dxdv - Bovy (UofT)
+    """
+    # x is rectangular so calculate R and phi
+    R = numpy.sqrt(x[0] ** 2.0 + x[1] ** 2.0)
+    phi = numpy.arccos(x[0] / R)
+    sinphi = x[1] / R
+    cosphi = x[0] / R
+    if x[1] < 0.0:
+        phi = 2.0 * numpy.pi - phi
+    z = x[2]
+    # Cartesian forces -> accelerations
+    Rforce = _evaluateRforces(pot, R, z, phi=phi, t=t)
+    phitorque = _evaluatephitorques(pot, R, z, phi=phi, t=t)
+    zforce = _evaluatezforces(pot, R, z, phi=phi, t=t)
+    # Cylindrical second derivatives of the potential
+    R2deriv = evaluateR2derivs(pot, R, z, phi=phi, t=t)
+    phi2deriv = evaluatephi2derivs(pot, R, z, phi=phi, t=t)
+    Rphideriv = evaluateRphiderivs(pot, R, z, phi=phi, t=t)
+    z2deriv = evaluatez2derivs(pot, R, z, phi=phi, t=t)
+    Rzderiv = evaluateRzderivs(pot, R, z, phi=phi, t=t)
+    zphideriv = evaluatephizderivs(pot, R, z, phi=phi, t=t)
+    # Symmetric Cartesian tidal tensor K = -grad grad Phi; in-plane (x,y) block
+    # identical to the verified 2D variational equations (z enters only through
+    # the second-derivative values above).
+    dFxdx = (
+        -(cosphi**2.0) * R2deriv
+        + 2.0 * cosphi * sinphi / R**2.0 * phitorque
+        + sinphi**2.0 / R * Rforce
+        + 2.0 * sinphi * cosphi / R * Rphideriv
+        - sinphi**2.0 / R**2.0 * phi2deriv
+    )
+    dFxdy = (
+        -sinphi * cosphi * R2deriv
+        + (sinphi**2.0 - cosphi**2.0) / R**2.0 * phitorque
+        - cosphi * sinphi / R * Rforce
+        - (cosphi**2.0 - sinphi**2.0) / R * Rphideriv
+        + cosphi * sinphi / R**2.0 * phi2deriv
+    )
+    dFydy = (
+        -(sinphi**2.0) * R2deriv
+        - 2.0 * sinphi * cosphi / R**2.0 * phitorque
+        - 2.0 * sinphi * cosphi / R * Rphideriv
+        + cosphi**2.0 / R * Rforce
+        - cosphi**2.0 / R**2.0 * phi2deriv
+    )
+    # z-coupling (K symmetric: dFzdx=dFxdz, dFzdy=dFydz, dFydx=dFxdy)
+    dFxdz = -cosphi * Rzderiv + sinphi / R * zphideriv
+    dFydz = -sinphi * Rzderiv - cosphi / R * zphideriv
+    dFzdz = -z2deriv
+    dx, dy, dz = x[6], x[7], x[8]
+    return numpy.array(
+        [
+            x[3],
+            x[4],
+            x[5],
+            cosphi * Rforce - 1.0 / R * sinphi * phitorque,
+            sinphi * Rforce + 1.0 / R * cosphi * phitorque,
+            zforce,
+            x[9],
+            x[10],
+            x[11],
+            dFxdx * dx + dFxdy * dy + dFxdz * dz,
+            dFxdy * dx + dFydy * dy + dFydz * dz,
+            dFxdz * dx + dFydz * dy + dFzdz * dz,
         ]
     )

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -97,9 +97,12 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &MiyamotoNagaiPotentialzforce;
       potentialArgs->phitorque= &ZeroForce;
       potentialArgs->dens= &MiyamotoNagaiPotentialDens;
-      //potentialArgs->R2deriv= &MiyamotoNagaiPotentialR2deriv;
-      //potentialArgs->planarphi2deriv= &ZeroForce;
-      //potentialArgs->planarRphideriv= &ZeroForce;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      // Axisymmetric: phi2deriv/Rphideriv/zphideriv are 0 -> left NULL
+      // (the NULL-safe aggregators return 0 for them).
+      potentialArgs->R2deriv= &MiyamotoNagaiPotentialR2deriv;
+      potentialArgs->z2deriv= &MiyamotoNagaiPotentialz2deriv;
+      potentialArgs->Rzderiv= &MiyamotoNagaiPotentialRzderiv;
       potentialArgs->nargs= 3;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
@@ -263,7 +266,12 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &PlummerPotentialzforce;
       potentialArgs->phitorque= &ZeroForce;
       potentialArgs->dens= &PlummerPotentialDens;
-      //potentialArgs->R2deriv= &PlummerPotentialR2deriv;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      // Axisymmetric: phi2deriv/Rphideriv/zphideriv are 0 -> left NULL
+      // (the NULL-safe aggregators return 0 for them).
+      potentialArgs->R2deriv= &PlummerPotentialR2deriv;
+      potentialArgs->z2deriv= &PlummerPotentialz2deriv;
+      potentialArgs->Rzderiv= &PlummerPotentialRzderiv;
       potentialArgs->nargs= 2;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -926,8 +926,7 @@ EXPORT void integrateFullOrbit_sos(
   free(potentialArgs);
   //Done!
 }
-// LCOV_EXCL_START
-void integrateOrbit_dxdv(double *yo,
+EXPORT void integrateFullOrbit_dxdv(double *yo,
 			 int nt,
 			 double *t,
 			 int npot,
@@ -954,12 +953,11 @@ void integrateOrbit_dxdv(double *yo,
 		      double *,int *);
   void (*odeint_deriv_func)(double, double *, double *,
 			    int,struct potentialArg *);
+  // Only the non-symplectic integrators support the 12D variational (dxdv)
+  // system; Orbit.integrate_dxdv enforces this upstream
+  // (check_integrator(no_symplec=True)), so the symplectic/leapfrog/ias15
+  // odeint_types never reach here -- mirroring integratePlanarOrbit_dxdv.
   switch ( odeint_type ) {
-  case 0: //leapfrog
-    odeint_func= &leapfrog;
-    odeint_deriv_func= &evalRectForce;
-    dim= 6;
-    break;
   case 1: //RK4
     odeint_func= &bovy_rk4;
     odeint_deriv_func= &evalRectDeriv_dxdv;
@@ -969,16 +967,6 @@ void integrateOrbit_dxdv(double *yo,
     odeint_func= &bovy_rk6;
     odeint_deriv_func= &evalRectDeriv_dxdv;
     dim= 12;
-    break;
-  case 3: //symplec4
-    odeint_func= &symplec4;
-    odeint_deriv_func= &evalRectForce;
-    dim= 6;
-    break;
-  case 4: //symplec6
-    odeint_func= &symplec6;
-    odeint_deriv_func= &evalRectForce;
-    dim= 6;
     break;
   case 5: //DOPR54
     odeint_func= &bovy_dopr54;
@@ -990,11 +978,6 @@ void integrateOrbit_dxdv(double *yo,
     odeint_deriv_func= &evalRectDeriv_dxdv;
     dim= 12;
     break;
-  case 7: //ias15
-    odeint_func= &wez_ias15;
-    odeint_deriv_func= &evalRectForce;
-    dim= 6;
-    break;
   }
   odeint_func(odeint_deriv_func,dim,yo,nt,-9999.99,t,npot,potentialArgs,
 	      rtol,atol,result,err);
@@ -1003,7 +986,6 @@ void integrateOrbit_dxdv(double *yo,
   free(potentialArgs);
   //Done!
 }
-// LCOV_EXCL_STOP
 void evalRectForce(double t, double *q, double *a,
 		   int nargs, struct potentialArg * potentialArgs){
   double sinphi, cosphi, x, y, phi,R,Rforce,phitorque, z;
@@ -1193,16 +1175,18 @@ void initChandrasekharDynamicalFrictionSplines(struct potentialArg * potentialAr
   free(r);
 }
 
-// LCOV_EXCL_START
 void evalRectDeriv_dxdv(double t, double *q, double *a,
 			int nargs, struct potentialArg * potentialArgs){
-  double sinphi, cosphi, x, y, phi,R,Rforce,phitorque,z,zforce;
-  double R2deriv, phi2deriv, Rphideriv, dFxdx, dFxdy, dFydx, dFydy;
+  // 12D state q = (x,y,z,vx,vy,vz | dx,dy,dz,dvx,dvy,dvz): the orbit plus one
+  // phase-space deviation propagated by the variational equation dw'=A w' with
+  // A=[[0,I],[K,0]] and K the symmetric Cartesian tidal tensor (-grad grad Phi).
+  double sinphi, cosphi, x, y, phi, R, Rforce, phitorque, z, zforce;
+  double R2deriv, phi2deriv, Rphideriv, z2deriv, Rzderiv, zphideriv;
+  double dFxdx, dFxdy, dFydy, dFxdz, dFydz, dFzdz, dx, dy, dz;
   //first three derivatives are just the velocities
   *a++= *(q+3);
   *a++= *(q+4);
   *a++= *(q+5);
-  //Rest is force
   //q is rectangular so calculate R and phi
   x= *q;
   y= *(q+1);
@@ -1212,22 +1196,26 @@ void evalRectDeriv_dxdv(double t, double *q, double *a,
   sinphi= y/R;
   cosphi= x/R;
   if ( y < 0. ) phi= 2.*M_PI-phi;
-  //Calculate the forces
+  //Calculate the forces -> Cartesian accelerations
   Rforce= calcRforce(R,z,phi,t,nargs,potentialArgs);
   zforce= calczforce(R,z,phi,t,nargs,potentialArgs);
   phitorque= calcphitorque(R,z,phi,t,nargs,potentialArgs);
   *a++= cosphi*Rforce-1./R*sinphi*phitorque;
   *a++= sinphi*Rforce+1./R*cosphi*phitorque;
   *a++= zforce;
-  //dx derivatives are just dv
+  //d(deviation position)/dt = deviation velocity
   *a++= *(q+9);
   *a++= *(q+10);
   *a++= *(q+11);
-  //for the dv derivatives we need also R2deriv, phi2deriv, and Rphideriv
+  // d(deviation velocity)/dt = K . (dx,dy,dz); K needs the full 3D Hessian
   R2deriv= calcR2deriv(R,z,phi,t,nargs,potentialArgs);
   phi2deriv= calcphi2deriv(R,z,phi,t,nargs,potentialArgs);
   Rphideriv= calcRphideriv(R,z,phi,t,nargs,potentialArgs);
-  //..and dFxdx, dFxdy, dFydx, dFydy
+  z2deriv= calcz2deriv(R,z,phi,t,nargs,potentialArgs);
+  Rzderiv= calcRzderiv(R,z,phi,t,nargs,potentialArgs);
+  zphideriv= calczphideriv(R,z,phi,t,nargs,potentialArgs);
+  // In-plane (x,y) block: identical to the verified 2D variational equations
+  // (z enters only through the values of the second derivatives above).
   dFxdx= -cosphi*cosphi*R2deriv
     +2.*cosphi*sinphi/R/R*phitorque
     +sinphi*sinphi/R*Rforce
@@ -1238,19 +1226,19 @@ void evalRectDeriv_dxdv(double t, double *q, double *a,
     -cosphi*sinphi/R*Rforce
     -(cosphi*cosphi-sinphi*sinphi)/R*Rphideriv
     +cosphi*sinphi/R/R*phi2deriv;
-  dFydx= -cosphi*sinphi*R2deriv
-    +(sinphi*sinphi-cosphi*cosphi)/R/R*phitorque
-    +(sinphi*sinphi-cosphi*cosphi)/R*Rphideriv
-    -sinphi*cosphi/R*Rforce
-    +sinphi*cosphi/R/R*phi2deriv;
   dFydy= -sinphi*sinphi*R2deriv
     -2.*sinphi*cosphi/R/R*phitorque
     -2.*sinphi*cosphi/R*Rphideriv
     +cosphi*cosphi/R*Rforce
     -cosphi*cosphi/R/R*phi2deriv;
-  *a++= dFxdx * *(q+4) + dFxdy * *(q+5);
-  *a++= dFydx * *(q+4) + dFydy * *(q+5);
-  *a= 0; //BOVY: PUT IN Z2DERIVS
+  // z-coupling (K symmetric: dFzdx=dFxdz, dFzdy=dFydz, dFydx=dFxdy)
+  dFxdz= -cosphi*Rzderiv+sinphi/R*zphideriv;
+  dFydz= -sinphi*Rzderiv-cosphi/R*zphideriv;
+  dFzdz= -z2deriv;
+  dx= *(q+6);
+  dy= *(q+7);
+  dz= *(q+8);
+  *a++= dFxdx*dx+dFxdy*dy+dFxdz*dz;
+  *a++= dFxdy*dx+dFydy*dy+dFydz*dz;
+  *a  = dFxdz*dx+dFydz*dy+dFzdz*dz;
 }
-
-// LCOV_EXCL_STOP

--- a/galpy/potential/potential_c_ext/MiyamotoNagaiPotential.c
+++ b/galpy/potential/potential_c_ext/MiyamotoNagaiPotential.c
@@ -63,6 +63,58 @@ double MiyamotoNagaiPotentialPlanarR2deriv(double R,double phi,
   double denom= R*R+pow(a+b,2.);
   return amp * (pow(denom,-1.5) - 3. * R * R * pow(denom,-2.5));
 }
+double MiyamotoNagaiPotentialR2deriv(double R,double z, double phi,
+				     double t,
+				     struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args++;
+  double a= *args++;
+  double b= *args;
+  //calculate R2deriv (d^2Phi/dR^2)
+  double sqrtbz= pow(b*b+z*z,0.5);
+  double asqrtbz= a+sqrtbz;
+  double denom= R*R+asqrtbz*asqrtbz;
+  return amp * (pow(denom,-1.5) - 3. * R * R * pow(denom,-2.5));
+}
+double MiyamotoNagaiPotentialz2deriv(double R,double z, double phi,
+				     double t,
+				     struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args++;
+  double a= *args++;
+  double b= *args;
+  //calculate z2deriv (d^2Phi/dz^2)
+  double b2= b*b;
+  double sqrtbz= pow(b2+z*z,0.5);
+  double asqrtbz= a+sqrtbz;
+  if ( a == 0. )
+    return amp * (b2+R*R-2.*z*z) * pow(b2+R*R+z*z,-2.5);
+  else
+    return amp * ( a*a*a*b2
+		   + a*a*(3.*b2-2.*z*z)*sqrtbz
+		   + (b2+R*R-2.*z*z)*pow(b2+z*z,1.5)
+		   + a*(3.*b2*b2-4.*z*z*z*z+b2*(R*R-z*z)) )
+      / ( pow(b2+z*z,1.5) * pow(R*R+asqrtbz*asqrtbz,2.5) );
+}
+double MiyamotoNagaiPotentialRzderiv(double R,double z, double phi,
+				     double t,
+				     struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args++;
+  double a= *args++;
+  double b= *args;
+  //calculate Rzderiv (d^2Phi/dR/dz)
+  double sqrtbz= pow(b*b+z*z,0.5);
+  double asqrtbz= a+sqrtbz;
+  if ( a == 0. )
+    return amp * ( -3. * R * z * pow(R*R+asqrtbz*asqrtbz,-2.5) );
+  else
+    return amp * ( -3. * R * z * asqrtbz / sqrtbz
+		   * pow(R*R+asqrtbz*asqrtbz,-2.5) );
+}
 double MiyamotoNagaiPotentialDens(double R,double z, double phi,
 				  double t,
 				  struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/PlummerPotential.c
+++ b/galpy/potential/potential_c_ext/PlummerPotential.c
@@ -52,6 +52,36 @@ double PlummerPotentialPlanarR2deriv(double R,double phi,
   //Calculate Rforce
   return amp * (b2 - 2.*R*R)*pow(R*R+b2,-2.5);
 }
+double PlummerPotentialR2deriv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double b2= *(args+1) * *(args+1);
+  //Calculate R2deriv (d^2Phi/dR^2)
+  return amp * (b2 - 2.*R*R + Z*Z) * pow(R*R+Z*Z+b2,-2.5);
+}
+double PlummerPotentialz2deriv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double b2= *(args+1) * *(args+1);
+  //Calculate z2deriv (d^2Phi/dz^2)
+  return amp * (b2 + R*R - 2.*Z*Z) * pow(R*R+Z*Z+b2,-2.5);
+}
+double PlummerPotentialRzderiv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double b2= *(args+1) * *(args+1);
+  //Calculate Rzderiv (d^2Phi/dR/dz)
+  return amp * ( -3. * R * Z * pow(R*R+Z*Z+b2,-2.5) );
+}
 double PlummerPotentialDens(double R,double Z, double phi,
 			    double t,
 			    struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/galpy_potentials.c
+++ b/galpy/potential/potential_c_ext/galpy_potentials.c
@@ -162,6 +162,14 @@ double (calcPlanarphitorque)(double R, double phi, double t,
 }
 
 // LCOV_EXCL_START
+// TODO(Pvar-pot): remove this LCOV_EXCL once the full 3D second-derivative
+// machinery is exercised by tests for every aggregator. The 3D variational RHS
+// (evalRectDeriv_dxdv) now calls all six; test_liouville_3d reaches R2deriv/
+// z2deriv/Rzderiv via the axisymmetric MiyamotoNagai/Plummer validation set, but
+// the phi2deriv/Rphideriv/zphideriv branches stay unexercised until a
+// non-axisymmetric potential with a complete 3D Hessian (including zphideriv) is
+// implemented and added to test_liouville_3d (the Pvar-pot fan-out). Drop the
+// exclusion then so all six aggregators are covered.
 double calcR2deriv(double R, double Z, double phi, double t,
 		   int nargs, struct potentialArg * potentialArgs){
   int ii;

--- a/galpy/potential/potential_c_ext/galpy_potentials.c
+++ b/galpy/potential/potential_c_ext/galpy_potentials.c
@@ -3,8 +3,11 @@ void init_potentialArgs(int npot, struct potentialArg * potentialArgs){
   int ii;
   for (ii=0; ii < npot; ii++) {
     // Full-3D second-derivative pointers default to NULL so the 3D variational
-    // aggregators (calcz2deriv etc.) skip potentials that do not (yet) provide
-    // them; potentials that support the 3D Hessian set these in parse_*.
+    // aggregators skip potentials that do not (yet) provide them; potentials
+    // that support the 3D Hessian set these in parse_*.
+    (potentialArgs+ii)->R2deriv= NULL;
+    (potentialArgs+ii)->phi2deriv= NULL;
+    (potentialArgs+ii)->Rphideriv= NULL;
     (potentialArgs+ii)->z2deriv= NULL;
     (potentialArgs+ii)->Rzderiv= NULL;
     (potentialArgs+ii)->zphideriv= NULL;
@@ -164,8 +167,8 @@ double calcR2deriv(double R, double Z, double phi, double t,
   int ii;
   double R2deriv= 0.;
   for (ii=0; ii < nargs; ii++){
-    R2deriv+= potentialArgs->R2deriv(R,Z,phi,t,
-				     potentialArgs);
+    if ( potentialArgs->R2deriv )
+      R2deriv+= potentialArgs->R2deriv(R,Z,phi,t,potentialArgs);
     potentialArgs++;
   }
   potentialArgs-= nargs;
@@ -177,8 +180,8 @@ double calcphi2deriv(double R, double Z, double phi, double t,
   int ii;
   double phi2deriv= 0.;
   for (ii=0; ii < nargs; ii++){
-    phi2deriv+= potentialArgs->phi2deriv(R,Z,phi,t,
-					 potentialArgs);
+    if ( potentialArgs->phi2deriv )
+      phi2deriv+= potentialArgs->phi2deriv(R,Z,phi,t,potentialArgs);
     potentialArgs++;
   }
   potentialArgs-= nargs;
@@ -189,8 +192,8 @@ double calcRphideriv(double R, double Z, double phi, double t,
   int ii;
   double Rphideriv= 0.;
   for (ii=0; ii < nargs; ii++){
-    Rphideriv+= potentialArgs->Rphideriv(R,Z,phi,t,
-					 potentialArgs);
+    if ( potentialArgs->Rphideriv )
+      Rphideriv+= potentialArgs->Rphideriv(R,Z,phi,t,potentialArgs);
     potentialArgs++;
   }
   potentialArgs-= nargs;

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -252,6 +252,12 @@ double MiyamotoNagaiPotentialzforce(double,double,double,double,
 				    struct potentialArg *);
 double MiyamotoNagaiPotentialPlanarR2deriv(double ,double, double,
 					   struct potentialArg *);
+double MiyamotoNagaiPotentialR2deriv(double ,double , double, double,
+				     struct potentialArg *);
+double MiyamotoNagaiPotentialz2deriv(double ,double , double, double,
+				     struct potentialArg *);
+double MiyamotoNagaiPotentialRzderiv(double ,double , double, double,
+				     struct potentialArg *);
 double MiyamotoNagaiPotentialDens(double ,double , double, double,
 				  struct potentialArg *);
 //LopsidedDiskPotential
@@ -408,6 +414,12 @@ double PlummerPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
 double PlummerPotentialPlanarR2deriv(double,double,double,
 					    struct potentialArg *);
+double PlummerPotentialR2deriv(double,double,double,double,
+			       struct potentialArg *);
+double PlummerPotentialz2deriv(double,double,double,double,
+			       struct potentialArg *);
+double PlummerPotentialRzderiv(double,double,double,double,
+			       struct potentialArg *);
 double PlummerPotentialDens(double,double,double,double,
 			    struct potentialArg *);
 //PseudoIsothermalPotential

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,25 @@ def pytest_generate_tests(metafunc):
     # Maybe I should define a cmdline option to set the config instead...
     from galpy import potential
 
+    if metafunc.function.__name__ in (
+        "test_liouville_3d",
+        "test_liouville_3d_2d_bridge",
+    ):
+        liouville3d_pots = [
+            potential.MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True),
+            # a==0 exercises the disk->spherical special branch of the C Hessian
+            potential.MiyamotoNagaiPotential(amp=1.0, a=0.0, b=0.3, normalize=True),
+            potential.PlummerPotential(amp=1.0, b=0.7, normalize=True),
+        ]
+        metafunc.parametrize(
+            "pot",
+            liouville3d_pots,
+            ids=[
+                "MiyamotoNagaiPotential",
+                "MiyamotoNagaiPotential_a0",
+                "PlummerPotential",
+            ],
+        )
     if metafunc.function.__name__ == "test_energy_jacobi_conservation":
         # Generate orbit integration tests for all potentials
         # Grab all of the potentials

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -973,6 +973,257 @@ def test_liouville_planar():
     return None
 
 
+def _cart_accel_3d(pot, rect):
+    """Cartesian acceleration (ax,ay,az) at rectangular position rect=(x,y,z)."""
+    from galpy.potential import (
+        evaluatephitorques,
+        evaluateRforces,
+        evaluatezforces,
+    )
+
+    x, y, z = rect[0], rect[1], rect[2]
+    R = numpy.sqrt(x**2.0 + y**2.0)
+    phi = numpy.arctan2(y, x)
+    cp, sp = numpy.cos(phi), numpy.sin(phi)
+    Rforce = evaluateRforces(pot, R, z, phi=phi)
+    phitorque = evaluatephitorques(pot, R, z, phi=phi)
+    zforce = evaluatezforces(pot, R, z, phi=phi)
+    ax = cp * Rforce - sp / R * phitorque
+    ay = sp * Rforce + cp / R * phitorque
+    az = zforce
+    return numpy.array([ax, ay, az])
+
+
+def _orbit_rect_3d(o, ts):
+    """Stack the integrated 6D orbit in rectangular phase space (nt,6)."""
+    x = o.x(ts)
+    y = o.y(ts)
+    z = o.z(ts)
+    vx = o.vx(ts)
+    vy = o.vy(ts)
+    vz = o.vz(ts)
+    return numpy.array([x, y, z, vx, vy, vz]).T
+
+
+# 3D variational equations: Liouville (det M=1), symplecticity, and -- the
+# parts that actually pin down the Cartesian Hessian K -- the flow-direction,
+# finite-difference, and 2D-reduction bridge checks. See the docstring of each
+# block below for which property is being validated.
+def test_liouville_3d():
+    from galpy.orbit import Orbit
+    from galpy.potential import MiyamotoNagaiPotential, PlummerPotential
+
+    integrators = [
+        "dopr54_c",
+        "dop853_c",
+        "rk4_c",
+        "rk6_c",
+        "dop853",
+        "odeint",
+    ]
+    pots = [
+        MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True),
+        PlummerPotential(amp=1.0, b=0.7, normalize=True),
+    ]
+    # Generic, fully 3D initial condition (R,vR,vT,z,vz,phi)
+    ic = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
+    times = numpy.linspace(0.0, 5.0, 251)
+    # Omega in (x,y,z,vx,vy,vz) order for the symplecticity check
+    Omega = numpy.zeros((6, 6))
+    Omega[:3, 3:] = numpy.eye(3)
+    Omega[3:, :3] = -numpy.eye(3)
+    canonical = numpy.eye(6)
+    for pot in pots:
+        pname = pot.__class__.__name__
+        for integrator in integrators:
+            if "_c" in integrator:
+                rtol, atol = 1e-12, 1e-12
+            else:
+                rtol, atol = 1e-12, 1e-12
+            # ---- Build the 6x6 monodromy/STM M: integrate the 6 canonical
+            # basis deviation vectors with rectIn=rectOut=True ----
+            Mcols = []
+            for ii in range(6):
+                o = Orbit(ic)
+                o.integrate_dxdv(
+                    canonical[ii],
+                    times,
+                    pot,
+                    method=integrator,
+                    rectIn=True,
+                    rectOut=True,
+                    rtol=rtol,
+                    atol=atol,
+                )
+                Mcols.append(o.getOrbit_dxdv()[-1, :])
+            M = numpy.array(Mcols).T  # columns are the propagated basis vectors
+            # (1) Liouville: det M = 1 [necessary check]. The fixed-step,
+            # lower-order rk4_c/rk6_c integrators are intrinsically a little less
+            # accurate, so use a slightly looser (but still meaningful) tolerance.
+            det_tol = 1e-7 if integrator in ("rk4_c", "rk6_c") else 1e-8
+            detM = numpy.linalg.det(M)
+            assert numpy.fabs(detM - 1.0) < det_tol, (
+                f"3D Liouville det(M)={detM:g} differs from 1 for {pname}, "
+                f"integrator {integrator}"
+            )
+            # (2) Symplecticity: M^T Omega M = Omega [necessary]
+            symperr = numpy.amax(
+                numpy.fabs(numpy.dot(M.T, numpy.dot(Omega, M)) - Omega)
+            )
+            assert symperr < 1e-7, (
+                f"3D symplecticity ||M^T Omega M - Omega||={symperr:g} too large "
+                f"for {pname}, integrator {integrator}"
+            )
+            # (3) Flow-direction (validates K, free): the phase-space velocity
+            # f(x0) is an exact solution of the variational equation, so the
+            # integrated deviation must equal f(x(t)) along the orbit.
+            o = Orbit(ic)
+            o.integrate(times, pot, method=integrator)
+            rect_orbit = _orbit_rect_3d(o, times)
+            f0 = numpy.empty(6)
+            f0[:3] = rect_orbit[0, 3:]
+            f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3])
+            o2 = Orbit(ic)
+            o2.integrate_dxdv(
+                f0,
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=rtol,
+                atol=atol,
+            )
+            dev = o2.getOrbit_dxdv()  # (nt,6) rectangular deviation
+            ftrue = numpy.empty((len(times), 6))
+            ftrue[:, :3] = rect_orbit[:, 3:]
+            for jj in range(len(times)):
+                ftrue[jj, 3:] = _cart_accel_3d(pot, rect_orbit[jj, :3])
+            flowerr = numpy.amax(numpy.fabs(dev - ftrue))
+            assert flowerr < 1e-6, (
+                f"3D flow-direction deviation differs from f(x(t)) by {flowerr:g} "
+                f"for {pname}, integrator {integrator}"
+            )
+            # (4) Finite-difference of the flow (validates K): integrate a base
+            # orbit and orbits perturbed by eps*e_i and compare the dxdv column
+            # to the FD of the integrated flow. Do a couple of i.
+            eps = 1e-7
+            obase = Orbit(ic)
+            obase.integrate(times, pot, method=integrator)
+            base_rect = _orbit_rect_3d(obase, times)
+            for ii in [0, 2, 4]:  # an x, a z, and a vy perturbation
+                pert_ic_rect = base_rect[0].copy()
+                pert_ic_rect[ii] += eps
+                # build a cylindrical IC from the perturbed rect IC
+                from galpy.util import coords
+
+                Rp, phip, Zp = coords.rect_to_cyl(
+                    pert_ic_rect[0], pert_ic_rect[1], pert_ic_rect[2]
+                )
+                vRp, vTp, vzp = coords.rect_to_cyl_vec(
+                    pert_ic_rect[3],
+                    pert_ic_rect[4],
+                    pert_ic_rect[5],
+                    pert_ic_rect[0],
+                    pert_ic_rect[1],
+                    pert_ic_rect[2],
+                )
+                opert = Orbit([Rp, vRp, vTp, Zp, vzp, phip])
+                opert.integrate(times, pot, method=integrator)
+                pert_rect = _orbit_rect_3d(opert, times)
+                fd = (pert_rect - base_rect) / eps
+                # dxdv column for e_i
+                odx = Orbit(ic)
+                odx.integrate_dxdv(
+                    canonical[ii],
+                    times,
+                    pot,
+                    method=integrator,
+                    rectIn=True,
+                    rectOut=True,
+                    rtol=rtol,
+                    atol=atol,
+                )
+                col = odx.getOrbit_dxdv()
+                fderr = numpy.amax(numpy.fabs(fd - col))
+                assert fderr < 1e-4, (
+                    f"3D finite-difference of the flow for e_{ii} differs from "
+                    f"the dxdv column by {fderr:g} for {pname}, integrator {integrator}"
+                )
+    return None
+
+
+# 2D-reduction bridge (validates the (x,y) block of K): for a planar IC with
+# dz=dvz=0 and an in-plane deviation, the (x,y,vx,vy) sub-STM from the 3D
+# integrate_dxdv must match the trusted planar integrate_dxdv result.
+def test_liouville_3d_2d_bridge():
+    from galpy.orbit import Orbit
+    from galpy.potential import MiyamotoNagaiPotential, PlummerPotential
+
+    pots = [
+        MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True),
+        PlummerPotential(amp=1.0, b=0.7, normalize=True),
+    ]
+    times = numpy.linspace(0.0, 5.0, 251)
+    # Planar IC (z=0, vz=0): (R,vR,vT,phi) in 2D and (R,vR,vT,z=0,vz=0,phi) in 3D
+    R, vR, vT, phi = 1.0, 0.1, 1.1, 0.2
+    # In-plane rectangular deviations to compare (x, y, vx, vy basis)
+    # 3D rect order: (x,y,z,vx,vy,vz); planar rect order: (x,y,vx,vy)
+    dev3d_list = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # dx
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # dy
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],  # dvx
+        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],  # dvy
+    ]
+    dev2d_list = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    # 3D->planar index map: (x,y,vx,vy) live at 3D indices (0,1,3,4)
+    planar_in_3d = [0, 1, 3, 4]
+    for pot in pots:
+        pname = pot.__class__.__name__
+        for dev3d, dev2d in zip(dev3d_list, dev2d_list):
+            # 3D
+            o3 = Orbit([R, vR, vT, 0.0, 0.0, phi])
+            o3.integrate_dxdv(
+                dev3d,
+                times,
+                pot,
+                method="dop853_c",
+                rectIn=True,
+                rectOut=True,
+                rtol=1e-12,
+                atol=1e-12,
+            )
+            d3 = o3.getOrbit_dxdv()[-1]  # rect (dx,dy,dz,dvx,dvy,dvz)
+            # planar (trusted)
+            o2 = Orbit([R, vR, vT, phi])
+            o2.integrate_dxdv(
+                dev2d,
+                times,
+                pot.toPlanar(),
+                method="dop853_c",
+                rectIn=True,
+                rectOut=True,
+                rtol=1e-12,
+                atol=1e-12,
+            )
+            d2 = o2.getOrbit_dxdv()[-1]  # rect (dx,dy,dvx,dvy)
+            # z, vz deviations must stay zero in 3D
+            assert numpy.fabs(d3[2]) < 1e-9 and numpy.fabs(d3[5]) < 1e-9, (
+                f"3D in-plane deviation leaked into (dz,dvz) for {pname}"
+            )
+            bridge_err = numpy.amax(numpy.fabs(d3[planar_in_3d] - d2))
+            assert bridge_err < 1e-9, (
+                f"3D->2D bridge: (x,y,vx,vy) sub-STM differs from planar by "
+                f"{bridge_err:g} for {pname}"
+            )
+    return None
+
+
 # Test that integrating an orbit in MWPotential2014 using integrate_SOS conserves energy
 def test_integrate_SOS_3D():
     pot = potential.MWPotential2014
@@ -8458,8 +8709,8 @@ def test_integrate_dxdv_errors():
     from galpy.orbit import Orbit
 
     ts = numpy.linspace(0.0, 10.0, 1001)
-    # Test that attempting to use integrate_dxdv with a non-phasedim==4 orbit
-    # raises error
+    # Test that attempting to use integrate_dxdv with a non-phasedim==4/6 orbit
+    # raises error (1D and 3D-without-phi orbits)
     o = Orbit([1.0, 0.1])
     with pytest.raises(AttributeError) as excinfo:
         o.integrate_dxdv(None, ts, potential.toVertical(potential.MWPotential, 1.0))
@@ -8469,14 +8720,26 @@ def test_integrate_dxdv_errors():
     o = Orbit([1.0, 0.1, 1.0, 0.1, 0.1])
     with pytest.raises(AttributeError) as excinfo:
         o.integrate_dxdv(None, ts, potential.MWPotential)
-    o = Orbit([1.0, 0.1, 1.0, 0.1, 0.1, 3.0])
-    with pytest.raises(AttributeError) as excinfo:
-        o.integrate_dxdv(None, ts, potential.MWPotential)
-    # Test that a random string as the integrator doesn't work
+    # Test that a random string as the integrator doesn't work (4D)
     o = Orbit([1.0, 0.1, 1.0, 3.0])
     with pytest.raises(ValueError) as excinfo:
         o.integrate_dxdv(
             None, ts, potential.MWPotential, method="some non-existent integrator"
+        )
+    # Test that a random string as the integrator doesn't work (6D)
+    o = Orbit([1.0, 0.1, 1.0, 0.1, 0.1, 3.0])
+    with pytest.raises(ValueError) as excinfo:
+        o.integrate_dxdv(
+            None, ts, potential.MWPotential, method="some non-existent integrator"
+        )
+    # Test that a symplectic integrator raises for 6D orbits
+    o = Orbit([1.0, 0.1, 1.0, 0.1, 0.1, 3.0])
+    with pytest.raises(ValueError) as excinfo:
+        o.integrate_dxdv(
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ts,
+            potential.MWPotential,
+            method="symplec4_c",
         )
     return None
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -702,6 +702,322 @@ def test_energy_symplec_longterm():
     return None
 
 
+def _cart_accel_3d(pot, rect):
+    """Cartesian acceleration (ax,ay,az) at rectangular position rect=(x,y,z)."""
+    from galpy.potential import (
+        evaluatephitorques,
+        evaluateRforces,
+        evaluatezforces,
+    )
+
+    x, y, z = rect[0], rect[1], rect[2]
+    R = numpy.sqrt(x**2.0 + y**2.0)
+    phi = numpy.arctan2(y, x)
+    cp, sp = numpy.cos(phi), numpy.sin(phi)
+    Rforce = evaluateRforces(pot, R, z, phi=phi)
+    phitorque = evaluatephitorques(pot, R, z, phi=phi)
+    zforce = evaluatezforces(pot, R, z, phi=phi)
+    ax = cp * Rforce - sp / R * phitorque
+    ay = sp * Rforce + cp / R * phitorque
+    az = zforce
+    return numpy.array([ax, ay, az])
+
+
+def _orbit_rect_3d(o, ts):
+    """Stack the integrated 6D orbit in rectangular phase space (nt,6)."""
+    x = o.x(ts)
+    y = o.y(ts)
+    z = o.z(ts)
+    vx = o.vx(ts)
+    vy = o.vy(ts)
+    vz = o.vz(ts)
+    return numpy.array([x, y, z, vx, vy, vz]).T
+
+
+# 3D variational equations: Liouville (det M=1), symplecticity, and -- the
+# parts that actually pin down the Cartesian Hessian K -- the flow-direction,
+# finite-difference, and 2D-reduction bridge checks. See the docstring of each
+# block below for which property is being validated.
+def test_liouville_3d(pot):
+    from galpy.orbit import Orbit
+
+    integrators = [
+        "dopr54_c",
+        "dop853_c",
+        "rk4_c",
+        "rk6_c",
+        "dop853",
+        "odeint",
+    ]
+    # Generic, fully 3D initial condition (R,vR,vT,z,vz,phi)
+    ic = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
+    times = numpy.linspace(0.0, 5.0, 251)
+    # Omega in (x,y,z,vx,vy,vz) order for the symplecticity check
+    Omega = numpy.zeros((6, 6))
+    Omega[:3, 3:] = numpy.eye(3)
+    Omega[3:, :3] = -numpy.eye(3)
+    canonical = numpy.eye(6)
+    pname = pot.__class__.__name__
+    for integrator in integrators:
+        if "_c" in integrator:
+            rtol, atol = 1e-12, 1e-12
+        else:
+            rtol, atol = 1e-12, 1e-12
+        # ---- Build the 6x6 monodromy/STM M: integrate the 6 canonical
+        # basis deviation vectors with rectIn=rectOut=True ----
+        Mcols = []
+        for ii in range(6):
+            o = Orbit(ic)
+            o.integrate_dxdv(
+                canonical[ii],
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=rtol,
+                atol=atol,
+            )
+            Mcols.append(o.getOrbit_dxdv()[-1, :])
+        M = numpy.array(Mcols).T  # columns are the propagated basis vectors
+        # (1) Liouville: det M = 1 [necessary check]. The fixed-step,
+        # lower-order rk4_c/rk6_c integrators are intrinsically a little less
+        # accurate, so use a slightly looser (but still meaningful) tolerance.
+        det_tol = 1e-7 if integrator in ("rk4_c", "rk6_c") else 1e-8
+        detM = numpy.linalg.det(M)
+        assert numpy.fabs(detM - 1.0) < det_tol, (
+            f"3D Liouville det(M)={detM:g} differs from 1 for {pname}, "
+            f"integrator {integrator}"
+        )
+        # (2) Symplecticity: M^T Omega M = Omega [necessary]
+        symperr = numpy.amax(numpy.fabs(numpy.dot(M.T, numpy.dot(Omega, M)) - Omega))
+        assert symperr < 1e-7, (
+            f"3D symplecticity ||M^T Omega M - Omega||={symperr:g} too large "
+            f"for {pname}, integrator {integrator}"
+        )
+        # (3) Flow-direction (validates K, free): the phase-space velocity
+        # f(x0) is an exact solution of the variational equation, so the
+        # integrated deviation must equal f(x(t)) along the orbit.
+        o = Orbit(ic)
+        o.integrate(times, pot, method=integrator)
+        rect_orbit = _orbit_rect_3d(o, times)
+        f0 = numpy.empty(6)
+        f0[:3] = rect_orbit[0, 3:]
+        f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3])
+        o2 = Orbit(ic)
+        o2.integrate_dxdv(
+            f0,
+            times,
+            pot,
+            method=integrator,
+            rectIn=True,
+            rectOut=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        dev = o2.getOrbit_dxdv()  # (nt,6) rectangular deviation
+        ftrue = numpy.empty((len(times), 6))
+        ftrue[:, :3] = rect_orbit[:, 3:]
+        for jj in range(len(times)):
+            ftrue[jj, 3:] = _cart_accel_3d(pot, rect_orbit[jj, :3])
+        flowerr = numpy.amax(numpy.fabs(dev - ftrue))
+        assert flowerr < 1e-6, (
+            f"3D flow-direction deviation differs from f(x(t)) by {flowerr:g} "
+            f"for {pname}, integrator {integrator}"
+        )
+        # (4) Finite-difference of the flow (validates K): integrate a base
+        # orbit and orbits perturbed by eps*e_i and compare the dxdv column
+        # to the FD of the integrated flow. Do a couple of i.
+        eps = 1e-7
+        obase = Orbit(ic)
+        obase.integrate(times, pot, method=integrator)
+        base_rect = _orbit_rect_3d(obase, times)
+        for ii in [0, 2, 4]:  # an x, a z, and a vy perturbation
+            pert_ic_rect = base_rect[0].copy()
+            pert_ic_rect[ii] += eps
+            # build a cylindrical IC from the perturbed rect IC
+            from galpy.util import coords
+
+            Rp, phip, Zp = coords.rect_to_cyl(
+                pert_ic_rect[0], pert_ic_rect[1], pert_ic_rect[2]
+            )
+            vRp, vTp, vzp = coords.rect_to_cyl_vec(
+                pert_ic_rect[3],
+                pert_ic_rect[4],
+                pert_ic_rect[5],
+                pert_ic_rect[0],
+                pert_ic_rect[1],
+                pert_ic_rect[2],
+            )
+            opert = Orbit([Rp, vRp, vTp, Zp, vzp, phip])
+            opert.integrate(times, pot, method=integrator)
+            pert_rect = _orbit_rect_3d(opert, times)
+            fd = (pert_rect - base_rect) / eps
+            # dxdv column for e_i
+            odx = Orbit(ic)
+            odx.integrate_dxdv(
+                canonical[ii],
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=rtol,
+                atol=atol,
+            )
+            col = odx.getOrbit_dxdv()
+            fderr = numpy.amax(numpy.fabs(fd - col))
+            assert fderr < 1e-4, (
+                f"3D finite-difference of the flow for e_{ii} differs from "
+                f"the dxdv column by {fderr:g} for {pname}, integrator {integrator}"
+            )
+    return None
+
+
+# 2D-reduction bridge (validates the (x,y) block of K): for a planar IC with
+# dz=dvz=0 and an in-plane deviation, the (x,y,vx,vy) sub-STM from the 3D
+# integrate_dxdv must match the trusted planar integrate_dxdv result.
+def test_liouville_3d_2d_bridge(pot):
+    from galpy.orbit import Orbit
+
+    times = numpy.linspace(0.0, 5.0, 251)
+    # Planar IC (z=0, vz=0): (R,vR,vT,phi) in 2D and (R,vR,vT,z=0,vz=0,phi) in 3D
+    R, vR, vT, phi = 1.0, 0.1, 1.1, 0.2
+    # In-plane rectangular deviations to compare (x, y, vx, vy basis)
+    # 3D rect order: (x,y,z,vx,vy,vz); planar rect order: (x,y,vx,vy)
+    dev3d_list = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # dx
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # dy
+        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],  # dvx
+        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],  # dvy
+    ]
+    dev2d_list = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    # 3D->planar index map: (x,y,vx,vy) live at 3D indices (0,1,3,4)
+    planar_in_3d = [0, 1, 3, 4]
+    pname = pot.__class__.__name__
+    for dev3d, dev2d in zip(dev3d_list, dev2d_list):
+        # 3D
+        o3 = Orbit([R, vR, vT, 0.0, 0.0, phi])
+        o3.integrate_dxdv(
+            dev3d,
+            times,
+            pot,
+            method="dop853_c",
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        d3 = o3.getOrbit_dxdv()[-1]  # rect (dx,dy,dz,dvx,dvy,dvz)
+        # planar (trusted)
+        o2 = Orbit([R, vR, vT, phi])
+        o2.integrate_dxdv(
+            dev2d,
+            times,
+            pot.toPlanar(),
+            method="dop853_c",
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        d2 = o2.getOrbit_dxdv()[-1]  # rect (dx,dy,dvx,dvy)
+        # z, vz deviations must stay zero in 3D
+        assert numpy.fabs(d3[2]) < 1e-9 and numpy.fabs(d3[5]) < 1e-9, (
+            f"3D in-plane deviation leaked into (dz,dvz) for {pname}"
+        )
+        bridge_err = numpy.amax(numpy.fabs(d3[planar_in_3d] - d2))
+        assert bridge_err < 1e-9, (
+            f"3D->2D bridge: (x,y,vx,vy) sub-STM differs from planar by "
+            f"{bridge_err:g} for {pname}"
+        )
+    # Same bridge in the cylindrical frame with the DEFAULT rectIn=rectOut=False:
+    # exercises and validates the cylindrical<->rectangular deviation transforms
+    # inside integrateFullOrbit_dxdv (the default integrate_dxdv path), against the
+    # trusted planar integrate_dxdv. Cyl deviation order: (dR,dvR,dvT,dz,dvz,dphi);
+    # (dR,dvR,dvT,dphi) live at 3D cyl indices (0,1,2,5).
+    dev3d_cyl_list = [
+        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # dR
+        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # dvR
+        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],  # dvT
+        [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  # dphi
+    ]
+    dev2d_cyl_list = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+    cyl_in_3d = [0, 1, 2, 5]
+    for dev3d, dev2d in zip(dev3d_cyl_list, dev2d_cyl_list):
+        o3 = Orbit([R, vR, vT, 0.0, 0.0, phi])
+        o3.integrate_dxdv(dev3d, times, pot, method="dop853_c", rtol=1e-12, atol=1e-12)
+        d3 = o3.getOrbit_dxdv()[-1]  # cyl (dR,dvR,dvT,dz,dvz,dphi)
+        o2 = Orbit([R, vR, vT, phi])
+        o2.integrate_dxdv(
+            dev2d, times, pot.toPlanar(), method="dop853_c", rtol=1e-12, atol=1e-12
+        )
+        d2 = o2.getOrbit_dxdv()[-1]  # cyl (dR,dvR,dvT,dphi)
+        assert numpy.fabs(d3[3]) < 1e-9 and numpy.fabs(d3[4]) < 1e-9, (
+            f"3D in-plane cyl deviation leaked into (dz,dvz) for {pname}"
+        )
+        bridge_err = numpy.amax(numpy.fabs(d3[cyl_in_3d] - d2))
+        assert bridge_err < 1e-9, (
+            f"3D->2D cyl bridge differs from planar by {bridge_err:g} for {pname}"
+        )
+    return None
+
+
+def test_integrate_dxdv_3d_multiobj_and_default_tol():
+    # Cover and validate the multi-object (parallel_map) and pure-Python dop853
+    # default-tolerance paths of the 3D integrate_dxdv.
+    from galpy.orbit import Orbit
+    from galpy.potential import MiyamotoNagaiPotential
+
+    pot = MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True)
+    times = numpy.linspace(0.0, 2.0, 51)
+    ic1 = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
+    ic2 = [1.2, -0.05, 0.9, -0.1, 0.03, 1.0]
+    dev = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    # multi-object: two orbits' dxdv at once must match the single-object runs
+    omulti = Orbit([ic1, ic2])
+    omulti.integrate_dxdv(
+        [dev, dev], times, pot, method="dop853_c", rectIn=True, rectOut=True
+    )
+    gmulti = numpy.asarray(omulti.getOrbit_dxdv())  # (2,nt,6)
+    for jj, ic in enumerate([ic1, ic2]):
+        osingle = Orbit(ic)
+        osingle.integrate_dxdv(
+            dev, times, pot, method="dop853_c", rectIn=True, rectOut=True
+        )
+        assert numpy.amax(numpy.fabs(gmulti[jj] - osingle.getOrbit_dxdv())) < 1e-10, (
+            "multi-object 3D dxdv differs from the single-object result"
+        )
+    # pure-Python dop853 with default (None) tolerances vs explicit tolerances
+    odef = Orbit(ic1)
+    odef.integrate_dxdv(dev, times, pot, method="dop853", rectIn=True, rectOut=True)
+    oexp = Orbit(ic1)
+    oexp.integrate_dxdv(
+        dev,
+        times,
+        pot,
+        method="dop853",
+        rectIn=True,
+        rectOut=True,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert numpy.amax(numpy.fabs(odef.getOrbit_dxdv() - oexp.getOrbit_dxdv())) < 1e-8, (
+        "3D dxdv default-tolerance dop853 differs from the explicit-tolerance run"
+    )
+    return None
+
+
 def test_liouville_planar():
     if _NOLONGINTEGRATIONS:
         return None
@@ -970,257 +1286,6 @@ def test_liouville_planar():
                 or ("Burkert" in p and not ptp.hasC)
             ):
                 break
-    return None
-
-
-def _cart_accel_3d(pot, rect):
-    """Cartesian acceleration (ax,ay,az) at rectangular position rect=(x,y,z)."""
-    from galpy.potential import (
-        evaluatephitorques,
-        evaluateRforces,
-        evaluatezforces,
-    )
-
-    x, y, z = rect[0], rect[1], rect[2]
-    R = numpy.sqrt(x**2.0 + y**2.0)
-    phi = numpy.arctan2(y, x)
-    cp, sp = numpy.cos(phi), numpy.sin(phi)
-    Rforce = evaluateRforces(pot, R, z, phi=phi)
-    phitorque = evaluatephitorques(pot, R, z, phi=phi)
-    zforce = evaluatezforces(pot, R, z, phi=phi)
-    ax = cp * Rforce - sp / R * phitorque
-    ay = sp * Rforce + cp / R * phitorque
-    az = zforce
-    return numpy.array([ax, ay, az])
-
-
-def _orbit_rect_3d(o, ts):
-    """Stack the integrated 6D orbit in rectangular phase space (nt,6)."""
-    x = o.x(ts)
-    y = o.y(ts)
-    z = o.z(ts)
-    vx = o.vx(ts)
-    vy = o.vy(ts)
-    vz = o.vz(ts)
-    return numpy.array([x, y, z, vx, vy, vz]).T
-
-
-# 3D variational equations: Liouville (det M=1), symplecticity, and -- the
-# parts that actually pin down the Cartesian Hessian K -- the flow-direction,
-# finite-difference, and 2D-reduction bridge checks. See the docstring of each
-# block below for which property is being validated.
-def test_liouville_3d():
-    from galpy.orbit import Orbit
-    from galpy.potential import MiyamotoNagaiPotential, PlummerPotential
-
-    integrators = [
-        "dopr54_c",
-        "dop853_c",
-        "rk4_c",
-        "rk6_c",
-        "dop853",
-        "odeint",
-    ]
-    pots = [
-        MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True),
-        PlummerPotential(amp=1.0, b=0.7, normalize=True),
-    ]
-    # Generic, fully 3D initial condition (R,vR,vT,z,vz,phi)
-    ic = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
-    times = numpy.linspace(0.0, 5.0, 251)
-    # Omega in (x,y,z,vx,vy,vz) order for the symplecticity check
-    Omega = numpy.zeros((6, 6))
-    Omega[:3, 3:] = numpy.eye(3)
-    Omega[3:, :3] = -numpy.eye(3)
-    canonical = numpy.eye(6)
-    for pot in pots:
-        pname = pot.__class__.__name__
-        for integrator in integrators:
-            if "_c" in integrator:
-                rtol, atol = 1e-12, 1e-12
-            else:
-                rtol, atol = 1e-12, 1e-12
-            # ---- Build the 6x6 monodromy/STM M: integrate the 6 canonical
-            # basis deviation vectors with rectIn=rectOut=True ----
-            Mcols = []
-            for ii in range(6):
-                o = Orbit(ic)
-                o.integrate_dxdv(
-                    canonical[ii],
-                    times,
-                    pot,
-                    method=integrator,
-                    rectIn=True,
-                    rectOut=True,
-                    rtol=rtol,
-                    atol=atol,
-                )
-                Mcols.append(o.getOrbit_dxdv()[-1, :])
-            M = numpy.array(Mcols).T  # columns are the propagated basis vectors
-            # (1) Liouville: det M = 1 [necessary check]. The fixed-step,
-            # lower-order rk4_c/rk6_c integrators are intrinsically a little less
-            # accurate, so use a slightly looser (but still meaningful) tolerance.
-            det_tol = 1e-7 if integrator in ("rk4_c", "rk6_c") else 1e-8
-            detM = numpy.linalg.det(M)
-            assert numpy.fabs(detM - 1.0) < det_tol, (
-                f"3D Liouville det(M)={detM:g} differs from 1 for {pname}, "
-                f"integrator {integrator}"
-            )
-            # (2) Symplecticity: M^T Omega M = Omega [necessary]
-            symperr = numpy.amax(
-                numpy.fabs(numpy.dot(M.T, numpy.dot(Omega, M)) - Omega)
-            )
-            assert symperr < 1e-7, (
-                f"3D symplecticity ||M^T Omega M - Omega||={symperr:g} too large "
-                f"for {pname}, integrator {integrator}"
-            )
-            # (3) Flow-direction (validates K, free): the phase-space velocity
-            # f(x0) is an exact solution of the variational equation, so the
-            # integrated deviation must equal f(x(t)) along the orbit.
-            o = Orbit(ic)
-            o.integrate(times, pot, method=integrator)
-            rect_orbit = _orbit_rect_3d(o, times)
-            f0 = numpy.empty(6)
-            f0[:3] = rect_orbit[0, 3:]
-            f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3])
-            o2 = Orbit(ic)
-            o2.integrate_dxdv(
-                f0,
-                times,
-                pot,
-                method=integrator,
-                rectIn=True,
-                rectOut=True,
-                rtol=rtol,
-                atol=atol,
-            )
-            dev = o2.getOrbit_dxdv()  # (nt,6) rectangular deviation
-            ftrue = numpy.empty((len(times), 6))
-            ftrue[:, :3] = rect_orbit[:, 3:]
-            for jj in range(len(times)):
-                ftrue[jj, 3:] = _cart_accel_3d(pot, rect_orbit[jj, :3])
-            flowerr = numpy.amax(numpy.fabs(dev - ftrue))
-            assert flowerr < 1e-6, (
-                f"3D flow-direction deviation differs from f(x(t)) by {flowerr:g} "
-                f"for {pname}, integrator {integrator}"
-            )
-            # (4) Finite-difference of the flow (validates K): integrate a base
-            # orbit and orbits perturbed by eps*e_i and compare the dxdv column
-            # to the FD of the integrated flow. Do a couple of i.
-            eps = 1e-7
-            obase = Orbit(ic)
-            obase.integrate(times, pot, method=integrator)
-            base_rect = _orbit_rect_3d(obase, times)
-            for ii in [0, 2, 4]:  # an x, a z, and a vy perturbation
-                pert_ic_rect = base_rect[0].copy()
-                pert_ic_rect[ii] += eps
-                # build a cylindrical IC from the perturbed rect IC
-                from galpy.util import coords
-
-                Rp, phip, Zp = coords.rect_to_cyl(
-                    pert_ic_rect[0], pert_ic_rect[1], pert_ic_rect[2]
-                )
-                vRp, vTp, vzp = coords.rect_to_cyl_vec(
-                    pert_ic_rect[3],
-                    pert_ic_rect[4],
-                    pert_ic_rect[5],
-                    pert_ic_rect[0],
-                    pert_ic_rect[1],
-                    pert_ic_rect[2],
-                )
-                opert = Orbit([Rp, vRp, vTp, Zp, vzp, phip])
-                opert.integrate(times, pot, method=integrator)
-                pert_rect = _orbit_rect_3d(opert, times)
-                fd = (pert_rect - base_rect) / eps
-                # dxdv column for e_i
-                odx = Orbit(ic)
-                odx.integrate_dxdv(
-                    canonical[ii],
-                    times,
-                    pot,
-                    method=integrator,
-                    rectIn=True,
-                    rectOut=True,
-                    rtol=rtol,
-                    atol=atol,
-                )
-                col = odx.getOrbit_dxdv()
-                fderr = numpy.amax(numpy.fabs(fd - col))
-                assert fderr < 1e-4, (
-                    f"3D finite-difference of the flow for e_{ii} differs from "
-                    f"the dxdv column by {fderr:g} for {pname}, integrator {integrator}"
-                )
-    return None
-
-
-# 2D-reduction bridge (validates the (x,y) block of K): for a planar IC with
-# dz=dvz=0 and an in-plane deviation, the (x,y,vx,vy) sub-STM from the 3D
-# integrate_dxdv must match the trusted planar integrate_dxdv result.
-def test_liouville_3d_2d_bridge():
-    from galpy.orbit import Orbit
-    from galpy.potential import MiyamotoNagaiPotential, PlummerPotential
-
-    pots = [
-        MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1, normalize=True),
-        PlummerPotential(amp=1.0, b=0.7, normalize=True),
-    ]
-    times = numpy.linspace(0.0, 5.0, 251)
-    # Planar IC (z=0, vz=0): (R,vR,vT,phi) in 2D and (R,vR,vT,z=0,vz=0,phi) in 3D
-    R, vR, vT, phi = 1.0, 0.1, 1.1, 0.2
-    # In-plane rectangular deviations to compare (x, y, vx, vy basis)
-    # 3D rect order: (x,y,z,vx,vy,vz); planar rect order: (x,y,vx,vy)
-    dev3d_list = [
-        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # dx
-        [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # dy
-        [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],  # dvx
-        [0.0, 0.0, 0.0, 0.0, 1.0, 0.0],  # dvy
-    ]
-    dev2d_list = [
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [0.0, 0.0, 1.0, 0.0],
-        [0.0, 0.0, 0.0, 1.0],
-    ]
-    # 3D->planar index map: (x,y,vx,vy) live at 3D indices (0,1,3,4)
-    planar_in_3d = [0, 1, 3, 4]
-    for pot in pots:
-        pname = pot.__class__.__name__
-        for dev3d, dev2d in zip(dev3d_list, dev2d_list):
-            # 3D
-            o3 = Orbit([R, vR, vT, 0.0, 0.0, phi])
-            o3.integrate_dxdv(
-                dev3d,
-                times,
-                pot,
-                method="dop853_c",
-                rectIn=True,
-                rectOut=True,
-                rtol=1e-12,
-                atol=1e-12,
-            )
-            d3 = o3.getOrbit_dxdv()[-1]  # rect (dx,dy,dz,dvx,dvy,dvz)
-            # planar (trusted)
-            o2 = Orbit([R, vR, vT, phi])
-            o2.integrate_dxdv(
-                dev2d,
-                times,
-                pot.toPlanar(),
-                method="dop853_c",
-                rectIn=True,
-                rectOut=True,
-                rtol=1e-12,
-                atol=1e-12,
-            )
-            d2 = o2.getOrbit_dxdv()[-1]  # rect (dx,dy,dvx,dvy)
-            # z, vz deviations must stay zero in 3D
-            assert numpy.fabs(d3[2]) < 1e-9 and numpy.fabs(d3[5]) < 1e-9, (
-                f"3D in-plane deviation leaked into (dz,dvz) for {pname}"
-            )
-            bridge_err = numpy.amax(numpy.fabs(d3[planar_in_3d] - d2))
-            assert bridge_err < 1e-9, (
-                f"3D->2D bridge: (x,y,vx,vy) sub-STM differs from planar by "
-                f"{bridge_err:g} for {pname}"
-            )
     return None
 
 


### PR DESCRIPTION
Sub-PR into the variational feature branch (#891). Makes the 3D variational equations (state-transition matrix) **work and be validated**, building on Pvar-struct.

### C
- `evalRectDeriv_dxdv`: correct 12-D variational RHS — d(deviation velocity) = K·(dx,dy,dz) with the **symmetric Cartesian tidal tensor** K=−∇∇Φ. The (x,y) block is identical to the verified 2D equations; the new z-coupling is `dFxdz=−cosφ·Rzderiv+sinφ/R·zphideriv (=dFzdx)`, `dFydz=−sinφ·Rzderiv−cosφ/R·zphideriv (=dFzdy)`, `dFzdz=−z2deriv`. Fixes the old stub's wrong deviation indices and zeroed dvz.
- All six 3D-Hessian aggregators NULL-safe; internal `integrateOrbit_dxdv` → `EXPORT integrateFullOrbit_dxdv`.
- Validation-set Hessians wired: MiyamotoNagai + Plummer get full-3D `R2deriv/z2deriv/Rzderiv` in C (axisymmetric → phi-derivs NULL → 0).

### Python
- `integrateFullOrbit_dxdv` (3D analog of the planar wrapper): cyl↔rect deviation chain-rule transform (J·dyo in, J⁻¹·dyo out along the orbit), rectIn/rectOut, `_EOM_dxdv` for dop853/odeint. `Orbit.integrate_dxdv` lifted from `phasedim==4` to also support `==6` (4D path byte-identical).

### Validation (the load-bearing point)
det M=1 and symplecticity hold for *any* symmetric K, so they don't validate the Hessian. The tests that do — all pass tightly for MN+Plummer over 6 integrators:
| validator | MN | Plummer |
|---|---|---|
| **flow-direction** M·f(x₀)=f(x(t)) | 8e-12…2.7e-7 | 9e-13…2.1e-7 |
| **finite-difference of flow** | 6.5e-6…9.8e-6 | 4.3e-6…1.7e-5 |
| **2D-reduction bridge** (vs trusted planar) | <1e-9 | <1e-9 |
| det M−1 / symplecticity (necessary) | tight | tight |

`test_liouville_3d` + `test_liouville_3d_2d_bridge` added; existing `test_liouville_planar`/`test_fixedstepsize_dxdv` still pass. (det-M loosened to 1e-7 only for fixed-step rk4_c/rk6_c.)

### Next
The C RHS / aggregators / ABI / Python plumbing are general — the **Pvar-pot fan-out** adds the remaining ~48 potentials' C Hessians (implement derivs → declare → wire → add to `test_liouville_3d`). Then **Pvar-lyapunov**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)