### PR TITLE
DiskSCF family: planar 2nd derivatives in C (planar variational equations)

### DIFF
--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -329,6 +329,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->potentialEval= &DiskSCFPotentialEval;
       potentialArgs->planarRforce= &DiskSCFPotentialPlanarRforce;
       potentialArgs->planarphitorque= &ZeroPlanarForce;
+      potentialArgs->planarR2deriv= &DiskSCFPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &ZeroPlanarForce;
+      potentialArgs->planarRphideriv= &ZeroPlanarForce;
       potentialArgs->nargs= (int) **pot_args + 3;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -89,6 +89,12 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         if self._Sigma_dict is not None and self._hz_dict is not None:
             self.hasC = True
             self.hasC_dens = True
+            # The planar 2nd derivatives of the correction terms are in C
+            # (they vanish identically at z=0 because H(0)=0, but are wired
+            # so the planar variational equations work), so C planar
+            # integrate_dxdv works whenever the embedded SCF/Multipole part
+            # supports it
+            self.hasC_dxdv = self._me.hasC_dxdv
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):

--- a/galpy/potential/potential_c_ext/DiskSCFPotential.c
+++ b/galpy/potential/potential_c_ext/DiskSCFPotential.c
@@ -142,6 +142,19 @@ double DiskSCFPotentialPlanarRforce(double R,double phi,
   //Calculate Rforce
   return -dSigmadR(R,Sigma_args) * Hz(0.,hz_args);
 }
+double DiskSCFPotentialPlanarR2deriv(double R,double phi,
+				     double t,
+				     struct potentialArg * potentialArgs){
+  //Supposed to be zero (bc H(0) supposed to be zero), but just to make sure,
+  //mirroring PlanarRforce; planar phi2deriv/Rphideriv are exactly zero
+  //(axisymmetric) and are wired to ZeroPlanarForce in the orbit parsing
+  double * args= potentialArgs->args;
+  //Get args
+  int nsigma_args= (int) *args;
+  double * Sigma_args= args+1;
+  double * hz_args= args+1+nsigma_args;
+  return d2SigmadR2(R,Sigma_args) * Hz(0.,hz_args);
+}
 double DiskSCFPotentialzforce(double R,double Z, double phi,
 			      double t,
 			      struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -510,6 +510,8 @@ double DiskSCFPotentialzforce(double,double,double,double,
 				        struct potentialArg *);
 double DiskSCFPotentialPlanarRforce(double,double,double,
 					      struct potentialArg *);
+double DiskSCFPotentialPlanarR2deriv(double,double,double,
+					      struct potentialArg *);
 double DiskSCFPotentialDens(double,double,double,double,
 			    struct potentialArg *);
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -802,10 +802,8 @@ def test_liouville_planar():
     # rmpots.append('PowerSphericalPotentialwCutoff')
     # Doesn't have the R2deriv
     rmpots.append("SoftenedNeedleBarPotential")
-    rmpots.append("DiskSCFPotential")
     rmpots.append("SphericalShellPotential")
     rmpots.append("RingPotential")
-    rmpots.append("DiskMultipoleExpansionPotential")
     for p in rmpots:
         pots.remove(p)
     # tolerances in log10
@@ -826,6 +824,9 @@ def test_liouville_planar():
     tol["mockMultipoleExpansionLimitedGridPotential"] = -5.0
     tol["mockTDMultipoleExpansionLimitedGridPotential"] = -4.0
     tol["mockFlatWeaklyTDNonaxiM3MultipoleExpansionPotential"] = -4.0
+    # grid-spline-interpolated embedded Multipole part -> grid-level accuracy
+    tol["DiskMultipoleExpansionPotential"] = -5.5
+    tol["DiskSCFPotential"] = -7.0  # more difficult
     firstTest = True
     for p in pots:
         # Setup instance of potential

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -7564,11 +7564,17 @@ def test_harmonic_planar_stm_vs_fd_of_flow():
     # wrong-but-symmetric Hessian is still a Hamiltonian flow -- but it shifts the
     # actual deviation vectors. FD of the flow uses only the (trusted) forces, so
     # it is independent of any second-derivative code and pins their absolute
-    # value. This regression-guards the SCF planar 2nd-deriv sign fix. (The 3D
-    # Hessian and DiskSCF are validated in the variational-3D PR, where that C
-    # code lives.)
+    # value. This regression-guards the SCF planar 2nd-deriv sign fix and the
+    # DiskSCF planar variational wiring (the disk correction terms vanish
+    # identically at z=0 because H(0)=0, so the planar STM is driven by the
+    # embedded SCF part plus the trivially-zero correction Hessian). (The 3D
+    # Hessian is validated in the variational-3D PR, where that C code lives.)
     from galpy.orbit import Orbit
-    from galpy.potential import SCFPotential, scf_compute_coeffs_spherical
+    from galpy.potential import (
+        DiskSCFPotential,
+        SCFPotential,
+        scf_compute_coeffs_spherical,
+    )
 
     def _hern(R, z=0.0, phi=0.0):
         r = numpy.sqrt(R**2 + z**2)
@@ -7587,6 +7593,7 @@ def test_harmonic_planar_stm_vs_fd_of_flow():
     mp_axi.normalize(1.0)
     mp_nonaxi = mockMultipoleExpansionPotential()
     mp_nonaxi.normalize(1.0)
+    dscf = DiskSCFPotential(normalize=1.0)
     # (label, planar potential, tolerance): SCF and the axisymmetric Multipole
     # are analytic/near-exact (~1e-6); the non-axisymmetric Multipole is
     # grid-spline interpolated, so it agrees only to grid accuracy (~1e-4) -- far
@@ -7596,6 +7603,7 @@ def test_harmonic_planar_stm_vs_fd_of_flow():
         ("SCF (non-axi)", scf_nonaxi.toPlanar(), 1e-5),
         ("Multipole (axi)", mp_axi.toPlanar(), 1e-5),
         ("Multipole (non-axi)", mp_nonaxi.toPlanar(), 5e-4),
+        ("DiskSCF", dscf.toPlanar(), 1e-5),
     ]
     times = numpy.linspace(0.0, 2.0, 101)
     R0, vR0, vT0, phi0 = 1.0, 0.1, 1.1, 0.3


