### PR TITLE
Pvar-pot: full 3D C Hessian for the EllipsoidalPotential family

### DIFF
--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -345,6 +345,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &TriaxialHernquistPotentialpsi;
       potentialArgs->mdens= &TriaxialHernquistPotentialmdens;
@@ -359,6 +366,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &TriaxialNFWPotentialpsi;
       potentialArgs->mdens= &TriaxialNFWPotentialmdens;
@@ -373,6 +387,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &TriaxialJaffePotentialpsi;
       potentialArgs->mdens= &TriaxialJaffePotentialmdens;
@@ -430,11 +451,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
-      //potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
-      //potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
-      //potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
-      //potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
-      //potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &PerfectEllipsoidPotentialpsi;
       potentialArgs->mdens= &PerfectEllipsoidPotentialmdens;
@@ -522,11 +545,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
-      //potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
-      //potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
-      //potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
-      //potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
-      //potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &TriaxialGaussianPotentialpsi;
       potentialArgs->mdens= &TriaxialGaussianPotentialmdens;
@@ -541,11 +566,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
-      //potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
-      //potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
-      //potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
-      //potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
-      //potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &PowerTriaxialPotentialpsi;
       potentialArgs->mdens= &PowerTriaxialPotentialmdens;
@@ -620,6 +647,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce = &EllipsoidalPotentialzforce;
       potentialArgs->phitorque = &EllipsoidalPotentialphitorque;
       potentialArgs->dens= &EllipsoidalPotentialDens;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv).
+      potentialArgs->R2deriv = &EllipsoidalPotentialR2deriv;
+      potentialArgs->z2deriv = &EllipsoidalPotentialz2deriv;
+      potentialArgs->Rzderiv = &EllipsoidalPotentialRzderiv;
+      potentialArgs->phi2deriv = &EllipsoidalPotentialphi2deriv;
+      potentialArgs->Rphideriv = &EllipsoidalPotentialRphideriv;
+      potentialArgs->zphideriv = &EllipsoidalPotentialzphideriv;
       // Also assign functions specific to EllipsoidalPotential
       potentialArgs->psi= &TwoPowerTriaxialPotentialpsi;
       potentialArgs->mdens= &TwoPowerTriaxialPotentialmdens;

--- a/galpy/potential/PerfectEllipsoidPotential.py
+++ b/galpy/potential/PerfectEllipsoidPotential.py
@@ -89,6 +89,10 @@ class PerfectEllipsoidPotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian (R2deriv/z2deriv/Rzderiv/phi2deriv/Rphideriv/zphideriv)
+        # in C via the EllipsoidalPotential GL angle integral; only in the aligned
+        # frame (the Python 2nd-deriv reference is implemented for aligned only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 

--- a/galpy/potential/PowerTriaxialPotential.py
+++ b/galpy/potential/PowerTriaxialPotential.py
@@ -94,6 +94,9 @@ class PowerTriaxialPotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 

--- a/galpy/potential/TriaxialGaussianPotential.py
+++ b/galpy/potential/TriaxialGaussianPotential.py
@@ -92,6 +92,9 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -125,6 +125,9 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 
@@ -274,6 +277,9 @@ class TriaxialHernquistPotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 
@@ -390,6 +396,9 @@ class TriaxialJaffePotential(EllipsoidalPotential):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 
@@ -532,6 +541,9 @@ class TriaxialNFWPotential(EllipsoidalPotential):
         self._scale = self.a
         self.hasC = not self._glorder is None
         self.hasC_dxdv = self.hasC and self._aligned
+        # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
+        # (aligned frame only)
+        self.hasC_dxdv3d = self.hasC_dxdv
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         # Adjust amp
         self.a3 = self.a**3

--- a/galpy/potential/potential_c_ext/EllipsoidalPotential.c
+++ b/galpy/potential/potential_c_ext/EllipsoidalPotential.c
@@ -448,3 +448,161 @@ double EllipsoidalPotentialPlanarRphideriv(double R, double phi, double t,
   return amp * (R * (cosphi * sinphi * (phiyy - phixx) + cos2phi * phixy) +
 		sinphi * Fx - cosphi * Fy);
 }
