### PR TITLE
Audit/fix spherical xp.where dead-branch regimes (R=0/seams)

### DIFF
--- a/galpy/potential/BurkertPotential.py
+++ b/galpy/potential/BurkertPotential.py
@@ -128,8 +128,15 @@ class BurkertPotential(SphericalPotential):
         d2 = R**2.0 - self.a**2.0
         safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
         Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
-        # Edge (R == a) branch
-        za = z / self.a
+        # Edge (R == a) branch. It carries a 1/z that is singular at z == 0;
+        # under the eager xp.where it is evaluated everywhere, so in its DEAD
+        # region (generic, R != a) it must use a finite z or it NaN-poisons
+        # reverse-mode gradients at z == 0 (a valid, finite input where surfdens
+        # == 0). Use the real z on the edge (live) and 1 in the generic region
+        # (dead). At the genuine edge point R == a, z == 0 the limb singularity
+        # is real (kept).
+        z_edge = xp.where(at_edge, z, xp.ones_like(z * 1.0))
+        za = z_edge / self.a
         edge = (
             self.a**2.0
             / 2.0
@@ -139,10 +146,10 @@ class BurkertPotential(SphericalPotential):
                     - 2.0 * xp.sqrt(za**2.0 + 1)
                     + 2.0**0.5 * za * xp.arctan(za / 2.0**0.5)
                 )
-                / z
+                / z_edge
                 + xp.sqrt(2 * za**2.0 + 2.0)
                 * xp.arctanh(za / xp.sqrt(2.0 * (za**2.0 + 1)))
-                / xp.sqrt(self.a**2.0 + z**2.0)
+                / xp.sqrt(self.a**2.0 + z_edge**2.0)
             )
         )
         # Generic (R != a) branch; .real of the complex combination

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -617,16 +617,23 @@ class HernquistPotential(DehnenSphericalPotential):
         # also guard (r^2 - a^2), which vanishes at the edge when z == 0
         d2r = r**2.0 - self.a**2.0
         safe_d2r = xp.where(at_edge, xp.ones_like(d2r * 1.0), d2r)
