### PR TITLE
Pvar-pot: 3D C Hessian for DehnenBarPotential

### DIFF
--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -90,6 +90,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &DehnenBarPotentialRforce;
       potentialArgs->phitorque= &DehnenBarPotentialphitorque;
       potentialArgs->zforce= &DehnenBarPotentialzforce;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv= &DehnenBarPotentialR2deriv;
+      potentialArgs->z2deriv= &DehnenBarPotentialz2deriv;
+      potentialArgs->phi2deriv= &DehnenBarPotentialphi2deriv;
+      potentialArgs->Rzderiv= &DehnenBarPotentialRzderiv;
+      potentialArgs->Rphideriv= &DehnenBarPotentialRphideriv;
+      potentialArgs->zphideriv= &DehnenBarPotentialzphideriv;
       potentialArgs->nargs= 6;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -119,6 +119,7 @@ class DehnenBarPotential(Potential):
         Af = conversion.parse_energy(Af, vo=self._vo)
         self.hasC = True
         self.hasC_dxdv = True
+        self.hasC_dxdv3d = True
         self.isNonAxi = True
         self._barphi = barphi
         if omegab is None:

--- a/galpy/potential/potential_c_ext/DehnenBarPotential.c
+++ b/galpy/potential/potential_c_ext/DehnenBarPotential.c
@@ -176,3 +176,139 @@ double DehnenBarPotentialPlanarRphideriv(double R,double phi,double t,
   else
     return -6.*amp*smooth*sin(2.*(phi-omegab*t-barphi))*pow(rb/R,3.)/R;
 }
+// Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+double DehnenBarPotentialR2deriv(double R,double z,double phi,double t,
+				 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, r4, r6, R2, z2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  z2= z * z;
+  r2= R2 + z2;
+  r4= r2 * r2;
+  r6= r4 * r2;
+  prefac= amp * smooth * cos(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return prefac * ( pow(r2,1.5)/(rb*rb*rb)
+		      * ( (9.*R2+2.*z2)/r4 - R2/r6*(3.*R2+2.*z2) )
+		      + 4.*z2/r6*(4.*R2-r2) );
+  else
+    return prefac * pow(rb,3.)*pow(r2,-1.5)/r6
+      * ( (r2-7.*R2)*(3.*R2-2.*z2) + 6.*R2*r2 );
+}
+double DehnenBarPotentialphi2deriv(double R,double z,double phi,double t,
+				   struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, R2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  r2= R2 + z * z;
+  prefac= 4. * amp * smooth * cos(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return -prefac * ( pow(r2,1.5)/(rb*rb*rb) - 2. ) * R2/r2;
+  else
+    return prefac * pow(rb,3.)*pow(r2,-1.5) * R2/r2;
+}
+double DehnenBarPotentialRphideriv(double R,double z,double phi,double t,
+				   struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, r4, R2, z2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  z2= z * z;
+  r2= R2 + z2;
+  r4= r2 * r2;
+  prefac= -2. * amp * smooth * sin(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return prefac * ( pow(r2,1.5)/(rb*rb*rb)*R*(3.*R2+2.*z2)
+		      - 4.*R*z2 ) / r4;
+  else
+    return prefac * pow(rb,3.)*pow(r2,-1.5) * R/r4 * (3.*R2-2.*z2);
+}
+double DehnenBarPotentialz2deriv(double R,double z,double phi,double t,
+				 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, r6, R2, z2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  z2= z * z;
+  r2= R2 + z2;
+  r6= r2 * r2 * r2;
+  prefac= amp * smooth * cos(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return prefac * R2/r6
+      * ( pow(r2,1.5)/(rb*rb*rb)*(r2-z2) + 4.*(r2-4.*z2) );
+  else
+    return prefac * 5. * pow(rb,3.)*pow(r2,-1.5) * R2/r6 * (r2-7.*z2);
+}
+double DehnenBarPotentialRzderiv(double R,double z,double phi,double t,
+				 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, r6, R2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  r2= R2 + z * z;
+  r6= r2 * r2 * r2;
+  prefac= amp * smooth * cos(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return prefac * R*z/r6
+      * ( pow(r2,1.5)/(rb*rb*rb)*(2.*r2-R2) + 8.*(r2-2.*R2) );
+  else
+    return prefac * 5. * pow(rb,3.)*pow(r2,-1.5) * R*z/r6 * (2.*r2-7.*R2);
+}
+double DehnenBarPotentialzphideriv(double R,double z,double phi,double t,
+				   struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double smooth, r2, r4, R2, prefac;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double rb= *args++;
+  double omegab= *args++;
+  double barphi= *args++;
+  smooth= dehnenBarSmooth(t,tform,tsteady);
+  R2= R * R;
+  r2= R2 + z * z;
+  r4= r2 * r2;
+  prefac= -2. * amp * smooth * sin(2.*(phi-omegab*t-barphi));
+  if ( r2 <= rb * rb )
+    return prefac * ( pow(r2,1.5)/(rb*rb*rb) + 4. ) * R2*z/r4;
+  else
+    return prefac * 5. * pow(rb,3.)*pow(r2,-1.5) * R2*z/r4;
+}

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -232,6 +232,18 @@ double DehnenBarPotentialPlanarphi2deriv(double,double,double,
 					 struct potentialArg *);
 double DehnenBarPotentialPlanarRphideriv(double,double,double,
 					 struct potentialArg *);
+double DehnenBarPotentialR2deriv(double,double,double,double,
+				 struct potentialArg *);
+double DehnenBarPotentialz2deriv(double,double,double,double,
+				 struct potentialArg *);
+double DehnenBarPotentialphi2deriv(double,double,double,double,
+				   struct potentialArg *);
+double DehnenBarPotentialRzderiv(double,double,double,double,
+				 struct potentialArg *);
+double DehnenBarPotentialRphideriv(double,double,double,double,
+				   struct potentialArg *);
+double DehnenBarPotentialzphideriv(double,double,double,double,
+				   struct potentialArg *);
 //TransientLogSpiralPotential
 double TransientLogSpiralPotentialRforce(double,double,double,
 		       struct potentialArg *);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,6 +213,17 @@ def pytest_generate_tests(metafunc):
                 "PowerTriaxialPotential",
                 "nonaxisymmetric",
             ),
+            # Time-dependent, non-axisymmetric 3D bar: tform=-4 (in bar periods)
+            # keeps the smoothing prefactor at 1 over the test interval, so the
+            # full cos/sin(2(phi-Omega_b t-barphi)) angular dependence (incl. a
+            # nonzero zphideriv off-plane) is exercised. alpha=0.05 (a standard
+            # bar strength) raises |d2Phi/dz/dphi| along the fixed IC above the
+            # 1e-3 guard so the C zphideriv coupling is genuinely tested.
+            (
+                potential.DehnenBarPotential(alpha=0.05),
+                "DehnenBarPotential",
+                "nonaxisymmetric",
+            ),
         ]
         ids = [entry[1] for entry in liouville3d_registry]
         if metafunc.function.__name__ == "test_dxdv_3d_c_vs_python":

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1048,6 +1048,50 @@ def test_kuzmindisk_dxdv_3d_c_vs_python_offplane():
     return None
 
 
+def test_dehnenbar_dxdv_inside_rb_c_vs_python():
+    # DehnenBarPotential's 3D C Hessian has a separate branch for r <= rb (the bar
+    # break radius); the liouville3d_registry DehnenBar entry uses the shared IC at
+    # R~1 (r > rb ~ 0.42), exercising only the r > rb branch. This test integrates a
+    # deviation along an orbit that spends a substantial fraction of its time INSIDE
+    # rb, exercising (and validating, against the pure-Python reference) the r <= rb
+    # branch of each second derivative -- otherwise both untested.
+    from galpy.orbit import Orbit
+    from galpy.potential import DehnenBarPotential
+
+    pot = DehnenBarPotential(alpha=0.05)
+    assert pot.hasC_dxdv3d, "DehnenBar should advertise hasC_dxdv3d"
+    ic = [0.2, 0.05, 0.1, 0.08, 0.03, 0.2]  # r ~ 0.22 < rb -> starts inside the bar
+    times = numpy.linspace(0.0, 2.0, 101)
+    obase = Orbit(ic)
+    obase.integrate(times, pot, method="dop853_c")
+    r = numpy.sqrt(obase.R(times) ** 2 + obase.z(times) ** 2)
+    assert numpy.mean(r < pot._rb) > 0.1, (
+        "test precondition: the orbit must spend time inside rb to exercise the "
+        "r <= rb branch of the C Hessian"
+    )
+    canonical = numpy.eye(6)
+    maxdiff = 0.0
+    for ii in [0, 2, 4]:  # e_x, e_z, e_vy unit deviations
+        oc = Orbit(ic)
+        oc.integrate_dxdv(
+            canonical[ii], times, pot, method="dopr54_c",
+            rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+        )  # fmt: skip
+        op = Orbit(ic)
+        op.integrate_dxdv(
+            canonical[ii], times, pot, method="dop853",
+            rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+        )  # fmt: skip
+        diff = numpy.amax(numpy.fabs(oc.getOrbit_dxdv() - op.getOrbit_dxdv()))
+        maxdiff = max(maxdiff, diff)
+    # the bar orbit is mildly chaotic, so C-vs-Python agree to ~1e-6; 1e-5 is safe
+    assert maxdiff < 1e-5, (
+        f"inside-rb 3D C variational integration for DehnenBar differs from the "
+        f"pure-Python reference by {maxdiff:g} (unit deviation)"
+    )
+    return None
+
+
 def test_spherical_dxdv_3d_c_vs_python_extra():
     # PseudoIsothermal, Einasto, and interpSpherical have verified-correct full 3D C
     # Hessians (hasC_dxdv3d=True) but are deliberately excluded from the strict

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -729,11 +729,23 @@ def _cart_accel_3d(pot, rect, t=0.0):
     return numpy.array([ax, ay, az])
 
 
-def _is_time_dependent_3d(pot):
-    """Detect an explicitly time-dependent potential by comparing the Cartesian
-    acceleration at the test IC at two different times. Returns True if the force
-    depends on t (e.g. a rotating bar), in which case dx/dt is not a solution of
-    the variational equation and the flow-direction identity check is skipped."""
+def _skip_flowdir_identity(pot):
+    """Whether to skip ONLY the flow-direction identity check (check (3) in
+    test_liouville_3d) for this potential. This does NOT gate Liouville
+    (det M = 1), symplecticity (M^T Omega M = Omega), or the FD-of-flow check --
+    those are run for every potential, time-dependent or not, exactly as in the
+    2D test_liouville_planar.
+
+    The flow-direction identity M.f(x0) = f(x(t)) relies on the phase-space
+    velocity f(x) being itself a solution of the variational equation, which only
+    holds for an AUTONOMOUS system. For an explicitly time-dependent potential
+    (e.g. a rotating bar) d/dt f(x(t),t) = J.f + df/dt picks up the extra df/dt
+    term, so dx/dt no longer solves the (df/dt-free) variational equation and the
+    identity fails -- a property of this particular check, not of the Hessian,
+    which remains pinned by checks (2) and (4) and by test_dxdv_3d_c_vs_python.
+
+    Detect time dependence by comparing the Cartesian acceleration at the test IC
+    at two different times; returns True if the force depends on t."""
     rect = numpy.array([0.9, 0.18, 0.05])  # generic off-plane, off-axis point
     a0 = _cart_accel_3d(pot, rect, t=0.0)
     a1 = _cart_accel_3d(pot, rect, t=1.3)
@@ -825,7 +837,7 @@ def test_liouville_3d(pot):
         o = Orbit(ic)
         o.integrate(times, pot, method=integrator)
         rect_orbit = _orbit_rect_3d(o, times)
-        if not _is_time_dependent_3d(pot):
+        if not _skip_flowdir_identity(pot):  # gates ONLY check (3) below
             f0 = numpy.empty(6)
             f0[:3] = rect_orbit[0, 3:]
             f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3], t=times[0])

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -702,8 +702,14 @@ def test_energy_symplec_longterm():
     return None
 
 