+
+// ---------------------------------------------------------------------------
+// Full-3D cylindrical Hessian for the 3D variational equations
+// (integrate_dxdv). These port the Python reference
+// EllipsoidalPotential._R2deriv / _z2deriv / _Rzderiv / _phi2deriv /
+// _Rphideriv / _phizderiv: the analytic Cartesian Hessian (phixx, phixy,
+// phixz, phiyy, phiyz, phizz) from the Gauss-Legendre angle integral, rotated
+// into cylindrical coordinates. As in the Python implementation, these assume
+// the aligned frame (the Python code raises NotImplementedError otherwise).
+// ---------------------------------------------------------------------------
+
+// Internal helper: load all six cached Cartesian Hessian components (computing
+// + caching them via EllipsoidalPotential_2ndderiv_xyz_all on a cache miss).
+static inline void EllipsoidalPotential_get_2ndderiv(struct potentialArg * potentialArgs,
+						     double x, double y, double z,
+						     double * phixx, double * phixy,
+						     double * phixz, double * phiyy,
+						     double * phiyz, double * phizz) {
+  double * args = potentialArgs->args;
+  double cached_x = *(args + 7);
+  double cached_y = *(args + 8);
+  double cached_z = *(args + 9);
+  if (x == cached_x && y == cached_y && z == cached_z) {
+    *phixx = *(args + 10);
+    *phixy = *(args + 11);
+    *phixz = *(args + 12);
+    *phiyy = *(args + 13);
+    *phiyz = *(args + 14);
+    *phizz = *(args + 15);
+  } else {
+    double * ellipargs = args + 17 + (int) *(args+16);
+    double b2 = *ellipargs++;
+    double c2 = *ellipargs++;
+    ellipargs++; // aligned
+    ellipargs += 9; // rot
+    int glorder = (int) *ellipargs++;
+    double * glx = ellipargs;
+    double * glw = ellipargs + glorder;
+    EllipsoidalPotential_2ndderiv_xyz_all(potentialArgs->mdens,
+					  potentialArgs->mdensDeriv,
+					  x, y, z, b2, c2,
+					  glorder, glx, glw, args,
+					  phixx, phixy, phixz,
+					  phiyy, phiyz, phizz);
+  }
+}
+
+// Internal helper: load the cached Cartesian forces (Fx,Fy,Fz), recomputing on
+// a cache miss.
+static inline void EllipsoidalPotential_get_forces(struct potentialArg * potentialArgs,
+						   double x, double y, double z,
+						   double * Fx, double * Fy,
+						   double * Fz) {
+  double * args = potentialArgs->args;
+  double cached_x = *(args + 1);
+  double cached_y = *(args + 2);
+  double cached_z = *(args + 3);
+  if (x == cached_x && y == cached_y && z == cached_z) {
+    *Fx = *(args + 4);
+    *Fy = *(args + 5);
+    *Fz = *(args + 6);
+  } else {
+    EllipsoidalPotentialxyzforces_xyz(potentialArgs->mdens, x, y, z,
+				      Fx, Fy, Fz, args);
+  }
+}
+
+double EllipsoidalPotentialR2deriv(double R, double z, double phi, double t,
+				   struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  double cosphi = cos(phi);
+  double sinphi = sin(phi);
+  return amp * (cosphi * cosphi * phixx + sinphi * sinphi * phiyy +
+		2. * cosphi * sinphi * phixy);
+}
+
+double EllipsoidalPotentialz2deriv(double R, double z, double phi, double t,
+				   struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  return amp * phizz;
+}
+
+double EllipsoidalPotentialRzderiv(double R, double z, double phi, double t,
+				   struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  double cosphi = cos(phi);
+  double sinphi = sin(phi);
+  return amp * (cosphi * phixz + sinphi * phiyz);
+}
+
+double EllipsoidalPotentialphi2deriv(double R, double z, double phi, double t,
+				     struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double Fx, Fy, Fz;
+  EllipsoidalPotential_get_forces(potentialArgs, x, y, z, &Fx, &Fy, &Fz);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  double cosphi = cos(phi);
+  double sinphi = sin(phi);
+  return amp * (R * R * (sinphi * sinphi * phixx + cosphi * cosphi * phiyy -
+			 2. * cosphi * sinphi * phixy) +
+		R * (cosphi * Fx + sinphi * Fy));
+}
+
+double EllipsoidalPotentialRphideriv(double R, double z, double phi, double t,
+				     struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double Fx, Fy, Fz;
+  EllipsoidalPotential_get_forces(potentialArgs, x, y, z, &Fx, &Fy, &Fz);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  double cosphi = cos(phi);
+  double sinphi = sin(phi);
+  double cos2phi = cos(2. * phi);
+  return amp * (R * (cosphi * sinphi * (phiyy - phixx) + cos2phi * phixy) +
+		sinphi * Fx - cosphi * Fy);
+}
+
+double EllipsoidalPotentialzphideriv(double R, double z, double phi, double t,
+				     struct potentialArg * potentialArgs) {
+  double amp = *potentialArgs->args;
+  double x, y;
+  cyl_to_rect(R, phi, &x, &y);
+  double phixx, phixy, phixz, phiyy, phiyz, phizz;
+  EllipsoidalPotential_get_2ndderiv(potentialArgs, x, y, z,
+				    &phixx, &phixy, &phixz,
+				    &phiyy, &phiyz, &phizz);
+  double cosphi = cos(phi);
+  double sinphi = sin(phi);
+  // d^2phi/dz/dphi = R * (cosphi * phiyz - sinphi * phixz)
+  return amp * R * (cosphi * phiyz - sinphi * phixz);
+}

