### PR TITLE
Pvar-pot: 3D C Hessian for LogarithmicHaloPotential (non-axisymmetric, incl. triaxial zphideriv)

### DIFF
--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -76,9 +76,12 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &LogarithmicHaloPotentialzforce;
       potentialArgs->phitorque= &LogarithmicHaloPotentialphitorque;
       potentialArgs->dens= &LogarithmicHaloPotentialDens;
-      //potentialArgs->R2deriv= &LogarithmicHaloPotentialR2deriv;
-      //potentialArgs->planarphi2deriv= &ZeroForce;
-      //potentialArgs->planarRphideriv= &ZeroForce;
+      potentialArgs->R2deriv= &LogarithmicHaloPotentialR2deriv;
+      potentialArgs->z2deriv= &LogarithmicHaloPotentialz2deriv;
+      potentialArgs->phi2deriv= &LogarithmicHaloPotentialphi2deriv;
+      potentialArgs->Rzderiv= &LogarithmicHaloPotentialRzderiv;
+      potentialArgs->Rphideriv= &LogarithmicHaloPotentialRphideriv;
+      potentialArgs->zphideriv= &LogarithmicHaloPotentialzphideriv;
       potentialArgs->nargs= 4;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/potential/LogarithmicHaloPotential.py
+++ b/galpy/potential/LogarithmicHaloPotential.py
@@ -60,6 +60,7 @@ class LogarithmicHaloPotential(Potential):
         core = conversion.parse_length(core, ro=self._ro)
         self.hasC = True
         self.hasC_dxdv = True
+        self.hasC_dxdv3d = True  # Full 3D Hessian (incl. zphideriv for triaxial) in C
         self.hasC_dens = True
         self._core2 = core**2.0
         self._q = q

--- a/galpy/potential/potential_c_ext/LogarithmicHaloPotential.c
+++ b/galpy/potential/potential_c_ext/LogarithmicHaloPotential.c
@@ -154,6 +154,133 @@ double LogarithmicHaloPotentialPlanarRphideriv(double R,double phi,
   } else
     return 0.;
 }
+double LogarithmicHaloPotentialR2deriv(double R,double Z, double phi,
+				       double t,
+				       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate R2deriv
+  double zq= Z/q;
+  double Rt2, denom;
+  if ( onem1overb2 < 1 ) {
+    Rt2= R*R * (1. - onem1overb2 * pow(sin(phi),2));
+    denom= 1. / ( Rt2 + zq*zq + c );
+    return amp * ( denom - 2. * Rt2 * denom * denom ) * Rt2 / ( R * R );
+  } else {
+    denom= 1. / ( R*R + zq*zq + c );
+    return amp * ( denom - 2. * R * R * denom * denom );
+  }
+}
+double LogarithmicHaloPotentialz2deriv(double R,double Z, double phi,
+				       double t,
+				       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate z2deriv
+  double zq= Z/q;
+  double q2= q*q;
+  double Rt2, denom;
+  if ( onem1overb2 < 1 )
+    Rt2= R*R * (1. - onem1overb2 * pow(sin(phi),2));
+  else
+    Rt2= R*R;
+  denom= 1. / ( Rt2 + zq*zq + c );
+  return amp * ( denom / q2 - 2. * Z * Z * denom * denom / ( q2 * q2 ) );
+}
+double LogarithmicHaloPotentialRzderiv(double R,double Z, double phi,
+				       double t,
+				       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate Rzderiv
+  double zq= Z/q;
+  double q2= q*q;
+  double Rt2, denom;
+  if ( onem1overb2 < 1 ) {
+    Rt2= R*R * (1. - onem1overb2 * pow(sin(phi),2));
+    denom= 1. / ( Rt2 + zq*zq + c );
+    return - amp * 2. * Rt2 / R * Z / q2 * denom * denom;
+  } else {
+    denom= 1. / ( R*R + zq*zq + c );
+    return - amp * 2. * R * Z / q2 * denom * denom;
+  }
+}
+double LogarithmicHaloPotentialphi2deriv(double R,double Z, double phi,
+					 double t,
+					 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate phi2deriv
+  double zq= Z/q;
+  double R2= R*R;
+  double Rt2, denom, s2phi;
+  if ( onem1overb2 < 1 ) {
+    Rt2= R2 * (1. - onem1overb2 * pow(sin(phi),2));
+    denom= 1. / ( Rt2 + zq*zq + c );
+    s2phi= sin( 2. * phi );
+    return - amp * onem1overb2 * ( 0.5 * R2 * R2 * s2phi * s2phi * onem1overb2 \
+				   * denom * denom \
+				   + R2 * denom * cos( 2. * phi ) );
+  } else
+    return 0.;
+}
+double LogarithmicHaloPotentialRphideriv(double R,double Z, double phi,
+					 double t,
+					 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate Rphideriv
+  double zq= Z/q;
+  double Rt2, denom;
+  if ( onem1overb2 < 1 ) {
+    Rt2= R*R * (1. - onem1overb2 * pow(sin(phi),2));
+    denom= 1. / ( Rt2 + zq*zq + c );
+    return - amp * ( denom - Rt2 * denom * denom ) * R * sin( 2. * phi ) \
+      * onem1overb2;
+  } else
+    return 0.;
+}
+double LogarithmicHaloPotentialzphideriv(double R,double Z, double phi,
+					 double t,
+					 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args;
+  double q= *(args+1);
+  double c= *(args+2);
+  double onem1overb2= *(args+3);
+  //Calculate zphideriv
+  double zq= Z/q;
+  double q2= q*q;
+  double Rt2, denom;
+  if ( onem1overb2 < 1 ) {
+    Rt2= R*R * (1. - onem1overb2 * pow(sin(phi),2));
+    denom= 1. / ( Rt2 + zq*zq + c );
+    return amp * 2. * R * R * Z * sin( phi ) * cos( phi ) * onem1overb2 \
+      * denom * denom / q2;
+  } else
+    return 0.;
+}
 double LogarithmicHaloPotentialDens(double R,double Z, double phi,
 				    double t,
 				    struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -203,6 +203,18 @@ double LogarithmicHaloPotentialPlanarRphideriv(double ,double, double,
 					       struct potentialArg *);
 double LogarithmicHaloPotentialDens(double ,double , double, double,
 				    struct potentialArg *);
+double LogarithmicHaloPotentialR2deriv(double ,double , double, double,
+				    struct potentialArg *);
+double LogarithmicHaloPotentialz2deriv(double ,double , double, double,
+				    struct potentialArg *);
+double LogarithmicHaloPotentialRzderiv(double ,double , double, double,
+				    struct potentialArg *);
+double LogarithmicHaloPotentialphi2deriv(double ,double , double, double,
+				    struct potentialArg *);
+double LogarithmicHaloPotentialRphideriv(double ,double , double, double,
+				    struct potentialArg *);
+double LogarithmicHaloPotentialzphideriv(double ,double , double, double,
+				    struct potentialArg *);
 //DehnenBarPotential
 double DehnenBarPotentialRforce(double,double,double,double,
 				struct potentialArg *);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,15 @@ def pytest_generate_tests(metafunc):
                 "SpiralArmsPotential",
                 "nonaxisymmetric",
             ),
