### PR TITLE
P2.5: MultipoleExpansionPotential backend-agnostic (static path)

### DIFF
--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -14,6 +14,8 @@ from scipy.interpolate import (
     make_interp_spline,
 )
 
+from ..backend import get_namespace
+from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
 from ..util.special import compute_legendre, sph_harm_normalization
@@ -277,6 +279,8 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
             self._precompute_radial_integrals()
             self._force_cache_key = None
             self._2nd_deriv_cache_key = None
+        # Lazily-built constant tables for the jax/torch evaluation path
+        self._backend_data = None
         self.hasC = True
         self.hasC_dxdv = True
         self.hasC_dens = True
@@ -1225,7 +1229,13 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         Notes
         -----
         - 2026-02-13 - Written - Bovy (UofT)
+        - 2026-06-09 - Added jax/torch evaluation path - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            if not self.isNonAxi and phi is None:
+                phi = 0.0
+            return self._backend_evaluate(xp, R, z, phi, t)
         if not self.isNonAxi and phi is None:
             phi = 0.0
         R = numpy.array(R, dtype=float)
@@ -1619,7 +1629,11 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         Notes
         -----
         - 2026-02-13 - Written - Bovy (UofT)
+        - 2026-06-09 - Added jax/torch evaluation path - Bovy (UofT)
         """
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            return self._backend_dens(xp, R, z, phi, t)
         if self._tdep:
             self._ensure_rho_for_time(t)
         if not self.isNonAxi and phi is None:
@@ -1996,6 +2010,435 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
 
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         return self._evaluate_cyl_2nd_deriv("phiz", R, z, phi, t=t)
+
+    ###########################################################################
+    # Backend (jax/torch) evaluation path.
+    #
+    # The numpy path above evaluates the radial functions point-by-point
+    # through the scipy BPoly/spline objects and is kept bit-for-bit
+    # unchanged (the dispatchers below only route non-numpy inputs away from
+    # it). For jax/torch arrays the same piecewise polynomials are evaluated
+    # in a vectorized, autodiff/jit-friendly way: the BPoly radial integrals
+    # are converted once to power-basis (PPoly) coefficient stacks evaluated
+    # by searchsorted + Horner (exactly the representation _serialize_for_c
+    # hands to the C code), and the angular part uses the backend-agnostic
+    # galpy.backend.special.assoc_legendre router. Time-dependent (tgrid=...)
+    # instances remain numpy-only for now.
+    ###########################################################################
+    def _Rforce(self, R, z, phi=0, t=0):
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            return self._backend_cyl_force(xp, "R", R, z, phi, t)
+        return SphericalHarmonicPotentialMixin._Rforce(self, R, z, phi=phi, t=t)
+
+    def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            return self._backend_cyl_force(xp, "z", R, z, phi, t)
+        return SphericalHarmonicPotentialMixin._zforce(self, R, z, phi=phi, t=t)
+
+    def _phitorque(self, R, z, phi=0, t=0):
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            return self._backend_cyl_force(xp, "phi", R, z, phi, t)
+        return SphericalHarmonicPotentialMixin._phitorque(self, R, z, phi=phi, t=t)
+
+    def _evaluate_cyl_2nd_deriv(self, deriv_type, R, z, phi, t=0.0):
+        xp = get_namespace(R, z)
+        if xp is not numpy:
+            return self._backend_cyl_2nd_deriv(xp, deriv_type, R, z, phi, t)
+        return SphericalHarmonicPotentialMixin._evaluate_cyl_2nd_deriv(
+            self, deriv_type, R, z, phi, t=t
+        )
+
+    def _backend_static_data(self):
+        """Build (once) the numpy constant tables for the backend path.
+
+        Converts the per-(l, m, cos/sin) BPoly radial integrals to stacked
+        power-basis (PPoly) coefficient arrays plus the analytic
+        extrapolation constants of _below_grid_integrals / _eval_R_lm, and
+        the FITPACK density splines to cubic PPoly pieces. All entries are
+        plain numpy arrays/floats; the evaluators convert them to the active
+        backend with ``xp.asarray``.
+
+        Notes
+        -----
+        - 2026-06-09 - Written - Bovy (UofT)
+        """
+        if self._tdep:
+            raise NotImplementedError(
+                "jax/torch evaluation of time-dependent (tgrid=...) "
+                "MultipoleExpansionPotential instances is not implemented; "
+                "evaluate with numpy inputs instead"
+            )
+        if self._backend_data is not None:
+            return self._backend_data
+        comps = []  # (l, m, is_sin) component order, shared by all tables
+        for l in range(self._L):
+            for m in range(min(l + 1, self._M)):
+                comps.append((l, m, False))
+                if m > 0:
+                    comps.append((l, m, True))
+        rmin, rmax = self._rgrid[0], self._rgrid[-1]
+        breaks, rho_breaks = None, None
+        inner_c, outer_c, rho_c = [], [], []
+        I_outer_rmin, I_inner_rmax = [], []
+        for l, m, is_sin in comps:
+            I_inner = (self._I_inner_sin if is_sin else self._I_inner_cos)[l][m]
+            I_outer = (self._I_outer_sin if is_sin else self._I_outer_cos)[l][m]
+            rho_sp = (self._rho_sin_splines if is_sin else self._rho_cos_splines)[l][m]
+            pp_in = PPoly.from_bernstein_basis(I_inner)
+            pp_out = PPoly.from_bernstein_basis(I_outer)
+            if breaks is None:
+                breaks = pp_in.x
+            inner_c.append(pp_in.c)  # (6, Nr-1), highest power first
+            outer_c.append(pp_out.c)
+            I_outer_rmin.append(float(pp_out(rmin)))
+            I_inner_rmax.append(float(pp_in(rmax)))
+            # Density spline -> cubic PPoly pieces; drop FITPACK's zero-width
+            # boundary-knot intervals so searchsorted lookup is well-defined
+            pp_rho = PPoly.from_spline(rho_sp._eval_args)
+            keep = numpy.diff(pp_rho.x) > 0
+            if rho_breaks is None:
+                rho_breaks = numpy.append(pp_rho.x[:-1][keep], pp_rho.x[-1])
+            rho_c.append(pp_rho.c[:, keep])
+        l_arr = numpy.array([c[0] for c in comps])
+        m_arr = numpy.array([c[1] for c in comps])
+        inner_c = numpy.stack(inner_c)
+        # Below-grid constant-density constants: P_rho0 = I_inner'(rmin) /
+        # rmin^{l+2} (= pref*rho(rmin), cf. _below_grid_integrals); the
+        # l-dependent prefactors are precomputed so the l == 2 logarithmic
+        # special case reduces to a constant mask
+        self._backend_data = {
+            "breaks": breaks,
+            "inner_c": inner_c,  # (n_comp, 6, Nr-1)
+            "outer_c": numpy.stack(outer_c),
+            "rho_breaks": rho_breaks,
+            "rho_c": numpy.stack(rho_c),  # (n_comp, 4, n_int)
+            "l_idx": l_arr,
+            "m_idx": m_arr,
+            "lf": l_arr.astype(float)[:, None],
+            "mf": m_arr.astype(float)[:, None],
+            "is_sin": numpy.array([c[2] for c in comps])[:, None],
+            "I_outer_rmin": numpy.array(I_outer_rmin)[:, None],
+            "I_inner_rmax": numpy.array(I_inner_rmax)[:, None],
+            "P_rho0": (inner_c[:, 4, 0] / rmin ** (l_arr + 2.0))[:, None],
+            "inv_lp3": (1.0 / (l_arr + 3.0))[:, None],
+            "inv_2ml": numpy.where(
+                l_arr == 2, 0.0, 1.0 / numpy.where(l_arr == 2, 1.0, 2.0 - l_arr)
+            )[:, None],
+            "l2mask": (l_arr == 2)[:, None],
+            "rmin_pow_2ml": (rmin ** (2.0 - l_arr))[:, None],
+            # value the numpy path returns at the exact center:
+            # R_00(rmin) * P_00 with P_00 = 1
+            "R00": I_outer_rmin[0],
+        }
+        return self._backend_data
+
+    @staticmethod
+    def _backend_prepare(xp, R, z, phi):
+        """Broadcast (R, z, phi) to a common shape and flatten to 1-D."""
+        R = xp.asarray(R) * 1.0
+        z = xp.asarray(z) * 1.0
+        phi = xp.asarray(phi) * 1.0
+        R, z, phi = xp.broadcast_arrays(R, z, phi)
+        shape = R.shape
+        return (
+            xp.reshape(R, (-1,)),
+            xp.reshape(z, (-1,)),
+            xp.reshape(phi, (-1,)),
+            shape,
+        )
+
+    def _backend_radial(self, xp, r, mode=0):
+        """Vectorized R_lm(r) (and dR/dr, d2R/dr2) for every component.
+
+        Mirrors _eval_R_lm / _eval_dR_lm / _eval_d2R_lm: quintic Horner on
+        the power-basis I_inner/I_outer coefficients in-grid, the analytic
+        constant-density extrapolation below rmin and the point-mass form
+        above rmax. Each piecewise branch is evaluated with a 'safe' radius
+        so its dead side stays finite under eager backends / autodiff.
+
+        Parameters
+        ----------
+        xp : module
+            Array namespace.
+        r : array
+            1-D backend array of spherical radii.
+        mode : int
+            0=value, 1=value+deriv, 2=value+deriv+2nd deriv.
+
+        Returns
+        -------
+        (R, dR, d2R) : tuple of arrays of shape (n_comp, len(r))
+            dR / d2R are None when not requested via mode.
+
+        Notes
+        -----
+        - 2026-06-09 - Written - Bovy (UofT)
+        """
+        data = self._backend_static_data()
+        breaks = xp.asarray(data["breaks"])
+        ci = xp.asarray(data["inner_c"])
+        co = xp.asarray(data["outer_c"])
+        lf = xp.asarray(data["lf"])
+        P_rho0 = xp.asarray(data["P_rho0"])
+        I_outer_rmin = xp.asarray(data["I_outer_rmin"])
+        I_inner_rmax = xp.asarray(data["I_inner_rmax"])
+        inv_lp3 = xp.asarray(data["inv_lp3"])
+        inv_2ml = xp.asarray(data["inv_2ml"])
+        l2mask = xp.asarray(data["l2mask"])
+        rmin_pow = xp.asarray(data["rmin_pow_2ml"])
+        rmin = float(data["breaks"][0])
+        rmax = float(data["breaks"][-1])
+        nint = data["breaks"].shape[0] - 1
+        below = r < rmin
+        in_grid = r <= rmax
+        # --- in-grid branch: searchsorted + Horner on r clipped into the grid
+        r_in = xp.clip(r, rmin, rmax)
+        idx = xp.clip(xp.searchsorted(breaks, r_in, side="right") - 1, 0, nint - 1)
+        dr = r_in - breaks[idx]
+        cin = ci[:, :, idx]  # (n_comp, 6, N)
+        cout = co[:, :, idx]
+
+        def _val(c):
+            out = c[:, 0]
+            for k in range(1, 6):
+                out = out * dr + c[:, k]
+            return out
+
+        def _d1(c):
+            out = 5.0 * c[:, 0]
+            for k, f in zip(range(1, 5), (4.0, 3.0, 2.0, 1.0)):
+                out = out * dr + f * c[:, k]
+            return out
+
+        def _d2(c):
+            out = 20.0 * c[:, 0]
+            for k, f in zip(range(1, 4), (12.0, 6.0, 2.0)):
+                out = out * dr + f * c[:, k]
+            return out
+
+        I_in, I_out = _val(cin), _val(cout)
+        rl = r_in**lf
+        rml = r_in ** (-(lf + 1.0))
+        R_in = rml * I_in + rl * I_out
+        # --- below-grid branch (constant density rho(rmin) below rmin):
+        # r^{-(l+1)} I_inner_ext simplifies to P_rho0/(l+3) r^2, so the only
+        # negative powers act on rb, which is guarded away from 0
+        rb = xp.where(xp.logical_and(below, r > 0.0), r, rmin)
+        extra = xp.where(
+            l2mask,
+            P_rho0 * xp.log(rmin / rb),
+            P_rho0 * inv_2ml * (rmin_pow - rb ** (2.0 - lf)),
+        )
+        I_outer_ext = I_outer_rmin + extra
+        R_below = P_rho0 * inv_lp3 * rb * rb + rb**lf * I_outer_ext
+        # --- above-grid branch (point mass: I_outer(rmax) = 0)
+        ra = xp.where(r > rmax, r, rmax)
+        R_above = I_inner_rmax * ra ** (-(lf + 1.0))
+        Rlm = xp.where(below, R_below, xp.where(in_grid, R_in, R_above))
+        dRlm, d2Rlm = None, None
+        if mode >= 1:
+            dI_in, dI_out = _d1(cin), _d1(cout)
+            dR_in = (
+                -(lf + 1.0) * r_in ** (-(lf + 2.0)) * I_in
+                + rml * dI_in
+                + lf * r_in ** (lf - 1.0) * I_out
+                + rl * dI_out
+            )
+            dR_below = (
+                -(lf + 1.0) * P_rho0 * inv_lp3 * rb
+                + lf * rb ** (lf - 1.0) * I_outer_ext
+            )
+            dR_above = -(lf + 1.0) * I_inner_rmax * ra ** (-(lf + 2.0))
+            dRlm = xp.where(below, dR_below, xp.where(in_grid, dR_in, dR_above))
+        if mode >= 2:
+            d2I_in, d2I_out = _d2(cin), _d2(cout)
+            d2R_in = (
+                (lf + 1.0) * (lf + 2.0) * r_in ** (-(lf + 3.0)) * I_in
+                - 2.0 * (lf + 1.0) * r_in ** (-(lf + 2.0)) * dI_in
+                + rml * d2I_in
+                + lf * (lf - 1.0) * r_in ** (lf - 2.0) * I_out
+                + 2.0 * lf * r_in ** (lf - 1.0) * dI_out
+                + rl * d2I_out
+            )
+            d2R_below = (
+                (lf + 1.0) * (lf + 2.0) * P_rho0 * inv_lp3
+                + lf * (lf - 1.0) * rb ** (lf - 2.0) * I_outer_ext
+                - (2.0 * lf + 1.0) * P_rho0
+            )
+            d2R_above = (lf + 1.0) * (lf + 2.0) * I_inner_rmax * ra ** (-(lf + 3.0))
+            d2Rlm = xp.where(below, d2R_below, xp.where(in_grid, d2R_in, d2R_above))
+        return Rlm, dRlm, d2Rlm
+
+    def _backend_angular(self, xp, costheta, phi, deriv=0):
+        """Per-component Legendre tables and cos/sin(m phi) factors.
+
+        Returns (tables, trig, dtrig): ``tables`` is a tuple of (n_comp, N)
+        arrays (P, and its requested x-derivatives) selected per component
+        from the assoc_legendre (L, M) table; ``trig`` is cos(m phi) for
+        cosine components / sin(m phi) for sine components; ``dtrig`` its
+        phi-derivative.
+
+        Notes
+        -----
+        - 2026-06-09 - Written - Bovy (UofT)
+        """
+        data = self._backend_static_data()
+        l_idx = xp.asarray(data["l_idx"])
+        m_idx = xp.asarray(data["m_idx"])
+        mf = xp.asarray(data["mf"])
+        is_sin = xp.asarray(data["is_sin"])
+        tables = assoc_legendre(self._L, self._M, costheta, deriv=deriv)
+        if deriv == 0:
+            tables = (tables,)
+        sel = tuple(xp.moveaxis(tab[..., l_idx, m_idx], -1, 0) for tab in tables)
+        mphi = mf * phi
+        cosm = xp.cos(mphi)
+        sinm = xp.sin(mphi)
+        trig = xp.where(is_sin, sinm, cosm)
+        dtrig = mf * xp.where(is_sin, cosm, -sinm)
+        return sel, trig, dtrig
+
+    def _backend_evaluate(self, xp, R, z, phi, t):
+        """Backend-array (jax/torch) version of _evaluate."""
+        data = self._backend_static_data()
+        Rf, zf, phif, shape = self._backend_prepare(xp, R, z, phi)
+        r = xp.sqrt(Rf * Rf + zf * zf)
+        ctheta = xp.cos(xp.arctan2(Rf, zf))
+        (PP,), trig, _ = self._backend_angular(xp, ctheta, phif, deriv=0)
+        Rlm, _, _ = self._backend_radial(xp, r, mode=0)
+        out = xp.sum(PP * trig * Rlm, axis=0)
+        # exact center: the numpy path returns R_00(rmin) * P_00
+        out = xp.where(r == 0.0, data["R00"], out)
+        return xp.reshape(out, shape)
+
+    def _backend_spher_forces(self, xp, r, ctheta, stheta, phi):
+        """Backend version of _compute_spher_forces_at_point (vectorized)."""
+        (PP, dPP), trig, dtrig = self._backend_angular(xp, ctheta, phi, deriv=1)
+        Rlm, dRlm, _ = self._backend_radial(xp, r, mode=1)
+        dPhi_dr = xp.sum(PP * trig * dRlm, axis=0)
+        dPhi_dtheta = xp.sum(dPP * (-stheta) * trig * Rlm, axis=0)
+        dPhi_dphi = xp.sum(PP * dtrig * Rlm, axis=0)
+        return -dPhi_dr, -dPhi_dtheta, -dPhi_dphi
+
+    def _backend_cyl_force(self, xp, which, R, z, phi, t):
+        """Backend-array version of the mixin's _Rforce/_zforce/_phitorque."""
+        if not self.isNonAxi and phi is None:
+            phi = 0.0
+        Rf, zf, phif, shape = self._backend_prepare(xp, R, z, phi)
+        r = xp.sqrt(Rf * Rf + zf * zf)
+        theta = xp.arctan2(Rf, zf)
+        Fr, Ftheta, Fphi = self._backend_spher_forces(
+            xp, r, xp.cos(theta), xp.sin(theta), phif
+        )
+        rsafe = xp.where(r == 0.0, 1.0, r)
+        if which == "R":
+            out = Rf / rsafe * Fr + zf / rsafe**2 * Ftheta
+        elif which == "z":
+            out = zf / rsafe * Fr - Rf / rsafe**2 * Ftheta
+        else:  # phi torque
+            out = Fphi
+        out = xp.where(r == 0.0, 0.0, out)
+        return xp.reshape(out, shape)
+
+    def _backend_spher_2nd_derivs(self, xp, r, ctheta, stheta, phi):
+        """Backend version of _compute_spher_2nd_derivs_at_point (vectorized)."""
+        (PP, dPP, d2PP), trig, dtrig = self._backend_angular(xp, ctheta, phi, deriv=2)
+        Rlm, dRlm, d2Rlm = self._backend_radial(xp, r, mode=2)
+        mf = xp.asarray(self._backend_static_data()["mf"])
+        dP_dtheta = dPP * (-stheta)
+        d2P_dtheta2 = d2PP * stheta**2 - dPP * ctheta
+        Phi_r = xp.sum(PP * trig * dRlm, axis=0)
+        Phi_t = xp.sum(dP_dtheta * trig * Rlm, axis=0)
+        Phi_rr = xp.sum(PP * trig * d2Rlm, axis=0)
+        Phi_tt = xp.sum(d2P_dtheta2 * trig * Rlm, axis=0)
+        Phi_pp = xp.sum(-(mf**2) * PP * trig * Rlm, axis=0)
+        Phi_rt = xp.sum(dP_dtheta * trig * dRlm, axis=0)
+        Phi_rp = xp.sum(PP * dtrig * dRlm, axis=0)
+        Phi_tp = xp.sum(dP_dtheta * dtrig * Rlm, axis=0)
+        return Phi_rr, Phi_tt, Phi_pp, Phi_rt, Phi_rp, Phi_tp, Phi_r, Phi_t
+
+    def _backend_cyl_2nd_deriv(self, xp, deriv_type, R, z, phi, t):
+        """Backend-array version of the mixin's _evaluate_cyl_2nd_deriv."""
+        if not self.isNonAxi and phi is None:
+            phi = 0.0
+        Rf, zf, phif, shape = self._backend_prepare(xp, R, z, phi)
+        r = xp.sqrt(Rf * Rf + zf * zf)
+        theta = xp.arctan2(Rf, zf)
+        ctheta = xp.cos(theta)
+        stheta = xp.sin(theta)
+        if self._M > 1:
+            # mirror the numpy path's pole clamp (d2P/dx2 diverges at the
+            # poles for m > 0); guard the dead side of the where
+            polemask = xp.abs(1.0 - ctheta * ctheta) < 1e-14
+            ctclamp = xp.sign(ctheta) * (1.0 - 1e-7)
+            ctheta = xp.where(polemask, ctclamp, ctheta)
+            stheta = xp.where(polemask, xp.sqrt(1.0 - ctclamp**2), stheta)
+        (Phi_rr, Phi_tt, Phi_pp, Phi_rt, Phi_rp, Phi_tp, Phi_r, Phi_t) = (
+            self._backend_spher_2nd_derivs(xp, r, ctheta, stheta, phif)
+        )
+        rs = xp.where(r == 0.0, 1.0, r)
+        rs2 = rs * rs
+        rs3 = rs * rs2
+        rs4 = rs2 * rs2
+        if deriv_type == "R2":
+            out = (
+                Phi_rr * Rf * Rf / rs2
+                + Phi_r * zf * zf / rs3
+                + 2.0 * Phi_rt * Rf * zf / rs3
+                + Phi_tt * zf * zf / rs4
+                + Phi_t * (-2.0 * Rf * zf) / rs4
+            )
+        elif deriv_type == "z2":
+            out = (
+                Phi_rr * zf * zf / rs2
+                + Phi_r * Rf * Rf / rs3
+                - 2.0 * Phi_rt * zf * Rf / rs3
+                + Phi_tt * Rf * Rf / rs4
+                + Phi_t * 2.0 * Rf * zf / rs4
+            )
+        elif deriv_type == "Rz":
+            out = (
+                Phi_rr * Rf * zf / rs2
+                + Phi_r * (-Rf * zf) / rs3
+                + Phi_rt * (zf * zf - Rf * Rf) / rs3
+                + Phi_tt * (-zf * Rf) / rs4
+                + Phi_t * (Rf * Rf - zf * zf) / rs4
+            )
+        elif deriv_type == "phi2":
+            out = Phi_pp
+        elif deriv_type == "Rphi":
+            out = Phi_rp * Rf / rs + Phi_tp * zf / rs2
+        elif deriv_type == "phiz":
+            out = Phi_rp * zf / rs + Phi_tp * (-Rf) / rs2
+        out = xp.where(r == 0.0, 0.0, out)
+        return xp.reshape(out, shape)
+
+    def _backend_dens(self, xp, R, z, phi, t):
+        """Backend-array (jax/torch) version of _dens."""
+        data = self._backend_static_data()
+        if not self.isNonAxi and phi is None:
+            phi = 0.0
+        Rf, zf, phif, shape = self._backend_prepare(xp, R, z, phi)
+        r = xp.sqrt(Rf * Rf + zf * zf)
+        ctheta = xp.cos(xp.arctan2(Rf, zf))
+        (PP,), trig, _ = self._backend_angular(xp, ctheta, phif, deriv=0)
+        rho_breaks = xp.asarray(data["rho_breaks"])
+        rho_c = xp.asarray(data["rho_c"])
+        rmin = float(data["rho_breaks"][0])
+        rmax = float(data["rho_breaks"][-1])
+        nint = data["rho_breaks"].shape[0] - 1
+        # below rmin the numpy path clamps r to rmin; above rmax it returns 0
+        rd = xp.clip(r, rmin, rmax)
+        idx = xp.clip(xp.searchsorted(rho_breaks, rd, side="right") - 1, 0, nint - 1)
+        dr = rd - rho_breaks[idx]
+        c = rho_c[:, :, idx]
+        rho = ((c[:, 0] * dr + c[:, 1]) * dr + c[:, 2]) * dr + c[:, 3]
+        out = xp.sum(PP * trig * rho, axis=0)
+        out = xp.where(r > rmax, 0.0, out)
+        return xp.reshape(out, shape)
 
     def OmegaP(self):
         return 0

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -341,14 +341,16 @@ def test_tdep_backend_raises(backend_name):
 def test_axi_phi_none_default(backend_name):
     # The backend paths default phi=None to 0 for axisymmetric expansions in
     # four places (the _evaluate dispatch, _backend_cyl_force,
