### PR TITLE
RotateAndTiltWrapperPotential C: include t in the force-cache key

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -9,6 +9,12 @@ v1.12.0 (expected around 2026-07-01)
   the C potential parsers now raise a clear error for any potential that
   claims C support without having a C implementation.
 
+- Fixed a bug in the C implementation of ``RotateAndTiltWrapperPotential``
+  where the internal force cache was keyed on position only, so that
+  re-evaluating the force at the same position but a different time returned
+  stale forces when wrapping a time-dependent potential. The cache key now
+  includes the time.
+
 - Added a ``cinterp`` option (default ``True``, resolution set by ``cinterp_n``)
   to ``NonInertialFrameForce`` that, during C orbit integration, replaces the
   time-dependent inputs (``a0``, ``x0``, ``v0``, ``Omega``) by cubic-spline

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -518,7 +518,8 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
             pot_args.extend(wrap_pot_args)
             pot_tfuncs.extend(wrap_pot_tfuncs)
             pot_args.extend([p._amp])
-            pot_args.extend([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # for caching
+            # for caching: x,y,z,t key + Fx,Fy,Fz
+            pot_args.extend([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
             pot_args.extend(list(p._rot.flatten()))
             pot_args.append(not p._norot)
             pot_args.append(not p._offset is None)

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -654,7 +654,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->Rforce= &RotateAndTiltWrapperPotentialRforce;
       potentialArgs->zforce= &RotateAndTiltWrapperPotentialzforce;
       potentialArgs->phitorque= &RotateAndTiltWrapperPotentialphitorque;
-      potentialArgs->nargs= 21;
+      potentialArgs->nargs= 22;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/RotateAndTiltWrapperPotential.c
@@ -8,10 +8,10 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
                  double t, double * Fx, double * Fy, double * Fz,
                  struct potentialArg * potentialArgs){
     double * args= potentialArgs->args;
-    double * rot= args+7;
-    bool rotSet= (bool) *(args+16);
-    bool offsetSet= (bool) *(args+17);
-    double * offset= args+18;
+    double * rot= args+8;
+    bool rotSet= (bool) *(args+17);
+    bool offsetSet= (bool) *(args+18);
+    double * offset= args+19;
     double x, y;
     double Rforce, phitorque;
     cyl_to_rect(R, phi, &x, &y);
@@ -19,6 +19,7 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
     *(args + 1)= x;
     *(args + 2)= y;
     *(args + 3)= z;
+    *(args + 4)= t;
     //now get the forces in R, phi, z in the aligned frame
     if (rotSet) {
       rotate(&x,&y,&z,rot);
@@ -43,26 +44,27 @@ void RotateAndTiltWrapperPotentialxyzforces(double R, double z, double phi,
       rotate_force(Fx,Fy,Fz,rot);
     }
     //cache
-    *(args + 4)= *Fx;
-    *(args + 5)= *Fy;
-    *(args + 6)= *Fz;
+    *(args + 5)= *Fx;
+    *(args + 6)= *Fy;
+    *(args + 7)= *Fz;
 }
 double RotateAndTiltWrapperPotentialRforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
    double * args = potentialArgs->args;
-   //get cached xyz
+   //get cached xyzt
    double cached_x = *(args + 1);
    double cached_y = *(args + 2);
    double cached_z = *(args + 3);
+   double cached_t = *(args + 4);
    // change the zvector, calculate Rforce
    double Fx, Fy, Fz;
    double x, y;
    cyl_to_rect(R, phi, &x, &y);
-   if ( x == cached_x && y == cached_y && z == cached_z ){
-    Fx = *(args + 4);
-    Fy = *(args + 5);
-    Fz = *(args + 6);
+   if ( x == cached_x && y == cached_y && z == cached_z && t == cached_t ){
+    Fx = *(args + 5);
+    Fy = *(args + 6);
+    Fz = *(args + 7);
    }
    else
     RotateAndTiltWrapperPotentialxyzforces(R, z, phi, t, &Fx, &Fy, &Fz,
@@ -73,18 +75,19 @@ double RotateAndTiltWrapperPotentialphitorque(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
-    //get cached xyz
+    //get cached xyzt
     double cached_x = *(args + 1);
     double cached_y = *(args + 2);
     double cached_z = *(args + 3);
+    double cached_t = *(args + 4);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
     double x, y;
     cyl_to_rect(R, phi, &x, &y);
-    if ( x == cached_x && y == cached_y && z == cached_z ){
-     Fx = *(args + 4);
-     Fy = *(args + 5);
-     Fz = *(args + 6);
+    if ( x == cached_x && y == cached_y && z == cached_z && t == cached_t ){
+     Fx = *(args + 5);
+     Fy = *(args + 6);
+     Fz = *(args + 7);
     }
     else
     // LCOV_EXCL_START
@@ -97,18 +100,19 @@ double RotateAndTiltWrapperPotentialzforce(double R, double z, double phi,
         double t,
         struct potentialArg * potentialArgs){
     double * args = potentialArgs->args;
-    //get cached xyz
+    //get cached xyzt
     double cached_x = *(args + 1);
     double cached_y = *(args + 2);
     double cached_z = *(args + 3);
+    double cached_t = *(args + 4);
     // change the zvector, calculate Rforce
     double Fx, Fy, Fz;
     double x, y;
     cyl_to_rect(R, phi, &x, &y);
-    if ( x == cached_x && y == cached_y && z == cached_z ){
-     Fx = *(args + 4);
-     Fy = *(args + 5);
-     Fz = *(args + 6);
+    if ( x == cached_x && y == cached_y && z == cached_z && t == cached_t ){
+     Fx = *(args + 5);
+     Fy = *(args + 6);
+     Fz = *(args + 7);
     }
     else
     // LCOV_EXCL_START

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -7266,6 +7266,45 @@ def test_integration_RotateAndTiltWrapper():
     return None
 
 
+def test_integration_RotateAndTiltWrapper_timedependent_forcecache():
+    # Regression test for the C force cache of RotateAndTiltWrapperPotential
+    # being keyed on position only: with a time-dependent wrapped potential,
+    # re-evaluating the force at the same position but a different time
+    # returned stale forces. Exercised by an orbit initially at rest in a
+    # potential that only forms at t > 0 (zero force before tform, so the
+    # position repeats exactly at every force evaluation while t advances):
+    # with the stale cache, the C-integrated orbit never starts moving
+    mn = potential.MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.05)
+    tdep = potential.DehnenSmoothWrapperPotential(pot=mn, tform=1.0, tsteady=2.0)
+    rotpot = potential.RotateAndTiltWrapperPotential(
+        pot=tdep,
+        zvec=[numpy.sin(0.3), 0.0, numpy.cos(0.3)],
+        offset=[0.5, 0.3, 0.2],
+    )
+    ts = numpy.linspace(0.0, 5.0, 101)
+    orb_py = orbit.Orbit([1.0, 0.0, 0.0, 0.3, 0.0, 0.7])
+    orb_c = orbit.Orbit([1.0, 0.0, 0.0, 0.3, 0.0, 0.7])
+    orb_py.integrate(ts, rotpot, method="dop853")
+    orb_c.integrate(ts, rotpot, method="dop853_c")
+    # The orbit should move once the potential has formed
+    assert numpy.fabs(orb_c.R(ts[-1]) - orb_c.R(ts[0])) > 0.1, (
+        "C-integrated orbit in a time-dependent RotateAndTiltWrapperPotential does not move, indicating that the C force cache returns stale forces"
+    )
+    # and the C integration should agree with the pure-Python one
+    vxvv_py = orb_py.getOrbit()
+    vxvv_c = orb_c.getOrbit()
+    assert numpy.all(numpy.fabs(vxvv_py[:, :5] - vxvv_c[:, :5]) < 10.0**-6), (
+        "C orbit integration in a time-dependent RotateAndTiltWrapperPotential does not agree with the pure-Python integration"
+    )
+    dphi = vxvv_py[:, 5] - vxvv_c[:, 5]
+    assert numpy.all(
+        numpy.fabs(numpy.arctan2(numpy.sin(dphi), numpy.cos(dphi))) < 10.0**-6
+    ), (
+        "C orbit integration in a time-dependent RotateAndTiltWrapperPotential does not agree with the pure-Python integration"
+    )
+    return None
+
+
 def test_vtermnegl_issue314():
     # Test related to issue 314: vterm for negative l
     rp = potential.RazorThinExponentialDiskPotential(normalize=1.0, hr=3.0 / 8.0)


### PR DESCRIPTION
The C force cache keyed on (x,y,z) only, so with a **time-dependent wrapped potential** a re-evaluation at the same position but different t returned stale forces. Honest scoping: within one EOM evaluation the three force components share (position, t) and `pot_args` are rebuilt per `integrate()` call, so generic orbits never hit it — it bites when the exact same position recurs at different t, e.g. **an orbit at rest in a not-yet-formed potential**: on unpatched main, `RotateAndTilt(DehnenSmooth(MiyamotoNagai, tform=1, tsteady=2), zvec, offset)` started at rest never moves under `dop853_c` (the zero force cached at t=0 is returned forever) while the Python orbit falls correctly — divergence ~3 natural units.

Fix: cache key extended to (x,y,z,t) (args layout shifted by one; Python parse extends the cache zeros; C nargs 21→22). Post-fix C matches Python to <1e-9 per coordinate. Static-wrapped-potential path verified byte-identical pre/post via orbit hash. Regression test fails pre-fix (stash-verified) and passes post-fix; the heavy C users of the wrapper (arbitraryaxisrotation suite in test_noninertial.py, streamspraydf) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)