### PR TITLE
Backend f32 policy: table-backed potentials cast to input dtype at exit (f64 interior preserved)

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -7,7 +7,12 @@
 #   of the array arguments), with an explicit ``xp=`` override and a
 #   context-manager/global default as fallbacks. See ``_resolver`` for details.
 ###############################################################################
-from ._namespaces import is_backend_array, match_input_dtype
+from ._namespaces import (
+    asarray_on_device,
+    device_of,
+    is_backend_array,
+    match_input_dtype,
+)
 from ._resolver import (
     _seed_from_config,
     backend,
@@ -26,4 +31,6 @@ __all__ = [
     "set_default_backend",
     "is_backend_array",
     "match_input_dtype",
+    "device_of",
+    "asarray_on_device",
 ]

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -7,7 +7,7 @@
 #   of the array arguments), with an explicit ``xp=`` override and a
 #   context-manager/global default as fallbacks. See ``_resolver`` for details.
 ###############################################################################
-from ._namespaces import is_backend_array
+from ._namespaces import is_backend_array, match_input_dtype
 from ._resolver import (
     _seed_from_config,
     backend,
@@ -25,4 +25,5 @@ __all__ = [
     "use",
     "set_default_backend",
     "is_backend_array",
+    "match_input_dtype",
 ]

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -47,6 +47,72 @@ def is_backend_array(x):
     return False
 
 
+def _is_floating_dtype(dtype):
+    """True for real floating-point dtypes of any backend.
+
+    numpy and jax expose numpy dtypes (checked via ``numpy.issubdtype``);
+    torch dtypes expose an ``is_floating_point`` attribute (which for torch is
+    False for complex dtypes, matching ``numpy.floating``).
+    """
+    is_fp = getattr(dtype, "is_floating_point", None)
+    if is_fp is not None:  # torch.dtype
+        return bool(is_fp)
+    try:
+        return numpy.issubdtype(dtype, numpy.floating)
+    except TypeError:  # pragma: no cover - defensive: not a dtype-like
+        return False
+
+
+def match_input_dtype(out, *coords):
+    """Cast ``out`` to the common (result) dtype of the coordinate inputs.
+
+    Potentials whose interiors deliberately work in float64 (expansion-
+    coefficient tables, Ogata quadrature nodes/weights, spline coefficients --
+    SCF, DoubleExponentialDisk, interpSpherical, MultipoleExpansion) call this
+    at compute-method exit so that float32 coordinates give a float32 result
+    computed at float64 quality (the tables are *not* anchored to the input
+    dtype). The function is a strict no-op -- returning the ``out`` object
+    itself -- when no coordinate carries a floating dtype (plain Python
+    scalars), when ``out`` has no real floating dtype, or when the dtypes
+    already match; in particular the float64 numpy path returns its result
+    object unchanged (bit-identical). Mixed floating input dtypes resolve via
+    the namespace's ``result_type``. When a cast is needed it uses the
+    namespace's ``astype`` (differentiable under jax/torch, so autodiff flows
+    through it).
+    """
+    out_dtype = getattr(out, "dtype", None)
+    if (out_dtype is None and not isinstance(out, float)) or (
+        out_dtype is not None and not _is_floating_dtype(out_dtype)
+    ):
+        return out
+    dtypes = [
+        dtype
+        for dtype in (getattr(coord, "dtype", None) for coord in coords)
+        if dtype is not None and _is_floating_dtype(dtype)
+    ]
+    if not dtypes:
+        return out
+    if out_dtype is None:
+        # Plain Python float output (float64 by construction; e.g. the scalar
+        # _dens path of MultipoleExpansion): cast only when the coordinates
+        # all carry a NARROWER floating dtype, so that float64 and plain-
+        # scalar inputs keep the plain-float return type bit-identically
+        target = dtypes[0] if all(d == dtypes[0] for d in dtypes) else None
+        if target is not None and target != numpy.float64:
+            return numpy.asarray(out, dtype=target)[()]
+        return out
+    if all(dtype == dtypes[0] for dtype in dtypes):
+        target = dtypes[0]
+    else:
+        target = namespace_from_arrays((out,)).result_type(*dtypes)
+    if target == out_dtype:
+        return out
+    if isinstance(out, (numpy.ndarray, numpy.generic)):
+        # plain numpy: ndarray.astype works on every supported numpy version
+        return out.astype(target)
+    return namespace_from_arrays((out,)).astype(out, target)
+
+
 def namespace_for_name(name):
     """Map a backend name ('numpy'|'jax'|'torch') to its array namespace module.
 

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -113,6 +113,42 @@ def match_input_dtype(out, *coords):
     return namespace_from_arrays((out,)).astype(out, target)
 
 
+def device_of(*coords):
+    """Return the device of the first backend (jax/torch) array in ``coords``.
+
+    The table-backed potentials anchor their stored numpy constant tables
+    (expansion coefficients, quadrature nodes/weights, spline coefficients) on
+    the device of the coordinate inputs through this helper: a plain
+    ``xp.asarray(table)`` materializes on the CPU, and torch raises a
+    mixed-device error when CUDA coordinates meet a CPU table. Plain Python
+    scalars, numpy arrays, and traced values (jax tracers expose no concrete
+    ``device``) yield None, which makes ``asarray_on_device`` omit the
+    ``device`` keyword entirely -- so the numpy path keeps issuing the exact
+    same ``asarray`` call as before (byte-identical, and safe on numpy
+    versions without an ``asarray`` device keyword), and device placement
+    under jit tracing is left to the tracer.
+    """
+    for coord in coords:
+        if is_backend_array(coord):
+            device = getattr(coord, "device", None)
+            if device is not None:
+                return device
+    return None
+
+
+def asarray_on_device(xp, a, device, dtype=None):
+    """``xp.asarray(a, dtype=dtype)`` placed on ``device`` when one is given.
+
+    ``device`` is the result of ``device_of`` on the coordinate inputs; when
+    it is None (numpy arrays, plain scalars, traced values) the keyword is
+    omitted so the call reduces to today's plain ``xp.asarray`` (and
+    ``dtype=None`` is the default pass-through on every backend).
+    """
+    if device is None:
+        return xp.asarray(a, dtype=dtype)
+    return xp.asarray(a, dtype=dtype, device=device)
+
+
 def namespace_for_name(name):
     """Map a backend name ('numpy'|'jax'|'torch') to its array namespace module.
 

--- a/galpy/backend/special/_fallback/bessel_k.py
+++ b/galpy/backend/special/_fallback/bessel_k.py
@@ -23,6 +23,8 @@
 ###############################################################################
 import numpy
 
+from ..._namespaces import asarray_on_device, device_of
+
 _GAMMA = 0.5772156649015328606  # Euler-Mascheroni
 _NSERIES = 30  # ascending-series terms (x <= 2)
 _TRAP_H = 0.25  # trapezoidal step (in the 1/sqrt(x)-scaled variable)
@@ -63,8 +65,11 @@ def _k01(xp, x):
     K1s = 1.0 / xs + xp.log(xs / 2.0) * i1(xs) - (xs / 2.0) * s1
 
     # --- peak-resolving scaled trapezoidal (x > 2) ---
-    nodes = xp.asarray(_TRAP_NODES)
-    weights = xp.asarray(_TRAP_W)
+    # node/weight tables stay float64 (precision is the point; the router
+    # exit-casts) but must live on the input's device (CUDA support)
+    dev = device_of(x)
+    nodes = asarray_on_device(xp, _TRAP_NODES, dev)
+    weights = asarray_on_device(xp, _TRAP_W, dev)
     sc = 1.0 / xp.sqrt(xt)
     t = sc[..., None] * nodes  # (..., N+1)
     cosh_t = xp.cosh(t)

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -23,6 +23,7 @@
 ###############################################################################
 import math
 
+from ..._namespaces import asarray_on_device, device_of
 from ._quadrature import gauss_legendre_01
 
 # 128 nodes: ~1e-10 or better vs scipy at realistic radii (|z| = r/a <~ 50);
@@ -68,9 +69,12 @@ def hyp2f1_fallback(xp, a, b, c, z):
     k = min(12.0, max(1.0, float(math.ceil(6.0 / B))))
     pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(q))
 
+    # node/weight tables stay float64 (precision is the point; the router
+    # exit-casts) but must live on the input's device (CUDA support)
     nodes, weights = gauss_legendre_01(_NODES)
-    xg = xp.asarray(nodes)
-    wg = xp.asarray(weights)
+    dev = device_of(z)
+    xg = asarray_on_device(xp, nodes, dev)
+    wg = asarray_on_device(xp, weights, dev)
     X = xg**k
     dX = k * xg ** (k - 1.0)
 

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -4,6 +4,7 @@
 ###############################################################################
 import numpy
 
+from .._namespaces import match_input_dtype
 from .._resolver import get_namespace
 
 # Per-backend functions whose NATIVE implementation is simply absent, so the
@@ -89,7 +90,15 @@ def _dispatch(fnname, args, fallback, ns_args=None):
                     for a in args
                 )
         return getattr(sp, fnname)(*args)
-    return fallback(xp, *args)
+    # The fallbacks' constant tables (Gauss-Legendre / trapezoid quadrature
+    # nodes and weights) are deliberately float64 -- precision is the point --
+    # which under torch/jax promotes float32 inputs to float64. Cast the
+    # result back to the input dtype at exit (float32 in -> float32 out at
+    # float64 quality; a strict no-op for float64 inputs, and the numpy
+    # backend never reaches the fallbacks since scipy.special is complete).
+    return match_input_dtype(
+        fallback(xp, *args), *(args if ns_args is None else ns_args)
+    )
 
 
 def _no_fallback(fnname):

--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -7,7 +7,12 @@
 import numpy
 from scipy import special
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import (
+    asarray_on_device,
+    device_of,
+    get_namespace,
+    match_input_dtype,
+)
 from ..util import conversion
 from .Potential import Potential, check_potential_inputs_not_arrays
 
@@ -175,8 +180,11 @@ class DoubleExponentialDiskPotential(Potential):
         xp = get_namespace(R, z)
         # the Ogata quadrature nodes/weights are deliberately float64
         # (precision); the result is cast to the input dtype at exit (no-op
