### PR TITLE
P2.5: SCFPotential backend-agnostic / jit-clean (jax/torch)

### DIFF
--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -13,6 +13,8 @@ if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
 else:
     from scipy.special import assoc_legendre_p_all
 
+from ..backend import get_namespace
+from ..backend.special import assoc_legendre, gegenbauer
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
 from ..util.special import compute_legendre, sph_harm_normalization
@@ -282,21 +284,34 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         -----
          - Written on 2016-05-17 by Aladdin Seaifan (UofT)
         """
+        xp = get_namespace(r)
         xi = _RToxi(r, self._a)
         CC = _C(xi, N, L)
         a = self._a
-        rho = numpy.zeros((N, L), float)
         n = numpy.arange(0, N, dtype=float)[:, numpy.newaxis]
         l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
         K = 0.5 * n * (n + 4 * l + 3) + (l + 1.0) * (2 * l + 1)
-        rho[:, :] = (
+        if xp is numpy:
+            rho = numpy.zeros((N, L), float)
+            rho[:, :] = (
+                K
+                * ((a * r) ** l)
+                / ((r / a) * (a + r) ** (2 * l + 3.0))
+                * CC[:, :]
+                * (numpy.pi) ** -0.5
+            )
+            return rho
+        # backend path: same expression, functional (no in-place writes); the
+        # constant (n,l) grids are built in numpy and converted once.
+        K = xp.asarray(K)
+        l = xp.asarray(l)
+        return (
             K
             * ((a * r) ** l)
             / ((r / a) * (a + r) ** (2 * l + 3.0))
-            * CC[:, :]
+            * CC
             * (numpy.pi) ** -0.5
         )
-        return rho
 
     def _phiTilde(self, r, N, L):
         """
@@ -321,23 +336,39 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         - Written on 2016-05-17 by Aladdin Seaifan (UofT)
 
         """
+        xp = get_namespace(r)
         xi = _RToxi(r, self._a)
         CC = _C(xi, N, L)
         a = self._a
-        phi = numpy.zeros((N, L), float)
-        n = numpy.arange(0, N)[:, numpy.newaxis]
-        l = numpy.arange(0, L)[numpy.newaxis, :]
-        if r == 0:
-            phi[:, :] = -1.0 / a * CC[:, :] * (4 * numpy.pi) ** 0.5
-        else:
-            phi[:, :] = (
-                -(a**l)
-                * r ** (-l - 1.0)
-                / ((1.0 + a / r) ** (2 * l + 1.0))
-                * CC[:, :]
-                * (4 * numpy.pi) ** 0.5
-            )
-        return phi
+        if xp is numpy:
+            phi = numpy.zeros((N, L), float)
+            n = numpy.arange(0, N)[:, numpy.newaxis]
+            l = numpy.arange(0, L)[numpy.newaxis, :]
+            if r == 0:
+                phi[:, :] = -1.0 / a * CC[:, :] * (4 * numpy.pi) ** 0.5
+            else:
+                phi[:, :] = (
+                    -(a**l)
+                    * r ** (-l - 1.0)
+                    / ((1.0 + a / r) ** (2 * l + 1.0))
+                    * CC[:, :]
+                    * (4 * numpy.pi) ** 0.5
+                )
+            return phi
+        # backend path: branchless r == 0 handling. Both xp.where branches are
+        # evaluated under tracing/eager AD, so the generic branch is computed at
+        # a guarded rsafe (the r == 0 column then takes the -CC/a limit instead).
+        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
+        rsafe = xp.where(r == 0, 1.0, r)
+        generic = (
+            -(a**l)
+            * rsafe ** (-l - 1.0)
+            / ((1.0 + a / rsafe) ** (2 * l + 1.0))
+            * CC
+            * (4 * numpy.pi) ** 0.5
+        )
+        centre = -1.0 / a * CC * (4 * numpy.pi) ** 0.5
+        return xp.where(r == 0, centre, generic)
 
     def _compute_at_point(self, radial_func, R, z, phi):
         """
@@ -366,20 +397,32 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2016-05-18 - Written - Aladdin Seaifan (UofT)
         - 2026-02-11 - Simplified - Bovy (UofT)
         """
-        Acos, Asin = self._Acos, self._Asin
-        N, L, M = Acos.shape
+        xp = get_namespace(R, z, phi)
+        N, L, M = self._Acos.shape
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
-        # Radial part: (N, L)
+        if xp is numpy:
+            Acos, Asin = self._Acos, self._Asin
+            # Radial part: (N, L)
+            radial = radial_func(r, N, L)
+            # Angular part: associated Legendre polynomials (L, M)
+            PP = compute_legendre(numpy.cos(theta), L, M)
+            # Azimuthal part: cos(m*phi), sin(m*phi)
+            m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
+            mcos = numpy.cos(m * phi)
+            msin = numpy.sin(m * phi)
+            return numpy.sum(
+                radial[:, :, None] * (Acos * mcos + Asin * msin) * PP[None, :, :]
+            )
+        # backend path: same sum with the backend-agnostic special-function
+        # router; the coefficient tables are converted to the backend once.
+        Acos = xp.asarray(self._Acos)
+        Asin = xp.asarray(self._Asin)
         radial = radial_func(r, N, L)
-        # Angular part: associated Legendre polynomials (L, M)
-        PP = compute_legendre(numpy.cos(theta), L, M)
-        # Azimuthal part: cos(m*phi), sin(m*phi)
-        m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
-        mcos = numpy.cos(m * phi)
-        msin = numpy.sin(m * phi)
-        return numpy.sum(
-            radial[:, :, None] * (Acos * mcos + Asin * msin) * PP[None, :, :]
-        )
+        PP = assoc_legendre(L, M, xp.cos(theta))
+        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        mcos = xp.cos(m * phi)
+        msin = xp.sin(m * phi)
+        return xp.sum(radial[:, :, None] * (Acos * mcos + Asin * msin) * PP[None, :, :])
 
     def _evaluate_expansion(self, radial_func, R, z, phi):
         """