-    # _backend_cyl_2nd_deriv, and _backend_dens); call each without phi and
-    # check against the explicit phi=0 result
+    # _backend_cyl_2nd_deriv, and _backend_dens). The PUBLIC API forwards
+    # phi=None when phi is omitted (the private-method signature default is
+    # 0.0, NOT None -- so phi=None must be passed explicitly here to exercise
+    # the guards) and the result must equal the explicit phi=0 one
     R = _asarray(backend_name, [0.5, 1.0, 2.0])
     z = _asarray(backend_name, [0.1, 0.2, 0.3])
     for meth in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
-        nophi = numpy.asarray(getattr(_AXI, meth)(R, z))
+        nophi = numpy.asarray(getattr(_AXI, meth)(R, z, phi=None))
         withphi = numpy.asarray(getattr(_AXI, meth)(R, z, phi=0.0))
         assert numpy.amax(numpy.fabs(nophi - withphi)) == 0.0, (
-            f"backend {backend_name} {meth} with phi omitted differs from phi=0"
+            f"backend {backend_name} {meth} with phi=None differs from phi=0"
         )
     return None

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -1,0 +1,337 @@
+###############################################################################
+# test_backend_multipole.py: multi-backend tests for the
+# MultipoleExpansionPotential backend (jax/torch) evaluation path (P2.5).
+#
+# The numpy path evaluates the radial BPoly/spline objects point-by-point and
+# is bit-for-bit unchanged; the backend path evaluates the same piecewise
+# polynomials as power-basis (PPoly) coefficient stacks via searchsorted +
+# Horner and the angular part via galpy.backend.special.assoc_legendre. This
+# module proves, for spherical / axisymmetric / non-axisymmetric expansions:
+#   1. numpy / jax / torch value parity for the potential, all three forces,
+#      all six second derivatives, and the density -- on a grid that spans the
+#      below-grid (r < rmin), in-grid, and above-grid (r > rmax) regions of the
+#      radial expansion (so every piecewise branch and its dead-side guards
+#      are exercised),
+#   2. autodiff of _evaluate matches finite differences of the numpy path,
+#   3. the analytic identities AD(_evaluate) == -force and AD(force) ==
+#      -second-derivative, including the phi pairs of the non-axisymmetric
+#      case and the below-/above-grid extrapolation regions,
+#   4. jax.jit produces identical values,
+#   5. time-dependent (tgrid=...) instances raise NotImplementedError on
+#      backend arrays (that path is numpy-only for now).
+#
+# Value/force parity is asserted at 1e-12; second derivatives at 1e-9
+# (power-basis Horner vs Bernstein de-Casteljau evaluation of d2I/dr2 differs
+# at the ~1e-10 rounding level -- the C backend uses the same power-basis
+# representation and is held to 1e-8 in test_potential).
+###############################################################################
+import numpy
+import pytest
+
+from galpy.potential import MiyamotoNagaiPotential, MultipoleExpansionPotential
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+###############################################################################
+# Test potentials: a pure monopole (L=1), an axisymmetric expansion of a
+# Miyamoto-Nagai disk (L=6), and a non-axisymmetric expansion with both
+# cos(phi) and sin(2 phi) terms (L=4). The coarse radial grid keeps the
+# expansion cheap; rmin=0.05 / rmax=10 leave room to test both extrapolation
+# regions.
+###############################################################################
+_RGRID = numpy.geomspace(0.05, 10.0, 101)
+_HERN = lambda r: 1.0 / (2.0 * numpy.pi) / r / (1 + r) ** 3
+
+_SPH = MultipoleExpansionPotential.from_density(
+    _HERN, L=1, symmetry="spherical", rgrid=_RGRID
+)
+_AXI = MultipoleExpansionPotential.from_density(
+    MiyamotoNagaiPotential(amp=1.3, a=0.5, b=0.3),
+    L=6,
+    symmetry="axisymmetric",
+    rgrid=_RGRID,
+)
+_NONAXI = MultipoleExpansionPotential.from_density(
+    lambda R, z, phi: (
+        (1.0 + 0.5 * numpy.cos(phi) + 0.3 * numpy.sin(2.0 * phi))
+        * _HERN(numpy.sqrt(R**2 + z**2))
+    ),
+    L=4,
+    rgrid=_RGRID,
+)
+
+CASES = [_SPH, _AXI, _NONAXI]
+CASE_IDS = ["spherical", "axisymmetric", "nonaxisymmetric"]
+
+_FIRST_ORDER = ["_evaluate", "_Rforce", "_zforce", "_phitorque", "_dens"]
+_SECOND_ORDER = [
+    "_R2deriv",
+    "_z2deriv",
+    "_Rzderiv",
+    "_phi2deriv",
+    "_Rphideriv",
+    "_phizderiv",
+]
+
+# Grid spanning below-grid (r < rmin = 0.05), in-grid, and above-grid
+# (r > rmax = 10) points; phi spans all quadrants.
+_RS = [0.03, 0.5, 1.0, 2.0, 12.0]
+_ZS = [0.02, 0.1, 0.2, 0.3, 3.0]
+_PHIS = [0.3, 1.1, 2.0, 4.0, 5.5]
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    if backend_name == "torch":
+        return torch.tensor(x, dtype=torch.float64)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, pot):
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    phi = _asarray(backend_name, _PHIS)
+    for method in _FIRST_ORDER + _SECOND_ORDER:
+        ref = numpy.asarray(
+            getattr(pot, method)(
+                numpy.asarray(_RS), numpy.asarray(_ZS), numpy.asarray(_PHIS)
+            )
+        )
+        got = _tonumpy(getattr(pot, method)(R, z, phi))
+        rtol = 1e-9 if method in _SECOND_ORDER else 1e-12
+        numpy.testing.assert_allclose(
+            got,
+            ref,
+            rtol=rtol,
+            atol=1e-13,
+            err_msg=f"{CASE_IDS[CASES.index(pot)]}.{method}",
+        )
+
+
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity_scalar(backend_name, pot):
+    # Scalar (0-d) inputs must work and agree with the numpy scalar path.
+    for method in _FIRST_ORDER + _SECOND_ORDER:
+        ref = float(numpy.asarray(getattr(pot, method)(1.3, 0.4, 0.7)))
+        got = float(
+            _tonumpy(
+                getattr(pot, method)(
+                    _asarray(backend_name, 1.3),
+                    _asarray(backend_name, 0.4),
+                    _asarray(backend_name, 0.7),
+                )
+            )
+        )
+        rtol = 1e-9 if method in _SECOND_ORDER else 1e-12
+        numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13)
+
+
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_public_value_parity(backend_name, pot):
+    # The public Rforce (through the unit decorators and _amp) must give
+    # identical values across backends.
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    phi = _asarray(backend_name, _PHIS)
+    ref = numpy.asarray(
+        pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS), phi=numpy.asarray(_PHIS))
+    )
+    got = _tonumpy(pot.Rforce(R, z, phi=phi))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_vs_finite_difference(backend_name, pot):
+    # Independent (finite-difference, numpy-path) cross-check that the
+    # backend _evaluate is differentiable end-to-end; the exact analytic
+    # identity is asserted (more tightly) in test_force_hessian_identities.
+    R0, z0, phi0 = 1.3, 0.4, 0.7
+    eps = 1e-6
+
+    def phi_np(R):
+        return float(pot._evaluate(numpy.asarray(R), numpy.asarray(z0), phi0))
+
+    fd = (phi_np(R0 + eps) - phi_np(R0 - eps)) / (2 * eps)
+    if backend_name == "jax":
+        ad = float(
+            jax.grad(lambda R: pot._evaluate(R, jnp.asarray(z0), jnp.asarray(phi0)))(
+                jnp.asarray(R0)
+            )
+        )
+    else:
+        R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+        y = pot._evaluate(
+            R,
+            torch.tensor(z0, dtype=torch.float64),
+            torch.tensor(phi0, dtype=torch.float64),
+        )
+        y.backward()
+        ad = float(R.grad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)
+
+
+###############################################################################
+# Analytic-identity autodiff checks (galpy sign conventions):
+#   AD(_evaluate wrt R) == -_Rforce      AD(_evaluate wrt z) == -_zforce
+#   AD(_evaluate wrt phi) == -_phitorque
+#   AD(_Rforce wrt R) == -_R2deriv       AD(_Rforce wrt z) == -_Rzderiv
+#   AD(_Rforce wrt phi) == -_Rphideriv   AD(_zforce wrt z) == -_z2deriv
+#   AD(_zforce wrt phi) == -_phizderiv   AD(_phitorque wrt phi) == -_phi2deriv
+# For the axisymmetric/spherical cases the phi pairs are identically zero,
+# which the atol covers.
+###############################################################################
+_R, _Z, _PHI = 0, 1, 2
+_ID_PAIRS = [
+    ("_evaluate", _R, "_Rforce"),
+    ("_evaluate", _Z, "_zforce"),
+    ("_evaluate", _PHI, "_phitorque"),
+    ("_Rforce", _R, "_R2deriv"),
+    ("_Rforce", _Z, "_Rzderiv"),
+    ("_Rforce", _PHI, "_Rphideriv"),
+    ("_zforce", _Z, "_z2deriv"),
+    ("_zforce", _PHI, "_phizderiv"),
+    ("_phitorque", _PHI, "_phi2deriv"),
+]
+
+
+def _grad_wrt(backend_name, fn, *args, argnum=0):
+    # AD of scalar-valued fn(*args) wrt args[argnum].
+    if backend_name == "jax":
+        jargs = [jnp.asarray(a) for a in args]
+
+        def f(x):
+            full = list(jargs)
+            full[argnum] = x
+            return fn(*full)
+
+        return float(jax.grad(f)(jargs[argnum]))
+    targs = [torch.tensor(a, dtype=torch.float64) for a in args]
+    leaf = torch.tensor(args[argnum], dtype=torch.float64, requires_grad=True)
+    targs[argnum] = leaf
+    out = fn(*targs)
+    out.backward()
+    return float(leaf.grad)
+
+
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_hessian_identities(backend_name, pot):
+    R0, z0, phi0 = 1.3, 0.4, 0.7
+    for lower, argnum, higher in _ID_PAIRS:
+        ad = _grad_wrt(
+            backend_name,
+            lambda R, z, phi, _l=lower: getattr(pot, _l)(R, z, phi),
+            R0,
+            z0,
+            phi0,
+            argnum=argnum,
+        )
+        ref = -float(numpy.asarray(getattr(pot, higher)(R0, z0, phi0)))
+        numpy.testing.assert_allclose(
+            ad,
+            ref,
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"{CASE_IDS[CASES.index(pot)]}: AD({lower})==-{higher}",
+        )
+
+
+@pytest.mark.parametrize(
+    "point", [(0.03, 0.02, 0.7), (11.0, 2.0, 0.7)], ids=["below-grid", "above-grid"]
+)
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_extrapolation_region_identities(backend_name, pot, point):
+    # The constant-density (r < rmin) and point-mass (r > rmax) extrapolation
+    # branches must also be consistent under autodiff (their dead sides are
+    # guarded with safe radii).
+    R0, z0, phi0 = point
+    for lower, argnum, higher in [
+        ("_evaluate", _R, "_Rforce"),
+        ("_evaluate", _Z, "_zforce"),
+        ("_Rforce", _R, "_R2deriv"),
+    ]:
+        ad = _grad_wrt(
+            backend_name,
+            lambda R, z, phi, _l=lower: getattr(pot, _l)(R, z, phi),
+            R0,
+            z0,
+            phi0,
+            argnum=argnum,
+        )
+        ref = -float(numpy.asarray(getattr(pot, higher)(R0, z0, phi0)))
+        numpy.testing.assert_allclose(
+            ad,
+            ref,
+            rtol=1e-9,
+            atol=1e-12,
+            err_msg=f"{CASE_IDS[CASES.index(pot)]}@{point}: AD({lower})==-{higher}",
+        )
+
+
+@pytest.mark.skipif(jax is None, reason="jax not available")
+@pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
+def test_jax_jit_matches(pot):
+    R = jnp.asarray(_RS)
+    z = jnp.asarray(_ZS)
+    phi = jnp.asarray(_PHIS)
+    for method in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
+        fn = getattr(pot, method)
+        ref = numpy.asarray(fn(R, z, phi))
+        got = numpy.asarray(jax.jit(fn)(R, z, phi))
+        numpy.testing.assert_allclose(got, ref, rtol=1e-15, atol=1e-15)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_tdep_backend_raises(backend_name):
+    # Time-dependent (tgrid=...) instances are numpy-only: backend arrays
+    # must raise a clear NotImplementedError instead of silently failing.
+    tdep = MultipoleExpansionPotential.from_density(
+        lambda R, z, phi, t=0.0: (1.0 + 0.1 * t) * _HERN(numpy.sqrt(R**2 + z**2)),
+        L=1,
+        symmetry="spherical",
+        rgrid=_RGRID,
+        tgrid=numpy.linspace(0.0, 2.0, 5),
+    )
+    R = _asarray(backend_name, 1.3)
+    z = _asarray(backend_name, 0.4)
+    # numpy evaluation still works
+    assert numpy.isfinite(float(numpy.asarray(tdep._evaluate(1.3, 0.4, 0.7, 0.5))))
+    for method in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
+        with pytest.raises(NotImplementedError, match="time-dependent"):
+            getattr(tdep, method)(R, z, 0.7, 0.5)

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -335,3 +335,20 @@ def test_tdep_backend_raises(backend_name):
     for method in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
         with pytest.raises(NotImplementedError, match="time-dependent"):
             getattr(tdep, method)(R, z, 0.7, 0.5)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_axi_phi_none_default(backend_name):