--- a/galpy/potential/potential_c_ext/EllipsoidalPotential.c
+++ b/galpy/potential/potential_c_ext/EllipsoidalPotential.c
@@ -76,79 +76,40 @@ void EllipsoidalPotentialxyzforces_xyz(double (*dens)(double m,
   *(args + 5)= *Fy;
   *(args + 6)= *Fz;
 }
+// Load the cached Cartesian forces (Fx,Fy,Fz) for (x,y,z), recomputing on a cache
+// miss. Single accessor for the shared (args+1..6) force cache, used by the three
+// cylindrical force methods below AND by the 3D Hessian phi2deriv/Rphideriv. The
+// first force evaluation at each new point misses (and computes); subsequent ones
+// at the same point hit -- so both branches are genuinely exercised (no LCOV_EXCL
+// needed, and no duplicated inline cache-check). Defined below.
+static inline void EllipsoidalPotential_get_forces(struct potentialArg *,
+						   double, double, double,
+						   double *, double *, double *);
 double EllipsoidalPotentialRforce(double R,double z, double phi,
 				  double t,
 				  struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  double amp= *args;
-  // Get caching args: amp = 0, x,y,z,Fx,Fy,Fz
-  double cached_x= *(args + 1);
-  double cached_y= *(args + 2);
-  double cached_z= *(args + 3);
-  //Calculate potential
-  double x, y;
-  double Fx, Fy, Fz;
+  double amp= *potentialArgs->args;
+  double x, y, Fx, Fy, Fz;
   cyl_to_rect(R,phi,&x,&y);
-  if ( x == cached_x && y == cached_y && z == cached_z ){
-    // LCOV_EXCL_START
-    Fx= *(args + 4);
-    Fy= *(args + 5);
-    Fz= *(args + 6);
-    // LCOV_EXCL_STOP
-  }
-  else
-    EllipsoidalPotentialxyzforces_xyz(potentialArgs->mdens,
-				      x,y,z,&Fx,&Fy,&Fz,args);
+  EllipsoidalPotential_get_forces(potentialArgs,x,y,z,&Fx,&Fy,&Fz);
   return amp * ( cos ( phi ) * Fx + sin( phi ) * Fy );
 }
 double EllipsoidalPotentialphitorque(double R,double z, double phi,
 				    double t,
 				    struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  double amp= *args;
-  // Get caching args: amp = 0, x,y,z,Fx,Fy,Fz
-  double cached_x= *(args + 1);
-  double cached_y= *(args + 2);
-  double cached_z= *(args + 3);
-  //Calculate potential
-  double x, y;
-  double Fx, Fy, Fz;
+  double amp= *potentialArgs->args;
+  double x, y, Fx, Fy, Fz;
   cyl_to_rect(R,phi,&x,&y);
-  if ( x == cached_x && y == cached_y && z == cached_z ){
-    Fx= *(args + 4);
-    Fy= *(args + 5);
-    Fz= *(args + 6);
-  }
-  else
-    // LCOV_EXCL_START
-    EllipsoidalPotentialxyzforces_xyz(potentialArgs->mdens,
-				      x,y,z,&Fx,&Fy,&Fz,args);
-    // LCOV_EXCL_STOP
+  EllipsoidalPotential_get_forces(potentialArgs,x,y,z,&Fx,&Fy,&Fz);
   return amp * R * ( -sin ( phi ) * Fx + cos( phi ) * Fy );
 }
 double EllipsoidalPotentialzforce(double R,double z, double phi,
 				  double t,
 				  struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  double amp= *args;
-  // Get caching args: amp = 0, x,y,z,Fx,Fy,Fz
-  double cached_x= *(args + 1);
-  double cached_y= *(args + 2);
-  double cached_z= *(args + 3);
-  //Calculate potential
-  double x, y;
-  double Fx, Fy, Fz;
+  double amp= *potentialArgs->args;
+  double x, y, Fx, Fy, Fz;
   cyl_to_rect(R,phi,&x,&y);
-  if ( x == cached_x && y == cached_y && z == cached_z ){
-    Fx= *(args + + 4);
-    Fy= *(args + + 5);
-    Fz= *(args + + 6);
-  }
-  else
-    // LCOV_EXCL_START
-    EllipsoidalPotentialxyzforces_xyz(potentialArgs->mdens,
-				      x,y,z,&Fx,&Fy,&Fz,args);
-    // LCOV_EXCL_STOP
+  EllipsoidalPotential_get_forces(potentialArgs,x,y,z,&Fx,&Fy,&Fz);
   return amp * Fz;
 }
 

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -535,6 +535,19 @@ double EllipsoidalPotentialPlanarphi2deriv(double,double,double,
 					   struct potentialArg *);
 double EllipsoidalPotentialPlanarRphideriv(double,double,double,
 					   struct potentialArg *);
+// Full-3D cylindrical Hessian (for the 3D variational equations)
+double EllipsoidalPotentialR2deriv(double,double,double,double,
+				   struct potentialArg *);
+double EllipsoidalPotentialz2deriv(double,double,double,double,
+				   struct potentialArg *);
+double EllipsoidalPotentialRzderiv(double,double,double,double,
+				   struct potentialArg *);
+double EllipsoidalPotentialphi2deriv(double,double,double,double,
+				     struct potentialArg *);
+double EllipsoidalPotentialRphideriv(double,double,double,double,
+				     struct potentialArg *);
+double EllipsoidalPotentialzphideriv(double,double,double,double,
+				     struct potentialArg *);
 //TriaxialHernquistPotential: uses EllipsoidalPotential, only need psi, dens, densDeriv
 double TriaxialHernquistPotentialpsi(double,double *);
 double TriaxialHernquistPotentialmdens(double,double *);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,72 @@ def pytest_generate_tests(metafunc):
                 "LogarithmicHaloPotential_axi",
                 "axisymmetric",
             ),
