### PR TITLE
P2.6: backend-agnostic wrapper potentials (jax/torch)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -45,6 +45,14 @@ from .actionAngle import UnboundError, actionAngle
 from .actionAngleStaeckel_c import _ext_loaded as ext_loaded
 
 
+def _coerce_delta_arraylike(delta):
+    """Coerce a plain Python sequence delta (allowed by the public API for
+    individual-delta inputs) to an ndarray: the backend-agnostic coords
+    transforms resolve their namespace from the data, and plain sequences
+    are not backend-resolvable. Scalars/arrays pass through untouched."""
+    return numpy.array(delta) if isinstance(delta, (list, tuple)) else delta
+
+
 class actionAngleStaeckel(actionAngle):
     """Action-angle formalism for axisymmetric potentials using Binney (2012)'s Staeckel approximation"""
 
@@ -96,7 +104,9 @@ class actionAngleStaeckel(actionAngle):
         self._useu0 = kwargs.get("useu0", False)
         self._delta = kwargs["delta"]
         self._order = kwargs.get("order", 10)
-        self._delta = conversion.parse_length(self._delta, ro=self._ro)
+        self._delta = _coerce_delta_arraylike(
+            conversion.parse_length(self._delta, ro=self._ro)
+        )
         # Check the units
         self._check_consistent_units()
         return None