-        # for float64/scalar inputs), so keep the original inputs for that
+        # for float64/scalar inputs), so keep the original inputs for that.
+        # The tables are anchored on the input's device (CUDA support; None
+        # for numpy/scalars, leaving the numpy path byte-identical).
         in_coords = (R, z, phi, t)
+        dev = device_of(R, z)
         if isinstance(R, (float, int)):
             floatIn = True
             R = xp.atleast_1d(xp.asarray(R))
@@ -210,7 +218,10 @@ class DoubleExponentialDiskPotential(Potential):
             / Rs
             * _de_quadsum(
                 xp,
-                (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights)),
+                (
+                    fun(asarray_on_device(xp, self._de_j0_xs, dev)),
+                    asarray_on_device(xp, self._de_j0_weights, dev),
+                ),
                 axis=1,
             )
         )
@@ -249,6 +260,8 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 Ogata tables anchored on the input's device (see _evaluate)
+        dev = device_of(R, z)
         fun = lambda x: (
             x
             * (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
@@ -265,7 +278,11 @@ class DoubleExponentialDiskPotential(Potential):
             * self._alpha
             / R**2.0
             * _de_quadsum(
-                xp, (fun(xp.asarray(self._de_j1_xs)), xp.asarray(self._de_j1_weights))
+                xp,
+                (
+                    fun(asarray_on_device(xp, self._de_j1_xs, dev)),
+                    asarray_on_device(xp, self._de_j1_weights, dev),
+                ),
             ),
             R,
             z,
@@ -301,6 +318,8 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 Ogata tables anchored on the input's device (see _evaluate)
+        dev = device_of(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * x
@@ -315,7 +334,11 @@ class DoubleExponentialDiskPotential(Potential):
             * self._beta
             / R
             * _de_quadsum(
-                xp, (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights))
+                xp,
+                (
+                    fun(asarray_on_device(xp, self._de_j0_xs, dev)),
+                    asarray_on_device(xp, self._de_j0_weights, dev),
+                ),
             )
         )
         # Odd in z: out for z > 0, -out otherwise. The +-1.0 factor is exact
@@ -350,6 +373,8 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 Ogata tables anchored on the input's device (see _evaluate)
+        dev = device_of(R, z)
         fun = lambda x: (
             x**2
             * (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
@@ -367,12 +392,16 @@ class DoubleExponentialDiskPotential(Potential):
             / R**3.0
             * _de_quadsum(
                 xp,
-                (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights)),
+                (
+                    fun(asarray_on_device(xp, self._de_j0_xs, dev)),
+                    asarray_on_device(xp, self._de_j0_weights, dev),
+                ),
                 # f1*w1 - f2*w2 as f1*w1 + (-f2)*w2: bitwise-identical ((-a)*b
                 # == -(a*b) and x + (-y) == x - y exactly in IEEE arithmetic).
                 (
-                    -fun(xp.asarray(self._de_j1_xs)) / xp.asarray(self._de_j1_xs),
-                    xp.asarray(self._de_j1_weights),
+                    -fun(asarray_on_device(xp, self._de_j1_xs, dev))
+                    / asarray_on_device(xp, self._de_j1_xs, dev),
+                    asarray_on_device(xp, self._de_j1_weights, dev),
                 ),
             ),
             R,
@@ -408,6 +437,8 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 Ogata tables anchored on the input's device (see _evaluate)
+        dev = device_of(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * x
@@ -426,7 +457,11 @@ class DoubleExponentialDiskPotential(Potential):
             * self._beta
             / R
             * _de_quadsum(
-                xp, (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights))
+                xp,
+                (
+                    fun(asarray_on_device(xp, self._de_j0_xs, dev)),
+                    asarray_on_device(xp, self._de_j0_weights, dev),
+                ),
             ),
             R,
             z,
@@ -461,6 +496,8 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 Ogata tables anchored on the input's device (see _evaluate)
+        dev = device_of(R, z)
         fun = lambda x: (
             (self._alpha**2.0 + (x / R) ** 2.0) ** -1.5
             * (x / R) ** 2.0
@@ -474,7 +511,11 @@ class DoubleExponentialDiskPotential(Potential):
             * self._beta
             / R
             * _de_quadsum(
-                xp, (fun(xp.asarray(self._de_j1_xs)), xp.asarray(self._de_j1_weights))
+                xp,
+                (
+                    fun(asarray_on_device(xp, self._de_j1_xs, dev)),
+                    asarray_on_device(xp, self._de_j1_weights, dev),
+                ),
             )
         )
         # Odd in z (see _zforce): exact +-1.0 factor instead of an if on z.

--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -7,7 +7,7 @@
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import get_namespace, match_input_dtype
 from ..util import conversion
 from .Potential import Potential, check_potential_inputs_not_arrays
 
@@ -173,6 +173,10 @@ class DoubleExponentialDiskPotential(Potential):
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # the Ogata quadrature nodes/weights are deliberately float64
+        # (precision); the result is cast to the input dtype at exit (no-op
+        # for float64/scalar inputs), so keep the original inputs for that
+        in_coords = (R, z, phi, t)
         if isinstance(R, (float, int)):
             floatIn = True
             R = xp.atleast_1d(xp.asarray(R))
@@ -213,9 +217,9 @@ class DoubleExponentialDiskPotential(Potential):
         out = xp.where((R == 0) & (z == 0), float(self._pot_zero), out)
         out = xp.where((R == 0) & (z != 0), numpy.nan, out)
         if floatIn:
-            return out[0]
+            return match_input_dtype(out[0], *in_coords)
         else:
-            return xp.reshape(out, outShape)
+            return match_input_dtype(xp.reshape(out, outShape), *in_coords)
 
     @check_potential_inputs_not_arrays
     def _Rforce(self, R, z, phi=0.0, t=0.0):
@@ -254,14 +258,19 @@ class DoubleExponentialDiskPotential(Potential):
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
-        return (
+        # float64 quadrature interior, input-dtype exit cast (see _evaluate)
+        return match_input_dtype(
             -4.0
             * numpy.pi
             * self._alpha
             / R**2.0
             * _de_quadsum(
                 xp, (fun(xp.asarray(self._de_j1_xs)), xp.asarray(self._de_j1_weights))
-            )
+            ),
+            R,
+            z,
+            phi,
+            t,
         )
 
     @check_potential_inputs_not_arrays
@@ -311,7 +320,8 @@ class DoubleExponentialDiskPotential(Potential):
         )
         # Odd in z: out for z > 0, -out otherwise. The +-1.0 factor is exact
         # (mult by +-1.0 is bitwise) and, unlike an if on z, jit-traceable.
-        return out * (2.0 * (z > 0.0) - 1.0)
+        # float64 quadrature interior, input-dtype exit cast (see _evaluate)
+        return match_input_dtype(out * (2.0 * (z > 0.0) - 1.0), R, z, phi, t)
 
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
@@ -349,7 +359,8 @@ class DoubleExponentialDiskPotential(Potential):
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
-        return (
+        # float64 quadrature interior, input-dtype exit cast (see _evaluate)
+        return match_input_dtype(
             4.0
             * numpy.pi
             * self._alpha
@@ -363,7 +374,11 @@ class DoubleExponentialDiskPotential(Potential):
                     -fun(xp.asarray(self._de_j1_xs)) / xp.asarray(self._de_j1_xs),
                     xp.asarray(self._de_j1_weights),
                 ),
-            )
+            ),
+            R,
+            z,
+            phi,
+            t,
         )
 
     @check_potential_inputs_not_arrays
@@ -403,7 +418,8 @@ class DoubleExponentialDiskPotential(Potential):
             )
             / (self._beta**2.0 - (x / R) ** 2.0)
         )
-        return (
+        # float64 quadrature interior, input-dtype exit cast (see _evaluate)
+        return match_input_dtype(
             -4.0
             * numpy.pi
             * self._alpha
@@ -411,7 +427,11 @@ class DoubleExponentialDiskPotential(Potential):
             / R
             * _de_quadsum(
                 xp, (fun(xp.asarray(self._de_j0_xs)), xp.asarray(self._de_j0_weights))
-            )
+            ),
+            R,
+            z,
+            phi,
+            t,
         )
 
     @check_potential_inputs_not_arrays
@@ -458,7 +478,8 @@ class DoubleExponentialDiskPotential(Potential):
             )
         )
         # Odd in z (see _zforce): exact +-1.0 factor instead of an if on z.
-        return out * (2.0 * (z > 0.0) - 1.0)
+        # float64 quadrature interior, input-dtype exit cast (see _evaluate)
+        return match_input_dtype(out * (2.0 * (z > 0.0) - 1.0), R, z, phi, t)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -14,7 +14,7 @@ from scipy.interpolate import (
     make_interp_spline,
 )
 
-from ..backend import get_namespace
+from ..backend import get_namespace, match_input_dtype
 from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -1232,19 +1232,26 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2026-06-09 - Added jax/torch evaluation path - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # the expansion tables are deliberately float64 (precision); cast the
+        # result to the input dtype at exit (no-op for float64/scalar inputs)
         if xp is not numpy:
             if not self.isNonAxi and phi is None:
                 phi = 0.0
-            return self._backend_evaluate(xp, R, z, phi, t)
+            return match_input_dtype(
+                self._backend_evaluate(xp, R, z, phi, t), R, z, phi, t
+            )
         if not self.isNonAxi and phi is None:
             phi = 0.0
+        in_coords = (R, z, phi, t)
         R = numpy.array(R, dtype=float)
         z = numpy.array(z, dtype=float)
         phi = numpy.array(phi, dtype=float)
         t = numpy.array(t, dtype=float)
         shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape, t.shape)
         if shape == ():
-            return self._evaluate_at_point(R, z, phi, t=t)
+            return match_input_dtype(
+                self._evaluate_at_point(R, z, phi, t=t), *in_coords
+            )
         R = R * numpy.ones(shape)
         z = z * numpy.ones(shape)
         phi = phi * numpy.ones(shape)
@@ -1252,7 +1259,7 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         result = numpy.zeros(shape, float)
         for idx in numpy.ndindex(*shape):
             result[idx] = self._evaluate_at_point(R[idx], z[idx], phi[idx], t=t[idx])
-        return result
+        return match_input_dtype(result, *in_coords)
 
     def _below_grid_integrals(self, r, l, I_inner_spline, I_outer_spline):
         """Compute extended I_inner and I_outer for r < rmin.
@@ -1632,25 +1639,27 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2026-06-09 - Added jax/torch evaluation path - Bovy (UofT)
         """
         xp = get_namespace(R, z)