@@ -406,19 +449,44 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2016-06-02 - Written - Aladdin Seaifan (UofT)
         - 2026-02-11 - Simplified - Bovy (UofT)
         """
-        R = numpy.array(R, dtype=float)
-        z = numpy.array(z, dtype=float)
-        phi = numpy.array(phi, dtype=float)
+        xp = get_namespace(R, z, phi)
+        if xp is numpy:
+            R = numpy.array(R, dtype=float)
+            z = numpy.array(z, dtype=float)
+            phi = numpy.array(phi, dtype=float)
+            shape = (R * z * phi).shape
+            if shape == ():
+                return self._compute_at_point(radial_func, R, z, phi)
+            R = R * numpy.ones(shape)
+            z = z * numpy.ones(shape)
+            phi = phi * numpy.ones(shape)
+            result = numpy.zeros(shape, float)
+            for idx in numpy.ndindex(*shape):
+                result[idx] = self._compute_at_point(
+                    radial_func, R[idx], z[idx], phi[idx]
+                )
+            return result
+        # backend path: identical per-point evaluation, but assembled
+        # functionally (stack instead of in-place writes) so it traces and
+        # differentiates under jax/torch.
+        R = xp.asarray(R) * 1.0
+        z = xp.asarray(z) * 1.0
+        phi = xp.asarray(phi) * 1.0
         shape = (R * z * phi).shape
         if shape == ():
             return self._compute_at_point(radial_func, R, z, phi)
-        R = R * numpy.ones(shape)
-        z = z * numpy.ones(shape)
-        phi = phi * numpy.ones(shape)
-        result = numpy.zeros(shape, float)
-        for idx in numpy.ndindex(*shape):
-            result[idx] = self._compute_at_point(radial_func, R[idx], z[idx], phi[idx])
-        return result
+        R = xp.broadcast_to(R, shape)
+        z = xp.broadcast_to(z, shape)
+        phi = xp.broadcast_to(phi, shape)
+        return xp.reshape(
+            xp.stack(
+                [
+                    self._compute_at_point(radial_func, R[idx], z[idx], phi[idx])
+                    for idx in numpy.ndindex(*shape)
+                ]
+            ),
+            shape,
+        )
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi and phi is None:
@@ -438,14 +506,30 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         return self._evaluate_expansion(self._phiTilde, R, z, phi)
 
     def _dphiTilde(self, r, N, L):
+        xp = get_namespace(r)
         a = self._a
-        l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
-        n = numpy.arange(0, N, dtype=float)[:, numpy.newaxis]
         xi = _RToxi(r, self._a)
         dC = _dC(xi, N, L)
+        if xp is numpy:
+            l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
+            n = numpy.arange(0, N, dtype=float)[:, numpy.newaxis]
+            return -((4 * numpy.pi) ** 0.5) * (
+                numpy.power(a * r, l)
+                * (l * (a + r) * numpy.power(r, -1) - (2 * l + 1))
+                / ((a + r) ** (2 * l + 2))
+                * _C(xi, N, L)
+                + a**-1
+                * (1 - xi) ** 2
+                * (a * r) ** l
+                / (a + r) ** (2 * l + 1)
+                * dC
+                / 2.0
+            )
+        # backend path: identical expression with xp arithmetic.
+        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
         return -((4 * numpy.pi) ** 0.5) * (
-            numpy.power(a * r, l)
-            * (l * (a + r) * numpy.power(r, -1) - (2 * l + 1))
+            (a * r) ** l
+            * (l * (a + r) * r ** (-1.0) - (2 * l + 1))
             / ((a + r) ** (2 * l + 2))
             * _C(xi, N, L)
             + a**-1 * (1 - xi) ** 2 * (a * r) ** l / (a + r) ** (2 * l + 1) * dC / 2.0
@@ -458,38 +542,77 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # Gegenbauer polynomial and its 1st/2nd xi-derivatives; the dxi/dr
         # factors are already folded into the algebra below. (r=0 -- the centre
         # -- is a removable singularity never hit along an orbit; guarded.)
+        xp = get_namespace(r)
         a = self._a
-        ar = a + r
-        l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
         xi = _RToxi(r, a)
         CC = _C(xi, N, L)
         dCC = _dC(xi, N, L)
         d2CC = _d2C(xi, N, L)
-        if r == 0:
-            return numpy.zeros((N, L), float)
+        if xp is numpy:
+            ar = a + r
+            l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
+            if r == 0:
+                return numpy.zeros((N, L), float)
+            ar2 = ar * ar
+            ar3 = ar2 * ar
+            ar4 = ar3 * ar
+            # Factored as (a r / ar^2)^l / (r^2 ar^5) -- a small, stable number
+            # for large r -- rather than (a r)^l / ar^(5+2l), whose intermediate
+            # powers overflow to inf/inf=NaN at large l (matches the C
+            # compute_d2phiTilde).
+            rterm = numpy.power(a * r / ar2, l) / (r * r * ar3 * ar2)
+            out = rterm * (
+                CC
+                * (
+                    l * (1.0 - l) * ar4
+                    - (4.0 * l**2 + 6.0 * l + 2.0) * r * r * ar2
+                    + l * (4.0 * l + 2.0) * r * ar3
+                )
+                + a
+                * r
+                * (
+                    (
+                        4.0 * r * r
+                        + 4.0 * a * r
+                        + (8.0 * l + 4.0) * r * ar
+                        - 4.0 * l * ar2
+                    )
+                    * dCC
+                    - 4.0 * a * r * d2CC
+                )
+            )
+            return out * (4.0 * numpy.pi) ** 0.5
+        # backend path: same factored expression at a guarded radius (the r == 0
+        # column is exactly zero; both xp.where branches are evaluated under
+        # tracing/eager AD, so the generic branch must stay finite there).
+        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
+        rs = xp.where(r == 0, 1.0, r)
+        ar = a + rs
         ar2 = ar * ar
         ar3 = ar2 * ar
         ar4 = ar3 * ar
-        # Factored as (a r / ar^2)^l / (r^2 ar^5) -- a small, stable number for
-        # large r -- rather than (a r)^l / ar^(5+2l), whose intermediate powers
-        # overflow to inf/inf=NaN at large l (matches the C compute_d2phiTilde).
-        rterm = numpy.power(a * r / ar2, l) / (r * r * ar3 * ar2)
+        rterm = (a * rs / ar2) ** l / (rs * rs * ar3 * ar2)
         out = rterm * (
             CC
             * (
                 l * (1.0 - l) * ar4
-                - (4.0 * l**2 + 6.0 * l + 2.0) * r * r * ar2
-                + l * (4.0 * l + 2.0) * r * ar3
+                - (4.0 * l**2 + 6.0 * l + 2.0) * rs * rs * ar2
+                + l * (4.0 * l + 2.0) * rs * ar3
             )
             + a
-            * r
+            * rs
             * (
-                (4.0 * r * r + 4.0 * a * r + (8.0 * l + 4.0) * r * ar - 4.0 * l * ar2)
+                (
+                    4.0 * rs * rs
+                    + 4.0 * a * rs
+                    + (8.0 * l + 4.0) * rs * ar
+                    - 4.0 * l * ar2
+                )
                 * dCC
-                - 4.0 * a * r * d2CC
+                - 4.0 * a * rs * d2CC
             )
         )
-        return out * (4.0 * numpy.pi) ** 0.5
+        return xp.where(r == 0, 0.0, out * (4.0 * numpy.pi) ** 0.5)
 
     def _compute_spher_forces_at_point(self, R, z, phi=0, t=0):
         """
