### PR TITLE
Fix wrapper repr for direct WrapperPotential subclasses (eaten first character)

### DIFF
--- a/galpy/potential/WrapperPotential.py
+++ b/galpy/potential/WrapperPotential.py
@@ -149,7 +149,10 @@ class WrapperPotential(Potential):
             )
 
         # Build own parameter string (excluding pot, ro, vo, _init)
-        class_name = type(self).__name__[1:]
+        # Factory-created wrapper instance classes carry a leading underscore
+        # (see parentWrapperPotential.__new__); direct subclasses (e.g.,
+        # RotateAndTiltWrapperPotential, KuzminLikeWrapperPotential) do not
+        class_name = type(self).__name__.removeprefix("_")
         params = _build_params_string(
             self, exclude_params=["self", "ro", "vo", "pot", "_init"]
         )
@@ -291,7 +294,10 @@ class planarWrapperPotential(planarPotential):
             )
 
         # Build own parameter string (excluding pot, ro, vo, _init)
-        class_name = type(self).__name__[1:]
+        # Factory-created wrapper instance classes carry a leading underscore
+        # (see parentWrapperPotential.__new__); direct subclasses (e.g.,
+        # RotateAndTiltWrapperPotential, KuzminLikeWrapperPotential) do not
+        class_name = type(self).__name__.removeprefix("_")
         params = _build_params_string(
             self, exclude_params=["self", "ro", "vo", "pot", "_init"]
         )

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1821,6 +1821,161 @@ def test_repr_wrapper_classes():
     return None
 
 