+        # float64 table interior, input-dtype exit cast (see _evaluate)
         if xp is not numpy:
-            return self._backend_dens(xp, R, z, phi, t)
+            return match_input_dtype(self._backend_dens(xp, R, z, phi, t), R, z, phi, t)
         if self._tdep:
             self._ensure_rho_for_time(t)
         if not self.isNonAxi and phi is None:
             phi = 0.0
+        in_coords = (R, z, phi, t)
         R = numpy.array(R, dtype=float)
         z = numpy.array(z, dtype=float)
         phi = numpy.array(phi, dtype=float)
         shape = numpy.broadcast_shapes(R.shape, z.shape, phi.shape)
         if shape == ():
-            return self._dens_at_point(R, z, phi)
+            return match_input_dtype(self._dens_at_point(R, z, phi), *in_coords)
         R = R * numpy.ones(shape)
         z = z * numpy.ones(shape)
         phi = phi * numpy.ones(shape)
         result = numpy.zeros(shape, float)
         for idx in numpy.ndindex(*shape):
             result[idx] = self._dens_at_point(R[idx], z[idx], phi[idx])
-        return result
+        return match_input_dtype(result, *in_coords)
 
     def _ensure_rho_for_time(self, t):
         """Lazy rho spline creation for time-dependent density evaluation.
@@ -2032,25 +2041,35 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
     def _Rforce(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z)
         if xp is not numpy:
-            return self._backend_cyl_force(xp, "R", R, z, phi, t)
+            # float64 table interior, input-dtype exit cast (see _evaluate);
+            # the numpy path inherits the same cast from the mixin
+            return match_input_dtype(
+                self._backend_cyl_force(xp, "R", R, z, phi, t), R, z, phi, t
+            )
         return SphericalHarmonicPotentialMixin._Rforce(self, R, z, phi=phi, t=t)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if xp is not numpy:
-            return self._backend_cyl_force(xp, "z", R, z, phi, t)
+            return match_input_dtype(
+                self._backend_cyl_force(xp, "z", R, z, phi, t), R, z, phi, t
+            )
         return SphericalHarmonicPotentialMixin._zforce(self, R, z, phi=phi, t=t)
 
     def _phitorque(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z)
         if xp is not numpy:
-            return self._backend_cyl_force(xp, "phi", R, z, phi, t)
+            return match_input_dtype(
+                self._backend_cyl_force(xp, "phi", R, z, phi, t), R, z, phi, t
+            )
         return SphericalHarmonicPotentialMixin._phitorque(self, R, z, phi=phi, t=t)
 
     def _evaluate_cyl_2nd_deriv(self, deriv_type, R, z, phi, t=0.0):
         xp = get_namespace(R, z)
         if xp is not numpy:
-            return self._backend_cyl_2nd_deriv(xp, deriv_type, R, z, phi, t)
+            return match_input_dtype(
+                self._backend_cyl_2nd_deriv(xp, deriv_type, R, z, phi, t), R, z, phi, t
+            )
         return SphericalHarmonicPotentialMixin._evaluate_cyl_2nd_deriv(
             self, deriv_type, R, z, phi, t=t
         )

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -14,7 +14,12 @@ from scipy.interpolate import (
     make_interp_spline,
 )
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import (
+    asarray_on_device,
+    device_of,
+    get_namespace,
+    match_input_dtype,
+)
 from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -2121,7 +2126,8 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         extrapolation constants of _below_grid_integrals / _eval_R_lm, and
         the FITPACK density splines to cubic PPoly pieces. All entries are
         plain numpy arrays/floats; the evaluators convert them to the active
-        backend with ``xp.asarray``.
+        backend with ``asarray_on_device`` (placed on the coordinate inputs'
+        device).
 
         Notes
         -----
@@ -2207,7 +2213,8 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         Time extrapolation outside tgrid matches the numpy path (clamped
         interval index = edge-interval cubic extrapolation, scipy's
         ``extrapolate=True``). All entries are plain numpy arrays/floats;
-        the evaluators convert them with ``xp.asarray``.
+        the evaluators convert them with ``asarray_on_device`` (placed on
+        the coordinate inputs' device).
 
         Notes
         -----
@@ -2283,14 +2290,20 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
 
     @staticmethod
     def _backend_prepare(xp, R, z, phi, t):
-        """Broadcast (R, z, phi, t) to a common shape and flatten to 1-D."""
-        R = xp.asarray(R) * 1.0
-        z = xp.asarray(z) * 1.0
-        phi = xp.asarray(phi) * 1.0
+        """Broadcast (R, z, phi, t) to a common shape and flatten to 1-D.
+
+        Scalar coordinates (e.g. the default phi=0.0/t=0.0) are placed on the
+        device of the array coordinates (CUDA support): the broadcast below
+        expands them to full-size arrays, which torch cannot mix with CUDA
+        tensors (unlike 0-d scalars)."""
+        dev = device_of(R, z, phi, t)
+        R = asarray_on_device(xp, R, dev) * 1.0
+        z = asarray_on_device(xp, z, dev) * 1.0
+        phi = asarray_on_device(xp, phi, dev) * 1.0
         if isinstance(t, (int, float)):
             # route Python scalars through numpy so torch keeps float64
             t = numpy.asarray(t, dtype=float)
-        t = xp.asarray(t) * 1.0
+        t = asarray_on_device(xp, t, dev) * 1.0
         R, z, phi, t = xp.broadcast_arrays(R, z, phi, t)
         shape = R.shape
         return (
@@ -2316,7 +2329,7 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         Returns (i_t, dt = t - tgrid[i_t]); outside tgrid the clamped index
         reproduces scipy's edge-interval cubic extrapolation.
         """
-        tg = xp.asarray(data["tgrid"])
+        tg = asarray_on_device(xp, data["tgrid"], device_of(t))
         n_t = data["tgrid"].shape[0]
         i_t = xp.clip(xp.searchsorted(tg, t, side="right") - 1, 0, n_t - 2)
         return i_t, t - tg[i_t]
@@ -2358,12 +2371,15 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2026-06-10 - Added the time-dependent path - Bovy (UofT)
         """
         data = self._backend_tables()
-        breaks = xp.asarray(data["breaks"])
-        lf = xp.asarray(data["lf"])
-        inv_lp3 = xp.asarray(data["inv_lp3"])
-        inv_2ml = xp.asarray(data["inv_2ml"])
-        l2mask = xp.asarray(data["l2mask"])
-        rmin_pow = xp.asarray(data["rmin_pow_2ml"])
+        # the tables stay float64 (precision is the point; the callers
+        # exit-cast) but must live on the input's device (CUDA support)
+        dev = device_of(r)
+        breaks = asarray_on_device(xp, data["breaks"], dev)
+        lf = asarray_on_device(xp, data["lf"], dev)
+        inv_lp3 = asarray_on_device(xp, data["inv_lp3"], dev)
+        inv_2ml = asarray_on_device(xp, data["inv_2ml"], dev)
+        l2mask = asarray_on_device(xp, data["l2mask"], dev)
+        rmin_pow = asarray_on_device(xp, data["rmin_pow_2ml"], dev)
         rmin = float(data["breaks"][0])
         rmax = float(data["breaks"][-1])
         nint = data["breaks"].shape[0] - 1
@@ -2380,32 +2396,32 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
             i_t, dt = self._backend_time_interval(xp, data, t)
             flat = i_t * nint + idx
             cin = self._backend_horner_t(
-                xp.asarray(data["inner_tc"])[:, :, :, flat], dt
+                asarray_on_device(xp, data["inner_tc"], dev)[:, :, :, flat], dt
             )  # (n_comp, 6, N)
             cout = self._backend_horner_t(
-                xp.asarray(data["outer_tc"])[:, :, :, flat], dt
+                asarray_on_device(xp, data["outer_tc"], dev)[:, :, :, flat], dt
             )
             P_rho0 = self._backend_horner_t(
-                xp.asarray(data["dIin_rmin_tc"])[:, :, i_t], dt
-            ) / xp.asarray(data["rmin_pow_lp2"])
+                asarray_on_device(xp, data["dIin_rmin_tc"], dev)[:, :, i_t], dt
+            ) / asarray_on_device(xp, data["rmin_pow_lp2"], dev)
             I_outer_rmin = self._backend_horner_t(
-                xp.asarray(data["Iout_rmin_tc"])[:, :, i_t], dt
+                asarray_on_device(xp, data["Iout_rmin_tc"], dev)[:, :, i_t], dt
             )
             # I_inner(rmax, t): dt-Horner of the last interval's stack, then
             # the quintic Horner at dr_max (same op order as the numpy path)
             clast = self._backend_horner_t(
-                xp.asarray(data["inner_last_tc"])[:, :, :, i_t], dt
+                asarray_on_device(xp, data["inner_last_tc"], dev)[:, :, :, i_t], dt
             )  # (n_comp, 6, N)
             dr_max = float(data["breaks"][-1] - data["breaks"][-2])
             I_inner_rmax = clast[:, 0]
             for k in range(1, 6):
                 I_inner_rmax = I_inner_rmax * dr_max + clast[:, k]
         else:
-            cin = xp.asarray(data["inner_c"])[:, :, idx]  # (n_comp, 6, N)
-            cout = xp.asarray(data["outer_c"])[:, :, idx]
-            P_rho0 = xp.asarray(data["P_rho0"])
-            I_outer_rmin = xp.asarray(data["I_outer_rmin"])
-            I_inner_rmax = xp.asarray(data["I_inner_rmax"])
+            cin = asarray_on_device(xp, data["inner_c"], dev)[:, :, idx]
+            cout = asarray_on_device(xp, data["outer_c"], dev)[:, :, idx]
+            P_rho0 = asarray_on_device(xp, data["P_rho0"], dev)
+            I_outer_rmin = asarray_on_device(xp, data["I_outer_rmin"], dev)
+            I_inner_rmax = asarray_on_device(xp, data["I_inner_rmax"], dev)
 
         def _val(c):
             out = c[:, 0]
@@ -2492,10 +2508,12 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         - 2026-06-09 - Written - Bovy (UofT)
         """
         data = self._backend_tables()
