### PR TITLE
CI: remove the unused 'ci skip' commit-message guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -18,7 +18,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `build` jobs in `build.yml` and `build_windows.yml` carried

```yaml
if: "!contains(github.event.head_commit.message, 'ci skip')"
```

Two problems, and it's unused anyway:
- `contains()` is a **case-insensitive substring** match, not the conventional bracketed `[ci skip]`/`[skip ci]` token — so any commit whose message merely *mentions* "ci skip" (e.g. a body line describing tests that "CI skips" on certain runners) silently skipped the push-triggered build.
- It reads `github.event.head_commit.message`, which is **null for `pull_request` events**, so it only ever affected push-triggered runs — never gave a usable skip on PRs.

Removed from both workflows (2 lines). No other skip mechanism is in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)