### PR TITLE
Pvar-pot: planar + 3D dxdv for MovingObjectPotential

### DIFF
--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -858,6 +858,17 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &MovingObjectPotentialRforce;
       potentialArgs->zforce= &MovingObjectPotentialzforce;
       potentialArgs->phitorque= &MovingObjectPotentialphitorque;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv):
+      // the kernel's Hessian at the shifted point x-x_obj(t), evaluated
+      // through the wrapped potential's pointers exactly like the forces
+      // (only used when the kernel itself has its 3D Hessian in C, gated by
+      // hasC_dxdv3d = _check_c(kernel, dxdv3d=True) on the Python side).
+      potentialArgs->R2deriv= &MovingObjectPotentialR2deriv;
+      potentialArgs->z2deriv= &MovingObjectPotentialz2deriv;
+      potentialArgs->Rzderiv= &MovingObjectPotentialRzderiv;
+      potentialArgs->phi2deriv= &MovingObjectPotentialphi2deriv;
+      potentialArgs->Rphideriv= &MovingObjectPotentialRphideriv;
+      potentialArgs->zphideriv= &MovingObjectPotentialzphideriv;
       potentialArgs->nargs= 3;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -610,6 +610,14 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
     case -6: //MovingObjectPotential
       potentialArgs->planarRforce= &MovingObjectPotentialPlanarRforce;
       potentialArgs->planarphitorque= &MovingObjectPotentialPlanarphitorque;
+      // Planar 2D Hessian for the planar variational equations
+      // (integrate_dxdv): the kernel's planar Hessian at the shifted point
+      // x-x_obj(t); nonaxisymmetric (the object is off-center). Only used
+      // when the kernel's planar Hessian is in C (gated by hasC_dxdv =
+      // _check_c(kernel, dxdv=True) on the Python side).
+      potentialArgs->planarR2deriv= &MovingObjectPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &MovingObjectPotentialPlanarphi2deriv;
+      potentialArgs->planarRphideriv= &MovingObjectPotentialPlanarRphideriv;
       potentialArgs->nargs= 3;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/potential/MovingObjectPotential.py
+++ b/galpy/potential/MovingObjectPotential.py
@@ -14,7 +14,10 @@ from .Potential import (
     _isNonAxi,
     evaluateDensities,
     evaluatePotentials,
+    evaluateR2derivs,
     evaluateRforces,
+    evaluateRzderivs,
+    evaluatez2derivs,
     evaluatezforces,
 )
 
@@ -63,6 +66,13 @@ class MovingObjectPotential(Potential):
         self._orb.turn_physical_off()
         self.isNonAxi = True
         self.hasC = _check_c(self._pot)
+        # The second derivatives (for the variational equations) are the
+        # kernel's second derivatives at the shifted point x-x_obj(t), both in
+        # Python (below) and in C, where they are evaluated through the
+        # wrapped potential's pointers exactly like the forces. They are thus
+        # available in C exactly when the kernel's are (same gating as hasC).
+        self.hasC_dxdv = _check_c(self._pot, dxdv=True)
+        self.hasC_dxdv3d = _check_c(self._pot, dxdv3d=True)
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
@@ -103,6 +113,88 @@ class MovingObjectPotential(Potential):
         RF = evaluateRforces(self._pot, Rdist, zd, t=t, use_physical=False)
         # Return phi force, negative of phi vector to evaluate location
         return -RF * R * (numpy.cos(phi) * yd - numpy.sin(phi) * xd) / Rdist