-        l_idx = xp.asarray(data["l_idx"])
-        m_idx = xp.asarray(data["m_idx"])
-        mf = xp.asarray(data["mf"])
-        is_sin = xp.asarray(data["is_sin"])
+        # index/constant tables on the input's device (CUDA support)
+        dev = device_of(costheta)
+        l_idx = asarray_on_device(xp, data["l_idx"], dev)
+        m_idx = asarray_on_device(xp, data["m_idx"], dev)
+        mf = asarray_on_device(xp, data["mf"], dev)
+        is_sin = asarray_on_device(xp, data["is_sin"], dev)
         tables = assoc_legendre(self._L, self._M, costheta, deriv=deriv)
         if deriv == 0:
             tables = (tables,)
@@ -2521,8 +2539,9 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
             # R_00(rmin, t) = rmin^{-1} I_inner,00(rmin, t) + I_outer,00(rmin, t)
             # (in-grid branch of _eval_radial_lm_timedep at i_r = 0, dr = 0)
             i_t, dt = self._backend_time_interval(xp, data, tf)
-            cin0 = xp.asarray(data["Iin_rmin_tc"])[0][:, i_t]  # (4, N)
-            cout0 = xp.asarray(data["Iout_rmin_tc"])[0][:, i_t]
+            dev = device_of(r)
+            cin0 = asarray_on_device(xp, data["Iin_rmin_tc"], dev)[0][:, i_t]
+            cout0 = asarray_on_device(xp, data["Iout_rmin_tc"], dev)[0][:, i_t]
             Iin00 = ((cin0[0] * dt + cin0[1]) * dt + cin0[2]) * dt + cin0[3]
             Iout00 = ((cout0[0] * dt + cout0[1]) * dt + cout0[2]) * dt + cout0[3]
             rmin = float(data["breaks"][0])
@@ -2565,7 +2584,7 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         """Backend version of _compute_spher_2nd_derivs_at_point (vectorized)."""
         (PP, dPP, d2PP), trig, dtrig = self._backend_angular(xp, ctheta, phi, deriv=2)
         Rlm, dRlm, d2Rlm = self._backend_radial(xp, r, t, mode=2)
-        mf = xp.asarray(self._backend_tables()["mf"])
+        mf = asarray_on_device(xp, self._backend_tables()["mf"], device_of(r))
         dP_dtheta = dPP * (-stheta)
         d2P_dtheta2 = d2PP * stheta**2 - dPP * ctheta
         Phi_r = xp.sum(PP * trig * dRlm, axis=0)
@@ -2643,7 +2662,8 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         r = xp.sqrt(Rf * Rf + zf * zf)
         ctheta = xp.cos(xp.arctan2(Rf, zf))
         (PP,), trig, _ = self._backend_angular(xp, ctheta, phif, deriv=0)
-        rho_breaks = xp.asarray(data["rho_breaks"])
+        dev = device_of(r)
+        rho_breaks = asarray_on_device(xp, data["rho_breaks"], dev)
         rmin = float(data["rho_breaks"][0])
         rmax = float(data["rho_breaks"][-1])
         nint = data["rho_breaks"].shape[0] - 1
@@ -2656,9 +2676,11 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
             # of spline interpolation in the data; cf. _backend_tdep_data)
             i_t, dt = self._backend_time_interval(xp, data, tf)
             flat = i_t * nint + idx
-            c = self._backend_horner_t(xp.asarray(data["rho_tc"])[:, :, :, flat], dt)
+            c = self._backend_horner_t(
+                asarray_on_device(xp, data["rho_tc"], dev)[:, :, :, flat], dt
+            )
         else:
-            c = xp.asarray(data["rho_c"])[:, :, idx]
+            c = asarray_on_device(xp, data["rho_c"], dev)[:, :, idx]
         rho = ((c[:, 0] * dr + c[:, 1]) * dr + c[:, 2]) * dr + c[:, 3]
         out = xp.sum(PP * trig * rho, axis=0)
         out = xp.where(r > rmax, 0.0, out)

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -13,7 +13,7 @@ if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
 else:
     from scipy.special import assoc_legendre_p_all
 
-from ..backend import get_namespace
+from ..backend import get_namespace, match_input_dtype
 from ..backend.special import assoc_legendre, gegenbauer
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -491,7 +491,11 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
     def _dens(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi and phi is None:
             phi = 0.0
-        return self._evaluate_expansion(self._rhoTilde, R, z, phi)
+        # the expansion tables are deliberately float64 (precision); cast the
+        # result to the input dtype at exit (no-op for float64/scalar inputs)
+        return match_input_dtype(
+            self._evaluate_expansion(self._rhoTilde, R, z, phi), R, z, phi, t
+        )
 
     def _mass(self, R, z=None, t=0.0):
         if not z is None:
@@ -503,7 +507,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi and phi is None:
             phi = 0.0
-        return self._evaluate_expansion(self._phiTilde, R, z, phi)
+        # float64 interior, input-dtype exit cast (see _dens)
+        return match_input_dtype(
+            self._evaluate_expansion(self._phiTilde, R, z, phi), R, z, phi, t
+        )
 
     def _dphiTilde(self, r, N, L):
         xp = get_namespace(r)

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -13,7 +13,12 @@ if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
 else:
     from scipy.special import assoc_legendre_p_all
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import (
+    asarray_on_device,
+    device_of,
+    get_namespace,
+    match_input_dtype,
+)
 from ..backend.special import assoc_legendre, gegenbauer
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -302,9 +307,11 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             )
             return rho
         # backend path: same expression, functional (no in-place writes); the
-        # constant (n,l) grids are built in numpy and converted once.
-        K = xp.asarray(K)
-        l = xp.asarray(l)
+        # constant (n,l) grids are built in numpy and converted once, on the
+        # input's device (CUDA support).
+        dev = device_of(r)
+        K = asarray_on_device(xp, K, dev)
+        l = asarray_on_device(xp, l, dev)
         return (
             K
             * ((a * r) ** l)
@@ -358,7 +365,9 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # backend path: branchless r == 0 handling. Both xp.where branches are
         # evaluated under tracing/eager AD, so the generic branch is computed at
         # a guarded rsafe (the r == 0 column then takes the -CC/a limit instead).
-        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
+        l = asarray_on_device(
+            xp, numpy.arange(0, L, dtype=float)[numpy.newaxis, :], device_of(r)
+        )
         rsafe = xp.where(r == 0, 1.0, r)
         generic = (
             -(a**l)
@@ -414,12 +423,14 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
                 radial[:, :, None] * (Acos * mcos + Asin * msin) * PP[None, :, :]
             )
         # backend path: same sum with the backend-agnostic special-function
-        # router; the coefficient tables are converted to the backend once.
-        Acos = xp.asarray(self._Acos)
-        Asin = xp.asarray(self._Asin)
+        # router; the coefficient tables are converted to the backend once,
+        # on the input's device (CUDA support).
+        dev = device_of(r, theta, phi)
+        Acos = asarray_on_device(xp, self._Acos, dev)
+        Asin = asarray_on_device(xp, self._Asin, dev)
         radial = radial_func(r, N, L)
         PP = assoc_legendre(L, M, xp.cos(theta))
-        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        m = asarray_on_device(xp, numpy.arange(0, M, dtype=float)[None, None, :], dev)
         mcos = xp.cos(m * phi)
         msin = xp.sin(m * phi)
         return xp.sum(radial[:, :, None] * (Acos * mcos + Asin * msin) * PP[None, :, :])
@@ -533,7 +544,9 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
                 / 2.0
             )
         # backend path: identical expression with xp arithmetic.