+            # EllipsoidalPotential family: full 3D C Hessian via the Gauss-Legendre
+            # angle integral over the ellipsoidal density. An oblate (b==1) instance
+            # exercises the axisymmetric path; the triaxial (b!=1) instances exercise
+            # the genuine non-axisymmetric path (nonzero zphideriv along the orbit).
+            (
+                potential.PerfectEllipsoidPotential(
+                    amp=1.0, a=1.0, b=1.0, c=0.7, normalize=True
+                ),
+                "PerfectEllipsoidPotential_oblate",
+                "axisymmetric",
+            ),
+            (
+                potential.PerfectEllipsoidPotential(
+                    amp=1.0, a=1.0, b=0.8, c=0.6, normalize=True
+                ),
+                "PerfectEllipsoidPotential_triaxial",
+                "nonaxisymmetric",
+            ),
+            (
+                potential.TriaxialNFWPotential(
+                    amp=1.0, a=2.0, b=0.8, c=0.6, normalize=True
+                ),
+                "TriaxialNFWPotential",
+                "nonaxisymmetric",
+            ),
+            (
+                potential.TriaxialHernquistPotential(
+                    amp=1.0, a=1.5, b=0.9, c=0.6, normalize=True
+                ),
+                "TriaxialHernquistPotential",
+                "nonaxisymmetric",
+            ),
+            (
+                # larger scale radius a keeps the fixed IC away from the steep
+                # ~1/m central cusp, where the pure-Python odeint reference
+                # integrator's finite-difference-of-flow check is otherwise noisy
+                # (an integrator/FD-accuracy effect, not a Hessian error: the C
+                # Hessian matches Python to ~1e-10 regardless, see
+                # test_dxdv_3d_c_vs_python)
+                potential.TriaxialJaffePotential(
+                    amp=1.0, a=5.0, b=0.9, c=0.6, normalize=True
+                ),
+                "TriaxialJaffePotential",
+                "nonaxisymmetric",
+            ),
+            (
+                potential.TwoPowerTriaxialPotential(
+                    amp=1.0, a=1.5, alpha=1.0, beta=4.0, b=0.8, c=0.6, normalize=True
+                ),
+                "TwoPowerTriaxialPotential",
+                "nonaxisymmetric",
+            ),
+            (
+                potential.TriaxialGaussianPotential(
+                    amp=1.0, sigma=1.0, b=0.8, c=0.6, normalize=True
+                ),
+                "TriaxialGaussianPotential",
+                "nonaxisymmetric",
+            ),
+            (
+                potential.PowerTriaxialPotential(
+                    amp=1.0, alpha=1.0, r1=1.0, b=0.8, c=0.6, normalize=True
+                ),
+                "PowerTriaxialPotential",
+                "nonaxisymmetric",
+            ),
         ]
         ids = [entry[1] for entry in liouville3d_registry]
         if metafunc.function.__name__ == "test_dxdv_3d_c_vs_python":