+
+    def _xyzHess(self, R, z, phi, t):
+        """Cartesian first (phix, phiy; phiz is never needed) and second
+        derivatives of the potential at the field point (R, z, phi) at time t
+        (without the overall amp, which the Potential base class applies).
+
+        Phi(x,t) = Psi(R'(x,y), z'(z)) with R'^2 = (x-x_o(t))^2+(y-y_o(t))^2
+        and z' = z_o(t)-z (the conventions of the force methods above). The
+        moving-object shift is a pure translation of the evaluation point, so
+        the Hessian is the kernel's Hessian at the shifted point chain-ruled
+        to the field point's coordinates: the time-dependence enters only
+        through (R', z'), with no extra terms. The kernel Psi is required to
+        be axisymmetric (enforced in __init__), so its phi derivatives vanish.
+        """
+        # Cylindrical distance
+        Rdist = _cylR(R, phi, self._orb.R(t), self._orb.phi(t))
+        # Difference vector
+        orbz = self._orb.z(t) if self._orb.dim() == 3 else 0
+        (xd, yd, zd) = _cyldiff(self._orb.R(t), self._orb.phi(t), orbz, R, phi, z)
+        # Kernel cylindrical derivatives at the shifted point (R',z')=(Rdist,zd)
+        RF = evaluateRforces(self._pot, Rdist, zd, t=t, use_physical=False)
+        R2d = evaluateR2derivs(self._pot, Rdist, zd, t=t, use_physical=False)
+        Rzd = evaluateRzderivs(self._pot, Rdist, zd, t=t, use_physical=False)
+        z2d = evaluatez2derivs(self._pot, Rdist, zd, t=t, use_physical=False)
+        # Chain rule with dR'/dx = (x-x_o)/R' = -xd/R' and dz'/dz = -1; the
+        # minus signs cancel pairwise in the pure-second-derivative terms
+        phix = RF * xd / Rdist
+        phiy = RF * yd / Rdist
+        phixx = R2d * xd**2.0 / Rdist**2.0 - RF * yd**2.0 / Rdist**3.0
+        phiyy = R2d * yd**2.0 / Rdist**2.0 - RF * xd**2.0 / Rdist**3.0
+        phixy = (R2d + RF / Rdist) * xd * yd / Rdist**2.0
+        phixz = Rzd * xd / Rdist
+        phiyz = Rzd * yd / Rdist
+        phizz = z2d
+        return (phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz)
+
+    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        cp, sp = numpy.cos(phi), numpy.sin(phi)
+        return cp**2.0 * phixx + 2.0 * cp * sp * phixy + sp**2.0 * phiyy
+
+    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        return phizz
+
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        cp, sp = numpy.cos(phi), numpy.sin(phi)
+        return cp * phixz + sp * phiyz
+
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        cp, sp = numpy.cos(phi), numpy.sin(phi)
+        return R**2.0 * (
+            sp**2.0 * phixx - 2.0 * cp * sp * phixy + cp**2.0 * phiyy
+        ) - R * (cp * phix + sp * phiy)
+
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        cp, sp = numpy.cos(phi), numpy.sin(phi)
+        return (
+            R * (cp * sp * (phiyy - phixx) + (cp**2.0 - sp**2.0) * phixy)
+            - sp * phix
+            + cp * phiy
+        )
+
+    def _phizderiv(self, R, z, phi=0.0, t=0.0):
+        phix, phiy, phixx, phixy, phiyy, phixz, phiyz, phizz = self._xyzHess(
+            R, z, phi, t
+        )
+        cp, sp = numpy.cos(phi), numpy.sin(phi)
+        return R * (cp * phiyz - sp * phixz)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         # Cylindrical distance

--- a/galpy/potential/potential_c_ext/MovingObjectPotential.c
+++ b/galpy/potential/potential_c_ext/MovingObjectPotential.c
@@ -133,3 +133,191 @@ double MovingObjectPotentialPlanarphitorque(double R, double phi,
 		       potentialArgs->wrappedPotentialArg);
   return -amp*RF*R*(cos(phi)*(obj_y-y)-sin(phi)*(obj_x-x))/Rdist;
 }