+            # triaxial (b!=1) -> isNonAxi, exercises the full non-axi C Hessian
+            # incl. zphideriv (nonzero off-plane for z!=0, phi!=0)
+            (
+                potential.LogarithmicHaloPotential(
+                    amp=1.0, core=0.5, q=0.8, b=0.7, normalize=True
+                ),
+                "LogarithmicHaloPotential_triaxial",
+                "nonaxisymmetric",
+            ),
         ]
         ids = [entry[1] for entry in liouville3d_registry]
         if metafunc.function.__name__ == "test_dxdv_3d_c_vs_python":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,16 @@ def pytest_generate_tests(metafunc):
                 "LogarithmicHaloPotential_triaxial",
                 "nonaxisymmetric",
             ),
+            # axisymmetric (b=None) -> the C Hessian's faster onem1overb2>=1
+            # branch (no sin(phi) term), which the triaxial entry above never
+            # exercises; covers those else-branches of R2/z2/Rz/phi2/Rphi/zphi.
+            (
+                potential.LogarithmicHaloPotential(
+                    amp=1.0, core=0.5, q=0.8, normalize=True
+                ),
+                "LogarithmicHaloPotential_axi",
+                "axisymmetric",
+            ),
         ]
         ids = [entry[1] for entry in liouville3d_registry]
         if metafunc.function.__name__ == "test_dxdv_3d_c_vs_python":


### PR DESCRIPTION
## Summary

Adds the full 3D variational Hessian (six second derivatives) of `LogarithmicHaloPotential` in C, so `Orbit.integrate_dxdv` works in 6D for the log halo, including the **triaxial** (`b != 1`) non-axisymmetric case where `phi2deriv`/`Rphideriv`/`zphideriv` are nonzero.

This is the non-axisymmetric counterpart to the SpiralArms (#901) work.

## Changes

- **`LogarithmicHaloPotential.c`**: new `R2deriv`/`z2deriv`/`Rzderiv`/`phi2deriv`/`Rphideriv`/`zphideriv`, ported analytically from the Python `_R2deriv`/.../`_phizderiv`. The last three return 0 in the axisymmetric branch and the true off-plane expressions in the triaxial branch.
- **`integrateFullOrbit.c`** (case 0): wire all six Hessian pointers.
- **`galpy_potentials.h`**: declare the six new functions.
- **`LogarithmicHaloPotential.py`**: `hasC_dxdv3d = True`.
- **`tests/conftest.py`**: add triaxial `LogarithmicHaloPotential` to `liouville3d_registry` (category `nonaxisymmetric`). The registry's fixed IC has `z != 0` and `phi != 0`, so the `zphideriv` term is genuinely exercised (the test asserts `d2Phi/dz/dphi` is nonzero along the orbit).

## Scope note

The other six potentials in the original fan-out list (CosmphiDisk, LopsidedDisk, EllipticalDisk, HenonHeiles, SteadyLogSpiral, TransientLogSpiral) are `planarPotential` subclasses with no z dimension. They cannot participate in 6D `integrate_dxdv` and have no 3D Hessian to implement, so `LogarithmicHaloPotential` is the only genuine 3D non-axisymmetric target in the family.

## Tests

`pytest tests/test_orbit.py -q -k "dxdv or liouville"` → **59 passed**. For the triaxial LogHalo: `test_dxdv_3d_c_vs_python`, `test_liouville_3d`, and `test_liouville_3d_2d_bridge` all pass. C-vs-Python dxdv agree to ~1e-11 in both the axisymmetric and triaxial branches.

The numpy path is unchanged (purely additive C functions + one flag + registry entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)