### PR TITLE
P2.5: EinastoPotential backend-agnostic (numpy/jax/torch)

### DIFF
--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -1,10 +1,13 @@
 ###############################################################################
-#   BurkertPotential.py: Potential with a Burkert density
+#   EinastoPotential.py: Potential with an Einasto density
 ###############################################################################
 import numpy
 from scipy import special
 from scipy.optimize import fsolve
 
+from ..backend import get_namespace
+from ..backend.special import gamma as _gamma
+from ..backend.special import gammaincc as _gammaincc
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
 
@@ -95,37 +98,37 @@ class EinastoPotential(SphericalPotential):
 
     def _revaluate(self, r, t=0.0):
         """Potential as a function of r and time"""
+        xp = get_namespace(r)
         s = r / self.h
-        gamma_3n = special.gamma(3 * self.n)
-        gamma_2n = special.gamma(2 * self.n)
-        gamma_upper_3n = special.gammaincc(3 * self.n, (s ** (1 / self.n)))
-        gamma_upper_2n = special.gammaincc(2 * self.n, (s ** (1 / self.n)))
+        # r == 0 is handled by the separate `core` branch below; eager backends
+        # evaluate BOTH xp.where branches, so the generic branch must stay
+        # NaN-free there: its (1-Q)/s term is 0/0 at s == 0 and, for n > 1,
+        # d(s**(1/n))/ds is infinite at s == 0 (which would NaN-poison reverse-
+        # mode autodiff). Evaluate the dead branch at the safe s == 1 instead.
+        ssafe = xp.where(r == 0, 1.0, s)
+        gamma_3n = _gamma(3 * self.n)
+        gamma_2n = _gamma(2 * self.n)
+        gamma_upper_3n = _gammaincc(3 * self.n, (ssafe ** (1 / self.n)))
+        gamma_upper_2n = _gammaincc(2 * self.n, (ssafe ** (1 / self.n)))
         # written to handle s = numpy.inf
         out = -(4 * numpy.pi * (self.h**2) * self.n * gamma_3n) * (
-            (1 - gamma_upper_3n) / s + gamma_upper_2n * (gamma_2n / gamma_3n)
+            (1 - gamma_upper_3n) / ssafe + gamma_upper_2n * (gamma_2n / gamma_3n)
         )
-        core = -(4 * numpy.pi * (self.h**2) * self.n) * special.gamma(2 * self.n)
-        if isinstance(r, (float, int)):
-            if r == 0:
-                return core
-            else:
-                return out
-        else:
-            out[r == 0] = core
-            return out
+        core = -(4 * numpy.pi * (self.h**2) * self.n) * _gamma(2 * self.n)
+        return xp.where(r == 0, core, out)
 
     def _rforce(self, r, t=0.0):
         s = r / self.h
-        gamma_3n = special.gamma(3 * self.n)
-        gamma_upper_3n = special.gammaincc(3 * self.n, (s ** (1 / self.n)))
+        gamma_3n = _gamma(3 * self.n)
+        gamma_upper_3n = _gammaincc(3 * self.n, (s ** (1 / self.n)))
         return (
             (4 * numpy.pi * self.h * self.n * gamma_3n) * (s**-2) * (gamma_upper_3n - 1)
         )
 
     def _r2deriv(self, r, t=0.0):
         s = r / self.h