@@ -522,40 +645,60 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2016-05-18 - Written - Aladdin Seaifan (UofT)
         - 2026-02-11 - Simplified - Bovy (UofT)
         """
-        Acos, Asin = self._Acos, self._Asin
-        N, L, M = Acos.shape
+        xp = get_namespace(R, z, phi)
+        N, L, M = self._Acos.shape
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
-        new_hash = hashlib.md5(numpy.array([R, z, phi])).hexdigest()
+        if xp is numpy:
+            Acos, Asin = self._Acos, self._Asin
+            new_hash = hashlib.md5(numpy.array([R, z, phi])).hexdigest()
 
-        if new_hash == self._force_hash:
-            dPhi_dr = self._cached_dPhi_dr
-            dPhi_dtheta = self._cached_dPhi_dtheta
-            dPhi_dphi = self._cached_dPhi_dphi
-        else:
-            # Angular part: Legendre polynomials and their derivatives
-            PP, dPP = compute_legendre(numpy.cos(theta), L, M, deriv=True)
-            PP = PP[None, :, :]
-            dPP = dPP[None, :, :]
-            # Radial part: potential basis and its radial derivative
-            phi_tilde = self._phiTilde(r, N, L)[:, :, numpy.newaxis]
-            dphi_tilde = self._dphiTilde(r, N, L)[:, :, numpy.newaxis]
-            # Azimuthal part
-            m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
-            mcos = numpy.cos(m * phi)
-            msin = numpy.sin(m * phi)
-            # Coefficient-weighted angular factors
-            cos_sin_sum = Acos * mcos + Asin * msin
-            # Force components in spherical coordinates
-            dPhi_dr = -numpy.sum(cos_sin_sum * PP * dphi_tilde)
-            dPhi_dtheta = -numpy.sum(
-                cos_sin_sum * phi_tilde * dPP * (-numpy.sin(theta))
-            )
-            dPhi_dphi = -numpy.sum(m * (Asin * mcos - Acos * msin) * phi_tilde * PP)
-            # Cache for reuse (e.g., _Rforce and _zforce called at same point)
-            self._force_hash = new_hash
-            self._cached_dPhi_dr = dPhi_dr
-            self._cached_dPhi_dtheta = dPhi_dtheta
-            self._cached_dPhi_dphi = dPhi_dphi
+            if new_hash == self._force_hash:
+                dPhi_dr = self._cached_dPhi_dr
+                dPhi_dtheta = self._cached_dPhi_dtheta
+                dPhi_dphi = self._cached_dPhi_dphi
+            else:
+                # Angular part: Legendre polynomials and their derivatives
+                PP, dPP = compute_legendre(numpy.cos(theta), L, M, deriv=True)
+                PP = PP[None, :, :]
+                dPP = dPP[None, :, :]
+                # Radial part: potential basis and its radial derivative
+                phi_tilde = self._phiTilde(r, N, L)[:, :, numpy.newaxis]
+                dphi_tilde = self._dphiTilde(r, N, L)[:, :, numpy.newaxis]
+                # Azimuthal part
+                m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
+                mcos = numpy.cos(m * phi)
+                msin = numpy.sin(m * phi)
+                # Coefficient-weighted angular factors
+                cos_sin_sum = Acos * mcos + Asin * msin
+                # Force components in spherical coordinates
+                dPhi_dr = -numpy.sum(cos_sin_sum * PP * dphi_tilde)
+                dPhi_dtheta = -numpy.sum(
+                    cos_sin_sum * phi_tilde * dPP * (-numpy.sin(theta))
+                )
+                dPhi_dphi = -numpy.sum(m * (Asin * mcos - Acos * msin) * phi_tilde * PP)
+                # Cache for reuse (e.g., _Rforce and _zforce called at same point)
+                self._force_hash = new_hash
+                self._cached_dPhi_dr = dPhi_dr
+                self._cached_dPhi_dtheta = dPhi_dtheta
+                self._cached_dPhi_dphi = dPhi_dphi
+            return dPhi_dr, dPhi_dtheta, dPhi_dphi
+        # backend path: same computation, but functional and cache-free (the
+        # per-point Python hash cache is trace-hostile under jit and useless on
+        # traced values; numpy keeps it above).
+        Acos = xp.asarray(self._Acos)
+        Asin = xp.asarray(self._Asin)
+        PP, dPP = assoc_legendre(L, M, xp.cos(theta), deriv=1)
+        PP = PP[None, :, :]
+        dPP = dPP[None, :, :]
+        phi_tilde = self._phiTilde(r, N, L)[:, :, None]
+        dphi_tilde = self._dphiTilde(r, N, L)[:, :, None]
+        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        mcos = xp.cos(m * phi)
+        msin = xp.sin(m * phi)
+        cos_sin_sum = Acos * mcos + Asin * msin
+        dPhi_dr = -xp.sum(cos_sin_sum * PP * dphi_tilde)
+        dPhi_dtheta = -xp.sum(cos_sin_sum * phi_tilde * dPP * (-xp.sin(theta)))
+        dPhi_dphi = -xp.sum(m * (Asin * mcos - Acos * msin) * phi_tilde * PP)
         return dPhi_dr, dPhi_dtheta, dPhi_dphi
 
     def _compute_spher_2nd_derivs_at_point(self, R, z, phi, t=0.0):
@@ -572,61 +715,107 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         -----
         - 2026-06-08 - Written - Bovy (UofT)
         """
-        # Cache the full spherical 2nd-derivative set: the six cylindrical
-        # second derivatives at a point all transform from it, so this is
-        # computed once per point instead of once per component.
-        cache_key = (float(R), float(z), float(phi), float(t))
-        if cache_key == self._2nd_deriv_cache_key:
-            return self._cached_2nd_derivs
-        Acos, Asin = self._Acos, self._Asin
-        N, L, M = Acos.shape
-        r, theta, phi = coords.cyl_to_spher(R, z, phi)
-        if r == 0.0 or not numpy.isfinite(r):
+        xp = get_namespace(R, z, phi)
+        N, L, M = self._Acos.shape
+        if xp is numpy:
+            # Cache the full spherical 2nd-derivative set: the six cylindrical
+            # second derivatives at a point all transform from it, so this is
+            # computed once per point instead of once per component.
+            cache_key = (float(R), float(z), float(phi), float(t))
+            if cache_key == self._2nd_deriv_cache_key:
+                return self._cached_2nd_derivs
+            Acos, Asin = self._Acos, self._Asin
+            r, theta, phi = coords.cyl_to_spher(R, z, phi)
+            if r == 0.0 or not numpy.isfinite(r):
+                self._2nd_deriv_cache_key = cache_key
+                self._cached_2nd_derivs = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                return self._cached_2nd_derivs
+            costheta = numpy.cos(theta)
+            sintheta = numpy.sin(theta)
+            # nudge off the pole so the m>0 angular derivatives stay finite
+            if M > 1 and abs(1.0 - costheta * costheta) < 1e-14:
+                costheta = numpy.sign(costheta) * (1.0 - 1e-7)
+                sintheta = numpy.sqrt(1.0 - costheta**2)
+            PP, dPP, d2PP = compute_legendre(costheta, L, M, deriv=2)
+            # theta-derivatives of the (angular) Legendre functions
+            dPth = dPP * (-sintheta)
+            d2Pth = d2PP * sintheta**2 - dPP * costheta
+            PP = PP[numpy.newaxis, :, :]
+            dPth = dPth[numpy.newaxis, :, :]
+            d2Pth = d2Pth[numpy.newaxis, :, :]
+            # radial basis and its first/second radial derivatives
+            phi_tilde = self._phiTilde(r, N, L)[:, :, numpy.newaxis]
+            dphi_tilde = self._dphiTilde(r, N, L)[:, :, numpy.newaxis]
+            d2phi_tilde = self._d2phiTilde(r, N, L)[:, :, numpy.newaxis]
+            m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
+            mcos = numpy.cos(m * phi)
+            msin = numpy.sin(m * phi)
+            cos_sin = Acos * mcos + Asin * msin  # angular azimuthal coefficient
+            dphi_coef = m * (Asin * mcos - Acos * msin)  # d/dphi of cos_sin
+            Phi_rr = numpy.sum(cos_sin * PP * d2phi_tilde)
+            Phi_tt = numpy.sum(cos_sin * d2Pth * phi_tilde)
+            Phi_pp = numpy.sum(-m * m * cos_sin * PP * phi_tilde)
+            Phi_rt = numpy.sum(cos_sin * dPth * dphi_tilde)
+            Phi_rp = numpy.sum(dphi_coef * PP * dphi_tilde)
+            Phi_tp = numpy.sum(dphi_coef * dPth * phi_tilde)
+            Phi_r = numpy.sum(cos_sin * PP * dphi_tilde)
+            Phi_t = numpy.sum(cos_sin * dPth * phi_tilde)
             self._2nd_deriv_cache_key = cache_key