+# Test that wrapper reprs start with the exact public class name, both for
+# wrappers created through the parentWrapperPotential factory (whose instance
+# classes carry a leading underscore, e.g., _DehnenSmoothWrapperPotential) and
+# for direct WrapperPotential subclasses (RotateAndTiltWrapperPotential,
+# KuzminLikeWrapperPotential), which have no underscore to strip; regression
+# test for the repr eating the first character of direct subclasses' names
+@pytest.mark.parametrize(
+    "setup_wrapper,class_name,expected_params",
+    [
+        (
+            lambda: potential.DehnenSmoothWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                tform=-4.0,
+                tsteady=1.0,
+            ),
+            "DehnenSmoothWrapperPotential",
+            ["tform=-4.0", "tsteady=-3.0"],
+        ),
+        (
+            lambda: potential.DehnenSmoothWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0).toPlanar(),
+                tform=-4.0,
+                tsteady=1.0,
+            ),
+            "DehnenSmoothWrapperPotential",
+            ["tform=-4.0", "tsteady=-3.0"],
+        ),
+        (
+            lambda: potential.SolidBodyRotationWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                omega=1.1,
+                pa=0.3,
+            ),
+            "SolidBodyRotationWrapperPotential",
+            ["omega=1.1", "pa=0.3"],
+        ),
+        (
+            lambda: potential.SolidBodyRotationWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0).toPlanar(),
+                omega=1.1,
+                pa=0.3,
+            ),
+            "SolidBodyRotationWrapperPotential",
+            ["omega=1.1", "pa=0.3"],
+        ),
+        (
+            lambda: potential.GaussianAmplitudeWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                to=1.0,
+                sigma=1.0,
+            ),
+            "GaussianAmplitudeWrapperPotential",
+            ["to=1.0"],
+        ),
+        (
+            lambda: potential.GaussianAmplitudeWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0).toPlanar(),
+                to=1.0,
+                sigma=1.0,
+            ),
+            "GaussianAmplitudeWrapperPotential",
+            ["to=1.0"],
+        ),
+        (
+            lambda: potential.RotateAndTiltWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                zvec=[0.0, 1.0 / numpy.sqrt(2.0), 1.0 / numpy.sqrt(2.0)],
+                galaxy_pa=0.3,
+            ),
+            "RotateAndTiltWrapperPotential",
+            ["amp=1.0"],
+        ),
+        (
+            lambda: potential.KuzminLikeWrapperPotential(
+                pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                a=1.1,
+                b=0.2,
+            ),
+            "KuzminLikeWrapperPotential",
+            ["a=1.1", "b=0.2"],
+        ),
+        (
+            lambda: potential.DehnenSmoothWrapperPotential(
+                pot=potential.GaussianAmplitudeWrapperPotential(
+                    pot=potential.MiyamotoNagaiPotential(normalize=1.0),
+                    to=1.0,
+                    sigma=1.0,
+                ),
+                tform=-4.0,
+                tsteady=1.0,
+            ),
+            "DehnenSmoothWrapperPotential",
+            ["tform=-4.0", "GaussianAmplitudeWrapperPotential"],
+        ),
+    ],
+    ids=[
+        "DehnenSmooth-3D",
+        "DehnenSmooth-planar",
+        "SolidBodyRotation-3D",
+        "SolidBodyRotation-planar",
+        "GaussianAmplitude-3D",
+        "GaussianAmplitude-planar",
+        "RotateAndTilt-directsubclass",
+        "KuzminLike-directsubclass",
+        "DehnenSmooth-of-GaussianAmplitude",
+    ],
+)
+def test_repr_wrapper_class_name(setup_wrapper, class_name, expected_params):
+    """Test that wrapper reprs start with the exact public class name for both
+    factory-created wrappers and direct WrapperPotential subclasses"""
+    wrap = setup_wrapper()
+    repr_str = repr(wrap)
+    assert repr_str.startswith(class_name), (
+        f"Expected repr to start with '{class_name}', got '{repr_str}'"
+    )
+    assert not repr_str.startswith("_"), (
+        f"Did not expect repr to start with an underscore, got '{repr_str}'"
+    )
+    for param in expected_params:
+        assert param in repr_str, f"Expected '{param}' in repr, got '{repr_str}'"
+    # str should agree with repr, as for all other potentials
+    assert str(wrap) == repr_str, (
+        f"Expected str to equal repr, got str '{str(wrap)}' and repr '{repr_str}'"
+    )
+    return None
+
+
+# Test that both factory-created wrappers and direct WrapperPotential
+# subclasses survive a pickle round trip and evaluate identically
+def test_wrapper_pickling():
+    import pickle
+
+    # Factory-created wrapper (instance class built in parentWrapperPotential)
+    dwrap = potential.DehnenSmoothWrapperPotential(
+        pot=potential.MiyamotoNagaiPotential(normalize=1.0), tform=-4.0, tsteady=1.0
+    )
+    dwrap_pickled = pickle.loads(pickle.dumps(dwrap))
+    assert (
+        numpy.fabs(
+            dwrap(1.1, 0.2, phi=0.3, t=0.5) - dwrap_pickled(1.1, 0.2, phi=0.3, t=0.5)
+        )
+        < 10.0**-10.0
+    ), "Pickled DehnenSmoothWrapperPotential does not evaluate as the original"
+    # Direct WrapperPotential subclass (no factory, no underscore)
+    kwrap = potential.KuzminLikeWrapperPotential(
+        pot=potential.MiyamotoNagaiPotential(normalize=1.0), a=1.1, b=0.2
+    )
+    kwrap_pickled = pickle.loads(pickle.dumps(kwrap))
+    assert (
+        numpy.fabs(kwrap(1.1, 0.2, phi=0.3) - kwrap_pickled(1.1, 0.2, phi=0.3))
+        < 10.0**-10.0
+    ), "Pickled KuzminLikeWrapperPotential does not evaluate as the original"
+    return None
+
+
 # Test whether potentials that support array input do so correctly
 def test_potential_array_input():
     # Grab all of the potentials


### PR DESCRIPTION
`WrapperPotential.__repr__` and `planarWrapperPotential.__repr__` strip the leading character of the class name unconditionally (`type(self).__name__[1:]`), written for the factory-created instance classes from `parentWrapperPotential.__new__`, which carry a leading underscore (`_DehnenSmoothWrapperPotential` — that mechanism is intact, for both 3D and planar instances). But `RotateAndTiltWrapperPotential` and `KuzminLikeWrapperPotential` are deliberate 3D-only **direct** subclasses (no factory, no underscore), so their repr printed `'otateAndTiltWrapperPotential with internal parameters: …'`.

Regression from the enhanced-repr PR #804 (first released v1.11.2); that PR's `_repr_utils._build_params_string` already handles the distinction conditionally — only the two `__repr__` methods hard-sliced, and #804's tests covered only a factory wrapper. Fix: `type(self).__name__.removeprefix("_")` at both sites, mirroring `_repr_utils`.

Tests: parametrized repr/str over factory wrappers × {3D, planar} (DehnenSmooth, SolidBodyRotation, GaussianAmplitude), both direct subclasses, and a wrapper-of-wrapper — asserting the exact public class name and parameter substrings; plus pickle round-trips for one factory and one direct wrapper. With the fix stashed, exactly the two direct-subclass cases fail with the eaten-character repr; all 10 pass with it. Existing repr (14) and wrapper (34) batteries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)