### PR TITLE
Fix interpolation-range warning for multiple orbits

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1908,20 +1908,11 @@ class Orbit:
                     dtype="bool",
                 )
             ][0]
-            if numpy.any(
-                self.r(self.t, use_physical=False) < lpot[isp_indx]._rmin
-            ) or numpy.any(self.r(self.t, use_physical=False) > lpot[isp_indx]._rmax):
-                warnings.warn(
-                    """Orbit integration with """
-                    """interpSphericalPotential visited radii """
-                    """outside of the interpolation range; """
-                    """initialize interpSphericalPotential """
-                    """with a wider radial range to avoid this """
-                    """if you wish (min/max r = {:.3f},{:.3f}""".format(
-                        self.rperi(), self.rap()
-                    ),
-                    galpyWarning,
-                )
+            self._warn_radii_outside_interpolation_range(
+                lpot[isp_indx]._rmin,
+                lpot[isp_indx]._rmax,
+                "interpSphericalPotential",
+            )
         from ..potential import MultipoleExpansionPotential
 
         if (
@@ -1945,23 +1936,41 @@ class Orbit:
                     dtype="bool",
                 )
             ][0]
-            if numpy.any(
-                self.r(self.t, use_physical=False) < lpot[mep_indx]._rgrid[0]
-            ) or numpy.any(
-                self.r(self.t, use_physical=False) > lpot[mep_indx]._rgrid[-1]
-            ):
-                warnings.warn(
-                    """Orbit integration with """
-                    """MultipoleExpansionPotential visited radii """
-                    """outside of the interpolation range; """
-                    """initialize MultipoleExpansionPotential """
-                    """with a wider radial range to avoid this """
-                    """if you wish (min/max r = {:.3f},{:.3f}""".format(
-                        self.rperi(), self.rap()
-                    ),
-                    galpyWarning,
-                )
+            self._warn_radii_outside_interpolation_range(
+                lpot[mep_indx]._rgrid[0],
+                lpot[mep_indx]._rgrid[-1],
+                "MultipoleExpansionPotential",
+            )
         return None
+
+    def _warn_radii_outside_interpolation_range(self, rmin, rmax, potname):
+        """Warn if the integrated orbit(s) visited radii outside of the
+        interpolation range [rmin, rmax] of the potential potname"""
+        rs = self.r(self.t, use_physical=False)
+        outside = numpy.any((rs < rmin) | (rs > rmax), axis=-1)
+        if not numpy.any(outside):
+            return
+        if self.shape == ():
+            warnings.warn(
+                f"Orbit integration with {potname} visited radii "
+                f"outside of the interpolation range; initialize "
+                f"{potname} with a wider radial range to avoid this "
+                f"if you wish (min/max r = "
+                f"{self.rperi():.3f},{self.rap():.3f})",
+                galpyWarning,
+            )
+        else:
+            warnings.warn(
+                f"Orbit integration with {potname} visited radii "
+                f"outside of the interpolation range for "
+                f"{numpy.sum(outside)} out of {self.size} orbits; "
+                f"initialize {potname} with a wider radial range to "
+                f"avoid this if you wish (min/max r = "
+                f"{numpy.amin(self.rperi()):.3f},"
+                f"{numpy.amax(self.rap()):.3f}, which is the full "
+                f"range over all orbits)",
+                galpyWarning,
+            )
 
     @singledispatchmethod
     def integrate(

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -9196,3 +9196,105 @@ def test_orbits_continuation_1d():
     )
 
     return None
