### PR TITLE
Pvar-pot: 3D variational Hessian in C for the SCF/Multipole harmonic + disk family

### DIFF
--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -715,7 +715,10 @@ def _parse_scf_pot(p, extra_amp=1.0):
     pot_args.extend(extra_amp * p._amp * p._Acos.flatten(order="C"))
     if isNonAxi:
         pot_args.extend(extra_amp * p._amp * p._Asin.flatten(order="C"))
-    pot_args.extend([-1.0, 0, 0, 0, 0, 0, 0])
+    # Cache slots: cached_type(1) + cached_coords(3) + cached_values(6). Six
+    # value slots so the full 3D Hessian (R2/z2/Rz/phi2/Rphi/zphi deriv) can be
+    # cached in one go, as well as the 3-component force/2nd-deriv results.
+    pot_args.extend([-1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     return (24, pot_args, [])  # latter is pot_tfuncs
 
 

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -456,6 +456,11 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &DiskSCFPotentialzforce;
       potentialArgs->dens= &DiskSCFPotentialDens;
       potentialArgs->phitorque= &ZeroForce;
+      potentialArgs->R2deriv= &DiskSCFPotentialR2deriv;
+      potentialArgs->z2deriv= &DiskSCFPotentialz2deriv;
+      potentialArgs->Rzderiv= &DiskSCFPotentialRzderiv;
+      // phi2deriv/Rphideriv/zphideriv are identically zero (axisymmetric) ->
+      // left NULL, the 3D Hessian aggregators skip them.
       potentialArgs->nargs= (int) **pot_args + 3;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -431,7 +431,13 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &SCFPotentialzforce;
       potentialArgs->phitorque= &SCFPotentialphitorque;
       potentialArgs->dens= &SCFPotentialDens;
-      potentialArgs->nargs= (int) (5 + (1 + *(*pot_args + 1)) * *(*pot_args+2) * *(*pot_args+3)* *(*pot_args+4) + 7);
+      potentialArgs->R2deriv= &SCFPotentialR2deriv;
+      potentialArgs->z2deriv= &SCFPotentialz2deriv;
+      potentialArgs->Rzderiv= &SCFPotentialRzderiv;
+      potentialArgs->phi2deriv= &SCFPotentialphi2deriv;
+      potentialArgs->Rphideriv= &SCFPotentialRphideriv;
+      potentialArgs->zphideriv= &SCFPotentialzphideriv;
+      potentialArgs->nargs= (int) (5 + (1 + *(*pot_args + 1)) * *(*pot_args+2) * *(*pot_args+3)* *(*pot_args+4) + 10);
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
@@ -703,6 +709,12 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->zforce= &MultipoleExpansionPotentialzforce;
       potentialArgs->phitorque= &MultipoleExpansionPotentialphitorque;
       potentialArgs->dens= &MultipoleExpansionPotentialDens;
+      potentialArgs->R2deriv= &MultipoleExpansionPotentialR2deriv;
+      potentialArgs->z2deriv= &MultipoleExpansionPotentialz2deriv;
+      potentialArgs->Rzderiv= &MultipoleExpansionPotentialRzderiv;
+      potentialArgs->phi2deriv= &MultipoleExpansionPotentialphi2deriv;
+      potentialArgs->Rphideriv= &MultipoleExpansionPotentialRphideriv;
+      potentialArgs->zphideriv= &MultipoleExpansionPotentialzphideriv;
       potentialArgs->nargs= 0; // arguments handled in the initialization code run for this potential
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -313,7 +313,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &SCFPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &SCFPotentialPlanarphi2deriv;
       potentialArgs->planarRphideriv= &SCFPotentialPlanarRphideriv;
-      potentialArgs->nargs= (int) (5 + (1 + *(*pot_args + 1)) * *(*pot_args+2) * *(*pot_args+3)* *(*pot_args+4) + 7);
+      potentialArgs->nargs= (int) (5 + (1 + *(*pot_args + 1)) * *(*pot_args+2) * *(*pot_args+3)* *(*pot_args+4) + 10);
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -89,6 +89,11 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         if self._Sigma_dict is not None and self._hz_dict is not None:
             self.hasC = True
             self.hasC_dens = True
+            # 3D variational (dxdv) integration is supported iff BOTH the
+            # analytic disk pairs (their full 3D Hessian is in C here) AND the
+            # expansion sub-potential self._me (SCF / MultipoleExpansion) have
+            # the full 3D Hessian in C.
+            self.hasC_dxdv3d = getattr(self._me, "hasC_dxdv3d", False)
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -279,6 +279,10 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
             self._2nd_deriv_cache_key = None
         self.hasC = True
         self.hasC_dxdv = True
+        # Full 3D Hessian (R2/z2/Rz/phi2/Rphi/zphi deriv) is implemented in C
+        # via the spherical-harmonic expansion, so 3D variational (dxdv)
+        # integration is supported.
+        self.hasC_dxdv3d = True
         self.hasC_dens = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -150,6 +150,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         self._cached_2nd_derivs = None
         self.hasC = True
         self.hasC_dxdv = True
+        # Full 3D Hessian (R2/z2/Rz/phi2/Rphi/zphi deriv) is implemented in C
+        # via the spherical-harmonic expansion, so 3D variational (dxdv)
+        # integration is supported.
+        self.hasC_dxdv3d = True
         self.hasC_dens = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/potential_c_ext/DiskSCFPotential.c
+++ b/galpy/potential/potential_c_ext/DiskSCFPotential.c
@@ -155,6 +155,52 @@ double DiskSCFPotentialzforce(double R,double Z, double phi,
   return -dSigmadR(r,Sigma_args) * Hz(Z,hz_args) * Z / r \
     -Sigma(r,Sigma_args) * dHzdz(Z,hz_args);
 }
+// Full 3D Hessian of a single approximation pair Phi(R,Z)=Sigma(r) Hz(Z),
+// r=sqrt(R^2+Z^2). The phi-derivatives are identically zero (axisymmetric), so
+// phi2deriv/Rphideriv/zphideriv are left NULL (the C aggregators skip them).
+// Uses Hz''(z) = hz(z) (the vertical density; 1D Poisson).
+double DiskSCFPotentialR2deriv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  int nsigma_args= (int) *args;
+  double * Sigma_args= args+1;
+  double * hz_args= args+1+nsigma_args;
+  double r= sqrt( R * R + Z * Z );
+  double r2= r * r;
+  double sp= dSigmadR(r,Sigma_args);
+  double spp= d2SigmadR2(r,Sigma_args);
+  return Hz(Z,hz_args) * ( spp * R * R / r2 + sp * Z * Z / r2 / r );
+}
+double DiskSCFPotentialz2deriv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  int nsigma_args= (int) *args;
+  double * Sigma_args= args+1;
+  double * hz_args= args+1+nsigma_args;
+  double r= sqrt( R * R + Z * Z );
+  double r2= r * r;
+  double sp= dSigmadR(r,Sigma_args);
+  double spp= d2SigmadR2(r,Sigma_args);
+  return Hz(Z,hz_args) * ( spp * Z * Z / r2 + sp * R * R / r2 / r )	\
+    + 2. * sp * Z / r * dHzdz(Z,hz_args)				\
+    + Sigma(r,Sigma_args) * hz(Z,hz_args);
+}
+double DiskSCFPotentialRzderiv(double R,double Z, double phi,
+			       double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  int nsigma_args= (int) *args;
+  double * Sigma_args= args+1;
+  double * hz_args= args+1+nsigma_args;
+  double r= sqrt( R * R + Z * Z );
+  double r2= r * r;
+  double sp= dSigmadR(r,Sigma_args);
+  double spp= d2SigmadR2(r,Sigma_args);
+  return Hz(Z,hz_args) * R * Z * ( spp / r2 - sp / r2 / r )		\
+    + sp * R / r * dHzdz(Z,hz_args);
+}
 double DiskSCFPotentialDens(double R,double Z, double phi,
 			    double t,
 			    struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/MultipoleExpansionPotential.c
+++ b/galpy/potential/potential_c_ext/MultipoleExpansionPotential.c
@@ -12,6 +12,7 @@
 // Cache tags for force/deriv caching
 #define MEP_CACHE_FORCE 1
 #define MEP_CACHE_DERIV 2
+#define MEP_CACHE_HESSIAN 3
 
 // PPoly order (quintic from BPoly.from_derivatives with 3 constraints)
 #define PPOLY_K 6
@@ -47,6 +48,7 @@ struct multipole_data {
     double cached_R, cached_Z, cached_phi;
     double cached_F[3];     // dPhi/dr, dPhi/dtheta, dPhi/dphi
     double cached_D[3];     // d2Phi/dr2, d2Phi/dphi2, d2Phi/drdphi
+    double cached_H[6];     // R2/z2/Rz/phi2/Rphi/zphi deriv (full 3D Hessian)
     int cache_valid;
     // Time-dependent fields (all NULL/0 for static)
     int Nt;                      // 0 = static
@@ -70,6 +72,8 @@ struct multipole_data {
     // (R, z) coordinates (costheta would differ, causing a race condition).
     double *P_buf;               // Psize doubles for P_l^m
     double *dP_buf;              // Psize doubles for dP_l^m/d(costheta)
+    double *dPth_buf;            // Psize doubles for dP_l^m/dtheta
+    double *d2Pth_buf;           // Psize doubles for d2P_l^m/dtheta2
 
 };
 
@@ -88,6 +92,8 @@ static void freeMultipoleData(void *data)
     if (d->rho_scratch) free(d->rho_scratch);
     if (d->P_buf) free(d->P_buf);
     if (d->dP_buf) free(d->dP_buf);
+    if (d->dPth_buf) free(d->dPth_buf);
+    if (d->d2Pth_buf) free(d->d2Pth_buf);
     free(d);
 }
 
@@ -383,6 +389,8 @@ void initMultipoleExpansionPotentialArgs(struct potentialArg *potentialArgs,
     // For forces/2nd derivs, we need both P and dP (2*Psize)
     d->P_buf = (double *)malloc(d->Psize * sizeof(double));
     d->dP_buf = (double *)malloc(d->Psize * sizeof(double));
+    d->dPth_buf = (double *)malloc(d->Psize * sizeof(double));
+    d->d2Pth_buf = (double *)malloc(d->Psize * sizeof(double));
 
 
     // Initialize caches
@@ -1236,6 +1244,231 @@ static void compute_multipole_spher_2nd_derivs(struct multipole_data *d,
     free(r_neg_lp1_arr);
     free(cos_m);
     free(sin_m);
+}
+
+// ============================================================================
+// Full 3D Hessian: the six cylindrical second derivatives, for 3D variational
+// (dxdv) integration. Mirrors SCFPotential: sum the full set of
+// spherical-coordinate potential derivatives (incl. the theta-derivatives of
+// the Legendre functions) then apply the exact spherical->cylindrical
+// chain-rule transform (R=r sin theta, z=r cos theta).
+// ============================================================================
+
+static void compute_multipole_hessian_cyl(struct multipole_data *d,
+                                           struct potentialArg *potentialArgs,
+                                           double R, double Z, double phi,
+                                           double t, double *H)
+{
+    // Check cache
+    if (d->cache_valid == MEP_CACHE_HESSIAN
+        && d->cached_R == R && d->cached_Z == Z
+        && d->cached_phi == phi && d->cached_t == t) {
+        for (int k = 0; k < 6; k++)
+            H[k] = d->cached_H[k];
+        return;
+    }
+
+    int L = d->L, M = d->M;
+    double r, theta;
+    cyl_to_spher(R, Z, &r, &theta);
+
+    if (r == 0.0 || !isfinite(r)) { // LCOV_EXCL_START
+        for (int k = 0; k < 6; k++)
+            H[k] = 0.0;
+        d->cache_valid = MEP_CACHE_HESSIAN;
+        d->cached_R = R; d->cached_Z = Z; d->cached_phi = phi; d->cached_t = t;
+        for (int k = 0; k < 6; k++)
+            d->cached_H[k] = 0.0;
+        return;
+    } // LCOV_EXCL_STOP
+
+    double costheta = cos(theta);
+    double *P = d->P_buf;
+    double *dPdx = d->dP_buf;
+    double *dPth = d->dPth_buf;
+    double *d2Pth = d->d2Pth_buf;
+    if (d->isNonAxi)
+        compute_legendre_deriv(costheta, L, M, P, dPdx);
+    else
+        compute_legendre_deriv(costheta, L, 1, P, dPdx);
+    legendre_theta_from_x(theta, L, d->isNonAxi ? M : 1, P, dPdx, dPth, d2Pth);
+
+    // Spherical-coordinate potential derivatives:
+    // S[0]=Phi_r S[1]=Phi_theta S[2]=Phi_rr S[3]=Phi_thetatheta
+    // S[4]=Phi_rtheta S[5]=Phi_phiphi S[6]=Phi_rphi S[7]=Phi_thetaphi
+    double S[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    int n_r = PPOLY_K * (d->Nr - 1);
+
+    double *r_l_arr = (double *)malloc(L * sizeof(double));
+    double *r_neg_lp1_arr = (double *)malloc(L * sizeof(double));
+    {
+        double rp = 1.0, rnp = 1.0 / r;
+        for (int ll = 0; ll < L; ll++) {
+            r_l_arr[ll] = rp; r_neg_lp1_arr[ll] = rnp;
+            rp *= r; rnp /= r;
+        }
+    }
+    double *cos_m = (double *)malloc(M * sizeof(double));
+    double *sin_m = (double *)malloc(M * sizeof(double));
+    cos_m[0] = 1.0; sin_m[0] = 0.0;
+    if (M > 1) {
+        double cp = cos(phi), sp = sin(phi);
+        cos_m[1] = cp; sin_m[1] = sp;
+        for (int mm = 2; mm < M; mm++) {
+            cos_m[mm] = 2.0 * cp * cos_m[mm - 1] - cos_m[mm - 2];
+            sin_m[mm] = 2.0 * cp * sin_m[mm - 1] - sin_m[mm - 2];
+        }
+    }
+
+    for (int l = 0; l < L; l++) {
+        int mmax = l + 1 < M ? l + 1 : M;
+        double r_l = r_l_arr[l], r_neg_lp1 = r_neg_lp1_arr[l];
+        for (int m = 0; m < mmax; m++) {
+            int pi = d->isNonAxi ? legendre_index(l, m, L) : l;
+            double cmf = cos_m[m], smf = sin_m[m];
+            double radc, dradc, d2radc;
+            if (d->Nt > 0) {
+                const double *tp_inner, *tp_outer;
+                get_time_ppoly_ptrs(d, l, m, 0, &tp_inner, &tp_outer);
+                radc = eval_radial_lm_timedep(tp_inner, tp_outer, n_r,
+                    d->rgrid, d->Nr, &d->last_interval, d->tgrid, d->Nt,
+                    &d->last_t_interval, r, t, l, d->rmin, d->rmax,
+                    r_l, r_neg_lp1, EVAL_DERIV2, &dradc, &d2radc);
+            } else {
+                const double *I_inner_pp, *I_outer_pp;
+                get_ppoly_ptrs(d, l, m, 0, &I_inner_pp, &I_outer_pp);
+                radc = eval_radial_lm(I_inner_pp, I_outer_pp, d->rgrid, d->Nr,
+                    &d->last_interval, r, l, d->rmin, d->rmax,
+                    r_l, r_neg_lp1, EVAL_DERIV2, &dradc, &d2radc);
+            }
+            // cos(m phi) angular block
+            S[0] += P[pi] * cmf * dradc;
+            S[1] += dPth[pi] * cmf * radc;
+            S[2] += P[pi] * cmf * d2radc;
+            S[3] += d2Pth[pi] * cmf * radc;
+            S[4] += dPth[pi] * cmf * dradc;
+            S[5] += P[pi] * (-m * m * cmf) * radc;
+            S[6] += P[pi] * (-m * smf) * dradc;
+            S[7] += dPth[pi] * (-m * smf) * radc;
+            if (m > 0) {
+                double rads, drads, d2rads;
+                if (d->Nt > 0) {
+                    const double *tp_inner, *tp_outer;
+                    get_time_ppoly_ptrs(d, l, m, 1, &tp_inner, &tp_outer);
+                    rads = eval_radial_lm_timedep(tp_inner, tp_outer, n_r,
+                        d->rgrid, d->Nr, &d->last_interval, d->tgrid, d->Nt,
+                        &d->last_t_interval, r, t, l, d->rmin, d->rmax,
+                        r_l, r_neg_lp1, EVAL_DERIV2, &drads, &d2rads);
+                } else {
+                    const double *I_inner_pp, *I_outer_pp;
+                    get_ppoly_ptrs(d, l, m, 1, &I_inner_pp, &I_outer_pp);
+                    rads = eval_radial_lm(I_inner_pp, I_outer_pp, d->rgrid, d->Nr,
+                        &d->last_interval, r, l, d->rmin, d->rmax,
+                        r_l, r_neg_lp1, EVAL_DERIV2, &drads, &d2rads);
+                }
+                // sin(m phi) angular block
+                S[0] += P[pi] * smf * drads;
+                S[1] += dPth[pi] * smf * rads;
+                S[2] += P[pi] * smf * d2rads;
+                S[3] += d2Pth[pi] * smf * rads;
+                S[4] += dPth[pi] * smf * drads;
+                S[5] += P[pi] * (-m * m * smf) * rads;
+                S[6] += P[pi] * (m * cmf) * drads;
+                S[7] += dPth[pi] * (m * cmf) * rads;
+            }
+        }
+    }
+    free(r_l_arr); free(r_neg_lp1_arr); free(cos_m); free(sin_m);
+
+    for (int k = 0; k < 8; k++)
+        S[k] *= d->amp;
+
+    double Phi_r = S[0], Phi_th = S[1];
+    double Phi_rr = S[2], Phi_thth = S[3], Phi_rth = S[4];
+    double Phi_phiphi = S[5], Phi_rphi = S[6], Phi_thphi = S[7];
+
+    // Spherical -> cylindrical chain rule
+    double ir = 1.0 / r, ir2 = 1.0 / (r * r), ir3 = ir2 * ir, ir4 = ir2 * ir2;
+    double rR = R * ir, rz = Z * ir;
+    double thR = Z * ir2, thz = -R * ir2;
+    double rRR = Z * Z * ir3, rzz = R * R * ir3, rRz = -R * Z * ir3;
+    double thRR = -2.0 * R * Z * ir4, thzz = 2.0 * R * Z * ir4,
+           thRz = (R * R - Z * Z) * ir4;
+
+    H[0] = Phi_rr * rR * rR + 2.0 * Phi_rth * rR * thR + Phi_thth * thR * thR
+           + Phi_r * rRR + Phi_th * thRR;
+    H[1] = Phi_rr * rz * rz + 2.0 * Phi_rth * rz * thz + Phi_thth * thz * thz
+           + Phi_r * rzz + Phi_th * thzz;
+    H[2] = Phi_rr * rR * rz + Phi_rth * (rR * thz + rz * thR)
+           + Phi_thth * thR * thz + Phi_r * rRz + Phi_th * thRz;
+    H[3] = Phi_phiphi;
+    H[4] = Phi_rphi * rR + Phi_thphi * thR;
+    H[5] = Phi_rphi * rz + Phi_thphi * thz;
+
+    d->cache_valid = MEP_CACHE_HESSIAN;
+    d->cached_R = R; d->cached_Z = Z; d->cached_phi = phi; d->cached_t = t;
+    for (int k = 0; k < 6; k++)
+        d->cached_H[k] = H[k];
+}
+
+double MultipoleExpansionPotentialR2deriv(double R, double Z, double phi, double t,
+                                          struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[0];
+}
+
+double MultipoleExpansionPotentialz2deriv(double R, double Z, double phi, double t,
+                                          struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[1];
+}
+
+double MultipoleExpansionPotentialRzderiv(double R, double Z, double phi, double t,
+                                          struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[2];
+}
+
+double MultipoleExpansionPotentialphi2deriv(double R, double Z, double phi, double t,
+                                            struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[3];
+}
+
+double MultipoleExpansionPotentialRphideriv(double R, double Z, double phi, double t,
+                                            struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[4];
+}
+
+double MultipoleExpansionPotentialzphideriv(double R, double Z, double phi, double t,
+                                            struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_multipole_hessian_cyl(
+        (struct multipole_data *)potentialArgs->pot_data,
+        potentialArgs, R, Z, phi, t, H);
+    return H[5];
 }
 
 // ============================================================================

--- a/galpy/potential/potential_c_ext/SCFPotential.c
+++ b/galpy/potential/potential_c_ext/SCFPotential.c
@@ -20,6 +20,7 @@
 // Cache tags for force/derivative caching
 #define CACHE_FORCE 1
 #define CACHE_DERIV 2
+#define CACHE_HESSIAN 3
 
 // ============================================================================
 // Pre-computed SCF data: parsed parameters (immutable after init).
@@ -506,6 +507,194 @@ static void compute_spher_2nd_derivs(struct scf_data *d,
 }
 
 // ============================================================================
+// Full 3D Hessian: the six cylindrical second derivatives
+//   (R2deriv, z2deriv, Rzderiv, phi2deriv, Rphideriv, zphideriv)
+// needed for 3D variational (dxdv) integration. Built from the full set of
+// spherical-coordinate derivatives of Phi(r,theta,phi) and an exact
+// spherical->cylindrical chain-rule transform (R=r sin theta, z=r cos theta).
+// ============================================================================
+
+// From the Legendre values P_l^m(cos theta) and their x=cos(theta) derivatives
+// dP/dx, compute the theta-derivatives dP/dtheta and d2P/dtheta2 (same GSL
+// storage layout). Uses the exact identities
+//   dP/dtheta   = -sin(theta) * dP/dx
+//   d2P/dtheta2 = cos(theta) * dP/dx - l(l+1) P + m^2/sin^2(theta) P
+// (the latter from the associated-Legendre ODE). The m^2/sin^2 term is a
+// genuine coordinate singularity on the z-axis (theta=0,pi i.e. R=0), where
+// the cylindrical Hessian of an individual m>0 harmonic is undefined; orbit
+// integration never evaluates exactly on the axis (the forces stay regular
+// there). For m=0 (incl. the axisymmetric M==1 case) the term is absent and
+// the result is regular everywhere.
+void legendre_theta_from_x(double theta, int L, int M,
+                           double *P, double *dPdx,
+                           double *dPth, double *d2Pth)
+{
+    double s = sin(theta);
+    double c = cos(theta);
+    double inv_s2 = 1.0 / (s * s);
+    if (M == 1) {
+        for (int l = 0; l < L; l++) {
+            dPth[l] = -s * dPdx[l];
+            d2Pth[l] = c * dPdx[l] - l * (l + 1) * P[l];
+        }
+    } else {
+        for (int l = 0; l < L; l++) {
+            for (int m = 0; m <= l; m++) {
+                int i = legendre_index(l, m, L);
+                dPth[i] = -s * dPdx[i];
+                d2Pth[i] = c * dPdx[i] - l * (l + 1) * P[i]
+                           + (m ? m * m * inv_s2 * P[i] : 0.0);
+            }
+        }
+    }
+}
+
+// Sum the full set of spherical-coordinate derivatives of the potential:
+//   S[0]=dPhi/dr        S[1]=dPhi/dtheta
+//   S[2]=d2Phi/dr2      S[3]=d2Phi/dtheta2   S[4]=d2Phi/drdtheta
+//   S[5]=d2Phi/dphi2    S[6]=d2Phi/drdphi    S[7]=d2Phi/dthetadphi
+// All are derivatives of the *potential* (not forces).
+static void sum_spher_full(int N, int L, int M, int isNonAxi,
+                           double *Acos, double *Asin,
+                           double *phiTilde, double *dphiTilde,
+                           double *d2phiTilde, double *P,
+                           double *dPth, double *d2Pth,
+                           double phi, double *S)
+{
+    for (int k = 0; k < 8; k++)
+        S[k] = 0.0;
+    if (isNonAxi) {
+        for (int l = 0; l < L; l++) {
+            for (int m = 0; m <= l; m++) {
+                double mcos = cos(m * phi);
+                double msin = sin(m * phi);
+                int pi = legendre_index(l, m, L);
+                for (int n = 0; n < N; n++) {
+                    int ci = n * L * M + l * M + m;
+                    int ri = l * N + n;
+                    // angular azimuthal coefficient and its phi-derivative
+                    double cos_sum = Acos[ci] * mcos + Asin[ci] * msin;
+                    double dphi_sum = m * (Asin[ci] * mcos - Acos[ci] * msin);
+                    S[0] += cos_sum * P[pi] * dphiTilde[ri];
+                    S[1] += cos_sum * dPth[pi] * phiTilde[ri];
+                    S[2] += cos_sum * P[pi] * d2phiTilde[ri];
+                    S[3] += cos_sum * d2Pth[pi] * phiTilde[ri];
+                    S[4] += cos_sum * dPth[pi] * dphiTilde[ri];
+                    S[5] -= m * m * cos_sum * P[pi] * phiTilde[ri];
+                    S[6] += dphi_sum * P[pi] * dphiTilde[ri];
+                    S[7] += dphi_sum * dPth[pi] * phiTilde[ri];
+                }
+            }
+        }
+    } else {
+        for (int l = 0; l < L; l++) {
+            for (int n = 0; n < N; n++) {
+                double Acoef = Acos[n * L * M + l * M];
+                int ri = l * N + n;
+                S[0] += Acoef * P[l] * dphiTilde[ri];
+                S[1] += Acoef * dPth[l] * phiTilde[ri];
+                S[2] += Acoef * P[l] * d2phiTilde[ri];
+                S[3] += Acoef * d2Pth[l] * phiTilde[ri];
+                S[4] += Acoef * dPth[l] * dphiTilde[ri];
+                // m==0: all phi-derivatives vanish (S[5]=S[6]=S[7]=0)
+            }
+        }
+    }
+    double sqrt4pi = sqrt(4.0 * M_PI);
+    for (int k = 0; k < 8; k++)
+        S[k] *= sqrt4pi;
+}
+
+// Compute the six cylindrical second derivatives of the potential at (R,Z,phi),
+// with caching. H = [R2deriv, z2deriv, Rzderiv, phi2deriv, Rphideriv, zphideriv].
+static void compute_scf_hessian_cyl(struct scf_data *d,
+                                    double R, double Z, double phi, double *H)
+{
+    // Check cache
+    if ((int)*d->cached_type == CACHE_HESSIAN
+        && d->cached_coords[0] == R
+        && d->cached_coords[1] == Z
+        && d->cached_coords[2] == phi) {
+        for (int k = 0; k < 6; k++)
+            H[k] = d->cached_values[k];
+        return;
+    }
+
+    double r, theta;
+    cyl_to_spher(R, Z, &r, &theta);
+    double xi = calculateXi(r, d->a);
+
+    int NL = d->N * d->L;
+    int Ps = d->Psize;
+    // Workspace: 6*NL radial + 4*Ps angular
+    double *ws = (double *)malloc((6 * NL + 4 * Ps) * sizeof(double));
+    double *C      = ws;
+    double *dCArr  = ws + NL;
+    double *d2CArr = ws + 2 * NL;
+    double *phiT   = ws + 3 * NL;
+    double *dphiT  = ws + 4 * NL;
+    double *d2phiT = ws + 5 * NL;
+    double *P      = ws + 6 * NL;
+    double *dPdx   = ws + 6 * NL + Ps;
+    double *dPth   = ws + 6 * NL + 2 * Ps;
+    double *d2Pth  = ws + 6 * NL + 3 * Ps;
+
+    // Radial part
+    compute_C(xi, d->N, d->L, C);
+    compute_dC(xi, d->N, d->L, dCArr);
+    compute_d2C(xi, d->N, d->L, d2CArr);
+    compute_phiTilde(r, d->a, d->N, d->L, C, phiT);
+    compute_dphiTilde(r, d->a, d->N, d->L, C, dCArr, dphiT);
+    compute_d2phiTilde(r, d->a, d->N, d->L, C, dCArr, d2CArr, d2phiT);
+
+    // Angular part: P, dP/dx, then theta-derivatives
+    compute_legendre_deriv(cos(theta), d->L, d->M_eff, P, dPdx);
+    legendre_theta_from_x(theta, d->L, d->M_eff, P, dPdx, dPth, d2Pth);
+
+    // Full set of spherical-coordinate potential derivatives
+    double S[8];
+    sum_spher_full(d->N, d->L, d->M, d->isNonAxi,
+                   d->Acos, d->Asin, phiT, dphiT, d2phiT,
+                   P, dPth, d2Pth, phi, S);
+    free(ws);
+
+    double Phi_r = S[0], Phi_th = S[1];
+    double Phi_rr = S[2], Phi_thth = S[3], Phi_rth = S[4];
+    double Phi_phiphi = S[5], Phi_rphi = S[6], Phi_thphi = S[7];
+
+    // Spherical -> cylindrical chain rule. With r=sqrt(R^2+Z^2),
+    // theta=atan2(R,Z): r_R=R/r, r_z=Z/r, th_R=Z/r^2, th_z=-R/r^2, and the
+    // second partials below.
+    double ir = 1.0 / r;
+    double ir2 = ir * ir;
+    double ir3 = ir2 * ir;
+    double ir4 = ir2 * ir2;
+    double rR = R * ir, rz = Z * ir;
+    double thR = Z * ir2, thz = -R * ir2;
+    double rRR = Z * Z * ir3, rzz = R * R * ir3, rRz = -R * Z * ir3;
+    double thRR = -2.0 * R * Z * ir4, thzz = 2.0 * R * Z * ir4,
+           thRz = (R * R - Z * Z) * ir4;
+
+    H[0] = Phi_rr * rR * rR + 2.0 * Phi_rth * rR * thR + Phi_thth * thR * thR
+           + Phi_r * rRR + Phi_th * thRR;                       // R2deriv
+    H[1] = Phi_rr * rz * rz + 2.0 * Phi_rth * rz * thz + Phi_thth * thz * thz
+           + Phi_r * rzz + Phi_th * thzz;                       // z2deriv
+    H[2] = Phi_rr * rR * rz + Phi_rth * (rR * thz + rz * thR)
+           + Phi_thth * thR * thz + Phi_r * rRz + Phi_th * thRz; // Rzderiv
+    H[3] = Phi_phiphi;                                          // phi2deriv
+    H[4] = Phi_rphi * rR + Phi_thphi * thR;                     // Rphideriv
+    H[5] = Phi_rphi * rz + Phi_thphi * thz;                     // zphideriv
+
+    // Update cache
+    *d->cached_type = (double)CACHE_HESSIAN;
+    d->cached_coords[0] = R;
+    d->cached_coords[1] = Z;
+    d->cached_coords[2] = phi;
+    for (int k = 0; k < 6; k++)
+        d->cached_values[k] = H[k];
+}
+
+// ============================================================================
 // Public API: potential, forces, derivatives, density
 // ============================================================================
 
@@ -607,6 +796,61 @@ double SCFPotentialPlanarRphideriv(double R, double phi, double t,
     compute_spher_2nd_derivs((struct scf_data *)potentialArgs->pot_data,
                              R, 0.0, phi, F);
     return F[2];
+}
+
+// Full 3D Hessian components (for 3D variational integration)
+double SCFPotentialR2deriv(double R, double Z, double phi, double t,
+                           struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[0];
+}
+
+double SCFPotentialz2deriv(double R, double Z, double phi, double t,
+                           struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[1];
+}
+
+double SCFPotentialRzderiv(double R, double Z, double phi, double t,
+                           struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[2];
+}
+
+double SCFPotentialphi2deriv(double R, double Z, double phi, double t,
+                             struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[3];
+}
+
+double SCFPotentialRphideriv(double R, double Z, double phi, double t,
+                             struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[4];
+}
+
+double SCFPotentialzphideriv(double R, double Z, double phi, double t,
+                             struct potentialArg *potentialArgs)
+{
+    double H[6];
+    compute_scf_hessian_cyl((struct scf_data *)potentialArgs->pot_data,
+                            R, Z, phi, H);
+    return H[5];
 }
 
 double SCFPotentialDens(double R, double Z, double phi, double t,

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -601,6 +601,8 @@ void cyl_to_spher(double R, double Z, double *r, double *theta);
 int legendre_index(int l, int m, int L);
 void compute_legendre(double x, int L, int M, double *P);
 void compute_legendre_deriv(double x, int L, int M, double *P, double *dP);
+void legendre_theta_from_x(double theta, int L, int M, double *P, double *dPdx,
+			   double *dPth, double *d2Pth);
 //SCFPotential
 void initSCFPotentialArgs(struct potentialArg *);
 double SCFPotentialEval(double,double,double,double,
@@ -622,6 +624,18 @@ double SCFPotentialPlanarphi2deriv(double,double,double,
 				        struct potentialArg *);
 double SCFPotentialPlanarRphideriv(double,double,double,
 				        struct potentialArg *);
+double SCFPotentialR2deriv(double,double,double,double,
+			struct potentialArg *);
+double SCFPotentialz2deriv(double,double,double,double,
+			struct potentialArg *);
+double SCFPotentialRzderiv(double,double,double,double,
+			struct potentialArg *);
+double SCFPotentialphi2deriv(double,double,double,double,
+			struct potentialArg *);
+double SCFPotentialRphideriv(double,double,double,double,
+			struct potentialArg *);
+double SCFPotentialzphideriv(double,double,double,double,
+			struct potentialArg *);
 double SCFPotentialDens(double,double,double,double,
 			struct potentialArg *);
 //SoftenedNeedleBarPotential
@@ -1030,6 +1044,18 @@ double MultipoleExpansionPotentialPlanarphi2deriv(double,double,double,
 						  struct potentialArg *);
 double MultipoleExpansionPotentialPlanarRphideriv(double,double,double,
 						  struct potentialArg *);
+double MultipoleExpansionPotentialR2deriv(double,double,double,double,
+					  struct potentialArg *);
+double MultipoleExpansionPotentialz2deriv(double,double,double,double,
+					  struct potentialArg *);
+double MultipoleExpansionPotentialRzderiv(double,double,double,double,
+					  struct potentialArg *);
+double MultipoleExpansionPotentialphi2deriv(double,double,double,double,
+					    struct potentialArg *);
+double MultipoleExpansionPotentialRphideriv(double,double,double,double,
+					    struct potentialArg *);
+double MultipoleExpansionPotentialzphideriv(double,double,double,double,
+					    struct potentialArg *);
 
 #ifdef __cplusplus
 }

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -660,6 +660,12 @@ double DiskSCFPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
 double DiskSCFPotentialPlanarRforce(double,double,double,
 					      struct potentialArg *);
+double DiskSCFPotentialR2deriv(double,double,double,double,
+			       struct potentialArg *);
+double DiskSCFPotentialz2deriv(double,double,double,double,
+			       struct potentialArg *);
+double DiskSCFPotentialRzderiv(double,double,double,double,
+			       struct potentialArg *);
 double DiskSCFPotentialDens(double,double,double,double,
 			    struct potentialArg *);
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1250,6 +1250,7 @@ def _check_dxdv_3d_c(
     integrators=("dop853_c", "dopr54_c", "rk6_c"),
     det_tol=1e-7,
     symp_tol=1e-6,
+    fd_tol=1e-4,
 ):
     # Shared 3D variational (dxdv) validation for the harmonic-expansion
     # potentials (SCF / MultipoleExpansion), exercised through the C
@@ -1320,7 +1321,7 @@ def _check_dxdv_3d_c(
                 atol=1e-10,
             )
             fderr = numpy.amax(numpy.fabs(fd - odx.getOrbit_dxdv()))
-            assert fderr < 1e-4, (
+            assert fderr < fd_tol, (
                 f"3D FD-of-flow for e_{ii} differs from the dxdv column by "
                 f"{fderr:g} for {name}, {integrator}"
             )
@@ -1399,6 +1400,31 @@ def test_multipole_dxdv_3d():
         integrators=("dop853_c", "dopr54_c"),
         det_tol=5e-6,
         symp_tol=5e-6,
+    )
+    # Time-dependent (rotating, weakly perturbed) multipole: exercises the
+    # time-dependent radial-coefficient path of the C 3D Hessian (the Nt>0
+    # branch of compute_multipole_hessian_cyl). Still a Hamiltonian flow, so
+    # det(M)=1 / symplecticity hold.
+    omega = 0.8
+    hp = HernquistPotential(amp=2.0, a=1.0)
+    mep_tdep = MultipoleExpansionPotential.from_density(
+        dens=lambda R, z, phi, t=0.0: hp.dens(R, z, use_physical=False)
+        * (1.0 + 0.05 * numpy.cos(2.0 * (phi - omega * t))),
+        L=4,
+        rgrid=rgrid,
+        tgrid=numpy.linspace(0.0, 5.0, 41),
+    )
+    assert mep_tdep.isNonAxi, "time-dependent multipole should be non-axisymmetric"
+    # det(M)=1 / symplecticity still hold to ~1e-8 (the Hessian is correct); the
+    # FD-of-flow is looser because the coarse (rgrid x tgrid) interpolation of the
+    # time-dependent radial coefficients is less accurate than the static splines.
+    _check_dxdv_3d_c(
+        mep_tdep,
+        "MultipoleExpansion (time-dependent)",
+        integrators=("dop853_c", "dopr54_c"),
+        det_tol=5e-6,
+        symp_tol=5e-6,
+        fd_tol=1e-3,
     )
     return None
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1244,6 +1244,165 @@ def test_doubleexp_dxdv_planar_c_vs_python():
     return None
 
 
+def _check_dxdv_3d_c(
+    pot,
+    name,
+    integrators=("dop853_c", "dopr54_c", "rk6_c"),
+    det_tol=1e-7,
+    symp_tol=1e-6,
+):
+    # Shared 3D variational (dxdv) validation for the harmonic-expansion
+    # potentials (SCF / MultipoleExpansion), exercised through the C
+    # integrators only (their pure-Python reference is impractically slow --
+    # SCF's numerical 2nd derivatives need many Python force evaluations per
+    # RHS step). Checks, per integrator: (1) Liouville det(M)=1, (2)
+    # symplecticity MᵀΩM=Ω in canonical Cartesian variables (necessary; pins
+    # K's symmetry), and -- the part that actually pins the K VALUES against
+    # the C forces -- (3) finite-difference-of-the-flow. (det_tol/symp_tol are
+    # looser for the spline-interpolated MultipoleExpansion than for the
+    # analytic-radial-basis SCF.)
+    from galpy.orbit import Orbit
+    from galpy.util import coords
+
+    ic = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
+    times = numpy.linspace(0.0, 3.0, 151)
+    canonical = numpy.eye(6)
+    Omega = numpy.zeros((6, 6))
+    Omega[:3, 3:] = numpy.eye(3)
+    Omega[3:, :3] = -numpy.eye(3)
+    for integrator in integrators:
+        Mcols = []
+        for ii in range(6):
+            o = Orbit(ic)
+            o.integrate_dxdv(
+                canonical[ii],
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=1e-10,
+                atol=1e-10,
+            )
+            Mcols.append(o.getOrbit_dxdv()[-1, :])
+        M = numpy.array(Mcols).T
+        this_det_tol = max(det_tol, 1e-6) if integrator == "rk6_c" else det_tol
+        detM = numpy.linalg.det(M)
+        assert numpy.fabs(detM - 1.0) < this_det_tol, (
+            f"3D Liouville det(M)={detM:g} differs from 1 for {name}, {integrator}"
+        )
+        symperr = numpy.amax(numpy.fabs(M.T @ Omega @ M - Omega))
+        assert symperr < symp_tol, (
+            f"3D symplecticity err={symperr:g} too large for {name}, {integrator}"
+        )
+        # finite-difference of the flow (validates the K values vs the C forces)
+        eps = 1e-7
+        obase = Orbit(ic)
+        obase.integrate(times, pot, method=integrator)
+        base = _orbit_rect_3d(obase, times)
+        for ii in [0, 2, 4]:  # x, z, vy perturbations
+            p = base[0].copy()
+            p[ii] += eps
+            Rp, phip, Zp = coords.rect_to_cyl(p[0], p[1], p[2])
+            vRp, vTp, vzp = coords.rect_to_cyl_vec(p[3], p[4], p[5], p[0], p[1], p[2])
+            opert = Orbit([Rp, vRp, vTp, Zp, vzp, phip])
+            opert.integrate(times, pot, method=integrator)
+            fd = (_orbit_rect_3d(opert, times) - base) / eps
+            odx = Orbit(ic)
+            odx.integrate_dxdv(
+                canonical[ii],
+                times,
+                pot,
+                method=integrator,
+                rectIn=True,
+                rectOut=True,
+                rtol=1e-10,
+                atol=1e-10,
+            )
+            fderr = numpy.amax(numpy.fabs(fd - odx.getOrbit_dxdv()))
+            assert fderr < 1e-4, (
+                f"3D FD-of-flow for e_{ii} differs from the dxdv column by "
+                f"{fderr:g} for {name}, {integrator}"
+            )
+    return None
+
+
+def test_scf_dxdv_3d():
+    # SCFPotential has a full 3D C Hessian (hasC_dxdv3d=True) via the
+    # Hernquist-Ostriker spherical-harmonic expansion. Validate the 3D
+    # variational integration for an axisymmetric and a genuinely
+    # non-axisymmetric (m=2 -> nonzero zphideriv) instance. SCF is NOT in the
+    # strict liouville3d_registry because its pure-Python integrators are far
+    # too slow for the per-potential registry sweep; this dedicated test uses
+    # the C integrators only.
+    from galpy.potential import SCFPotential, scf_compute_coeffs_spherical
+
+    def _hern(R, z=0.0, phi=0.0):
+        r = numpy.sqrt(R**2 + z**2)
+        return 1.0 / (2.0 * numpy.pi) / (r * (1.0 + r) ** 3)
+
+    Acos_s, _ = scf_compute_coeffs_spherical(_hern, 5, a=1.0)
+    N = Acos_s.shape[0]
+    # axisymmetric: spherical monopole only
+    scf_axi = SCFPotential(Acos=Acos_s, a=1.0, normalize=True)
+    assert scf_axi.hasC_dxdv3d, "SCFPotential should advertise hasC_dxdv3d"
+    # non-axisymmetric: inject an l=2,m=2 term (exercises zphideriv)
+    Acos = numpy.zeros((N, 3, 3))
+    Asin = numpy.zeros((N, 3, 3))
+    Acos[:, 0, 0] = Acos_s[:, 0, 0]
+    Acos[0, 2, 2] = 0.05 * Acos_s[0, 0, 0]
+    Asin[0, 2, 2] = 0.03 * Acos_s[0, 0, 0]
+    scf_tri = SCFPotential(Acos=Acos, Asin=Asin, a=1.0, normalize=True)
+    assert scf_tri.isNonAxi, "injected-m2 SCF should be non-axisymmetric"
+    _check_dxdv_3d_c(scf_axi, "SCFPotential (axi)")
+    _check_dxdv_3d_c(scf_tri, "SCFPotential (m=2)")
+    return None
+
+
+def test_multipole_dxdv_3d():
+    # MultipoleExpansionPotential has a full 3D C Hessian (hasC_dxdv3d=True) via
+    # the same spherical-harmonic machinery as SCF (shared transform). Validate
+    # a spherical and a genuinely triaxial (nonzero zphideriv) instance. Like
+    # SCF it is excluded from the strict registry (slow Python integrators; its
+    # radial functions are spline-interpolated, so the FD-of-flow sits at
+    # spline accuracy, not analytic accuracy).
+    from galpy.potential import (
+        HernquistPotential,
+        MultipoleExpansionPotential,
+        TriaxialNFWPotential,
+    )
+
+    rgrid = numpy.geomspace(1e-2, 30.0, 201)
+    mep_sph = MultipoleExpansionPotential.from_density(
+        dens=HernquistPotential(amp=2.0, a=1.0), symmetry="spherical", rgrid=rgrid
+    )
+    assert mep_sph.hasC_dxdv3d, "MultipoleExpansion should advertise hasC_dxdv3d"
+    mep_tri = MultipoleExpansionPotential.from_density(
+        dens=TriaxialNFWPotential(amp=3.0, a=2.0, b=0.8, c=0.6),
+        symmetry="triaxial",
+        L=6,
+        rgrid=rgrid,
+    )
+    assert mep_tri.isNonAxi, "triaxial MultipoleExpansion should be non-axisymmetric"
+    # spline-interpolated radial functions -> looser det/symp; use the adaptive
+    # C integrators (fixed-step rk*_c is dominated by the spline error here).
+    _check_dxdv_3d_c(
+        mep_sph,
+        "MultipoleExpansion (spherical)",
+        integrators=("dop853_c", "dopr54_c"),
+        det_tol=5e-6,
+        symp_tol=5e-6,
+    )
+    _check_dxdv_3d_c(
+        mep_tri,
+        "MultipoleExpansion (triaxial)",
+        integrators=("dop853_c", "dopr54_c"),
+        det_tol=5e-6,
+        symp_tol=5e-6,
+    )
+    return None
+
+
 # 2D-reduction bridge (validates the (x,y) block of K): for a planar IC with
 # dz=dvz=0 and an in-plane deviation, the (x,y,vx,vy) sub-STM from the 3D
 # integrate_dxdv must match the trusted planar integrate_dxdv result.

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1408,8 +1408,10 @@ def test_multipole_dxdv_3d():
     omega = 0.8
     hp = HernquistPotential(amp=2.0, a=1.0)
     mep_tdep = MultipoleExpansionPotential.from_density(
-        dens=lambda R, z, phi, t=0.0: hp.dens(R, z, use_physical=False)
-        * (1.0 + 0.05 * numpy.cos(2.0 * (phi - omega * t))),
+        dens=lambda R, z, phi, t=0.0: (
+            hp.dens(R, z, use_physical=False)
+            * (1.0 + 0.05 * numpy.cos(2.0 * (phi - omega * t)))
+        ),
         L=4,
         rgrid=rgrid,
         tgrid=numpy.linspace(0.0, 5.0, 41),

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1403,6 +1403,48 @@ def test_multipole_dxdv_3d():
     return None
 
 
+def test_disk_composite_dxdv_3d():
+    # The DiskSCF / DiskMultipole (Kuijken-Dubinski) composites have a full 3D C
+    # Hessian (hasC_dxdv3d=True) once BOTH the analytic [Sigma_i(r), Hz_i(z)]
+    # disk pairs (their R2/z2/Rz deriv are in C; phi-derivs are identically
+    # zero) AND the expansion sub-potential (SCF / MultipoleExpansion) have the
+    # Hessian in C. A SMOOTH sech2 vertical profile is used: the exp |z| profile
+    # is only C^0 across the disk plane (like KuzminDisk), so its FD-of-flow
+    # sits at the z=0 kink, not at analytic accuracy (det(M)=1/symplecticity
+    # still pass for it -- the Hessian itself is correct).
+    from galpy.potential import DiskMultipoleExpansionPotential, DiskSCFPotential
+
+    def _sphdens(R, z):
+        return numpy.exp(-numpy.sqrt(R**2 + z**2)) / (4.0 * numpy.pi)
+
+    Sigma = {"type": "exp", "h": 1.0 / 3.0, "amp": 1.0}
+    hz = {"type": "sech2", "h": 1.0 / 27.0}
+    dscf = DiskSCFPotential(
+        dens=_sphdens, Sigma=Sigma, hz=hz, a=1.0, N=4, L=4, normalize=True
+    )
+    assert dscf.hasC_dxdv3d, "DiskSCFPotential should advertise hasC_dxdv3d"
+    # analytic SCF + analytic disk pairs -> tight
+    _check_dxdv_3d_c(dscf, "DiskSCFPotential", det_tol=1e-7, symp_tol=1e-6)
+    dmep = DiskMultipoleExpansionPotential(
+        dens=_sphdens,
+        Sigma=Sigma,
+        hz=hz,
+        L=4,
+        rgrid=numpy.geomspace(1e-2, 30.0, 201),
+        normalize=True,
+    )
+    assert dmep.hasC_dxdv3d, "DiskMultipoleExpansion should advertise hasC_dxdv3d"
+    # spline-interpolated multipole part -> looser det/symp, adaptive integrators
+    _check_dxdv_3d_c(
+        dmep,
+        "DiskMultipoleExpansionPotential",
+        integrators=("dop853_c", "dopr54_c"),
+        det_tol=5e-6,
+        symp_tol=5e-6,
+    )
+    return None
+
+
 # 2D-reduction bridge (validates the (x,y) block of K): for a planar IC with
 # dz=dvz=0 and an in-plane deviation, the (x,y,vx,vy) sub-STM from the 3D
 # integrate_dxdv must match the trusted planar integrate_dxdv result.


### PR DESCRIPTION
Part of the **3D variational equations** track (Pvar-pot fan-out). Implements the full 3D potential Hessian in C for the spherical-harmonic-expansion family — **`SCFPotential`**, **`MultipoleExpansionPotential`**, and the **`DiskSCFPotential` / `DiskMultipoleExpansionPotential` (Kuijken–Dubinski) composites** — enabling 3D variational (`integrate_dxdv`) integration for all of them (`hasC_dxdv3d=True`).

## SCF / MultipoleExpansion (harmonic core)
Both store $\Phi = \sum_{nlm} A_{nlm}\,\mathrm{radial}_{nl}(r)\,P_l^m(\cos\theta)\,[\cos/\sin](m\phi)$, and the Python side uses `NumericalPotentialDerivativesMixin` (no analytic 3D Hessian to port). So the C Hessian is **derived**:
- Sum the full set of spherical-coordinate potential derivatives $\Phi_r,\Phi_\theta,\Phi_{rr},\Phi_{\theta\theta},\Phi_{r\theta},\Phi_{\phi\phi},\Phi_{r\phi},\Phi_{\theta\phi}$ (φ-derivatives from $m[\cos/\sin]$; the new θ-derivatives from the Legendre functions).
- θ-derivatives of $P_l^m$ from the existing $x=\cos\theta$ arrays via exact identities $dP/d\theta=-\sin\theta\,dP/dx$ and $d^2P/d\theta^2=\cos\theta\,dP/dx-l(l+1)P+\tfrac{m^2}{\sin^2\theta}P$ (associated-Legendre ODE). The $m^2/\sin^2\theta$ term is a genuine z-axis (R=0) coordinate singularity for m>0 (forces stay regular there); orbits never evaluate exactly on the axis. Shared helper `legendre_theta_from_x`.
- Spherical→cylindrical chain rule; the planar (z=0) reduction recovers the existing `PlanarR2deriv=`$\Phi_{rr}$ etc.

SCF cache widened 3→6 value slots (`nargs` +7→+10 in both orbit parsers); MultipoleExpansion caches in its `malloc`'d struct (`cached_H[6]`). Pointers wired in cases 24, 44.

## DiskSCF / DiskMultipole / KuijkenDubinski composites
The analytic $[\Sigma_i(r),H_{z,i}(z)]$ disk-approximation pairs (C type 26) get their 3D Hessian: for $\Phi=\Sigma(r)H_z(Z)$,
- $\Phi_{RR}=H_z(\Sigma''R^2/r^2+\Sigma'Z^2/r^3)$, $\Phi_{ZZ}=H_z(\Sigma''Z^2/r^2+\Sigma'R^2/r^3)+2\Sigma'(Z/r)H_z'+\Sigma\,h_z$, $\Phi_{RZ}=H_zRZ(\Sigma''/r^2-\Sigma'/r^3)+\Sigma'(R/r)H_z'$
using the existing $\Sigma,\Sigma',\Sigma'',H_z,H_z'$ and the identity $H_z''(z)=h_z(z)$ (1D Poisson). φ-derivatives are identically zero (left NULL). The composite advertises `hasC_dxdv3d=True` only when the disk pairs are C-capable **and** the expansion sub-potential (`self._me`) has its 3D Hessian — both now true.

## Validation (new tests)
`test_scf_dxdv_3d`, `test_multipole_dxdv_3d`, `test_disk_composite_dxdv_3d`: axisymmetric **and** genuinely non-axisymmetric (m=2 → nonzero `zphideriv`) instances, via the C integrators for Liouville `det(M)=1`, symplecticity `MᵀΩM=Ω`, and finite-difference-of-the-flow (pins the K *values* against the C forces).
- SCF: det/symp ~1e-9. MultipoleExpansion (spline radial functions): det/symp ~1e-8, FD-of-flow ~1e-6.
- DiskSCF: det/symp ~1e-11/1e-10, FD-of-flow ~1e-5. DiskMultipole: det/symp ~1e-8, FD-of-flow ~6e-6. (Smooth sech2 vertical profile; the exp $|z|$ profile is only C⁰ across the disk plane like KuzminDisk, so its FD-of-flow sits at the z=0 kink — det/symp still pass, the Hessian is correct.)

All deliberately kept out of the strict `liouville3d_registry` — their pure-Python integrators are far too slow for the per-potential sweep (Einasto/interpSpherical precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)