+    # The backend paths default phi=None to 0 for axisymmetric expansions in
+    # four places (the _evaluate dispatch, _backend_cyl_force,
+    # _backend_cyl_2nd_deriv, and _backend_dens); call each without phi and
+    # check against the explicit phi=0 result
+    R = _asarray(backend_name, [0.5, 1.0, 2.0])
+    z = _asarray(backend_name, [0.1, 0.2, 0.3])
+    for meth in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
+        nophi = numpy.asarray(getattr(_AXI, meth)(R, z))
+        withphi = numpy.asarray(getattr(_AXI, meth)(R, z, phi=0.0))
+        assert numpy.amax(numpy.fabs(nophi - withphi)) == 0.0, (
+            f"backend {backend_name} {meth} with phi omitted differs from phi=0"
+        )
+    return None


### PR DESCRIPTION
Part of the **P2.5** fan-out. The radial spline interpolation did **not** block jax/torch for static potentials: the per-(l,m) BPoly radial integrals are lazily converted (numpy-side, once) to stacked power-basis PPoly coefficients evaluated backend-agnostically; angular part via `galpy.backend.special.assoc_legendre`.

**Explicit scope limit (not hidden):** time-dependent (`tgrid=`) instances stay numpy-only — backend arrays raise `NotImplementedError` with a clear message (backend time-interpolation is a later work item).

**Verification (adversarial, vs pristine):** numpy value grid byte-identical; backend tests pass; verdict pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)