### PR TITLE
Planar 2nd derivatives + dxdv for SteadyLogSpiral/TransientLogSpiral; document the rotated-ellipsoidal wrapper route

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,11 @@
 v1.12.0 (expected around 2026-07-01)
 ====================
 
+- Added analytic planar second derivatives (R2deriv, phi2deriv, Rphideriv) of
+  ``SteadyLogSpiralPotential`` and ``TransientLogSpiralPotential`` in Python
+  and C, enabling the planar variational equations of ``Orbit.integrate_dxdv``
+  in C for these spirals (``hasC_dxdv=True``).
+
 - Added ``Orbit.lyapunov`` to estimate the largest Lyapunov exponent of an
   orbit from the variational equations (``integrate_dxdv``) using the
   renormalization method of Benettin et al. (1980). Works for planar

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2333,6 +2333,12 @@ class Orbit:
           preserves phase-space volume). The pure-Python methods ('odeint',
           'dop853') raise a ``NotImplementedError`` for dissipative forces.
 
+        - Rotated ``EllipsoidalPotential`` instances (non-trivial ``zvec``/``pa``)
+          do not support C-based variational integration directly
+          (``hasC_dxdv3d=False``); wrap the aligned potential in a
+          ``RotateAndTiltWrapperPotential`` instead (identical physics, full 3D
+          dxdv support).
+
         - 2011-10-17 - Written - Bovy (IAS)
         - 2014-06-29 - Added rectIn and rectOut - Bovy (IAS)
         - 2019-05-21 - Parallelized and incorporated into new Orbits class - Bovy (UofT)

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -78,6 +78,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
     case 2: //TransientLogSpiralPotential, 8 arguments
       potentialArgs->planarRforce= &TransientLogSpiralPotentialRforce;
       potentialArgs->planarphitorque= &TransientLogSpiralPotentialphitorque;
+      potentialArgs->planarR2deriv= &TransientLogSpiralPotentialR2deriv;
+      potentialArgs->planarphi2deriv= &TransientLogSpiralPotentialphi2deriv;
+      potentialArgs->planarRphideriv= &TransientLogSpiralPotentialRphideriv;
       potentialArgs->nargs= 8;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
@@ -85,6 +88,9 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
     case 3: //SteadyLogSpiralPotential, 8 arguments
       potentialArgs->planarRforce= &SteadyLogSpiralPotentialRforce;
       potentialArgs->planarphitorque= &SteadyLogSpiralPotentialphitorque;
+      potentialArgs->planarR2deriv= &SteadyLogSpiralPotentialR2deriv;
+      potentialArgs->planarphi2deriv= &SteadyLogSpiralPotentialphi2deriv;
+      potentialArgs->planarRphideriv= &SteadyLogSpiralPotentialRphideriv;
       potentialArgs->nargs= 8;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;

--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -33,6 +33,8 @@ class EllipsoidalPotential(Potential):
         \\psi(m) = -\\int_{m^2}^\\infty d m^2 \\rho(m^2)
 
     See PerfectEllipsoidPotential for an example and `Merritt & Fridman (1996) <http://adsabs.harvard.edu/abs/1996ApJ...460..136M>`_ for the formalism.
