### PR TITLE
Fix silent-skip in _parse_pot: planarized potentials without planar C support segfaulted the C integrator

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,14 @@
 v1.12.0 (expected around 2026-07-01)
 ====================
 
+- Fixed a segmentation fault (or silently-dropped force) when integrating
+  planar orbits with a C integrator for potentials whose 3D version has a C
+  implementation, but whose planar version does not (e.g., interpRZPotential,
+  ChandrasekharDynamicalFrictionForce, FDMDynamicalFrictionForce). Such
+  potentials now fall back to Python integration with the usual warning, and
+  the C potential parsers now raise a clear error for any potential that
+  claims C support without having a C implementation.
+
 - Added a ``cinterp`` option (default ``True``, resolution set by ``cinterp_n``)
   to ``NonInertialFrameForce`` that, during C orbit integration, replaces the
   time-dependent inputs (``a0``, ``x0``, ``v0``, ``Omega``) by cubic-spline

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -559,6 +559,14 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
             pot_args.extend(wrap_pot_args)
             pot_tfuncs.extend(wrap_pot_tfuncs)
             pot_args.extend([p._amp, p._Rp, p._refpot])
+        else:
+            # Should never get here: a potential that gets to this point
+            # claims to have a C implementation (hasC=True), but has no
+            # entry above; silently skipping it would corrupt the arguments
+            # passed to C (npot counts it), leading to a crash
+            raise NotImplementedError(
+                f"Potential {type(p).__name__} is not supported by the C orbit-integration backend, but claims to be (hasC=True); please report this to the galpy developers"
+            )
     pot_type = numpy.array(pot_type, dtype=numpy.int32, order="C")
     pot_args = _finalize_pot_args(pot_args)
     return (npot, pot_type, pot_args, pot_tfuncs)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -641,6 +641,17 @@ def _parse_pot(pot, t=None):
             pot_args.extend(wrap_pot_args)
             pot_tfuncs.extend(wrap_pot_tfuncs)
             pot_args.extend([p._amp, p._Rp, p._refpot])
+        else:
+            # Should never get here: a potential that gets to this point
+            # claims to have a C implementation (hasC=True), but has no
+            # entry above; silently skipping it would corrupt the arguments
+            # passed to C (npot counts it), leading to a crash
+            pname = type(p).__name__
+            if hasattr(p, "_Pot") and not isinstance(p._Pot, list):
+                pname += f" (wrapping {type(p._Pot).__name__})"
+            raise NotImplementedError(
+                f"Potential {pname} is not supported by the C planar-orbit-integration backend, but claims to be (hasC=True); please report this to the galpy developers"
+            )
 
     pot_type = numpy.array(pot_type, dtype=numpy.int32, order="C")
     pot_args = _finalize_pot_args(pot_args)

--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -156,6 +156,10 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
         self._amp *= 4.0 * numpy.pi
         self._force_hash = None
         self.hasC = _check_c(self._dens_pot, dens=True)
+        # No planar version of (Chandrasekhar/FDM) dynamical friction in the
+        # C integrator (also covers FDMDynamicalFrictionForce, which inherits
+        # its hasC* attributes from here)
+        self.hasC_planar = False
         return None
 
     def GMs(self, gms):

--- a/galpy/potential/DissipativeForce.py
+++ b/galpy/potential/DissipativeForce.py
@@ -41,6 +41,11 @@ class DissipativeForce(Force):
         self.hasC = False
         self.hasC_dxdv = False
         self.hasC_dens = False
+        # Whether the C implementation (if hasC) extends to the planar
+        # (z=0) version of this force obtained through toPlanar/
+        # toPlanarPotential; classes with C support that is *not* hooked up
+        # in the planar C integrator should set this to False
+        self.hasC_planar = True
 
     @potential_physical_input
     @physical_conversion("force", pop=True)

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -171,6 +171,11 @@ class Potential(Force):
         self.hasC = False
         self.hasC_dxdv = False
         self.hasC_dens = False
+        # Whether the C implementation (if hasC) extends to the planar
+        # (z=0) version of this potential obtained through toPlanar/
+        # toPlanarPotential; classes with C support that is *not* hooked up
+        # in the planar C integrator should set this to False
+        self.hasC_planar = True
         return None
 
     @potential_physical_input

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -204,6 +204,8 @@ class interpRZPotential(Potential):
         self._interpverticalfreq = interpverticalfreq
         self._enable_c = enable_c * ext_loaded
         self.hasC = self._enable_c
+        # No planar version of interpRZPotential in the C integrator
+        self.hasC_planar = False
         self._zsym = zsym
         if interpPot:
             if use_c * ext_loaded:

--- a/galpy/potential/planarDissipativeForce.py
+++ b/galpy/potential/planarDissipativeForce.py
@@ -117,8 +117,11 @@ class planarDissipativeForceFromFullDissipativeForce(planarDissipativeForce):
         self._roSet = Pot._roSet
         self._voSet = Pot._voSet
         self._Pot = Pot
-        self.hasC = Pot.hasC
-        self.hasC_dxdv = Pot.hasC_dxdv
+        # Only advertise C support when the wrapped force's C
+        # implementation extends to its planar version (hasC_planar)
+        _hasC_planar = getattr(Pot, "hasC_planar", True)
+        self.hasC = Pot.hasC and _hasC_planar
+        self.hasC_dxdv = Pot.hasC_dxdv and _hasC_planar
         self.hasC_dens = Pot.hasC_dens
         return None
 

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -548,8 +548,11 @@ class planarPotentialFromRZPotential(planarAxiPotential):
         self._roSet = RZPot._roSet
         self._voSet = RZPot._voSet
         self._Pot = RZPot
-        self.hasC = RZPot.hasC
-        self.hasC_dxdv = RZPot.hasC_dxdv
+        # Only advertise C support when the wrapped potential's C
+        # implementation extends to its planar version (hasC_planar)
+        _hasC_planar = getattr(RZPot, "hasC_planar", True)
+        self.hasC = RZPot.hasC and _hasC_planar
+        self.hasC_dxdv = RZPot.hasC_dxdv and _hasC_planar
         self.hasC_dens = RZPot.hasC_dens
         return None
 
@@ -724,8 +727,11 @@ class planarPotentialFromFullPotential(planarPotential):
         self._roSet = Pot._roSet
         self._voSet = Pot._voSet
         self._Pot = Pot
-        self.hasC = Pot.hasC
-        self.hasC_dxdv = Pot.hasC_dxdv
+        # Only advertise C support when the wrapped potential's C
+        # implementation extends to its planar version (hasC_planar)
+        _hasC_planar = getattr(Pot, "hasC_planar", True)
+        self.hasC = Pot.hasC and _hasC_planar
+        self.hasC_dxdv = Pot.hasC_dxdv and _hasC_planar
         self.hasC_dens = Pot.hasC_dens
         return None
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -8164,6 +8164,134 @@ def test_orbitint_pythonfallback():
     return None
 
 
