### PR TITLE
Fix 3D dxdv base-orbit corruption: z overwritten by vT (view aliasing)

### DIFF
--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -945,6 +945,13 @@ def integrateFullOrbit_dxdv(
     vRout, vTout, vzout = coords.rect_to_cyl_vec(
         out[..., 3], out[..., 4], out[..., 5], out[..., 0], out[..., 1], out[..., 2]
     )
+    # rect_to_cyl/rect_to_cyl_vec pass Z/vz through BY REFERENCE, so Zout and
+    # vzout are views into out[...,2]/out[...,5]; copy them before the in-place
+    # assignments below overwrite those columns (otherwise out[...,3] ends up
+    # holding vT instead of z, corrupting the returned base orbit and any
+    # restart that uses it, e.g. the lyapunov renormalization segments)
+    Zout = numpy.copy(Zout)
+    vzout = numpy.copy(vzout)
     out[..., 0] = Rout
     out[..., 1] = vRout
     out[..., 2] = vTout

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1576,6 +1576,46 @@ def test_liouville_3d_2d_bridge(pot):
     return None
 
 
+def test_integrate_dxdv_3d_base_orbit_integrity():
+    # Regression: integrateFullOrbit_dxdv's returned BASE orbit must equal a
+    # plain orbit integration in every phase-space coordinate. Previously
+    # coords.rect_to_cyl/rect_to_cyl_vec passed Z/vz through by reference, so
+    # the in-place column assignments clobbered them and the returned base
+    # orbit had z replaced by vT -- invisible to every deviation-based test
+    # (the rectOut deviation columns were correct) but corrupting anything
+    # that restarts from the dxdv orbit (e.g. lyapunov renormalization
+    # segments)
+    from galpy.orbit import Orbit
+    from galpy.potential import MWPotential2014
+
+    ts = numpy.linspace(0.0, 5.0, 51)
+    ic = [1.0, 0.1, 1.1, 0.2, 0.15, 0.3]
+    for method in ["dop853_c", "dop853"]:
+        odx = Orbit(ic)
+        odx.integrate_dxdv(
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ts,
+            MWPotential2014,
+            method=method,
+            rectIn=True,
+            rectOut=True,
+        )
+        oref = Orbit(ic)
+        oref.integrate(ts, MWPotential2014, method=method)
+        diff = odx.getOrbit() - oref.getOrbit()
+        # phi wrapping conventions differ between the two code paths
+        diff[:, 5] = numpy.fabs(
+            numpy.mod(diff[:, 5] + numpy.pi, 2.0 * numpy.pi) - numpy.pi
+        )
+        maxdiff = numpy.amax(numpy.fabs(diff), axis=0)
+        for ii, name in enumerate(["R", "vR", "vT", "z", "vz", "phi"]):
+            assert maxdiff[ii] < 1e-6, (
+                f"dxdv base orbit {name} differs from plain integration by "
+                f"{maxdiff[ii]:g} for method {method}"
+            )
+    return None
+
+
 def test_integrate_dxdv_3d_multiobj_and_default_tol():
     # Cover and validate the multi-object (parallel_map) and pure-Python dop853
     # default-tolerance paths of the 3D integrate_dxdv.


### PR DESCRIPTION
## Summary

Found while measuring the Track G variational figures: `integrateFullOrbit_dxdv` converts its rectangular output to cylindrical **in-place**, and `coords.rect_to_cyl`/`rect_to_cyl_vec` pass Z/vz through **by reference** — so `Zout` aliased `out[...,2]`, which `out[...,2]=vTout` clobbered before `out[...,3]=Zout` ran. The returned **base orbit had z replaced by vT** (z==vT exactly; all other columns match a plain integration to 1e-12).

**Why nothing caught it:** the `rectOut` deviation columns were unaffected, so every deviation-based validation (det M=1, symplecticity, C-vs-Python, FD-of-flow) passed. Anything *restarting from the dxdv orbit* — `Orbit.lyapunov`'s renormalization segments — silently used a corrupted orbit; and the lyapunov *integrable* test still passed because in an integrable potential the corrupted restart is merely a different regular orbit (λ decays either way).

**Fix:** copy `Zout`/`vzout` before the in-place assignments (7 lines).
**Regression test:** `test_integrate_dxdv_3d_base_orbit_integrity` — dxdv base orbit vs plain integration, column-by-column (phi mod 2π), C + Python methods; **mutation-verified to fail at O(1) on the unfixed code**. Battery: 122 passed (121 + new).

**Note:** #926's MW-3D lyapunov example values were computed with corrupted restarts and will be refreshed when that branch rebases onto this fix (its HH planar values are unaffected — the planar path is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)