-        gamma_3n = special.gamma(3 * self.n)
-        gamma_upper_3n = special.gammaincc(3 * self.n, (s ** (1 / self.n)))
+        gamma_3n = _gamma(3 * self.n)
+        gamma_upper_3n = _gammaincc(3 * self.n, (s ** (1 / self.n)))
         # (self.h**2)
         return -(4 * numpy.pi * self.n * gamma_3n) * (
             (-2 * (s**-3)) * (gamma_upper_3n - 1)

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -24,6 +24,7 @@ from galpy.potential import (
     BurkertPotential,
     DehnenCoreSphericalPotential,
     DehnenSphericalPotential,
+    EinastoPotential,
     HernquistPotential,
     HomogeneousSpherePotential,
     JaffePotential,
@@ -155,6 +156,17 @@ CASES = [
             "_Rzderiv",
             "_dens",
         ],
+        _ONE_D,
+        True,
+    ),
+    # Einasto: _revaluate/_rforce/_r2deriv migrated through the special-function
+    # router (gamma/gammaincc; native on numpy/jax/torch) and the r == 0 core
+    # branch through a guarded xp.where; _rdens is closed-form. The derived 3D
+    # methods come from the SphericalPotential base. n=1.5 exercises the
+    # non-trivial s**(1/n) exponent.
+    (
+        EinastoPotential(amp=1.3, h=1.1, n=1.5),
+        _THREE_D,
         _ONE_D,
         True,
     ),
@@ -488,6 +500,40 @@ def test_surfdens_z0_value_parity(backend_name, pot):
     assert numpy.isfinite(float(val)), (
         f"{type(pot).__name__} surfdens(R!=a,z=0) not finite"
     )
+
+
+###############################################################################
+# Einasto r == 0 core branch. _revaluate has a separate finite value at r == 0
+# (the generic branch's (1-Q)/s term is 0/0 there) handled by a guarded
+# xp.where: the dead generic branch is evaluated at the safe s == 1 so that,
+# under eager backends, neither the 0/0 nor the (n > 1) infinite d(s**(1/n))/ds
+# can NaN-poison values or reverse-mode gradients at the core.
+###############################################################################
+_EINASTO_NS = [1, 1.5, 3]
+
+
+@pytest.mark.parametrize("n", _EINASTO_NS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_einasto_revaluate_core_value_parity(backend_name, n):
+    pot = EinastoPotential(amp=1.3, h=1.1, n=n)
+    # grid including r == 0 (the guarded core branch) and generic points
+    rs = [0.0, 0.5, 1.3]
+    ref = numpy.asarray(pot._revaluate(numpy.asarray(rs)))
+    got = _tonumpy(pot._revaluate(_asarray(backend_name, rs)))
+    assert numpy.all(numpy.isfinite(ref))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("n", _EINASTO_NS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_einasto_revaluate_grad_finite_at_core(backend_name, n):
+    # At r == 0 the radial force vanishes (the Einasto density is cored), so
+    # AD(_revaluate) there must be 0 and in particular FINITE: without the
+    # ssafe guard the dead generic branch NaN-poisons the gradient.
+    pot = EinastoPotential(amp=1.3, h=1.1, n=n)
+    ad = _grad_wrt(backend_name, lambda r: pot._revaluate(r), 0.0)
+    assert numpy.isfinite(ad), f"Einasto(n={n}) d_revaluate/dr NaN at r=0"
+    numpy.testing.assert_allclose(ad, 0.0, atol=1e-12)
 
 
 @pytest.mark.parametrize("pot", _SURFDENS_CASES, ids=_SURFDENS_IDS)


### PR DESCRIPTION
Part of the **P2.5 special-function-backed** fan-out. Routes gamma/gammaincc through `galpy.backend.special` (native on all three backends); the r=0 core branch becomes a dead-side-guarded `xp.where` (no AD NaN-poisoning). Init-time dn solver stays numpy by design.

**Verification (adversarial, vs pristine feat/backends):** 868-entry value grid byte-identical (incl. r=0/inf, scalar+array); 25 new backend tests (parity 1e-12, jax+torch grad-vs-FD, AD identities incl. AD(_revaluate)==-_rforce); full test_backend_spherical.py 191 passed.

**Flagged numpy-path deltas (type/side-effect only, values identical):** (1) scalar-input `_revaluate` now returns a 0-d ndarray instead of numpy.float64 (same accepted pattern as #922); (2) the old r=0 RuntimeWarning (0/0 before overwrite) is no longer emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)