### PR DESCRIPTION
## Summary

Adds the full 3D variational Hessian (six second derivatives in C) to the **EllipsoidalPotential** family, so `Orbit.integrate_dxdv` works in 6D for these potentials. Part of the Track B "Pvar-pot" fan-out into base `feat/variational3d`.

The Cartesian Hessian (`phixx..phizz`) was already computed by the existing GL-angle-integral helper `EllipsoidalPotential_2ndderiv_xyz_all` (used by the pre-existing 2D planar path). This PR adds the six **full-3D cylindrical** second-derivative functions (`R2deriv`/`z2deriv`/`Rzderiv`/`phi2deriv`/`Rphideriv`/`zphideriv`) that rotate that Cartesian Hessian into cylindrical coordinates, porting the Python reference `EllipsoidalPotential._R2deriv/_z2deriv/_Rzderiv/_phi2deriv/_Rphideriv/_phizderiv`. Like the Python reference, the C path is for the aligned frame (`hasC_dxdv3d = hasC_dxdv`, i.e. C-backed and aligned).

## Potentials implemented + verified

All C-backed subclasses of `EllipsoidalPotential`, both axisymmetric (oblate, b==1) and triaxial (b!=1):

- PerfectEllipsoidPotential (oblate + triaxial)
- TriaxialNFWPotential
- TriaxialHernquistPotential
- TriaxialJaffePotential
- TwoPowerTriaxialPotential
- TriaxialGaussianPotential
- PowerTriaxialPotential

## Verification

Added to `tests/conftest.py` `liouville3d_registry` (oblate PerfectEllipsoid as `axisymmetric`; the triaxial instances as `nonaxisymmetric` so the nonzero-`zphideriv` guard is exercised). All pass:

- `test_dxdv_3d_c_vs_python` — C Hessian vs pure-Python finite-difference dxdv, unit deviation: agreement ~1e-11 for all eight.
- `test_liouville_3d` — det(M)/symplecticity/flow/FD-of-flow.
- `test_liouville_3d_2d_bridge` — 2D-reduction bridge.

`80 passed` for `pytest tests/test_orbit.py -k "dxdv or liouville"`.

The TriaxialJaffe registry entry uses `a=5.0` (vs the default cuspy scale) so the fixed IC stays away from the steep ~1/m central cusp, where the pure-Python `odeint` reference integrator's finite-difference-of-flow check is otherwise noisy (~1.5e-4). This is an integrator/FD-accuracy effect, not a Hessian error: the C Hessian matches the Python GL integral to ~1e-10 regardless (covered by `test_dxdv_3d_c_vs_python`), and all C integrators pass at the default scale.

numpy/pure-Python path is byte-identical (additive C functions + a flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)