@@ -498,7 +508,7 @@ class actionAngleStaeckel(actionAngle):
         -----
         - 2017-12-12 - Written - Bovy (UofT)
         """
-        delta = kwargs.get("delta", self._delta)
+        delta = _coerce_delta_arraylike(kwargs.get("delta", self._delta))
         umin, umax, vmin = self._uminumaxvmin(*args, **kwargs)
         rperi = coords.uv_to_Rz(umin, numpy.pi / 2.0, delta=delta)[0]
         rap_tmp, zmax = coords.uv_to_Rz(umax, vmin, delta=delta)
@@ -660,7 +670,7 @@ class actionAngleStaeckelSingle(actionAngle):
         self._pot = kwargs["pot"]
         if not "delta" in kwargs:  # pragma: no cover
             raise OSError("Must specify delta= for actionAngleStaeckel")
-        self._delta = kwargs["delta"]
+        self._delta = _coerce_delta_arraylike(kwargs["delta"])
         # Pre-calculate everything
         self._ux, self._vx = coords.Rz_to_uv(self._R, self._z, delta=self._delta)
         self._sinvx = numpy.sin(self._vx)

--- a/galpy/potential/CylindricallySeparablePotentialWrapper.py
+++ b/galpy/potential/CylindricallySeparablePotentialWrapper.py
@@ -8,8 +8,11 @@
 #   WRAPPERS
 #
 ###############################################################################
+import numpy
+
 from galpy.util import conversion
 
+from ..backend import get_namespace
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -89,9 +92,16 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
+        # The numpy path passes the plain scalars through untouched
+        # (byte-identical); on a non-numpy backend the reference coordinates are
+        # anchored on the inputs so the wrapped potential sees backend arrays
+        # (torch functions require Tensors) on the right device/dtype.
+        xp = get_namespace(R, z, phi, t)
+        zero = 0.0 if xp is numpy else xp.zeros_like(R)
+        Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return (
-            _evaluatePotentials(self._pot, R, 0.0)
-            + _evaluatePotentials(self._pot, self._Rp, z)
+            _evaluatePotentials(self._pot, R, zero)
+            + _evaluatePotentials(self._pot, Rp, z)
             - self._refpot
         )
 
@@ -111,7 +121,9 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        return _evaluateRforces(self._pot, R, 0.0)
+        xp = get_namespace(R, z, phi, t)
+        zero = 0.0 if xp is numpy else xp.zeros_like(R)
+        return _evaluateRforces(self._pot, R, zero)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         """
@@ -129,7 +141,9 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        return _evaluatezforces(self._pot, self._Rp, z)
+        xp = get_namespace(R, z, phi, t)
+        Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
+        return _evaluatezforces(self._pot, Rp, z)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -147,7 +161,9 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        return evaluateR2derivs(self._pot, R, 0.0, use_physical=False)
+        xp = get_namespace(R, z, phi, t)
+        zero = 0.0 if xp is numpy else xp.zeros_like(R)
+        return evaluateR2derivs(self._pot, R, zero, use_physical=False)
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -165,7 +181,9 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        return evaluatez2derivs(self._pot, self._Rp, z, use_physical=False)
+        xp = get_namespace(R, z, phi, t)
+        Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
+        return evaluatez2derivs(self._pot, Rp, z, use_physical=False)
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         """

--- a/galpy/potential/DehnenSmoothWrapperPotential.py
+++ b/galpy/potential/DehnenSmoothWrapperPotential.py
@@ -1,6 +1,9 @@
 ###############################################################################
 #   DehnenSmoothWrapperPotential.py: Wrapper to smoothly grow a potential
 ###############################################################################
+import numpy
+
+from ..backend import get_namespace
 from ..util import conversion
 from .WrapperPotential import parentWrapperPotential
 
@@ -66,15 +69,32 @@ class DehnenSmoothWrapperPotential(parentWrapperPotential):
         self.hasC_dxdv = True
 
     def _smooth(self, t):
-        # Calculate relevant time
-        if t < self._tform:
-            smooth = 0.0
-        elif t < self._tsteady:
+        # Growth factor (0 before tform, smoothly to 1 at tsteady). The namespace
+        # follows t itself: a concrete (Python/numpy) t keeps the original scalar
+        # branching (byte-identical; returns a plain float that multiplies into
+        # any backend's spatial arrays); a backend-array/traced t (the in-backend
+        # diffrax/torchdiffeq integrator, or autodiff wrt time) uses that
+        # backend's branch-free where, so it is traceable and differentiable.
+        xp = get_namespace(t)
+        if xp is numpy:
+            # Calculate relevant time
+            if t < self._tform:
+                smooth = 0.0
+            elif t < self._tsteady:
+                deltat = t - self._tform
+                xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
+                smooth = (
+                    3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
+                )
+            else:  # bar is fully on
+                smooth = 1.0
+        else:
             deltat = t - self._tform
             xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
-            smooth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
-        else:  # bar is fully on
-            smooth = 1.0
+            growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
+            smooth = xp.where(
+                t < self._tform, 0.0, xp.where(t < self._tsteady, growth, 1.0)
+            )
         return smooth if self._grow else 1.0 - smooth
 
     def _wrap(self, attribute, *args, **kwargs):

--- a/galpy/potential/GaussianAmplitudeWrapperPotential.py
+++ b/galpy/potential/GaussianAmplitudeWrapperPotential.py
@@ -2,8 +2,7 @@
 #   GaussianAmplitudeWrapperPotential.py: Wrapper to modulate the amplitude
 #                                         of a potential with a Gaussian
 ###############################################################################
-import numpy
-
+from ..backend import get_namespace
 from ..util import conversion
 from .WrapperPotential import parentWrapperPotential
 
@@ -47,7 +46,11 @@ class GaussianAmplitudeWrapperPotential(parentWrapperPotential):
         self.hasC_dxdv = True
 
     def _smooth(self, t):
-        return numpy.exp(-0.5 * (t - self._to) ** 2.0 / self._sigma2)
+        # The namespace follows t itself: a concrete (Python/numpy) t keeps the
+        # numpy path byte-identical; a traced t (in-backend integrator, autodiff
+        # wrt time) uses that backend's exp, so it is differentiable.
+        xp = get_namespace(t)
+        return xp.exp(-0.5 * (t - self._to) ** 2.0 / self._sigma2)
 
     def _wrap(self, attribute, *args, **kwargs):
         return self._smooth(kwargs.get("t", 0.0)) * self._wrap_pot_func(attribute)(

--- a/galpy/potential/KuzminLikeWrapperPotential.py
+++ b/galpy/potential/KuzminLikeWrapperPotential.py
@@ -4,6 +4,7 @@
 ###############################################################################
 import numpy
 
+from ..backend import get_namespace
 from ..util import conversion
 from .Potential import (
     _evaluatePotentials,
@@ -76,29 +77,31 @@ class KuzminLikeWrapperPotential(WrapperPotential):
         self.isNonAxi = False
 
     def _xi(self, R, z):
-        return numpy.sqrt(R**2.0 + (self._a + numpy.sqrt(z**2.0 + self._b2)) ** 2.0)
+        xp = get_namespace(R, z)
+        return xp.sqrt(R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0)
 
     def _dxidR(self, R, z):
         return R / self._xi(R, z)
 
     def _dxidz(self, R, z):
+        xp = get_namespace(R, z)
         return (
-            (self._a + numpy.sqrt(z**2.0 + self._b2))
+            (self._a + xp.sqrt(z**2.0 + self._b2))
             * z
             / self._xi(R, z)
-            / numpy.sqrt(z**2.0 + self._b2)
+            / xp.sqrt(z**2.0 + self._b2)
         )
 
     def _d2xidR2(self, R, z):
-        return ((self._a + numpy.sqrt(z**2.0 + self._b2)) ** 2.0) / self._xi(
-            R, z
-        ) ** 3.0
+        xp = get_namespace(R, z)
+        return ((self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) / self._xi(R, z) ** 3.0
 
     def _d2xidz2(self, R, z):
+        xp = get_namespace(R, z)
         return (
             (
                 self._a**3.0 * self._b2
-                + 3.0 * self._a**2.0 * self._b2 * numpy.sqrt(self._b2 + z**2.0)
+                + 3.0 * self._a**2.0 * self._b2 * xp.sqrt(self._b2 + z**2.0)
                 + self._a * self._b2 * (3.0 * self._b2 + R**2.0 + 3.0 * z**2.0)
                 + (self._b2 + R**2.0) * (self._b2 + z**2.0) ** (1.5)
             )
@@ -107,44 +110,64 @@ class KuzminLikeWrapperPotential(WrapperPotential):
         )
 
     def _d2xidRdz(self, R, z):
-        return -(R * z * (self._a + numpy.sqrt(self._b2 + z**2.0))) / (
-            numpy.sqrt(self._b2 + z**2.0)
-            * ((self._a + numpy.sqrt(self._b2 + z**2.0)) ** 2.0 + R**2.0) ** 1.5
+        xp = get_namespace(R, z)
+        return -(R * z * (self._a + xp.sqrt(self._b2 + z**2.0))) / (
+            xp.sqrt(self._b2 + z**2.0)
+            * ((self._a + xp.sqrt(self._b2 + z**2.0)) ** 2.0 + R**2.0) ** 1.5
         )
 
+    def _zero_like(self, xp, R):
+        # The numpy path passes the plain scalar through untouched
+        # (byte-identical); on a non-numpy backend the z = 0 reference
+        # coordinate is anchored on the inputs so the wrapped potential sees a
+        # backend array (torch functions require Tensors) on the right
+        # device/dtype.
+        return 0.0 if xp is numpy else xp.zeros_like(R)
+
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        return _evaluatePotentials(self._pot, self._xi(R, z), 0.0, phi=phi, t=t)
+        xp = get_namespace(R, z, phi, t)
+        return _evaluatePotentials(
+            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
+        )
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         return _evaluateRforces(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
         ) * self._dxidR(R, z)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         return _evaluateRforces(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
         ) * self._dxidz(R, z)
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         return 0.0
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
+        zero = self._zero_like(xp, R)
         return evaluateR2derivs(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidR(R, z) ** 2.0 - _evaluateRforces(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._d2xidR2(R, z)
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
+        zero = self._zero_like(xp, R)
         return evaluateR2derivs(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidz(R, z) ** 2.0 - _evaluateRforces(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._d2xidz2(R, z)
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
+        zero = self._zero_like(xp, R)
         return evaluateR2derivs(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidR(R, z) * self._dxidz(R, z) - _evaluateRforces(
-            self._pot, self._xi(R, z), 0.0, phi=phi, t=t
+            self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._d2xidRdz(R, z)

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -10,7 +10,9 @@
 import numpy
 
 from galpy.util import conversion, coords
+from galpy.util.coords import _promote_scalars_for
 
+from ..backend import get_namespace
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -126,17 +128,18 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-12-15 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi, t)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
         return (
             (
-                -self._dUdu(u) * self._delta * numpy.sin(v) * numpy.cosh(u)
-                + self._dVdv(v) * numpy.tanh(u) * z
+                -self._dUdu(u) * self._delta * xp.sin(v) * xp.cosh(u)
+                + self._dVdv(v) * xp.tanh(u) * z
                 + (self._U(u) - self._V(v))
                 * (
-                    dprefacdu * self._delta * numpy.sin(v) * numpy.cosh(u)
-                    + dprefacdv * numpy.tanh(u) * z
+                    dprefacdu * self._delta * xp.sin(v) * xp.cosh(u)
+                    + dprefacdv * xp.tanh(u) * z
                 )
                 / prefac
             )
@@ -160,17 +163,18 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-12-15 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi, t)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
         return (
             (
-                -self._dUdu(u) * R / numpy.tan(v)
-                - self._dVdv(v) * self._delta * numpy.sin(v) * numpy.cosh(u)
+                -self._dUdu(u) * R / xp.tan(v)
+                - self._dVdv(v) * self._delta * xp.sin(v) * xp.cosh(u)
                 + (self._U(u) - self._V(v))
                 * (
-                    dprefacdu / numpy.tan(v) * R
-                    - dprefacdv * self._delta * numpy.sin(v) * numpy.cosh(u)
+                    dprefacdu / xp.tan(v) * R
+                    - dprefacdv * self._delta * xp.sin(v) * xp.cosh(u)
                 )
                 / prefac
             )
@@ -194,13 +198,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-21 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi, t)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
         d2prefacdu2, d2prefacdv2 = _dstaeckel_prefactord2ud2v(u, v)
         umvfac = (
-            dprefacdu * self._delta * numpy.sin(v) * numpy.cosh(u)
-            + dprefacdv * numpy.tanh(u) * z
+            dprefacdu * self._delta * xp.sin(v) * xp.cosh(u)
+            + dprefacdv * xp.tanh(u) * z
         ) / prefac  # xs (U-V) in Rforce
         U = self._U(u)
         dUdu = self._dUdu(u)
@@ -209,23 +214,20 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         dVdv = self._dVdv(v)
         d2Vdv2 = self._d2Vdv2(v)
         return (
-            d2Udu2 * numpy.sin(v) ** 2.0 * numpy.cosh(u) ** 2.0
-            + dUdu * numpy.sinh(u) * numpy.cosh(u)
-            - d2Vdv2 * numpy.sinh(u) ** 2.0 * numpy.cos(v) ** 2.0
-            - dVdv * numpy.sin(v) * numpy.cos(v)
+            d2Udu2 * xp.sin(v) ** 2.0 * xp.cosh(u) ** 2.0
+            + dUdu * xp.sinh(u) * xp.cosh(u)
+            - d2Vdv2 * xp.sinh(u) ** 2.0 * xp.cos(v) ** 2.0
+            - dVdv * xp.sin(v) * xp.cos(v)
             + (
-                (
-                    -dUdu * numpy.cosh(u) * numpy.sin(v)
-                    + dVdv * numpy.sinh(u) * numpy.cos(v)
-                )
+                (-dUdu * xp.cosh(u) * xp.sin(v) + dVdv * xp.sinh(u) * xp.cos(v))
                 / self._delta
                 * umvfac
                 + (U - V)
                 * (
-                    -d2prefacdu2 * numpy.cosh(u) ** 2.0 * numpy.sin(v) ** 2.0
-                    - dprefacdu * numpy.sinh(u) * numpy.cosh(u)
-                    - d2prefacdv2 * numpy.sinh(u) ** 2.0 * numpy.cos(v) ** 2.0
-                    - dprefacdv * numpy.sin(v) * numpy.cos(v)
+                    -d2prefacdu2 * xp.cosh(u) ** 2.0 * xp.sin(v) ** 2.0
+                    - dprefacdu * xp.sinh(u) * xp.cosh(u)
+                    - d2prefacdv2 * xp.sinh(u) ** 2.0 * xp.cos(v) ** 2.0
+                    - dprefacdv * xp.sin(v) * xp.cos(v)
                 )
                 / prefac
                 + (U - V)
@@ -233,15 +235,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
                 / prefac
                 / self._delta
                 * (
-                    dprefacdu * numpy.cosh(u) * numpy.sin(v)
-                    + dprefacdv * numpy.sinh(u) * numpy.cos(v)
+                    dprefacdu * xp.cosh(u) * xp.sin(v)
+                    + dprefacdv * xp.sinh(u) * xp.cos(v)
                 )
             )
         ) / self._delta**2.0 / prefac**3.0 + 2.0 * self._Rforce(
             R, z, phi=phi, t=t
         ) / prefac**2.0 * (
-            dprefacdu * numpy.cosh(u) * numpy.sin(v)
-            + dprefacdv * numpy.sinh(u) * numpy.cos(v)
+            dprefacdu * xp.cosh(u) * xp.sin(v) + dprefacdv * xp.sinh(u) * xp.cos(v)
         ) / self._delta
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
@@ -260,13 +261,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-21 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi, t)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
         d2prefacdu2, d2prefacdv2 = _dstaeckel_prefactord2ud2v(u, v)
         umvfac = (
-            dprefacdu / numpy.tan(v) * R  # xs (U-V) in zforce
-            - dprefacdv * self._delta * numpy.sin(v) * numpy.cosh(u)
+            dprefacdu / xp.tan(v) * R  # xs (U-V) in zforce
+            - dprefacdv * self._delta * xp.sin(v) * xp.cosh(u)
         ) / prefac
         U = self._U(u)
         dUdu = self._dUdu(u)
@@ -275,23 +277,20 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         dVdv = self._dVdv(v)
         d2Vdv2 = self._d2Vdv2(v)
         return (
-            d2Udu2 * numpy.sinh(u) ** 2.0 * numpy.cos(v) ** 2.0
-            + dUdu * numpy.cosh(u) * numpy.sinh(u)
-            - d2Vdv2 * numpy.sin(v) ** 2.0 * numpy.cosh(u) ** 2.0
-            - dVdv * numpy.cos(v) * numpy.sin(v)
+            d2Udu2 * xp.sinh(u) ** 2.0 * xp.cos(v) ** 2.0
+            + dUdu * xp.cosh(u) * xp.sinh(u)
+            - d2Vdv2 * xp.sin(v) ** 2.0 * xp.cosh(u) ** 2.0
+            - dVdv * xp.cos(v) * xp.sin(v)
             + (
-                (
-                    -dUdu * numpy.sinh(u) * numpy.cos(v)
-                    - dVdv * numpy.cosh(u) * numpy.sin(v)
-                )
+                (-dUdu * xp.sinh(u) * xp.cos(v) - dVdv * xp.cosh(u) * xp.sin(v))
                 / self._delta
                 * umvfac
                 + (U - V)
                 * (
-                    -d2prefacdu2 * numpy.sinh(u) ** 2.0 * numpy.cos(v) ** 2.0
-                    - dprefacdu * numpy.sinh(u) * numpy.cosh(u)
-                    - d2prefacdv2 * numpy.sin(v) ** 2.0 * numpy.cosh(u) ** 2.0
-                    - dprefacdv * numpy.cos(v) * numpy.sin(v)
+                    -d2prefacdu2 * xp.sinh(u) ** 2.0 * xp.cos(v) ** 2.0
+                    - dprefacdu * xp.sinh(u) * xp.cosh(u)
+                    - d2prefacdv2 * xp.sin(v) ** 2.0 * xp.cosh(u) ** 2.0
+                    - dprefacdv * xp.cos(v) * xp.sin(v)
                 )
                 / prefac
                 - (U - V)
@@ -299,15 +298,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
                 / prefac
                 / self._delta
                 * (
-                    -dprefacdu * numpy.sinh(u) * numpy.cos(v)
-                    + dprefacdv * numpy.cosh(u) * numpy.sin(v)
+                    -dprefacdu * xp.sinh(u) * xp.cos(v)
+                    + dprefacdv * xp.cosh(u) * xp.sin(v)
                 )
             )
         ) / self._delta**2.0 / prefac**3.0 - 2.0 * self._zforce(
             R, z, phi=phi, t=t
         ) / prefac**2.0 * (
-            -dprefacdu * numpy.sinh(u) * numpy.cos(v)
-            + dprefacdv * numpy.cosh(u) * numpy.sin(v)
+            -dprefacdu * xp.sinh(u) * xp.cos(v) + dprefacdv * xp.cosh(u) * xp.sin(v)
         ) / self._delta
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
@@ -326,13 +324,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-22 - Written - Bovy (UofT)
         """
