### PR TITLE
P2.5: DoubleExponentialDiskPotential backend-agnostic (Ogata quadrature)

### DIFF
--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -7,6 +7,7 @@
 import numpy
 from scipy import special
 
+from ..backend import get_namespace
 from ..util import conversion
 from .Potential import Potential, check_potential_inputs_not_arrays
 
@@ -19,6 +20,28 @@ def _de_psiprime(t):
     return (numpy.sinh(numpy.pi * numpy.sinh(t)) + numpy.pi * t * numpy.cosh(t)) / (
         numpy.cosh(numpy.pi * numpy.sinh(t)) + 1
     )
+
+
+def _de_quadsum(xp, *fw, axis=None):
+    """Backend-agnostic numpy.nansum(f1*w1 + f2*w2 + ..., axis=axis) over the
+    Ogata quadrature products (f = integrand at the nodes, w = the precomputed
+    weights). numpy.nansum substitutes 0 for NaN before summing, which this
+    replicates bitwise on the numpy path; jax/torch nansum APIs differ (torch
+    uses dim=), so the substitution is spelled out. The weights contain NaN at
+    the largest nodes when de_n is large (_de_psiprime overflows to inf/inf and
+    numpy.nansum is what drops those terms), so the NaN weights must ALSO be
+    zeroed inside the discarded branch: otherwise the product-rule cotangent
+    0 * NaN-weight NaN-poisons jax/torch gradients of the integrand."""
+    v = None
+    for f, w in fw:
+        t = f * w
+        v = t if v is None else v + t
+    bad = xp.isnan(v)
+    out = None
+    for f, w in fw:
+        t = f * xp.where(bad, 0.0, w)
+        out = t if out is None else out + t
+    return xp.sum(xp.where(bad, 0.0, out), axis=axis)
 
 
 class DoubleExponentialDiskPotential(Potential):
@@ -149,40 +172,50 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         if isinstance(R, (float, int)):
             floatIn = True
-            R = numpy.atleast_1d(R)
-            z = numpy.atleast_1d(z)
+            R = xp.atleast_1d(xp.asarray(R))
+            z = xp.atleast_1d(xp.asarray(z))
         else:
             if isinstance(z, float):
-                z = z * numpy.ones_like(R)
+                z = z * xp.ones_like(R)
             floatIn = False
             outShape = R.shape  # this code can't do arbitrary shapes
             R = R.flatten()
             z = z.flatten()
+        # Guard R == 0 (where x/R -> inf NaN-poisons autodiff through xp.where's
+        # dead branch); the R == 0 rows are overwritten below with the original
+        # values (the analytic potential at z == 0, NaN otherwise).
+        Rs = xp.where(R == 0, 1.0, R)
         fun = lambda x: (
-            (self._alpha**2.0 + (x / R[:, numpy.newaxis]) ** 2.0) ** -1.5
+            (self._alpha**2.0 + (x / Rs[:, numpy.newaxis]) ** 2.0) ** -1.5
             * (
                 self._beta
-                * numpy.exp(-x / R[:, numpy.newaxis] * numpy.fabs(z[:, numpy.newaxis]))
+                * xp.exp(-x / Rs[:, numpy.newaxis] * xp.abs(z[:, numpy.newaxis]))
                 - x
-                / R[:, numpy.newaxis]
-                * numpy.exp(-self._beta * numpy.fabs(z[:, numpy.newaxis]))
+                / Rs[:, numpy.newaxis]
+                * xp.exp(-self._beta * xp.abs(z[:, numpy.newaxis]))
             )
-            / (self._beta**2.0 - (x / R[:, numpy.newaxis]) ** 2.0)
+            / (self._beta**2.0 - (x / Rs[:, numpy.newaxis]) ** 2.0)
         )
         out = (
             -4.0
             * numpy.pi
             * self._alpha
-            / R
-            * numpy.nansum(fun(self._de_j0_xs) * self._de_j0_weights, axis=1)
+            / Rs
+            * _de_quadsum(
+                xp,
+                (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights)),
+                axis=1,
+            )
         )
-        out[(R == 0) * (z == 0)] = self._pot_zero
+        out = xp.where((R == 0) & (z == 0), float(self._pot_zero), out)
+        out = xp.where((R == 0) & (z != 0), numpy.nan, out)
         if floatIn:
             return out[0]
         else:
-            return numpy.reshape(out, outShape)
+            return xp.reshape(out, outShape)
 
     @check_potential_inputs_not_arrays
     def _Rforce(self, R, z, phi=0.0, t=0.0):
