### PR TITLE
P2.5: DiskSCF/KuijkenDubinski/DiskMultipole backend-agnostic correction layer

### DIFF
--- a/galpy/backend/special/__init__.py
+++ b/galpy/backend/special/__init__.py
@@ -30,6 +30,7 @@ from ._router import (
     k0,
     k1,
     kn,
+    logsumexp,
     xlogy,
 )
 
@@ -43,6 +44,7 @@ __all__ = [
     "i0",
     "i1",
     "xlogy",
+    "logsumexp",
     "hyp2f1",
     "hyp1f1",
     "ellipk",

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -235,5 +235,23 @@ def xlogy(x, y):
     return _dispatch("xlogy", (x, y), xlogy_fallback)
 
 
+def logsumexp(a, axis=None):
+    """Overflow-safe log(sum(exp(a), axis)) (disk-expansion sech^2 profiles).
+
+    Native on every backend, so no fallback: scipy.special.logsumexp for numpy
+    (byte-identical), jax.scipy.special.logsumexp for jax, and torch.logsumexp
+    for torch. Handled outside ``_dispatch`` because the ``axis`` argument is a
+    plain int that must not be promoted to a tensor (and torch's ``dim`` is
+    required, so ``axis=None`` reduces over all axes explicitly).
+    """
+    xp = get_namespace(a)
+    name, sp = _backend_special(xp)
+    if name == "torch":
+        import torch
+
+        return torch.logsumexp(a, dim=tuple(range(a.ndim)) if axis is None else axis)
+    return sp.logsumexp(a, axis=axis)
+
+
 # Silence "imported but unused" for numpy (kept for potential defensive use).
 _ = numpy

--- a/galpy/potential/DiskMultipoleExpansionPotential.py
+++ b/galpy/potential/DiskMultipoleExpansionPotential.py
@@ -92,6 +92,7 @@ class DiskMultipoleExpansionPotential(KuijkenDubinskiDiskExpansionPotential):
         Notes
         -----
         - Either specify (Sigma,hz) or (Sigma_amp,Sigma,dSigmadR,d2SigmadR2,hz,Hz,dHzdz)
+        - The built-in dict-specified Sigma/hz profiles are backend-agnostic (numpy/jax/torch); for jax/torch evaluation, any *user-provided* Sigma/dSigmadR/d2SigmadR2/hz/Hz/dHzdz callables must accept backend arrays (e.g., be written with ``galpy.backend.get_namespace``)
         - 2026-02-22 - Written - Bovy (UofT)
 
         """

--- a/galpy/potential/DiskSCFPotential.py
+++ b/galpy/potential/DiskSCFPotential.py
@@ -96,6 +96,7 @@ class DiskSCFPotential(KuijkenDubinskiDiskExpansionPotential):
         Notes
         -----
         - Either specify (Sigma,hz) or (Sigma_amp,Sigma,dSigmadR,d2SigmadR2,hz,Hz,dHzdz)
+        - The built-in dict-specified Sigma/hz profiles are backend-agnostic (numpy/jax/torch); for jax/torch evaluation, any *user-provided* Sigma/dSigmadR/d2SigmadR2/hz/Hz/dHzdz callables must accept backend arrays (e.g., be written with ``galpy.backend.get_namespace``)
         - Written - Bovy (UofT) - 2016-12-26
 
         """

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -5,19 +5,10 @@
 import copy
 
 import numpy
-import scipy
-from packaging.version import parse as parse_version
-
-_SCIPY_VERSION = parse_version(scipy.__version__)
-if _SCIPY_VERSION < parse_version("0.10"):  # pragma: no cover
-    from scipy.maxentropy import logsumexp
-elif _SCIPY_VERSION < parse_version("0.19"):  # pragma: no cover
-    from scipy.misc import logsumexp
-else:
-    from scipy.special import logsumexp
-
 from scipy import integrate
 
+from ..backend import get_namespace
+from ..backend.special import logsumexp
 from .Potential import Potential
 
 
@@ -29,6 +20,14 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     Subclasses (DiskSCFPotential, DiskMultipoleExpansionPotential) only differ
     in how they create the expansion sub-potential (self._me).
+
+    The correction-term math (the built-in dict-specified Sigma/hz profiles and
+    all force/derivative/density methods) is backend-agnostic (numpy/jax/torch).
+    Full backend support additionally requires (a) the expansion sub-potential
+    ``self._me`` to be backend-agnostic and (b) any *user-provided*
+    Sigma/dSigmadR/d2SigmadR2/hz/Hz/dHzdz callables to accept backend arrays
+    (e.g., be written with ``galpy.backend.get_namespace``); callables written
+    against plain numpy silently degrade backend inputs to numpy.
     """
 
     def __init__(
@@ -132,24 +131,27 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         return None
 
     def _parse_Sigma_dict_indiv(self, Sigma):
+        # The built-in profiles resolve their array namespace per call
+        # (get_namespace), so they run under numpy (byte-identical: the numpy
+        # namespace IS the numpy module), jax, and torch.
         stype = Sigma.get("type", "exp")
         if stype == "exp" and not "Rhole" in Sigma:
             rd = Sigma.get("h", 1.0 / 3.0)
             ta = Sigma.get("amp", 1.0)
-            ts = lambda R, trd=rd: numpy.exp(-R / trd)
-            tds = lambda R, trd=rd: -numpy.exp(-R / trd) / trd
-            td2s = lambda R, trd=rd: numpy.exp(-R / trd) / trd**2.0
+            ts = lambda R, trd=rd: get_namespace(R).exp(-R / trd)
+            tds = lambda R, trd=rd: -get_namespace(R).exp(-R / trd) / trd
+            td2s = lambda R, trd=rd: get_namespace(R).exp(-R / trd) / trd**2.0
         elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
             rd = Sigma.get("h", 1.0 / 3.0)
             rm = Sigma.get("Rhole", 0.5)
             ta = Sigma.get("amp", 1.0)
-            ts = lambda R, trd=rd, trm=rm: numpy.exp(-trm / R - R / trd)
+            ts = lambda R, trd=rd, trm=rm: get_namespace(R).exp(-trm / R - R / trd)
             tds = lambda R, trd=rd, trm=rm: (
-                (trm / R**2.0 - 1.0 / trd) * numpy.exp(-trm / R - R / trd)
+                (trm / R**2.0 - 1.0 / trd) * get_namespace(R).exp(-trm / R - R / trd)
             )
             td2s = lambda R, trd=rd, trm=rm: (
                 ((trm / R**2.0 - 1.0 / trd) ** 2.0 - 2.0 * trm / R**3.0)
-                * numpy.exp(-trm / R - R / trd)
+                * get_namespace(R).exp(-trm / R - R / trd)
             )
         return (ta, ts, tds, td2s)
 
@@ -196,75 +198,96 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         return None
 
     def _parse_hz_dict_indiv(self, hz):
+        # Backend-agnostic like _parse_Sigma_dict_indiv: xp.abs == numpy.fabs
+        # bit-for-bit on real floats, xp.stack of same-shape inputs ==
+        # numpy.array of that list, and galpy.backend.special.logsumexp routes
+        # numpy to scipy.special.logsumexp -- so the numpy path is unchanged.
         htype = hz.get("type", "exp")
         if htype == "exp":
             zd = hz.get("h", 0.0375)
-            th = lambda z, tzd=zd: 1.0 / 2.0 / tzd * numpy.exp(-numpy.fabs(z) / tzd)
-            tH = lambda z, tzd=zd: (
-                (numpy.exp(-numpy.fabs(z) / tzd) - 1.0 + numpy.fabs(z) / tzd)
-                * tzd
-                / 2.0
-            )
-            tdH = lambda z, tzd=zd: (
-                0.5 * numpy.sign(z) * (1.0 - numpy.exp(-numpy.fabs(z) / tzd))
-            )
+
+            def th(z, tzd=zd):
+                xp = get_namespace(z)
+                return 1.0 / 2.0 / tzd * xp.exp(-xp.abs(z) / tzd)
+
+            def tH(z, tzd=zd):
+                xp = get_namespace(z)
+                return (xp.exp(-xp.abs(z) / tzd) - 1.0 + xp.abs(z) / tzd) * tzd / 2.0
+
+            def tdH(z, tzd=zd):
+                xp = get_namespace(z)
+                return 0.5 * xp.sign(z) * (1.0 - xp.exp(-xp.abs(z) / tzd))
+
         elif htype == "sech2":
             zd = hz.get("h", 0.0375)
+
             # th/tH written so as to avoid overflow in cosh
-            th = lambda z, tzd=zd: (
-                numpy.exp(
-                    -logsumexp(
-                        numpy.array(
-                            [z / tzd, -z / tzd, numpy.log(2.0) * numpy.ones_like(z)]
-                        ),
-                        axis=0,
+            def th(z, tzd=zd):
+                xp = get_namespace(z)
+                return (
+                    xp.exp(
+                        -logsumexp(
+                            xp.stack(
+                                [z / tzd, -z / tzd, numpy.log(2.0) * xp.ones_like(z)]
+                            ),
+                            axis=0,
+                        )
                     )
+                    / tzd
                 )
-                / tzd
-            )
-            tH = lambda z, tzd=zd: (
-                tzd
-                * (
-                    logsumexp(numpy.array([z / 2.0 / tzd, -z / 2.0 / tzd]), axis=0)
+
+            def tH(z, tzd=zd):
+                xp = get_namespace(z)
+                return tzd * (
+                    logsumexp(xp.stack([z / 2.0 / tzd, -z / 2.0 / tzd]), axis=0)
                     - numpy.log(2.0)
                 )
-            )
-            tdH = lambda z, tzd=zd: numpy.tanh(z / 2.0 / tzd) / 2.0
+
+            def tdH(z, tzd=zd):
+                xp = get_namespace(z)
+                return xp.tanh(z / 2.0 / tzd) / 2.0
+
         return (th, tH, tdH)
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        # Here and below: out-of-place accumulation (out = out + ...) instead of
+        # += so torch autograd never sees an in-place op; identical numpy values.
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me(R, z, phi=phi, use_physical=False)
         for a, s, H in zip(self._Sigma_amp, self._Sigma, self._Hz):
-            out += 4.0 * numpy.pi * a * s(r) * H(z)
+            out = out + 4.0 * numpy.pi * a * s(r) * H(z)
         return out
 
     def _Rforce(self, R, z, phi=0, t=0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rforce(R, z, phi=phi, use_physical=False)
         for a, ds, H in zip(self._Sigma_amp, self._dSigmadR, self._Hz):
-            out -= 4.0 * numpy.pi * a * ds(r) * H(z) * R / r
+            out = out - 4.0 * numpy.pi * a * ds(r) * H(z) * R / r
         return out
 
     def _zforce(self, R, z, phi=0, t=0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.zforce(R, z, phi=phi, use_physical=False)
         for a, s, ds, H, dH in zip(
             self._Sigma_amp, self._Sigma, self._dSigmadR, self._Hz, self._dHzdz
         ):
-            out -= 4.0 * numpy.pi * a * (ds(r) * H(z) * z / r + s(r) * dH(z))
+            out = out - 4.0 * numpy.pi * a * (ds(r) * H(z) * z / r + s(r) * dH(z))
         return out
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         return self._me.phitorque(R, z, phi=phi, use_physical=False)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.R2deriv(R, z, phi=phi, use_physical=False)
         for a, ds, d2s, H in zip(
             self._Sigma_amp, self._dSigmadR, self._d2SigmadR2, self._Hz
         ):
-            out += (
+            out = out + (
                 4.0
                 * numpy.pi
                 * a
@@ -275,7 +298,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         return out
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.z2deriv(R, z, phi=phi, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(
             self._Sigma_amp,
@@ -286,7 +310,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             self._Hz,
             self._dHzdz,
         ):
-            out += (
+            out = out + (
                 4.0
                 * numpy.pi
                 * a
@@ -299,12 +323,13 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         return out
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rzderiv(R, z, phi=phi, use_physical=False)
         for a, ds, d2s, H, dH in zip(
             self._Sigma_amp, self._dSigmadR, self._d2SigmadR2, self._Hz, self._dHzdz
         ):
-            out += (
+            out = out + (
                 4.0
                 * numpy.pi
                 * a
@@ -316,7 +341,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         return self._me.phi2deriv(R, z, phi=phi, use_physical=False)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
-        r = numpy.sqrt(R**2.0 + z**2.0)
+        xp = get_namespace(R, z)
+        r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.dens(R, z, phi=phi, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(
             self._Sigma_amp,
@@ -327,7 +353,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             self._Hz,
             self._dHzdz,
         ):
-            out += a * (
+            out = out + a * (
                 s(r) * h(z) + d2s(r) * H(z) + 2.0 / r * ds(r) * (H(z) + z * dH(z))
             )
         return out
@@ -354,11 +380,15 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
 
 def phiME_dens(R, z, phi, dens, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz, Sigma_amp):
-    """The density corresponding to phi_ME"""
-    r = numpy.sqrt(R**2.0 + z**2.0)
+    """The density corresponding to phi_ME (backend-agnostic provided that the
+    user-supplied ``dens`` callable accepts backend arrays)"""
+    xp = get_namespace(R, z)
+    r = xp.sqrt(R**2.0 + z**2.0)
     out = dens(R, z, phi)
     for a, s, ds, d2s, h, H, dH in zip(
         Sigma_amp, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz
     ):
-        out -= a * (s(r) * h(z) + d2s(r) * H(z) + 2.0 / r * ds(r) * (H(z) + z * dH(z)))
+        out = out - a * (
+            s(r) * h(z) + d2s(r) * H(z) + 2.0 / r * ds(r) * (H(z) + z * dH(z))
+        )
     return out

--- a/tests/test_backend_diskexpansion.py
+++ b/tests/test_backend_diskexpansion.py
@@ -1,0 +1,271 @@
+###############################################################################
+# test_backend_diskexpansion.py: backend-agnostic tests for the
+# KuijkenDubinskiDiskExpansionPotential layer (P2.5) -- the analytic
+# Sigma(r) * Hz(z) correction terms shared by DiskSCFPotential and
+# DiskMultipoleExpansionPotential.
+#
+# The expansion sub-potential self._me (SCFPotential /
+# MultipoleExpansionPotential) is a separate migration item, so these tests
+# isolate the migrated Kuijken-Dubinski layer by attaching an
+# already-backend-clean PlummerPotential as self._me: every KD method
+# (_evaluate, forces, second derivatives, _dens) then runs its full code path
+# -- the built-in dict Sigma/hz profiles (exp, expwhole, exp/sech2 hz,
+# multi-component) plus the _me delegation -- under numpy, jax, and torch.
+#
+# For each configuration and method this proves:
+#   1. numpy / jax / torch produce identical values (rtol=1e-12, atol=1e-14),
+#      including at the z == 0 kink of the exp vertical profile,
+#   2. autodiff (jax.grad / torch.autograd) of _evaluate matches central
+#      finite differences,
+#   3. the analytic identities AD(_evaluate) == -force, AD(force) == -2nd-deriv
+#      hold to rtol=1e-9,
+#   4. the phiME effective-density helper is backend-clean when the user
+#      density callable is (the documented requirement).
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import get_namespace
+from galpy.potential import PlummerPotential
+from galpy.potential.KuijkenDubinskiDiskExpansionPotential import (
+    KuijkenDubinskiDiskExpansionPotential,
+)
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+
+def _asarray(backend_name, x, requires_grad=False):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+def _dens_xp(R, z):
+    # backend-clean stand-in for the default (numpy-lambda) disk density
+    xp = get_namespace(R, z)
+    return 13.5 * xp.exp(-3.0 * R) * xp.exp(-27.0 * xp.abs(z))
+
+
+def _kd_pot(Sigma, hz):
+    """A KuijkenDubinski-layer potential with a backend-clean _me (Plummer),
+    so the migrated correction-term math is exercised end-to-end on every
+    backend without depending on the SCF/Multipole migrations."""
+    pot = KuijkenDubinskiDiskExpansionPotential(
+        amp=1.0, dens=_dens_xp, Sigma=Sigma, hz=hz
+    )
+    pot._me = PlummerPotential(amp=1.1, b=0.8)
+    pot._finish_init(False)
+    return pot
+
+
+# --- CASES: every built-in dict profile type + multi-component ---------------
+_POTS = [
+    # (id, potential)
+    (
+        "exp-exp",
+        _kd_pot(
+            {"type": "exp", "h": 1.0 / 3.0, "amp": 1.0},
+            {"type": "exp", "h": 1.0 / 27.0},
+        ),
+    ),
+    (
+        "expwhole-sech2",
+        _kd_pot(
+            {"type": "expwhole", "h": 1.0 / 3.0, "amp": 1.0, "Rhole": 0.5},
+            {"type": "sech2", "h": 1.0 / 27.0},
+        ),
+    ),
+    # two Sigma components with per-component vertical profiles
+    (
+        "two-component",
+        _kd_pot(
+            [
+                {"type": "exp", "h": 1.0 / 3.0, "amp": 1.0},
+                {"type": "expwhole", "h": 0.5, "amp": 0.5, "Rhole": 0.4},
+            ],
+            [{"type": "exp", "h": 1.0 / 27.0}, {"type": "sech2", "h": 1.0 / 20.0}],
+        ),
+    ),
+]
+_POT_IDS = [pid for pid, _ in _POTS]
+
+_METHODS = [
+    "_evaluate",
+    "_Rforce",
+    "_zforce",
+    "_R2deriv",
+    "_z2deriv",
+    "_Rzderiv",
+    "_dens",
+]
+
+_RS = [0.4, 1.0, 2.1]
+_ZS = [-0.3, 0.05, 0.2]
+
+
+# --- value parity -------------------------------------------------------------
+@pytest.mark.parametrize("method", _METHODS)
+@pytest.mark.parametrize("pot", [p for _, p in _POTS], ids=_POT_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, pot, method):
+    ref = numpy.asarray(getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS)))
+    got = _tonumpy(
+        getattr(pot, method)(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+# The exp vertical profile has a |z| kink (xp.sign / xp.abs): values at z == 0
+# must agree exactly across backends (cf. the KuzminDisk z-kink test).
+@pytest.mark.parametrize("method", ["_zforce", "_Rzderiv", "_z2deriv", "_dens"])
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_zkink_at_zero(backend_name, method):
+    pot = _POTS[0][1]  # exp-exp
+    R = [0.5, 1.0, 2.0]
+    z = [0.0, 0.0, 0.0]
+    ref = numpy.asarray(getattr(pot, method)(numpy.asarray(R), numpy.asarray(z)))
+    got = _tonumpy(
+        getattr(pot, method)(_asarray(backend_name, R), _asarray(backend_name, z))
+    )
+    assert numpy.all(numpy.isfinite(ref))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+# sech2's logsumexp overflow guard: large |z| must stay finite on every backend.
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_sech2_large_z_no_overflow(backend_name):
+    pot = _POTS[1][1]  # expwhole-sech2
+    R = [1.0, 1.0]
+    z = [-40.0, 40.0]
+    ref = numpy.asarray(pot._evaluate(numpy.asarray(R), numpy.asarray(z)))
+    assert numpy.all(numpy.isfinite(ref))
+    got = _tonumpy(pot._evaluate(_asarray(backend_name, R), _asarray(backend_name, z)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+# --- autodiff vs finite difference ---------------------------------------------
+@pytest.mark.parametrize("pot", [p for _, p in _POTS], ids=_POT_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_vs_finite_difference(backend_name, pot):
+    # Independent FD cross-check of the migrated _evaluate gradient (the exact
+    # analytic identities are asserted, far more tightly, below). z0 != 0 keeps
+    # away from the exp-profile |z| kink.
+    R0, z0 = 1.3, 0.4
+    eps = 1e-6
+
+    def phi_np(R, z):
+        return float(pot._evaluate(numpy.asarray(R), numpy.asarray(z)))
+
+    fdR = (phi_np(R0 + eps, z0) - phi_np(R0 - eps, z0)) / (2 * eps)
+    fdz = (phi_np(R0, z0 + eps) - phi_np(R0, z0 - eps)) / (2 * eps)
+    if backend_name == "jax":
+        adR = float(
+            jax.grad(lambda R: pot._evaluate(R, jnp.asarray(z0)))(jnp.asarray(R0))
+        )
+        adz = float(
+            jax.grad(lambda z: pot._evaluate(jnp.asarray(R0), z))(jnp.asarray(z0))
+        )
+    else:
+        R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+        z = torch.tensor(z0, dtype=torch.float64, requires_grad=True)
+        pot._evaluate(R, z).backward()
+        adR, adz = float(R.grad), float(z.grad)
+    numpy.testing.assert_allclose(adR, fdR, rtol=1e-5)
+    numpy.testing.assert_allclose(adz, fdz, rtol=1e-5)
+
+
+###############################################################################
+# Analytic-identity autodiff checks (galpy sign conventions):
+#   AD(_evaluate wrt R) == -_Rforce      AD(_evaluate wrt z) == -_zforce
+#   AD(_Rforce  wrt R) == -_R2deriv      AD(_Rforce  wrt z) == -_Rzderiv
+#   AD(_zforce  wrt z) == -_z2deriv
+# This cross-validates the hand-coded correction-term forces / 2nd derivatives.
+###############################################################################
+_R, _Z = 0, 1
+_ID_PAIRS = [
+    ("_evaluate", _R, "_Rforce"),
+    ("_evaluate", _Z, "_zforce"),
+    ("_Rforce", _R, "_R2deriv"),
+    ("_Rforce", _Z, "_Rzderiv"),
+    ("_zforce", _Z, "_z2deriv"),
+]
+
+
+def _grad_wrt(backend_name, fn, *args, argnum=0):
+    if backend_name == "jax":
+        jargs = [jnp.asarray(a) for a in args]
+
+        def f(x):
+            full = list(jargs)
+            full[argnum] = x
+            return fn(*full)
+
+        return float(jax.grad(f)(jargs[argnum]))
+    targs = [torch.tensor(a, dtype=torch.float64) for a in args]
+    leaf = torch.tensor(args[argnum], dtype=torch.float64, requires_grad=True)
+    targs[argnum] = leaf
+    fn(*targs).backward()
+    return float(leaf.grad)
+
+
+@pytest.mark.parametrize("pot", [p for _, p in _POTS], ids=_POT_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_hessian_identities(backend_name, pot):
+    R0, z0 = 1.3, 0.4
+    for lower, argnum, higher in _ID_PAIRS:
+        ad = _grad_wrt(
+            backend_name,
+            lambda R, z, _l=lower: getattr(pot, _l)(R, z),
+            R0,
+            z0,
+            argnum=argnum,
+        )
+        ref = -float(getattr(pot, higher)(R0, z0))
+        numpy.testing.assert_allclose(
+            ad, ref, rtol=1e-9, err_msg=f"AD({lower}) == -{higher} ({backend_name})"
+        )
+
+
+# --- phiME effective density (coefficient-computation helper) ------------------
+# Backend-clean iff the user dens callable is (the documented requirement);
+# this is the right-hand side fed to SCF/Multipole from_density.
+@pytest.mark.parametrize("pot", [p for _, p in _POTS], ids=_POT_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_phiME_dens_value_parity(backend_name, pot):
+    ref = numpy.asarray(pot._phiME_dens_func(numpy.asarray(_RS), numpy.asarray(_ZS)))
+    got = _tonumpy(
+        pot._phiME_dens_func(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -107,6 +107,45 @@ def test_xlogy_value_parity_incl_zero(backend):
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_logsumexp_value_parity(backend):
+    # incl. +-800 to exercise the overflow guard (naive exp would inf/0 out)
+    a = numpy.array([[-1.2, 0.3, 800.0, -800.0], [0.5, 2.0, 799.0, 0.0]])
+    for axis in (0, 1, None):
+        ref = scipy_special.logsumexp(a, axis=axis)
+        got = _tonumpy(gsp.logsumexp(_asarray(backend, a), axis=axis))
+        rtol = 0.0 if backend == "numpy" else 1e-12
+        numpy.testing.assert_allclose(
+            got, ref, rtol=rtol, atol=1e-12, err_msg=f"logsumexp axis={axis}"
+        )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_logsumexp_grad_vs_fd(backend):
+    rest = [-0.7, 1.1]
+    x0 = 0.3
+    eps = 1e-6
+
+    def f_np(x):
+        return float(scipy_special.logsumexp(numpy.array([x] + rest)))
+
+    fd = (f_np(x0 + eps) - f_np(x0 - eps)) / (2 * eps)
+    if backend == "jax":
+        ad = float(
+            jax.grad(lambda x: gsp.logsumexp(jnp.stack([x, *map(jnp.asarray, rest)])))(
+                jnp.asarray(x0)
+            )
+        )
+    else:
+        xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        gsp.logsumexp(
+            torch.stack([xt, *(torch.tensor(r, dtype=torch.float64) for r in rest)])
+        ).backward()
+        ad = float(xt.grad)
+    assert not numpy.isnan(ad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)
+
+
 @pytest.mark.parametrize("name,fn,sp_fn,pts", UNARY, ids=[u[0] for u in UNARY])
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_unary_grad_vs_fd(backend, name, fn, sp_fn, pts):


### PR DESCRIPTION
Part of the **P2.5** fan-out. Migrates the Kuijken–Dubinski disk-expansion layer (base of DiskSCFPotential + DiskMultipoleExpansionPotential): built-in Sigma (exp, expwhole) and hz (exp, sech2) profile dicts + the correction-term assembly now xp-dispatch per call (+ a logsumexp router addition). User-supplied Sigma/hz callables documented as requiring xp-compatible functions for backend use.

**Merge-order note:** end-to-end jax/torch evaluation of DiskSCF/DiskMultipole additionally needs the embedded-expansion migrations — merge **after** #930 (SCF) and #931's sibling (Multipole, #93x). The KD-layer migration here is independently correct and tested.

**Verification (adversarial, vs pristine):** numpy value grid byte-identical; backend tests pass; verdict pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)