### PR TITLE
Backend: torch/jax time-dependent amplitude for DehnenSmooth + GaussianAmplitude wrappers

### DIFF
--- a/galpy/potential/DehnenSmoothWrapperPotential.py
+++ b/galpy/potential/DehnenSmoothWrapperPotential.py
@@ -66,6 +66,7 @@ class DehnenSmoothWrapperPotential(parentWrapperPotential):
             self._tsteady = self._tform + tsteady
         self._grow = not decay
         self.hasC = True
+        self._backend_compatible = True
         self.hasC_dxdv = True
         # Advertise the 3D variational capability unconditionally, as for
         # hasC/hasC_dxdv: _check_c recurses into the wrapped potential's own
@@ -81,7 +82,11 @@ class DehnenSmoothWrapperPotential(parentWrapperPotential):
         # diffrax/torchdiffeq integrator, or autodiff wrt time) uses that
         # backend's branch-free where, so it is traceable and differentiable.
         xp = get_namespace(t)
-        if xp is numpy:
+        if xp is numpy or isinstance(t, (float, int)):
+            # numpy/python scalar fast path: a concrete (Python/numpy) t keeps
+            # the original scalar branching, byte-identical, even when a backend
+            # is forced (get_namespace then returns jax/torch for a plain float,
+            # but jax/torch ops on a python scalar/python-bool condition fail).
             # Calculate relevant time
             if t < self._tform:
                 smooth = 0.0

--- a/galpy/potential/GaussianAmplitudeWrapperPotential.py
+++ b/galpy/potential/GaussianAmplitudeWrapperPotential.py
@@ -2,6 +2,10 @@
 #   GaussianAmplitudeWrapperPotential.py: Wrapper to modulate the amplitude
 #                                         of a potential with a Gaussian
 ###############################################################################
+import math
+
+import numpy
+
 from ..backend import get_namespace
 from ..util import conversion
 from .WrapperPotential import parentWrapperPotential
@@ -43,6 +47,7 @@ class GaussianAmplitudeWrapperPotential(parentWrapperPotential):
         self._to = to
         self._sigma2 = sigma**2.0
         self.hasC = True
+        self._backend_compatible = True
         self.hasC_dxdv = True
         # Advertise the 3D variational capability unconditionally, as for
         # hasC/hasC_dxdv: _check_c recurses into the wrapped potential's own
@@ -52,10 +57,18 @@ class GaussianAmplitudeWrapperPotential(parentWrapperPotential):
 
     def _smooth(self, t):
         # The namespace follows t itself: a concrete (Python/numpy) t keeps the
-        # numpy path byte-identical; a traced t (in-backend integrator, autodiff
-        # wrt time) uses that backend's exp, so it is differentiable.
+        # original scalar path (byte-identical; returns a plain float that
+        # multiplies into any backend's spatial arrays); a backend-array/traced t
+        # (the in-backend integrator, or autodiff wrt time) uses that backend's
+        # exp, so it is differentiable.
         xp = get_namespace(t)
-        return xp.exp(-0.5 * (t - self._to) ** 2.0 / self._sigma2)
+        arg = -0.5 * (t - self._to) ** 2.0 / self._sigma2
+        if xp is numpy or isinstance(t, (float, int)):
+            # numpy/python scalar fast path: use math.exp so a concrete (and even
+            # forced-backend) Python/numpy-scalar t stays byte-identical and does
+            # not feed a Python scalar to a backend's exp (torch rejects that).
+            return math.exp(arg)
+        return xp.exp(arg)
 
     def _wrap(self, attribute, *args, **kwargs):
         return self._smooth(kwargs.get("t", 0.0)) * self._wrap_pot_func(attribute)(

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -164,9 +164,14 @@ def test_check_backend_compatible_semantics():
         cbc(potential.KuzminLikeWrapperPotential(amp=1.0, pot=pit, a=1.0, b=0.2))
         is False
     )
-    # amplitude-only wrappers stay unmigrated; the inner potential self-coerces
+    # migrated amplitude wrappers: compatible iff the wrapped potential is too
     assert (
         cbc(potential.DehnenSmoothWrapperPotential(pot=mn, tform=-1.0, tsteady=1.0))
+        is True
+    )
+    # a still-unmigrated amplitude wrapper backs out (own flag defaults to False)
+    assert (
+        cbc(potential.TimeDependentAmplitudeWrapperPotential(pot=mn, A=lambda t: 1.0))
         is False
     )
     # opts back out despite its interpSphericalPotential base

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -388,6 +388,25 @@ def test_dehnensmooth_backend_t_window_parity(backend_name, t0):
     numpy.testing.assert_allclose(got, ref, rtol=1e-15, atol=1e-15)
 
 
+# Backend-array t value parity for GaussianAmplitude: a non-numpy, non-Python t
+# takes the xp.exp branch of _smooth (the math.exp fast path handles only a
+# concrete Python/numpy scalar t). Mirrors the DehnenSmooth window test above.
+@pytest.mark.parametrize("t0", [-2.0, 0.15, 3.0])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_gaussianamplitude_backend_t_parity(backend_name, t0):
+    pot = _WRAPPERS[2][1]  # GaussianAmplitude, to=0.5, sigma=1.3
+    ref = float(pot._evaluate(1.1, 0.23, phi=0.4, t=t0))
+    got = float(
+        pot._evaluate(
+            _toscalar(backend_name, 1.1),
+            _toscalar(backend_name, 0.23),
+            phi=_toscalar(backend_name, 0.4),
+            t=_toscalar(backend_name, t0),
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-15, atol=1e-15)
+
+
 # --- wrapper-of-wrapper chain -------------------------------------------------------
 _CHAIN = DehnenSmoothWrapperPotential(
     pot=GaussianAmplitudeWrapperPotential(pot=_PP, to=0.5, sigma=1.3),


### PR DESCRIPTION
Part (c) of the Track-A `potential/` tail. Stacked on #960; retarget to `feat/backends` once #960 merges.

The time-dependent amplitude `_smooth` of these two wrappers raised under forced torch/jax: `get_namespace(t)` resolves to the forced backend even for a python-float `t`, so `torch.exp(<float>)` and DehnenSmooth's data-dependent `torch.where(<python bool>, ...)` failed.

- Keep the numpy/python scalar fast path (gate `xp is numpy or isinstance(t,(float,int))`, returning a plain float — byte-identical numpy, safe under any forced backend); use `xp.exp`/`xp.where` only for a genuinely traced/array `t` (the in-backend integrator / autodiff-w.r.t.-time path).
- Set `_backend_compatible = True` on both wrappers: `WrapperPotential` delegates to the wrapped potential via `_Rforce_nodecorator`, **bypassing its coercing decorator**, so the wrapper itself must coerce its coordinate inputs (with the flag False, scalar `R,z` reached `torch.sqrt(float)`).

**Validation:** numpy byte-identical; full public path (scalar + array, several `t` including grow/decay) jax+torch parity ≤ 1e-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)