-def _cart_accel_3d(pot, rect):
-    """Cartesian acceleration (ax,ay,az) at rectangular position rect=(x,y,z)."""
+def _cart_accel_3d(pot, rect, t=0.0):
+    """Cartesian acceleration (ax,ay,az) at rectangular position rect=(x,y,z).
+
+    The time t is forwarded to the force evaluators so this is also correct for
+    explicitly time-dependent potentials (e.g. a rotating bar): the tangent
+    vector along the flow is dx/dt = f(x(t),t), which is an exact solution of the
+    (time-dependent) variational equation only when f is evaluated at the same t.
+    """
     from galpy.potential import (
         evaluatephitorques,
         evaluateRforces,
@@ -714,13 +720,24 @@ def _cart_accel_3d(pot, rect):
     R = numpy.sqrt(x**2.0 + y**2.0)
     phi = numpy.arctan2(y, x)
     cp, sp = numpy.cos(phi), numpy.sin(phi)
-    Rforce = evaluateRforces(pot, R, z, phi=phi)
-    phitorque = evaluatephitorques(pot, R, z, phi=phi)
-    zforce = evaluatezforces(pot, R, z, phi=phi)
+    Rforce = evaluateRforces(pot, R, z, phi=phi, t=t)
+    phitorque = evaluatephitorques(pot, R, z, phi=phi, t=t)
+    zforce = evaluatezforces(pot, R, z, phi=phi, t=t)
     ax = cp * Rforce - sp / R * phitorque
     ay = sp * Rforce + cp / R * phitorque
     az = zforce
     return numpy.array([ax, ay, az])
+
+
+def _is_time_dependent_3d(pot):
+    """Detect an explicitly time-dependent potential by comparing the Cartesian
+    acceleration at the test IC at two different times. Returns True if the force
+    depends on t (e.g. a rotating bar), in which case dx/dt is not a solution of
+    the variational equation and the flow-direction identity check is skipped."""
+    rect = numpy.array([0.9, 0.18, 0.05])  # generic off-plane, off-axis point
+    a0 = _cart_accel_3d(pot, rect, t=0.0)
+    a1 = _cart_accel_3d(pot, rect, t=1.3)
+    return numpy.amax(numpy.fabs(a1 - a0)) > 1e-12
 
 
 def _orbit_rect_3d(o, ts):
@@ -795,36 +812,44 @@ def test_liouville_3d(pot):
             f"3D symplecticity ||M^T Omega M - Omega||={symperr:g} too large "
             f"for {pname}, integrator {integrator}"
         )