+
+// ---------------------------------------------------------------------------
+// Second derivatives for the variational equations (integrate_dxdv).
+// Phi(x,t) = amp * Psi(R'(x,y), z'(z)) with R'^2 = (x-x_o(t))^2 + (y-y_o(t))^2
+// and z' = z_o(t) - z (the same conventions as the force evaluators above).
+// The moving-object shift x_o(t) is a pure translation of the evaluation
+// point, so the Hessian is just the kernel's Hessian at the shifted point
+// chain-ruled to the field point's cylindrical coordinates: the
+// time-dependence enters only through (R', z'), with no extra terms.
+// The kernel Psi is required to be axisymmetric (enforced at setup in
+// MovingObjectPotential.__init__), so its phi derivatives vanish and the four
+// quantities dPsi/dR', d2Psi/dR'2, d2Psi/dR'dz', d2Psi/dz'2 -- evaluated
+// through the wrapped potential's force/Hessian pointers, exactly like the
+// forces -- determine the full Cartesian Hessian of Phi at the field point.
+// ---------------------------------------------------------------------------
+static void MovingObjectPotentialxyzHess(double R, double z, double phi,
+					 double t,
+					 struct potentialArg * potentialArgs,
+					 double * phix, double * phiy,
+					 double * phixx, double * phixy,
+					 double * phiyy, double * phixz,
+					 double * phiyz, double * phizz){
+  // Cartesian first (phix,phiy; phiz is never needed) and second derivatives
+  // of Phi at the field point (R,z,phi) at time t, incl. the overall amp.
+  double amp,t0,tf,d_ind,x,y,obj_x,obj_y,obj_z,xd,yd,zd,Rdist,RF,R2d,Rzd,z2d;
+  double * args= potentialArgs->args;
+  //Get args
+  amp= *args;
+  t0= *(args+1);
+  tf= *(args+2);
+  d_ind= (t-t0)/(tf-t0);
+  x= R*cos(phi);
+  y= R*sin(phi);
+  constrain_range(&d_ind);
+  // Interpolate x, y, z
+  obj_x= gsl_spline_eval(*potentialArgs->spline1d,d_ind,*potentialArgs->acc1d);
+  obj_y= gsl_spline_eval(*(potentialArgs->spline1d+1),d_ind,
+			 *(potentialArgs->acc1d+1));
+  obj_z= gsl_spline_eval(*(potentialArgs->spline1d+2),d_ind,
+			 *(potentialArgs->acc1d+2));
+  xd= obj_x-x;
+  yd= obj_y-y;
+  zd= obj_z-z;
+  Rdist= sqrt(xd*xd+yd*yd);
+  // Kernel cylindrical derivatives at the shifted point (R',z')=(Rdist,zd)
+  RF= calcRforce(Rdist,zd,phi,t,potentialArgs->nwrapped,
+		 potentialArgs->wrappedPotentialArg); // = -dPsi/dR'
+  R2d= calcR2deriv(Rdist,zd,phi,t,potentialArgs->nwrapped,
+		   potentialArgs->wrappedPotentialArg); // = d2Psi/dR'2
+  Rzd= calcRzderiv(Rdist,zd,phi,t,potentialArgs->nwrapped,
+		   potentialArgs->wrappedPotentialArg); // = d2Psi/dR'dz'
+  z2d= calcz2deriv(Rdist,zd,phi,t,potentialArgs->nwrapped,
+		   potentialArgs->wrappedPotentialArg); // = d2Psi/dz'2
+  // Chain rule with dR'/dx = (x-obj_x)/R' = -xd/R' and dz'/dz = -1; the minus
+  // signs cancel pairwise in the pure-second-derivative terms below
+  *phix= amp*RF*xd/Rdist;
+  *phiy= amp*RF*yd/Rdist;
+  *phixx= amp*(R2d*xd*xd/Rdist/Rdist-RF*yd*yd/Rdist/Rdist/Rdist);
+  *phiyy= amp*(R2d*yd*yd/Rdist/Rdist-RF*xd*xd/Rdist/Rdist/Rdist);
+  *phixy= amp*(R2d+RF/Rdist)*xd*yd/Rdist/Rdist;
+  *phixz= amp*Rzd*xd/Rdist;
+  *phiyz= amp*Rzd*yd/Rdist;
+  *phizz= amp*z2d;
+}
+
+double MovingObjectPotentialR2deriv(double R,double z,double phi,double t,
+				    struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz,cp,sp;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  cp= cos(phi);
+  sp= sin(phi);
+  return cp*cp*phixx+2.*cp*sp*phixy+sp*sp*phiyy;
+}
+
+double MovingObjectPotentialz2deriv(double R,double z,double phi,double t,
+				    struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  return phizz;
+}
+
+double MovingObjectPotentialRzderiv(double R,double z,double phi,double t,
+				    struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz,cp,sp;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  cp= cos(phi);
+  sp= sin(phi);
+  return cp*phixz+sp*phiyz;
+}
+
+double MovingObjectPotentialphi2deriv(double R,double z,double phi,double t,
+				      struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz,cp,sp;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  cp= cos(phi);
+  sp= sin(phi);
+  return R*R*(sp*sp*phixx-2.*cp*sp*phixy+cp*cp*phiyy)-R*(cp*phix+sp*phiy);
+}
+
+double MovingObjectPotentialRphideriv(double R,double z,double phi,double t,
+				      struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz,cp,sp;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  cp= cos(phi);
+  sp= sin(phi);
+  return R*(cp*sp*(phiyy-phixx)+(cp*cp-sp*sp)*phixy)-sp*phix+cp*phiy;
+}
+
+double MovingObjectPotentialzphideriv(double R,double z,double phi,double t,
+				      struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,phixz,phiyz,phizz,cp,sp;
+  MovingObjectPotentialxyzHess(R,z,phi,t,potentialArgs,&phix,&phiy,
+			       &phixx,&phixy,&phiyy,&phixz,&phiyz,&phizz);
+  cp= cos(phi);
+  sp= sin(phi);
+  return R*(cp*phiyz-sp*phixz);
+}
+
+// Planar (2D, in-plane object track) second derivatives: same translation
+// argument with the kernel's PLANAR force/R2deriv (the kernel at z'=0),
+// mirroring how MovingObjectPotentialPlanarRforce evaluates the kernel.
+static void MovingObjectPotentialPlanarxyHess(double R, double phi, double t,
+					      struct potentialArg * potentialArgs,
+					      double * phix, double * phiy,
+					      double * phixx, double * phixy,
+					      double * phiyy){
+  double amp,t0,tf,d_ind,x,y,obj_x,obj_y,xd,yd,Rdist,RF,R2d;
+  double * args= potentialArgs->args;
+  //Get args
+  amp= *args;
+  t0= *(args+1);
+  tf= *(args+2);
+  d_ind= (t-t0)/(tf-t0);
+  x= R*cos(phi);
+  y= R*sin(phi);
+  constrain_range(&d_ind);
+  // Interpolate x, y
+  obj_x= gsl_spline_eval(*potentialArgs->spline1d,d_ind,*potentialArgs->acc1d);
+  obj_y= gsl_spline_eval(*(potentialArgs->spline1d+1),d_ind,
+			 *(potentialArgs->acc1d+1));
+  xd= obj_x-x;
+  yd= obj_y-y;
+  Rdist= sqrt(xd*xd+yd*yd);
+  RF= calcPlanarRforce(Rdist,phi,t,potentialArgs->nwrapped,
+		       potentialArgs->wrappedPotentialArg); // = -dPsi/dR'
+  R2d= calcPlanarR2deriv(Rdist,phi,t,potentialArgs->nwrapped,
+			 potentialArgs->wrappedPotentialArg); // = d2Psi/dR'2
+  *phix= amp*RF*xd/Rdist;
+  *phiy= amp*RF*yd/Rdist;
+  *phixx= amp*(R2d*xd*xd/Rdist/Rdist-RF*yd*yd/Rdist/Rdist/Rdist);
+  *phiyy= amp*(R2d*yd*yd/Rdist/Rdist-RF*xd*xd/Rdist/Rdist/Rdist);
+  *phixy= amp*(R2d+RF/Rdist)*xd*yd/Rdist/Rdist;
+}
+
+double MovingObjectPotentialPlanarR2deriv(double R,double phi,double t,
+					  struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,cp,sp;
+  MovingObjectPotentialPlanarxyHess(R,phi,t,potentialArgs,&phix,&phiy,
+				    &phixx,&phixy,&phiyy);
+  cp= cos(phi);
+  sp= sin(phi);
+  return cp*cp*phixx+2.*cp*sp*phixy+sp*sp*phiyy;
+}
+
+double MovingObjectPotentialPlanarphi2deriv(double R,double phi,double t,
+					    struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,cp,sp;
+  MovingObjectPotentialPlanarxyHess(R,phi,t,potentialArgs,&phix,&phiy,
+				    &phixx,&phixy,&phiyy);
+  cp= cos(phi);
+  sp= sin(phi);
+  return R*R*(sp*sp*phixx-2.*cp*sp*phixy+cp*cp*phiyy)-R*(cp*phix+sp*phiy);
+}
+
+double MovingObjectPotentialPlanarRphideriv(double R,double phi,double t,
+					    struct potentialArg * potentialArgs){
+  double phix,phiy,phixx,phixy,phiyy,cp,sp;
+  MovingObjectPotentialPlanarxyHess(R,phi,t,potentialArgs,&phix,&phiy,
+				    &phixx,&phixy,&phiyy);
+  cp= cos(phi);
+  sp= sin(phi);
+  return R*(cp*sp*(phiyy-phixx)+(cp*cp-sp*sp)*phixy)-sp*phix+cp*phiy;
+}

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -1049,6 +1049,24 @@ double MovingObjectPotentialPlanarRforce(double,double,double,
 					struct potentialArg *);
 double MovingObjectPotentialPlanarphitorque(double,double,double,
 					    struct potentialArg *);