+        # The edge branch carries a z**-5 that is singular at z == 0; under the
+        # eager xp.where it is evaluated everywhere, so in its DEAD region
+        # (generic, R != a) it must use a finite z or it NaN-poisons reverse-mode
+        # gradients at z == 0 (a valid, finite input where surfdens == 0). Use the
+        # real z on the edge (live) and 1 in the generic region (dead). At the
+        # genuine edge point R == a, z == 0 the limb singularity is real (kept).
+        z_edge = xp.where(at_edge, z, xp.ones_like(z * 1.0))
         edge = (
             (
                 -12.0 * self.a**3
-                - 5.0 * self.a * z**2
-                + xp.sqrt(1.0 + z**2 / self.a**2)
-                * (12.0 * self.a**3 - self.a * z**2 + 2 / self.a * z**4)
+                - 5.0 * self.a * z_edge**2
+                + xp.sqrt(1.0 + z_edge**2 / self.a**2)
+                * (12.0 * self.a**3 - self.a * z_edge**2 + 2 / self.a * z_edge**4)
             )
             / 30.0
             / math.pi
-            * z**-5.0
+            * z_edge**-5.0
         )
         generic = (
             self.a
@@ -772,17 +779,24 @@ class JaffePotential(DehnenSphericalPotential):
         d2 = R**2.0 - self.a**2.0
         safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
         Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
+        # The edge branch carries a z**-3 that is singular at z == 0; under the
+        # eager xp.where it is evaluated everywhere, so in its DEAD region
+        # (generic, R != a) it must use a finite z or it NaN-poisons reverse-mode
+        # gradients at z == 0 (a valid, finite input where surfdens == 0). Use the
+        # real z on the edge (live) and 1 in the generic region (dead). At the
+        # genuine edge point R == a, z == 0 the limb singularity is real (kept).
+        z_edge = xp.where(at_edge, z, xp.ones_like(z * 1.0))
         edge = (
             (
-                3.0 * z**2.0
+                3.0 * z_edge**2.0
                 - 2.0 * self.a**2.0
                 + 2.0
-                * xp.sqrt(1.0 + (z / self.a) ** 2.0)
-                * (self.a**2.0 - 2.0 * z**2.0)
-                + 3.0 * z**3.0 / self.a * xp.arctan(z / self.a)
+                * xp.sqrt(1.0 + (z_edge / self.a) ** 2.0)
+                * (self.a**2.0 - 2.0 * z_edge**2.0)
+                + 3.0 * z_edge**3.0 / self.a * xp.arctan(z_edge / self.a)
             )
             / self.a
-            / z**3.0
+            / z_edge**3.0
             / 6.0
             / math.pi
         )
@@ -998,8 +1012,21 @@ class NFWPotential(TwoPowerSphericalPotential):
         d2 = R**2.0 - self.a**2.0
         safe_d2 = xp.where(at_edge, xp.ones_like(d2 * 1.0), d2)
         Rma = xp.sqrt(xp.astype(safe_d2, xp.complex128))
-        za2 = (z / self.a) ** 2
-        edge = self.a * (2.0 + xp.sqrt(za2 + 1.0) * (za2 - 2.0)) / 6.0 / math.pi / z**3
+        # The edge branch carries a z**-3 that is singular at z == 0; under the
+        # eager xp.where it is evaluated everywhere, so in its DEAD region
+        # (generic, R != a) it must use a finite z or it NaN-poisons reverse-mode
+        # gradients at z == 0 (a valid, finite input where surfdens == 0). Use the
+        # real z on the edge (live) and 1 in the generic region (dead). At the
+        # genuine edge point R == a, z == 0 the limb singularity is real (kept).
+        z_edge = xp.where(at_edge, z, xp.ones_like(z * 1.0))
+        za2 = (z_edge / self.a) ** 2
+        edge = (
+            self.a
+            * (2.0 + xp.sqrt(za2 + 1.0) * (za2 - 2.0))
+            / 6.0
+            / math.pi
+            / z_edge**3
+        )
         generic = (
             xp.real(
                 self.a

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -458,3 +458,49 @@ def test_powerspherical_wcutoff_dens_parity(backend_name):
         ref = numpy.asarray(getattr(pot, method)(numpy.asarray(Rs)))
         got = _tonumpy(getattr(pot, method)(_asarray(backend_name, Rs)))
         numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14, err_msg=method)
+
+
+def _surfdens_grad_z(backend_name, pot, R0, z0):
+    """d(surfdens)/dz via autodiff at fixed R."""
+    if backend_name == "jax":
+        return float(
+            jax.grad(lambda z: pot._surfdens(jnp.asarray(R0), z))(jnp.asarray(z0))
+        )
+    z = torch.tensor(z0, dtype=torch.float64, requires_grad=True)
+    pot._surfdens(torch.tensor(R0, dtype=torch.float64), z).backward()
+    return float(z.grad)
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_surfdens_z0_value_parity(backend_name, pot):
+    # The R == a edge branch of _surfdens carries a 1/z**n (n in {3, 5}) that is
+    # singular at z == 0. Under the eager xp.where BOTH branches are evaluated,
+    # so in the generic region (R != a) at z == 0 that dead edge branch must be
+    # z-guarded. The VALUE there is the generic branch's 0 and must be parity-
+    # identical (and equal to numpy's 0) across backends, with no scalar crash.
+    R0 = 0.6  # != a (== 1.1 for all cases)
+    val = _tonumpy(
+        pot._surfdens(_asarray(backend_name, R0), _asarray(backend_name, 0.0))
+    )
+    ref = numpy.asarray(pot._surfdens(numpy.asarray(R0), numpy.asarray(0.0)))
+    numpy.testing.assert_allclose(val, ref, rtol=1e-12, atol=0.0)
+    assert numpy.isfinite(float(val)), (
+        f"{type(pot).__name__} surfdens(R!=a,z=0) not finite"
+    )
+
+
+@pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_surfdens_grad_z_finite_off_edge(backend_name, pot):
+    # In the generic region (R != a), z == 0 is a valid finite-value input
+    # (surfdens == 0). Without z-guarding the dead R == a edge branch, its
+    # 1/z**n NaN-poisons reverse-mode d(surfdens)/dz at z == 0. The guard must
+    # keep this gradient FINITE (matching the analytic _dens at the midplane).
+    R0 = 0.6
+    ad = _surfdens_grad_z(backend_name, pot, R0, 0.0)
+    assert numpy.isfinite(ad), f"{type(pot).__name__} dSurf/dz NaN at z=0 (R!=a)"
+    # surfdens integrates rho over [-z, z], so d(surfdens)/dz|_{z=0} = 2*rho(R,0);
+    # cross-check the gradient against the analytic density (the true slope).
+    rho = float(numpy.asarray(pot._dens(numpy.asarray(R0), numpy.asarray(0.0))))
+    numpy.testing.assert_allclose(ad, 2.0 * rho, rtol=1e-7, atol=1e-10)


### PR DESCRIPTION
## Summary

Systematic audit of the backend-migrated **spherical** potentials for `xp.where` dead-branch correctness bugs at degenerate regimes (`r=0`, `z=0`, piecewise seams), across numpy / jax / torch. Same bug class as the recent CosmphiDisk fix: `xp.where` eagerly evaluates BOTH branches, so a singular *dead* (selected-away) branch can NaN-poison reverse-mode gradients (and crash scalars) even when the selected VALUE is correct.

## Bugs found & fixed

**`_surfdens` of Burkert / Hernquist / Jaffe / NFW** — the `xp.where(at_edge, EDGE(z), GENERIC(...))` edge branch (the `R == a` removable-singularity limit) carries a `z**-n` (n in {1,3,5}). The previous migration guarded the *generic* branch's `Rma`/`(R^2-a^2)` denominators but left the EDGE branch's `z`-singularity unguarded. So in the generic region (`R != a`) at `z == 0` — a valid, finite input where `surfdens == 0` — the dead edge branch's `z**-n` → `inf` NaN-poisoned reverse-mode `d(surfdens)/dz` under jax & torch (numpy used a real `if/else`, so only its value path ran and was unaffected).

**Fix:** apply the CosmphiDisk dead-branch pattern — `z_edge = xp.where(at_edge, z, ones)` (real z where the edge branch is live, a safe `1` where it is dead), used everywhere the edge branch divides by z. The genuine edge point `R == a, z == 0` keeps its real limb singularity (`inf`/`nan`), matching `origin/main`.

## Verified clean (no change needed)

- **HomogeneousSphere** (all methods, `r2 < R^2` seam): outside branch correctly guarded by `safe`; inside branch is constant — AD identity `AD(_evaluate)==-Rforce` holds, no crash/NaN at `r=0` or the seam.
- **PowerSpherical `_evaluate`** (`alpha>2` `bad=r2==0` guard): finite dead branch, genuine `-inf` cusp at `r=0`; AD matches `-Rforce`. Force/deriv methods use unguarded `1/r^n` — a *genuine* center singularity (true `if/else`-free in origin too), not a dead-branch bug; left as-is.
- **SphericalShell `_revaluate`/`_rforce`/`_r2deriv`** (`r <= a` seam): inside branches constant/zero, outside guarded by `safe`; no crash at `r=0` or `r==a`. `_surfdens` (`outside | (z<h)` + `safe_arg`) has no z-singular dead branch — grad finite at `z=0`. `_rdens` `inf` at `r==a` is genuine.
- **Burkert `_revaluate`** (`isinf` guard) and **NFW `_evaluate`** (`at0`/`atinf` guards): correctly guarded; `Phi(0)=-1/a` finite, AD matches `-force`; Burkert's `r=0` `nan` is the genuine `1/x` center singularity (matches origin/main).

## Parity

numpy values **byte-identical** to the pre-migration `origin/main` implementation for all non-degenerate inputs (verified inside/outside the edge, scalar and array mixing edge+generic+z=0); jax/torch agree to rtol 1e-12. The fix is a pure additive dead-branch guard — no value path changes.

## Tests

Added to `tests/test_backend_spherical.py`: per fixed potential, `surfdens(R!=a, z=0)` value parity + no-scalar-crash (numpy/jax/torch), and finite (NaN-free) `d(surfdens)/dz` at `z=0` off the edge, cross-checked against `2*rho(R,0)` (the analytic midplane slope). Full `test_backend_spherical.py` (166 passed, 7 skipped) and the main-suite spherical surfdens/dens tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)