+
+    Note that rotated instances (non-trivial ``zvec``/``pa``) do not support C-based variational integration (``Orbit.integrate_dxdv``; ``hasC_dxdv3d=False``): wrap the aligned potential in a ``RotateAndTiltWrapperPotential`` instead, which implements identical physics with full 3D dxdv support.
     """
 
     def __init__(

--- a/galpy/potential/SteadyLogSpiralPotential.py
+++ b/galpy/potential/SteadyLogSpiralPotential.py
@@ -93,6 +93,7 @@ class SteadyLogSpiralPotential(planarPotential):
             else:
                 self._tsteady = self._tform + 2.0 * self._ts
         self.hasC = True
+        self.hasC_dxdv = True
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         if not self._tform is None:
@@ -162,6 +163,77 @@ class SteadyLogSpiralPotential(planarPotential):
             / self._alpha
             * self._m
             * numpy.sin(
+                self._alpha * numpy.log(R)
+                - self._m * (phi - self._omegas * t - self._gamma)
+            )
+        )
+
+    def _R2deriv(self, R, phi=0.0, t=0.0):
+        if not self._tform is None:
+            if t < self._tform:
+                smooth = 0.0
+            elif t < self._tsteady:
+                deltat = t - self._tform
+                xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
+                smooth = (
+                    3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
+                )
+            else:  # spiral is fully on
+                smooth = 1.0
+        else:
+            smooth = 1.0
+        chi = self._alpha * numpy.log(R) - self._m * (
+            phi - self._omegas * t - self._gamma
+        )
+        return (
+            smooth * self._A / R**2.0 * (numpy.sin(chi) - self._alpha * numpy.cos(chi))
+        )
+
+    def _phi2deriv(self, R, phi=0.0, t=0.0):
+        if not self._tform is None:
+            if t < self._tform:
+                smooth = 0.0
+            elif t < self._tsteady:
+                deltat = t - self._tform
+                xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
+                smooth = (
+                    3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
+                )
+            else:  # spiral is fully on
+                smooth = 1.0
+        else:
+            smooth = 1.0
+        return (
+            -smooth
+            * self._A
+            / self._alpha
+            * self._m**2.0
+            * numpy.cos(
+                self._alpha * numpy.log(R)
+                - self._m * (phi - self._omegas * t - self._gamma)
+            )
+        )
+
+    def _Rphideriv(self, R, phi=0.0, t=0.0):
+        if not self._tform is None:
+            if t < self._tform:
+                smooth = 0.0
+            elif t < self._tsteady:
+                deltat = t - self._tform
+                xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
+                smooth = (
+                    3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
+                )
+            else:  # spiral is fully on
+                smooth = 1.0
+        else:
+            smooth = 1.0
+        return (
+            smooth
+            * self._A
+            * self._m
+            / R
+            * numpy.cos(
                 self._alpha * numpy.log(R)
                 - self._m * (phi - self._omegas * t - self._gamma)
             )

--- a/galpy/potential/TransientLogSpiralPotential.py
+++ b/galpy/potential/TransientLogSpiralPotential.py
@@ -87,6 +87,7 @@ class TransientLogSpiralPotential(planarPotential):
         else:
             self._alpha = alpha
         self.hasC = True
+        self.hasC_dxdv = True
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         return (
@@ -117,6 +118,41 @@ class TransientLogSpiralPotential(planarPotential):
             / self._alpha
             * self._m
             * numpy.sin(
+                self._alpha * numpy.log(R)
+                - self._m * (phi - self._omegas * t - self._gamma)
+            )
+        )
+
+    def _R2deriv(self, R, phi=0.0, t=0.0):
+        chi = self._alpha * numpy.log(R) - self._m * (
+            phi - self._omegas * t - self._gamma
+        )
+        return (
+            self._A
+            * numpy.exp(-((t - self._to) ** 2.0) / 2.0 / self._sigma2)
+            / R**2.0
+            * (numpy.sin(chi) - self._alpha * numpy.cos(chi))
+        )
+
+    def _phi2deriv(self, R, phi=0.0, t=0.0):
+        return (
+            -self._A
+            * numpy.exp(-((t - self._to) ** 2.0) / 2.0 / self._sigma2)
+            / self._alpha
+            * self._m**2.0
+            * numpy.cos(
+                self._alpha * numpy.log(R)
+                - self._m * (phi - self._omegas * t - self._gamma)
+            )
+        )
+
+    def _Rphideriv(self, R, phi=0.0, t=0.0):
+        return (
+            self._A
+            * numpy.exp(-((t - self._to) ** 2.0) / 2.0 / self._sigma2)
+            * self._m
+            / R
+            * numpy.cos(
                 self._alpha * numpy.log(R)
                 - self._m * (phi - self._omegas * t - self._gamma)
             )

--- a/galpy/potential/potential_c_ext/SteadyLogSpiralPotential.c
+++ b/galpy/potential/potential_c_ext/SteadyLogSpiralPotential.c
@@ -56,3 +56,60 @@ double SteadyLogSpiralPotentialphitorque(double R,double phi,double t,
   return -amp * smooth * A / alpha * m *
     sin(alpha * log(R) - m * (phi-omegas*t-gamma));
 }
+double SteadyLogSpiralPotentialR2deriv(double R,double phi,double t,
+				       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //declare
+  double smooth, chi;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double A= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate R2deriv
+  smooth= dehnenSpiralSmooth(t,tform,tsteady);
+  chi= alpha * log(R) - m * (phi-omegas*t-gamma);
+  return amp * smooth * A / R / R * ( sin(chi) - alpha * cos(chi) );
+}
+double SteadyLogSpiralPotentialphi2deriv(double R,double phi,double t,
+					 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //declare
+  double smooth;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double A= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate phi2deriv
+  smooth= dehnenSpiralSmooth(t,tform,tsteady);
+  return -amp * smooth * A / alpha * m * m *
+    cos(alpha * log(R) - m * (phi-omegas*t-gamma));
+}
+double SteadyLogSpiralPotentialRphideriv(double R,double phi,double t,
+					 struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //declare
+  double smooth;
+  //Get args
+  double amp= *args++;
+  double tform= *args++;
+  double tsteady= *args++;
+  double A= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate Rphideriv
+  smooth= dehnenSpiralSmooth(t,tform,tsteady);
+  return amp * smooth * A * m / R *
+    cos(alpha * log(R) - m * (phi-omegas*t-gamma));
+}

--- a/galpy/potential/potential_c_ext/TransientLogSpiralPotential.c
+++ b/galpy/potential/potential_c_ext/TransientLogSpiralPotential.c
@@ -34,3 +34,54 @@ double TransientLogSpiralPotentialphitorque(double R,double phi,double t,
   return -amp * A * exp(-pow(t-to,2.)/2./sigma2) / alpha * m
     * sin(alpha*log(R)-m*(phi-omegas*t-gamma));
 }
+double TransientLogSpiralPotentialR2deriv(double R,double phi,double t,
+					  struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //declare
+  double chi;
+  //Get args
+  double amp= *args++;
+  double A= *args++;
+  double to= *args++;
+  double sigma2= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate R2deriv
+  chi= alpha*log(R)-m*(phi-omegas*t-gamma);
+  return amp * A * exp(-pow(t-to,2.)/2./sigma2) / R / R
+    * ( sin(chi) - alpha * cos(chi) );
+}
+double TransientLogSpiralPotentialphi2deriv(double R,double phi,double t,
+					    struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args++;
+  double A= *args++;
+  double to= *args++;
+  double sigma2= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate phi2deriv
+  return -amp * A * exp(-pow(t-to,2.)/2./sigma2) / alpha * m * m
+    * cos(alpha*log(R)-m*(phi-omegas*t-gamma));
+}
+double TransientLogSpiralPotentialRphideriv(double R,double phi,double t,
+					    struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  //Get args
+  double amp= *args++;
+  double A= *args++;
+  double to= *args++;
+  double sigma2= *args++;
+  double alpha= *args++;
+  double m= *args++;
+  double omegas= *args++;
+  double gamma= *args++;
+  //Calculate Rphideriv
+  return amp * A * exp(-pow(t-to,2.)/2./sigma2) * m / R
+    * cos(alpha*log(R)-m*(phi-omegas*t-gamma));
+}

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -278,10 +278,22 @@ double TransientLogSpiralPotentialRforce(double,double,double,
 		       struct potentialArg *);
 double TransientLogSpiralPotentialphitorque(double,double,double,
 		       struct potentialArg *);
+double TransientLogSpiralPotentialR2deriv(double,double,double,
+		       struct potentialArg *);
+double TransientLogSpiralPotentialphi2deriv(double,double,double,
+		       struct potentialArg *);
+double TransientLogSpiralPotentialRphideriv(double,double,double,
+		       struct potentialArg *);
 //SteadyLogSpiralPotential
 double SteadyLogSpiralPotentialRforce(double,double,double,
 		       struct potentialArg *);
 double SteadyLogSpiralPotentialphitorque(double,double,double,
+		       struct potentialArg *);
+double SteadyLogSpiralPotentialR2deriv(double,double,double,
+		       struct potentialArg *);
+double SteadyLogSpiralPotentialphi2deriv(double,double,double,
+		       struct potentialArg *);
+double SteadyLogSpiralPotentialRphideriv(double,double,double,
 		       struct potentialArg *);
 //EllipticalDiskPotential
 double EllipticalDiskPotentialRforce(double,double,double,

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -29,6 +29,7 @@ from test_potential import (
     fullyRotatedTriaxialNFWPotential,
     mockAdiabaticContractionMWP14WrapperPotential,
     mockCombLinearPotential,
+    mockFlatActiveTransientLogSpiralPotential,
     mockFlatCorotatingRotationSpiralArmsPotential,
     mockFlatCosmphiDiskPotential,
     mockFlatCosmphiDiskwBreakPotential,
@@ -4713,8 +4714,10 @@ def test_liouville_planar():
     pots.append("mockFlatSpiralArmsPotential")
     pots.append("mockRotatingFlatSpiralArmsPotential")
     pots.append("mockSpecialRotatingFlatSpiralArmsPotential")
-    # pots.append('mockFlatSteadyLogSpiralPotential')
-    # pots.append('mockFlatTransientLogSpiralPotential')
+    pots.append("mockFlatSteadyLogSpiralPotential")
+    # active transient (peaks mid-window; the plain mockFlatTransientLogSpiral
+    # peaks at to=-10, which would be vacuous for the spiral Hessian here)
+    pots.append("mockFlatActiveTransientLogSpiralPotential")
     pots.append("mockFlatDehnenSmoothBarPotential")
     pots.append("mockSlowFlatDehnenSmoothBarPotential")
     pots.append("mockSlowFlatDecayingDehnenSmoothBarPotential")
@@ -4799,6 +4802,8 @@ def test_liouville_planar():
     tol["mockFlatCosmphiDiskwBreakPotential"] = -7.0  # more difficult
     # rotating halo+bar: the fixed-step rk4_c reaches ~3e-7 over the ~1 Gyr horizon
     tol["mockFlatSoftenedNeedleBarPotential"] = -6.0
+    # halo+transient spiral: the fixed-step rk4_c reaches ~2e-7 over the horizon
+    tol["mockFlatActiveTransientLogSpiralPotential"] = -6.0
     tol["mockFlatTrulyCorotatingRotationSpiralArmsPotential"] = -5.0  # more difficult
     tol["mockMultipoleExpansionPotential"] = -6.5
     tol["mockMultipoleExpansionLimitedGridPotential"] = -5.0
@@ -4835,11 +4840,19 @@ def test_liouville_planar():
                 and not p == "FerrersPotential"
                 and not p == "MultipoleExpansionPotential"
                 and not p == "DoubleExponentialDiskPotential"
+                and not p == "mockFlatSteadyLogSpiralPotential"
             ):
                 ttol = -4.0
             elif (
                 integrator == "odeint" or not thasC
             ) and p == "MultipoleExpansionPotential":
+                ttol = -3.0
+            elif (
+                integrator == "odeint" or not thasC
+            ) and p == "mockFlatSteadyLogSpiralPotential":
+                # default-tolerance odeint drifts to ~2.6e-4 over the ~1 Gyr
+                # horizon (integrator accuracy, not a Hessian error; the C
+                # integrators reach ~2e-9)
                 ttol = -3.0
             elif (
                 integrator == "odeint" or not thasC
@@ -5125,6 +5138,81 @@ def test_flattenedpower_planar_dxdv_c_vs_python():
             "C planar dxdv (FlattenedPower) disagrees with the pure-Python result "
             f"(method={method}): max diff "
             f"{numpy.amax(numpy.fabs(dev_c - dev_py)):g} (PlanarR2deriv bug?)"
+        )
+    return None
+
+
+def test_logspiral_planar_dxdv_c_vs_python():
+    # The Steady/TransientLogSpiralPotential planar Hessians
+    # (R2deriv/phi2deriv/Rphideriv) in C must reproduce the pure-Python analytic
+    # reference (det(M)=1 in test_liouville_planar is necessary but not sufficient:
+    # it holds for ANY symmetric in-plane Hessian, so only this direct C-vs-Python
+    # comparison pins the actual Hessian values). Both spirals are explicitly
+    # time-dependent, so integrate over a window in which the perturbation is
+    # ACTIVE: the steady spiral grows from tform through tsteady inside the window
+    # (exercising all three branches of the C dehnenSpiralSmooth in the new
+    # derivatives) and the transient spiral's Gaussian envelope peaks mid-window.
+    from galpy.orbit import Orbit
+    from galpy.potential import (
+        LogarithmicHaloPotential,
+        SteadyLogSpiralPotential,
+        TransientLogSpiralPotential,
+    )
+
+    halo = LogarithmicHaloPotential(normalize=1.0).toPlanar()
+    for sp in [
+        SteadyLogSpiralPotential(),  # always on (tform=None -> NaN branch in C)
+        SteadyLogSpiralPotential(tform=0.25, tsteady=2.0),  # grows over the window
+        TransientLogSpiralPotential(to=14.0, sigma=2.0),  # peaks mid-window
+    ]:
+        # non-vacuity: the C variational path must actually be advertised --
+        # without this, a flipped flag would silently fall back to odeint and
+        # the parity comparison would test python against python
+        assert sp.hasC_dxdv, f"{type(sp).__name__} should advertise hasC_dxdv"
+        pot = halo + sp
+        times = numpy.linspace(0.0, 28.0, 1001)
+        ic = [1.0, 0.1, 1.1, 0.3]  # planar [R, vR, vT, phi]
+        # Use a UNIT deviation: the variational equation is linear in the deviation,
+        # so a unit dx makes the STM column O(1) and any relative Hessian error shows
+        # up as a comparable absolute discrepancy.
+        dev = [1.0, 0.0, 0.0, 0.0]
+        o_c = Orbit(ic)
+        o_c.integrate_dxdv(
+            dev,
+            times,
+            pot,
+            method="dopr54_c",
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        o_py = Orbit(ic)
+        o_py.integrate_dxdv(
+            dev,
+            times,
+            pot,
+            method="dop853",
+            rectIn=True,
+            rectOut=True,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        dev_c = numpy.asarray(o_c.getOrbit_dxdv())[-1]
+        dev_py = numpy.asarray(o_py.getOrbit_dxdv())[-1]
+        assert numpy.amax(numpy.fabs(dev_c - dev_py)) < 1e-8, (
+            f"C planar dxdv ({type(sp).__name__}) disagrees with the pure-Python "
+            f"result: max diff {numpy.amax(numpy.fabs(dev_c - dev_py)):g} "
+            "(planar 2nd-derivative bug?)"
+        )
+        # Non-vacuity: the spiral perturbation must actually act along the orbit
+        # (guards against a silently-off spiral making the comparison halo-only)
+        torques = numpy.array(
+            [sp.phitorque(o_c.R(t), phi=o_c.phi(t), t=t) for t in times[::50]]
+        )
+        assert numpy.amax(numpy.fabs(torques)) > 1e-3, (
+            f"{type(sp).__name__} exerts no torque along the test orbit: "
+            "the dxdv C-vs-Python comparison is vacuous"
         )
     return None
 

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -12405,6 +12405,24 @@ class mockFlatTransientLogSpiralPotential(testplanarMWPotential):
         return self._potlist[1].OmegaP()
 
 
+class mockFlatActiveTransientLogSpiralPotential(testplanarMWPotential):
+    # Transient spiral whose Gaussian envelope peaks INSIDE the
+    # test_liouville_planar integration window [0, 28] (the plain
+    # mockFlatTransientLogSpiralPotential peaks at to=-10, so its perturbation
+    # is ~exp(-50) there and the test would be vacuous for the spiral Hessian)
+    def __init__(self):
+        testplanarMWPotential.__init__(
+            self,
+            potlist=[
+                potential.LogarithmicHaloPotential(normalize=1.0),
+                potential.TransientLogSpiralPotential(to=14.0, sigma=4.0),
+            ],
+        )
+
+    def OmegaP(self):
+        return self._potlist[1].OmegaP()
+
+
 class mockFlatSpiralArmsPotential(testMWPotential):
     def __init__(self):
         testMWPotential.__init__(


### PR DESCRIPTION
Closes the last two real capability gaps from the variational-track audit:

**Log-spiral planar Hessians**: `SteadyLogSpiralPotential` and `TransientLogSpiralPotential` had `hasC=True` but no second derivatives anywhere. With χ = α ln R − m(φ − Ω_s t − γ) and s(t) the envelope: Φ_RR = s·A/R²·(sin χ − α cos χ), Φ_φφ = −s·A·m²/α·cos χ, Φ_Rφ = s·A·m/R·cos χ — derived from the class definitions, validated at 300 points vs central FD of the existing forces (1.6e-9) **before** the C port, plus an independent agent re-derivation. C transcriptions wired in the planar parser; `hasC_dxdv=True`.

Tests: planar C-vs-Python dxdv parity over three configs covering all `dehnenSpiralSmooth` branches and an active transient window (non-vacuity: flag asserted + spiral torque >1e-3 along the orbit; verified to run under `-W error::galpyWarning`, i.e. genuinely on the C path); both spirals added to `test_liouville_planar` (new active-transient mock — the pre-existing one peaks at to=−10 and is ~e⁻⁵⁰ in the test window); generic 2nd-deriv-vs-FD coverage confirmed non-vacuous. gcov: 100% of both C files (75/75, 61/61) + all parser wiring lines, CI-exact build; mutations killed per file.

**Rotated ellipsoidals (docs only, per maintainer decision)**: notes in the EllipsoidalPotential docstring and `integrate_dxdv` pointing rotated (zvec/pa) instances — which have `hasC_dxdv3d=False` by design — to `RotateAndTiltWrapperPotential` around the aligned potential (identical physics, full dxdv3d support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)