### PR TITLE
Fix incorrect SpiralArms C R2deriv/PlanarR2deriv used by integrate_dxdv

### DIFF
--- a/galpy/potential/potential_c_ext/SpiralArmsPotential.c
+++ b/galpy/potential/potential_c_ext/SpiralArmsPotential.c
@@ -314,7 +314,7 @@ double SpiralArmsPotentialR2deriv(double R, double z, double phi, double t,
                                                                             + cos_ng * (ztanhzKB * Kn *
                                                                                         (dKn_dR / Kn - dBn_dR / Bn)
                                                                                         - dBn_dR * log_sechzKB
-                                                                                        + dKn_dR / Kn / Kn
+                                                                                        + dKn_dR / Kn
                                                                                         + dDn_dR / Dn))
                                                 + (n * (sin_ng * (d2g_dR2 / Kn - dg_dR / Kn / Kn * dKn_dR)
                                                         + dg_dR * dg_dR / Kn * cos_ng * n)
@@ -755,7 +755,7 @@ double SpiralArmsPotentialPlanarR2deriv(double R, double phi, double t,
                             + cos_ng * (dKn_dR / Kn / Kn
                                         + dDn_dR / Dn / Kn))
                            - (Rs * (1 / Kn * (-dDn_dR / Dn) * (n * dg_dR * sin_ng
-                                                               + cos_ng * (dKn_dR / Kn / Kn
+                                                               + cos_ng * (dKn_dR / Kn
                                                                            + dDn_dR / Dn))
                                     + (n * (sin_ng * (d2g_dR2 / Kn - dg_dR / Kn / Kn * dKn_dR)
                                             + dg_dR * dg_dR / Kn * cos_ng * n)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -973,6 +973,55 @@ def test_liouville_planar():
     return None
 
 
+def test_spiralarms_planar_dxdv_c_vs_python():
+    # Regression test for a bug in the C SpiralArmsPotentialPlanarR2deriv (the planar
+    # d^2Phi/dR^2 used by the C planar integrate_dxdv variational RHS): a stray extra
+    # 1/Kn factor made the in-plane tidal tensor wrong by ~3e-4. It was invisible to
+    # test_liouville_planar because det(M)=1 and symplecticity hold for ANY symmetric
+    # K; only comparing the C dxdv path against the (correct) pure-Python path exposes
+    # it. The C (dopr54_c) and Python (dop853) planar dxdv integrations must agree.
+    from galpy.orbit import Orbit
+    from galpy.potential import SpiralArmsPotential
+
+    pot = SpiralArmsPotential()
+    times = numpy.linspace(0.0, 4.0, 401)
+    ic = [1.0, 0.1, 1.1, 0.3]  # planar [R, vR, vT, phi]
+    # Use a UNIT deviation: the variational equation is linear in the deviation, so a
+    # unit dx makes the STM column O(1) and the ~2.6e-4 *relative* PlanarR2deriv error
+    # show up as an O(2.6e-4) absolute discrepancy (a tiny dx would scale it below tol).
+    dev = [1.0, 0.0, 0.0, 0.0]
+    o_c = Orbit(ic)
+    o_c.integrate_dxdv(
+        dev,
+        times,
+        pot,
+        method="dopr54_c",
+        rectIn=True,
+        rectOut=True,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    o_py = Orbit(ic)
+    o_py.integrate_dxdv(
+        dev,
+        times,
+        pot,
+        method="dop853",
+        rectIn=True,
+        rectOut=True,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    dev_c = numpy.asarray(o_c.getOrbit_dxdv())[-1]
+    dev_py = numpy.asarray(o_py.getOrbit_dxdv())[-1]
+    # Pre-fix the C path disagreed with the (correct) Python path by ~2.6e-4.
+    assert numpy.amax(numpy.fabs(dev_c - dev_py)) < 1e-6, (
+        "C planar dxdv (SpiralArms) disagrees with the pure-Python result: "
+        f"max diff {numpy.amax(numpy.fabs(dev_c - dev_py)):g} (PlanarR2deriv bug?)"
+    )
+    return None
+
+
 # Test that integrating an orbit in MWPotential2014 using integrate_SOS conserves energy
 def test_integrate_SOS_3D():
     pot = potential.MWPotential2014


### PR DESCRIPTION
## Summary
`SpiralArmsPotentialPlanarR2deriv` and `SpiralArmsPotentialR2deriv` (the C ∂²Φ/∂R² routines consumed by the C variational integrator, `evalPlanarRectDeriv_dxdv` / `evalRectDeriv_dxdv`) each had a **stray extra factor of 1/Kn**: one term read `dKn_dR / Kn / Kn` where it should read `dKn_dR / Kn` (`Kn` is the spiral radial wavenumber). This made the in-plane Cartesian tidal tensor used by `Orbit.integrate_dxdv` **wrong by ~2.6e-4**, producing incorrect deviation vectors / state-transition matrices / phase-space volumes for `SpiralArmsPotential` when integrating `dxdv` with a C integrator.

Note this code has several *legitimate* `/ Kn / Kn` (=1/Kn²) terms; only the two that pair with a first-order `+ dDn_dR / Dn` term (not `/Dn/Kn`) were wrong.

## Impact
- **Affected:** `Orbit.integrate_dxdv` for `SpiralArmsPotential` via a C integrator (e.g. `dopr54_c`) — the planar (released) path and, in downstream work, the 3D path.
- **Not affected:** forces, energies, regular orbit integration, and the Python `.R2deriv()` / `evaluateR2derivs` API. The Python second derivative is correct (matches a finite difference of the force to ~2e-11), and the **fixed C now agrees with it to ~3e-13**.

## Why it was invisible
`test_liouville_planar` only checks `det(M)=1` and symplecticity (`MᵀΩM=Ω`), which hold for *any* symmetric `K` — so a symmetric error in the Hessian slips through. It is only exposed by comparing the C path directly to the correct pure-Python path or to a finite-difference of the flow. Found during multi-backend variational-equations work via a C-vs-Python cross-check.

## Test
Adds `test_spiralarms_planar_dxdv_c_vs_python`, which integrates a planar `SpiralArmsPotential` `dxdv` with `dopr54_c` and `dop853` and asserts agreement:
- **without** this fix: `max|C − Python| ≈ 2.6e-4` (fails)
- **with** this fix: `max|C − Python| ≈ 3e-13` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)