+def test_orbitint_planar_interprz_pythonfallback():
+    # Planar version of an interpRZPotential has no C implementation in the
+    # planar C integrator; used to segfault, because the planar potential
+    # advertised hasC=True, but the C parser silently skipped it
+    from galpy.orbit import Orbit
+
+    mp = potential.MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.05)
+    ip = potential.interpRZPotential(
+        RZPot=mp,
+        rgrid=(0.5, 1.5, 21),
+        zgrid=(0.0, 0.2, 21),
+        interpPot=True,
+        interpRforce=True,
+        interpzforce=True,
+        enable_c=True,
+        zsym=True,
+    )
+    pip = ip.toPlanar()
+    # Root cause: the planarized potential should not advertise C support
+    assert not pip.hasC, (
+        "Planar interpRZPotential should not advertise C support (hasC=True), because it has no planar C implementation"
+    )
+    o = Orbit([1.0, 0.1, 1.1, 0.1])
+    ts = numpy.linspace(0.0, 1.0, 101)
+    with pytest.warns(galpyWarning) as record:
+        warnings.simplefilter("always", galpyWarning)
+        o.integrate(ts, pip, method="dop853_c")
+    raisedWarning = False
+    for rec in record:
+        raisedWarning += str(rec.message.args[0]).startswith(
+            "Cannot use C integration because some of the potentials are not implemented in C"
+        )
+    assert raisedWarning, (
+        "Integrating a planar orbit in a planar interpRZPotential with a C method did not raise the Python-fallback warning"
+    )
+    # Integration should have completed sensibly
+    assert numpy.all(numpy.isfinite(o.R(ts))), (
+        "Integrating a planar orbit in a planar interpRZPotential did not complete correctly"
+    )
+    return None
+
+
+def test_orbitint_planar_dynamfric_pythonfallback():
+    # Planar version of ChandrasekharDynamicalFrictionForce has no C
+    # implementation in the planar C integrator; used to be silently
+    # dropped by the C parser, such that the friction had no effect
+    from galpy.orbit import Orbit
+
+    lp = potential.LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    cdf = potential.ChandrasekharDynamicalFrictionForce(
+        GMs=0.05, rhm=0.1, dens=lp, sigmar=lambda r: 1.0 / numpy.sqrt(2.0)
+    )
+    pot = potential.toPlanarPotential(lp + cdf)
+    # Root cause: the planarized friction force should not advertise C support
+    assert not pot[1].hasC, (
+        "Planar ChandrasekharDynamicalFrictionForce should not advertise C support (hasC=True), because it has no planar C implementation"
+    )
+    o = Orbit([1.0, 0.1, 1.1, 0.1])
+    ts = numpy.linspace(0.0, 10.0, 101)
+    with pytest.warns(galpyWarning) as record:
+        warnings.simplefilter("always", galpyWarning)
+        o.integrate(ts, pot, method="dop853_c")
+    raisedWarning = False
+    for rec in record:
+        raisedWarning += str(rec.message.args[0]).startswith(
+            "Cannot use C integration because some of the potentials are not implemented in C"
+        )
+    assert raisedWarning, (
+        "Integrating a planar orbit with planar dynamical friction with a C method did not raise the Python-fallback warning"
+    )
+    # Check that the dynamical friction was actually applied: angular
+    # momentum should decay (it was silently dropped before this fix)
+    Lzs = o.R(ts) * o.vT(ts)
+    assert Lzs[-1] < Lzs[0] - 0.05, (
+        "Dynamical friction was not applied when integrating a planar orbit with planar dynamical friction"
+    )
+    return None
+
+
+def test_parse_pot_unparsed_potential_raises():
+    # A potential that claims to have a C implementation (hasC=True), but
+    # has no entry in the C parsers' if/elif chains should raise a clear
+    # error rather than silently corrupting the arguments passed to C
+    from galpy.orbit.integrateFullOrbit import _parse_pot as _parse_pot_full
+    from galpy.orbit.integratePlanarOrbit import _parse_pot as _parse_pot_planar
+    from galpy.potential.planarPotential import planarPotential
+
+    class FakeCFullPotential(potential.Potential):
+        def __init__(self, amp=1.0):
+            potential.Potential.__init__(self, amp=amp)
+            self.hasC = True
+
+        def _evaluate(self, R, z, phi=0.0, t=0.0):
+            return 0.0
+
+        def _Rforce(self, R, z, phi=0.0, t=0.0):
+            return 0.0
+
+        def _zforce(self, R, z, phi=0.0, t=0.0):
+            return 0.0
+
+    class FakeCPlanarPotential(planarPotential):
+        def __init__(self, amp=1.0):
+            planarPotential.__init__(self, amp=amp)
+            self.hasC = True
+
+        def _evaluate(self, R, phi=0.0, t=0.0):
+            return 0.0
+
+        def _Rforce(self, R, phi=0.0, t=0.0):
+            return 0.0
+
+    # Full C parser
+    with pytest.raises(NotImplementedError) as excinfo:
+        _parse_pot_full([FakeCFullPotential()])
+    assert "FakeCFullPotential" in str(excinfo.value)
+    # Planar C parser, with a native planar potential
+    with pytest.raises(NotImplementedError) as excinfo:
+        _parse_pot_planar([FakeCPlanarPotential()])
+    assert "FakeCPlanarPotential" in str(excinfo.value)
+    # Planar C parser, with a planarized 3D potential, such that the
+    # error names the wrapped potential
+    with pytest.raises(NotImplementedError) as excinfo:
+        _parse_pot_planar([potential.toPlanarPotential(FakeCFullPotential())])
+    assert "wrapping FakeCFullPotential" in str(excinfo.value)
+    return None
+
+
 def test_orbitint_dissipativefallback():
     # Check if a warning is raised when one tries to integrate an orbit
     # in a dissipative force law with a symplectic integrator


### PR DESCRIPTION
`_parse_pot`'s if/elif chain has no final `else`: a potential with `hasC=True` but no matching parse case contributes nothing to `pot_type`/`pot_args` while `npot` still counts it, so the C parser reads garbage. Two reproducers on unpatched main: `interpRZPotential(...).toPlanar()` with `dop853_c` **segfaults** (exit 139), and a planarized `ChandrasekharDynamicalFrictionForce` is **silently dropped** — the C orbit is byte-identical to frictionless while the Python orbit decays to R~0.002 (arguably worse than the crash).

Fix at two altitudes:
1. **Root cause**: new `hasC_planar` attribute (default `True`, alongside the other `hasC*` flags) meaning "the C implementation extends to the planar version"; set `False` exactly where full-parser C cases exist but planar ones don't (interpRZPotential, ChandrasekharDynamicalFrictionForce; FDM inherits). The planar adapters consult it, so these potentials now fall back to the Python integrator with the standard `galpyWarning` and produce correct results.
2. **Defense in depth**: final `else` in *both* `_parse_pot` chains (planar and full) raising a clear error naming the offending class — any future flag/case mismatch fails loudly in Python instead of corrupting C args.

Regression tests: both reproducers (assert the fallback warning + correct physics: the planarized-friction orbit now matches Python), plus a direct unit test that an unparseable `hasC=True` potential raises. Batteries: planar/dxdv/SOS orbit subsets, interp/dynamfric/FDM suites, full-orbit C paths for CDF and interpRZ confirmed still on C (no fallback warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)