-        # (3) Flow-direction (validates K, free): the phase-space velocity
-        # f(x0) is an exact solution of the variational equation, so the
-        # integrated deviation must equal f(x(t)) along the orbit.
+        # (3) Flow-direction (validates K, free): for an AUTONOMOUS (time-
+        # independent) system the phase-space velocity f(x) is an exact solution
+        # of the variational equation, so the integrated deviation seeded with
+        # f(x0) must equal f(x(t)) along the orbit. This identity does NOT hold
+        # for an explicitly time-dependent potential: there d/dt f(x(t),t) =
+        # J.f + df/dt picks up the extra df/dt term, so dx/dt no longer solves
+        # the (df/dt-free) variational equation. Skip this single check for
+        # time-dependent potentials -- their Hessian is still pinned by the
+        # symplecticity check (2) above, the FD-of-flow check (4) below, and the
+        # C-vs-Python check in test_dxdv_3d_c_vs_python.
         o = Orbit(ic)
         o.integrate(times, pot, method=integrator)
         rect_orbit = _orbit_rect_3d(o, times)
-        f0 = numpy.empty(6)
-        f0[:3] = rect_orbit[0, 3:]
-        f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3])
-        o2 = Orbit(ic)
-        o2.integrate_dxdv(
-            f0,
-            times,
-            pot,
-            method=integrator,
-            rectIn=True,
-            rectOut=True,
-            rtol=rtol,
-            atol=atol,
-        )
-        dev = o2.getOrbit_dxdv()  # (nt,6) rectangular deviation
-        ftrue = numpy.empty((len(times), 6))
-        ftrue[:, :3] = rect_orbit[:, 3:]
-        for jj in range(len(times)):
-            ftrue[jj, 3:] = _cart_accel_3d(pot, rect_orbit[jj, :3])
-        flowerr = numpy.amax(numpy.fabs(dev - ftrue))
-        assert flowerr < 1e-6, (
-            f"3D flow-direction deviation differs from f(x(t)) by {flowerr:g} "
-            f"for {pname}, integrator {integrator}"
-        )
+        if not _is_time_dependent_3d(pot):
+            f0 = numpy.empty(6)
+            f0[:3] = rect_orbit[0, 3:]
+            f0[3:] = _cart_accel_3d(pot, rect_orbit[0, :3], t=times[0])
+            o2 = Orbit(ic)
+            o2.integrate_dxdv(
+                f0,
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=rtol,
+                atol=atol,
+            )
+            dev = o2.getOrbit_dxdv()  # (nt,6) rectangular deviation
+            ftrue = numpy.empty((len(times), 6))
+            ftrue[:, :3] = rect_orbit[:, 3:]
+            for jj in range(len(times)):
+                ftrue[jj, 3:] = _cart_accel_3d(pot, rect_orbit[jj, :3], t=times[jj])
+            flowerr = numpy.amax(numpy.fabs(dev - ftrue))
+            assert flowerr < 1e-6, (
+                f"3D flow-direction deviation differs from f(x(t)) by {flowerr:g} "
+                f"for {pname}, integrator {integrator}"
+            )
         # (4) Finite-difference of the flow (validates K): integrate a base
         # orbit and orbits perturbed by eps*e_i and compare the dxdv column
         # to the FD of the integrated flow. Do a couple of i.


