### PR TITLE
PowerSphericalPotentialwCutoff: backend-agnostic / jit-clean (+ torch router fixes)

### DIFF
--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -72,6 +72,14 @@ def _dispatch(fnname, args, fallback, ns_args=None):
     xp = get_namespace(*(args if ns_args is None else ns_args))
     name, sp = _backend_special(xp)
     if fnname not in _NEEDS_FALLBACK.get(name, frozenset()) and hasattr(sp, fnname):
+        if name == "torch":
+            # torch.special.* require every argument to be a Tensor (they don't
+            # broadcast Python scalars like scipy/jax do), so promote any plain
+            # scalar parameters (e.g. the order `a` of gammainc(a, x)).
+            args = tuple(
+                a if hasattr(a, "ndim") else xp.asarray(a, dtype=xp.float64)
+                for a in args
+            )
         return getattr(sp, fnname)(*args)
     return fallback(xp, *args)
 

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -75,11 +75,16 @@ def _dispatch(fnname, args, fallback, ns_args=None):
         if name == "torch":
             # torch.special.* require every argument to be a Tensor (they don't
             # broadcast Python scalars like scipy/jax do), so promote any plain
-            # scalar parameters (e.g. the order `a` of gammainc(a, x)).
-            args = tuple(
-                a if hasattr(a, "ndim") else xp.asarray(a, dtype=xp.float64)
-                for a in args
-            )
+            # scalar parameters (e.g. the order `a` of gammainc(a, x)) to a
+            # Tensor on the same device/dtype as the array argument(s).
+            ref = next((a for a in args if hasattr(a, "ndim")), None)
+            if ref is not None:
+                args = tuple(
+                    a
+                    if hasattr(a, "ndim")
+                    else xp.asarray(a, dtype=ref.dtype, device=ref.device)
+                    for a in args
+                )
         return getattr(sp, fnname)(*args)
     return fallback(xp, *args)
 

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -9,6 +9,8 @@ import numpy
 from scipy import special
 
 from ..backend import get_namespace
+from ..backend.special import gamma as _gamma
+from ..backend.special import gammainc as _gammainc
 from ..util import conversion
 from ..util._optional_deps import _JAX_LOADED
 from .Potential import Potential, kms_to_kpcGyrDecorator
@@ -73,7 +75,11 @@ class PowerSphericalPotentialwCutoff(Potential):
         self._nemo_accname = "PowSphwCut"
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
+        # guard r=0 in the dead branch (the 1/r term -> 0/0=NaN there) so the
+        # xp.where stays finite under autodiff/jit; the value at r=0 is 0.
+        rsafe = xp.where(r == 0, 1.0, r)
         out = (
             2.0
             * numpy.pi
@@ -81,44 +87,57 @@ class PowerSphericalPotentialwCutoff(Potential):
             * (
                 1
                 / self.rc
-                * special.gamma(1.0 - self.alpha / 2.0)
-                * special.gammainc(1.0 - self.alpha / 2.0, (r / self.rc) ** 2.0)
-                - special.gamma(1.5 - self.alpha / 2.0)
-                * special.gammainc(1.5 - self.alpha / 2.0, (r / self.rc) ** 2.0)
-                / r
+                * _gamma(1.0 - self.alpha / 2.0)
+                * _gammainc(1.0 - self.alpha / 2.0, (rsafe / self.rc) ** 2.0)
+                - _gamma(1.5 - self.alpha / 2.0)
+                * _gammainc(1.5 - self.alpha / 2.0, (rsafe / self.rc) ** 2.0)
+                / rsafe
             )
         )
-        if isinstance(r, (float, int)):
-            if r == 0:
-                return 0.0
-            else:
-                return out
-        else:
-            out[r == 0] = 0.0
-            return out
+        return xp.where(r == 0, 0.0, out)
+
+    def _rforce(self, r):
+        # Radial force (amp-free): -M(<r)/r^2. The enclosed mass is written with
+        # the regularized lower incomplete gamma P(a,x)=gammainc(a,x), so the
+        # whole force path is backend-agnostic and jit-clean -- gammainc and
+        # gamma are native (and reliable) on numpy/jax/torch, unlike the
+        # hyp1f1 form of _mass (which only the numpy mass API still uses).
+        return (
+            -2.0
+            * numpy.pi
+            * self.rc ** (3.0 - self.alpha)
+            * _gamma(1.5 - 0.5 * self.alpha)
+            * _gammainc(1.5 - 0.5 * self.alpha, (r / self.rc) ** 2.0)
+            / r**2.0
+        )
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R * R + z * z)
-        return -self._mass(r) * R / r**3.0
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R * R + z * z)
+        return self._rforce(r) * R / r
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R * R + z * z)
-        return -self._mass(r) * z / r**3.0
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R * R + z * z)
+        return self._rforce(r) * z / r
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R * R + z * z)
-        return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * numpy.exp(
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R * R + z * z)
+        return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
         ) * R**2.0 + self._mass(r) / r**5.0 * (z**2.0 - 2.0 * R**2.0)
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R * R + z * z)
-        return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * numpy.exp(
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R * R + z * z)
+        return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
         ) * z**2.0 + self._mass(r) / r**5.0 * (R**2.0 - 2.0 * z**2.0)
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R * R + z * z)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R * R + z * z)
         return (
             R
             * z
@@ -126,7 +145,7 @@ class PowerSphericalPotentialwCutoff(Potential):
                 4.0
                 * numpy.pi
                 * r ** (-2.0 - self.alpha)
-                * numpy.exp(-((r / self.rc) ** 2.0))
+                * xp.exp(-((r / self.rc) ** 2.0))
                 - 3.0 * self._mass(r) / r**5.0
             )
         )