+        xp = get_namespace(R, z, phi, t)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
         d2prefacdu2, d2prefacdv2 = _dstaeckel_prefactord2ud2v(u, v)
         umvfac = (
-            dprefacdu / numpy.tan(v) * R  # xs (U-V) in zforce
-            - dprefacdv * self._delta * numpy.sin(v) * numpy.cosh(u)
+            dprefacdu / xp.tan(v) * R  # xs (U-V) in zforce
+            - dprefacdv * self._delta * xp.sin(v) * xp.cosh(u)
         ) / prefac
         U = self._U(u)
         dUdu = self._dUdu(u)
@@ -341,29 +340,22 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         dVdv = self._dVdv(v)
         d2Vdv2 = self._d2Vdv2(v)
         return (
-            (d2Udu2 + d2Vdv2)
-            * numpy.cosh(u)
-            * numpy.sin(v)
-            * numpy.cos(v)
-            * numpy.sinh(u)
-            + dUdu * numpy.sin(v) * numpy.cos(v)
-            + dVdv * numpy.sinh(u) * numpy.cosh(u)
+            (d2Udu2 + d2Vdv2) * xp.cosh(u) * xp.sin(v) * xp.cos(v) * xp.sinh(u)
+            + dUdu * xp.sin(v) * xp.cos(v)
+            + dVdv * xp.sinh(u) * xp.cosh(u)
             + (
-                (
-                    -dUdu * numpy.cosh(u) * numpy.sin(v)
-                    + dVdv * numpy.sinh(u) * numpy.cos(v)
-                )
+                (-dUdu * xp.cosh(u) * xp.sin(v) + dVdv * xp.sinh(u) * xp.cos(v))
                 / self._delta
                 * umvfac
                 + (U - V)
                 * (
                     (-d2prefacdu2 + d2prefacdv2)
-                    * numpy.sin(v)
-                    * numpy.cosh(u)
-                    * numpy.sinh(u)
-                    * numpy.cos(v)
-                    - dprefacdu * numpy.sin(v) * numpy.cos(v)
-                    + dprefacdv * numpy.cosh(u) * numpy.sinh(u)
+                    * xp.sin(v)
+                    * xp.cosh(u)
+                    * xp.sinh(u)
+                    * xp.cos(v)
+                    - dprefacdu * xp.sin(v) * xp.cos(v)
+                    + dprefacdv * xp.cosh(u) * xp.sinh(u)
                 )
                 / prefac
                 + (U - V)
@@ -371,52 +363,49 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
                 / prefac
                 / self._delta
                 * (
-                    dprefacdu * numpy.cosh(u) * numpy.sin(v)
-                    + dprefacdv * numpy.sinh(u) * numpy.cos(v)
+                    dprefacdu * xp.cosh(u) * xp.sin(v)
+                    + dprefacdv * xp.sinh(u) * xp.cos(v)
                 )
             )
         ) / self._delta**2.0 / prefac**3.0 + 2.0 * self._zforce(
             R, z, phi=phi, t=t
         ) / prefac**2.0 * (
-            dprefacdu * numpy.cosh(u) * numpy.sin(v)
-            + dprefacdv * numpy.sinh(u) * numpy.cos(v)
+            dprefacdu * xp.cosh(u) * xp.sin(v) + dprefacdv * xp.sinh(u) * xp.cos(v)
         ) / self._delta
 
     def _U(self, u):
         """Approximated U(u) = cosh^2(u) Phi(u,pi/2)"""
