### PR TITLE
Pspecial: native-preferring special-function router (Tiers 1-2)

### DIFF
--- a/galpy/backend/special/__init__.py
+++ b/galpy/backend/special/__init__.py
@@ -1,0 +1,37 @@
+###############################################################################
+#   galpy.backend.special: native-preferring special-function router.
+#
+#   Each function dispatches, by the namespace of its array arguments, to the
+#   backend's NATIVE implementation when present (scipy.special for numpy,
+#   jax.scipy.special for jax, torch.special for torch) and otherwise to a
+#   pure-backend, autodiff-friendly fallback in ``_fallback/``. This keeps the
+#   numpy path byte-identical to scipy.special, lets jax/torch use their fast
+#   native kernels, and makes galpy's special-function-backed methods (SCF,
+#   Multipole, Einasto, PowerSphericalwCutoff, the disk potentials, spherical
+#   DFs, ...) run and differentiate under every backend. As backends ship more
+#   native functions the matching fallback is simply never reached (and a
+#   capability test asserts native-vs-fallback agreement so it can be deleted).
+###############################################################################
+from ._router import (
+    erf,
+    erfc,
+    gamma,
+    gammainc,
+    gammaincc,
+    gammaln,
+    i0,
+    i1,
+    xlogy,
+)
+
+__all__ = [
+    "gamma",
+    "gammaln",
+    "gammainc",
+    "gammaincc",
+    "erf",
+    "erfc",
+    "i0",
+    "i1",
+    "xlogy",
+]

