### PR TITLE
Fix sign of SCFPotential C planar 2nd derivatives (variational STM)

### DIFF
--- a/galpy/potential/potential_c_ext/SCFPotential.c
+++ b/galpy/potential/potential_c_ext/SCFPotential.c
@@ -344,6 +344,13 @@ static void sum_spher_2nd_derivs(int N, int L, int M, int isNonAxi,
                                  double *d2phiTilde, double *P,
                                  double phi, double *F)
 {
+    // Returns the (potential) second derivatives F = (d2Phi/dr2, d2Phi/dphi2,
+    // d2Phi/drdphi) -- NOT force-like (-d2Phi). Unlike the forces (-dPhi), the
+    // second derivatives carry no extra minus sign, so the accumulation signs
+    // here are the opposite of those in sum_spher_forces:
+    //   d2Phi/dr2    =  sum cos_sum * P * d2phiTilde
+    //   d2Phi/dphi2  = -sum m^2 * cos_sum * P * phiTilde
+    //   d2Phi/drdphi = -sum m * sin_diff * P * dphiTilde
     F[0] = F[1] = F[2] = 0.0;
     if (isNonAxi) {
         for (int l = 0; l < L; l++) {
@@ -356,9 +363,9 @@ static void sum_spher_2nd_derivs(int N, int L, int M, int isNonAxi,
                     int ri = l * N + n;
                     double cos_sum = Acos[ci] * mcos + Asin[ci] * msin;
                     double sin_diff = Acos[ci] * msin - Asin[ci] * mcos;
-                    F[0] -= cos_sum * P[pi] * d2phiTilde[ri];
-                    F[1] += m * m * cos_sum * P[pi] * phiTilde[ri];
-                    F[2] += m * sin_diff * P[pi] * dphiTilde[ri];
+                    F[0] += cos_sum * P[pi] * d2phiTilde[ri];
+                    F[1] -= m * m * cos_sum * P[pi] * phiTilde[ri];
+                    F[2] -= m * sin_diff * P[pi] * dphiTilde[ri];
                 }
             }
         }
@@ -366,7 +373,7 @@ static void sum_spher_2nd_derivs(int N, int L, int M, int isNonAxi,
         for (int l = 0; l < L; l++) {
             for (int n = 0; n < N; n++) {
                 int ci = n * L * M + l * M;
-                F[0] -= Acos[ci] * P[l] * d2phiTilde[l * N + n];
+                F[0] += Acos[ci] * P[l] * d2phiTilde[l * N + n];
             }
         }
     }

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -7555,6 +7555,89 @@ def test_NumericalPotentialDerivativesMixin():
     return None
 
 
+def test_harmonic_planar_stm_vs_fd_of_flow():
+    # Ground-truth (finite-difference-of-the-flow) check of the C planar
+    # variational state-transition matrix for the spherical-harmonic family
+    # (SCFPotential, MultipoleExpansionPotential). Their C planar second
+    # derivatives feed the 2D variational equations (integrate_dxdv); a
+    # sign/factor error there is invisible to the Liouville det(M)=1 test -- a
+    # wrong-but-symmetric Hessian is still a Hamiltonian flow -- but it shifts the
+    # actual deviation vectors. FD of the flow uses only the (trusted) forces, so
+    # it is independent of any second-derivative code and pins their absolute
+    # value. This regression-guards the SCF planar 2nd-deriv sign fix. (The 3D
+    # Hessian and DiskSCF are validated in the variational-3D PR, where that C
+    # code lives.)
+    from galpy.orbit import Orbit
+    from galpy.potential import SCFPotential, scf_compute_coeffs_spherical
+
+    def _hern(R, z=0.0, phi=0.0):
+        r = numpy.sqrt(R**2 + z**2)
+        return 1.0 / (2.0 * numpy.pi) / (r * (1.0 + r) ** 3)
+
+    Acos_s, _ = scf_compute_coeffs_spherical(_hern, 6, a=1.3)
+    Nn = Acos_s.shape[0]
+    Acos = numpy.zeros((Nn, 3, 3))
+    Asin = numpy.zeros((Nn, 3, 3))
+    Acos[:, 0, 0] = Acos_s[:, 0, 0]
+    Acos[0, 2, 2] = 0.05 * Acos_s[0, 0, 0]  # l=2,m=2 -> non-axisymmetric
+    Asin[0, 2, 2] = 0.03 * Acos_s[0, 0, 0]
+    scf_axi = SCFPotential(Acos=Acos_s, a=1.3, normalize=True)
+    scf_nonaxi = SCFPotential(Acos=Acos, Asin=Asin, a=1.3, normalize=True)
+    mp_axi = mockMultipoleExpansionAxiPotential()
+    mp_axi.normalize(1.0)
+    mp_nonaxi = mockMultipoleExpansionPotential()
+    mp_nonaxi.normalize(1.0)
+    # (label, planar potential, tolerance): SCF and the axisymmetric Multipole
+    # are analytic/near-exact (~1e-6); the non-axisymmetric Multipole is
+    # grid-spline interpolated, so it agrees only to grid accuracy (~1e-4) -- far
+    # tighter than the O(1) shift a sign/factor error would produce.
+    pots = [
+        ("SCF (axi)", scf_axi.toPlanar(), 1e-5),
+        ("SCF (non-axi)", scf_nonaxi.toPlanar(), 1e-5),
+        ("Multipole (axi)", mp_axi.toPlanar(), 1e-5),
+        ("Multipole (non-axi)", mp_nonaxi.toPlanar(), 5e-4),
+    ]
+    times = numpy.linspace(0.0, 2.0, 101)
+    R0, vR0, vT0, phi0 = 1.0, 0.1, 1.1, 0.3
+
+    def cyl2rect(R, vR, vT, phi):
+        c, s = numpy.cos(phi), numpy.sin(phi)
+        return numpy.array([R * c, R * s, vR * c - vT * s, vR * s + vT * c])
+
+    def rect2cyl(x, y, vx, vy):
+        R = numpy.hypot(x, y)
+        c, s = x / R, y / R
+        return [R, vx * c + vy * s, -vx * s + vy * c, numpy.arctan2(y, x)]
+
+    eps = 1e-6
+    for name, ptp, tol in pots:
+
+        def flow(rect0):
+            o = Orbit(rect2cyl(*rect0))
+            o.integrate(times, ptp, method="dop853_c")
+            of = o.getOrbit()[-1]
+            return cyl2rect(of[0], of[1], of[2], of[3])
+
+        rect0 = cyl2rect(R0, vR0, vT0, phi0)
+        base = flow(rect0)
+        for ii in range(4):
+            pert = numpy.zeros(4)
+            pert[ii] = eps
+            fd = (flow(rect0 + pert) - base) / eps
+            o = Orbit([R0, vR0, vT0, phi0])
+            dxdv = numpy.zeros(4)
+            dxdv[ii] = 1.0
+            o.integrate_dxdv(
+                dxdv, times, ptp, method="dop853_c", rectIn=True, rectOut=True
+            )
+            stm = o.getOrbit_dxdv()[-1, :]
+            assert numpy.all(numpy.fabs(stm - fd) < tol), (
+                f"{name} C planar STM column {ii} disagrees with "
+                f"finite-difference-of-the-flow by {numpy.amax(numpy.fabs(stm - fd)):g}"
+            )
+    return None
+
+
 # Test that we don't get the "FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated" numpy warning for the SCF potential; issue #347
 def test_scf_tupleindexwarning():
     import warnings


### PR DESCRIPTION
## Summary

`SCFPotential.c::sum_spher_2nd_derivs` accumulated the second derivatives with the **force**-sign convention (`F[0] -= …·d2phiTilde`, i.e. $-\partial^2\Phi/\partial r^2$), but the planar accessors `SCFPotentialPlanarR2deriv/phi2deriv/Rphideriv` return `F` directly and must give $+\partial^2\Phi$ (not the force-like $-\partial^2\Phi$). All three components were sign-flipped, so the **C planar variational equations** (`integrate_dxdv` / the 2D state-transition matrix) were **wrong for SCFPotential**.

### Why it was never caught
`test_liouville_planar` only checks $\det M = 1$. A sign-flipped-but-symmetric Hessian is the Hessian of $-\Phi$, whose flow is *also* Hamiltonian, so $\det M = 1$ holds regardless. Nothing ever compared SCF's C variational STM to ground truth. `MultipoleExpansionPotential` and `LogarithmicHaloPotential` were already correct — this was SCF-specific.

### Fix + test
- Return the true $(\partial^2\Phi/\partial r^2,\ \partial^2\Phi/\partial\phi^2,\ \partial^2\Phi/\partial r\partial\phi)$.
- Add `test_harmonic_planar_stm_vs_fd_of_flow`: a **finite-difference-of-the-flow** check of the C planar STM (uses only the trusted forces → independent of the 2nd-deriv code) for SCF and Multipole, axisymmetric and non-axisymmetric. Post-fix the C STM matches FD-of-flow to ~1e-6 (SCF, axi Multipole) / ~1e-4 (grid-interpolated non-axi Multipole); pre-fix it differed at O(1).

### Scope / sequencing
Pure bug fix to existing functionality → targets `main` directly. The analytic-Python SCF 2nd derivs (#921) and the 3D variational Hessian (#920) stack on top; #920 reuses this same summation, so its 3D SCF STM must be re-validated against FD-of-flow after rebasing (3D + DiskSCF FD-of-flow checks belong there, where that C code lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)