### PR DESCRIPTION
## Summary

Enables the **C planar variational equations** (`integrate_dxdv`) for `DiskSCFPotential`, `DiskMultipoleExpansionPotential`, and `KuijkenDubinskiDiskExpansionPotential` — the last members of the harmonic family without them.

**Physics**: the KuijkenDubinski correction terms vanish identically in the plane — $H(0)=0$ exactly for both the exp and sech² vertical profiles — so their planar Hessian contributions are exactly zero, and the planar dynamics/STM is carried by the embedded SCF/Multipole part (whose C planar 2nd derivatives were fixed in #923). This PR:

- adds `DiskSCFPotentialPlanarR2deriv` (defensively evaluated as $\Sigma''(R)H(0)$, mirroring the existing `PlanarRforce` style) + wires `planarR2deriv`/`planarphi2deriv`/`planarRphideriv` (the latter two `ZeroPlanarForce`, axisymmetric) in the planar orbit parsing,
- propagates `hasC_dxdv` from the embedded expansion in `_finish_init`.

**Tests**:
- `DiskSCFPotential` + `DiskMultipoleExpansionPotential` removed from `test_liouville_planar`'s exclusion list ("Doesn't have the R2deriv") — both now run the full planar det(M)=1 battery (with grid-accuracy tolerances matching the existing Multipole-mock entries).
- `test_harmonic_planar_stm_vs_fd_of_flow` gains a DiskSCF case — the finite-difference-of-the-flow **absolute-value** check (independent of any 2nd-derivative code): matches to <1e-5.

Follows the "functionality that should already have existed goes to main first" flow; `feat/variational3d` will absorb the tiny overlap (#920 added the 3D accessors there) at its next routine rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)