@@ -209,26 +228,17 @@ class PowerSphericalPotentialwCutoff(Potential):
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
             raise AttributeError  # use general implementation
-        R = numpy.array(R)
-        out = numpy.ones_like(R)
-        out[~numpy.isinf(R)] = (
-            2.0
-            * numpy.pi
-            * R[~numpy.isinf(R)] ** (3.0 - self.alpha)
-            / (1.5 - self.alpha / 2.0)
-            * special.hyp1f1(
-                1.5 - self.alpha / 2.0,
-                2.5 - self.alpha / 2.0,
-                -((R[~numpy.isinf(R)] / self.rc) ** 2.0),
-            )
-        )
-        out[numpy.isinf(R)] = (
+        # M(<R) via the regularized lower incomplete gamma P(a,x)=gammainc(a,x).
+        # This is backend-agnostic/jit-clean and needs no separate R=inf branch:
+        # gammainc(a, inf)=1 recovers the total mass automatically. (The previous
+        # hyp1f1 form is an equivalent representation; values agree to ~1e-15.)
+        return (
             2.0
             * numpy.pi
             * self.rc ** (3.0 - self.alpha)
-            * special.gamma(1.5 - self.alpha / 2.0)
+            * _gamma(1.5 - 0.5 * self.alpha)
+            * _gammainc(1.5 - 0.5 * self.alpha, (R / self.rc) ** 2.0)
         )
-        return out
 
     @kms_to_kpcGyrDecorator
     def _nemo_accpars(self, vo, ro):


### PR DESCRIPTION
Migrates **`PowerSphericalPotentialwCutoff`** (the bulge of MWPotential2014) to be backend-agnostic and jit-clean, so the full MWPotential2014 can be integrated/differentiated under jax & torch (it was the last MWPotential2014 component still numpy-only). Part of Track A / P2.5.

### The problem
PSCwCutoff's forces used raw `numpy` + `scipy.special.hyp1f1` + in-place mutation — works eagerly (`numpy.sqrt(jax_array)` etc.), but breaks under jit (`TracerArrayConversionError`). The disk (MN) and halo (NFW) were already migrated; this was the gap.

### What's here
- **Forces / `_mass`**: write $M(<r)$ with the regularized lower incomplete gamma $P(a,x)=$`gammainc(a,x)` (routed through `galpy.backend.special`), instead of the `hyp1f1` form. `gammainc`/`gamma` are native + reliable on numpy/jax/torch, and `gammainc(a,∞)=1` recovers the total mass with no separate `R=∞` branch. New amp-free `_rforce(r)`.
- **`_evaluate`**: `gamma`/`gammainc` via the router; in-place `out[r==0]=0` → `xp.where` with a `1/r` dead-branch guard at `r=0`.
- **2nd derivatives**: `numpy.sqrt`/`exp` → `xp` via `get_namespace`.
- **2 Pspecial router fixes**: `torch.special.*` require *all*-Tensor args on a matching device, so promote scalar params (e.g. the order `a` of `gammainc(a, x)`) to a Tensor on the array's device/dtype. Without this the torch path failed (`argument must be Tensor, not float`, then a CPU/CUDA device mismatch).
- **Tests**: add PSCwCutoff to the parametrized `test_backend_spherical` CASES — value parity, grad(`_evaluate`)-vs-FD, and force/Hessian autodiff identities across numpy/jax/torch (13 cases pass).

### ⚠️ numpy-path value change
The `gammainc` form replaces the `hyp1f1` form, so numpy potential/force/mass/2nd-deriv values shift at the **~1e-15 level** (equivalent representations) — not byte-identical.

### Validation
Every method jit-clean with numpy↔jax parity to ~1e-14; `R2 = -dFR/dR` to ~5e-10. The in-backend **jax and torch** MWPotential2014 orbits match the C integrator to **~1e-9** over 2 Gyr. This unblocks galpy's own GPU orbit integration of MWPotential2014 (a Track G figure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)