@@ -211,12 +244,13 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         fun = lambda x: (
             x
             * (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * (
-                self._beta * numpy.exp(-x / R * numpy.fabs(z))
-                - x / R * numpy.exp(-self._beta * numpy.fabs(z))
+                self._beta * xp.exp(-x / R * xp.abs(z))
+                - x / R * xp.exp(-self._beta * xp.abs(z))
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
@@ -225,7 +259,9 @@ class DoubleExponentialDiskPotential(Potential):
             * numpy.pi
             * self._alpha
             / R**2.0
-            * numpy.nansum(fun(self._de_j1_xs) * self._de_j1_weights)
+            * _de_quadsum(
+                xp, (fun(xp.asarray(self._de_j1_xs)), xp.asarray(self._de_j1_weights))
+            )
         )
 
     @check_potential_inputs_not_arrays
@@ -255,14 +291,12 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * x
             / R
-            * (
-                numpy.exp(-x / R * numpy.fabs(z))
-                - numpy.exp(-self._beta * numpy.fabs(z))
-            )
+            * (xp.exp(-x / R * xp.abs(z)) - xp.exp(-self._beta * xp.abs(z)))
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
         out = (
@@ -271,12 +305,13 @@ class DoubleExponentialDiskPotential(Potential):
             * self._alpha
             * self._beta
             / R
-            * numpy.nansum(fun(self._de_j0_xs) * self._de_j0_weights)
+            * _de_quadsum(
+                xp, (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights))
+            )
         )
-        if z > 0.0:
-            return out
-        else:
-            return -out
+        # Odd in z: out for z > 0, -out otherwise. The +-1.0 factor is exact
+        # (mult by +-1.0 is bitwise) and, unlike an if on z, jit-traceable.
+        return out * (2.0 * (z > 0.0) - 1.0)
 
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
@@ -304,12 +339,13 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-27 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         fun = lambda x: (
             x**2
             * (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * (
-                self._beta * numpy.exp(-x / R * numpy.fabs(z))
-                - x / R * numpy.exp(-self._beta * numpy.fabs(z))
+                self._beta * xp.exp(-x / R * xp.abs(z))
+                - x / R * xp.exp(-self._beta * xp.abs(z))
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
@@ -318,9 +354,15 @@ class DoubleExponentialDiskPotential(Potential):
             * numpy.pi
             * self._alpha
             / R**3.0
-            * numpy.nansum(
-                fun(self._de_j0_xs) * self._de_j0_weights
-                - fun(self._de_j1_xs) / self._de_j1_xs * self._de_j1_weights
+            * _de_quadsum(
+                xp,
+                (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights)),
+                # f1*w1 - f2*w2 as f1*w1 + (-f2)*w2: bitwise-identical ((-a)*b
+                # == -(a*b) and x + (-y) == x - y exactly in IEEE arithmetic).
+                (
+                    -fun(xp.asarray(self._de_j1_xs)) / xp.asarray(self._de_j1_xs),
+                    xp.asarray(self._de_j1_weights),
+                ),
             )
         )
 
@@ -350,13 +392,14 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * x
             / R
             * (
-                x / R * numpy.exp(-x / R * numpy.fabs(z))
-                - self._beta * numpy.exp(-self._beta * numpy.fabs(z))
+                x / R * xp.exp(-x / R * xp.abs(z))
+                - self._beta * xp.exp(-self._beta * xp.abs(z))
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
@@ -366,7 +409,9 @@ class DoubleExponentialDiskPotential(Potential):
             * self._alpha
             * self._beta
             / R
-            * numpy.nansum(fun(self._de_j0_xs) * self._de_j0_weights)
+            * _de_quadsum(
+                xp, (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights))
+            )
         )
 
     @check_potential_inputs_not_arrays
@@ -395,13 +440,11 @@ class DoubleExponentialDiskPotential(Potential):
         - 2013-08-28 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * (x / R) ** 2.0
-            * (
-                numpy.exp(-x / R * numpy.fabs(z))
-                - numpy.exp(-self._beta * numpy.fabs(z))
-            )
+            * (xp.exp(-x / R * xp.abs(z)) - xp.exp(-self._beta * xp.abs(z)))
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
         out = (
@@ -410,20 +453,22 @@ class DoubleExponentialDiskPotential(Potential):
             * self._alpha
             * self._beta
             / R
-            * numpy.nansum(fun(self._de_j1_xs) * self._de_j1_weights)
+            * _de_quadsum(
+                xp, (fun(xp.asarray(self._de_j1_xs)), xp.asarray(self._de_j1_weights))
+            )
         )
-        if z > 0.0:
-            return out
-        else:
-            return -out
+        # Odd in z (see _zforce): exact +-1.0 factor instead of an if on z.
+        return out * (2.0 * (z > 0.0) - 1.0)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        return numpy.exp(-self._alpha * R - self._beta * numpy.fabs(z))
+        xp = get_namespace(R, z)
+        return xp.exp(-self._alpha * R - self._beta * xp.abs(z))
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         return (
             2.0
-            * numpy.exp(-self._alpha * R)
+            * xp.exp(-self._alpha * R)
             / self._beta
-            * (1.0 - numpy.exp(-self._beta * numpy.fabs(z)))
+            * (1.0 - xp.exp(-self._beta * xp.abs(z)))
         )

--- a/tests/test_backend_disk.py
+++ b/tests/test_backend_disk.py
@@ -13,6 +13,7 @@ import numpy
 import pytest
 
 from galpy.potential import (
+    DoubleExponentialDiskPotential,
     FlattenedPowerPotential,
     IsothermalDiskPotential,
     KGPotential,
@@ -44,6 +45,19 @@ except ImportError:  # pragma: no cover
     torch = None
 
 AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# DoubleExponentialDisk's Ogata/Bessel quadrature nodes+weights are numpy
+# constants computed in __init__ (the j0/j1 Bessel values live inside the
+# precomputed weights); the per-call quadrature sums are elementary ops, so the
+# potential is backend-agnostic without any j0/j1 special-function router entry.
+# _evaluate/_dens/_surfdens are array-capable; the force/2nd-derivative methods
+# are scalar-only (check_potential_inputs_not_arrays) and get dedicated
+# scalar-parity + autodiff-identity tests at the bottom of this module. The
+# default de_n=10000 keeps the quadrature error of the AD identities below
+# machine precision (at de_n=1000 the R-direction identities only hold to the
+# quadrature accuracy ~1e-8, because Phi and Rforce use different - j0 vs j1 -
+# Ogata rules).
+_DEXP = DoubleExponentialDiskPotential(amp=1.3, hr=0.4, hz=0.1)
 
 # --- 3D potentials: (R,z) signature ------------------------------------------
 # Each entry: (instance, [migrated methods]).
@@ -96,6 +110,7 @@ _POTS_3D = [
     ),
     # Only _surfdens is analytically clean (the rest use scipy.special).
     (RazorThinExponentialDiskPotential(amp=1.0, hr=0.4), ["_surfdens"]),
+    (_DEXP, ["_evaluate", "_dens", "_surfdens"]),
 ]
 _POT3D_IDS = [f"{type(p).__name__}-{i}" for i, (p, _) in enumerate(_POTS_3D)]
 
@@ -346,9 +361,14 @@ _ID3D_IDS = [f"{type(p).__name__}-{i}" for i, (p, _) in enumerate(_ID_POTS_3D)]
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)
 def test_force_hessian_identities_3d(backend_name, pot, methods):
     # For EVERY identity pair where both methods are migrated for this potential,
-    # AD(lower wrt var) == -higher, exact to rtol=1e-9.
-    if not (set(methods) & {"_evaluate", "_Rforce", "_zforce"}):
-        pytest.skip("no migrated force/evaluate methods to form an identity pair")
+    # AD(lower wrt var) == -higher, exact to rtol=1e-9. Skip when no pair is
+    # complete (e.g. DoubleExponentialDisk lists only its array-capable methods
+    # here; its scalar-only force/Hessian identities are checked in
+    # test_doubleexp_force_hessian_identities below).
+    if not any(
+        lower in methods and higher in methods for lower, _, higher, _ in _ID_PAIRS_2D
+    ):
+        pytest.skip("no complete identity pair among the migrated methods")
     R0, z0 = 1.3, 0.4
     n_checked = 0
     for lower, argnum, higher, vn in _ID_PAIRS_2D:
@@ -381,3 +401,103 @@ def test_force_identity_1d(backend_name, pot):
     ad = _grad_wrt(backend_name, lambda x: pot._evaluate(x), x0)
     ref = -float(pot._force(x0))
     numpy.testing.assert_allclose(ad, ref, rtol=1e-9)
+
+
+###############################################################################
+# DoubleExponentialDiskPotential: dedicated tests for the scalar-only
+# (check_potential_inputs_not_arrays) Ogata-quadrature methods. These need
+# explicit positional phi/t (the decorator's wrapper takes them positionally)
+# and 0-d backend arrays, so they don't fit the array-grid CASES tables above.
+###############################################################################
+_DEXP_SCALAR_METHODS = ["_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv"]
+# Points include z < 0 and z == 0 (the odd-in-z +-1.0 sign factor of
+# _zforce/_Rzderiv) on top of generic ones.
+_DEXP_POINTS = [(0.5, 0.1), (1.0, 0.2), (2.0, -0.3), (1.3, 0.0), (0.7, 0.4)]
+
+
+@pytest.mark.parametrize("method", _DEXP_SCALAR_METHODS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_doubleexp_scalar_value_parity(backend_name, method):
+    for R0, z0 in _DEXP_POINTS:
+        ref = numpy.asarray(getattr(_DEXP, method)(R0, z0, 0.0, 0.0))
+        got = _tonumpy(
+            getattr(_DEXP, method)(
+                _asarray(backend_name, R0), _asarray(backend_name, z0), 0.0, 0.0
+            )
+        )
+        numpy.testing.assert_allclose(
+            got,
+            ref,
+            rtol=1e-12,
+            atol=1e-14,
+            err_msg=f"DoubleExponentialDisk.{method} at (R,z)=({R0},{z0}) "
+            f"({backend_name})",
+        )
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_doubleexp_evaluate_zero_point(backend_name):
+    # The R == 0, z == 0 point is patched to the analytic _pot_zero through
+    # xp.where (in-place assignment on the numpy path historically); it must be
+    # identical across backends, also as an entry of an array evaluation.
+    ref = float(_DEXP._evaluate(0.0, 0.0))
+    got = float(
+        _tonumpy(
+            _DEXP._evaluate(_asarray(backend_name, 0.0), _asarray(backend_name, 0.0))
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-15)
+    gotarr = _tonumpy(
+        _DEXP._evaluate(
+            _asarray(backend_name, [0.0, 1.0]), _asarray(backend_name, [0.0, 0.2])
+        )
+    )
+    refarr = numpy.asarray(
+        _DEXP._evaluate(numpy.asarray([0.0, 1.0]), numpy.asarray([0.0, 0.2]))
+    )
+    numpy.testing.assert_allclose(gotarr, refarr, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_doubleexp_force_hessian_identities(backend_name):
+    # Same identity battery as test_force_hessian_identities_3d, with the
+    # explicit positional phi/t the decorated scalar-only methods require. At
+    # the default de_n=10000 ALL pairs hold to machine precision; this includes
+    # the cross-quadrature ones (AD of the j0-rule Phi vs the j1-rule Rforce),
+    # which are exact only because the quadrature error is < 1e-15 there. A
+    # negative-z point exercises the +-1.0 odd-in-z factor under autodiff.
+    for R0, z0 in [(1.3, 0.4), (1.3, -0.4)]:
+        n_checked = 0
+        for lower, argnum, higher, vn in _ID_PAIRS_2D:
+            ad = _grad_wrt(
+                backend_name,
+                lambda R, z, _l=lower: getattr(_DEXP, _l)(R, z, 0.0, 0.0),
+                R0,
+                z0,
+                argnum=argnum,
+            )
+            ref = -float(getattr(_DEXP, higher)(R0, z0, 0.0, 0.0))
+            numpy.testing.assert_allclose(
+                ad,
+                ref,
+                rtol=1e-9,
+                err_msg=f"DoubleExponentialDisk: AD({lower}/{vn})==-{higher} "
+                f"at (R,z)=({R0},{z0})",
+            )
+            n_checked += 1
+        assert n_checked == len(_ID_PAIRS_2D)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_doubleexp_grad_z_vs_finite_difference(backend_name):
+    # FD cross-check of d(_evaluate)/dz (the R-gradient is FD-checked by
+    # test_grad_evaluate_vs_finite_difference_3d); catches a latent bug shared
+    # by both the AD gradient and the hand-coded _zforce.
+    R0, z0 = 1.3, 0.4
+    eps = 1e-6
+    fd = (
+        float(_DEXP._evaluate(numpy.asarray(R0), numpy.asarray(z0 + eps)))
+        - float(_DEXP._evaluate(numpy.asarray(R0), numpy.asarray(z0 - eps)))
+    ) / (2 * eps)
+    ad = _grad_wrt(backend_name, lambda R, z: _DEXP._evaluate(R, z), R0, z0, argnum=1)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)


### PR DESCRIPTION
Part of the **P2.5** fan-out. Surprise finding: **no Bessel router needed** — the j0/j1 values are baked into the Ogata quadrature weights precomputed with scipy at `__init__` (stays numpy, byte-identical); the per-call path is elementary ops, now xp-dispatched. Key fix: the default-de_n weight arrays contain 7772 NaNs that `numpy.nansum` silently dropped — a new `_de_quadsum` replicates nansum bitwise while zeroing NaN weights inside the discarded branch so jax/torch AD survives. `if z>0` branches became the exact, traceable `(2.0*(z>0.0)-1.0)` factor. jax.jit-traceable (verified).

**Verification (adversarial):** numpy value grid byte-identical except one flagged NaN-bit-pattern change (R==0,z≠0: arithmetic 0*inf NaN → explicit numpy.nan; same NaN semantics); backend tests pass; stored weight arrays untouched (C extension reads them raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)