-        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
+        l = asarray_on_device(
+            xp, numpy.arange(0, L, dtype=float)[numpy.newaxis, :], device_of(r)
+        )
         return -((4 * numpy.pi) ** 0.5) * (
             (a * r) ** l
             * (l * (a + r) * r ** (-1.0) - (2 * l + 1))
@@ -592,7 +605,9 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # backend path: same factored expression at a guarded radius (the r == 0
         # column is exactly zero; both xp.where branches are evaluated under
         # tracing/eager AD, so the generic branch must stay finite there).
-        l = xp.asarray(numpy.arange(0, L, dtype=float)[numpy.newaxis, :])
+        l = asarray_on_device(
+            xp, numpy.arange(0, L, dtype=float)[numpy.newaxis, :], device_of(r)
+        )
         rs = xp.where(r == 0, 1.0, r)
         ar = a + rs
         ar2 = ar * ar
@@ -691,15 +706,17 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             return dPhi_dr, dPhi_dtheta, dPhi_dphi
         # backend path: same computation, but functional and cache-free (the
         # per-point Python hash cache is trace-hostile under jit and useless on
-        # traced values; numpy keeps it above).
-        Acos = xp.asarray(self._Acos)
-        Asin = xp.asarray(self._Asin)
+        # traced values; numpy keeps it above). The coefficient tables are
+        # converted onto the input's device (CUDA support).
+        dev = device_of(r, theta, phi)
+        Acos = asarray_on_device(xp, self._Acos, dev)
+        Asin = asarray_on_device(xp, self._Asin, dev)
         PP, dPP = assoc_legendre(L, M, xp.cos(theta), deriv=1)
         PP = PP[None, :, :]
         dPP = dPP[None, :, :]
         phi_tilde = self._phiTilde(r, N, L)[:, :, None]
         dphi_tilde = self._dphiTilde(r, N, L)[:, :, None]
-        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        m = asarray_on_device(xp, numpy.arange(0, M, dtype=float)[None, None, :], dev)
         mcos = xp.cos(m * phi)
         msin = xp.sin(m * phi)
         cos_sin_sum = Acos * mcos + Asin * msin
@@ -783,9 +800,11 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # float(R), which is trace-hostile under jit) and branchless. The
         # r == 0 / r == inf centre is handled by computing the generic branch
         # at a guarded radius and zeroing the result with xp.where, so both
-        # branches stay finite under tracing/eager AD.
-        Acos = xp.asarray(self._Acos)
-        Asin = xp.asarray(self._Asin)
+        # branches stay finite under tracing/eager AD. The coefficient tables
+        # are converted onto the input's device (CUDA support).
+        dev = device_of(R, z, phi)
+        Acos = asarray_on_device(xp, self._Acos, dev)
+        Asin = asarray_on_device(xp, self._Asin, dev)
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
         degenerate = (r == 0.0) | ~xp.isfinite(r)
         rs = xp.where(degenerate, 1.0, r)
@@ -805,7 +824,7 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         phi_tilde = self._phiTilde(rs, N, L)[:, :, None]
         dphi_tilde = self._dphiTilde(rs, N, L)[:, :, None]
         d2phi_tilde = self._d2phiTilde(rs, N, L)[:, :, None]
-        m = xp.asarray(numpy.arange(0, M, dtype=float)[None, None, :])
+        m = asarray_on_device(xp, numpy.arange(0, M, dtype=float)[None, None, :], dev)
         mcos = xp.cos(m * phi)
         msin = xp.sin(m * phi)
         cos_sin = Acos * mcos + Asin * msin  # angular azimuthal coefficient
@@ -944,7 +963,7 @@ def _dC(xi, N, L):
     # backend path: the roll + zero-row idiom above (dC_n = 2 a C_{n-1}^{a+1},
     # with a zero n=0 row), written functionally as a concatenation.
     CC = xp.concat([xp.zeros_like(CC[:1]), CC[: N - 1]], axis=0)
-    return CC * xp.asarray(2 * (2 * l + 3.0 / 2))
+    return CC * asarray_on_device(xp, 2 * (2 * l + 3.0 / 2), device_of(xi))
 
 
 def _d2C(xi, N, L):
@@ -967,7 +986,7 @@ def _d2C(xi, N, L):
     # backend path: the roll + zero-rows idiom above, written functionally as a
     # concatenation (min(N, 2) zero rows, then C_{n-2}^{a+2} for n >= 2).
     CC = xp.concat([xp.zeros_like(CC[: min(N, 2)]), CC[: max(N - 2, 0)]], axis=0)
-    return CC * xp.asarray(4 * a * (a + 1))
+    return CC * asarray_on_device(xp, 4 * a * (a + 1), device_of(xi))
 
 
 def scf_compute_coeffs_spherical_nbody(pos, N, mass=1.0, a=1.0):

--- a/galpy/potential/SphericalHarmonicPotentialMixin.py
+++ b/galpy/potential/SphericalHarmonicPotentialMixin.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import get_namespace, match_input_dtype
 from ..util import coords
 
 
@@ -121,7 +121,16 @@ class SphericalHarmonicPotentialMixin:
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
         dr_dR = xp.divide(R, r)
         dtheta_dR = xp.divide(z, r**2)
-        return self._evaluate_cyl_force(dr_dR, dtheta_dR, 0, R, z, phi, t=t)
+        # the expansion tables of the implementing classes (SCF /
+        # MultipoleExpansion) are deliberately float64 (precision); cast the
+        # result to the input dtype at exit (no-op for float64/scalar inputs)
+        return match_input_dtype(
+            self._evaluate_cyl_force(dr_dR, dtheta_dR, 0, R, z, phi, t=t),
+            R,
+            z,
+            phi,
+            t,
+        )
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi and phi is None:
@@ -130,14 +139,36 @@ class SphericalHarmonicPotentialMixin:
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
         dr_dz = xp.divide(z, r)
         dtheta_dz = xp.divide(-R, r**2)
-        return self._evaluate_cyl_force(dr_dz, dtheta_dz, 0, R, z, phi, t=t)
+        # float64 interior, input-dtype exit cast (see _Rforce)
+        return match_input_dtype(
+            self._evaluate_cyl_force(dr_dz, dtheta_dz, 0, R, z, phi, t=t),
+            R,
+            z,
+            phi,
+            t,
+        )
 
     def _phitorque(self, R, z, phi=0, t=0):
         if not self.isNonAxi and phi is None:
             phi = 0.0
-        return self._evaluate_cyl_force(0, 0, 1, R, z, phi, t=t)
+        # float64 interior, input-dtype exit cast (see _Rforce)
+        return match_input_dtype(
+            self._evaluate_cyl_force(0, 0, 1, R, z, phi, t=t), R, z, phi, t
+        )
 
     def _evaluate_cyl_2nd_deriv(self, deriv_type, R, z, phi, t=0.0):
+        # float64 interior, input-dtype exit cast (see _Rforce); the core
+        # method below reassigns R/z/phi/t, so the cast wraps it here, where
+        # the original inputs (whose dtype is to be matched) are available
+        return match_input_dtype(
+            self._evaluate_cyl_2nd_deriv_core(deriv_type, R, z, phi, t=t),
+            R,
+            z,
+            phi,
+            t,
+        )
+
+    def _evaluate_cyl_2nd_deriv_core(self, deriv_type, R, z, phi, t=0.0):
         """
         Evaluate a cylindrical second derivative over an array of coordinates.
 

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -10,7 +10,7 @@ import math
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import asarray_on_device, device_of, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -651,13 +651,16 @@ class SpiralArmsPotential(Potential):
         # Anchor the stored float constants on the input dtype so that float32
         # inputs are not promoted to float64 by these (strong-typed under torch)
         # float64 tensors, and so that the default integer Cs=[1] does not route
-        # `Cs * self._rho0` through torch's default dtype. dtype=None for
-        # python-scalar inputs (and numpy.asarray(x, dtype=None) is a no-op
+        # `Cs * self._rho0` through torch's default dtype -- and on the input
+        # DEVICE (CUDA support). dtype=None/device=None for python-scalar and
+        # numpy inputs (and numpy.asarray(x, dtype=None) is a no-op
         # pass-through), so the numpy path is untouched.
         dtype = getattr(R, "dtype", None)
-        Cs = xp.asarray(self._Cs0, dtype=dtype)
-        ns = xp.asarray(self._ns0)  # keep integer: int tensors never promote floats
-        HNn = xp.asarray(self._HNn0, dtype=dtype)
+        dev = device_of(R, z)
+        Cs = asarray_on_device(xp, self._Cs0, dev, dtype=dtype)
+        # ns stays integer: int tensors never promote floats
+        ns = asarray_on_device(xp, self._ns0, dev)
+        HNn = asarray_on_device(xp, self._HNn0, dev, dtype=dtype)
         if ndR == 1 or ndz == 1:
             return (
                 xp.reshape(Cs, (-1, 1)),

--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -4,7 +4,7 @@
 import numpy
 from scipy import interpolate
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import asarray_on_device, device_of, get_namespace, match_input_dtype
 from ..util._optional_deps import _JAX_LOADED
 from ..util.conversion import get_physical, physical_compatible
 from .Potential import _evaluatePotentials, _evaluateRforces
@@ -44,8 +44,11 @@ def _ppoly_eval(xp, x, c, r):
     (finite extrapolation), which keeps the dead side of the callers'
     ``xp.where`` branch selections NaN-free under autodiff.
     """
-    xb = xp.asarray(x)
-    cb = xp.asarray(c)
+    # knots/coefficients stay float64 (precision is the point; the callers
+    # exit-cast) but must live on the input's device (CUDA support)
+    dev = device_of(r)
+    xb = asarray_on_device(xp, x, dev)
+    cb = asarray_on_device(xp, c, dev)
     idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, cb.shape[1] - 1)
     dr = r - xb[idx]
     out = cb[0, idx]

--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -4,7 +4,7 @@
 import numpy
 from scipy import interpolate
 
-from ..backend import get_namespace
+from ..backend import get_namespace, match_input_dtype
 from ..util._optional_deps import _JAX_LOADED
 from ..util.conversion import get_physical, physical_compatible
 from .Potential import _evaluatePotentials, _evaluateRforces
@@ -165,7 +165,10 @@ class interpSphericalPotential(SphericalPotential):
         )
         rsafe = xp.where(r >= self._rmax, r, 1.0)
         outside = -float(self._total_mass) / rsafe + float(self._Phimax)
-        return xp.where(r >= self._rmax, outside, inside)
+        # the spline knots/coefficients are deliberately float64 (precision);
+        # cast the result to the input dtype at exit (no-op for float64 input;
+        # the numpy path above already follows the input dtype via empty_like)
+        return match_input_dtype(xp.where(r >= self._rmax, outside, inside), r)
 
     def _rforce(self, r, t=0.0):
         xp = get_namespace(r)
@@ -178,7 +181,8 @@ class interpSphericalPotential(SphericalPotential):
         inside = _ppoly_eval(xp, self._ppoly_x, self._force_ppoly_c, r)
         rsafe = xp.where(r >= self._rmax, r, 1.0)
         outside = -float(self._total_mass) / rsafe**2.0
-        return xp.where(r >= self._rmax, outside, inside)
+        # float64 spline interior, input-dtype exit cast (see _revaluate)
+        return match_input_dtype(xp.where(r >= self._rmax, outside, inside), r)
 
     def _rforce_jax(self, r):
         if not _JAX_LOADED:  # pragma: no cover
@@ -198,7 +202,8 @@ class interpSphericalPotential(SphericalPotential):
         inside = -_ppoly_eval(xp, self._ppoly_x, self._r2deriv_ppoly_c, r)
         rsafe = xp.where(r >= self._rmax, r, 1.0)
         outside = -2.0 * float(self._total_mass) / rsafe**3.0
-        return xp.where(r >= self._rmax, outside, inside)
+        # float64 spline interior, input-dtype exit cast (see _revaluate)
+        return match_input_dtype(xp.where(r >= self._rmax, outside, inside), r)
 
     def _rdens(self, r, t=0.0):
         xp = get_namespace(r)
@@ -213,4 +218,5 @@ class interpSphericalPotential(SphericalPotential):
         # NaN-free (r >= rmax > 0, so the 1/r factors are safe there too).
         r = xp.asarray(r)
         inside = SphericalPotential._rdens(self, r, t=t)
-        return xp.where(r >= self._rmax, 0.0, inside)
+        # float64 spline interior, input-dtype exit cast (see _revaluate)
+        return match_input_dtype(xp.where(r >= self._rmax, 0.0, inside), r)

--- a/tests/test_backend_dtype_policy.py
+++ b/tests/test_backend_dtype_policy.py
@@ -512,6 +512,103 @@ def test_special_fallback_f32_exit_cast():
     assert zt.grad is not None and torch.isfinite(zt.grad)
 
 