### PR DESCRIPTION
## Summary

Adds the full 3D variational Hessian (six 2nd derivatives) to **DehnenBarPotential** in C, so `Orbit.integrate_dxdv` runs the fast C 3D variational path for this time-dependent, non-axisymmetric bar.

- Six C functions (`R2deriv`, `z2deriv`, `phi2deriv`, `Rzderiv`, `Rphideriv`, `zphideriv`) added to `DehnenBarPotential.c`, translated from the existing analytic Python `_R2deriv/.../_phizderiv`. Time dependence enters only through the scalar smoothing prefactor and the `cos/sin(2(phi-Omega_b t-barphi))` factor; `zphideriv` is nonzero off-plane and uses its true expression. Powers/divisions factored (`r2/r4/r6`, single prefactor).
- Declared in `galpy_potentials.h`; all six struct pointers wired in `integrateFullOrbit.c` case 1 (purely additive, behind `hasC_dxdv3d`).
- `hasC_dxdv3d=True` in `DehnenBarPotential.__init__`.
- Registered `DehnenBarPotential(alpha=0.05)` in `liouville3d_registry` (category `nonaxisymmetric`); the strength keeps `|d2Phi/dz/dphi|` above the non-axi guard along the fixed test IC.

## Test-framework change (time-dependent potentials)

`test_liouville_3d` check (3), the flow-direction identity, assumes an **autonomous** system: it seeds the deviation with the phase velocity `f(x0)` and asserts it stays equal to `f(x(t))`. For an explicitly time-dependent potential `d/dt f(x(t),t) = J.f + df/dt`, so `dx/dt` is not a solution of the (`df/dt`-free) variational equation and this identity legitimately fails. Check (3) is now skipped for time-dependent potentials (new `_is_time_dependent_3d` helper); their Hessian remains pinned by the symplecticity check (2), the FD-of-flow check (4), and `test_dxdv_3d_c_vs_python`. `_cart_accel_3d` now forwards `t` (no behavior change for the existing time-independent registry).

## Verification

`pytest tests/test_orbit.py -q -k "dxdv or liouville"` -> **59 passed, 0 failed**. DehnenBar passes `test_dxdv_3d_c_vs_python` (C vs Python FD, unit deviation), `test_liouville_3d` (det(M)=1, symplecticity, FD-of-flow), and `test_liouville_3d_2d_bridge`. Python analytic 2nd derivatives independently verified against finite differences of the forces.

## Excluded: SoftenedNeedleBarPotential

Genuinely 3D (in `integrateFullOrbit.c`), but it has **no analytic Python 2nd derivatives** (`hasC_dxdv=False`) and no C deriv functions — there is nothing to port. A full analytic derivation (Python + C, incl. a Cartesian->cylindrical Hessian rotation, since its forces are computed in the rotated Cartesian frame) would be net-new work beyond this port, so it is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)