+double MovingObjectPotentialR2deriv(double,double,double,double,
+				    struct potentialArg *);
+double MovingObjectPotentialz2deriv(double,double,double,double,
+				    struct potentialArg *);
+double MovingObjectPotentialRzderiv(double,double,double,double,
+				    struct potentialArg *);
+double MovingObjectPotentialphi2deriv(double,double,double,double,
+				      struct potentialArg *);
+double MovingObjectPotentialRphideriv(double,double,double,double,
+				      struct potentialArg *);
+double MovingObjectPotentialzphideriv(double,double,double,double,
+				      struct potentialArg *);
+double MovingObjectPotentialPlanarR2deriv(double,double,double,
+					  struct potentialArg *);
+double MovingObjectPotentialPlanarphi2deriv(double,double,double,
+					    struct potentialArg *);
+double MovingObjectPotentialPlanarRphideriv(double,double,double,
+					    struct potentialArg *);
 //RotateAndTiltWrapperPotential
 double RotateAndTiltWrapperPotentialRforce(double,double,double,double,
 					struct potentialArg *);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,6 +461,24 @@ def pytest_generate_tests(metafunc):
                 "KuzminLikeWrapperPotential",
                 "axisymmetric",
             ),
+            # NOTE: MovingObjectPotential has a verified-correct full 3D (and
+            # planar) C Hessian -- the kernel's Hessian at the shifted point
+            # x-x_obj(t), with hasC_dxdv3d/hasC_dxdv gated on the kernel's
+            # capability exactly like hasC -- but it is intentionally NOT in
+            # this registry: an entry would need an object orbit integrated at
+            # collection time, the physically meaningful configuration is the
+            # host+object composite (a bare moving object leaves the registry
+            # IC in near-free motion), and its forces/Hessian are evaluated on
+            # a spline-interpolated object track (GSL in C, Orbit interpolation
+            # in Python), following the precedent of the other interpolated
+            # potentials excluded above. It is instead validated by the
+            # dedicated tests test_orbit.test_movingobject_dxdv_3d_c_vs_python
+            # (C-vs-Python dxdv at ~6e-11 for unit deviations, incl. a nonzero-
+            # zphideriv guard), test_orbit.test_movingobject_dxdv_3d
+            # (det(M)/symplecticity/FD-of-flow), the planar
+            # test_orbit.test_movingobject_dxdv_planar, and the unit-level
+            # test_potential.test_MovingObject_2ndderivs_fd (analytic vs FD of
+            # the forces at ~3e-10).
         ]
         ids = [entry[1] for entry in liouville3d_registry]
         if metafunc.function.__name__ == "test_dxdv_3d_c_vs_python":

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -2938,6 +2938,204 @@ def test_dissipative_excluded_from_liouville3d_registry():
     return None
 
 