-            self._cached_2nd_derivs = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            self._cached_2nd_derivs = (
+                Phi_rr,
+                Phi_tt,
+                Phi_pp,
+                Phi_rt,
+                Phi_rp,
+                Phi_tp,
+                Phi_r,
+                Phi_t,
+            )
             return self._cached_2nd_derivs
-        costheta = numpy.cos(theta)
-        sintheta = numpy.sin(theta)
-        # nudge off the pole so the m>0 angular derivatives stay finite
-        if M > 1 and abs(1.0 - costheta * costheta) < 1e-14:
-            costheta = numpy.sign(costheta) * (1.0 - 1e-7)
-            sintheta = numpy.sqrt(1.0 - costheta**2)
-        PP, dPP, d2PP = compute_legendre(costheta, L, M, deriv=2)
-        # theta-derivatives of the (angular) Legendre functions
+        # backend path: cache-free (the per-point Python cache key calls
+        # float(R), which is trace-hostile under jit) and branchless. The
+        # r == 0 / r == inf centre is handled by computing the generic branch
+        # at a guarded radius and zeroing the result with xp.where, so both
+        # branches stay finite under tracing/eager AD.
+        Acos = xp.asarray(self._Acos)
+        Asin = xp.asarray(self._Asin)
+        r, theta, phi = coords.cyl_to_spher(R, z, phi)
+        degenerate = (r == 0.0) | ~xp.isfinite(r)
+        rs = xp.where(degenerate, 1.0, r)
+        costheta = xp.cos(theta)
+        sintheta = xp.sin(theta)
+        if M > 1:
+            # nudge off the pole so the m>0 angular derivatives stay finite
+            pole = xp.abs(1.0 - costheta * costheta) < 1e-14
+            costheta = xp.where(pole, xp.sign(costheta) * (1.0 - 1e-7), costheta)
+            sintheta = xp.where(pole, xp.sqrt(1.0 - costheta**2), sintheta)
+        PP, dPP, d2PP = assoc_legendre(L, M, costheta, deriv=2)
         dPth = dPP * (-sintheta)
         d2Pth = d2PP * sintheta**2 - dPP * costheta
-        PP = PP[numpy.newaxis, :, :]
-        dPth = dPth[numpy.newaxis, :, :]
-        d2Pth = d2Pth[numpy.newaxis, :, :]
-        # radial basis and its first/second radial derivatives
-        phi_tilde = self._phiTilde(r, N, L)[:, :, numpy.newaxis]
-        dphi_tilde = self._dphiTilde(r, N, L)[:, :, numpy.newaxis]
-        d2phi_tilde = self._d2phiTilde(r, N, L)[:, :, numpy.newaxis]
-        m = numpy.arange(0, M)[numpy.newaxis, numpy.newaxis, :]
-        mcos = numpy.cos(m * phi)
-        msin = numpy.sin(m * phi)
+        PP = PP[None, :, :]
+        dPth = dPth[None, :, :]
+        d2Pth = d2Pth[None, :, :]
+        phi_tilde = self._phiTilde(rs, N, L)[:, :, None]
+        dphi_tilde = self._dphiTilde(rs, N, L)[:, :, None]
+        d2phi_tilde = self._d2phiTilde(rs, N, L)[:, :, None]
+        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        mcos = xp.cos(m * phi)
+        msin = xp.sin(m * phi)
         cos_sin = Acos * mcos + Asin * msin  # angular azimuthal coefficient
         dphi_coef = m * (Asin * mcos - Acos * msin)  # d/dphi of cos_sin
