### PR TITLE
Fix list-of-Potential input to wrapper potentials: upgrade through _check_potential_list_and_deprecate

### DIFF
--- a/galpy/potential/WrapperPotential.py
+++ b/galpy/potential/WrapperPotential.py
@@ -18,6 +18,7 @@ from .planarPotential import (
 from .Potential import (
     Force,
     Potential,
+    _check_potential_list_and_deprecate,
     _dim,
     _evaluatephitorques,
     _evaluatePotentials,
@@ -45,6 +46,11 @@ class parentWrapperPotential:
             return object.__new__(cls)
         # Decide whether superclass is Wrapper or planarWrapper based on dim
         pot = kwargs.get("pot", None)
+        if isinstance(pot, list):
+            # Upgrade deprecated list input to a CompositePotential
+            # (emits a DeprecationWarning)
+            pot = _check_potential_list_and_deprecate(pot)
+            kwargs["pot"] = pot
         if _dim(pot) == 2:
             parentWrapperPotential = planarWrapperPotential
         elif _dim(pot) == 3:
@@ -108,7 +114,9 @@ class WrapperPotential(Potential):
         if not _init:
             return None  # Don't run __init__ at the end of setup
         Potential.__init__(self, amp=amp, ro=ro, vo=vo)
-        self._pot = pot
+        # Upgrade deprecated list input to a CompositePotential (emits a
+        # DeprecationWarning); no-op for non-list input
+        self._pot = _check_potential_list_and_deprecate(pot)
         # Check that we are not wrapping a non-potential Force object
         if (
             isinstance(self._pot, (CompositePotential, list))
@@ -263,7 +271,9 @@ class planarWrapperPotential(planarPotential):
         if not _init:
             return None  # Don't run __init__ at the end of setup
         planarPotential.__init__(self, amp=amp, ro=ro, vo=vo)
-        self._pot = pot
+        # Upgrade deprecated list input to a CompositePotential (emits a
+        # DeprecationWarning); no-op for non-list input
+        self._pot = _check_potential_list_and_deprecate(pot)
         self.isNonAxi = _isNonAxi(self._pot)
         # Check whether units are consistent between the wrapper and the
         # wrapped potential

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -6259,6 +6259,102 @@ def test_WrapperPotential_dims():
     return None
 
 
+def test_Wrapper_list_of_potentials_deprecation():
+    # Test that passing a list of potentials to a wrapper (a) works, with
+    # values identical to passing the equivalent CompositePotential, and
+    # (b) emits a single DeprecationWarning, while non-list input emits none
+    # (see issue with RotateAndTiltWrapperPotential failing for pot=[pot1,pot2])
+    import warnings
+
+    from packaging.version import Version
+
+    import galpy
+
+    def list_deprecation_warnings(ws):
+        return [
+            wa
+            for wa in ws
+            if issubclass(wa.category, DeprecationWarning)
+            and "list of potentials" in str(wa.message)
+        ]
+
+    pot1 = potential.MiyamotoNagaiPotential(normalize=0.6)
+    pot2 = potential.LogarithmicHaloPotential(normalize=0.4)
+    wrappers = [
+        lambda pot: potential.RotateAndTiltWrapperPotential(
+            pot=pot, galaxy_pa=0.3, zvec=[numpy.sin(0.1), 0.0, numpy.cos(0.1)]
+        ),
+        lambda pot: potential.OblateStaeckelWrapperPotential(
+            pot=pot, delta=0.5, u0=1.0
+        ),
+        lambda pot: potential.CylindricallySeparablePotentialWrapper(pot=pot),
+        lambda pot: potential.KuzminLikeWrapperPotential(pot=pot),
+        lambda pot: potential.DehnenSmoothWrapperPotential(pot=pot),
+        lambda pot: potential.GaussianAmplitudeWrapperPotential(pot=pot),
+        lambda pot: potential.SolidBodyRotationWrapperPotential(pot=pot, omega=1.1),
+        lambda pot: potential.CorotatingRotationWrapperPotential(pot=pot, vpo=1.0),
+        lambda pot: potential.TimeDependentAmplitudeWrapperPotential(
+            pot=pot, A=lambda t: 1.0
+        ),
+    ]
+    current_version = Version(galpy.__version__.split(".dev")[0])
+    for wrapper in wrappers:
+        if current_version > Version("1.13.99"):  # pragma: no cover
+            # After 1.13.x, list input should raise TypeError
+            with pytest.raises(TypeError):
+                wrapper([pot1, pot2])
+        else:
+            # Before 1.13.x, list input should work with a single
+            # DeprecationWarning
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                wrap_list = wrapper([pot1, pot2])
+                val_list = wrap_list(1.1, 0.2, phi=0.3, use_physical=False)
+            assert len(list_deprecation_warnings(w)) == 1, (
+                "Passing a list of potentials to a wrapper did not raise a single DeprecationWarning"
+            )
+            # Non-list input should emit no DeprecationWarning
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                wrap_comp = wrapper(pot1 + pot2)
+                val_comp = wrap_comp(1.1, 0.2, phi=0.3, use_physical=False)
+            assert len(list_deprecation_warnings(w)) == 0, (
+                "Passing a non-list potential to a wrapper raised a DeprecationWarning"
+            )
+            assert val_list == val_comp, (
+                "Wrapper of a list of potentials does not agree with wrapper of the equivalent CompositePotential"
+            )
+    # Also test the planar path
+    if current_version > Version("1.13.99"):  # pragma: no cover
+        with pytest.raises(TypeError):
+            potential.DehnenSmoothWrapperPotential(
+                pot=[pot1.toPlanar(), pot2.toPlanar()]
+            )
+    else:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrap_list = potential.DehnenSmoothWrapperPotential(
+                pot=[pot1.toPlanar(), pot2.toPlanar()]
+            )
+            val_list = wrap_list(1.1, phi=0.3, use_physical=False)
+        assert len(list_deprecation_warnings(w)) == 1, (
+            "Passing a list of planar potentials to a wrapper did not raise a single DeprecationWarning"
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wrap_comp = potential.DehnenSmoothWrapperPotential(
+                pot=pot1.toPlanar() + pot2.toPlanar()
+            )
+            val_comp = wrap_comp(1.1, phi=0.3, use_physical=False)
+        assert len(list_deprecation_warnings(w)) == 0, (
+            "Passing a non-list planar potential to a wrapper raised a DeprecationWarning"
+        )
+        assert val_list == val_comp, (
+            "Wrapper of a list of planar potentials does not agree with wrapper of the equivalent planarCompositePotential"
+        )
+    return None
+
+
 def test_Wrapper_potinputerror():
     # Test that setting up a WrapperPotential with anything other than a
     # (list of) planar/Potentials raises an error


### PR DESCRIPTION
On main, **every** wrapper potential fails when given a plain list of potentials: the factory-path wrappers (DehnenSmooth, GaussianAmplitude, SolidBodyRotation, CorotatingRotation, TimeDependentAmplitude) crash in `parentWrapperPotential.__new__` at `_dim(pot)` (`AttributeError: 'list' object has no attribute 'dim'`), and the direct 3D-only subclasses (RotateAndTilt, KuzminLike) construct fine but crash at first evaluation in the raw `_evaluatePotentials` helper (masked as `PotentialError: '_evaluate' function not implemented`). OblateStaeckel and CylindricallySeparable fail like the factory ones.

Fix at the shared altitude in `WrapperPotential.py`, using the canonical upgrade function `_check_potential_list_and_deprecate` (the same one used by streamspraydf, quasiisothermaldf, sphericaldf, actionAngleTorus, jeans, verticalPotential): once in `parentWrapperPotential.__new__` (before `_dim`, stored back into kwargs so all downstream code sees the `CompositePotential`) and once each in `WrapperPotential.__init__`/`planarWrapperPotential.__init__` for the direct subclasses. List input emits the standard DeprecationWarning exactly once; non-list input is a pure pass-through (no warning, byte-identical values); after 1.13.99 the same function raises TypeError, consistent with all other entry points.

Tests: `test_Wrapper_list_of_potentials_deprecation` covers all 9 wrappers (3D) + the planar path — list input works with values exactly equal to the equivalent `CompositePotential`, exactly one warning, none for non-list input; verified to fail on unpatched main. Existing wrapper/deprecation/actionAngle/quantity batteries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)