+
+
+def test_orbits_interpSphericalPotential_outside_interpolation_range_warning():
+    # Test that the warning about orbits straying outside of the
+    # interpolation range of interpSphericalPotential works for multiple
+    # orbits (used to fail with a TypeError) and reports the number
+    # of orbits outside of the range and the full radial range
+    import warnings
+
+    from galpy.orbit import Orbit
+    from galpy.potential import HernquistPotential, interpSphericalPotential
+    from galpy.util import galpyWarning
+
+    hp = HernquistPotential(amp=2.0)
+    ip = interpSphericalPotential(rforce=hp, rgrid=numpy.geomspace(0.5, 1.5, 101))
+    # First orbit strays outside of the interpolation range, second (circular)
+    # one does not
+    o = Orbit([[1.0, 0.5, 0.3, 0.0], [1.0, 0.0, hp.vcirc(1.0), 0.0]])
+    ts = numpy.linspace(0.0, 20.0, 1001)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        o.integrate(ts, ip)
+        range_warnings = [
+            str(warning.message)
+            for warning in w
+            if issubclass(warning.category, galpyWarning)
+            and "outside of the interpolation range" in str(warning.message)
+        ]
+    assert len(range_warnings) == 1, (
+        "Integrating multiple orbits outside of the interpolation range of "
+        "interpSphericalPotential should raise exactly one warning"
+    )
+    assert "1 out of 2 orbits" in range_warnings[0], (
+        "Warning for multiple orbits outside of the interpolation range "
+        "should report the number of orbits outside of the range"
+    )
+    assert "full range over all orbits" in range_warnings[0], (
+        "Warning for multiple orbits outside of the interpolation range "
+        "should make clear that the reported range is over all orbits"
+    )
+    expected_range = f"{numpy.amin(o.rperi()):.3f},{numpy.amax(o.rap()):.3f}"
+    assert expected_range in range_warnings[0], (
+        "Warning for multiple orbits outside of the interpolation range "
+        "should report amin(rperi) and amax(rap) over all orbits"
+    )
+    # No warning when all orbits remain within the interpolation range
+    o = Orbit([[1.0, 0.0, hp.vcirc(1.0), 0.0], [1.2, 0.0, hp.vcirc(1.2), 0.0]])
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        o.integrate(ts, ip)
+        range_warnings = [
+            warning
+            for warning in w
+            if "outside of the interpolation range" in str(warning.message)
+        ]
+    assert len(range_warnings) == 0, (
+        "Integrating multiple orbits within the interpolation range of "
+        "interpSphericalPotential should not raise a warning"
+    )
+    return None
+
+
+def test_orbits_MultipoleExpansionPotential_outside_interpolation_range_warning():
+    # Test that the warning about orbits straying outside of the
+    # interpolation range of MultipoleExpansionPotential works for multiple
+    # orbits (used to fail with a TypeError) and reports the number
+    # of orbits outside of the range and the full radial range
+    import warnings
+
+    from galpy.orbit import Orbit
+    from galpy.potential import HernquistPotential, MultipoleExpansionPotential
+    from galpy.util import galpyWarning
+
+    hp = HernquistPotential(amp=2.0)
+    mep = MultipoleExpansionPotential.from_density(
+        hp, rgrid=numpy.geomspace(0.5, 1.5, 31), L=2, symmetry="spherical"
+    )
+    # Both orbits stray outside of the interpolation range
+    o = Orbit([[1.0, 0.5, 0.3, 0.0], [1.0, 0.0, 1.0, 0.0]])
+    ts = numpy.linspace(0.0, 20.0, 1001)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        o.integrate(ts, mep)
+        range_warnings = [
+            str(warning.message)
+            for warning in w
+            if issubclass(warning.category, galpyWarning)
+            and "outside of the interpolation range" in str(warning.message)
+        ]
+    assert len(range_warnings) == 1, (
+        "Integrating multiple orbits outside of the interpolation range of "
+        "MultipoleExpansionPotential should raise exactly one warning"
+    )
+    assert "2 out of 2 orbits" in range_warnings[0], (
+        "Warning for multiple orbits outside of the interpolation range "
+        "should report the number of orbits outside of the range"
+    )
+    assert "full range over all orbits" in range_warnings[0], (
+        "Warning for multiple orbits outside of the interpolation range "
+        "should make clear that the reported range is over all orbits"
+    )
+    return None


### PR DESCRIPTION
## Summary

The warnings emitted when orbit integration with `interpSphericalPotential` or `MultipoleExpansionPotential` visits radii outside of the interpolation range failed with a `TypeError` for multiple orbits, because `rperi()`/`rap()` return arrays that cannot be formatted with `{:.3f}`.

## Changes

- Refactored the duplicated warning code into a single `_warn_radii_outside_interpolation_range` helper.
- For multiple orbits, the warning now reports the number of orbits that strayed outside of the interpolation range (so the user can judge how big of an issue this is) and shows `amin(rperi)`/`amax(rap)`, making clear that this is the full range over all orbits:
  > Orbit integration with interpSphericalPotential visited radii outside of the interpolation range for 1 out of 2 orbits; initialize interpSphericalPotential with a wider radial range to avoid this if you wish (min/max r = 0.365,1.987, which is the full range over all orbits)
- Fixed the missing closing parenthesis in the single-orbit message.
- Added regression tests for both potentials covering the multiple-orbit warning (count, full-range wording, amin/amax values) and the no-warning case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)