-        Phi_rr = numpy.sum(cos_sin * PP * d2phi_tilde)
-        Phi_tt = numpy.sum(cos_sin * d2Pth * phi_tilde)
-        Phi_pp = numpy.sum(-m * m * cos_sin * PP * phi_tilde)
-        Phi_rt = numpy.sum(cos_sin * dPth * dphi_tilde)
-        Phi_rp = numpy.sum(dphi_coef * PP * dphi_tilde)
-        Phi_tp = numpy.sum(dphi_coef * dPth * phi_tilde)
-        Phi_r = numpy.sum(cos_sin * PP * dphi_tilde)
-        Phi_t = numpy.sum(cos_sin * dPth * phi_tilde)
-        self._2nd_deriv_cache_key = cache_key
-        self._cached_2nd_derivs = (
-            Phi_rr,
-            Phi_tt,
-            Phi_pp,
-            Phi_rt,
-            Phi_rp,
-            Phi_tp,
-            Phi_r,
-            Phi_t,
+        return tuple(
+            xp.where(degenerate, 0.0, val)
+            for val in (
+                xp.sum(cos_sin * PP * d2phi_tilde),  # Phi_rr
+                xp.sum(cos_sin * d2Pth * phi_tilde),  # Phi_tt
+                xp.sum(-m * m * cos_sin * PP * phi_tilde),  # Phi_pp
+                xp.sum(cos_sin * dPth * dphi_tilde),  # Phi_rt
+                xp.sum(dphi_coef * PP * dphi_tilde),  # Phi_rp
+                xp.sum(dphi_coef * dPth * phi_tilde),  # Phi_tp
+                xp.sum(cos_sin * PP * dphi_tilde),  # Phi_r
+                xp.sum(cos_sin * dPth * phi_tilde),  # Phi_t
+            )
         )
-        return self._cached_2nd_derivs
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         return self._evaluate_cyl_2nd_deriv("R2", R, z, phi, t=t)
@@ -655,13 +844,20 @@ def _xiToR(xi, a=1):
 
 
 def _RToxi(r, a=1):
-    out = numpy.divide((r / a - 1.0), (r / a + 1.0), where=True ^ numpy.isinf(r))
-    if numpy.any(numpy.isinf(r)):
-        if hasattr(r, "__len__"):
-            out[numpy.isinf(r)] = 1.0
-        else:
-            return 1.0
-    return out
+    xp = get_namespace(r)
+    if xp is numpy:
+        out = numpy.divide((r / a - 1.0), (r / a + 1.0), where=True ^ numpy.isinf(r))
+        if numpy.any(numpy.isinf(r)):
+            if hasattr(r, "__len__"):
+                out[numpy.isinf(r)] = 1.0
+            else:
+                return 1.0
+        return out
+    # backend path: functional version of the above. The division is computed
+    # at a guarded radius (inf/inf = NaN would poison tracing/eager AD) and the
+    # r = inf entries are set to the xi = 1 limit with xp.where.
+    rsafe = xp.where(xp.isinf(r), 0.0, r)
+    return xp.where(xp.isinf(r), 1.0, (rsafe / a - 1.0) / (rsafe / a + 1.0))
 
 
 def _C(xi, N, L, alpha=lambda x: 2 * x + 3.0 / 2, singleL=False):
@@ -692,57 +888,79 @@ def _C(xi, N, L, alpha=lambda x: 2 * x + 3.0 / 2, singleL=False):
     - 2021-02-22 - Upgraded to array xi - Bovy (UofT)
     - 2021-02-22 - Added singleL for use in compute...nbody - Bovy (UofT)
     """
-    floatIn = False
-    if isinstance(xi, (float, int)):
-        floatIn = True
-        xi = numpy.array([xi])
-    if singleL:
-        Ls = [L]
-    else:
-        Ls = range(L)
-    CC = numpy.zeros((N, len(Ls), len(xi)))
-    for l, ll in enumerate(Ls):
-        for n in range(N):
-            a = alpha(ll)
-            if n == 0:
-                CC[n, l] = 1.0
-                continue
-            elif n == 1:
-                CC[n, l] = 2.0 * a * xi
-            if n + 1 != N:
-                CC[n + 1, l] = (
-                    2 * (n + a) * xi * CC[n, l] - (n + 2 * a - 1) * CC[n - 1, l]
-                ) / (n + 1.0)
-    if floatIn:
-        return CC[:, :, 0]
-    else:
-        return CC
+    xp = get_namespace(xi)
+    if xp is numpy:
+        floatIn = False
+        if isinstance(xi, (float, int)):
+            floatIn = True
+            xi = numpy.array([xi])
+        if singleL:
+            Ls = [L]
+        else:
+            Ls = range(L)
+        CC = numpy.zeros((N, len(Ls), len(xi)))
+        for l, ll in enumerate(Ls):
+            for n in range(N):
+                a = alpha(ll)
+                if n == 0:
+                    CC[n, l] = 1.0
+                    continue
+                elif n == 1:
+                    CC[n, l] = 2.0 * a * xi
+                if n + 1 != N:
+                    CC[n + 1, l] = (
+                        2 * (n + a) * xi * CC[n, l] - (n + 2 * a - 1) * CC[n - 1, l]
+                    ) / (n + 1.0)
+        if floatIn:
+            return CC[:, :, 0]
+        else:
+            return CC
+    # backend path: the special-function router's Gegenbauer recurrence (same
+    # three-term recurrence, built functionally so it traces/differentiates).
+    # gegenbauer returns xi.shape + (N,); stack the l values along the last
+    # axis and move (n, l) to the front to match the numpy layout: (N, len(Ls))
+    # for scalar xi, (N, len(Ls)) + xi.shape for array xi.
+    Ls = [L] if singleL else range(L)
+    CC = xp.stack([gegenbauer(N, alpha(ll), xi) for ll in Ls], axis=-1)
+    return xp.moveaxis(CC, (-2, -1), (0, 1))
 
 
 def _dC(xi, N, L):
+    xp = get_namespace(xi)
     l = numpy.arange(0, L)[numpy.newaxis, :]
     CC = _C(xi, N + 1, L, alpha=lambda x: 2 * x + 5.0 / 2)
-    CC = numpy.roll(CC, 1, axis=0)[:-1, :]
-    CC[0, :] = 0
-    CC *= 2 * (2 * l + 3.0 / 2)
-    return CC
+    if xp is numpy:
+        CC = numpy.roll(CC, 1, axis=0)[:-1, :]
+        CC[0, :] = 0
+        CC *= 2 * (2 * l + 3.0 / 2)
+        return CC
+    # backend path: the roll + zero-row idiom above (dC_n = 2 a C_{n-1}^{a+1},
+    # with a zero n=0 row), written functionally as a concatenation.
+    CC = xp.concat([xp.zeros_like(CC[:1]), CC[: N - 1]], axis=0)
+    return CC * xp.asarray(2 * (2 * l + 3.0 / 2))
 
 
 def _d2C(xi, N, L):
     # Second xi-derivative of the Gegenbauer polynomials, via
     #   d2C_n^a/dxi2 = 4 a (a+1) C_{n-2}^{a+2}(xi),   a = 2l + 3/2
     # (the analogue of _dC's dC_n^a/dxi = 2a C_{n-1}^{a+1}).
+    xp = get_namespace(xi)
     l = numpy.arange(0, L)[numpy.newaxis, :]
     a = 2 * l + 3.0 / 2
     CC = _C(xi, N + 2, L, alpha=lambda x: 2 * x + 7.0 / 2)
-    CC = numpy.roll(CC, 2, axis=0)[:-2, :]
-    # n=0 (and n=1, when present) have zero second derivative; for N=1 only the
-    # n=0 row exists, so guard the n=1 assignment.
-    CC[0, :] = 0
-    if N > 1:
-        CC[1, :] = 0
-    CC *= 4 * a * (a + 1)
-    return CC
+    if xp is numpy:
+        CC = numpy.roll(CC, 2, axis=0)[:-2, :]
+        # n=0 (and n=1, when present) have zero second derivative; for N=1 only
+        # the n=0 row exists, so guard the n=1 assignment.
+        CC[0, :] = 0
+        if N > 1:
+            CC[1, :] = 0
+        CC *= 4 * a * (a + 1)
+        return CC
+    # backend path: the roll + zero-rows idiom above, written functionally as a
+    # concatenation (min(N, 2) zero rows, then C_{n-2}^{a+2} for n >= 2).
+    CC = xp.concat([xp.zeros_like(CC[: min(N, 2)]), CC[: max(N - 2, 0)]], axis=0)
+    return CC * xp.asarray(4 * a * (a + 1))
 
 
 def scf_compute_coeffs_spherical_nbody(pos, N, mass=1.0, a=1.0):

--- a/galpy/potential/SphericalHarmonicPotentialMixin.py
+++ b/galpy/potential/SphericalHarmonicPotentialMixin.py
@@ -4,6 +4,7 @@
 ###############################################################################
 import numpy
 
+from ..backend import get_namespace
 from ..util import coords
 
 
@@ -50,49 +51,85 @@ class SphericalHarmonicPotentialMixin:
         - 2026-02-11 - Simplified - Bovy (UofT)
         - 2026-02-13 - Moved to SphericalHarmonicPotentialMixin - Bovy (UofT)
         """
-        R = numpy.array(R, dtype=float)
-        z = numpy.array(z, dtype=float)
-        phi = numpy.array(phi, dtype=float)
-        t = numpy.array(t, dtype=float)
-        shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape, t.shape)
+        xp = get_namespace(R, z, phi)
+        if xp is numpy:
+            R = numpy.array(R, dtype=float)
+            z = numpy.array(z, dtype=float)
+            phi = numpy.array(phi, dtype=float)
+            t = numpy.array(t, dtype=float)
+            shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape, t.shape)
+            if shape == ():
+                dPhi_dr, dPhi_dtheta, dPhi_dphi = self._compute_spher_forces_at_point(
+                    R, z, phi, t=t
+                )
+                return dr_dx * dPhi_dr + dtheta_dx * dPhi_dtheta + dPhi_dphi * dphi_dx
+            R = R * numpy.ones(shape)
+            z = z * numpy.ones(shape)
+            phi = phi * numpy.ones(shape)
+            t = t * numpy.ones(shape)
+            force = numpy.zeros(shape, float)
+            dr_dx = dr_dx * numpy.ones(shape)
+            dtheta_dx = dtheta_dx * numpy.ones(shape)
+            dphi_dx = dphi_dx * numpy.ones(shape)
+            for idx in numpy.ndindex(*shape):
+                dPhi_dr, dPhi_dtheta, dPhi_dphi = self._compute_spher_forces_at_point(
+                    R[idx], z[idx], phi[idx], t=t[idx]
+                )
+                force[idx] = (
+                    dr_dx[idx] * dPhi_dr
+                    + dtheta_dx[idx] * dPhi_dtheta
+                    + dPhi_dphi * dphi_dx[idx]
+                )
+            return force
+        # backend path: identical per-point evaluation, assembled functionally
+        # (stack instead of in-place writes) so it traces and differentiates.
+        R = xp.asarray(R) * 1.0
+        z = xp.asarray(z) * 1.0
+        phi = xp.asarray(phi) * 1.0
+        t = xp.asarray(t) * 1.0
+        shape = numpy.broadcast_shapes(
+            tuple(R.shape), tuple(z.shape), tuple(phi.shape), tuple(t.shape)
+        )
         if shape == ():
             dPhi_dr, dPhi_dtheta, dPhi_dphi = self._compute_spher_forces_at_point(
                 R, z, phi, t=t
             )
             return dr_dx * dPhi_dr + dtheta_dx * dPhi_dtheta + dPhi_dphi * dphi_dx