+        xp = get_namespace(u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
-        return numpy.cosh(u) ** 2.0 * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
+        return xp.cosh(u) ** 2.0 * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
 
     def _dUdu(self, u):
+        xp = get_namespace(u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         # 1e-12 bc force should win the 0/0 battle
-        return 2.0 * numpy.cosh(u) * numpy.sinh(u) * _evaluatePotentials(
+        return 2.0 * xp.cosh(u) * xp.sinh(u) * _evaluatePotentials(
             self._pot, Rz0[0], Rz0[1]
-        ) - numpy.cosh(u) ** 2.0 * (
-            _evaluateRforces(self._pot, Rz0[0], Rz0[1])
-            * Rz0[0]
-            / (numpy.tanh(u) + 1e-12)
-            + _evaluatezforces(self._pot, Rz0[0], Rz0[1]) * Rz0[1] * numpy.tanh(u)
+        ) - xp.cosh(u) ** 2.0 * (
+            _evaluateRforces(self._pot, Rz0[0], Rz0[1]) * Rz0[0] / (xp.tanh(u) + 1e-12)
+            + _evaluatezforces(self._pot, Rz0[0], Rz0[1]) * Rz0[1] * xp.tanh(u)
         )
 
     def _d2Udu2(self, u):
+        xp = get_namespace(u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, Rz0[0], Rz0[1])
         tzforce = _evaluatezforces(self._pot, Rz0[0], Rz0[1])
         return (
-            2.0 * numpy.cosh(2 * u) * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
+            2.0 * xp.cosh(2 * u) * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
             - 4.0
-            * numpy.cosh(u)
-            * numpy.sinh(u)
-            * (
-                tRforce * Rz0[0] / (numpy.tanh(u) + 1e-12)
-                + tzforce * Rz0[1] * numpy.tanh(u)
-            )
-            - numpy.cosh(u) ** 2.0
+            * xp.cosh(u)
+            * xp.sinh(u)
+            * (tRforce * Rz0[0] / (xp.tanh(u) + 1e-12) + tzforce * Rz0[1] * xp.tanh(u))
+            - xp.cosh(u) ** 2.0
             * (
                 -evaluateR2derivs(self._pot, Rz0[0], Rz0[1], use_physical=False)
                 * Rz0[0] ** 2.0
-                / (numpy.tanh(u) + 1e-12) ** 2.0
+                / (xp.tanh(u) + 1e-12) ** 2.0
                 - 2.0
                 * evaluateRzderivs(self._pot, Rz0[0], Rz0[1], use_physical=False)
                 * Rz0[0]
@@ -424,7 +413,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
                 + tRforce * Rz0[0]
                 - evaluatez2derivs(self._pot, Rz0[0], Rz0[1], use_physical=False)
                 * Rz0[1] ** 2.0
-                * numpy.tanh(u) ** 2.0
+                * xp.tanh(u) ** 2.0
                 + tzforce * Rz0[1]
             )
         )
@@ -438,28 +427,30 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         )
 
     def _dVdv(self, v):
+        xp = get_namespace(v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
-        return -2.0 * numpy.sin(v) * numpy.cos(v) * _evaluatePotentials(
+        return -2.0 * xp.sin(v) * xp.cos(v) * _evaluatePotentials(
             self._pot, R0z[0], R0z[1]
         ) + _staeckel_prefactor(self._u0, v) * (
-            _evaluateRforces(self._pot, R0z[0], R0z[1]) * R0z[0] / numpy.tan(v)
-            - _evaluatezforces(self._pot, R0z[0], R0z[1]) * R0z[1] * numpy.tan(v)
+            _evaluateRforces(self._pot, R0z[0], R0z[1]) * R0z[0] / xp.tan(v)
+            - _evaluatezforces(self._pot, R0z[0], R0z[1]) * R0z[1] * xp.tan(v)
         )
 
     def _d2Vdv2(self, v):
+        xp = get_namespace(v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, R0z[0], R0z[1])
         tzforce = _evaluatezforces(self._pot, R0z[0], R0z[1])
         return (
-            -2.0 * numpy.cos(2.0 * v) * _evaluatePotentials(self._pot, R0z[0], R0z[1])
+            -2.0 * xp.cos(2.0 * v) * _evaluatePotentials(self._pot, R0z[0], R0z[1])
             + 2.0
-            * numpy.sin(2.0 * v)
-            * (tRforce * R0z[0] / numpy.tan(v) - tzforce * R0z[1] * numpy.tan(v))
+            * xp.sin(2.0 * v)
+            * (tRforce * R0z[0] / xp.tan(v) - tzforce * R0z[1] * xp.tan(v))
             + _staeckel_prefactor(self._u0, v)
             * (
                 -evaluateR2derivs(self._pot, R0z[0], R0z[1], use_physical=False)
                 * R0z[0] ** 2.0
-                / numpy.tan(v) ** 2.0
+                / xp.tan(v) ** 2.0
                 + 2.0
                 * evaluateRzderivs(self._pot, R0z[0], R0z[1], use_physical=False)
                 * R0z[0]
@@ -467,19 +458,25 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
                 - tRforce * R0z[0]
                 - evaluatez2derivs(self._pot, R0z[0], R0z[1], use_physical=False)
                 * R0z[1] ** 2.0
-                * numpy.tan(v) ** 2.0
+                * xp.tan(v) ** 2.0
                 - tzforce * R0z[1]
             )
         )
 
 
 def _staeckel_prefactor(u, v):
-    return numpy.sinh(u) ** 2.0 + numpy.sin(v) ** 2.0
+    xp = get_namespace(u, v)
+    u, v = _promote_scalars_for(xp, u, v)
+    return xp.sinh(u) ** 2.0 + xp.sin(v) ** 2.0
 
 
 def _dstaeckel_prefactordudv(u, v):
-    return (2.0 * numpy.sinh(u) * numpy.cosh(u), 2.0 * numpy.sin(v) * numpy.cos(v))
+    xp = get_namespace(u, v)
+    u, v = _promote_scalars_for(xp, u, v)
+    return (2.0 * xp.sinh(u) * xp.cosh(u), 2.0 * xp.sin(v) * xp.cos(v))
 
 
 def _dstaeckel_prefactord2ud2v(u, v):
-    return (2.0 * numpy.cosh(2.0 * u), 2.0 * numpy.cos(2.0 * v))
+    xp = get_namespace(u, v)
+    u, v = _promote_scalars_for(xp, u, v)
+    return (2.0 * xp.cosh(2.0 * u), 2.0 * xp.cos(2.0 * v))

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -4,6 +4,7 @@
 ###############################################################################
 import numpy
 
+from ..backend import get_namespace
 from ..util import _rotate_to_arbitrary_vector, conversion, coords
 from .Potential import (
     _evaluatephitorques,
@@ -20,6 +21,21 @@ from .Potential import (
     evaluatez2derivs,
 )
 from .WrapperPotential import WrapperPotential
+
+
+def _as_xp_constant(xp, value, ref):
+    """Bring a stored numpy constant (rotation matrix / offset) into the active
+    namespace, anchored on the dtype/device of ``ref`` (a backend array derived
+    from the coordinate inputs). The numpy path passes the stored array through
+    untouched (byte-identical)."""
+    if xp is numpy:
+        return value
+    dtype = getattr(ref, "dtype", None)
+    device = getattr(ref, "device", None)
+    try:
+        return xp.asarray(value, dtype=dtype, device=device)
+    except TypeError:  # pragma: no cover - namespace without device= kwarg
+        return xp.asarray(value, dtype=dtype)
 
 
 # Only implement 3D wrapper
@@ -155,27 +171,45 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     def __getattr__(self, attribute):
         return super().__getattr__(attribute)
 
+    def _rect_transformed(self, xp, R, z, phi, guard_inf=False):
+        """Rectangular coordinates in the rotated/tilted (+offset) frame.
+
+        With ``guard_inf`` (the _evaluate/_dens R == inf branch), the wrapped
+        potential is evaluated at rectangular (R, 0, z) instead; the finite-R
+        branch's input is guarded (eager backends evaluate both ``xp.where``
+        sides, and inf*cos(phi) would NaN-poison reverse-mode autodiff)."""
+        if guard_inf:
+            Rinf = xp.isinf(R)
+            x, y, z = coords.cyl_to_rect(xp.where(Rinf, 1.0, R), phi, z)
+            x = xp.where(Rinf, R, x)
+            y = xp.where(Rinf, 0.0, y)
+        else:
+            x, y, z = coords.cyl_to_rect(R, phi, z)
+        xyzp = xp.stack([x, y, z])
+        if not self._norot:
+            xyzp = _as_xp_constant(xp, self._rot, xyzp) @ xyzp
+        if self._offset is not None:
+            xyzp = xyzp + _as_xp_constant(xp, self._offset, xyzp)
+        return xyzp
+
     @check_potential_inputs_not_arrays
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        x, y, z = coords.cyl_to_rect(R, phi, z) if not numpy.isinf(R) else (R, 0.0, z)
-        if self._norot:
-            xyzp = numpy.array([x, y, z])
-        else:
-            xyzp = numpy.dot(self._rot, numpy.array([x, y, z]))
-        if self._offset is not None:
-            xyzp += self._offset
+        xp = get_namespace(R, z, phi, t)
+        xyzp = self._rect_transformed(xp, R, z, phi, guard_inf=True)
         Rp, phip, zp = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
         return _evaluatePotentials(self._pot, Rp, zp, phi=phip, t=t)
 
     @check_potential_inputs_not_arrays
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
-        return numpy.cos(phi) * Fxyz[0] + numpy.sin(phi) * Fxyz[1]
+        return xp.cos(phi) * Fxyz[0] + xp.sin(phi) * Fxyz[1]
 
     @check_potential_inputs_not_arrays
     def _phitorque(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
-        return R * (-numpy.sin(phi) * Fxyz[0] + numpy.cos(phi) * Fxyz[1])
+        return R * (-xp.sin(phi) * Fxyz[0] + xp.cos(phi) * Fxyz[1])
 
     @check_potential_inputs_not_arrays
     def _zforce(self, R, z, phi=0.0, t=0.0):
@@ -183,34 +217,32 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
 
     def _force_xyz(self, R, z, phi=0.0, t=0.0):
         """Get the rectangular forces in the transformed frame"""
-        x, y, z = coords.cyl_to_rect(R, phi, z)
-        if self._norot:
-            xyzp = numpy.array([x, y, z])
-        else:
-            xyzp = numpy.dot(self._rot, numpy.array([x, y, z]))
-        if self._offset is not None:
-            xyzp += self._offset
+        xp = get_namespace(R, z, phi, t)
+        xyzp = self._rect_transformed(xp, R, z, phi)
         Rp, phip, zp = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
         Rforcep = _evaluateRforces(self._pot, Rp, zp, phi=phip, t=t)
         phitorquep = _evaluatephitorques(self._pot, Rp, zp, phi=phip, t=t)
         zforcep = _evaluatezforces(self._pot, Rp, zp, phi=phip, t=t)
-        xforcep = numpy.cos(phip) * Rforcep - numpy.sin(phip) * phitorquep / Rp
-        yforcep = numpy.sin(phip) * Rforcep + numpy.cos(phip) * phitorquep / Rp
-        return numpy.dot(self._inv_rot, numpy.array([xforcep, yforcep, zforcep]))
+        xforcep = xp.cos(phip) * Rforcep - xp.sin(phip) * phitorquep / Rp
+        yforcep = xp.sin(phip) * Rforcep + xp.cos(phip) * phitorquep / Rp
+        Fxyzp = xp.stack([xforcep, yforcep, zforcep])
+        return _as_xp_constant(xp, self._inv_rot, Fxyzp) @ Fxyzp
 
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            numpy.cos(phi) ** 2.0 * phi2[0, 0]
-            + numpy.sin(phi) ** 2.0 * phi2[1, 1]
-            + 2.0 * numpy.cos(phi) * numpy.sin(phi) * phi2[0, 1]
+            xp.cos(phi) ** 2.0 * phi2[0, 0]
+            + xp.sin(phi) ** 2.0 * phi2[1, 1]
+            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
         )
 
     @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return numpy.cos(phi) * phi2[0, 2] + numpy.sin(phi) * phi2[1, 2]
+        return xp.cos(phi) * phi2[0, 2] + xp.sin(phi) * phi2[1, 2]
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
@@ -218,39 +250,37 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
 
     @check_potential_inputs_not_arrays
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return R**2.0 * (
-            numpy.sin(phi) ** 2.0 * phi2[0, 0]
-            + numpy.cos(phi) ** 2.0 * phi2[1, 1]
-            - 2.0 * numpy.cos(phi) * numpy.sin(phi) * phi2[0, 1]
-        ) + R * (numpy.cos(phi) * Fxyz[0] + numpy.sin(phi) * Fxyz[1])
+            xp.sin(phi) ** 2.0 * phi2[0, 0]
+            + xp.cos(phi) ** 2.0 * phi2[1, 1]
+            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
+        ) + R * (xp.cos(phi) * Fxyz[0] + xp.sin(phi) * Fxyz[1])
 
     @check_potential_inputs_not_arrays
     def _Rphideriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            R * numpy.cos(phi) * numpy.sin(phi) * (phi2[1, 1] - phi2[0, 0])
-            + R * numpy.cos(2.0 * phi) * phi2[0, 1]
-            + numpy.sin(phi) * Fxyz[0]
-            - numpy.cos(phi) * Fxyz[1]
+            R * xp.cos(phi) * xp.sin(phi) * (phi2[1, 1] - phi2[0, 0])
+            + R * xp.cos(2.0 * phi) * phi2[0, 1]
+            + xp.sin(phi) * Fxyz[0]
+            - xp.cos(phi) * Fxyz[1]
         )
 
     @check_potential_inputs_not_arrays
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return R * (numpy.cos(phi) * phi2[1, 2] - numpy.sin(phi) * phi2[0, 2])
+        return R * (xp.cos(phi) * phi2[1, 2] - xp.sin(phi) * phi2[0, 2])
 
     def _2ndderiv_xyz(self, R, z, phi=0.0, t=0.0):
         """Get the rectangular forces in the transformed frame"""
-        x, y, z = coords.cyl_to_rect(R, phi, z)
-        if self._norot:
-            xyzp = numpy.array([x, y, z])
-        else:
-            xyzp = numpy.dot(self._rot, numpy.array([x, y, z]))
-        if self._offset is not None:
-            xyzp += self._offset
+        xp = get_namespace(R, z, phi, t)
+        xyzp = self._rect_transformed(xp, R, z, phi)
         Rp, phip, zp = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
         Rforcep = _evaluateRforces(self._pot, Rp, zp, phi=phip, t=t)
         phitorquep = _evaluatephitorques(self._pot, Rp, zp, phi=phip, t=t)
@@ -272,7 +302,7 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         phizderivp = evaluatephizderivs(
             self._pot, Rp, zp, phi=phip, t=t, use_physical=False
         )
-        cp, sp = numpy.cos(phip), numpy.sin(phip)
+        cp, sp = xp.cos(phip), xp.sin(phip)
         cp2, sp2, cpsp = cp**2.0, sp**2.0, cp * sp
         Rp2 = Rp * Rp
         x2derivp = (
@@ -298,28 +328,20 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         )
         xzderivp = Rzderivp * cp - phizderivp * sp / Rp
         yzderivp = Rzderivp * sp + phizderivp * cp / Rp
-        return numpy.dot(
-            self._inv_rot,
-            numpy.dot(
-                numpy.array(
-                    [
-                        [x2derivp, xyderivp, xzderivp],
-                        [xyderivp, y2derivp, yzderivp],
-                        [xzderivp, yzderivp, z2derivp],
-                    ]
-                ),
-                self._inv_rot.T,
-            ),
+        deriv2p = xp.stack(
+            [
+                xp.stack([x2derivp, xyderivp, xzderivp]),
+                xp.stack([xyderivp, y2derivp, yzderivp]),
+                xp.stack([xzderivp, yzderivp, z2derivp]),
+            ]
         )
+        inv_rot = _as_xp_constant(xp, self._inv_rot, deriv2p)
+        inv_rot_T = _as_xp_constant(xp, self._inv_rot.T, deriv2p)
+        return inv_rot @ (deriv2p @ inv_rot_T)
 
     @check_potential_inputs_not_arrays
     def _dens(self, R, z, phi=0.0, t=0.0):
-        x, y, z = coords.cyl_to_rect(R, phi, z) if not numpy.isinf(R) else (R, 0.0, z)
-        if self._norot:
-            xyzp = numpy.array([x, y, z])
-        else:
-            xyzp = numpy.dot(self._rot, numpy.array([x, y, z]))
-        if self._offset is not None:
-            xyzp += self._offset
+        xp = get_namespace(R, z, phi, t)
+        xyzp = self._rect_transformed(xp, R, z, phi, guard_inf=True)
         Rp, phip, zp = coords.rect_to_cyl(xyzp[0], xyzp[1], xyzp[2])
         return evaluateDensities(self._pot, Rp, zp, phi=phip, t=t, use_physical=False)

--- a/galpy/potential/TimeDependentAmplitudeWrapperPotential.py
+++ b/galpy/potential/TimeDependentAmplitudeWrapperPotential.py
@@ -6,8 +6,6 @@
 from inspect import signature
 from numbers import Number
 
-from numpy import empty
-
 from .WrapperPotential import parentWrapperPotential
 
 

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -88,6 +88,35 @@ from ..util.config import __config__
 _APY_COORDS = __config__.getboolean("astropy", "astropy-coords")
 _APY_COORDS *= _APY_LOADED
 _DEGTORAD = numpy.pi / 180.0
+
+
+def _promote_scalars_for(xp, *vals):
+    """Promote plain Python scalars among ``vals`` to the active non-numpy
+    namespace, anchored on the dtype/device of the first array argument, so
+    that e.g. torch functions -- which require Tensors -- accept the mixed
+    scalar/array inputs that the numpy path has always supported. The numpy
+    path passes everything through untouched (byte-identical)."""
+    if xp is numpy:
+        return vals
+    ref = next((v for v in vals if hasattr(v, "ndim")), None)
+    if ref is None:
+        # Nothing to anchor on (e.g. all-scalar inputs under a forced backend
+        # default): pass through, the namespace's functions handle scalars
+        return vals
+    dtype = getattr(ref, "dtype", None)
+    device = getattr(ref, "device", None)
+
+    def _promote(v):
+        if hasattr(v, "ndim"):
+            return v
+        try:
+            return xp.asarray(v, dtype=dtype, device=device)
+        except TypeError:  # pragma: no cover - namespace without device kwarg
+            return xp.asarray(v, dtype=dtype)
+
+    return tuple(_promote(v) for v in vals)
+
+
 if _APY_LOADED:
     import astropy.coordinates as apycoords
     from astropy import units
@@ -1124,7 +1153,9 @@ def rect_to_cyl(X, Y, Z):
     - 2010-09-24 - Written - Bovy (NYU)
     - 2019-06-21 - Changed such that phi in [-pi,pi] - Bovy (UofT)
     """
-    return (numpy.sqrt(X**2.0 + Y**2.0), numpy.arctan2(Y, X), Z)
+    xp = get_namespace(X, Y, Z)
+    X, Y, Z = _promote_scalars_for(xp, X, Y, Z)
+    return (xp.sqrt(X**2.0 + Y**2.0), xp.arctan2(Y, X), Z)
 
 
 def cyl_to_rect(R, phi, Z):
@@ -1149,7 +1180,9 @@ def cyl_to_rect(R, phi, Z):
     -----
     - 2011-02-23 - Written - Bovy (NYU)
     """
-    return (R * numpy.cos(phi), R * numpy.sin(phi), Z)
+    xp = get_namespace(R, phi, Z)
+    R, phi, Z = _promote_scalars_for(xp, R, phi, Z)
+    return (R * xp.cos(phi), R * xp.sin(phi), Z)
 
 
 def cyl_to_spher(R, Z, phi):
@@ -2372,16 +2405,18 @@ def Rz_to_coshucosv(R, z, delta=1.0, oblate=False):
     - 2012-11-27 - Written - Bovy (IAS)
     - 2017-10-11 - Added oblate coordinates - Bovy (UofT)
     """
+    xp = get_namespace(R, z, delta)
+    R, z = _promote_scalars_for(xp, R, z)
     if oblate:
         d12 = (R + delta) ** 2.0 + z**2.0
         d22 = (R - delta) ** 2.0 + z**2.0
     else:
         d12 = (z + delta) ** 2.0 + R**2.0
         d22 = (z - delta) ** 2.0 + R**2.0
-    coshu = 0.5 / delta * (numpy.sqrt(d12) + numpy.sqrt(d22))
-    cosv = 0.5 / delta * (numpy.sqrt(d12) - numpy.sqrt(d22))
+    coshu = 0.5 / delta * (xp.sqrt(d12) + xp.sqrt(d22))
+    cosv = 0.5 / delta * (xp.sqrt(d12) - xp.sqrt(d22))
     if oblate:  # cosv is currently really sinv
-        cosv = numpy.sqrt(1.0 - cosv**2.0)
+        cosv = xp.sqrt(1.0 - cosv**2.0)
     return (coshu, cosv)
 
 
@@ -2411,9 +2446,10 @@ def Rz_to_uv(R, z, delta=1.0, oblate=False):
     - 2017-10-11 - Added oblate coordinates - Bovy (UofT)
 
     """
+    xp = get_namespace(R, z, delta)
     coshu, cosv = Rz_to_coshucosv(R, z, delta, oblate=oblate)
-    u = numpy.arccosh(coshu)
-    v = numpy.arccos(cosv)
+    u = xp.arccosh(coshu)
+    v = xp.arccos(cosv)
     return (u, v)
 
 
@@ -2443,12 +2479,14 @@ def uv_to_Rz(u, v, delta=1.0, oblate=False):
     - 2017-10-11 - Added oblate coordinates - Bovy (UofT)
 
     """
+    xp = get_namespace(u, v, delta)
+    u, v = _promote_scalars_for(xp, u, v)
     if oblate:
-        R = delta * numpy.cosh(u) * numpy.sin(v)
-        z = delta * numpy.sinh(u) * numpy.cos(v)
+        R = delta * xp.cosh(u) * xp.sin(v)
+        z = delta * xp.sinh(u) * xp.cos(v)
     else:
-        R = delta * numpy.sinh(u) * numpy.sin(v)
-        z = delta * numpy.cosh(u) * numpy.cos(v)
+        R = delta * xp.sinh(u) * xp.sin(v)
+        z = delta * xp.cosh(u) * xp.cos(v)
     return (R, z)
 
 

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -35,7 +35,21 @@ COMPUTE_METHODS = {
 }
 
 # Potentials migrated to the backend convention (extend as PRs land).
-MIGRATED = ["PlummerPotential", "IsochronePotential"]
+MIGRATED = [
+    "PlummerPotential",
+    "IsochronePotential",
+    # P2.6 wrappers (their __init__ machinery is numpy-by-design; only the
+    # private compute methods below are checked)
+    "DehnenSmoothWrapperPotential",
+    "GaussianAmplitudeWrapperPotential",
+    "TimeDependentAmplitudeWrapperPotential",
+    "SolidBodyRotationWrapperPotential",
+    "CorotatingRotationWrapperPotential",
+    "RotateAndTiltWrapperPotential",
+    "KuzminLikeWrapperPotential",
+    "OblateStaeckelWrapperPotential",
+    "CylindricallySeparablePotentialWrapper",
+]
 
 
 class _BareNumpyVisitor(ast.NodeVisitor):

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -1,0 +1,516 @@
+###############################################################################
+# test_backend_wrappers.py: backend-agnostic tests for the wrapper-potential
+# family (P2.6): DehnenSmooth / GaussianAmplitude / TimeDependentAmplitude /
+# SolidBodyRotation / CorotatingRotation / RotateAndTilt / KuzminLike /
+# OblateStaeckel / CylindricallySeparable wrappers (wrapping already-migrated
+# children) and AdiabaticContraction (which is an interpSphericalPotential at
+# runtime, so it inherits the P2.5 backend-evaluable spline machinery without
+# any wrapper-specific code).
+#
+# For every wrapper this proves:
+#   1. numpy / jax / torch value parity (rtol=1e-12, atol=1e-14) for all
+#      migrated methods over a grid of scalar (R, z, phi, t) points (the
+#      wrappers are scalar-evaluation classes via their children / decorators);
+#   2. jax/torch autodiff of _evaluate matches central finite differences and
+#      the analytic identities AD(_evaluate) == -_Rforce / -_zforce;
+#   3. jax jit + vmap survival of _Rforce;
+#   4. torch.autograd.gradcheck of _evaluate;
+#   5. the wrapper layer preserves the torch dtype its wrapped child produces
+#      (float32 stays float32 unless the child itself promotes);
+#   6. the time-modulation wrappers are differentiable wrt a *traced* t (the
+#      in-backend diffrax/torchdiffeq integrator case), exercising the
+#      branch-free xp.where smoothing path;
+#   7. wrapper-of-wrapper chains (DehnenSmooth(GaussianAmplitude(Plummer)))
+#      and planar (2D) wrappers evaluate identically across backends;
+#   8. the RotateAndTilt R == inf branch agrees across backends.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.potential import (
+    AdiabaticContractionWrapperPotential,
+    CorotatingRotationWrapperPotential,
+    CylindricallySeparablePotentialWrapper,
+    DehnenSmoothWrapperPotential,
+    GaussianAmplitudeWrapperPotential,
+    HernquistPotential,
+    KeplerPotential,
+    KuzminLikeWrapperPotential,
+    MiyamotoNagaiPotential,
+    OblateStaeckelWrapperPotential,
+    PlummerPotential,
+    RotateAndTiltWrapperPotential,
+    SolidBodyRotationWrapperPotential,
+    SpiralArmsPotential,
+    TimeDependentAmplitudeWrapperPotential,
+)
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# --- wrapped (already-migrated) children --------------------------------------
+_PP = PlummerPotential(amp=1.3, b=0.8)
+_MN = MiyamotoNagaiPotential(amp=1.1, a=0.7, b=0.3)
+_SP = SpiralArmsPotential(amp=1.0, N=2, alpha=0.2)
+_KP = KeplerPotential(amp=1.2)
+
+_AXI_METHODS = [
+    "_evaluate",
+    "_Rforce",
+    "_zforce",
+    "_R2deriv",
+    "_z2deriv",
+    "_Rzderiv",
+]
+# SpiralArms-wrapped wrappers also exercise the phi-direction methods; their
+# _dens is omitted because the bare SpiralArms child itself only matches at
+# ~1e-10 under torch (pre-existing child-level difference, not the wrapper).
+_NONAXI_METHODS = _AXI_METHODS + ["_phitorque", "_phi2deriv", "_Rphideriv"]
+
+# Each entry: (id, wrapper, [methods]).
+_WRAPPERS = [
+    (
+        "DehnenSmooth-grow",
+        DehnenSmoothWrapperPotential(pot=_PP, tform=-1.0, tsteady=2.0),
+        _AXI_METHODS + ["_dens"],
+    ),
+    (
+        "DehnenSmooth-decay",
+        DehnenSmoothWrapperPotential(pot=_MN, tform=-1.0, tsteady=2.0, decay=True),
+        _AXI_METHODS + ["_dens"],
+    ),
+    (
+        "GaussianAmplitude",
+        GaussianAmplitudeWrapperPotential(pot=_MN, to=0.5, sigma=1.3),
+        _AXI_METHODS + ["_dens"],
+    ),
+    (
+        "TimeDependentAmplitude",
+        TimeDependentAmplitudeWrapperPotential(
+            pot=_PP, A=lambda t: 1.0 + 0.1 * t + 0.02 * t**2
+        ),
+        _AXI_METHODS + ["_dens"],
+    ),
+    (
+        "SolidBodyRotation",
+        SolidBodyRotationWrapperPotential(pot=_SP, omega=1.1, pa=0.3),
+        _NONAXI_METHODS,
+    ),
+    (
+        "CorotatingRotation",
+        CorotatingRotationWrapperPotential(pot=_SP, vpo=1.1, beta=0.2, to=0.1, pa=0.2),
+        _NONAXI_METHODS,
+    ),
+    (
+        "RotateAndTilt-norot",
+        RotateAndTiltWrapperPotential(pot=_MN),
+        _NONAXI_METHODS + ["_phizderiv", "_dens"],
+    ),
+    (
+        "RotateAndTilt-zvecpa",
+        RotateAndTiltWrapperPotential(pot=_MN, zvec=[0.1, 0.2, 0.97], galaxy_pa=0.3),
+        _NONAXI_METHODS + ["_phizderiv", "_dens"],
+    ),
+    (
+        "RotateAndTilt-offset",
+        RotateAndTiltWrapperPotential(
+            pot=_MN, zvec=[0.1, 0.2, 0.97], galaxy_pa=0.3, offset=[0.1, -0.05, 0.02]
+        ),
+        _NONAXI_METHODS + ["_phizderiv", "_dens"],
+    ),
+    (
+        "RotateAndTilt-inclination",
+        RotateAndTiltWrapperPotential(
+            pot=_MN, inclination=0.4, galaxy_pa=0.3, sky_pa=0.2
+        ),
+        _NONAXI_METHODS + ["_phizderiv", "_dens"],
+    ),
+    (
+        "KuzminLike",
+        KuzminLikeWrapperPotential(pot=_KP, a=1.1, b=0.3),
+        _AXI_METHODS + ["_phitorque"],
+    ),
+    (
+        "OblateStaeckel",
+        OblateStaeckelWrapperPotential(pot=_MN, delta=0.5, u0=1.2),
+        _AXI_METHODS,
+    ),
+    (
+        "CylindricallySeparable",
+        CylindricallySeparablePotentialWrapper(pot=_MN, Rp=1.1),
+        _AXI_METHODS,
+    ),
+    (
+        "AdiabaticContraction",
+        AdiabaticContractionWrapperPotential(
+            pot=HernquistPotential(amp=1.4, a=1.1),
+            baryonpot=MiyamotoNagaiPotential(amp=0.4, a=0.7, b=0.1),
+        ),
+        ["_evaluate", "_Rforce", "_zforce"],
+    ),
+]
+_WRAPPER_IDS = [w[0] for w in _WRAPPERS]
+
+# Scalar evaluation points: z = 0 hits the OblateStaeckel v = pi/2 line and the
+# RotateAndTilt plane; t straddles the DehnenSmooth tform/tsteady window.
+_POINTS = [
+    (0.6, -0.3, 0.0, -2.0),
+    (1.1, 0.0, 0.9, 0.15),
+    (1.7, 0.23, 2.7, 3.0),
+]
+
+
+def _toscalar(backend_name, x):
+    if backend_name == "numpy":
+        return x
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    if backend_name == "torch":
+        return torch.tensor(x, dtype=torch.float64)
+
+
+def _iter_parity_cases():
+    for wid, w, methods in _WRAPPERS:
+        for m in methods:
+            yield pytest.param(w, m, id=f"{wid}-{m}")
+
+
+# --- value parity --------------------------------------------------------------
+@pytest.mark.parametrize("pot,method", list(_iter_parity_cases()))
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, pot, method):
+    for R, z, phi, t in _POINTS:
+        ref = float(getattr(pot, method)(R, z, phi=phi, t=t))
+        got = float(
+            getattr(pot, method)(
+                _toscalar(backend_name, R),
+                _toscalar(backend_name, z),
+                phi=_toscalar(backend_name, phi),
+                t=t,
+            )
+        )
+        numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+# --- autodiff vs finite differences + force identities ---------------------------
+@pytest.mark.parametrize("pot", [w[1] for w in _WRAPPERS], ids=_WRAPPER_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_vs_fd_and_forces(backend_name, pot):
+    R0, z0, phi0, t0 = 1.1, 0.23, 0.4, 0.15
+    eps = 1e-6
+
+    def phi_np(R, z):
+        return float(pot._evaluate(R, z, phi=phi0, t=t0))
+
+    fdR = (phi_np(R0 + eps, z0) - phi_np(R0 - eps, z0)) / (2 * eps)
+    fdz = (phi_np(R0, z0 + eps) - phi_np(R0, z0 - eps)) / (2 * eps)
+    refFR = -float(pot._Rforce(R0, z0, phi=phi0, t=t0))
+    refFz = -float(pot._zforce(R0, z0, phi=phi0, t=t0))
+    if backend_name == "jax":
+        adR = float(
+            jax.grad(
+                lambda R: pot._evaluate(R, jnp.asarray(z0), phi=jnp.asarray(phi0), t=t0)
+            )(jnp.asarray(R0))
+        )
+        adz = float(
+            jax.grad(
+                lambda z: pot._evaluate(jnp.asarray(R0), z, phi=jnp.asarray(phi0), t=t0)
+            )(jnp.asarray(z0))
+        )
+    else:
+        R = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+        pot._evaluate(
+            R,
+            torch.tensor(z0, dtype=torch.float64),
+            phi=torch.tensor(phi0, dtype=torch.float64),
+            t=t0,
+        ).backward()
+        adR = float(R.grad)
+        z = torch.tensor(z0, dtype=torch.float64, requires_grad=True)
+        pot._evaluate(
+            torch.tensor(R0, dtype=torch.float64),
+            z,
+            phi=torch.tensor(phi0, dtype=torch.float64),
+            t=t0,
+        ).backward()
+        adz = float(z.grad)
+    numpy.testing.assert_allclose(adR, fdR, rtol=1e-5)
+    numpy.testing.assert_allclose(adz, fdz, rtol=1e-5)
+    # Analytic identities (OblateStaeckel's hand-coded forces carry a 1e-12
+    # softening, so the identity holds to ~1e-12 rather than machine precision)
+    numpy.testing.assert_allclose(adR, refFR, rtol=1e-9)
+    numpy.testing.assert_allclose(adz, refFz, rtol=1e-9)
+
+
+# --- jax jit + vmap survival -----------------------------------------------------
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+@pytest.mark.parametrize("pot", [w[1] for w in _WRAPPERS], ids=_WRAPPER_IDS)
+def test_jax_jit_and_vmap(pot):
+    Rs = numpy.array([0.8, 1.1, 1.5])
+    zs = numpy.array([0.1, 0.23, -0.2])
+    phis = numpy.array([0.4, 1.0, 2.2])
+    ref = numpy.array(
+        [float(pot._Rforce(R, z, phi=phi, t=0.15)) for R, z, phi in zip(Rs, zs, phis)]
+    )
+    f = lambda R, z, phi: pot._Rforce(R, z, phi=phi, t=0.15)
+    jitted = numpy.array(
+        [
+            float(jax.jit(f)(jnp.asarray(R), jnp.asarray(z), jnp.asarray(phi)))
+            for R, z, phi in zip(Rs, zs, phis)
+        ]
+    )
+    numpy.testing.assert_allclose(jitted, ref, rtol=1e-12, atol=1e-14)
+    vmapped = numpy.asarray(
+        jax.vmap(f)(jnp.asarray(Rs), jnp.asarray(zs), jnp.asarray(phis))
+    )
+    numpy.testing.assert_allclose(vmapped, ref, rtol=1e-12, atol=1e-14)
+
+
+# --- torch gradcheck ------------------------------------------------------------
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+@pytest.mark.parametrize("pot", [w[1] for w in _WRAPPERS], ids=_WRAPPER_IDS)
+def test_torch_gradcheck(pot):
+    z0 = torch.tensor(0.23, dtype=torch.float64)
+    phi0 = torch.tensor(0.4, dtype=torch.float64)
+
+    def f(R):
+        return pot._evaluate(R, z0, phi=phi0, t=0.15)
+
+    R = torch.tensor(1.1, dtype=torch.float64, requires_grad=True)
+    assert torch.autograd.gradcheck(f, (R,), eps=1e-6, atol=1e-8, rtol=1e-6)
+
+
+# --- torch dtype preservation -----------------------------------------------------
+# The wrapper layer must not promote: its output dtype equals whatever its
+# wrapped child produces for the same inputs (SpiralArms itself promotes
+# float32 -> float64 -- a pre-existing child-level behavior, hence the
+# child-relative assertion). AdiabaticContraction has no wrapped child at
+# runtime (it *is* an interpSphericalPotential; see
+# test_backend_interpspherical.py for that machinery's tests).
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+@pytest.mark.parametrize(
+    "pot",
+    [w[1] for w in _WRAPPERS if w[0] != "AdiabaticContraction"],
+    ids=[w[0] for w in _WRAPPERS if w[0] != "AdiabaticContraction"],
+)
+def test_torch_dtype_preserved(pot):
+    from galpy.potential.Potential import _evaluateRforces
+
+    for dt in (torch.float64, torch.float32):
+        args = (
+            torch.tensor(1.1, dtype=dt),
+            torch.tensor(0.23, dtype=dt),
+        )
+        kwargs = dict(phi=torch.tensor(0.4, dtype=dt), t=0.15)
+        child_dtype = _evaluateRforces(pot._pot, *args, **kwargs).dtype
+        assert pot._Rforce(*args, **kwargs).dtype == child_dtype
+
+
+# --- traced t: the branch-free xp.where smoothing paths ----------------------------
+_TDEP_WRAPPERS = [
+    ("DehnenSmooth", _WRAPPERS[0][1]),
+    ("GaussianAmplitude", _WRAPPERS[2][1]),
+    ("TimeDependentAmplitude", _WRAPPERS[3][1]),
+    ("SolidBodyRotation", _WRAPPERS[4][1]),
+    ("CorotatingRotation", _WRAPPERS[5][1]),
+]
+
+
+@pytest.mark.parametrize(
+    "pot", [w[1] for w in _TDEP_WRAPPERS], ids=[w[0] for w in _TDEP_WRAPPERS]
+)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_wrt_time(backend_name, pot):
+    R0, z0, phi0, t0 = 1.1, 0.23, 0.4, 0.15
+    eps = 1e-6
+    fd = (
+        float(pot._evaluate(R0, z0, phi=phi0, t=t0 + eps))
+        - float(pot._evaluate(R0, z0, phi=phi0, t=t0 - eps))
+    ) / (2 * eps)
+    if backend_name == "jax":
+        ad = float(
+            jax.grad(
+                lambda t: pot._evaluate(
+                    jnp.asarray(R0), jnp.asarray(z0), phi=jnp.asarray(phi0), t=t
+                )
+            )(jnp.asarray(t0))
+        )
+    else:
+        t = torch.tensor(t0, dtype=torch.float64, requires_grad=True)
+        pot._evaluate(
+            torch.tensor(R0, dtype=torch.float64),
+            torch.tensor(z0, dtype=torch.float64),
+            phi=torch.tensor(phi0, dtype=torch.float64),
+            t=t,
+        ).backward()
+        ad = float(t.grad)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5, atol=1e-12)
+
+
+# Backend-array t value parity across the smoothing window (covers the
+# xp.where branches at t < tform, tform <= t <= tsteady, and t > tsteady).
+@pytest.mark.parametrize("t0", [-2.0, 0.15, 3.0])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_dehnensmooth_backend_t_window_parity(backend_name, t0):
+    pot = _WRAPPERS[0][1]  # DehnenSmooth-grow, tform=-1, tsteady at 1
+    ref = float(pot._evaluate(1.1, 0.23, phi=0.4, t=t0))
+    got = float(
+        pot._evaluate(
+            _toscalar(backend_name, 1.1),
+            _toscalar(backend_name, 0.23),
+            phi=_toscalar(backend_name, 0.4),
+            t=_toscalar(backend_name, t0),
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-15, atol=1e-15)
+
+
+# --- wrapper-of-wrapper chain -------------------------------------------------------
+_CHAIN = DehnenSmoothWrapperPotential(
+    pot=GaussianAmplitudeWrapperPotential(pot=_PP, to=0.5, sigma=1.3),
+    tform=-1.0,
+    tsteady=2.0,
+)
+
+
+@pytest.mark.parametrize("method", ["_evaluate", "_Rforce", "_zforce", "_R2deriv"])
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_chain_value_parity(backend_name, method):
+    for R, z, phi, t in _POINTS:
+        ref = float(getattr(_CHAIN, method)(R, z, phi=phi, t=t))
+        got = float(
+            getattr(_CHAIN, method)(
+                _toscalar(backend_name, R),
+                _toscalar(backend_name, z),
+                phi=_toscalar(backend_name, phi),
+                t=t,
+            )
+        )
+        numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_chain_jax_grad_and_jit():
+    R0, z0 = 1.1, 0.23
+    refF = -float(_CHAIN._Rforce(R0, z0, phi=0.0, t=0.15))
+    g = float(
+        jax.grad(lambda R: _CHAIN._evaluate(R, jnp.asarray(z0), phi=0.0, t=0.15))(
+            jnp.asarray(R0)
+        )
+    )
+    numpy.testing.assert_allclose(g, refF, rtol=1e-9)
+    jitted = float(
+        jax.jit(lambda R, z: _CHAIN._Rforce(R, z, phi=0.0, t=0.15))(
+            jnp.asarray(R0), jnp.asarray(z0)
+        )
+    )
+    numpy.testing.assert_allclose(jitted, -refF, rtol=1e-12)
+
+
+# --- planar (2D) wrappers -------------------------------------------------------------
+_PLANAR_WRAPPERS = [
+    (
+        "planar-DehnenSmooth",
+        DehnenSmoothWrapperPotential(pot=_PP.toPlanar(), tform=-1.0, tsteady=2.0),
+        ["_evaluate", "_Rforce", "_R2deriv"],
+    ),
+    (
+        "planar-SolidBody",
+        SolidBodyRotationWrapperPotential(pot=_SP.toPlanar(), omega=1.1, pa=0.3),
+        ["_evaluate", "_Rforce", "_phitorque", "_R2deriv", "_phi2deriv", "_Rphideriv"],
+    ),
+]
+
+
+def _iter_planar_cases():
+    for wid, w, methods in _PLANAR_WRAPPERS:
+        for m in methods:
+            yield pytest.param(w, m, id=f"{wid}-{m}")
+
+
+@pytest.mark.parametrize("pot,method", list(_iter_planar_cases()))
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_planar_value_parity(backend_name, pot, method):
+    for R, _, phi, t in _POINTS:
+        ref = float(getattr(pot, method)(R, phi=phi, t=t))
+        got = float(
+            getattr(pot, method)(
+                _toscalar(backend_name, R), phi=_toscalar(backend_name, phi), t=t
+            )
+        )
+        numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+# --- coords transforms under a forced backend default --------------------------------
+# All-scalar inputs with a forced (non-numpy) default exercise the
+# nothing-to-anchor-on path of the coords scalar promotion (jax handles plain
+# scalars natively; with x64 enabled the values match numpy's exactly).
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_coords_forced_backend_scalar_inputs():
+    from galpy import backend
+    from galpy.util import coords
+
+    ref_uv = coords.uv_to_Rz(1.2, 0.8, delta=0.5)
+    ref_cyl = coords.cyl_to_rect(1.1, 0.4, 0.23)
+    with backend.use("jax", force=True):
+        got_uv = coords.uv_to_Rz(1.2, 0.8, delta=0.5)
+        got_cyl = coords.cyl_to_rect(1.1, 0.4, 0.23)
+    numpy.testing.assert_allclose(
+        [float(g) for g in got_uv], [float(r) for r in ref_uv], rtol=1e-15
+    )
+    numpy.testing.assert_allclose(
+        [float(g) for g in got_cyl], [float(r) for r in ref_cyl], rtol=1e-15
+    )
+
+
+# --- RotateAndTilt R == inf branch ------------------------------------------------------
+@pytest.mark.parametrize(
+    "pot",
+    [w[1] for w in _WRAPPERS if w[0].startswith("RotateAndTilt")],
+    ids=[w[0] for w in _WRAPPERS if w[0].startswith("RotateAndTilt")],
+)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_rotateandtilt_Rinf(backend_name, pot):
+    ref = float(pot._evaluate(numpy.inf, 0.0, phi=0.3, t=0.0))
+    got = float(
+        pot._evaluate(
+            _toscalar(backend_name, numpy.inf),
+            _toscalar(backend_name, 0.0),
+            phi=_toscalar(backend_name, 0.3),
+            t=0.0,
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+    # finite-R autodiff is not poisoned by the guarded R == inf branch
+    if backend_name == "jax":
+        g = float(
+            jax.grad(
+                lambda R: pot._evaluate(
+                    R, jnp.asarray(0.1), phi=jnp.asarray(0.3), t=0.0
+                )
+            )(jnp.asarray(1.1))
+        )
+        assert numpy.isfinite(g)


### PR DESCRIPTION
Last Track-A family: all wrapper potentials now run and differentiate under numpy/jax/torch.

**Migrated**: DehnenSmooth (backend/traced t takes a branch-free `xp.where` path, numpy-scalar t keeps the original branching — DehnenBar precedent), GaussianAmplitude, RotateAndTilt (full 3D-rotation migration: dtype/device-anchored rot/inv_rot/offset constants, input-guarded `xp.where` for the R==inf branch), KuzminLike (ξ(R,z) under xp), OblateStaeckel (U/V reference-curve machinery + Staeckel prefactor helpers), CylindricallySeparable (anchored R′/z=0 reference coordinates), TimeDependentAmplitude (delegation, unused import removed). SolidBodyRotation/CorotatingRotation were already backend-clean arithmetic (no code change; fully tested). AdiabaticContraction *is* an `interpSphericalPotential` at runtime and inherits the #929 spline machinery (tests added following the interpspherical precedent). `WrapperPotential`/`parentWrapperPotential` delegation audited: passes backend arrays through untouched.

**Also**: five `util.coords` transforms the wrappers route through and that P0-util missed — `cyl_to_rect`, `rect_to_cyl`, `Rz_to_coshucosv`, `Rz_to_uv`, `uv_to_Rz` — migrated the same way (+ `_promote_scalars_for` anchoring plain scalars on the array args' dtype/device for torch).

**numpy byte-identity**: 14 wrapper configs × all private methods × dense (R,z,phi,t) grid + coords transforms = 18,822 values compared bitwise (`tobytes()`) against a pristine `origin/feat/backends` worktree: **zero non-identical values**. Behavioral (non-value) deltas, flagged for review:
- the five migrated coords functions now raise `TypeError` on plain-Python-list inputs (resolver rejects lists; matches the accepted P0 `cyl_to_spher` precedent; never used internally),
- some numpy-path intermediates become 0-d arrays where they were Python floats (`xp.where` outputs); all method outputs bit-equal,
- no new RuntimeWarnings at R==inf (the input-guard pattern avoids `inf*cos(phi)`).

**Tests**: new `tests/test_backend_wrappers.py` (474 passed): per-wrapper 3-backend value parity (incl. z=0 Staeckel line, t straddling the smoothing window), jax+torch grad-vs-FD + AD(eval)==−force identities, jit+vmap survival, torch gradcheck, child-relative dtype preservation, traced-t differentiability for the five time-modulation wrappers, wrapper-of-wrapper chain (DehnenSmooth∘GaussianAmplitude∘Plummer) parity+grad+jit. Full `tests/test_backend*.py`: 2069 passed. Existing numpy wrapper/coords/kuzminkutuzov/Staeckel-aa tests green.

Adversarially verified (independent byte-parity rerun, AD-quality stress incl. `xp.where` dead-branch audit at degenerate inputs, conventions sweep): no blockers. Pre-existing issues surfaced (not touched here): `WrapperPotential` repr drops the leading class-name character; RotateAndTilt wrapping a raw Python list fails in `_evaluatePotentials`; SpiralArms torch float32→float64 promotion. Happy to do these as a tiny follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)