### PR TITLE
Pspecial Tiers 3-4: Bessel K + associated Legendre + Gegenbauer

### DIFF
--- a/galpy/backend/special/__init__.py
+++ b/galpy/backend/special/__init__.py
@@ -25,6 +25,9 @@ from ._router import (
     hyp2f1,
     i0,
     i1,
+    k0,
+    k1,
+    kn,
     xlogy,
 )
 
@@ -42,4 +45,7 @@ __all__ = [
     "hyp1f1",
     "ellipk",
     "ellipe",
+    "k0",
+    "k1",
+    "kn",
 ]

--- a/galpy/backend/special/__init__.py
+++ b/galpy/backend/special/__init__.py
@@ -13,6 +13,7 @@
 #   capability test asserts native-vs-fallback agreement so it can be deleted).
 ###############################################################################
 from ._router import (
+    assoc_legendre,
     ellipe,
     ellipk,
     erf,
@@ -21,6 +22,7 @@ from ._router import (
     gammainc,
     gammaincc,
     gammaln,
+    gegenbauer,
     hyp1f1,
     hyp2f1,
     i0,
@@ -48,4 +50,6 @@ __all__ = [
     "k0",
     "k1",
     "kn",
+    "assoc_legendre",
+    "gegenbauer",
 ]

--- a/galpy/backend/special/_fallback/assoc_legendre.py
+++ b/galpy/backend/special/_fallback/assoc_legendre.py
@@ -1,0 +1,75 @@
+###############################################################################
+#   Backend-agnostic associated Legendre functions P_l^m(x) for all degrees
+#   l < L and orders 0 <= m < M, with the Condon-Shortley phase (matching
+#   scipy.special.assoc_legendre_p_all(..., branch_cut=2)). Replaces
+#   galpy.util.special.compute_legendre on the SCF / MultipoleExpansion path so
+#   those potentials run and differentiate under every backend.
+#
+#   P is built by the standard forward (Bonnet) recurrences:
+#     P_m^m   = (-1)^m (2m-1)!! (1-x^2)^{m/2}
+#     P_{m+1}^m = x (2m+1) P_m^m
+#     (l-m) P_l^m = x (2l-1) P_{l-1}^m - (l+m-1) P_{l-2}^m
+#   The optional first/second x-derivatives use
+#     (x^2-1) dP/dx = l x P_l^m - (l+m) P_{l-1}^m
+#     (1-x^2) d2P/dx^2 = 2x dP/dx - l(l+1) P + m^2/(1-x^2) P   (Legendre ODE)
+#   (these diverge at the poles x=+-1 for m>=1, exactly as scipy returns, and are
+#   multiplied by sin^2(theta) in the physical theta-derivatives downstream).
+#
+#   Everything is pure arithmetic built with lists + xp.stack (no in-place
+#   mutation), so it differentiates cleanly under jax and torch -- and the
+#   x-derivatives are also available straight from autodiff.
+###############################################################################
+
+
+def assoc_legendre(xp, L, M, x, deriv=0):
+    """P_l^m(x), shape ``x.shape + (L, M)`` (Condon-Shortley phase).
+
+    deriv: 0 -> P; 1 -> (P, dP/dx); 2 -> (P, dP/dx, d2P/dx2).
+    L, M are static ints; x is a backend array (or scalar) with |x| <= 1.
+    """
+    x = xp.asarray(x) * 1.0
+    one = xp.ones_like(x)
+    zero = xp.zeros_like(x)
+    # (1-x^2)^{1/2}; clip keeps it real at |x|=1 (interior x is unaffected).
+    somx2 = xp.sqrt(xp.where(x * x < 1.0, 1.0 - x * x, zero))
+
+    # P[l][m] as a list-of-lists of backend arrays (functional, no mutation).
+    P = [[zero for _ in range(M)] for _ in range(L)]
+    pmm = one  # running P_m^m diagonal
+    for m in range(M):
+        if m > 0:
+            pmm = pmm * (-(2 * m - 1)) * somx2
+        if m < L:
+            P[m][m] = pmm
+        if m + 1 < L:
+            P[m + 1][m] = x * (2 * m + 1) * pmm
+        for l in range(m + 2, L):
+            P[l][m] = (x * (2 * l - 1) * P[l - 1][m] - (l + m - 1) * P[l - 2][m]) / (
+                l - m
+            )
+
+    def _stack(grid):
+        return xp.stack([xp.stack(row, axis=-1) for row in grid], axis=-2)
+
+    Parr = _stack(P)
+    if deriv == 0:
+        return Parr
+
+    den = x * x - 1.0  # (x^2-1); singular only at the poles
+    dP = [[zero for _ in range(M)] for _ in range(L)]
+    for m in range(M):
+        for l in range(m, L):
+            plm1 = P[l - 1][m] if l - 1 >= m else zero
+            dP[l][m] = (l * x * P[l][m] - (l + m) * plm1) / den
+    dParr = _stack(dP)
+    if deriv == 1:
+        return Parr, dParr
+
+    om = 1.0 - x * x
+    d2 = [[zero for _ in range(M)] for _ in range(L)]
+    for m in range(M):
+        for l in range(m, L):
+            d2[l][m] = (
+                2.0 * x * dP[l][m] - l * (l + 1) * P[l][m] + (m * m) / om * P[l][m]
+            ) / om
+    return Parr, dParr, _stack(d2)

--- a/galpy/backend/special/_fallback/bessel_k.py
+++ b/galpy/backend/special/_fallback/bessel_k.py
@@ -1,0 +1,99 @@
+###############################################################################
+#   Fallbacks for the modified Bessel functions of the second kind K0, K1, Kn
+#   on real x > 0. Needed on BOTH jax and torch:
+#     - jax.scipy.special has no k0/k1/kn at all;
+#     - torch.special has modified_bessel_k0/k1 but they are NOT differentiable
+#       (no autograd backward) and lack kn entirely, so we use the fallback there
+#       too (the router sees no torch.special.k0 attribute -> treats it missing).
+#
+#   K0, K1 (``_k01``) use two regimes, each ~1e-15 vs scipy and AD-friendly:
+#     - x <= 2: the Abramowitz & Stegun ascending series (9.6.13/9.6.11), built
+#       on the native i0/i1 (Tier 1) plus elementary terms;
+#     - x  > 2: the trapezoidal rule on K_nu(x) = int_0^inf e^{-x cosh t}
+#       cosh(nu t) dt. The integrand is double-exponentially decaying, so the
+#       trapezoidal rule converges geometrically; its e^{-x(cosh t-1)} peak has
+#       width ~1/sqrt(x), so the nodes are scaled by 1/sqrt(x) to resolve it
+#       uniformly for all large x.
+#   Each branch's argument is clamped into its valid region wherever the OTHER
+#   branch is selected, so the unused branch cannot overflow (i0 at large x) or
+#   NaN-poison reverse-mode gradients.
+#
+#   Kn (``kn_fallback``) uses the upward recurrence K_{m+1}=K_{m-1}+(2m/x)K_m
+#   from K0, K1 -- the stable direction for K.
+###############################################################################
+import numpy
+
+_GAMMA = 0.5772156649015328606  # Euler-Mascheroni
+_NSERIES = 30  # ascending-series terms (x <= 2)
+_TRAP_H = 0.25  # trapezoidal step (in the 1/sqrt(x)-scaled variable)
+_TRAP_N = 64  # trapezoidal nodes
+# node positions i*h and weights (h/2 at the endpoint i=0), as numpy constants
+_TRAP_NODES = numpy.arange(_TRAP_N + 1) * _TRAP_H
+_TRAP_W = numpy.full(_TRAP_N + 1, _TRAP_H)
+_TRAP_W[0] = _TRAP_H / 2.0
+
+
+def _k01(xp, x):
+    """Return (K0(x), K1(x)) for real x > 0, ~1e-15 vs scipy, AD-friendly."""
+    x = xp.asarray(x) * 1.0
+    inside = x <= 2.0
+    # Clamp the dead region of each branch into its valid domain.
+    xs = xp.where(inside, x, xp.ones_like(x))  # series branch (x<=2)
+    xt = xp.where(inside, 2.0 * xp.ones_like(x), x)  # trapezoid branch (x>2)
+
+    # --- ascending series (x <= 2), via native i0/i1 ---
+    from .._router import i0, i1
+
+    x2 = xs * xs / 4.0
+    K0s = -(xp.log(xs / 2.0) + _GAMMA) * i0(xs)
+    term = xp.ones_like(xs)
+    harm = 0.0
+    for k in range(1, _NSERIES):
+        harm += 1.0 / k
+        term = term * x2 / (k * k)
+        K0s = K0s + term * harm
+    s1 = xp.zeros_like(xs)
+    term = xp.ones_like(xs)
+    hk = 0.0
+    for k in range(0, _NSERIES):
+        hk1 = hk + 1.0 / (k + 1)
+        s1 = s1 + term * ((hk + hk1) / 2.0 - _GAMMA)
+        term = term * x2 / ((k + 1) * (k + 2))
+        hk = hk1
+    K1s = 1.0 / xs + xp.log(xs / 2.0) * i1(xs) - (xs / 2.0) * s1
+
+    # --- peak-resolving scaled trapezoidal (x > 2) ---
+    nodes = xp.asarray(_TRAP_NODES)
+    weights = xp.asarray(_TRAP_W)
+    sc = 1.0 / xp.sqrt(xt)
+    t = sc[..., None] * nodes  # (..., N+1)
+    cosh_t = xp.cosh(t)
+    e = xp.exp(-xt[..., None] * cosh_t) * weights
+    K0t = xp.sum(e, axis=-1) * sc
+    K1t = xp.sum(e * cosh_t, axis=-1) * sc
+
+    return xp.where(inside, K0s, K0t), xp.where(inside, K1s, K1t)
+
+
+def k0_fallback(xp, x):
+    """Modified Bessel function of the second kind, order 0."""
+    return _k01(xp, x)[0]
+
+
+def k1_fallback(xp, x):
+    """Modified Bessel function of the second kind, order 1."""
+    return _k01(xp, x)[1]
+
+
+def kn_fallback(xp, n, x):
+    """Integer-order K_n(x) via the stable upward recurrence from K0, K1."""
+    n = int(n)
+    km1, k = _k01(xp, x)  # K0, K1
+    if n == 0:
+        return km1
+    if n == 1:
+        return k
+    x = xp.asarray(x) * 1.0
+    for m in range(1, n):
+        km1, k = k, km1 + (2.0 * m / x) * k
+    return k

--- a/galpy/backend/special/_fallback/gegenbauer.py
+++ b/galpy/backend/special/_fallback/gegenbauer.py
@@ -1,0 +1,30 @@
+###############################################################################
+#   Backend-agnostic Gegenbauer (ultraspherical) polynomials C_n^alpha(x) for
+#   0 <= n < N, via the standard three-term recurrence
+#       C_0 = 1,  C_1 = 2 alpha x,
+#       (n+1) C_{n+1} = 2(n+alpha) x C_n - (n+2 alpha-1) C_{n-1}.
+#   This is the SCFPotential radial basis (galpy.potential.SCFPotential._C uses
+#   the same recurrence with alpha = 2l + 3/2). Built with lists + xp.stack (no
+#   in-place mutation), so it differentiates under jax and torch; the numpy path
+#   reproduces SCF's existing recurrence value-for-value.
+###############################################################################
+
+
+def gegenbauer(xp, N, alpha, x):
+    """C_n^alpha(x) for 0 <= n < N, shape ``x.shape + (N,)``.
+
+    N is a static int, alpha a scalar, x a backend array (or scalar).
+    """
+    x = xp.asarray(x) * 1.0
+    cols = [xp.ones_like(x)]  # C_0 = 1
+    if N > 1:
+        cnm1 = cols[0]
+        cn = 2.0 * alpha * x  # C_1 = 2 alpha x
+        cols.append(cn)
+        for n in range(1, N - 1):
+            cnp1 = (2.0 * (n + alpha) * x * cn - (n + 2.0 * alpha - 1.0) * cnm1) / (
+                n + 1.0
+            )
+            cols.append(cnp1)
+            cnm1, cn = cn, cnp1
+    return xp.stack(cols, axis=-1)

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -175,6 +175,46 @@ def kn(n, x):
     return _dispatch("kn", (n, x), kn_fallback, ns_args=(x,))
 
 
+# --- Tier 4: associated Legendre P_l^m (SCF / MultipoleExpansion) -------------
+def _scipy_assoc_legendre(L, M, x, deriv):
+    """numpy path: scipy.special.assoc_legendre_p_all reshaped to (...,L,M),
+    byte-identical to scipy (the convention used by util.special.compute_legendre)."""
+    import scipy.special as sp
+
+    arr = numpy.asarray(
+        sp.assoc_legendre_p_all(
+            L - 1, M - 1, numpy.asarray(x, dtype=float), branch_cut=2, diff_n=deriv
+        )
+    )  # (deriv+1, L, 2M-1, *x.shape)  -- m=0..M-1 are the first M columns
+    out = numpy.moveaxis(arr[:, :, :M], (1, 2), (-2, -1))  # (deriv+1, *x.shape, L, M)
+    return out[0] if deriv == 0 else tuple(out[i] for i in range(deriv + 1))
+
+
+def assoc_legendre(L, M, x, deriv=0):
+    """P_l^m(x) for 0<=l<L, 0<=m<M (Condon-Shortley phase), shape x.shape+(L,M).
+
+    deriv: 0 -> P; 1 -> (P, dP/dx); 2 -> (P, dP/dx, d2P/dx2). numpy routes to
+    scipy (byte-identical); jax/torch use the pure-backend Bonnet recurrence.
+    """
+    name, _ = _backend_special(get_namespace(x))
+    if name == "numpy":
+        return _scipy_assoc_legendre(L, M, x, deriv)
+    from ._fallback.assoc_legendre import assoc_legendre as _fb
+
+    return _fb(get_namespace(x), L, M, x, deriv)
+
+
+def gegenbauer(N, alpha, x):
+    """Gegenbauer polynomials C_n^alpha(x) for 0<=n<N, shape x.shape+(N,).
+
+    N static int, alpha scalar, x a backend array. Uses the three-term
+    recurrence on every backend (galpy's SCF radial basis never used a scipy
+    Gegenbauer, so there is no native to prefer)."""
+    from ._fallback.gegenbauer import gegenbauer as _fb
+
+    return _fb(get_namespace(x), N, alpha, x)
+
+
 def xlogy(x, y):
     # x * log(y), with the scipy/native convention 0 * log(0) = 0.
     from ._fallback.xlogy import xlogy_fallback

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -12,10 +12,13 @@ from .._resolver import get_namespace
 # (hasattr on the backend's special module), so entries are removed as backends
 # add the native version. (numpy always has the full scipy.special.)
 _NATIVE_MISSING = {
-    "jax": frozenset(("ellipk", "ellipe")),
+    "jax": frozenset(("ellipk", "ellipe", "k0", "k1", "kn")),
+    # torch.special lacks all of these. (It does have modified_bessel_k0/k1, but
+    # they are NOT differentiable -- no autograd backward -- and there is no kn,
+    # so the k0/k1/kn fallbacks are used; the router sees no torch.special.k0.)
     "torch": frozenset(
-        ("gamma", "ellipk", "ellipe", "hyp2f1", "hyp1f1")
-    ),  # torch.special lacks all of these
+        ("gamma", "ellipk", "ellipe", "hyp2f1", "hyp1f1", "k0", "k1", "kn")
+    ),
 }
 
 # Functions whose native implementation EXISTS but is too inaccurate on galpy's
@@ -150,6 +153,26 @@ def ellipe(m):
     from ._fallback.elliptic import ellipe_fallback
 
     return _dispatch("ellipe", (m,), ellipe_fallback)
+
+
+# --- Tier 3: modified Bessel functions of the second kind (disk force paths) --
+def k0(x):
+    from ._fallback.bessel_k import k0_fallback
+
+    return _dispatch("k0", (x,), k0_fallback)
+
+
+def k1(x):
+    from ._fallback.bessel_k import k1_fallback
+
+    return _dispatch("k1", (x,), k1_fallback)
+
+
+def kn(n, x):
+    # Integer-order modified Bessel K_n; only the array arg x carries the namespace.
+    from ._fallback.bessel_k import kn_fallback
+
+    return _dispatch("kn", (n, x), kn_fallback, ns_args=(x,))
 
 
 def xlogy(x, y):

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -348,9 +348,10 @@ def test_bessel_k_value_parity(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_bessel_kn_value_parity(backend):
-    # kn via the upward recurrence from k0, k1 (galpy uses kn(2, .)).
+    # kn via the upward recurrence from k0, k1 (galpy uses kn(2, .)). n=0,1
+    # exercise the recurrence base cases (kn_fallback short-circuits to K0/K1).
     x = _BESSEL_X
-    for n in (2, 3, 5):
+    for n in (0, 1, 2, 3, 5):
         ref = scipy_special.kn(n, x)
         got = _tonumpy(gsp.kn(n, _asarray(backend, x)))
         rtol = 0.0 if backend == "numpy" else 1e-11  # recurrence amplifies a touch

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -130,7 +130,7 @@ def test_fallback_table_matches_installed_backends():
     # present, else there is nothing to override).
     tier12 = [
         "gammaln", "gamma", "gammainc", "gammaincc", "erf", "erfc", "i0", "i1",
-        "hyp2f1", "hyp1f1", "ellipk", "ellipe",
+        "hyp2f1", "hyp1f1", "ellipk", "ellipe", "k0", "k1", "kn",
     ]  # fmt: skip
     for backend in AD_BACKENDS:
         xp = _asarray(backend, 1.0)
@@ -326,3 +326,67 @@ def test_fallback_unsupported_regimes_raise():
     # 1F1 only implements b = a + 1
     with pytest.raises(NotImplementedError):
         hyp1f1_fallback(numpy, 1.0, 3.0, numpy.array([-1.0]))
+
+
+# --- Tier 3: modified Bessel functions of the second kind (k0, k1, kn) --------
+# RazorThinExponentialDisk forces use k0/k1/kn(2,.) on real x > 0.
+_BESSEL_X = numpy.array([0.01, 0.1, 0.5, 1.0, 2.0, 3.0, 7.0, 20.0, 80.0, 300.0])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_bessel_k_value_parity(backend):
+    x = _BESSEL_X
+    for name, fn, sp_fn in [
+        ("k0", gsp.k0, scipy_special.k0),
+        ("k1", gsp.k1, scipy_special.k1),
+    ]:
+        ref = sp_fn(x)
+        got = _tonumpy(fn(_asarray(backend, x)))
+        rtol = 0.0 if backend == "numpy" else 1e-12  # series + scaled-trapezoid
+        numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13, err_msg=name)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_bessel_kn_value_parity(backend):
+    # kn via the upward recurrence from k0, k1 (galpy uses kn(2, .)).
+    x = _BESSEL_X
+    for n in (2, 3, 5):
+        ref = scipy_special.kn(n, x)
+        got = _tonumpy(gsp.kn(n, _asarray(backend, x)))
+        rtol = 0.0 if backend == "numpy" else 1e-11  # recurrence amplifies a touch
+        numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13, err_msg=f"kn{n}")
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_bessel_k_grad_vs_fd(backend):
+    # K0'(x) = -K1(x); K1'(x) = -K0(x) - K1(x)/x. Check AD vs central FD on both
+    # the series (x<2) and the scaled-trapezoid (x>2) branches.
+    eps = 1e-6
+    for name, fn, sp_fn in [
+        ("k0", gsp.k0, scipy_special.k0),
+        ("k1", gsp.k1, scipy_special.k1),
+    ]:
+        for x0 in (0.7, 1.5, 4.0, 25.0):
+            fd = (float(sp_fn(x0 + eps)) - float(sp_fn(x0 - eps))) / (2 * eps)
+            if backend == "jax":
+                ad = float(jax.grad(lambda xx: fn(xx))(jnp.asarray(x0)))
+            else:
+                xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+                fn(xt).backward()
+                ad = float(xt.grad)
+            assert not numpy.isnan(ad), f"NaN grad for {name} at x={x0} ({backend})"
+            numpy.testing.assert_allclose(
+                ad, fd, rtol=1e-5, err_msg=f"{name} grad at x={x0} ({backend})"
+            )
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="needs torch")
+def test_torch_native_bessel_k_is_nondifferentiable():
+    # Tripwire / justification for using the fallback on torch: torch.special has
+    # modified_bessel_k0/k1 (accurate) but they have no autograd backward.
+    xt = torch.tensor(2.5, dtype=torch.float64, requires_grad=True)
+    out = torch.special.modified_bessel_k0(xt)
+    assert not out.requires_grad, (
+        "torch.special.modified_bessel_k0 is now differentiable; it can be routed "
+        "natively (with a k0/k1 name alias) instead of via the fallback"
+    )

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -390,3 +390,100 @@ def test_torch_native_bessel_k_is_nondifferentiable():
         "torch.special.modified_bessel_k0 is now differentiable; it can be routed "
         "natively (with a k0/k1 name alias) instead of via the fallback"
     )