-        R = R * numpy.ones(shape)
-        z = z * numpy.ones(shape)
-        phi = phi * numpy.ones(shape)
-        t = t * numpy.ones(shape)
-        force = numpy.zeros(shape, float)
-        dr_dx = dr_dx * numpy.ones(shape)
-        dtheta_dx = dtheta_dx * numpy.ones(shape)
-        dphi_dx = dphi_dx * numpy.ones(shape)
+        R = xp.broadcast_to(R, shape)
+        z = xp.broadcast_to(z, shape)
+        phi = xp.broadcast_to(phi, shape)
+        t = xp.broadcast_to(t, shape)
+        dr_dx = xp.broadcast_to(xp.asarray(dr_dx) * 1.0, shape)
+        dtheta_dx = xp.broadcast_to(xp.asarray(dtheta_dx) * 1.0, shape)
+        dphi_dx = xp.broadcast_to(xp.asarray(dphi_dx) * 1.0, shape)
+        force = []
         for idx in numpy.ndindex(*shape):
             dPhi_dr, dPhi_dtheta, dPhi_dphi = self._compute_spher_forces_at_point(
                 R[idx], z[idx], phi[idx], t=t[idx]
             )
-            force[idx] = (
+            force.append(
                 dr_dx[idx] * dPhi_dr
                 + dtheta_dx[idx] * dPhi_dtheta
                 + dPhi_dphi * dphi_dx[idx]
             )
-        return force
+        return xp.reshape(xp.stack(force), shape)
 
     def _Rforce(self, R, z, phi=0, t=0):
         if not self.isNonAxi and phi is None:
             phi = 0.0
+        xp = get_namespace(R, z, phi)
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
-        dr_dR = numpy.divide(R, r)
-        dtheta_dR = numpy.divide(z, r**2)
+        dr_dR = xp.divide(R, r)
+        dtheta_dR = xp.divide(z, r**2)
         return self._evaluate_cyl_force(dr_dR, dtheta_dR, 0, R, z, phi, t=t)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi and phi is None:
             phi = 0.0
+        xp = get_namespace(R, z, phi)
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
-        dr_dz = numpy.divide(z, r)
-        dtheta_dz = numpy.divide(-R, r**2)
+        dr_dz = xp.divide(z, r)
+        dtheta_dz = xp.divide(-R, r**2)
         return self._evaluate_cyl_force(dr_dz, dtheta_dz, 0, R, z, phi, t=t)
 
     def _phitorque(self, R, z, phi=0, t=0):
@@ -129,23 +166,50 @@ class SphericalHarmonicPotentialMixin:
         # axisymmetric potentials are evaluated with phi=None (phi irrelevant)
         if not self.isNonAxi and phi is None:
             phi = 0.0
-        R = numpy.array(R, dtype=float)
-        z = numpy.array(z, dtype=float)
-        phi = numpy.array(phi, dtype=float)
-        t = numpy.array(t, dtype=float)
-        shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape, t.shape)
+        xp = get_namespace(R, z, phi)
+        if xp is numpy:
+            R = numpy.array(R, dtype=float)
+            z = numpy.array(z, dtype=float)
+            phi = numpy.array(phi, dtype=float)
+            t = numpy.array(t, dtype=float)
+            shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape, t.shape)
+            if shape == ():
+                return self._cyl_2nd_deriv_at_point(deriv_type, R, z, phi, t=t)
+            R = R * numpy.ones(shape)
+            z = z * numpy.ones(shape)
+            phi = phi * numpy.ones(shape)
+            t = t * numpy.ones(shape)
+            result = numpy.zeros(shape, float)
+            for idx in numpy.ndindex(*shape):
+                result[idx] = self._cyl_2nd_deriv_at_point(
+                    deriv_type, R[idx], z[idx], phi[idx], t=t[idx]
+                )
+            return result
+        # backend path: identical per-point evaluation, assembled functionally.
+        R = xp.asarray(R) * 1.0
+        z = xp.asarray(z) * 1.0
+        phi = xp.asarray(phi) * 1.0
+        t = xp.asarray(t) * 1.0
+        shape = numpy.broadcast_shapes(
+            tuple(R.shape), tuple(z.shape), tuple(phi.shape), tuple(t.shape)
+        )
         if shape == ():
             return self._cyl_2nd_deriv_at_point(deriv_type, R, z, phi, t=t)
-        R = R * numpy.ones(shape)
-        z = z * numpy.ones(shape)
-        phi = phi * numpy.ones(shape)
-        t = t * numpy.ones(shape)
-        result = numpy.zeros(shape, float)
-        for idx in numpy.ndindex(*shape):
-            result[idx] = self._cyl_2nd_deriv_at_point(
-                deriv_type, R[idx], z[idx], phi[idx], t=t[idx]
-            )
-        return result
+        R = xp.broadcast_to(R, shape)
+        z = xp.broadcast_to(z, shape)
+        phi = xp.broadcast_to(phi, shape)
+        t = xp.broadcast_to(t, shape)
+        return xp.reshape(
+            xp.stack(
+                [
+                    self._cyl_2nd_deriv_at_point(
+                        deriv_type, R[idx], z[idx], phi[idx], t=t[idx]
+                    )
+                    for idx in numpy.ndindex(*shape)
+                ]
+            ),
+            shape,
+        )
 
     def _cyl_2nd_deriv_at_point(self, deriv_type, R, z, phi, t=0.0):
         """
@@ -155,6 +219,7 @@ class SphericalHarmonicPotentialMixin:
         -----
         - 2026-02-18 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi)
         (
             Phi_rr,
             Phi_tt,
@@ -166,13 +231,21 @@ class SphericalHarmonicPotentialMixin:
             Phi_t,
         ) = self._compute_spher_2nd_derivs_at_point(R, z, phi, t=t)
         r2 = R * R + z * z
-        r = numpy.sqrt(r2)
-        if r == 0.0:
-            return 0.0
+        r = xp.sqrt(r2)
+        if xp is numpy:
+            if r == 0.0:
+                return 0.0
+        else:
+            # backend path: branchless r == 0 guard. Both xp.where branches are
+            # evaluated under tracing/eager AD, so the chain rule below runs at
+            # a guarded radius and the centre is zeroed at the end.
+            degenerate = r == 0.0
+            r2 = xp.where(degenerate, 1.0, r2)
+            r = xp.where(degenerate, 1.0, r)
         r3 = r * r2
         r4 = r2 * r2
         if deriv_type == "R2":
-            return (
+            out = (
                 Phi_rr * R * R / r2
                 + Phi_r * z * z / r3
                 + 2.0 * Phi_rt * R * z / r3
@@ -180,7 +253,7 @@ class SphericalHarmonicPotentialMixin:
                 + Phi_t * (-2.0 * R * z) / r4
             )
         elif deriv_type == "z2":
-            return (
+            out = (
                 Phi_rr * z * z / r2
                 + Phi_r * R * R / r3
                 - 2.0 * Phi_rt * z * R / r3
@@ -188,7 +261,7 @@ class SphericalHarmonicPotentialMixin:
                 + Phi_t * 2.0 * R * z / r4
             )
         elif deriv_type == "Rz":
-            return (
+            out = (
                 Phi_rr * R * z / r2
                 + Phi_r * (-R * z) / r3
                 + Phi_rt * (z * z - R * R) / r3
@@ -196,8 +269,9 @@ class SphericalHarmonicPotentialMixin:
                 + Phi_t * (R * R - z * z) / r4
             )
         elif deriv_type == "phi2":
-            return Phi_pp
+            out = Phi_pp
         elif deriv_type == "Rphi":
-            return Phi_rp * R / r + Phi_tp * z / r2
+            out = Phi_rp * R / r + Phi_tp * z / r2
         elif deriv_type == "phiz":
-            return Phi_rp * z / r + Phi_tp * (-R) / r2
+            out = Phi_rp * z / r + Phi_tp * (-R) / r2
+        return out if xp is numpy else xp.where(degenerate, 0.0, out)

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -80,6 +80,7 @@ from functools import wraps
 
 import numpy
 
+from ..backend import get_namespace
 from ..util import _rotate_to_arbitrary_vector
 from ..util._optional_deps import _APY_LOADED
 from ..util.config import __config__
@@ -1173,7 +1174,8 @@ def cyl_to_spher(R, Z, phi):
     -----
     - 2016-05-16 - Written - Aladdin
     """