+def _movingobject_setup(planar=False):
+    # Host + softened moving object on an orbit integrated in the host: the
+    # physically meaningful configuration (satellite + host) and a genuinely
+    # non-axisymmetric, explicitly time-dependent potential. The object-track
+    # window extends well beyond the test integration interval so both the C
+    # (GSL spline) and the Python (Orbit interpolation) tracks are evaluated
+    # well inside their interpolation ranges.
+    from galpy.orbit import Orbit
+    from galpy.potential import (
+        LogarithmicHaloPotential,
+        MovingObjectPotential,
+        PlummerPotential,
+    )
+
+    host = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    ts_obj = numpy.linspace(-1.0, 7.0, 1601)
+    if planar:
+        obj = Orbit([1.1, 0.1, 1.1, 1.0])  # in-plane object track
+    else:
+        obj = Orbit([1.1, 0.1, 1.1, 0.1, 0.1, 1.0])  # off-plane object track
+    obj.integrate(ts_obj, host, method="dop853_c")
+    # massive, well-softened kernel: significant forces but a smooth Hessian
+    mop = MovingObjectPotential(obj, pot=PlummerPotential(amp=0.3, b=0.3), amp=1.2)
+    return host + mop, mop
+
+
+def test_movingobject_dxdv_3d_c_vs_python():
+    # MovingObjectPotential wires the full 3D Hessian in C (hasC_dxdv3d, gated
+    # on the kernel's own 3D C Hessian exactly like hasC): the kernel's Hessian
+    # at the shifted point x-x_obj(t) -- the moving-object shift is a pure
+    # translation of the evaluation point, so the time-dependence enters only
+    # through that point, with no extra terms. The C 3D variational integration
+    # must match the pure-Python analytic-2nd-derivative reference (dop853) for
+    # UNIT-magnitude deviations; that C-vs-Python comparison is what pins the
+    # Hessian VALUES (det(M)=1/symplecticity hold for any symmetric K).
+    import warnings
+
+    from galpy.orbit import Orbit
+    from galpy.potential import evaluatephizderivs
+
+    pot, mop = _movingobject_setup()
+    assert mop.hasC_dxdv3d, (
+        "MovingObjectPotential with a Plummer kernel should advertise hasC_dxdv3d"
+    )
+    # the host+object composite must propagate the capability (regression test
+    # for CompositePotential.hasC_dxdv3d, without which the C 3D variational
+    # path silently falls back to odeint for ANY composite)
+    assert pot.hasC_dxdv3d, "host+object composite should advertise hasC_dxdv3d"
+    ic = [1.0, 0.1, 1.1, 0.05, 0.08, 0.2]
+    times = numpy.linspace(0.0, 5.0, 251)
+    # Guard against a vacuous test: the off-center, off-plane object must give a
+    # genuinely nonzero z-phi coupling along the orbit, otherwise the C
+    # zphideriv term is multiplied by 0.
+    obase = Orbit(ic)
+    obase.integrate(times, pot, method="dop853_c")
+    zphi_vals = numpy.array(
+        [
+            evaluatephizderivs(
+                mop,
+                obase.R(tt),
+                obase.z(tt),
+                phi=obase.phi(tt),
+                t=tt,
+                use_physical=False,
+            )
+            for tt in times
+        ]
+    )
+    assert numpy.amax(numpy.fabs(zphi_vals)) > 1e-3, (
+        "d2Phi/dz/dphi must be nonzero along the orbit to exercise the C zphideriv term"
+    )
+    canonical = numpy.eye(6)
+    maxdiff = 0.0
+    for integrator in ("dopr54_c", "dop853_c"):
+        for ii in [0, 2, 4]:  # e_x, e_z, e_vy unit deviations
+            oc = Orbit(ic)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                oc.integrate_dxdv(
+                    canonical[ii], times, pot, method=integrator,
+                    rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+                )  # fmt: skip
+                # the C path must actually be taken (no odeint fallback)
+                assert not any("odeint" in str(ww.message) for ww in w), (
+                    "C 3D variational integration fell back to odeint for the "
+                    "host+moving-object potential"
+                )
+            op = Orbit(ic)
+            op.integrate_dxdv(
+                canonical[ii], times, pot, method="dop853",
+                rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+            )  # fmt: skip
+            diff = numpy.amax(numpy.fabs(oc.getOrbit_dxdv() - op.getOrbit_dxdv()))
+            maxdiff = max(maxdiff, diff)
+    # C-vs-Python agree to ~6e-11 (the dense object track makes the GSL-vs-Orbit
+    # track-interpolation difference negligible); 1e-8 leaves a wide margin
+    assert maxdiff < 1e-8, (
+        f"3D C variational integration for the host+moving-object potential "
+        f"differs from the pure-Python reference by {maxdiff:g} (unit deviation)"
+    )
+    return None
+
+
+def test_movingobject_dxdv_3d():
+    # det(M)=1 / symplecticity / finite-difference-of-the-flow for the
+    # host+moving-object potential through the C integrators (the FD-of-flow
+    # is the check that pins the C Hessian VALUES against the trusted C
+    # forces, independently of the Python reference).
+    pot, _ = _movingobject_setup()
+    _check_dxdv_3d_c(pot, "host+MovingObjectPotential")
+    return None
+
+
+def test_movingobject_dxdv_planar():
+    # PLANAR variational equations for an in-plane object track: the C planar
+    # Hessian (PlanarR2deriv/Planarphi2deriv/PlanarRphideriv -- genuinely
+    # non-axisymmetric, since the object is off-center) is the kernel's PLANAR
+    # Hessian at the shifted point, mirroring MovingObjectPotentialPlanarRforce.
+    # Checks: (1) C-vs-Python dxdv for unit deviations (pins the Hessian
+    # values), (2) Liouville det(M)=1 and FD-of-flow through the C integrators.
+    from galpy.orbit import Orbit
+    from galpy.util import coords
+
+    pot, mop = _movingobject_setup(planar=True)
+    assert mop.hasC_dxdv, (
+        "MovingObjectPotential with a Plummer kernel should advertise hasC_dxdv"
+    )
+    assert pot.hasC_dxdv, "host+object composite should advertise hasC_dxdv"
+    ic = [1.0, 0.1, 1.1, 0.2]  # planar (R, vR, vT, phi)
+    times = numpy.linspace(0.0, 5.0, 251)
+    canonical = numpy.eye(4)
+    # (1) C vs pure-Python analytic reference, unit deviations e_x, e_vx
+    maxdiff = 0.0
+    for ii in [0, 2]:
+        oc = Orbit(ic)
+        oc.integrate_dxdv(
+            canonical[ii], times, pot, method="dopr54_c",
+            rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+        )  # fmt: skip
+        op = Orbit(ic)
+        op.integrate_dxdv(
+            canonical[ii], times, pot, method="dop853",
+            rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+        )  # fmt: skip
+        diff = numpy.amax(numpy.fabs(oc.getOrbit_dxdv() - op.getOrbit_dxdv()))
+        maxdiff = max(maxdiff, diff)
+    assert maxdiff < 1e-8, (
+        f"planar C variational integration for the host+moving-object potential "
+        f"differs from the pure-Python reference by {maxdiff:g} (unit deviation)"
+    )
+    # (2) Liouville + FD-of-flow through the C integrators
+    for integrator in ("dopr54_c", "dop853_c"):
+        Mcols = []
+        for ii in range(4):
+            o = Orbit(ic)
+            o.integrate_dxdv(
+                canonical[ii], times, pot, method=integrator,
+                rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+            )  # fmt: skip
+            Mcols.append(o.getOrbit_dxdv()[-1, :])
+        M = numpy.array(Mcols).T
+        detM = numpy.linalg.det(M)
+        assert numpy.fabs(detM - 1.0) < 1e-8, (
+            f"planar Liouville det(M)={detM:g} differs from 1 for the "
+            f"host+moving-object potential, integrator {integrator}"
+        )
+        # FD-of-flow: column i = (x(t;x0+eps e_i)-x(t;x0))/eps vs the dxdv column
+        eps = 1e-7
+        obase = Orbit(ic)
+        obase.integrate(times, pot, method=integrator)
+        base = numpy.array(
+            [obase.x(times), obase.y(times), obase.vx(times), obase.vy(times)]
+        ).T
+        for ii in [0, 3]:  # an x and a vy perturbation
+            p = base[0].copy()
+            p[ii] += eps
+            Rp, phip, _ = coords.rect_to_cyl(p[0], p[1], 0.0)
+            vRp, vTp, _ = coords.rect_to_cyl_vec(p[2], p[3], 0.0, p[0], p[1], 0.0)
+            opert = Orbit([Rp, vRp, vTp, phip])
+            opert.integrate(times, pot, method=integrator)
+            pert = numpy.array(
+                [opert.x(times), opert.y(times), opert.vx(times), opert.vy(times)]
+            ).T
+            fd = (pert - base) / eps
+            odx = Orbit(ic)
+            odx.integrate_dxdv(
+                canonical[ii], times, pot, method=integrator,
+                rectIn=True, rectOut=True, rtol=1e-12, atol=1e-12,
+            )  # fmt: skip
+            fderr = numpy.amax(numpy.fabs(fd - odx.getOrbit_dxdv()))
+            assert fderr < 1e-4, (
+                f"planar FD-of-flow for e_{ii} differs from the dxdv column by "
+                f"{fderr:g} for the host+moving-object potential, integrator "
+                f"{integrator}"
+            )
+    return None
+
+
 def _planar_invariant(pot):
     """Whether the z=0 plane is invariant under the flow (F_z(z=0)=0
     everywhere), the premise of the 3D->2D bridge check below. A tilted or

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -4312,6 +4312,96 @@ def test_MovingObject_density():
     return None
 
 
+def test_MovingObject_2ndderivs_fd():
+    # Unit-level validation of MovingObjectPotential's analytic second
+    # derivatives (the kernel's Hessian at the shifted point x-x_obj(t),
+    # chain-ruled to the field point's cylindrical coordinates) against
+    # central finite differences of its forces, at several generic
+    # (R, z, phi, t) incl. t != 0 (the object has moved). Both a 3D and a
+    # planar (2D) object track are exercised (the latter covers the
+    # z_obj = 0 branch). These same formulas, evaluated through the wrapped
+    # potential's C pointers, make up the C Hessian used by integrate_dxdv
+    # (validated against this Python reference in
+    # test_orbit.test_movingobject_dxdv_3d_c_vs_python).
+    from galpy.orbit import Orbit
+
+    lp = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    ts = numpy.linspace(-1.0, 5.0, 1201)
+    o3 = Orbit([1.1, 0.1, 1.1, 0.1, 0.1, 1.0])
+    o3.integrate(ts, lp, method="dop853_c")
+    o2 = Orbit([1.1, 0.1, 1.1, 1.0])
+    o2.integrate(ts, lp, method="dop853_c")
+    kernel = potential.PlummerPotential(amp=0.3, b=0.3)
+    eps = 1e-6
+    for orb in (o3, o2):
+        mop = potential.MovingObjectPotential(orb, pot=kernel, amp=1.2)
+        for R, z, phi, t in [
+            (1.0, 0.05, 0.2, 0.0),
+            (0.8, -0.1, 2.3, 1.7),
+            (1.3, 0.2, -1.0, 3.1),
+            (0.9, 0.0, 4.0, 2.2),
+        ]:
+            checks = {
+                "R2deriv": (
+                    mop.R2deriv(R, z, phi=phi, t=t),
+                    -(
+                        mop.Rforce(R + eps / 2.0, z, phi=phi, t=t)
+                        - mop.Rforce(R - eps / 2.0, z, phi=phi, t=t)
+                    )
+                    / eps,
+                ),
+                "z2deriv": (
+                    mop.z2deriv(R, z, phi=phi, t=t),
+                    -(
+                        mop.zforce(R, z + eps / 2.0, phi=phi, t=t)
+                        - mop.zforce(R, z - eps / 2.0, phi=phi, t=t)
+                    )
+                    / eps,
+                ),
+                "Rzderiv": (
+                    mop.Rzderiv(R, z, phi=phi, t=t),
+                    -(
+                        mop.Rforce(R, z + eps / 2.0, phi=phi, t=t)
+                        - mop.Rforce(R, z - eps / 2.0, phi=phi, t=t)
+                    )
+                    / eps,
+                ),
+                "phi2deriv": (
+                    mop.phi2deriv(R, z, phi=phi, t=t),
+                    -(
+                        mop.phitorque(R, z, phi=phi + eps / 2.0, t=t)
+                        - mop.phitorque(R, z, phi=phi - eps / 2.0, t=t)
+                    )
+                    / eps,
+                ),
+                "Rphideriv": (
+                    mop.Rphideriv(R, z, phi=phi, t=t),
+                    -(
+                        mop.Rforce(R, z, phi=phi + eps / 2.0, t=t)
+                        - mop.Rforce(R, z, phi=phi - eps / 2.0, t=t)
+                    )
+                    / eps,
+                ),
+                "phizderiv": (
+                    mop.phizderiv(R, z, phi=phi, t=t),
+                    -(
+                        mop.zforce(R, z, phi=phi + eps / 2.0, t=t)
+                        - mop.zforce(R, z, phi=phi - eps / 2.0, t=t)
+                    )
+                    / eps,
+                ),
+            }
+            for name, (analytic, fd) in checks.items():
+                assert numpy.fabs(analytic - fd) < 1e-8, (
+                    f"MovingObjectPotential analytic {name} does not match the "
+                    f"finite difference of the force at "
+                    f"(R,z,phi,t)=({R},{z},{phi},{t}) "
+                    f"({orb.dim()}D object track): "
+                    f"|{analytic:g} - {fd:g}| = {numpy.fabs(analytic - fd):g}"
+                )
+    return None
+
+
 # test specialSelf for TwoPowerSphericalPotential
 def test_TwoPowerSphericalPotentialSpecialSelf():
     # TODO replace manual additions with an automatic method


### PR DESCRIPTION
Kernel Hessian at the time-shifted point H(x−x_obj(t)) (translation adds no extra terms; time-dependence only via the evaluation point), Plummer-class kernels, BOTH planar (non-axisymmetric wiring: object off-center) and 3D. Previously integrate_dxdv with a MovingObjectPotential **errored** (missing _R2deriv after odeint fallback) — this is new functionality, no value changes (forces untouched). C-vs-Python track interpolation difference ~6e-11. Regression 121→124. Not in the strict liouville3d registry (collection-time orbit integration; documented conftest NOTE). Verifier: **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)