+###############################################################################
+# Device preservation (CUDA). The stored float64 tables (expansion
+# coefficients, Ogata/Gauss-Legendre/trapezoid quadrature nodes and weights,
+# spline coefficients) and SpiralArms' input-dtype-anchored constants are
+# placed on the coordinate inputs' device via galpy.backend.device_of /
+# asarray_on_device -- a plain xp.asarray materializes them on the CPU and
+# torch raises 'Expected all tensors to be on the same device' for CUDA
+# coordinates. These tests run on GPU boxes and skip visibly on CPU-only CI.
+###############################################################################
+
+_CUDA = torch is not None and torch.cuda.is_available()
+
+# the table-backed five (+ the DiskSCF/DiskMultipole wrappers around the
+# expansions) and SpiralArms (input-dtype-anchored constant tables)
+_DEVICE_IDS = _TABLE_IDS + ["DiskSCF", "DiskMultipole", "SpiralArms"]
+
+
+def _device_params():
+    for entry_id, pot, kind, methods in REGISTRY:
+        if entry_id not in _DEVICE_IDS:
+            continue
+        for method in methods:
+            yield pytest.param(pot, kind, method, entry_id, id=f"{entry_id}-{method}")
+
+
+@pytest.mark.skipif(not _CUDA, reason="CUDA torch device not available")
+@pytest.mark.parametrize(
+    "dtype",
+    ["float32", "float64"] if torch is None else [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+@pytest.mark.parametrize("pot,kind,method,entry_id", list(_device_params()))
+def test_torch_cuda_device_preserved(pot, kind, method, entry_id, dtype):
+    # CUDA inputs -> no device-mismatch error, output on the input device,
+    # output dtype matches the input dtype, and the value equals the CPU
+    # result at dtype accuracy (the residual float32 differences are
+    # CUDA-vs-CPU reduction-order rounding, not table degradation; float64
+    # agrees to ~1e-15).
+    cpu_args = _gate_args(kind, dtype)
+    cuda_args = [a.to("cuda:0") for a in cpu_args]
+    out = getattr(pot, method)(*cuda_args)
+    assert out.device == cuda_args[0].device, (
+        f"{entry_id}.{method}: cuda input gave output on {out.device}"
+    )
+    assert out.dtype == dtype, (
+        f"{entry_id}.{method}: {dtype} cuda input gave {out.dtype} output"
+    )
+    ref = getattr(pot, method)(*cpu_args)
+    numpy.testing.assert_allclose(
+        float(out.cpu()),
+        float(ref),
+        rtol=2e-6 if dtype == torch.float32 else 1e-12,
+        err_msg=f"{entry_id}.{method}: cuda result differs from the cpu result",
+    )
+
+
+@pytest.mark.skipif(not _CUDA, reason="CUDA torch device not available")
+def test_special_fallback_cuda_device_preserved():
+    # the router fallbacks' float64 quadrature node tables (Gauss-Legendre /
+    # trapezoid) are anchored on the input device too: CUDA inputs -> CUDA
+    # output of the input dtype, equal to the CPU result at dtype accuracy.
+    import galpy.backend.special as gsp
+
+    cases = [
+        (
+            "hyp2f1",
+            lambda d, dev: gsp.hyp2f1(
+                1.5, 0.5, 2.5, torch.tensor(-0.7, dtype=d, device=dev)
+            ),
+        ),
+        (
+            "hyp1f1",
+            lambda d, dev: gsp.hyp1f1(
+                0.5, 1.5, torch.tensor(-0.7, dtype=d, device=dev)
+            ),
+        ),
+        ("k0", lambda d, dev: gsp.k0(torch.tensor(3.0, dtype=d, device=dev))),
+        ("k1", lambda d, dev: gsp.k1(torch.tensor(3.0, dtype=d, device=dev))),
+        ("kn", lambda d, dev: gsp.kn(2, torch.tensor(3.0, dtype=d, device=dev))),
+        ("ellipk", lambda d, dev: gsp.ellipk(torch.tensor(0.3, dtype=d, device=dev))),
+        ("ellipe", lambda d, dev: gsp.ellipe(torch.tensor(0.3, dtype=d, device=dev))),
+        ("gamma", lambda d, dev: gsp.gamma(torch.tensor(1.5, dtype=d, device=dev))),
+    ]
+    for name, call in cases:
+        for dtype, rtol in ((torch.float32, 1e-6), (torch.float64, 1e-12)):
+            out = call(dtype, "cuda:0")
+            ref = call(dtype, "cpu")
+            assert out.device.type == "cuda", f"{name}: cuda input gave {out.device}"
+            assert out.dtype == dtype, f"{name}: {dtype} cuda input gave {out.dtype}"
+            numpy.testing.assert_allclose(
+                float(out.cpu()),
+                float(ref),
+                rtol=rtol,
+                err_msg=f"{name}: cuda result differs from the cpu result",
+            )
+
+
 @pytest.mark.skipif(torch is None, reason="torch not installed")
 def test_torch_grad_flows_through_exit_cast():
     # torch.autograd at float32 must flow through the exit cast and reproduce

--- a/tests/test_backend_dtype_policy.py
+++ b/tests/test_backend_dtype_policy.py
@@ -1,0 +1,528 @@
+###############################################################################
+# test_backend_dtype_policy.py: shared regression gate for the backend dtype
+# policy across the migrated-potential registry.
+#
+# Policy: compute methods follow the dtype of their coordinate inputs --
+# float32 in -> float32 out, float64 in -> float64 out. Most migrated
+# potentials satisfy this naturally (their constants are Python floats, which
+# are dtype-weak under torch/jax). The table-backed potentials (SCFPotential,
+# DoubleExponentialDiskPotential, interpSphericalPotential/KingPotential,
+# MultipoleExpansionPotential and the DiskSCF/DiskMultipole wrappers around
+# them) deliberately keep float64 interiors -- expansion-coefficient tables,
+# Ogata quadrature nodes/weights, spline coefficients; precision is the point
+# -- and cast the result to the input dtype at method exit
+# (galpy.backend.match_input_dtype). This module asserts
+#   1. torch float32 inputs -> float32 output and float64 -> float64 for the
+#      gate methods (_evaluate and _Rforce where migrated) of EVERY registry
+#      entry,
+#   2. the float64-QUALITY pin for the four table-backed potentials: the
+#      torch-float32-input result equals the float64 result cast to float32
+#      (an implementation that anchored the tables to float32 -- degrading
+#      the interior -- would fail this),
+#   3. the numpy semantics of the exit cast: float64 numpy inputs return the
+#      raw result object unchanged (bit-identical no-op), float32 numpy
+#      arrays now return float32 (the documented semantic change),
+#   4. autodiff flows through the exit cast (jax.grad / torch.autograd at
+#      float32 reproduce -_Rforce).
+#
+# Backends that are not installed self-skip, so this is green on numpy alone
+# (the match_input_dtype no-op/cast branches are covered by the numpy tests).
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import match_input_dtype
+from galpy.potential import (
+    BurkertPotential,
+    CosmphiDiskPotential,
+    DehnenBarPotential,
+    DehnenCoreSphericalPotential,
+    DehnenSphericalPotential,
+    DiskMultipoleExpansionPotential,
+    DiskSCFPotential,
+    DoubleExponentialDiskPotential,
+    EinastoPotential,
+    EllipticalDiskPotential,
+    FlattenedPowerPotential,
+    HenonHeilesPotential,
+    HernquistPotential,
+    HomogeneousSpherePotential,
+    IsochronePotential,
+    IsothermalDiskPotential,
+    JaffePotential,
+    KeplerPotential,
+    KGPotential,
+    KingPotential,
+    KuzminDiskPotential,
+    LogarithmicHaloPotential,
+    LopsidedDiskPotential,
+    MiyamotoNagaiPotential,
+    MultipoleExpansionPotential,
+    NFWPotential,
+    PerfectEllipsoidPotential,
+    PlummerPotential,
+    PowerSphericalPotential,
+    PowerSphericalPotentialwCutoff,
+    PowerTriaxialPotential,
+    RazorThinExponentialDiskPotential,
+    SCFPotential,
+    SoftenedNeedleBarPotential,
+    SphericalShellPotential,
+    SpiralArmsPotential,
+    SteadyLogSpiralPotential,
+    TransientLogSpiralPotential,
+    TriaxialGaussianPotential,
+    TriaxialHernquistPotential,
+    TriaxialJaffePotential,
+    TriaxialNFWPotential,
+    TwoPowerSphericalPotential,
+    TwoPowerTriaxialPotential,
+    interpSphericalPotential,
+)
+
+# This module manages backends explicitly, so it is exempt from the global
+# --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+except ImportError:  # pragma: no cover
+    torch = None
+
+# Known in-flight failures: gate failures for these ids skip (visibly) with a
+# pointer to the branch carrying the fix instead of failing the suite.
+# Currently empty: the former entries -- TwoPowerSpherical-generic (scipy
+# hyp2f1 router bypass, fixed by the special-router migration + the router
+# fallbacks' input-dtype exit cast) and PerfectEllipsoid/TriaxialNFW
+# (all-tensor TypeError, fixed by the EllipsoidalPotential scalar-phi
+# anchoring) -- have landed on feat/backends.
+KNOWN_INFLIGHT = {}
+
+_HERN = HernquistPotential(amp=1.3, a=0.8)
+
+
+def _scf_coeffs():
+    Acos = numpy.zeros((3, 3, 3))
+    Asin = numpy.zeros((3, 3, 3))
+    Acos[0, 0, 0] = 1.0
+    Acos[1, 1, 0] = 0.05
+    Acos[2, 2, 2] = 0.02
+    Asin[1, 1, 1] = 0.03
+    return Acos, Asin
+
+
+def _make_registry():
+    """One instance per migrated potential family member.
+
+    Each entry: (id, instance, kind, gate methods); kind selects the call
+    signature: '3d' -> (R, z, phi, t), 'planar' -> (R, phi, t), 'linear' ->
+    (x, t). The gate methods default to (_evaluate, _Rforce) and are reduced
+    where only other methods are migrated (noted per entry).
+    """
+    Acos, Asin = _scf_coeffs()
+    entries = [
+        # --- spherical family ------------------------------------------------
+        ("Plummer", PlummerPotential(amp=1.3, b=0.7)),
+        ("Isochrone", IsochronePotential(amp=2.0, b=1.1)),
+        ("DehnenSpherical", DehnenSphericalPotential(amp=1.3, a=1.1, alpha=1.5)),
+        ("DehnenCoreSpherical", DehnenCoreSphericalPotential(amp=1.3, a=1.1)),
+        ("Hernquist", HernquistPotential(amp=1.3, a=1.1)),
+        ("Jaffe", JaffePotential(amp=1.3, a=1.1)),
+        ("NFW", NFWPotential(amp=1.3, a=1.1)),
+        ("PowerSpherical", PowerSphericalPotential(amp=1.3, alpha=1.5)),
+        # special-function-backed (gamma/gammainc router)
+        (
+            "PowerSphericalwCutoff",
+            PowerSphericalPotentialwCutoff(amp=1.3, alpha=1.0, rc=1.2),
+        ),
+        ("Kepler", KeplerPotential(amp=1.3)),
+        ("HomogeneousSphere", HomogeneousSpherePotential(amp=1.3, R=1.1)),
+        ("Burkert", BurkertPotential(amp=1.3, a=1.1)),
+        # special-function-backed (gamma/gammaincc router)
+        ("Einasto", EinastoPotential(amp=1.3, h=1.1, n=1.5)),
+        ("SphericalShell", SphericalShellPotential(amp=1.3, a=0.7)),
+        (
+            "TwoPowerSpherical-generic",
+            TwoPowerSphericalPotential(amp=1.3, a=1.1, alpha=1.5, beta=3.5),
+        ),
+        # --- disk family -----------------------------------------------------
+        ("MiyamotoNagai", MiyamotoNagaiPotential(amp=1.3, a=0.8, b=0.3)),
+        ("KuzminDisk", KuzminDiskPotential(amp=1.2, a=0.7)),
+        ("FlattenedPower", FlattenedPowerPotential(amp=1.1, alpha=0.5, q=0.9)),
+        # only _surfdens is migrated (the rest use scipy.special directly)
+        (
+            "RazorThinExpDisk",
+            RazorThinExponentialDiskPotential(amp=1.0, hr=0.4),
+            "3d",
+            ("_surfdens",),
+        ),
+        # table-backed (Ogata quadrature nodes/weights)
+        (
+            "DoubleExponentialDisk",
+            DoubleExponentialDiskPotential(amp=1.3, hr=0.4, hz=0.1, de_n=1000),
+        ),
+        (
+            "IsothermalDisk",
+            IsothermalDiskPotential(amp=1.0, sigma=0.2),
+            "linear",
+            ("_evaluate", "_force"),
+        ),
+        (
+            "KG",
+            KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8),
+            "linear",
+            ("_evaluate", "_force"),
+        ),
+        # --- ellipsoidal family ----------------------------------------------
+        ("PerfectEllipsoid", PerfectEllipsoidPotential(amp=1.3, a=1.5, b=0.9, c=0.7)),
+        (
+            "TriaxialGaussian",
+            TriaxialGaussianPotential(amp=1.3, sigma=1.5, b=0.9, c=0.7),
+        ),
+        ("PowerTriaxial", PowerTriaxialPotential(amp=1.3, alpha=1.2, b=0.9, c=0.7)),
+        (
+            "TriaxialHernquist",
+            TriaxialHernquistPotential(amp=1.3, a=1.5, b=0.9, c=0.7),
+        ),
+        ("TriaxialJaffe", TriaxialJaffePotential(amp=1.3, a=1.5, b=0.9, c=0.7)),
+        ("TriaxialNFW", TriaxialNFWPotential(amp=1.3, a=1.5, b=0.9, c=0.7)),
+        # _evaluate deferred (hyp2f1); the forces are migrated
+        (
+            "TwoPowerTriaxial-generic",
+            TwoPowerTriaxialPotential(
+                amp=1.3, a=1.5, alpha=1.5, beta=3.5, b=0.9, c=0.7
+            ),
+            "3d",
+            ("_Rforce",),
+        ),
+        # --- halo / bar / non-axisymmetric family -----------------------------
+        ("LogarithmicHalo", LogarithmicHaloPotential(amp=1.3, q=0.8, core=0.1)),
+        (
+            "LogarithmicHalo-triaxial",
+            LogarithmicHaloPotential(amp=1.1, q=0.9, b=0.7, core=0.1),
+        ),
+        (
+            "DehnenBar",
+            DehnenBarPotential(
+                amp=1.0, omegab=1.8, rb=0.6, Af=0.03, tform=-100.0, tsteady=1.0
+            ),
+        ),
+        (
+            "SoftenedNeedleBar",
+            SoftenedNeedleBarPotential(
+                amp=1.2, a=4.0, b=0.5, c=1.0, pa=0.3, omegab=1.8
+            ),
+        ),
+        ("SpiralArms", SpiralArmsPotential(N=2, alpha=0.2, Rs=0.3, H=0.125, omega=0.4)),
+        ("HenonHeiles", HenonHeilesPotential(amp=1.2), "planar"),
+        (
+            "CosmphiDisk",
+            CosmphiDiskPotential(amp=1.1, phib=0.3, p=1.0, phio=0.02, m=4, r1=1.0),
+            "planar",
+        ),
+        (
+            "LopsidedDisk",
+            LopsidedDiskPotential(amp=1.0, phib=0.3, p=1.0, phio=0.02),
+            "planar",
+        ),
+        (
+            "EllipticalDisk",
+            EllipticalDiskPotential(amp=1.0, phib=0.3, p=1.0, twophio=0.02),
+            "planar",
+        ),
+        (
+            "SteadyLogSpiral",
+            SteadyLogSpiralPotential(amp=1.0, omegas=0.65, A=-0.035, alpha=-7.0, m=2),
+            "planar",
+            ("_evaluate", "_Rforce"),
+        ),
+        (
+            "TransientLogSpiral",
+            TransientLogSpiralPotential(
+                amp=1.0, omegas=0.65, A=-0.035, alpha=-7.0, m=2, sigma=1.0, to=0.0
+            ),
+            "planar",
+            ("_evaluate", "_Rforce"),
+        ),
+        # --- table-backed (float64 interior + exit cast) ----------------------
+        ("SCF", SCFPotential(amp=1.3, Acos=Acos, Asin=Asin, a=1.2)),
+        (
+            "interpSpherical",
+            interpSphericalPotential(
+                rforce=HernquistPotential(amp=2.0, a=1.3),
+                rgrid=numpy.geomspace(0.01, 1.5, 151),
+            ),
+        ),
+        ("King", KingPotential(W0=3.0, M=2.3, rt=1.4)),
+        (
+            "Multipole",
+            MultipoleExpansionPotential.from_density(
+                lambda R, z, phi: (
+                    (1.0 + 0.5 * numpy.cos(phi)) * _HERN(numpy.sqrt(R**2 + z**2), 0.0)
+                ),
+                L=4,
+                rgrid=numpy.geomspace(1e-3, 10.0, 101),
+            ),
+        ),
+        # wrappers around the table-backed expansions (self._me inherits the cast)
+        (
+            "DiskSCF",
+            DiskSCFPotential(
+                dens=lambda R, z: (
+                    13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
+                ),
+                a=1.0,
+                N=4,
+                L=4,
+            ),
+        ),
+        (
+            "DiskMultipole",
+            DiskMultipoleExpansionPotential(
+                dens=lambda R, z: (
+                    13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
+                ),
+                L=6,
+            ),
+        ),
+    ]
+    # Normalize each entry to (id, pot, kind, methods)
+    return [
+        (
+            e[0],
+            e[1],
+            e[2] if len(e) > 2 else "3d",
+            e[3] if len(e) > 3 else ("_evaluate", "_Rforce"),
+        )
+        for e in entries
+    ]
+
+
+REGISTRY = _make_registry()
+
+# The four table-backed potentials (+ their inheritors) for the float64-quality
+# pin: 3d-signature gate methods, scalar-capable.
+_TABLE_IDS = ["SCF", "DoubleExponentialDisk", "interpSpherical", "King", "Multipole"]
+_TABLE_ENTRIES = [e for e in REGISTRY if e[0] in _TABLE_IDS]
+
+# Evaluation points: (R, z, phi, t); inside the interp spline domain and the
+# r > rmax Kepler-extrapolation region (R=2.5 row).
+_POINTS = [(0.7, 0.2, 0.3, 0.0), (1.1, 0.3, 0.4, 0.0), (2.5, 0.5, 1.1, 0.0)]
+
+
+def _gate_args(kind, dtype, point=(1.1, 0.3, 0.4, 0.1)):
+    R, z, phi, t = point
+    if kind == "3d":
+        vals = (R, z, phi, t)
+    elif kind == "planar":
+        vals = (R, phi, t)
+    else:  # linear
+        vals = (0.8, t)
+    return [torch.tensor(v, dtype=dtype) for v in vals]
+
+
+def _gate_params():
+    for entry_id, pot, kind, methods in REGISTRY:
+        for method in methods:
+            yield pytest.param(pot, kind, method, entry_id, id=f"{entry_id}-{method}")
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+@pytest.mark.parametrize(
+    "dtype",
+    ["float32", "float64"] if torch is None else [torch.float32, torch.float64],
+    ids=["float32", "float64"],
+)
+@pytest.mark.parametrize("pot,kind,method,entry_id", list(_gate_params()))
+def test_torch_dtype_follows_input(pot, kind, method, entry_id, dtype):
+    # torch float32 inputs -> float32 output; float64 -> float64, for every
+    # migrated potential's gate methods.
+    args = _gate_args(kind, dtype)
+    try:
+        out = getattr(pot, method)(*args)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        if entry_id in KNOWN_INFLIGHT:
+            pytest.skip(
+                f"{entry_id}.{method}: known in-flight backend failure "
+                f"(fix on {KNOWN_INFLIGHT[entry_id]}): {exc}"
+            )
+        raise
+    assert isinstance(out, torch.Tensor), (
+        f"{entry_id}.{method}: torch input gave {type(out).__name__} output"
+    )
+    if out.dtype != dtype and entry_id in KNOWN_INFLIGHT:
+        pytest.skip(
+            f"{entry_id}.{method}: known in-flight dtype failure "
+            f"({dtype} in, {out.dtype} out; fix on {KNOWN_INFLIGHT[entry_id]})"
+        )
+    assert out.dtype == dtype, (
+        f"{entry_id}.{method}: {dtype} input gave {out.dtype} output"
+    )
+
+
+def _table_params():
+    for entry_id, pot, kind, methods in _TABLE_ENTRIES:
+        for method in methods:
+            yield pytest.param(pot, method, entry_id, id=f"{entry_id}-{method}")
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+@pytest.mark.parametrize("pot,method,entry_id", list(_table_params()))
+def test_table_backed_f32_is_f64_quality(pot, method, entry_id):
+    # float64-QUALITY pin: the torch-float32-input result must equal the
+    # float64 result cast to float32 at float32 accuracy (rtol ~1e-6 with a
+    # small headroom for cancellation-prone points). An anchor-style
+    # implementation -- casting the tables (Ogata nodes/weights, expansion
+    # coefficients, spline coefficients) to float32 and computing the interior
+    # in float32 -- degrades the result by orders of magnitude more and fails.
+    f = getattr(pot, method)
+    for point in _POINTS:
+        out32 = f(*[torch.tensor(v, dtype=torch.float32) for v in point])
+        out64 = f(*[torch.tensor(v, dtype=torch.float64) for v in point])
+        expected = out64.to(torch.float32)
+        numpy.testing.assert_allclose(
+            float(out32),
+            float(expected),
+            rtol=2e-6,
+            atol=1e-9,
+            err_msg=f"{entry_id}.{method} at {point}: float32 result is not "
+            "float64-quality (was the interior degraded to float32?)",
+        )
+
+
+@pytest.mark.parametrize("pot,method,entry_id", list(_table_params()))
+def test_numpy_exit_cast_semantics(pot, method, entry_id):
+    # numpy semantics of the exit cast: float64 numpy inputs are a strict
+    # no-op (and stay float64); float32 numpy arrays now come back float32
+    # (the documented semantic change for these table-backed potentials);
+    # python-scalar inputs are returned as before (no dtype to match).
+    point = (1.1, 0.3, 0.4, 0.0)
+    f = getattr(pot, method)
+    out64 = f(*[numpy.float64(v) for v in point])
+    assert numpy.asarray(out64).dtype == numpy.float64
+    out32 = f(*[numpy.float32(v) for v in point])
+    assert numpy.asarray(out32).dtype == numpy.float32, (
+        f"{entry_id}.{method}: numpy float32 input gave "
+        f"{numpy.asarray(out32).dtype} output"
+    )
+    numpy.testing.assert_allclose(float(out32), float(out64), rtol=2e-6, atol=1e-9)
+    out_scalar = f(*point)
+    numpy.testing.assert_array_equal(numpy.asarray(out_scalar), numpy.asarray(out64))
+
+
+def test_match_input_dtype_helper_branches():
+    # Direct unit checks of the helper's no-op guarantees:
+    out = numpy.array([1.0, 2.0])
+    # float64 coords: the SAME object comes back (bit-identical numpy path)
+    assert match_input_dtype(out, numpy.array([0.5]), numpy.array(0.3)) is out
+    # python-scalar coords carry no dtype: no-op
+    assert match_input_dtype(out, 1.0, 2, None) is out
+    # a plain Python float result (f64 by construction, e.g. the scalar _dens
+    # path of MultipoleExpansion) is cast only when ALL coords carry a
+    # narrower floating dtype...
+    scast = match_input_dtype(2.5, numpy.array([0.5], dtype=numpy.float32))
+    assert isinstance(scast, numpy.float32) and scast == numpy.float32(2.5)
+    # ...and keeps the plain-float type bit-identically for f64, plain-scalar,
+    # and mixed-dtype coords
+    sout = 2.5
+    assert match_input_dtype(sout, numpy.array([0.5])) is sout
+    assert match_input_dtype(sout, 1.0, 0.3) is sout
+    assert (
+        match_input_dtype(
+            sout,
+            numpy.array([0.5], dtype=numpy.float32),
+            numpy.array([0.5], dtype=numpy.float64),
+        )
+        is sout
+    )
+    iout = numpy.array([1, 2])
+    assert match_input_dtype(iout, numpy.array([0.5], dtype=numpy.float32)) is iout
+    # mixed float32/float64 coords resolve by result_type -> float64: no-op
+    assert (
+        match_input_dtype(
+            out,
+            numpy.array([0.5], dtype=numpy.float32),
+            numpy.array([0.5], dtype=numpy.float64),
+        )
+        is out
+    )
+    # all-float32 coords: cast to float32
+    cast = match_input_dtype(out, numpy.array([0.5], dtype=numpy.float32))
+    assert cast.dtype == numpy.float32
+    # integer coords carry no floating dtype: no-op
+    assert match_input_dtype(out, numpy.array([1, 2])) is out
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_jax_grad_flows_through_exit_cast():
+    # jax.grad at float32 must flow through the exit cast and reproduce
+    # -_Rforce (float32 accuracy).
+    Acos, Asin = _scf_coeffs()
+    pot = SCFPotential(amp=1.3, Acos=Acos, Asin=Asin, a=1.2)
+    R0, z0, phi0 = 1.1, 0.3, 0.4
+    grad = jax.grad(
+        lambda R: pot._evaluate(
+            R, jnp.asarray(z0, dtype=jnp.float32), jnp.asarray(phi0, dtype=jnp.float32)
+        )
+    )(jnp.asarray(R0, dtype=jnp.float32))
+    assert grad.dtype == jnp.float32
+    ref = -float(pot._Rforce(R0, z0, phi0))
+    numpy.testing.assert_allclose(float(grad), ref, rtol=1e-4)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_special_fallback_f32_exit_cast():
+    # The galpy.backend.special router's fallbacks (hyp2f1/hyp1f1/k0/k1/kn/
+    # ellipk/ellipe/gamma) keep float64 quadrature tables and cast to the
+    # input dtype at exit: float32 in -> float32 out at float64 quality.
+    import galpy.backend.special as gsp
+
+    cases = [
+        ("hyp2f1", lambda d: gsp.hyp2f1(1.5, 0.5, 2.5, torch.tensor(-0.7, dtype=d))),
+        ("hyp1f1", lambda d: gsp.hyp1f1(0.5, 1.5, torch.tensor(-0.7, dtype=d))),
+        ("k0", lambda d: gsp.k0(torch.tensor(0.7, dtype=d))),
+        ("k1", lambda d: gsp.k1(torch.tensor(0.7, dtype=d))),
+        ("kn", lambda d: gsp.kn(2, torch.tensor(0.7, dtype=d))),
+        ("ellipk", lambda d: gsp.ellipk(torch.tensor(0.3, dtype=d))),
+        ("ellipe", lambda d: gsp.ellipe(torch.tensor(0.3, dtype=d))),
+        ("gamma", lambda d: gsp.gamma(torch.tensor(1.5, dtype=d))),
+    ]
+    for name, call in cases:
+        out32 = call(torch.float32)
+        out64 = call(torch.float64)
+        assert out32.dtype == torch.float32, f"{name}: float32 in gave {out32.dtype}"
+        assert out64.dtype == torch.float64, f"{name}: float64 in gave {out64.dtype}"
+        numpy.testing.assert_allclose(
+            float(out32),
+            float(out64.to(torch.float32)),
+            rtol=1e-6,
+            err_msg=f"{name}: float32 fallback result is not float64-quality",
+        )
+    # autodiff flows through the exit cast
+    zt = torch.tensor(-0.7, dtype=torch.float32, requires_grad=True)
+    gsp.hyp2f1(1.5, 0.5, 2.5, zt).backward()
+    assert zt.grad is not None and torch.isfinite(zt.grad)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_torch_grad_flows_through_exit_cast():
+    # torch.autograd at float32 must flow through the exit cast and reproduce
+    # -_Rforce (float32 accuracy).
+    pot = interpSphericalPotential(
+        rforce=HernquistPotential(amp=2.0, a=1.3),
+        rgrid=numpy.geomspace(0.01, 1.5, 151),
+    )
+    R0, z0 = 1.1, 0.3
+    Rt = torch.tensor(R0, dtype=torch.float32, requires_grad=True)
+    pot._evaluate(Rt, torch.tensor(z0, dtype=torch.float32)).backward()
+    assert Rt.grad.dtype == torch.float32
+    ref = -float(pot._Rforce(numpy.array(R0), numpy.array(z0)))
+    numpy.testing.assert_allclose(float(Rt.grad), ref, rtol=1e-4)


### PR DESCRIPTION
Implements the agreed float32 policy for the table-backed backend potentials — **keep the deliberately-float64 interiors** (SCF expansion tables, Ogata quadrature nodes/weights, spline coefficients, Multipole tables), **cast the result to the input dtype at method exit**: f32 in → f32 out at f64 interior quality.

- New `galpy.backend.match_input_dtype(out, *coords)` helper, applied at the exits of SCF (+ the SphericalHarmonic force/2nd-deriv mixin shared with Multipole), DoubleExponentialDisk, interpSpherical (King and DiskSCF/DiskMultipole inherit), and MultipoleExpansion. Strict no-op — same object back — for the f64 numpy path; plain-float scalar outputs keep their type unless *all* coords are narrower.
- **The gate caught a fifth instance while being built**: the `galpy.backend.special` router *fallbacks* carry f64 Gauss–Legendre/trapezoid node tables that promoted f32 (surfaced through the freshly-routed generic TwoPowerSpherical) — same exit cast applied in `_dispatch`.
- New `tests/test_backend_dtype_policy.py`: a 46-entry registry gate over every migrated potential (torch f32→f32 and f64→f64, **zero skips** — the two in-flight fixes landed mid-work and are folded in), f64-quality pins for the table-backed five (an input-anchored implementation would fail them), numpy no-op/cast semantics, AD-through-the-cast smoke tests (jax + torch).
- **numpy byte-identity**: 92-record `sha256(tobytes())` proof (all instances × methods × {f64 grids, python scalars, np.float64 scalars}) identical pre/post; independently re-verified by a second harness with 324 strict records incl. Quantity call paths.
- **Approved semantic change**: numpy users passing all-float32 arrays/scalars to these potentials now get float32 back (computed at f64 quality); previously float64.

Known residual (documented, not a regression): f32 deltas vs cast-f64 reach tens of f32-ulp where chain-rule prefactors run on f32 coordinates before the f64 interior — input-stage rounding, not table anchoring. Separately surfaced for follow-up: CUDA device preservation is broken for the table-backed potentials (+SpiralArms) — stored tables materialize on CPU; needs a device-anchoring pass validated on a GPU box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)