-    theta = numpy.arctan2(R, Z)
+    xp = get_namespace(R, Z)
+    theta = xp.arctan2(R, Z)
     r = (R**2 + Z**2) ** 0.5
     return (r, theta, phi)
 

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -1,0 +1,325 @@
+###############################################################################
+# test_backend_scf.py: multi-backend tests for SCFPotential (P2.5), migrated
+# to the galpy.backend namespace layer (Hernquist-basis expansion via the
+# galpy.backend.special Gegenbauer + associated-Legendre router).
+#
+# For each case (axisymmetric and non-axisymmetric expansions) and each
+# migrated compute method this proves:
+#   1. numpy / jax / torch produce identical values (rtol=1e-12, atol=1e-14),
+#      for scalar AND array inputs (the array path stacks per-point results),
+#   2. autodiff (jax.grad / torch.autograd) of _evaluate matches central finite
+#      differences (independent cross-check of differentiability),
+#   3. the analytic force / Hessian identities hold under AD:
+#      AD(_evaluate) == -force and AD(force) == -2nd-derivative, exact to
+#      ~1e-9 (cross-validates the hand-coded _dphiTilde/_d2phiTilde chain),
+#   4. the jax path is jit-compatible (the per-point md5 / float() caches are
+#      numpy-only, so tracing never touches them).
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+# The grids stay off the z-axis (R > 0): the backend associated-Legendre
+# derivative recurrence (like the numpy chain rule it feeds) is singular at
+# the poles, exactly as in the numpy implementation's nudged-pole handling.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.potential import SCFPotential
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# All compute methods of SCFPotential are migrated (forces and the analytic
+# second derivatives both ride on _phiTilde/_dphiTilde/_d2phiTilde).
+METHODS = [
+    "_evaluate",
+    "_Rforce",
+    "_zforce",
+    "_phitorque",
+    "_R2deriv",
+    "_z2deriv",
+    "_Rzderiv",
+    "_phi2deriv",
+    "_Rphideriv",
+    "_phizderiv",
+    "_dens",
+]
+
+
+def _make_cases():
+    rng = numpy.random.default_rng(42)
+    cases = []
+    # Hernquist limit: monopole-only (N=1, L=1); exercises the _d2C N==1 guard.
+    cases.append(("hernquist", SCFPotential(amp=1.3, Acos=numpy.array([[[1.0]]]))))
+    # axisymmetric, multi-(n,l): radial + costheta structure, M == 1.
+    Acos_axi = numpy.zeros((5, 4, 1))
+    Acos_axi[:, :, 0] = rng.normal(size=(5, 4)) * 0.1
+    Acos_axi[0, 0, 0] = 1.0
+    cases.append(("axi", SCFPotential(amp=2.6, Acos=Acos_axi, a=1.3)))
+    # non-axisymmetric: full (n,l,m) structure incl. Asin, exercises the
+    # phi-derivative (phitorque / phi-2nd-derivative) paths.
+    Acos_na = numpy.tril(rng.normal(size=(3, 3, 3)) * 0.1)
+    Asin_na = numpy.tril(rng.normal(size=(3, 3, 3)) * 0.1)
+    Acos_na[0, 0, 0] = 1.0
+    cases.append(("nonaxi", SCFPotential(amp=1.9, Acos=Acos_na, Asin=Asin_na, a=0.8)))
+    return cases
+
+
+CASES = _make_cases()
+CASE_IDS = [name for name, _ in CASES]
+
+# Evaluation grid: off-centre, off-axis, both signs of z, inside and outside
+# the expansion scale radius.
+_RS = numpy.array([0.3, 1.0, 2.7])
+_ZS = numpy.array([-0.4, 0.2, 1.1])
+_PHIS = numpy.array([0.3, 1.1, 2.2])
+# Smooth scalar point for the AD checks.
+_R0, _Z0, _PHI0 = 1.3, 0.4, 0.7
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    if backend_name == "torch":
+        return torch.tensor(x, dtype=torch.float64)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity_array(backend_name, name, pot):
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    phi = _asarray(backend_name, _PHIS)
+    for mname in METHODS:
+        method = getattr(pot, mname)
+        ref = numpy.asarray(method(_RS, _ZS, _PHIS))
+        got = _tonumpy(method(R, z, phi))
+        numpy.testing.assert_allclose(
+            got,
+            ref,
+            rtol=1e-12,
+            atol=1e-14,
+            err_msg=f"SCF[{name}].{mname} array parity ({backend_name})",
+        )
+
+
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity_scalar(backend_name, name, pot):
+    for mname in METHODS:
+        method = getattr(pot, mname)
+        for R0, z0, phi0 in zip(_RS, _ZS, _PHIS):
+            ref = numpy.asarray(method(R0, z0, phi0))
+            got = _tonumpy(
+                method(
+                    _asarray(backend_name, R0),
+                    _asarray(backend_name, z0),
+                    _asarray(backend_name, phi0),
+                )
+            )
+            numpy.testing.assert_allclose(
+                got,
+                ref,
+                rtol=1e-12,
+                atol=1e-14,
+                err_msg=f"SCF[{name}].{mname} scalar parity ({backend_name})",
+            )
+
+
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_public_value_parity(backend_name, name, pot):
+    # Through the unit decorators and _amp (public Rforce), values must be
+    # identical across backends.
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    phi = _asarray(backend_name, _PHIS)
+    ref = numpy.asarray(pot.Rforce(_RS, _ZS, phi=_PHIS))
+    got = _tonumpy(pot.Rforce(R, z, phi=phi))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("var", ["R", "z", "phi"])
+def test_grad_evaluate_vs_finite_difference(backend_name, name, pot, var):
+    # Independent (finite-difference) cross-check that the migrated _evaluate
+    # is differentiable end-to-end in every coordinate.
+    eps = 1e-6
+    argnum = {"R": 0, "z": 1, "phi": 2}[var]
+    x0 = (_R0, _Z0, _PHI0)[argnum]
+
+    def phi_np(x):
+        args = [_R0, _Z0, _PHI0]
+        args[argnum] = x
+        return float(pot._evaluate(*[numpy.asarray(a) for a in args]))
+
+    fd = (phi_np(x0 + eps) - phi_np(x0 - eps)) / (2 * eps)
+    ad = _grad_wrt(backend_name, lambda R, z, p: pot._evaluate(R, z, p), argnum=argnum)
+    numpy.testing.assert_allclose(
+        ad, fd, rtol=1e-5, atol=1e-10, err_msg=f"SCF[{name}] d_evaluate/d{var}"
+    )
+
+
+def _grad_wrt(backend_name, fn, argnum=0):
+    # AD of scalar-valued fn(R, z, phi) at the smooth point, wrt args[argnum].
+    args = (_R0, _Z0, _PHI0)
+    if backend_name == "jax":
+        jargs = [jnp.asarray(a) for a in args]
+
+        def f(x):
+            full = list(jargs)
+            full[argnum] = x
+            return fn(*full)
+
+        return float(jax.grad(f)(jargs[argnum]))
+    targs = [torch.tensor(a, dtype=torch.float64) for a in args]
+    leaf = torch.tensor(args[argnum], dtype=torch.float64, requires_grad=True)
+    targs[argnum] = leaf
+    out = fn(*targs)
+    out.backward()
+    return float(leaf.grad)
+
+
+###############################################################################
+# Analytic-identity autodiff checks; galpy's sign conventions give
+#   AD(_evaluate wrt R) == -_Rforce      AD(_evaluate wrt z) == -_zforce
+#   AD(_evaluate wrt phi) == -_phitorque
+#   AD(_Rforce wrt R) == -_R2deriv       AD(_Rforce wrt z) == -_Rzderiv
+#   AD(_zforce wrt z) == -_z2deriv       AD(_phitorque wrt phi) == -_phi2deriv
+#   AD(_phitorque wrt R) == -_Rphideriv  AD(_phitorque wrt z) == -_phizderiv
+# Exact to ~1e-9, which cross-validates the hand-coded radial-derivative chain
+# (_dphiTilde against _phiTilde, _d2phiTilde against _dphiTilde) and the
+# spherical-to-cylindrical chain rule, not just the AD plumbing.
+###############################################################################
+_R, _Z, _PHI = 0, 1, 2
+_ID_PAIRS = [
+    ("_evaluate", _R, "_Rforce"),
+    ("_evaluate", _Z, "_zforce"),
+    ("_evaluate", _PHI, "_phitorque"),
+    ("_Rforce", _R, "_R2deriv"),
+    ("_Rforce", _Z, "_Rzderiv"),
+    ("_zforce", _Z, "_z2deriv"),
+    ("_phitorque", _PHI, "_phi2deriv"),
+    ("_phitorque", _R, "_Rphideriv"),
+    ("_phitorque", _Z, "_phizderiv"),
+]
+
+
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_hessian_identities(backend_name, name, pot):
+    for lower, argnum, higher in _ID_PAIRS:
+        ad = _grad_wrt(
+            backend_name,
+            lambda R, z, p, _l=lower: getattr(pot, _l)(R, z, p),
+            argnum=argnum,
+        )
+        ref = -float(getattr(pot, higher)(_R0, _Z0, _PHI0))
+        numpy.testing.assert_allclose(
+            ad,
+            ref,
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"SCF[{name}]: AD({lower}/{argnum}) == -{higher} ({backend_name})",
+        )
+
+
+###############################################################################
+# jit-compatibility: the per-point Python caches (md5 force hash, float()-keyed
+# 2nd-derivative cache) are numpy-only, so the jax path must trace cleanly
+# under jit for forces AND second derivatives.
+###############################################################################
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+def test_jax_jit(name, pot):
+    if jax is None:  # pragma: no cover
+        pytest.skip("jax not available")
+    R = jnp.asarray(_R0)
+    z = jnp.asarray(_Z0)
+    phi = jnp.asarray(_PHI0)
+    for mname in ["_evaluate", "_Rforce", "_zforce", "_phitorque", "_R2deriv"]:
+        method = getattr(pot, mname)
+        ref = float(method(_R0, _Z0, _PHI0))
+        got = float(jax.jit(method)(R, z, phi))
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-12, atol=1e-14, err_msg=f"SCF[{name}].{mname} jit"
+        )
+    # gradient under jit as well
+    g = float(jax.jit(jax.grad(lambda R: pot._evaluate(R, z, phi)))(R))
+    numpy.testing.assert_allclose(g, -float(pot._Rforce(_R0, _Z0, _PHI0)), rtol=1e-9)
+
+
+###############################################################################
+# r = 0 / r = inf guards: the backend branches handle the expansion centre and
+# infinity branchlessly (xp.where with guarded dead branches); values must
+# match numpy and reverse-mode gradients of smooth quantities through those
+# guards must not be NaN-poisoned at ordinary points (checked above); here we
+# check the special points evaluate finitely and identically.
+###############################################################################
+@pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_centre_and_infinity_parity(backend_name, name, pot):
+    # potential at the centre is finite (the -CC/a limit of _phiTilde)
+    ref0 = float(pot._evaluate(0.0, 0.0, 0.3))
+    got0 = float(
+        _tonumpy(
+            pot._evaluate(
+                _asarray(backend_name, 0.0),
+                _asarray(backend_name, 0.0),
+                _asarray(backend_name, 0.3),
+            )
+        )
+    )
+    assert numpy.isfinite(got0)
+    numpy.testing.assert_allclose(got0, ref0, rtol=1e-12, atol=1e-14)
+    # potential at infinity -> 0, through the xi = 1 guard of _RToxi
+    gotinf = float(
+        _tonumpy(
+            pot._evaluate(
+                _asarray(backend_name, numpy.inf),
+                _asarray(backend_name, 0.0),
+                _asarray(backend_name, 0.3),
+            )
+        )
+    )
+    numpy.testing.assert_allclose(gotinf, 0.0, atol=1e-14)
+    # second derivatives at the centre are defined to be 0 (numpy convention)
+    refc = float(pot._R2deriv(0.0, 0.0, 0.3))
+    gotc = float(
+        _tonumpy(
+            pot._R2deriv(
+                _asarray(backend_name, 0.0),
+                _asarray(backend_name, 0.0),
+                _asarray(backend_name, 0.3),
+            )
+        )
+    )
+    numpy.testing.assert_allclose(gotc, refc, atol=1e-14)


### PR DESCRIPTION
Part of the **P2.5** fan-out. Full namespace-swap of SCFPotential: radial Gegenbauer/Legendre helpers + forces + the analytic 2nd derivatives through `galpy.backend.special` (gegenbauer + assoc_legendre); per-point Python caches bypassed for non-numpy namespaces (trace-hostile); in-place `CC[...]=0` patterns rewritten functionally with numpy kept byte-identical.

**NOTE — includes a cherry-pick of #921** (`17f92302`, analytic 2nd derivatives, already on main): feat/backends predates it. When feat/backends next merges main, the cherry-pick dedupes. Consequently the *branch* differs from base feat/backends exactly and only in the six 2nd-derivative methods (the user-approved #921 value change, ~1e-6 vs the old numerical mixin) — the migration itself is byte-identical on top of #921.

**Verification (adversarial):** 522-key value grid — all non-2nd-deriv keys byte-identical; the 163 differing keys are exactly the #921 analytic-2nd-deriv change; backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)