+
+
+# --- Tier 4a: associated Legendre P_l^m (SCF / MultipoleExpansion) -------------
+def _scipy_assoc_ref(L, M, x, deriv):
+    arr = numpy.asarray(
+        scipy_special.assoc_legendre_p_all(
+            L - 1, M - 1, numpy.asarray(x, dtype=float), branch_cut=2, diff_n=deriv
+        )
+    )
+    return numpy.moveaxis(arr[:, :, :M], (1, 2), (-2, -1))  # (deriv+1, *x.shape, L, M)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_assoc_legendre_value_parity(backend):
+    L, M = 7, 5
+    x = numpy.array([0.2, 0.5, -0.6, 0.9, -0.95])  # cos(theta), |x| < 1
+    ref = _scipy_assoc_ref(L, M, x, 2)  # P, dP/dx, d2P/dx2
+    P, dP, d2 = gsp.assoc_legendre(L, M, _asarray(backend, x), deriv=2)
+    if backend == "numpy":  # numpy must be byte-identical to scipy
+        assert numpy.array_equal(_tonumpy(P), ref[0])
+        assert numpy.array_equal(_tonumpy(dP), ref[1])
+        assert numpy.array_equal(_tonumpy(d2), ref[2])
+    else:
+        for got, r, nm in [(P, ref[0], "P"), (dP, ref[1], "dP"), (d2, ref[2], "d2P")]:
+            numpy.testing.assert_allclose(
+                _tonumpy(got), r, rtol=1e-11, atol=1e-11, err_msg=nm
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_assoc_legendre_value_only_and_shape(backend):
+    L, M = 5, 3
+    x = numpy.array([0.3, -0.4])
+    P = gsp.assoc_legendre(L, M, _asarray(backend, x))  # deriv=0 -> just P
+    assert tuple(_tonumpy(P).shape) == (2, L, M)
+    numpy.testing.assert_allclose(
+        _tonumpy(P), _scipy_assoc_ref(L, M, x, 0)[0], rtol=1e-11, atol=1e-11
+    )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_assoc_legendre_autodiff_matches_analytic(backend):
+    # d/dx of P_l^m via autodiff must match the analytically-returned dP/dx.
+    L, M = 6, 4
+    x0 = 0.4
+    _, dP_an = gsp.assoc_legendre(L, M, _asarray(backend, x0), deriv=1)
+    dP_an = _tonumpy(dP_an)
+    for ll, mm in [(3, 2), (5, 1), (4, 0), (5, 3)]:
+        if backend == "jax":
+            g = float(
+                jax.grad(lambda xx: gsp.assoc_legendre(L, M, xx)[ll, mm])(
+                    jnp.asarray(x0)
+                )
+            )
+        else:
+            xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+            gsp.assoc_legendre(L, M, xt)[ll, mm].backward()
+            g = float(xt.grad)
+        numpy.testing.assert_allclose(
+            g, dP_an[ll, mm], rtol=1e-6, err_msg=f"P_{ll}^{mm}"
+        )
+
+
+# --- Tier 4b: Gegenbauer C_n^alpha (SCF radial basis) -------------------------
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_gegenbauer_value_parity(backend):
+    N = 8
+    x = numpy.array([-0.9, -0.3, 0.0, 0.4, 0.95])
+    for alpha in (1.5, 3.5, 2 * 3 + 1.5):  # SCF uses alpha = 2l + 3/2
+        got = _tonumpy(gsp.gegenbauer(N, alpha, _asarray(backend, x)))
+        assert got.shape == x.shape + (N,)
+        for n in range(N):
+            ref = scipy_special.eval_gegenbauer(n, alpha, x)
+            numpy.testing.assert_allclose(
+                got[..., n], ref, rtol=1e-11, atol=1e-12, err_msg=f"C_{n}^{alpha}"
+            )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_gegenbauer_grad_vs_fd(backend):
+    # d/dx C_n^alpha(x) = 2 alpha C_{n-1}^{alpha+1}(x); check AD vs central FD.
+    N, alpha, x0 = 6, 2.5, 0.4
+    eps = 1e-6
+    n = 4
+    fd = (
+        float(scipy_special.eval_gegenbauer(n, alpha, x0 + eps))
+        - float(scipy_special.eval_gegenbauer(n, alpha, x0 - eps))
+    ) / (2 * eps)
+    if backend == "jax":
+        ad = float(
+            jax.grad(lambda xx: gsp.gegenbauer(N, alpha, xx)[n])(jnp.asarray(x0))
+        )
+    else:
+        xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        gsp.gegenbauer(N, alpha, xt)[n].backward()
+        ad = float(xt.grad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)


### PR DESCRIPTION
## Summary

Tiers 3 and 4 of the Pspecial special-function router (follows #916, into `feat/backends`).

### Tier 3 — modified Bessel functions of the second kind (`k0`, `k1`, `kn`)
Unblocks `RazorThinExponentialDiskPotential` forces. Native on neither backend (`jax.scipy.special` has none; `torch.special` has `modified_bessel_k0/k1` but they are **not differentiable** and there is no `kn`), so the fallback is used on both; a tripwire test pins the torch non-differentiability.
- `k0`/`k1` (~1e-15 vs scipy): A&S ascending series (on native `i0`/`i1`) for `x≤2`; trapezoidal rule on `K_ν(x)=∫₀^∞ e^{−x cosh t}cosh(νt)dt` for `x>2`, with nodes **scaled by 1/√x** to resolve the narrowing peak uniformly. Dead-branch-guarded.
- `kn`: stable upward recurrence from K0, K1.

### Tier 4 — associated Legendre + Gegenbauer (SCF / MultipoleExpansion)
- `assoc_legendre(L, M, x[, deriv])`: `P_l^m(x)` (Condon-Shortley phase) + optional 1st/2nd `x`-derivatives, matching `scipy.special.assoc_legendre_p_all(branch_cut=2)` — the function behind `util.special.compute_legendre`. **numpy routes to scipy (byte-identical)**; jax/torch use the forward (Bonnet) recurrences built with lists + `xp.stack` (no in-place mutation, so they differentiate; a test pins `AD == analytic derivative`).
- `gegenbauer(N, alpha, x)`: `C_n^α(x)` via the three-term recurrence — the SCF radial basis (`SCF._C` uses the same recurrence; galpy never used a scipy Gegenbauer, so the recurrence runs on every backend and reproduces SCF's values).

`sici` (the remaining Tier-4 function) is used only by `FDMDynamicalFrictionForce` and will land with the dissipative-force migration where it's consumed.

## Tests
106 in `test_backend_special.py`: value parity numpy (**byte-identical** where a scipy equivalent exists) / jax / torch vs scipy; AD-vs-FD and AD-vs-analytic-derivative; the torch-Bessel-non-differentiable tripwire; jit/vmap/jacfwd==jacrev survival. Auto-covered by the backend CI job under jax+torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)