### PR TITLE
Fix incorrect power of R in TwoPowerSpherical C PlanarR2deriv

### DIFF
--- a/galpy/potential/potential_c_ext/TwoPowerSphericalPotential.c
+++ b/galpy/potential/potential_c_ext/TwoPowerSphericalPotential.c
@@ -90,8 +90,8 @@ double TwoPowerSphericalPotentialPlanarR2deriv(double R,double phi,
                        * hyp2f1(4. - alpha, 1. + beta - alpha, 5. - alpha, -R/a);
 
   double term1 = A * pow(R, -alpha) * hyper;
-  double term2 = -alpha * A * pow(R, -alpha - 1.) * hyper;
-  double term3 = -A * pow(R, -alpha) * pow(a, -1.) * hyper_deriv;
+  double term2 = -alpha * A * pow(R, -alpha) * hyper;
+  double term3 = -A * pow(R, 1. - alpha) * pow(a, -1.) * hyper_deriv;
   return amp * (term1 + term2 + term3);
 }
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1022,6 +1022,68 @@ def test_spiralarms_planar_dxdv_c_vs_python():
     return None
 
 
+def test_twopower_planar_dxdv_c_vs_python():
+    # Regression test for a bug in the C TwoPowerSphericalPotentialPlanarR2deriv (the
+    # planar d^2Phi/dR^2 used by the C planar integrate_dxdv variational RHS): two terms
+    # had the wrong power of R (R^(-alpha-1) instead of R^(-alpha), and R^(-alpha)
+    # instead of R^(1-alpha)), making the in-plane tidal tensor wrong by ~7% (the error
+    # vanishes at R=1, where the wrong powers coincide). The pure-Python _R2deriv is
+    # correct (matches a finite-difference of -Rforce to ~1e-10). Only the BARE
+    # TwoPowerSphericalPotential is affected; its Dehnen/DehnenCore/Hernquist/NFW/Jaffe
+    # special-case subclasses use their own (correct) PlanarR2deriv. Comparing the C
+    # (dopr54_c / dop853) planar dxdv path against the (correct) pure-Python path
+    # exposes it.
+    from galpy.orbit import Orbit
+    from galpy.potential import TwoPowerSphericalPotential
+
+    # Non-degenerate (alpha, beta): must be the bare TwoPowerSphericalPotential, NOT a
+    # special-case subclass dispatch (which would use a different, correct C R2deriv).
+    pot = TwoPowerSphericalPotential(
+        amp=1.0, a=1.5, alpha=1.0, beta=4.5, normalize=True
+    )
+    assert pot._specialSelf is None, (
+        "test must use the bare TwoPowerSphericalPotential, not a subclass dispatch"
+    )
+    times = numpy.linspace(0.0, 4.0, 401)
+    ic = [1.0, 0.1, 1.1, 0.3]  # planar [R, vR, vT, phi]
+    # Use a UNIT deviation: the variational equation is linear in the deviation, so a
+    # unit dx makes the STM column O(1) and the ~7% *relative* PlanarR2deriv error show
+    # up as an O(0.07) absolute discrepancy (a tiny dx would scale it below tol).
+    dev = [1.0, 0.0, 0.0, 0.0]
+    for method in ["dopr54_c", "dop853"]:
+        o_c = Orbit(ic)
+        o_c.integrate_dxdv(
+            dev,
+            times,
+            pot,
+            method=method,
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        o_py = Orbit(ic)
+        o_py.integrate_dxdv(
+            dev,
+            times,
+            pot,
+            method="dop853",
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        dev_c = numpy.asarray(o_c.getOrbit_dxdv())[-1]
+        dev_py = numpy.asarray(o_py.getOrbit_dxdv())[-1]
+        # Pre-fix the C path disagreed with the (correct) Python path by ~0.86.
+        assert numpy.amax(numpy.fabs(dev_c - dev_py)) < 1e-6, (
+            "C planar dxdv (TwoPowerSpherical) disagrees with the pure-Python result "
+            f"(method={method}): max diff "
+            f"{numpy.amax(numpy.fabs(dev_c - dev_py)):g} (PlanarR2deriv bug?)"
+        )
+    return None
+
+
 # Test that integrating an orbit in MWPotential2014 using integrate_SOS conserves energy
 def test_integrate_SOS_3D():
     pot = potential.MWPotential2014

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1031,8 +1031,8 @@ def test_twopower_planar_dxdv_c_vs_python():
     # correct (matches a finite-difference of -Rforce to ~1e-10). Only the BARE
     # TwoPowerSphericalPotential is affected; its Dehnen/DehnenCore/Hernquist/NFW/Jaffe
     # special-case subclasses use their own (correct) PlanarR2deriv. Comparing the C
-    # (dopr54_c / dop853) planar dxdv path against the (correct) pure-Python path
-    # exposes it.
+    # (dopr54_c / dop853_c) planar dxdv path against the (correct) pure-Python (dop853)
+    # path exposes it.
     from galpy.orbit import Orbit
     from galpy.potential import TwoPowerSphericalPotential
 
@@ -1050,7 +1050,7 @@ def test_twopower_planar_dxdv_c_vs_python():
     # unit dx makes the STM column O(1) and the ~7% *relative* PlanarR2deriv error show
     # up as an O(0.07) absolute discrepancy (a tiny dx would scale it below tol).
     dev = [1.0, 0.0, 0.0, 0.0]
-    for method in ["dopr54_c", "dop853"]:
+    for method in ["dopr54_c", "dop853_c"]:
         o_c = Orbit(ic)
         o_c.integrate_dxdv(
             dev,


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in the C function `TwoPowerSphericalPotentialPlanarR2deriv` (`galpy/potential/potential_c_ext/TwoPowerSphericalPotential.c`), the planar `d^2Phi/dR^2` used by the C planar `integrate_dxdv` variational RHS (`calcPlanarR2deriv` -> `evalPlanarRectDeriv_dxdv`).

Two terms had the wrong power of `R`:

- `term2`: `R^(-alpha-1)` -> `R^(-alpha)`
- `term3`: `R^(-alpha)` -> `R^(1-alpha)`

This is the exact analogue of the SpiralArms `PlanarR2deriv` fix in #899, and was found during the 3D variational `Pvar`-potential work via the 2D-bridge (planar dxdv C-vs-Python) test.

## Impact

Only the **bare** `TwoPowerSphericalPotential` planar `integrate_dxdv` (dxdv / STM / Liouville) path is affected. The error is ~7% in the in-plane tidal tensor and conveniently vanishes at `R=1` (where the two wrong powers coincide), which is why it went unnoticed.

- The pure-Python `_R2deriv` is **correct** (matches a central finite-difference of `-Rforce` to ~1e-10) and is **unchanged**.
- The Dehnen / DehnenCore / Hernquist / NFW / Jaffe special-case subclasses have their **own** (correct) `PlanarR2deriv` and are **unaffected**.

## Before / after

Planar dxdv C (`dopr54_c`) vs pure-Python (`dop853`), bare `TwoPowerSphericalPotential(amp=1.,a=1.5,alpha=1.,beta=4.5,normalize=True)`, unit deviation `[1,0,0,0]`, IC `[1.0,0.1,1.1,0.3]`:

- Before fix: `max|C - Python| ~= 0.86`
- After fix:  `max|C - Python| ~= 8e-12` (and exactly `0` for `dop853` vs `dop853`)

## Test

Adds `test_twopower_planar_dxdv_c_vs_python` to `tests/test_orbit.py` (mirrors `test_spiralarms_planar_dxdv_c_vs_python` from #899): integrates a planar dxdv orbit with a unit deviation via `dopr54_c` and `dop853` and asserts the C path agrees with the pure-Python path to `< 1e-6`. Verified to FAIL on the unfixed code (~0.86) and PASS on the fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)