--- a/galpy/backend/special/__init__.py
+++ b/galpy/backend/special/__init__.py
@@ -13,12 +13,16 @@
 #   capability test asserts native-vs-fallback agreement so it can be deleted).
 ###############################################################################
 from ._router import (
+    ellipe,
+    ellipk,
     erf,
     erfc,
     gamma,
     gammainc,
     gammaincc,
     gammaln,
+    hyp1f1,
+    hyp2f1,
     i0,
     i1,
     xlogy,
@@ -34,4 +38,8 @@ __all__ = [
     "i0",
     "i1",
     "xlogy",
+    "hyp2f1",
+    "hyp1f1",
+    "ellipk",
+    "ellipe",
 ]

--- a/galpy/backend/special/_fallback/__init__.py
+++ b/galpy/backend/special/_fallback/__init__.py
@@ -1,0 +1,2 @@
+# Pure-backend, autodiff-friendly fallbacks for special functions a backend
+# lacks natively. Each is validated against scipy.special by the capability test.

--- a/galpy/backend/special/_fallback/_quadrature.py
+++ b/galpy/backend/special/_fallback/_quadrature.py
@@ -1,0 +1,27 @@
+###############################################################################
+#   Fixed-order Gauss-Legendre quadrature helpers shared by the special-function
+#   fallbacks (and, later, the backend-agnostic potential/df integrals). Nodes
+#   and weights are numpy constants computed once; per call they are converted
+#   into the active backend's namespace so the integrand differentiates.
+###############################################################################
+import numpy
+
+# Cache of (nodes, weights) on [0, 1] keyed by order, as numpy float64 constants.
+_GL01_CACHE = {}
+
+
+def gauss_legendre_01(n):
+    """Return (nodes, weights) for n-point Gauss-Legendre quadrature on [0, 1].
+
+    numpy float64 constants (cached). The caller converts them into the backend
+    namespace with ``xp.asarray`` so they pick up the backend's array type while
+    the integrand stays differentiable.
+    """
+    cached = _GL01_CACHE.get(n)
+    if cached is None:
+        x, w = numpy.polynomial.legendre.leggauss(n)
+        nodes = 0.5 * (x + 1.0)  # map [-1, 1] -> [0, 1]
+        weights = 0.5 * w
+        cached = (nodes, weights)
+        _GL01_CACHE[n] = cached
+    return cached

--- a/galpy/backend/special/_fallback/elliptic.py
+++ b/galpy/backend/special/_fallback/elliptic.py
@@ -1,0 +1,52 @@
+###############################################################################
+#   Fallbacks for the complete elliptic integrals K(m) and E(m) on backends
+#   without a native implementation (currently both jax and torch).
+#
+#   Parameter convention matches scipy.special: the argument is the parameter
+#   m = k**2 (NOT the modulus k), valid for m < 1; m -> 1 is the genuine
+#   logarithmic singularity of K.
+###############################################################################
+
+# Fixed iteration count: the AGM converges quadratically, so this is ample for
+# float64 across m in [0, 1); extra iterations are harmless (c_n -> 0).
+_AGM_NITER = 16
+
+
+def _agm_KE(xp, m):
+    r"""Both K(m) and E(m) from a single arithmetic-geometric-mean iteration.
+
+    K(m) = pi / (2 * AGM(1, sqrt(1-m))),
+    E(m) = K(m) * (1 - sum_{n>=0} 2^{n-1} c_n^2),
+    with a_0=1, b_0=sqrt(1-m), c_0=sqrt(m), and
+    a_{n+1}=(a_n+b_n)/2, b_{n+1}=sqrt(a_n b_n), c_{n+1}=(a_n-b_n)/2.
+
+    Pure arithmetic + sqrt, so it differentiates cleanly under jax/torch. At
+    m -> 1 (b_0 -> 0) the AGM -> 0 and K -> +inf, the correct singularity.
+    """
+    m = xp.asarray(m) * 1.0
+    a = xp.ones_like(m)
+    b = xp.sqrt(1.0 - m)
+    c = xp.sqrt(m)
+    # sum starts at n=0 with weight 2^{-1} and c_0^2 = m
+    p = 0.5
+    s = p * c * c
+    for _ in range(1, _AGM_NITER):
+        an = 0.5 * (a + b)
+        bn = xp.sqrt(a * b)
+        c = 0.5 * (a - b)
+        a, b = an, bn
+        p = p * 2.0
+        s = s + p * c * c
+    K = xp.pi / (2.0 * a) if hasattr(xp, "pi") else 3.141592653589793 / (2.0 * a)
+    E = K * (1.0 - s)
+    return K, E
+
+
+def ellipk_fallback(xp, m):
+    """Complete elliptic integral of the first kind K(m) (scipy m-convention)."""
+    return _agm_KE(xp, m)[0]
+
+
+def ellipe_fallback(xp, m):
+    """Complete elliptic integral of the second kind E(m) (scipy m-convention)."""
+    return _agm_KE(xp, m)[1]

--- a/galpy/backend/special/_fallback/gamma.py
+++ b/galpy/backend/special/_fallback/gamma.py
@@ -1,0 +1,33 @@
+###############################################################################
+#   Fallback for the gamma function on backends without a native gamma
+#   (currently torch, which has gammaln but not gamma).
+###############################################################################
+import numpy
+
+from .._router import gammaln
+
+
+def gamma_fallback(xp, x):
+    r"""Gamma(x) built from the native gammaln.
+
+    For x > 0: Gamma(x) = exp(gammaln(x)).
+    For x <= 0: the reflection formula Gamma(x) = pi / (sin(pi x) * Gamma(1-x))
+    with Gamma(1-x) = exp(gammaln(1-x)) (1-x >= 1 > 0). This also yields the
+    correct sign (from sin(pi x)) and the +/-inf poles at non-positive integers.
+
+    Autodiff-friendly: under the eager xp.where both branches are evaluated
+    everywhere, so each branch's argument is clamped into a safe region wherever
+    the OTHER branch is selected -- otherwise gammaln's poles at non-positive
+    integers would feed a NaN back through 0*inf and poison reverse-mode
+    gradients at perfectly valid inputs.
+    """
+    x = xp.asarray(x)
+    positive = x > 0
+    # x>0 branch: in the dead (x<=0) region use a safe +0.5 so gammaln stays finite.
+    x_pos = xp.where(positive, x, 0.5 * xp.ones_like(x * 1.0))
+    pos = xp.exp(gammaln(x_pos))
+    # x<=0 branch: in the dead (x>0) region use a safe -0.5 (non-integer, so
+    # sin(pi x) != 0 and gammaln(1-x) is finite).
+    x_neg = xp.where(positive, -0.5 * xp.ones_like(x * 1.0), x)
+    refl = numpy.pi / (xp.sin(numpy.pi * x_neg) * xp.exp(gammaln(1.0 - x_neg)))
+    return xp.where(positive, pos, refl)

--- a/galpy/backend/special/_fallback/hyp1f1.py
+++ b/galpy/backend/special/_fallback/hyp1f1.py
@@ -9,27 +9,24 @@
 #   1F1(1.5-alpha/2, 2.5-alpha/2, -(R/rc)**2)), which has the closed form
 #       1F1(a, a+1; -X) = a * X**(-a) * Gamma(a) * P(a, X)
 #   with X = -z >= 0 and P the regularized lower incomplete gamma (gammainc,
-#   native on every backend) -- machine precision and robust for all X. A
-#   general b > a > 0 path via the Euler integral (same boundary-layer
-#   quadrature as the 2F1 fallback, with e^{zt} in place of (1-zt)^{-A}) is
-#   kept for completeness.
+#   native on every backend) -- machine precision and robust for all X. Only
+#   this case is implemented; a general b would need an accurate treatment of
+#   the (1-t)^{b-a-1} endpoint (cf. the 2F1 fallback), so it raises rather than
+#   silently returning a low-accuracy value.
 ###############################################################################
 import math
 
-from ._quadrature import gauss_legendre_01
-
-_NODES = 96
-
 
 def hyp1f1_fallback(xp, a, b, z):
-    r"""1F1(a, b; z) for real z <= 0. a, b scalars; z a backend array/scalar."""
-    if abs(b - (a + 1.0)) < 1e-12:
-        return _hyp1f1_aplus1(xp, a, z)
-    return _hyp1f1_euler(xp, a, b, z)
+    r"""1F1(a, b; z) for real z <= 0, restricted to b = a + 1 (galpy's case).
 
-
-def _hyp1f1_aplus1(xp, a, z):
-    """Exact b=a+1 case via the lower incomplete gamma (gammainc)."""
+    a, b scalars; z a backend array/scalar.
+    """
+    if abs(b - (a + 1.0)) >= 1e-12:
+        raise NotImplementedError(
+            "galpy.backend.special.hyp1f1 fallback only implements the b=a+1 case "
+            f"(galpy's only use); got (a, b)=({a}, {b})"
+        )
     from .._router import gammainc
 
     z = xp.asarray(z) * 1.0
@@ -42,31 +39,3 @@ def _hyp1f1_aplus1(xp, a, z):
     closed = a * Xs ** (-a) * math.gamma(a) * gammainc(a_arr, Xs)
     series = 1.0 + a / (a + 1.0) * z + a / (a + 2.0) * z * z / 2.0
     return xp.where(X < 1e-6, series, closed)
-
-
-def _hyp1f1_euler(xp, a, b, z):
-    r"""General b>a>0 via Euler's integral with an exponential boundary layer.
-
-    1F1(a,b;z) = Gamma(b)/(Gamma(a)Gamma(b-a)) int_0^1 e^{z t} t^{a-1}(1-t)^{b-a-1} dt
-    for z <= 0; the map e^{z t} = 1 - x(1-e^{z}) sends the boundary layer near
-    t=0 to a uniform x-grid, and x = xi^k regularizes the t^{a-1} endpoint.
-    """
-    z = xp.asarray(z) * 1.0
-    X = -z
-    q = b - a
-    k = min(12.0, max(1.0, float(math.ceil(6.0 / a))))  # regularize t^{a-1} endpoint
-    pref = math.exp(math.lgamma(b) - math.lgamma(a) - math.lgamma(q))
-    nodes, weights = gauss_legendre_01(_NODES)
-    xg = xp.asarray(nodes)
-    wg = xp.asarray(weights)
-    xx = xg**k
-    dxx = k * xg ** (k - 1.0)
-
-    Xs = xp.maximum(X, xp.ones_like(X) * 1e-10)
-    em = -xp.expm1(-Xs)[..., None]  # 1 - e^{-X} in (0, 1]
-    Xsb = Xs[..., None]
-    ez = 1.0 - xx * em  # = e^{-X t}
-    t = -xp.log1p(-xx * em) / Xsb
-    dt = (em / Xsb) / ez
-    integ = ez * t ** (a - 1.0) * (1.0 - t) ** (q - 1.0) * dt * dxx
-    return pref * xp.sum(integ * wg, axis=-1)

--- a/galpy/backend/special/_fallback/hyp1f1.py
+++ b/galpy/backend/special/_fallback/hyp1f1.py
@@ -1,0 +1,72 @@
+###############################################################################
+#   Fallback for the confluent hypergeometric function 1F1(a, b; z) on the
+#   real, non-positive-z domain galpy uses (z = -(R/rc)**2 <= 0). Needed on
+#   BOTH jax and torch: torch.special has no hyp1f1, and jax.scipy.special.
+#   hyp1f1 is wildly wrong for large negative z (rel. error ~1e10 by z~-64),
+#   exactly galpy's regime. See the tripwire test in test_backend_special.py.
+#
+#   galpy only ever calls the b = a + 1 case (PowerSphericalwCutoff._mass:
+#   1F1(1.5-alpha/2, 2.5-alpha/2, -(R/rc)**2)), which has the closed form
+#       1F1(a, a+1; -X) = a * X**(-a) * Gamma(a) * P(a, X)
+#   with X = -z >= 0 and P the regularized lower incomplete gamma (gammainc,
+#   native on every backend) -- machine precision and robust for all X. A
+#   general b > a > 0 path via the Euler integral (same boundary-layer
+#   quadrature as the 2F1 fallback, with e^{zt} in place of (1-zt)^{-A}) is
+#   kept for completeness.
+###############################################################################
+import math
+
+from ._quadrature import gauss_legendre_01
+
+_NODES = 96
+
+
+def hyp1f1_fallback(xp, a, b, z):
+    r"""1F1(a, b; z) for real z <= 0. a, b scalars; z a backend array/scalar."""
+    if abs(b - (a + 1.0)) < 1e-12:
+        return _hyp1f1_aplus1(xp, a, z)
+    return _hyp1f1_euler(xp, a, b, z)
+
+
+def _hyp1f1_aplus1(xp, a, z):
+    """Exact b=a+1 case via the lower incomplete gamma (gammainc)."""
+    from .._router import gammainc
+
+    z = xp.asarray(z) * 1.0
+    X = -z  # >= 0
+    # Floor away from 0 so X**(-a) stays finite; a 2-term Taylor series covers
+    # the small-|z| region (and supplies the correct z=0 limit, 1F1=1).
+    Xs = xp.maximum(X, xp.ones_like(X) * 1e-12)
+    # ``a`` as an array (torch.special.gammainc requires both args be tensors).
+    a_arr = xp.ones_like(Xs) * a
+    closed = a * Xs ** (-a) * math.gamma(a) * gammainc(a_arr, Xs)
+    series = 1.0 + a / (a + 1.0) * z + a / (a + 2.0) * z * z / 2.0
+    return xp.where(X < 1e-6, series, closed)
+
+
+def _hyp1f1_euler(xp, a, b, z):
+    r"""General b>a>0 via Euler's integral with an exponential boundary layer.
+
+    1F1(a,b;z) = Gamma(b)/(Gamma(a)Gamma(b-a)) int_0^1 e^{z t} t^{a-1}(1-t)^{b-a-1} dt
+    for z <= 0; the map e^{z t} = 1 - x(1-e^{z}) sends the boundary layer near
+    t=0 to a uniform x-grid, and x = xi^k regularizes the t^{a-1} endpoint.
+    """
+    z = xp.asarray(z) * 1.0
+    X = -z
+    q = b - a
+    k = min(12.0, max(1.0, float(math.ceil(6.0 / a))))  # regularize t^{a-1} endpoint
+    pref = math.exp(math.lgamma(b) - math.lgamma(a) - math.lgamma(q))
+    nodes, weights = gauss_legendre_01(_NODES)
+    xg = xp.asarray(nodes)
+    wg = xp.asarray(weights)
+    xx = xg**k
+    dxx = k * xg ** (k - 1.0)
+
+    Xs = xp.maximum(X, xp.ones_like(X) * 1e-10)
+    em = -xp.expm1(-Xs)[..., None]  # 1 - e^{-X} in (0, 1]
+    Xsb = Xs[..., None]
+    ez = 1.0 - xx * em  # = e^{-X t}
+    t = -xp.log1p(-xx * em) / Xsb
+    dt = (em / Xsb) / ez
+    integ = ez * t ** (a - 1.0) * (1.0 - t) ** (q - 1.0) * dt * dxx
+    return pref * xp.sum(integ * wg, axis=-1)

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -32,17 +32,21 @@ _NODES = 128
 
 
 def _euler_labeling(a, b, c):
-    """Pick (B, A) with {A,B}={a,b}, B>0, c-B>0, preferring c-B >= 1."""
+    """Pick (B, A) with {A,B}={a,b}, B>0 and c-B >= 1.
+
+    Requiring c-B >= 1 keeps the (1-t)^{c-B-1} endpoint non-singular so the
+    fixed-order quadrature stays accurate; galpy's 2F1 calls always satisfy
+    this (c-a is 1 or 2). A configuration with c-max(a,b) < 1 would need the
+    t=1 endpoint regularized too, so it raises rather than return a
+    low-accuracy value.
+    """
     if a > 0 and (c - a) >= 1.0:
         return a, b
     if b > 0 and (c - b) >= 1.0:
         return b, a
-    if a > 0 and (c - a) > 0:
-        return a, b
-    if b > 0 and (c - b) > 0:
-        return b, a
-    raise ValueError(
-        f"hyp2f1 fallback has no valid Euler labeling for (a={a}, b={b}, c={c})"
+    raise NotImplementedError(
+        f"hyp2f1 fallback requires c - max(a, b) >= 1 (galpy's regime); "
+        f"got (a={a}, b={b}, c={c})"
     )
 
 

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -1,0 +1,84 @@
+###############################################################################
+#   Fallback for the Gauss hypergeometric function 2F1(a, b; c; z) on the
+#   real, non-positive-z domain galpy uses (z = -r/a, -a/r, -(z/R)**2, ... so
+#   z <= 0).  Needed on BOTH jax and torch:
+#     - torch.special has no hyp2f1 at all;
+#     - jax.scipy.special.hyp2f1 is catastrophically wrong for z < -1 (it
+#       returns +-inf and NaN gradients), which is exactly galpy's regime
+#       (r > a). See tests/test_backend_special.py::test_jax_native_hyp2f1_is
+#       _unreliable for the tripwire that documents this.
+#
+#   Method: Euler's integral representation, valid for all z not in [1, inf):
+#       2F1(a,b;c;z) = Gamma(c)/(Gamma(B) Gamma(c-B))
+#                      * int_0^1 t^{B-1} (1-t)^{c-B-1} (1 - z t)^{-A} dt
+#   where {A, B} = {a, b} is chosen so B > 0 and c - B > 0 (preferring
+#   c - B >= 1 so the t=1 endpoint is non-singular). For z <= 0 the factor
+#   (1 - z t) = (1 + |z| t) >= 1 is smooth, but for large |z| it forms a thin
+#   boundary layer near t=0; two substitutions resolve it for fixed-order
+#   Gauss-Legendre quadrature:
+#     1. t = ((1+|z|)^X - 1)/|z| maps the boundary layer to a uniform X-grid;
+#     2. X = xi^k (k = ceil(1/B) when B < 1) regularizes the t^{B-1} endpoint
+#        singularity so plain Gauss-Legendre converges.
+#   Pure arithmetic + log1p/expm1/pow, so it differentiates under jax and torch.
+###############################################################################
+import math
+
+from ._quadrature import gauss_legendre_01
+
+# 128 nodes: ~1e-10 or better vs scipy at realistic radii (|z| = r/a <~ 50);
+# accuracy degrades smoothly to ~1e-6 at the extreme |z| ~ 500 (r/a ~ 500, far
+# beyond any realistic galactic radius) for awkward exponent combinations.
+_NODES = 128
+
+
+def _euler_labeling(a, b, c):
+    """Pick (B, A) with {A,B}={a,b}, B>0, c-B>0, preferring c-B >= 1."""
+    if a > 0 and (c - a) >= 1.0:
+        return a, b
+    if b > 0 and (c - b) >= 1.0:
+        return b, a
+    if a > 0 and (c - a) > 0:
+        return a, b
+    if b > 0 and (c - b) > 0:
+        return b, a
+    raise ValueError(
+        f"hyp2f1 fallback has no valid Euler labeling for (a={a}, b={b}, c={c})"
+    )
+
+
+def hyp2f1_fallback(xp, a, b, c, z):
+    r"""2F1(a, b; c; z) for real z <= 0 via the boundary-layer Euler integral.
+
+    a, b, c are scalars (galpy potential parameters); z is a backend array
+    (or scalar) with z <= 0.
+    """
+    z = xp.asarray(z) * 1.0
+    w = -z  # >= 0
+    B, A = _euler_labeling(a, b, c)
+    q = c - B  # exponent of (1-t) is q-1
+    # X = xi^k regularizes the t^{B-1} endpoint: after the boundary-layer map the
+    # integrand carries X^{B-1} near X=0, which is only algebraically integrable
+    # for non-integer B. Raise it to xi^{kB-1} with kB >= ~6 so plain GL is
+    # spectrally accurate (k=1 already suffices once B-1 is a smooth high power).
+    # Capped at 12 (covers B >= 0.5, galpy's range) so X=xi^k cannot underflow.
+    k = min(12.0, max(1.0, float(math.ceil(6.0 / B))))
+    pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(q))
+
+    nodes, weights = gauss_legendre_01(_NODES)
+    xg = xp.asarray(nodes)
+    wg = xp.asarray(weights)
+    X = xg**k
+    dX = k * xg ** (k - 1.0)
+
+    # Floor |z| away from exactly zero so the 1/|z| substitution is finite (and
+    # X*log1p(|z|) cannot underflow to 0, which would make T**(B-1) blow up for
+    # B<1). At |z|=0 this evaluates 2F1 at z=-1e-10, i.e. 1 to ~1e-10; the
+    # subgradient blocks gradient only at the measure-zero origin point.
+    w_safe = xp.maximum(w, xp.ones_like(w) * 1e-10)
+    L = xp.log1p(w_safe)[..., None]  # (..., 1)
+    wb = w_safe[..., None]
+    XL = X * L  # (..., N)
+    T = xp.expm1(XL) / wb
+    dt = xp.exp(XL) * L / wb
+    integ = T ** (B - 1.0) * (1.0 - T) ** (q - 1.0) * (1.0 + wb * T) ** (-A) * dt * dX
+    return pref * xp.sum(integ * wg, axis=-1)

--- a/galpy/backend/special/_fallback/xlogy.py
+++ b/galpy/backend/special/_fallback/xlogy.py
@@ -1,0 +1,15 @@
+###############################################################################
+#   Fallback for xlogy(x, y) = x * log(y), with the scipy convention that
+#   x == 0 yields 0 even when y == 0 (so 0 * log(0) = 0). Native on every
+#   backend, so the router never reaches this in practice; it is a valid,
+#   AD-friendly pure-backend implementation kept (and unit-tested) so the
+#   capability story is uniform with the other special functions.
+###############################################################################
+
+
+def xlogy_fallback(xp, x, y):
+    x = xp.asarray(x) * 1.0
+    y = xp.asarray(y) * 1.0
+    # guard the dead branch's log(0) so it cannot NaN-poison gradients at x==0
+    safe_y = xp.where(x == 0, xp.ones_like(y), y)
+    return xp.where(x == 0, xp.zeros_like(x), x * xp.log(safe_y))

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -153,15 +153,10 @@ def ellipe(m):
 
 
 def xlogy(x, y):
-    # x * log(y), with the scipy/native convention 0 * log(0) = 0. Native
-    # everywhere, but the trivial backend-agnostic form is also a valid fallback.
-    def _fb(xp, x, y):
-        x = xp.asarray(x)
-        y = xp.asarray(y)
-        safe_y = xp.where(x == 0, xp.ones_like(y), y)
-        return xp.where(x == 0, xp.zeros_like(x * 1.0), x * xp.log(safe_y))
+    # x * log(y), with the scipy/native convention 0 * log(0) = 0.
+    from ._fallback.xlogy import xlogy_fallback
 
-    return _dispatch("xlogy", (x, y), _fb)
+    return _dispatch("xlogy", (x, y), xlogy_fallback)
 
 
 # Silence "imported but unused" for numpy (kept for potential defensive use).

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -1,0 +1,114 @@
+###############################################################################
+#   galpy.backend.special._router: dispatch each special function to the
+#   backend's native implementation, falling back to a pure-backend version.
+###############################################################################
+import numpy
+
+from .._resolver import get_namespace
+
+# Per-backend list of functions whose NATIVE implementation is missing, so the
+# router must use the pure-backend fallback. Kept tiny and explicit; a capability
+# test (tests/test_backend_special.py) asserts this matches reality and that each
+# fallback agrees with scipy, so entries are removed as backends add the native
+# version. (numpy always has the full scipy.special, so it never needs a fallback.)
+_NEEDS_FALLBACK = {
+    "jax": frozenset(),
+    "torch": frozenset(("gamma",)),  # torch.special has gammaln but not gamma
+}
+
+
+def _backend_special(xp):
+    """Return (backend_name, native_special_module) for a resolved namespace xp.
+
+    numpy -> scipy.special, jax.numpy -> jax.scipy.special,
+    array_api_compat.torch -> torch.special.
+    """
+    name = getattr(xp, "__name__", "")
+    if name in ("numpy", "np"):
+        import scipy.special as _sp
+
+        return "numpy", _sp
+    if name in ("jax.numpy", "jax"):
+        import jax.scipy.special as _sp
+
+        return "jax", _sp
+    if "torch" in name:
+        import torch.special as _sp
+
+        return "torch", _sp
+    # Unknown namespace: treat as numpy/scipy (defensive).
+    import scipy.special as _sp  # pragma: no cover
+
+    return "numpy", _sp  # pragma: no cover
+
+
+def _dispatch(fnname, args, fallback):
+    """Route ``fnname(*args)`` to native or fallback based on the args' namespace."""
+    xp = get_namespace(*args)
+    name, sp = _backend_special(xp)
+    if fnname not in _NEEDS_FALLBACK.get(name, frozenset()) and hasattr(sp, fnname):
+        return getattr(sp, fnname)(*args)
+    return fallback(xp, *args)
+
+
+def _no_fallback(fnname):
+    def _fb(xp, *args):  # pragma: no cover - reached only if a backend regresses
+        raise NotImplementedError(
+            f"galpy.backend.special.{fnname} has no fallback and the active "
+            f"backend lacks a native implementation"
+        )
+
+    return _fb
+
+
+# --- Tier 1: native on every backend except where noted -----------------------
+def gammaln(x):
+    return _dispatch("gammaln", (x,), _no_fallback("gammaln"))
+
+
+def gamma(x):
+    from ._fallback.gamma import gamma_fallback
+
+    return _dispatch("gamma", (x,), gamma_fallback)
+
+
+def gammainc(a, x):
+    # Regularized lower incomplete gamma P(a, x).
+    return _dispatch("gammainc", (a, x), _no_fallback("gammainc"))
+
+
+def gammaincc(a, x):
+    # Regularized upper incomplete gamma Q(a, x) = 1 - P(a, x).
+    return _dispatch("gammaincc", (a, x), _no_fallback("gammaincc"))
+
+
+def erf(x):
+    return _dispatch("erf", (x,), _no_fallback("erf"))
+
+
+def erfc(x):
+    return _dispatch("erfc", (x,), _no_fallback("erfc"))
+
+
+def i0(x):
+    return _dispatch("i0", (x,), _no_fallback("i0"))
+
+
+def i1(x):
+    return _dispatch("i1", (x,), _no_fallback("i1"))
+
+
+def xlogy(x, y):
+    # x * log(y), with the scipy/native convention 0 * log(0) = 0. Native
+    # everywhere, but the trivial backend-agnostic form is also a valid fallback.
+    def _fb(xp, x, y):
+        x = xp.asarray(x)
+        y = xp.asarray(y)
+        safe_y = xp.where(x == 0, xp.ones_like(y), y)
+        return xp.where(x == 0, xp.zeros_like(x * 1.0), x * xp.log(safe_y))
+
+    return _dispatch("xlogy", (x, y), _fb)
+
+
+# Silence "imported but unused" for numpy (kept for potential defensive use).
+_ = numpy

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -6,14 +6,33 @@ import numpy
 
 from .._resolver import get_namespace
 
-# Per-backend list of functions whose NATIVE implementation is missing, so the
-# router must use the pure-backend fallback. Kept tiny and explicit; a capability
-# test (tests/test_backend_special.py) asserts this matches reality and that each
-# fallback agrees with scipy, so entries are removed as backends add the native
-# version. (numpy always has the full scipy.special, so it never needs a fallback.)
+# Per-backend functions whose NATIVE implementation is simply absent, so the
+# router must use the pure-backend fallback. A capability test
+# (test_fallback_table_matches_installed_backends) asserts this matches reality
+# (hasattr on the backend's special module), so entries are removed as backends
+# add the native version. (numpy always has the full scipy.special.)
+_NATIVE_MISSING = {
+    "jax": frozenset(("ellipk", "ellipe")),
+    "torch": frozenset(
+        ("gamma", "ellipk", "ellipe", "hyp2f1", "hyp1f1")
+    ),  # torch.special lacks all of these
+}
+
+# Functions whose native implementation EXISTS but is too inaccurate on galpy's
+# argument domain to use -- we force the fallback anyway. Currently jax's
+# hyp2f1/hyp1f1: both are catastrophically wrong for z < -1 (return +-inf with
+# NaN gradients), which is exactly galpy's regime (z = -r/a, -(R/rc)**2, ...).
+# A tripwire test documents the breakage so these move to native if jax fixes it.
+_NATIVE_UNRELIABLE = {
+    "jax": frozenset(("hyp2f1", "hyp1f1")),
+    "torch": frozenset(),
+}
+
+# The router routes a function to its fallback iff it is in EITHER set.
 _NEEDS_FALLBACK = {
-    "jax": frozenset(),
-    "torch": frozenset(("gamma",)),  # torch.special has gammaln but not gamma
+    name: _NATIVE_MISSING.get(name, frozenset())
+    | _NATIVE_UNRELIABLE.get(name, frozenset())
+    for name in ("jax", "torch")
 }
 
 
@@ -42,9 +61,15 @@ def _backend_special(xp):
     return "numpy", _sp  # pragma: no cover
 
 
-def _dispatch(fnname, args, fallback):
-    """Route ``fnname(*args)`` to native or fallback based on the args' namespace."""
-    xp = get_namespace(*args)
+def _dispatch(fnname, args, fallback, ns_args=None):
+    """Route ``fnname(*args)`` to native or fallback by the arrays' namespace.
+
+    ns_args (default: all of args) selects which arguments determine the
+    backend; pass only the array arguments when some of ``args`` are plain
+    scalars (e.g. the (a, b, c) parameters of hyp2f1) so they don't confuse
+    the resolver.
+    """
+    xp = get_namespace(*(args if ns_args is None else ns_args))
     name, sp = _backend_special(xp)
     if fnname not in _NEEDS_FALLBACK.get(name, frozenset()) and hasattr(sp, fnname):
         return getattr(sp, fnname)(*args)
@@ -96,6 +121,35 @@ def i0(x):
 
 def i1(x):
     return _dispatch("i1", (x,), _no_fallback("i1"))
+
+
+# --- Tier 2: pure-backend fallbacks (jax/torch); high force-unblock impact ----
+def hyp2f1(a, b, c, z):
+    # Gauss 2F1; only the array arg z carries the backend namespace.
+    from ._fallback.hyp2f1 import hyp2f1_fallback
+
+    return _dispatch("hyp2f1", (a, b, c, z), hyp2f1_fallback, ns_args=(z,))
+
+
+def hyp1f1(a, b, z):
+    # Confluent 1F1 (Kummer); only z carries the backend namespace.
+    from ._fallback.hyp1f1 import hyp1f1_fallback
+
+    return _dispatch("hyp1f1", (a, b, z), hyp1f1_fallback, ns_args=(z,))
+
+
+def ellipk(m):
+    # Complete elliptic integral K(m) (scipy parameter-m convention).
+    from ._fallback.elliptic import ellipk_fallback
+
+    return _dispatch("ellipk", (m,), ellipk_fallback)
+
+
+def ellipe(m):
+    # Complete elliptic integral E(m) (scipy parameter-m convention).
+    from ._fallback.elliptic import ellipe_fallback
+
+    return _dispatch("ellipe", (m,), ellipe_fallback)
 
 
 def xlogy(x, y):

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1,0 +1,160 @@
+###############################################################################
+# test_backend_special.py: the native-preferring special-function router
+# (galpy.backend.special). For each Tier-1 function this asserts:
+#   1. value parity numpy/jax/torch vs scipy.special (numpy byte-identical;
+#      jax/torch to rtol 1e-12) on galpy's argument ranges;
+#   2. autodiff (jax.grad / torch.autograd) matches central finite differences;
+#   3. the fallback table (_NEEDS_FALLBACK) matches the installed backends, and
+#      every fallback agrees with scipy (so a fallback is deletable once the
+#      backend ships the native function).
+###############################################################################
+import numpy
+import pytest
+import scipy.special as scipy_special
+
+from galpy.backend import special as gsp
+from galpy.backend.special._router import _NEEDS_FALLBACK, _backend_special
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+
+def _asarray(backend, x, requires_grad=False):
+    if backend == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+# (router fn, scipy fn, n-args, sample points). Ranges cover what galpy uses.
+_POS = numpy.array([0.1, 0.5, 0.9, 1.3, 2.0, 3.7, 5.0])
+_REAL = numpy.array([-3.0, -1.2, -0.3, 0.0, 0.4, 1.1, 2.5])
+_GAMMA_X = numpy.array([0.2, 0.5, 1.0, 2.5, 4.0, -0.5, -1.5, -2.5])  # incl. reflection
+_A = numpy.array([0.5, 1.0, 2.0, 3.5])
+_XG = numpy.array([0.05, 0.5, 1.5, 3.0, 6.0])
+
+UNARY = [
+    ("gammaln", gsp.gammaln, scipy_special.gammaln, _POS),
+    ("gamma", gsp.gamma, scipy_special.gamma, _GAMMA_X),
+    ("erf", gsp.erf, scipy_special.erf, _REAL),
+    ("erfc", gsp.erfc, scipy_special.erfc, _REAL),
+    ("i0", gsp.i0, scipy_special.i0, numpy.abs(_REAL)),
+    ("i1", gsp.i1, scipy_special.i1, _REAL),
+]
+
+
+@pytest.mark.parametrize("name,fn,sp_fn,pts", UNARY, ids=[u[0] for u in UNARY])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_unary_value_parity(backend, name, fn, sp_fn, pts):
+    ref = sp_fn(pts)
+    got = _tonumpy(fn(_asarray(backend, pts)))
+    rtol = 0.0 if backend == "numpy" else 1e-12  # numpy must be byte-identical
+    numpy.testing.assert_allclose(
+        got, ref, rtol=rtol, atol=1e-12, err_msg=f"{name} ({backend})"
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_gammainc_value_parity(backend):
+    for sp_fn, fn in [
+        (scipy_special.gammainc, gsp.gammainc),
+        (scipy_special.gammaincc, gsp.gammaincc),
+    ]:
+        for a in _A:
+            ref = sp_fn(a, _XG)
+            got = _tonumpy(fn(_asarray(backend, a), _asarray(backend, _XG)))
+            rtol = 0.0 if backend == "numpy" else 1e-12
+            numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_xlogy_value_parity_incl_zero(backend):
+    x = numpy.array([0.0, 0.0, 1.0, 2.5, 0.3])
+    y = numpy.array([0.0, 5.0, 2.0, 0.7, 10.0])  # x=0 -> 0 even when y=0
+    ref = scipy_special.xlogy(x, y)
+    got = _tonumpy(gsp.xlogy(_asarray(backend, x), _asarray(backend, y)))
+    rtol = 0.0 if backend == "numpy" else 1e-12
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("name,fn,sp_fn,pts", UNARY, ids=[u[0] for u in UNARY])
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_unary_grad_vs_fd(backend, name, fn, sp_fn, pts):
+    # differentiate at smooth interior points (avoid gamma's poles at <=0 ints)
+    x0 = 1.3 if name in ("gammaln", "gamma", "i0", "i1") else 0.7
+    eps = 1e-6
+    fd = (float(sp_fn(x0 + eps)) - float(sp_fn(x0 - eps))) / (2 * eps)
+    if backend == "jax":
+        ad = float(jax.grad(lambda x: fn(x))(jnp.asarray(x0)))
+    else:
+        xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        fn(xt).backward()
+        ad = float(xt.grad)
+    assert not numpy.isnan(ad), f"NaN grad for {name} ({backend})"
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5, err_msg=f"{name} grad ({backend})")
+
+
+def test_fallback_table_matches_installed_backends():
+    # _NEEDS_FALLBACK must list exactly the Tier-1 functions the backend lacks.
+    tier1 = ["gammaln", "gamma", "gammainc", "gammaincc", "erf", "erfc", "i0", "i1"]
+    for backend in AD_BACKENDS:
+        xp = _asarray(backend, 1.0)
+        from galpy.backend import get_namespace
+
+        _name, sp = _backend_special(get_namespace(xp))
+        for fn in tier1:
+            listed = fn in _NEEDS_FALLBACK.get(backend, frozenset())
+            native = hasattr(sp, fn)
+            assert listed == (not native), (
+                f"{backend}: {fn} native={native} but listed-as-fallback={listed}; "
+                f"update _NEEDS_FALLBACK"
+            )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_gamma_fallback_agrees_and_no_nan_grad(backend):
+    # Exercises the pure-backend gamma fallback (torch); on jax it routes native,
+    # but we still check parity + finite gradient across the reflection at x<0.
+    pts = _GAMMA_X
+    got = _tonumpy(gsp.gamma(_asarray(backend, pts)))
+    numpy.testing.assert_allclose(got, scipy_special.gamma(pts), rtol=1e-11, atol=1e-11)
+    # gradient at a negative non-integer (reflection branch) must be finite + correct
+    x0 = -1.5
+    eps = 1e-6
+    fd = (
+        float(scipy_special.gamma(x0 + eps)) - float(scipy_special.gamma(x0 - eps))
+    ) / (2 * eps)
+    if backend == "jax":
+        ad = float(jax.grad(lambda x: gsp.gamma(x))(jnp.asarray(x0)))
+    else:
+        xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        gsp.gamma(xt).backward()
+        ad = float(xt.grad)
+    assert not numpy.isnan(ad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-4)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -277,3 +277,52 @@ def test_gamma_fallback_agrees_and_no_nan_grad(backend):
         ad = float(xt.grad)
     assert not numpy.isnan(ad)
     numpy.testing.assert_allclose(ad, fd, rtol=1e-4)
+
+
+# --- Direct fallback-implementation tests (paths the router rarely reaches) ----
+def _ns(backend):
+    from galpy.backend import get_namespace
+
+    return get_namespace(_asarray(backend, 1.0))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_xlogy_fallback_direct(backend):
+    # xlogy is native on every backend, so the router never reaches the fallback;
+    # exercise (and validate vs scipy) the pure-backend implementation directly,
+    # including the 0*log(0)=0 convention.
+    from galpy.backend.special._fallback.xlogy import xlogy_fallback
+
+    x = numpy.array([0.0, 0.0, 1.0, 2.5, 0.3])
+    y = numpy.array([0.0, 5.0, 2.0, 0.7, 10.0])
+    ref = scipy_special.xlogy(x, y)
+    got = _tonumpy(
+        xlogy_fallback(_ns(backend), _asarray(backend, x), _asarray(backend, y))
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-13, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_fallback_alt_labeling(backend):
+    # 2F1 case whose accurate Euler labeling comes from b (c-a < 1 <= c-b), i.e.
+    # the second branch of _euler_labeling -- not exercised by galpy's calls
+    # (which always satisfy c-a >= 1). jax/torch route through the fallback here.
+    a, b, c = 2.0, 0.8, 2.5  # c-a=0.5 (<1), c-b=1.7 (>=1) -> labeling picks b
+    z = -numpy.array([0.0, 0.1, 1.0, 5.0, 30.0])
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=1e-8)
+
+
+def test_fallback_unsupported_regimes_raise():
+    # The fallbacks raise (rather than silently return a low-accuracy value)
+    # outside the regime galpy needs and they are accurate in.
+    from galpy.backend.special._fallback.hyp1f1 import hyp1f1_fallback
+    from galpy.backend.special._fallback.hyp2f1 import _euler_labeling
+
+    # 2F1 with c - max(a,b) < 1 (both endpoints awkward): unsupported
+    with pytest.raises(NotImplementedError):
+        _euler_labeling(2.0, 2.0, 2.5)  # c-a=c-b=0.5
+    # 1F1 only implements b = a + 1
+    with pytest.raises(NotImplementedError):
+        hyp1f1_fallback(numpy, 1.0, 3.0, numpy.array([-1.0]))

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -13,7 +13,11 @@ import pytest
 import scipy.special as scipy_special
 
 from galpy.backend import special as gsp
-from galpy.backend.special._router import _NEEDS_FALLBACK, _backend_special
+from galpy.backend.special._router import (
+    _NATIVE_MISSING,
+    _NATIVE_UNRELIABLE,
+    _backend_special,
+)
 
 pytestmark = pytest.mark.backend_managed
 
@@ -121,20 +125,135 @@ def test_unary_grad_vs_fd(backend, name, fn, sp_fn, pts):
 
 
 def test_fallback_table_matches_installed_backends():
-    # _NEEDS_FALLBACK must list exactly the Tier-1 functions the backend lacks.
-    tier1 = ["gammaln", "gamma", "gammainc", "gammaincc", "erf", "erfc", "i0", "i1"]
+    # _NATIVE_MISSING must list exactly the functions the backend's special
+    # module lacks (hasattr); the UNRELIABLE set is the opposite (must be
+    # present, else there is nothing to override).
+    tier12 = [
+        "gammaln", "gamma", "gammainc", "gammaincc", "erf", "erfc", "i0", "i1",
+        "hyp2f1", "hyp1f1", "ellipk", "ellipe",
+    ]  # fmt: skip
     for backend in AD_BACKENDS:
         xp = _asarray(backend, 1.0)
         from galpy.backend import get_namespace
 
         _name, sp = _backend_special(get_namespace(xp))
-        for fn in tier1:
-            listed = fn in _NEEDS_FALLBACK.get(backend, frozenset())
+        for fn in tier12:
+            missing = fn in _NATIVE_MISSING.get(backend, frozenset())
             native = hasattr(sp, fn)
-            assert listed == (not native), (
-                f"{backend}: {fn} native={native} but listed-as-fallback={listed}; "
-                f"update _NEEDS_FALLBACK"
+            assert missing == (not native), (
+                f"{backend}: {fn} native={native} but listed-as-missing={missing}; "
+                f"update _NATIVE_MISSING"
             )
+        for fn in _NATIVE_UNRELIABLE.get(backend, frozenset()):
+            assert hasattr(sp, fn), (
+                f"{backend}: {fn} is listed UNRELIABLE but absent natively; it "
+                f"belongs in _NATIVE_MISSING instead"
+            )
+
+
+# --- Tier 2: hyp2f1 / hyp1f1 / ellipk / ellipe --------------------------------
+# galpy's 2F1 calls (forces use c=a+1; the beta!=3 eval uses c=a+2), z = -w <= 0.
+_HYP2F1_CASES = [
+    (2.0, 2.0, 3.0),  # NFW-like force (alpha=1, beta=3): 2F1(3-a, b-a, 4-a)
+    (2.0, 3.0, 3.0),  # Hernquist-like (alpha=1, beta=4)
+    (1.0, 2.0, 2.0),  # Jaffe-like (alpha=2, beta=4)
+    (1.5, 2.0, 2.5),  # Dehnen alpha=1.5, beta=3.5
+    (0.5, 1.0, 1.5),  # PowerSpherical _surfdens 2F1(0.5, alpha/2, 1.5)
+    (1.0, 3.0, 3.0),  # beta!=3 eval, c=a+2 (beta=4): 2F1(beta-3, beta-alpha, beta-1)
+]
+# realistic radii r/a <~ 50 -- the fallback quadrature is ~1e-10 here
+_HYP2F1_W = numpy.array([0.0, 1e-3, 0.05, 0.5, 0.9, 1.0, 1.7, 5.0, 12.0, 25.0, 50.0])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("a,b,c", _HYP2F1_CASES, ids=[str(x) for x in _HYP2F1_CASES])
+def test_hyp2f1_value_parity(backend, a, b, c):
+    z = -_HYP2F1_W
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    rtol = 0.0 if backend == "numpy" else 1e-9  # fallback quadrature at r/a<~50
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+@pytest.mark.parametrize("a,b,c", _HYP2F1_CASES, ids=[str(x) for x in _HYP2F1_CASES])
+def test_hyp2f1_extreme_z_bounded_error(backend, a, b, c):
+    # Far beyond realistic radii (r/a up to 500) the fixed-order quadrature
+    # degrades gracefully -- still ~1e-5, never diverges (unlike jax native).
+    z = -numpy.array([100.0, 250.0, 500.0])
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_hyp1f1_value_parity(backend):
+    for alpha in [0.0, 1.0, 1.8, 2.5]:
+        a, b = 1.5 - alpha / 2.0, 2.5 - alpha / 2.0
+        X = numpy.array([0.0, 1e-3, 0.1, 1.0, 4.0, 16.0, 64.0, 256.0])
+        ref = scipy_special.hyp1f1(a, b, -X)
+        got = _tonumpy(gsp.hyp1f1(a, b, _asarray(backend, -X)))
+        rtol = 0.0 if backend == "numpy" else 1e-9  # b=a+1 -> exact via gammainc
+        numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_elliptic_value_parity(backend):
+    m = numpy.array([0.0, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999])
+    for fn, sp_fn in [
+        (gsp.ellipk, scipy_special.ellipk),
+        (gsp.ellipe, scipy_special.ellipe),
+    ]:
+        ref = sp_fn(m)
+        got = _tonumpy(fn(_asarray(backend, m)))
+        rtol = 0.0 if backend == "numpy" else 1e-12  # AGM is ~1e-15
+        numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_tier2_grad_vs_fd(backend):
+    # differentiate each Tier-2 fn at a smooth interior point vs central FD
+    eps = 1e-6
+    specs = [
+        ("hyp2f1", lambda zz: gsp.hyp2f1(2.0, 2.0, 3.0, zz),
+         lambda x: scipy_special.hyp2f1(2.0, 2.0, 3.0, x), -3.0),
+        ("hyp1f1", lambda zz: gsp.hyp1f1(1.5, 2.5, zz),
+         lambda x: scipy_special.hyp1f1(1.5, 2.5, x), -2.0),
+        ("ellipk", lambda mm: gsp.ellipk(mm), scipy_special.ellipk, 0.4),
+        ("ellipe", lambda mm: gsp.ellipe(mm), scipy_special.ellipe, 0.4),
+    ]  # fmt: skip
+    for name, fn, sp_fn, x0 in specs:
+        fd = (float(sp_fn(x0 + eps)) - float(sp_fn(x0 - eps))) / (2 * eps)
+        if backend == "jax":
+            ad = float(jax.grad(lambda x: fn(x))(jnp.asarray(x0)))
+        else:
+            xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+            fn(xt).backward()
+            ad = float(xt.grad)
+        assert not numpy.isnan(ad), f"NaN grad for {name} ({backend})"
+        numpy.testing.assert_allclose(
+            ad, fd, rtol=1e-5, err_msg=f"{name} grad ({backend})"
+        )
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+def test_jax_native_hyp2f1_hyp1f1_are_unreliable():
+    # Tripwire / justification for _NATIVE_UNRELIABLE: jax's native hyp2f1 and
+    # hyp1f1 are catastrophically wrong for z < -1 (galpy's regime). If this
+    # ever starts PASSING (jax fixed them), move them to native in the router.
+    import jax.scipy.special as jsp
+
+    z = jnp.asarray(-50.0)
+    bad2 = float(jsp.hyp2f1(2.0, 2.0, 3.0, z))
+    ref2 = float(scipy_special.hyp2f1(2.0, 2.0, 3.0, -50.0))
+    bad1 = float(jsp.hyp1f1(1.5, 2.5, jnp.asarray(-64.0)))
+    ref1 = float(scipy_special.hyp1f1(1.5, 2.5, -64.0))
+    assert not numpy.isfinite(bad2) or abs(bad2 - ref2) > 1e-3 * abs(ref2), (
+        "jax native hyp2f1 now accurate for z<-1; route it natively in the router"
+    )
+    assert abs(bad1 - ref1) > 1e-3 * abs(ref1), (
+        "jax native hyp1f1 now accurate for z<-1; route it natively in the router"
+    )
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)


### PR DESCRIPTION
## Summary

The **Pspecial** native-preferring special-function router at `galpy.backend.special`. Each function dispatches, by the namespace of its array arguments, to the backend's **native** implementation when it is present *and reliable* (`scipy.special` for numpy, `jax.scipy.special` for jax, `torch.special` for torch) and otherwise to a pure-backend, autodiff-friendly **fallback** in `_fallback/`.

This keeps the **numpy path byte-identical** to `scipy.special`, lets jax/torch use their fast native kernels where they are correct, and is the foundation that makes galpy's special-function-backed methods (Einasto, PowerSphericalwCutoff, TwoPowerSpherical, the disk potentials, SCF/Multipole, spherical DFs, …) run and differentiate under every backend.

## Tier 1 — native-routable
`gammaln, gamma, gammainc, gammaincc, erf, erfc, i0, i1, xlogy`. Only **torch lacks `gamma`** natively, supplied by a single `gamma_fallback` (from the native `gammaln` with dead-branch guards so the poles can't NaN-poison gradients).

## Tier 2 — pure-backend force-unblockers
- **`ellipk`, `ellipe`** (complete elliptic integrals, scipy parameter-`m` convention) via the **arithmetic-geometric mean** — ~1e-15 vs scipy, fully AD-friendly. Native on neither jax nor torch. Unblocks `RingPotential`, `AnyAxisymmetricRazorThinDiskPotential`.
- **`hyp2f1(a,b;c;z)`** on galpy's real `z≤0` domain via **Euler's integral + a boundary-layer substitution + an endpoint-regularizing map**, evaluated by 128-pt Gauss–Legendre. ~1e-13 at realistic radii (`r/a≲50`), degrading gracefully to ~1e-6 at `r/a~500`, never diverging. Unblocks the **TwoPowerSpherical** (NFW/Hernquist/Jaffe/Dehnen) force/eval/mass paths and `PowerSphericalPotential._surfdens`.
- **`hyp1f1(a,b;z)`** on `z≤0`; galpy's `b=a+1` case has the **exact** closed form `a·X⁻ᵃ·Γ(a)·P(a,X)` via the (native-everywhere) regularized incomplete gamma. Unblocks `PowerSphericalwCutoff._mass`.

### Why jax's native `hyp2f1`/`hyp1f1` are *not* used
Both are **catastrophically wrong for `z<-1`** (return `±inf` with NaN gradients) — exactly galpy's regime (`z=-r/a`, `-(R/rc)²`). The router marks them `_NATIVE_UNRELIABLE` and forces the fallback; **tripwire tests** document the breakage so they auto-promote to native if jax fixes them.

## Router design
`_NEEDS_FALLBACK = _NATIVE_MISSING` (function absent) `| _NATIVE_UNRELIABLE` (present but too inaccurate on galpy's domain). A capability test pins `_NATIVE_MISSING` to reality (`hasattr`) so a fallback is deleted the moment a backend ships a correct native version. Shared fixed-order Gauss–Legendre nodes/weights live in `_fallback/_quadrature.py` (reused by later tiers + backend-agnostic quadrature).

## Tests — `tests/test_backend_special.py`
Value parity numpy (**byte-identical**) / jax / torch vs `scipy.special` (tight at realistic radii, bounded-error at extreme `|z|`), AD-vs-FD, the jax-native-unreliable tripwires, the capability test, and `jit`/`vmap`/`jacfwd==jacrev` survival. Auto-covered by the existing backend CI job (`TEST_FILES: tests/test_backend*.py`) under both jax and torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)