### PR TITLE
backend: general interpolation + quadrature utilities (galpy.backend.interpolate / quadrature)

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -1,0 +1,516 @@
+###############################################################################
+#   galpy.backend.interpolate: backend-agnostic interpolation.
+#
+#   numpy stays byte-identical to the scipy splines (the numpy code paths call
+#   the fitted scipy spline / RectBivariateSpline.ev directly, never the xp
+#   evaluators here); jax/torch evaluate the same piecewise polynomials natively
+#   so the result is exactly autodifferentiable. Two complementary capabilities:
+#
+#     mode 1 (frozen, eval-point-differentiable): a scipy spline fitted once at
+#       setup is converted to a power-basis piecewise-polynomial table
+#       (``spline_to_ppoly`` / ``rect_bivariate_to_ppoly``); ``eval_ppoly`` /
+#       ``eval_rect_ppoly`` then evaluate it through namespace ops, so the value
+#       is differentiable w.r.t. the EVALUATION POINT. This is what backs
+#       interpSphericalPotential and interpRZPotential.
+#
+#     mode 2 (in-backend construction, y-differentiable): ``cubic_spline_coeffs``
+#       builds the piecewise-cubic coefficients from (x, y) ENTIRELY in xp (a
+#       tridiagonal/linear solve via ``xp.linalg.solve``), so the spline is
+#       differentiable w.r.t. the y-VALUES (interpax / jax-cosmo style). This is
+#       what lets d(orbit)/d(param) flow through a parameter-dependent table
+#       (e.g. the dynamical-friction sigma_r(r) table). ``interp_linear`` is the
+#       trivially-differentiable degree-1 option.
+#
+#   Every ``xp.where`` here dead-branch-guards both sides (the namespaces
+#   evaluate both branches eagerly): the unused branch's argument is clamped
+#   into a safe region so no inf/nan poisons reverse-mode autodiff, exactly as
+#   in galpy.backend.special._fallback.bessel_k._k01.
+#
+#   NO internal jit: these functions are jit-COMPATIBLE (pure namespace ops,
+#   Python-level loops over the *static* polynomial degree only), so a caller
+#   may jit their galpy-using code; galpy never jits internally.
+###############################################################################
+import numpy
+from scipy import interpolate as _scipy_interpolate
+
+from ._namespaces import (
+    asarray_on_device,
+    device_of,
+    is_backend_array,
+)
+
+__all__ = [
+    "spline_to_ppoly",
+    "eval_ppoly",
+    "cubic_spline_coeffs",
+    "eval_cubic",
+    "interp_linear",
+    "rect_bivariate_to_ppoly",
+    "eval_rect_ppoly",
+    "Spline1D",
+    "Spline2D",
+]
+
+
+###############################################################################
+#   (1) Frozen 1D piecewise-power evaluator (promoted from
+#       interpSphericalPotential.py; VERBATIM, plus an ``extrapolate`` knob).
+###############################################################################
+def spline_to_ppoly(spl):
+    """Convert a FITPACK spline to de-duplicated piecewise-power coefficients.
+
+    Returns ``(x, c)`` with ``x`` the distinct breakpoints (shape ``(m+1,)``)
+    and ``c`` the power-basis coefficients (shape ``(k+1, m)``) such that on
+    ``x[i] <= r < x[i+1]`` the spline is ``sum_j c[j, i] * (r - x[i])**(k-j)``.
+    This is the exact piecewise-polynomial representation of the spline (scipy's
+    ``PPoly.from_spline``), with the zero-width intervals coming from FITPACK's
+    repeated boundary knots dropped so that interval lookup by ``searchsorted``
+    is unambiguous. Called once at setup (init-time numpy/scipy is fine); the
+    coefficients then feed the backend-agnostic ``eval_ppoly`` below.
+    """
+    ppoly = _scipy_interpolate.PPoly.from_spline(spl._eval_args)
+    keep = numpy.diff(ppoly.x) > 0.0
+    return numpy.append(ppoly.x[:-1][keep], ppoly.x[-1]), ppoly.c[:, keep]
+
+
+def eval_ppoly(xp, x, c, r, *, extrapolate=True):
+    """Evaluate a piecewise polynomial in the power basis at ``r``.
+
+    ``(x, c)`` are as returned by ``spline_to_ppoly`` (or ``cubic_spline_coeffs``
+    -- same layout); the evaluation (interval lookup by ``xp.searchsorted`` +
+    Horner) uses only namespace operations, so the spline value is computed
+    natively -- and is exactly autodifferentiable -- under jax/torch.
+    Mathematically this is the same piecewise polynomial as the scipy spline
+    (agreement at the ~1 ulp level); the numpy code paths keep calling the scipy
+    splines directly and never come through here.
+
+    ``extrapolate`` selects the out-of-range behaviour, matching the
+    ``InterpolatedUnivariateSpline`` ``ext`` modes callers use:
+
+    - ``True`` (default, scipy ``ext=0``): the edge polynomial is evaluated for
+      ``r`` outside ``[x[0], x[-1]]`` (finite polynomial extrapolation). This is
+      the original interpSphericalPotential behaviour and keeps the dead side of
+      the callers' ``xp.where`` branch selections NaN-free under autodiff.
+    - ``'clip'``: the evaluation point is clamped to ``[x[0], x[-1]]`` before
+      evaluation, so out-of-range ``r`` returns the corresponding edge VALUE.
+    - ``'const'`` (or the integer ``3``, scipy ``ext=3``): constant beyond the
+      ends, i.e. the edge value -- realized identically to ``'clip'`` (clamp the
+      evaluation point), since for the spline VALUE constant-beyond and
+      clamp-the-point coincide.
+    """
+    # knots/coefficients stay float64 (precision is the point; the callers
+    # exit-cast) but must live on the input's device (CUDA support)
+    dev = device_of(r)
+    xb = asarray_on_device(xp, x, dev)
+    cb = asarray_on_device(xp, c, dev)
+    if extrapolate is not True:
+        if extrapolate not in ("clip", "const", 3):
+            raise ValueError(
+                "eval_ppoly extrapolate must be True, 'clip', 'const', or 3; "
+                f"got {extrapolate!r}"
+            )
+        # 'clip' and 'const' both return the edge VALUE outside the range, which
+        # is the edge polynomial evaluated at the clamped point -> clamp r into
+        # [x[0], x[-1]]. xp.clip on both ends is itself dead-branch-safe (no
+        # division/log), so this stays AD-friendly.
+        r = xp.clip(r, xb[0], xb[-1])
+    idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, cb.shape[1] - 1)
+    dr = r - xb[idx]
+    out = cb[0, idx]
+    for j in range(1, cb.shape[0]):
+        out = out * dr + cb[j, idx]
+    return out
+
+
+###############################################################################
+#   (2) Differentiable in-backend 1D spline construction (mode 2).
+###############################################################################
+def cubic_spline_coeffs(xp, x, y, bc="natural"):
+    """Build piecewise-cubic power-basis coefficients from ``(x, y)`` in ``xp``.
+
+    Returns ``c`` of shape ``(4, n-1)`` in the same layout as
+    ``spline_to_ppoly`` -- on ``x[i] <= r < x[i+1]`` the spline is
+    ``sum_j c[j, i] * (r - x[i])**(3-j)`` -- so it feeds straight into
+    ``eval_ppoly``/``eval_cubic``. The whole construction (a tridiagonal linear
+    system for the second derivatives, solved with ``xp.linalg.solve``) is built
+    from namespace operations, so the coefficients -- and hence the spline value
+    -- are DIFFERENTIABLE w.r.t. the ``y`` values. This is the capability the
+    frozen scipy PPoly cannot provide: a parameter-dependent table (e.g. the
+    dynamical-friction ``sigma_r(r)`` table) becomes differentiable in its
+    parameters.
+
+    ``bc`` selects the end conditions:
+
+    - ``'natural'`` (default): zero second derivative at both ends (the
+      interpax / jax-cosmo default).
+    - ``'not-a-knot'``: continuous third derivative across the first/last
+      interior knot (scipy ``CubicSpline``'s default), for byte-for-byte
+      comparison against scipy.
+
+    ``x`` must be strictly increasing. ``x`` may be a frozen numpy array (its
+    spacing is just geometry); differentiability is in ``y``.
+    """
+    dev = device_of(y, x)
+    xb = asarray_on_device(xp, numpy.asarray(x), dev) * 1.0
+    yb = xp.astype(y, xb.dtype) if hasattr(xp, "astype") else y * 1.0
+    n = xb.shape[0]
+    if n < 3:
+        raise ValueError("cubic_spline_coeffs requires at least 3 points")
+    h = xb[1:] - xb[:-1]  # (n-1,)
+    # slopes of the secants
+    dslope = (yb[1:] - yb[:-1]) / h  # (n-1,)
+
+    # Tridiagonal system A M = rhs for the second derivatives M (length n).
+    # Interior rows i=1..n-2:  h[i-1] M[i-1] + 2(h[i-1]+h[i]) M[i] + h[i] M[i+1]
+    #                          = 6 (dslope[i] - dslope[i-1]).
+    # Build the dense (n, n) A from the *geometry only* (x), so A is a constant
+    # w.r.t. y; rhs carries the y-dependence (and hence the gradient). Assembled
+    # with numpy on x (init-time geometry), then placed on-device as a constant.
+    A = numpy.zeros((n, n))
+    hnp = numpy.asarray(numpy.diff(numpy.asarray(x, dtype=float)))
+    for i in range(1, n - 1):
+        A[i, i - 1] = hnp[i - 1]
+        A[i, i] = 2.0 * (hnp[i - 1] + hnp[i])
+        A[i, i + 1] = hnp[i]
+    if bc == "natural":
+        # zero second derivative at the ends: M[0] = M[n-1] = 0.
+        A[0, 0] = 1.0
+        A[n - 1, n - 1] = 1.0
+    elif bc == "not-a-knot":
+        # continuous third derivative across the first/last interior knot.
+        A[0, 0] = hnp[1]
+        A[0, 1] = -(hnp[0] + hnp[1])
+        A[0, 2] = hnp[0]
+        A[n - 1, n - 3] = hnp[-1]
+        A[n - 1, n - 2] = -(hnp[-2] + hnp[-1])
+        A[n - 1, n - 1] = hnp[-2]
+    else:
+        raise ValueError(
+            f"cubic_spline_coeffs bc must be 'natural' or 'not-a-knot'; got {bc!r}"
+        )
+    Ab = asarray_on_device(xp, A, dev)
+    Ab = xp.astype(Ab, xb.dtype) if hasattr(xp, "astype") else Ab
+
+    # rhs (length n): interior entries 6*(dslope[i]-dslope[i-1]); both end rows
+    # are homogeneous (0) for the two supported boundary conditions. The rhs
+    # carries the whole y-dependence, so the gradient flows through here.
+    zero = yb[:1] * 0.0  # (1,) on y's device/dtype, kept differentiable
+    interior = 6.0 * (dslope[1:] - dslope[:-1])  # (n-2,)
+    concat = getattr(xp, "concat", None) or xp.concatenate
+    rhs = concat([zero, interior, zero])  # (n,)
+
+    M = xp.linalg.solve(Ab, rhs)  # (n,)
+
+    # power-basis coefficients on each interval (descending degree to match
+    # spline_to_ppoly / Horner in eval_ppoly): c[0]=cubic, c[3]=constant.
+    a3 = (M[1:] - M[:-1]) / (6.0 * h)
+    a2 = M[:-1] / 2.0
+    a1 = dslope - h * (2.0 * M[:-1] + M[1:]) / 6.0
+    a0 = yb[:-1]
+    return xp.stack([a3, a2, a1, a0], axis=0)  # (4, n-1)
+
+
+def eval_cubic(xp, x, coeffs, r, *, extrapolate=True):
+    """Evaluate cubic coefficients from ``cubic_spline_coeffs`` at ``r``.
+
+    Thin alias for ``eval_ppoly`` (same power-basis layout); kept as a separate
+    public name so callers building in-backend cubics read symmetrically. The
+    spline value is differentiable w.r.t. both ``r`` and (through ``coeffs``) the
+    ``y`` values used to build it.
+    """
+    return eval_ppoly(xp, x, coeffs, r, extrapolate=extrapolate)
+
+
+def interp_linear(xp, x, y, r, *, extrapolate=True):
+    """Piecewise-linear interpolation of ``(x, y)`` at ``r``, built in ``xp``.
+
+    ``searchsorted`` for the interval + a lerp; trivially differentiable w.r.t.
+    both ``r`` and ``y``. ``x`` must be increasing. ``extrapolate=True`` extends
+    the edge line beyond the ends (matching ``eval_ppoly``'s finite
+    extrapolation); ``'clip'``/``'const'``/``3`` clamp ``r`` to the range first
+    (edge value beyond the ends).
+    """
+    dev = device_of(r, y, x)
+    xb = asarray_on_device(xp, numpy.asarray(x), dev) * 1.0
+    yb = y * 1.0
+    if extrapolate is not True:
+        if extrapolate not in ("clip", "const", 3):
+            raise ValueError(
+                "interp_linear extrapolate must be True, 'clip', 'const', or 3; "
+                f"got {extrapolate!r}"
+            )
+        r = xp.clip(r, xb[0], xb[-1])
+    # interval index in [0, n-2]
+    idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, xb.shape[0] - 2)
+    x0 = xb[idx]
+    x1 = xb[idx + 1]
+    y0 = yb[idx]
+    y1 = yb[idx + 1]
+    # (x1 - x0) is a strictly positive geometry difference (x increasing), so no
+    # dead-branch guard is needed: the denominator is never zero.
+    t = (r - x0) / (x1 - x0)
+    return y0 + t * (y1 - y0)
+
+
+###############################################################################
+#   (3) Frozen 2D tensor-product piecewise-power evaluator (mode 1, 2D).
+###############################################################################
+def rect_bivariate_to_ppoly(spl):
+    """Convert a scipy ``RectBivariateSpline`` to a tensor-product PPoly block.
+
+    Returns ``(xbr, ybr, c)`` where ``xbr`` (shape ``(mx+1,)``) and ``ybr``
+    (shape ``(my+1,)``) are the distinct breakpoints in each dimension and ``c``
+    has shape ``(kx+1, ky+1, mx, my)`` such that on
+    ``xbr[ix] <= X < xbr[ix+1]`` and ``ybr[iy] <= Y < ybr[iy+1]`` the spline is
+
+        sum_{px,py} c[px, py, ix, iy] * (X-xbr[ix])**(kx-px) * (Y-ybr[iy])**(ky-py).
+
+    A ``RectBivariateSpline`` is a tensor product of 1D B-splines, so this is
+    obtained by converting to the power basis one dimension at a time via the
+    scipy 1D ``PPoly.from_spline`` (the y-direction for each x B-spline
+    coefficient row, then the x-direction for each resulting (y-power,
+    y-interval) slice). FITPACK's repeated boundary knots give zero-width
+    intervals, which are dropped in BOTH dimensions so that the per-dimension
+    ``searchsorted`` lookups are unambiguous. Called once at setup; the block
+    then feeds the backend-agnostic ``eval_rect_ppoly`` below.
+    """
+    tx, ty, c = spl.tck
+    kx, ky = spl.degrees
+    nx = len(tx) - kx - 1
+    ny = len(ty) - ky - 1
+    C = numpy.asarray(c).reshape(nx, ny)
+
+    # y-direction: convert each x-coefficient row to a 1D PPoly in y.
+    Cy_list = []
+    ybreak_full = None
+    for i in range(nx):
+        pp = _scipy_interpolate.PPoly.from_spline(
+            _scipy_interpolate.BSpline(ty, C[i, :], ky)
+        )
+        ybreak_full = pp.x
+        Cy_list.append(pp.c)  # (ky+1, my_full)
+    Cy = numpy.stack(Cy_list, axis=0)  # (nx, ky+1, my_full)
+    keepy = numpy.diff(ybreak_full) > 0.0
+    ybr = numpy.append(ybreak_full[:-1][keepy], ybreak_full[-1])
+    Cy = Cy[:, :, keepy]  # (nx, ky+1, my)
+    my = Cy.shape[2]
+
+    # x-direction: for each (y-power, y-interval) slice the nx values are B-spline
+    # coefficients in x; convert each to a 1D PPoly in x.
+    out = None
+    xbreak_full = None
+    keepx = None
+    for py in range(ky + 1):
+        for iy in range(my):
+            pp = _scipy_interpolate.PPoly.from_spline(
+                _scipy_interpolate.BSpline(tx, Cy[:, py, iy], kx)
+            )
+            if out is None:
+                xbreak_full = pp.x
+                keepx = numpy.diff(xbreak_full) > 0.0
+                out = numpy.empty((kx + 1, ky + 1, int(keepx.sum()), my))
+            out[:, py, :, iy] = pp.c[:, keepx]  # (kx+1, mx)
+    xbr = numpy.append(xbreak_full[:-1][keepx], xbreak_full[-1])
+    return xbr, ybr, out
+
+
+def eval_rect_ppoly(xp, xbr, ybr, c, X, Y, *, extrapolate=True):
+    """Evaluate a tensor-product piecewise polynomial at points ``(X, Y)``.
+
+    ``(xbr, ybr, c)`` are as returned by ``rect_bivariate_to_ppoly``. Two
+    ``xp.searchsorted`` interval lookups (one per dimension) + a nested 2D Horner
+    using only namespace operations, so the value is computed natively and is
+    differentiable w.r.t. both ``X`` and ``Y`` under jax/torch. Mathematically
+    the same tensor-product spline as ``RectBivariateSpline.ev`` (agreement at
+    the ~1 ulp level); the numpy code paths call ``.ev`` directly and never come
+    through here.
+
+    ``extrapolate`` matches ``eval_ppoly``: ``True`` evaluates the edge
+    polynomial outside the grid (finite extrapolation, NaN-free dead branches);
+    ``'clip'``/``'const'``/``3`` clamp ``(X, Y)`` to the grid first (edge value).
+    """
+    dev = device_of(X, Y)
+    xb = asarray_on_device(xp, xbr, dev)
+    yb = asarray_on_device(xp, ybr, dev)
+    cb = asarray_on_device(xp, c, dev)
+    if extrapolate is not True:
+        if extrapolate not in ("clip", "const", 3):
+            raise ValueError(
+                "eval_rect_ppoly extrapolate must be True, 'clip', 'const', or 3; "
+                f"got {extrapolate!r}"
+            )
+        X = xp.clip(X, xb[0], xb[-1])
+        Y = xp.clip(Y, yb[0], yb[-1])
+    kx = cb.shape[0] - 1
+    ky = cb.shape[1] - 1
+    ix = xp.clip(xp.searchsorted(xb, X, side="right") - 1, 0, cb.shape[2] - 1)
+    iy = xp.clip(xp.searchsorted(yb, Y, side="right") - 1, 0, cb.shape[3] - 1)
+    dx = X - xb[ix]
+    dy = Y - yb[iy]
+    # 2D Horner: outer Horner in dx over the x-powers; each x-power coefficient is
+    # itself a Horner in dy over the y-powers.
+    out = None
+    for px in range(kx + 1):
+        cyacc = None
+        for py in range(ky + 1):
+            coef = cb[px, py, ix, iy]
+            cyacc = coef if cyacc is None else cyacc * dy + coef
+        out = cyacc if out is None else out * dx + cyacc
+    return out
+
+
+###############################################################################
+#   Spline1D / Spline2D convenience classes.
+###############################################################################
+class Spline1D:
+    """Backend-agnostic 1D spline.
+
+    Two construction modes, mirroring the two capabilities above:
+
+    - **mode 1 (frozen, fast, eval-point-differentiable)** -- built from numpy
+      ``(x, y)`` or a pre-fitted scipy spline. A scipy ``InterpolatedUnivariate``
+      spline is fitted (or reused) and frozen to a power-basis PPoly table.
+      ``__call__`` on numpy input calls the scipy spline (BYTE-IDENTICAL to using
+      scipy directly); on a backend array it evaluates the frozen table through
+      ``eval_ppoly`` (differentiable w.r.t. the evaluation point).
+
+    - **mode 2 (in-backend, differentiable in y)** -- triggered when ``y`` is a
+      backend (jax/torch) array. The cubic coefficients are built in-backend via
+      ``cubic_spline_coeffs``, so the spline is differentiable w.r.t. the
+      ``y`` values (for parameter-dependent tables). ``__call__`` evaluates those
+      coefficients through ``eval_cubic``. (numpy input still goes through the
+      scipy path when one was also fitted.)
+
+    Parameters
+    ----------
+    x : array_like
+        Strictly increasing abscissae.
+    y : array_like
+        Ordinates. A backend array selects mode 2 (and ``k`` must be 1 or 3).
+    k : int, optional
+        Spline degree for the scipy/frozen fit (default 3). For mode 2, ``k=3``
+        builds a cubic and ``k=1`` a piecewise-linear interpolant.
+    ext : int or str, optional
+        Out-of-range behaviour for the frozen/backend evaluation, passed through
+        to scipy's ``InterpolatedUnivariateSpline`` (``ext``) and mapped onto the
+        ``eval_ppoly`` ``extrapolate`` knob: ``0`` -> finite extrapolation,
+        ``3`` -> constant beyond the ends. (Default 0.)
+    bc : str, optional
+        Boundary condition for the mode-2 in-backend cubic (``'natural'`` or
+        ``'not-a-knot'``; default ``'natural'``).
+    """
+
+    def __init__(self, x, y, k=3, ext=0, bc="natural"):
+        self._k = int(k)
+        self._ext = ext
+        self._extrapolate = True if ext in (0, "extrapolate") else "const"
+        self._bc = bc
+        self._mode2 = is_backend_array(y)
+        if self._mode2:
+            import array_api_compat
+
+            self._xp = array_api_compat.array_namespace(y)
+            self._y = y
+            self._x = numpy.asarray(x, dtype=float)
+            if self._k == 3:
+                self._coeffs = cubic_spline_coeffs(self._xp, self._x, y, bc=bc)
+            elif self._k == 1:
+                self._coeffs = None  # interp_linear evaluates directly from (x,y)
+            else:
+                raise ValueError("Spline1D mode-2 (backend y) supports only k=1 or k=3")
+            self._spl = None
+        else:
+            self._x = numpy.asarray(x, dtype=float)
+            yn = numpy.asarray(y, dtype=float)
+            self._spl = _scipy_interpolate.InterpolatedUnivariateSpline(
+                self._x, yn, k=self._k, ext=ext
+            )
+            self._ppoly_x, self._ppoly_c = spline_to_ppoly(self._spl)
+
+    def __call__(self, r):
+        # numpy / scalar input: byte-identical scipy path (mode 1) or numpy-eval
+        # of the in-backend coefficients (mode 2 has no scipy spline).
+        if not is_backend_array(r):
+            if self._spl is not None:
+                return self._spl(r)
+            # mode 2 with a numpy query: evaluate the in-backend coeffs via numpy
+            if self._k == 1:
+                return interp_linear(
+                    numpy,
+                    self._x,
+                    numpy.asarray(self._y),
+                    r,
+                    extrapolate=self._extrapolate,
+                )
+            return eval_ppoly(
+                numpy,
+                self._x,
+                numpy.asarray(self._coeffs),
+                r,
+                extrapolate=self._extrapolate,
+            )
+        import array_api_compat
+
+        xp = array_api_compat.array_namespace(r)
+        if self._mode2:
+            if self._k == 1:
+                return interp_linear(
+                    xp, self._x, self._y, r, extrapolate=self._extrapolate
+                )
+            return eval_cubic(
+                xp, self._x, self._coeffs, r, extrapolate=self._extrapolate
+            )
+        return eval_ppoly(
+            xp, self._ppoly_x, self._ppoly_c, r, extrapolate=self._extrapolate
+        )
+
+
+class Spline2D:
+    """Backend-agnostic 2D tensor-product spline over a rectangular grid.
+
+    Frozen (mode 1) only: built from a grid ``(x, y, z)`` or a pre-fitted scipy
+    ``RectBivariateSpline``, and frozen to a tensor-product power-basis block.
+    ``__call__(X, Y)`` on numpy input calls ``RectBivariateSpline.ev``
+    (BYTE-IDENTICAL to scipy); on backend arrays it evaluates the frozen block
+    through ``eval_rect_ppoly`` (differentiable w.r.t. the evaluation points).
+    Serves interpRZPotential and the DF ``RectBivariateSpline`` tables.
+
+    Parameters
+    ----------
+    x, y : array_like
+        Strictly increasing grid abscissae (lengths ``nx``, ``ny``).
+    z : array_like
+        Grid values, shape ``(nx, ny)``.
+    kx, ky : int, optional
+        Spline degrees in each dimension (default 3).
+    spl : scipy.interpolate.RectBivariateSpline, optional
+        A pre-fitted spline to reuse instead of fitting from ``(x, y, z)``.
+    ext : int or str, optional
+        Out-of-range behaviour mapped onto ``eval_rect_ppoly``'s ``extrapolate``
+        (``0`` -> finite extrapolation, ``3`` -> constant). Default 0. (scipy's
+        ``.ev`` always extrapolates, so the numpy path matches ``ext=0``.)
+    """
+
+    def __init__(self, x=None, y=None, z=None, kx=3, ky=3, spl=None, ext=0):
+        if spl is None:
+            spl = _scipy_interpolate.RectBivariateSpline(
+                numpy.asarray(x, dtype=float),
+                numpy.asarray(y, dtype=float),
+                numpy.asarray(z, dtype=float),
+                kx=kx,
+                ky=ky,
+            )
+        self._spl = spl
+        self._extrapolate = True if ext in (0, "extrapolate") else "const"
+        self._xbr, self._ybr, self._c = rect_bivariate_to_ppoly(spl)
+
+    def __call__(self, X, Y):
+        if not (is_backend_array(X) or is_backend_array(Y)):
+            return self._spl.ev(X, Y)
+        import array_api_compat
+
+        ref = X if is_backend_array(X) else Y
+        xp = array_api_compat.array_namespace(ref)
+        return eval_rect_ppoly(
+            xp, self._xbr, self._ybr, self._c, X, Y, extrapolate=self._extrapolate
+        )

--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -6,12 +6,16 @@
 #   keyed by order) -- precision is the point, so the tables stay float64 and
 #   the result is exit-cast back to the input dtype with ``match_input_dtype``.
 #   Per call the tables are materialised into the active backend namespace with
-#   ``asarray_on_device`` (anchored on the device of the limits / an integrand
-#   sample, so CUDA inputs do not meet a CPU table), and every arithmetic step
-#   from there on is plain namespace ops, so the result differentiates under
-#   jax and torch w.r.t. the integration limits AND through the integrand (its
-#   parameters). There is no internal jit -- galpy is jit-COMPATIBLE, not
-#   jit-ing; users wrap their own galpy-using code.
+#   ``asarray_on_device``, anchored on the device of the limits (or an explicit
+#   ``device=`` hint), so CUDA inputs do not meet a CPU table. The integrand's
+#   own device cannot be probed (a CUDA-closure integrand rejects a CPU sample
+#   node before returning), so when the limits are plain Python scalars but the
+#   integrand closes over CUDA tensors, the caller passes ``device=`` (e.g. the
+#   device of its coordinates). Every arithmetic step from there on is plain
+#   namespace ops, so the result differentiates under jax and torch w.r.t. the
+#   integration limits AND through the integrand (its parameters). There is no
+#   internal jit -- galpy is jit-COMPATIBLE, not jit-ing; users wrap their own
+#   galpy-using code.
 #
 #   Fixed-order Gauss-Legendre is a differentiable APPROXIMATION, not adaptive:
 #   pick ``n`` large enough for the target accuracy on your integrand.
@@ -74,7 +78,7 @@ def _gl01_on(xp, n, dev):
     return asarray_on_device(xp, x01, dev), asarray_on_device(xp, w01, dev)
 
 
-def fixed_quad(xp, integrand, a, b, *, n=50):
+def fixed_quad(xp, integrand, a, b, *, n=50, device=None):
     r"""``int_a^b integrand(s) ds`` by fixed-order Gauss-Legendre quadrature.
 
     Backend-agnostic and differentiable in both the limits ``a, b`` and through
@@ -96,16 +100,20 @@ def fixed_quad(xp, integrand, a, b, *, n=50):
     n : int, optional
         Number of Gauss-Legendre nodes (default 50). Fixed-order GL is an
         approximation, not adaptive: raise ``n`` for tighter accuracy.
+    device : optional
+        Device for the node/weight tables. Defaults to the limits' device;
+        pass this when the limits are Python scalars but ``integrand`` closes
+        over CUDA tensors (so the nodes land on the integrand's device).
 
     Returns
     -------
     array
         The integral, exit-cast to the limits' floating dtype.
     """
-    dev = device_of(a, b)
+    dev = device if device is not None else device_of(a, b)
     x01, w01 = _gl01_on(xp, n, dev)
-    a = xp.asarray(a) * 1.0
-    b = xp.asarray(b) * 1.0
+    a = asarray_on_device(xp, a, dev) * 1.0
+    b = asarray_on_device(xp, b, dev) * 1.0
     span = b - a
     # Broadcast the affine remap over the node axis; a, b carry the autodiff.
     nodes = a[..., None] + span[..., None] * x01
@@ -114,7 +122,7 @@ def fixed_quad(xp, integrand, a, b, *, n=50):
     return match_input_dtype(result, a, b)
 
 
-def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip"):
+def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip", device=None):
     r"""``int_a^inf integrand(s) ds`` by fixed-order Gauss-Legendre quadrature.
 
     The semi-infinite range is mapped to a finite one before applying
@@ -159,9 +167,9 @@ def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip"):
     convention is still honoured: ``u`` is clamped strictly inside ``(0, 1)``
     before the map so no node can produce inf/NaN that would poison AD.
     """
-    dev = device_of(a)
+    dev = device if device is not None else device_of(a)
     x01, w01 = _gl01_on(xp, n, dev)
-    a = xp.asarray(a) * 1.0
+    a = asarray_on_device(xp, a, dev) * 1.0
     a_b = a[..., None]
     if kind == "recip":
         # s + (1 - a) = 1/u**2  =>  s = a - 1 + 1/u**2 ; ds = -2 u**-3 du.
@@ -205,7 +213,7 @@ def _boundary_layer_remap(xp, x01, w01, k):
     return X, w01 * dX
 
 
-def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None):
+def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None, device=None):
     r"""Finite GL on ``[a, b]``, optionally split at a near-singular interior point.
 
     For a smooth integrand this is ``fixed_quad``. When ``integrand`` has a
@@ -236,6 +244,9 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None):
         If given, an interior abscissa ``a < c < b`` at which to split; the
         integrand may be near-singular there. If None, a single n-point GL
         panel is used over ``[a, b]`` (== ``fixed_quad``).
+    device : optional
+        Device for the node/weight tables (see ``fixed_quad``); pass when the
+        limits are scalars but ``integrand`` closes over CUDA tensors.
 
     Returns
     -------
@@ -243,12 +254,12 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None):
         The integral, exit-cast to the limits' floating dtype.
     """
     if interior_point is None:
-        return fixed_quad(xp, integrand, a, b, n=n)
-    dev = device_of(a, b, interior_point)
+        return fixed_quad(xp, integrand, a, b, n=n, device=device)
+    dev = device if device is not None else device_of(a, b, interior_point)
     x01, w01 = _gl01_on(xp, n, dev)
-    a = xp.asarray(a) * 1.0
-    b = xp.asarray(b) * 1.0
-    c = xp.asarray(interior_point) * 1.0
+    a = asarray_on_device(xp, a, dev) * 1.0
+    b = asarray_on_device(xp, b, dev) * 1.0
+    c = asarray_on_device(xp, interior_point, dev) * 1.0
     # Cluster nodes toward the (interior) near-singular endpoint of each panel.
     # Left panel [a, c]: xi=0 maps to c (its right end) via 1 - X.
     # Right panel [c, b]: xi=0 maps to c (its left end) via X.
@@ -270,7 +281,7 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None):
     return match_input_dtype(result, a, b, c)
 
 
-def nested_quad(xp, integrand, bounds, *, n=50):
+def nested_quad(xp, integrand, bounds, *, n=50, device=None):
     r"""Tensor-product fixed-order GL over a hyper-rectangle.
 
     The backend-agnostic, vectorised generalisation of
@@ -300,6 +311,9 @@ def nested_quad(xp, integrand, bounds, *, n=50):
         Each ``a_i, b_i`` may be a scalar or a backend array.
     n : int or sequence of int, optional
         Number of GL nodes per dimension (a scalar is used for all; default 50).
+    device : optional
+        Device for the node/weight tables (see ``fixed_quad``); pass when the
+        bounds are scalars but ``integrand`` closes over CUDA tensors.
 
     Returns
     -------
@@ -312,15 +326,15 @@ def nested_quad(xp, integrand, bounds, *, n=50):
     else:
         ns = list(n)
     flat_lims = [lim for ab in bounds for lim in ab]
-    dev = device_of(*flat_lims)
+    dev = device if device is not None else device_of(*flat_lims)
     node_arrays = []
     weight_arrays = []
     spans = []
     cast_coords = []
     for i in range(d):
         x01, w01 = _gl01_on(xp, ns[i], dev)
-        a = xp.asarray(bounds[i][0]) * 1.0
-        b = xp.asarray(bounds[i][1]) * 1.0
+        a = asarray_on_device(xp, bounds[i][0], dev) * 1.0
+        b = asarray_on_device(xp, bounds[i][1], dev) * 1.0
         span = b - a
         # Place this dimension's nodes on its own (trailing) grid axis i; the
         # other d-1 node axes are length-1 here and broadcast.

--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -1,0 +1,343 @@
+###############################################################################
+#   galpy.backend.quadrature: backend-agnostic fixed-order Gauss-Legendre
+#   quadrature.
+#
+#   The nodes and weights are numpy float64 constants computed once (cached,
+#   keyed by order) -- precision is the point, so the tables stay float64 and
+#   the result is exit-cast back to the input dtype with ``match_input_dtype``.
+#   Per call the tables are materialised into the active backend namespace with
+#   ``asarray_on_device`` (anchored on the device of the limits / an integrand
+#   sample, so CUDA inputs do not meet a CPU table), and every arithmetic step
+#   from there on is plain namespace ops, so the result differentiates under
+#   jax and torch w.r.t. the integration limits AND through the integrand (its
+#   parameters). There is no internal jit -- galpy is jit-COMPATIBLE, not
+#   jit-ing; users wrap their own galpy-using code.
+#
+#   Fixed-order Gauss-Legendre is a differentiable APPROXIMATION, not adaptive:
+#   pick ``n`` large enough for the target accuracy on your integrand.
+#
+#   The semi-infinite and split-interval helpers reproduce the substitutions
+#   already used elsewhere in galpy (EllipsoidalPotential's t=1/s^2-1 tail,
+#   hyp2f1's boundary-layer X=xi^k map). As in
+#   ``special/_fallback/bessel_k.py::_k01``, every ``xp.where`` here is
+#   dead-branch guarded: both branches evaluate eagerly under jax/torch, so the
+#   unused side's argument is clamped into its valid domain to keep it finite
+#   and stop a NaN/inf from poisoning reverse-mode gradients.
+###############################################################################
+import numpy
+
+from ._namespaces import asarray_on_device, device_of, match_input_dtype
+
+# Cache of (nodes, weights) on [0, 1] keyed by order, as numpy float64 constants.
+_GL01_CACHE = {}
+
+
+def gauss_legendre_01(n):
+    """Return (nodes, weights) for n-point Gauss-Legendre quadrature on [0, 1].
+
+    numpy float64 constants (cached). The caller converts them into the backend
+    namespace with ``xp.asarray`` so they pick up the backend's array type while
+    the integrand stays differentiable.
+    """
+    cached = _GL01_CACHE.get(n)
+    if cached is None:
+        x, w = numpy.polynomial.legendre.leggauss(n)
+        nodes = 0.5 * (x + 1.0)  # map [-1, 1] -> [0, 1]
+        weights = 0.5 * w
+        cached = (nodes, weights)
+        _GL01_CACHE[n] = cached
+    return cached
+
+
+def gauss_legendre_nodes(n, a=0.0, b=1.0):
+    """Return (nodes, weights) for n-point Gauss-Legendre quadrature on [a, b].
+
+    numpy float64 constants. The canonical [0, 1] nodes/weights are cached
+    (keyed by order, via ``gauss_legendre_01``) and affinely remapped to
+    [a, b]: ``nodes = a + (b - a) * x01`` and ``weights = (b - a) * w01``, so
+    ``sum(weights * f(nodes))`` approximates ``int_a^b f``. ``a`` and ``b`` are
+    plain Python scalars (the quadrature panel boundaries); for limits that are
+    backend arrays / differentiable, pass [0, 1] here and fold the (b - a)
+    Jacobian in the namespace (this is what ``fixed_quad`` does so the result
+    differentiates w.r.t. the limits).
+    """
+    x01, w01 = gauss_legendre_01(n)
+    span = float(b) - float(a)
+    nodes = float(a) + span * x01
+    weights = span * w01
+    return nodes, weights
+
+
+def _gl01_on(xp, n, dev):
+    """[0, 1] GL nodes/weights as backend arrays on device ``dev`` (float64)."""
+    x01, w01 = gauss_legendre_01(n)
+    return asarray_on_device(xp, x01, dev), asarray_on_device(xp, w01, dev)
+
+
+def fixed_quad(xp, integrand, a, b, *, n=50):
+    r"""``int_a^b integrand(s) ds`` by fixed-order Gauss-Legendre quadrature.
+
+    Backend-agnostic and differentiable in both the limits ``a, b`` and through
+    ``integrand`` (its parameters). ``integrand`` is called ONCE with the full
+    array of quadrature nodes (it must be vectorised over a trailing node axis,
+    i.e. broadcast over the last dimension) and the result is reduced as
+    ``(b - a) * sum(w01 * integrand(nodes))`` where ``w01`` are the [0, 1]
+    weights and ``nodes = a + (b - a) * x01``.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace (numpy / jax.numpy / array_api_compat.torch).
+    integrand : callable
+        ``integrand(nodes) -> array`` broadcasting over the trailing node axis.
+    a, b : scalar or backend array
+        Finite integration limits. May be backend arrays (autodiff flows to
+        them through the affine remap and the (b - a) prefactor).
+    n : int, optional
+        Number of Gauss-Legendre nodes (default 50). Fixed-order GL is an
+        approximation, not adaptive: raise ``n`` for tighter accuracy.
+
+    Returns
+    -------
+    array
+        The integral, exit-cast to the limits' floating dtype.
+    """
+    dev = device_of(a, b)
+    x01, w01 = _gl01_on(xp, n, dev)
+    a = xp.asarray(a) * 1.0
+    b = xp.asarray(b) * 1.0
+    span = b - a
+    # Broadcast the affine remap over the node axis; a, b carry the autodiff.
+    nodes = a[..., None] + span[..., None] * x01
+    vals = integrand(nodes)
+    result = span * xp.sum(w01 * vals, axis=-1)
+    return match_input_dtype(result, a, b)
+
+
+def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip"):
+    r"""``int_a^inf integrand(s) ds`` by fixed-order Gauss-Legendre quadrature.
+
+    The semi-infinite range is mapped to a finite one before applying
+    fixed-order GL, with the substitution's Jacobian folded into the integrand.
+    Backend-agnostic and differentiable in the lower limit ``a`` and through
+    ``integrand``.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace.
+    integrand : callable
+        ``integrand(s) -> array`` broadcasting over the trailing node axis;
+        ``s`` lies in ``[a, inf)``.
+    a : scalar or backend array
+        Finite lower limit.
+    n : int, optional
+        Number of Gauss-Legendre nodes (default 50).
+    kind : {'recip', 'tan'}, optional
+        Substitution mapping ``[a, inf) -> (0, 1]`` (the GL panel):
+
+        - ``'recip'`` (default): ``s = a + 1/u**2 - 1`` for ``u in (0, 1]``,
+          i.e. ``s + 1 - a = 1/u**2``, ``ds = -2/u**3 du``. This is exactly the
+          ``t = 1/s**2 - 1`` substitution used in
+          ``galpy/potential/EllipsoidalPotential.py`` (there ``a = 0``):
+          ``u = 0`` is ``s = inf`` and ``u = 1`` is ``s = a``. Best for tails
+          that decay polynomially or faster.
+        - ``'tan'``: ``s = a + tan(pi/2 * u)`` for ``u in [0, 1)``,
+          ``ds = pi/2 * sec^2(pi/2 * u) du``. Good for slowly decaying /
+          oscillatory tails (e.g. ``1/(1+s**2)``).
+
+    Returns
+    -------
+    array
+        The integral, exit-cast to ``a``'s floating dtype.
+
+    Notes
+    -----
+    The endpoints of each map are degenerate (``u -> 0`` is ``s -> inf``;
+    ``u -> 1`` is the ``tan`` singularity). Gauss-Legendre nodes are strictly
+    interior so those points are never evaluated, but the dead-branch guarding
+    convention is still honoured: ``u`` is clamped strictly inside ``(0, 1)``
+    before the map so no node can produce inf/NaN that would poison AD.
+    """
+    dev = device_of(a)
+    x01, w01 = _gl01_on(xp, n, dev)
+    a = xp.asarray(a) * 1.0
+    a_b = a[..., None]
+    if kind == "recip":
+        # s + (1 - a) = 1/u**2  =>  s = a - 1 + 1/u**2 ; ds = -2 u**-3 du.
+        # u=1 -> s=a, u->0 -> s->inf. Clamp u off 0 so 1/u**2 stays finite.
+        u = xp.maximum(x01, xp.ones_like(x01) * 1e-300)
+        inv_u2 = 1.0 / (u * u)
+        s = a_b - 1.0 + inv_u2
+        jac = 2.0 * inv_u2 / u  # |ds/du| = 2 / u**3
+    elif kind == "tan":
+        # s = a + tan(pi/2 * u) ; ds = (pi/2) sec^2(pi/2 * u) du.
+        # u=0 -> s=a, u->1 -> s->inf. Clamp u off 1 so tan stays finite.
+        half_pi = numpy.pi / 2.0
+        u = xp.minimum(x01, xp.ones_like(x01) * (1.0 - 1e-15))
+        theta = half_pi * u
+        tan_t = xp.tan(theta)
+        s = a_b + tan_t
+        jac = half_pi * (1.0 + tan_t * tan_t)  # sec^2 = 1 + tan^2
+    else:  # pragma: no cover - guarded API misuse
+        raise ValueError(
+            f"fixed_quad_semiinfinite: unknown kind {kind!r} (use 'recip' or 'tan')"
+        )
+    vals = integrand(s) * jac
+    result = xp.sum(w01 * vals, axis=-1)
+    return match_input_dtype(result, a)
+
+
+def _boundary_layer_remap(xp, x01, w01, k):
+    r"""Apply the ``X = xi**k`` boundary-layer map to [0, 1] nodes/weights.
+
+    Reproduces the regularising substitution from
+    ``special/_fallback/hyp2f1.py``: with ``X = xi**k`` and
+    ``dX = k * xi**(k-1) dxi``, a node density that clusters toward ``X = 0``
+    resolves an endpoint near-singularity there for plain fixed-order GL. The
+    Jacobian ``dX`` is folded into the returned weights, so callers integrate
+    ``f(X)`` directly. ``k = 1`` is the identity.
+    """
+    if k == 1.0:
+        return x01, w01
+    X = x01**k
+    dX = k * x01 ** (k - 1.0)
+    return X, w01 * dX
+
+
+def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None):
+    r"""Finite GL on ``[a, b]``, optionally split at a near-singular interior point.
+
+    For a smooth integrand this is ``fixed_quad``. When ``integrand`` has a
+    near-singularity (a kink, an endpoint-type singularity, a sqrt-limit) at an
+    interior abscissa -- the disk ``a = R`` pattern, or a distribution-function
+    ``sqrt`` limit -- pass ``interior_point=c`` (with ``a < c < b``). The range
+    is then split into ``[a, c]`` and ``[c, b]`` and an n-point GL panel is
+    applied to each, so the singular point sits on a panel boundary (Gauss
+    nodes are strictly interior and never land on it). Each panel additionally
+    uses the ``X = xi**k`` boundary-layer node clustering from
+    ``special/_fallback/hyp2f1.py`` toward its boundary at ``c``, concentrating
+    nodes near the near-singularity.
+
+    Backend-agnostic and differentiable in ``a, b`` (and ``interior_point`` if
+    passed as a backend array) and through ``integrand``.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace.
+    integrand : callable
+        ``integrand(s) -> array`` broadcasting over the trailing node axis.
+    a, b : scalar or backend array
+        Finite integration limits.
+    n : int, optional
+        Number of Gauss-Legendre nodes PER panel (default 50).
+    interior_point : scalar or backend array or None, optional
+        If given, an interior abscissa ``a < c < b`` at which to split; the
+        integrand may be near-singular there. If None, a single n-point GL
+        panel is used over ``[a, b]`` (== ``fixed_quad``).
+
+    Returns
+    -------
+    array
+        The integral, exit-cast to the limits' floating dtype.
+    """
+    if interior_point is None:
+        return fixed_quad(xp, integrand, a, b, n=n)
+    dev = device_of(a, b, interior_point)
+    x01, w01 = _gl01_on(xp, n, dev)
+    a = xp.asarray(a) * 1.0
+    b = xp.asarray(b) * 1.0
+    c = xp.asarray(interior_point) * 1.0
+    # Cluster nodes toward the (interior) near-singular endpoint of each panel.
+    # Left panel [a, c]: xi=0 maps to c (its right end) via 1 - X.
+    # Right panel [c, b]: xi=0 maps to c (its left end) via X.
+    k = 3.0
+    X, wX = _boundary_layer_remap(xp, x01, w01, k)
+    a_b, b_b, c_b = a[..., None], b[..., None], c[..., None]
+    # Left panel [a, c] with X clustered at c: s = c - (c - a) * (1 - X)? Keep it
+    # simple and robust -- map X in [0,1] from c (X=0) to a (X=1):
+    span_l = c_b - a_b
+    s_l = c_b - span_l * X
+    vals_l = integrand(s_l)
+    int_l = (c - a) * xp.sum(wX * vals_l, axis=-1)
+    # Right panel [c, b] with X clustered at c: X=0 -> c, X=1 -> b.
+    span_r = b_b - c_b
+    s_r = c_b + span_r * X
+    vals_r = integrand(s_r)
+    int_r = (b - c) * xp.sum(wX * vals_r, axis=-1)
+    result = int_l + int_r
+    return match_input_dtype(result, a, b, c)
+
+
+def nested_quad(xp, integrand, bounds, *, n=50):
+    r"""Tensor-product fixed-order GL over a hyper-rectangle.
+
+    The backend-agnostic, vectorised generalisation of
+    ``galpy/potential/SCFPotential.py::_gaussianQuadrature``: integrate
+    ``integrand`` over the d-dimensional box defined by ``bounds`` using a
+    full tensor product of n-point Gauss-Legendre rules.
+
+    ``integrand`` is called ONCE with d node arrays, one per dimension, each
+    already broadcast onto its own axis of a d-dimensional node grid of shape
+    ``(n, n, ..., n)`` (so ``integrand`` is fully vectorised over the product
+    grid, NOT looped). Its return is contracted against the tensor-product
+    weights.
+
+    Backend-agnostic and differentiable in the ``bounds`` (if backend arrays)
+    and through ``integrand``.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace.
+    integrand : callable
+        ``integrand(s_0, s_1, ..., s_{d-1}) -> array``; each ``s_i`` is an array
+        broadcast onto axis ``i`` of the (n, n, ..., n) grid. The return is
+        reduced over those d node axes (which must be its TRAILING d axes).
+    bounds : sequence of (a_i, b_i)
+        Per-dimension finite limits, ``[[a_0, b_0], ..., [a_{d-1}, b_{d-1}]]``.
+        Each ``a_i, b_i`` may be a scalar or a backend array.
+    n : int or sequence of int, optional
+        Number of GL nodes per dimension (a scalar is used for all; default 50).
+
+    Returns
+    -------
+    array
+        The integral over the box, exit-cast to the bounds' floating dtype.
+    """
+    d = len(bounds)
+    if isinstance(n, int):
+        ns = [n] * d
+    else:
+        ns = list(n)
+    flat_lims = [lim for ab in bounds for lim in ab]
+    dev = device_of(*flat_lims)
+    node_arrays = []
+    weight_arrays = []
+    spans = []
+    cast_coords = []
+    for i in range(d):
+        x01, w01 = _gl01_on(xp, ns[i], dev)
+        a = xp.asarray(bounds[i][0]) * 1.0
+        b = xp.asarray(bounds[i][1]) * 1.0
+        span = b - a
+        # Place this dimension's nodes on its own (trailing) grid axis i; the
+        # other d-1 node axes are length-1 here and broadcast.
+        ax_shape = [1] * d
+        ax_shape[i] = ns[i]
+        nodes_i = a + span * xp.reshape(x01, tuple(ax_shape))
+        node_arrays.append(nodes_i)
+        weight_arrays.append(span * xp.reshape(w01, tuple(ax_shape)))
+        spans.append(span)
+        cast_coords.append(a)
+        cast_coords.append(b)
+    vals = integrand(*node_arrays)
+    # Tensor-product weight grid (product over dims), broadcast against vals.
+    wgrid = weight_arrays[0]
+    for wa in weight_arrays[1:]:
+        wgrid = wgrid * wa
+    # Sum over the trailing d node axes.
+    axes = tuple(range(-d, 0))
+    result = xp.sum(wgrid * vals, axis=axes)
+    return match_input_dtype(result, *cast_coords)

--- a/galpy/backend/special/_fallback/_quadrature.py
+++ b/galpy/backend/special/_fallback/_quadrature.py
@@ -1,27 +1,9 @@
 ###############################################################################
-#   Fixed-order Gauss-Legendre quadrature helpers shared by the special-function
-#   fallbacks (and, later, the backend-agnostic potential/df integrals). Nodes
-#   and weights are numpy constants computed once; per call they are converted
-#   into the active backend's namespace so the integrand differentiates.
+#   Thin shim: the fixed-order Gauss-Legendre helpers now live in the
+#   backend-agnostic galpy.backend.quadrature module. ``gauss_legendre_01``
+#   stays importable from this historical location (it is re-exported here)
+#   so the special-function fallbacks (hyp2f1) keep working unchanged.
 ###############################################################################
-import numpy
+from ...quadrature import gauss_legendre_01
 
-# Cache of (nodes, weights) on [0, 1] keyed by order, as numpy float64 constants.
-_GL01_CACHE = {}
-
-
-def gauss_legendre_01(n):
-    """Return (nodes, weights) for n-point Gauss-Legendre quadrature on [0, 1].
-
-    numpy float64 constants (cached). The caller converts them into the backend
-    namespace with ``xp.asarray`` so they pick up the backend's array type while
-    the integrand stays differentiable.
-    """
-    cached = _GL01_CACHE.get(n)
-    if cached is None:
-        x, w = numpy.polynomial.legendre.leggauss(n)
-        nodes = 0.5 * (x + 1.0)  # map [-1, 1] -> [0, 1]
-        weights = 0.5 * w
-        cached = (nodes, weights)
-        _GL01_CACHE[n] = cached
-    return cached
+__all__ = ["gauss_legendre_01"]

--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -4,7 +4,9 @@
 import numpy
 from scipy import interpolate
 
-from ..backend import asarray_on_device, device_of, get_namespace, match_input_dtype
+from ..backend import get_namespace, match_input_dtype
+from ..backend.interpolate import eval_ppoly as _ppoly_eval
+from ..backend.interpolate import spline_to_ppoly as _spline_to_ppoly_data
 from ..util._optional_deps import _JAX_LOADED
 from ..util.conversion import get_physical, physical_compatible
 from .Potential import _evaluatePotentials, _evaluateRforces
@@ -12,49 +14,6 @@ from .SphericalPotential import SphericalPotential
 
 if _JAX_LOADED:
     import jax.numpy as jnp
-
-
-def _spline_to_ppoly_data(spl):
-    """Convert a FITPACK spline to de-duplicated piecewise-power coefficients.
-
-    Returns ``(x, c)`` with ``x`` the distinct breakpoints (shape ``(m+1,)``)
-    and ``c`` the power-basis coefficients (shape ``(k+1, m)``) such that on
-    ``x[i] <= r < x[i+1]`` the spline is ``sum_j c[j, i] * (r - x[i])**(k-j)``.
-    This is the exact piecewise-polynomial representation of the spline (scipy's
-    ``PPoly.from_spline``), with the zero-width intervals coming from FITPACK's
-    repeated boundary knots dropped so that interval lookup by ``searchsorted``
-    is unambiguous. Called once at setup (init-time numpy/scipy is fine); the
-    coefficients then feed the backend-agnostic ``_ppoly_eval`` below.
-    """
-    ppoly = interpolate.PPoly.from_spline(spl._eval_args)
-    keep = numpy.diff(ppoly.x) > 0.0
-    return numpy.append(ppoly.x[:-1][keep], ppoly.x[-1]), ppoly.c[:, keep]
-
-
-def _ppoly_eval(xp, x, c, r):
-    """Evaluate a piecewise polynomial in the power basis at ``r``.
-
-    ``(x, c)`` are as returned by ``_spline_to_ppoly_data``; the evaluation
-    (interval lookup by ``xp.searchsorted`` + Horner) uses only namespace
-    operations, so the spline value is computed natively -- and is exactly
-    autodifferentiable -- under jax/torch. Mathematically this is the same
-    piecewise cubic as the scipy spline (agreement at the ~1 ulp level); the
-    numpy code paths keep calling the scipy splines directly and never come
-    through here. ``r`` outside ``[x[0], x[-1]]`` evaluates the edge polynomial
-    (finite extrapolation), which keeps the dead side of the callers'
-    ``xp.where`` branch selections NaN-free under autodiff.
-    """
-    # knots/coefficients stay float64 (precision is the point; the callers
-    # exit-cast) but must live on the input's device (CUDA support)
-    dev = device_of(r)
-    xb = asarray_on_device(xp, x, dev)
-    cb = asarray_on_device(xp, c, dev)
-    idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, cb.shape[1] - 1)
-    dr = r - xb[idx]
-    out = cb[0, idx]
-    for j in range(1, cb.shape[0]):
-        out = out * dr + cb[j, idx]
-    return out
 
 
 class interpSphericalPotential(SphericalPotential):

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -170,3 +170,222 @@ def test_grad_in_table_values(backend):
         Spline1D(txp.asarray(_XG), yt, k=3)(txp.asarray(r0)).backward()
         g = yt.grad.numpy()
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-8)
+
+
+# out-of-range query points (below x[0], above x[-1], and one in-range)
+_ROUT = numpy.array([-1.0, 0.1, 2.7, 7.0, 10.0])
+
+
+@pytest.mark.parametrize("ext", ["clip", "const", 3])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_eval_ppoly_clamp_modes(backend, ext):
+    # 'clip'/'const'/3 all clamp the eval point -> edge VALUE outside the range,
+    # which is byte-identical (numpy) / ~1e-9 (jax/torch) to scipy ext=3.
+    from galpy.backend.interpolate import eval_ppoly, spline_to_ppoly
+
+    spl0 = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=0)
+    x, c = spline_to_ppoly(spl0)
+    ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=3)(_ROUT)
+    xp = _xp(backend)
+    got = _tonumpy(
+        eval_ppoly(
+            xp,
+            _asarray(backend, x),
+            _asarray(backend, c),
+            _asarray(backend, _ROUT),
+            extrapolate=ext,
+        )
+    )
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_eval_ppoly_extrapolate_true(backend):
+    # extrapolate=True (default) extends the edge polynomial (scipy ext=0).
+    from galpy.backend.interpolate import eval_ppoly, spline_to_ppoly
+
+    spl0 = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=0)
+    x, c = spline_to_ppoly(spl0)
+    ref = spl0(_ROUT)
+    xp = _xp(backend)
+    got = _tonumpy(
+        eval_ppoly(
+            xp, _asarray(backend, x), _asarray(backend, c), _asarray(backend, _ROUT)
+        )
+    )
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+def test_eval_ppoly_bad_extrapolate():
+    from galpy.backend.interpolate import eval_ppoly, spline_to_ppoly
+
+    spl0 = si.InterpolatedUnivariateSpline(_XG, _YG, k=3)
+    x, c = spline_to_ppoly(spl0)
+    with pytest.raises(ValueError):
+        eval_ppoly(numpy, x, c, _RQ, extrapolate="nope")
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_cubic_not_a_knot(backend):
+    # bc='not-a-knot' matches scipy CubicSpline's DEFAULT (byte-identical numpy).
+    xp = _xp(backend)
+    x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _RQ)
+    c = cubic_spline_coeffs(xp, x, y, bc="not-a-knot")
+    got = _tonumpy(eval_cubic(xp, x, c, r))
+    ref = si.CubicSpline(_XG, _YG)(_RQ)  # default bc_type = 'not-a-knot'
+    rtol = 1e-12 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+def test_cubic_spline_coeffs_errors():
+    with pytest.raises(ValueError):
+        cubic_spline_coeffs(numpy, _XG[:2], _YG[:2])  # n < 3
+    with pytest.raises(ValueError):
+        cubic_spline_coeffs(numpy, _XG, _YG, bc="bogus")
+
+
+@pytest.mark.parametrize("ext", ["clip", "const", 3])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_interp_linear_clamp_modes(backend, ext):
+    # 'clip'/'const'/3 clamp the eval point -> edge value beyond the ends.
+    xp = _xp(backend)
+    x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _ROUT)
+    got = _tonumpy(interp_linear(xp, x, y, r, extrapolate=ext))
+    rclamp = numpy.clip(_ROUT, _XG[0], _XG[-1])
+    ref = numpy.interp(rclamp, _XG, _YG)
+    rtol = 1e-12 if backend == "numpy" else 1e-12
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+def test_interp_linear_bad_extrapolate():
+    with pytest.raises(ValueError):
+        interp_linear(numpy, _XG, _YG, _RQ, extrapolate="nope")
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline1d_mode2_linear(backend):
+    # mode 2 with k=1: in-backend piecewise-linear; numpy AND backend queries of
+    # the same instance both agree with numpy.interp.
+    y_b = _asarray(backend, _YG)
+    s = Spline1D(_XG, y_b, k=1)  # backend y, k=1 -> mode-2 linear (no scipy spline)
+    ref = numpy.interp(_RQ, _XG, _YG)
+    got = _tonumpy(s(_asarray(backend, _RQ)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-12)
+    # numpy query of the same mode-2 k=1 instance (interp_linear numpy branch)
+    numpy.testing.assert_allclose(_tonumpy(s(_RQ)), ref, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline1d_mode2_bad_k(backend):
+    y_b = _asarray(backend, _YG)
+    with pytest.raises(ValueError):
+        Spline1D(_XG, y_b, k=2)  # mode-2 supports only k=1 or k=3
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline1d_ext3_const(backend):
+    # ext=3 maps to the 'const' clamp: numpy byte-identical to scipy ext=3, and
+    # jax/torch return the edge value beyond the ends.
+    s = Spline1D(_XG, _YG, k=3, ext=3)
+    ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=3)(_ROUT)
+    got = _tonumpy(s(_asarray(backend, _ROUT)))
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+def _grid_spline():
+    xg = numpy.linspace(0.0, 3.0, 12)
+    yg = numpy.linspace(-1.0, 2.0, 10)
+    zz = numpy.outer(numpy.sin(xg), numpy.cos(yg)) + 0.1 * xg[:, None]
+    return xg, yg, zz
+
+
+@pytest.mark.parametrize("ext", ["clip", "const", 3])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_eval_rect_ppoly_clamp_modes(backend, ext):
+    # 2D 'clip'/'const'/3 clamp (X,Y) to the grid -> edge value == scipy .ev at the
+    # clamped point.
+    from galpy.backend.interpolate import eval_rect_ppoly, rect_bivariate_to_ppoly
+
+    xg, yg, zz = _grid_spline()
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    xbr, ybr, c = rect_bivariate_to_ppoly(spl)
+    X = numpy.array([-1.0, 1.5, 5.0])
+    Y = numpy.array([-3.0, 0.7, 4.0])
+    ref = spl.ev(numpy.clip(X, xg[0], xg[-1]), numpy.clip(Y, yg[0], yg[-1]))
+    xp = _xp(backend)
+    got = _tonumpy(
+        eval_rect_ppoly(
+            xp,
+            _asarray(backend, xbr),
+            _asarray(backend, ybr),
+            _asarray(backend, c),
+            _asarray(backend, X),
+            _asarray(backend, Y),
+            extrapolate=ext,
+        )
+    )
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+def test_eval_rect_ppoly_bad_extrapolate():
+    from galpy.backend.interpolate import eval_rect_ppoly, rect_bivariate_to_ppoly
+
+    xg, yg, zz = _grid_spline()
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    xbr, ybr, c = rect_bivariate_to_ppoly(spl)
+    with pytest.raises(ValueError):
+        eval_rect_ppoly(
+            numpy,
+            xbr,
+            ybr,
+            c,
+            numpy.array([1.0]),
+            numpy.array([0.0]),
+            extrapolate="nope",
+        )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline2d_from_prefitted_spl(backend):
+    # Spline2D(spl=...) reuses a pre-fitted RectBivariateSpline instead of
+    # re-fitting; numpy path byte-identical to .ev.
+    xg, yg, zz = _grid_spline()
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    X = numpy.array([0.2, 1.5, 2.8])
+    Y = numpy.array([-0.5, 0.7, 1.9])
+    ref = spl.ev(X, Y)
+    s = Spline2D(spl=spl)
+    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline2d_ext3_const(backend):
+    # Spline2D ext=3 clamps (X,Y) to the grid (edge value beyond it).
+    xg, yg, zz = _grid_spline()
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    s = Spline2D(x=xg, y=yg, z=zz, ext=3)
+    X = numpy.array([-1.0, 1.5, 5.0])
+    Y = numpy.array([-3.0, 0.7, 4.0])
+    ref = spl.ev(numpy.clip(X, xg[0], xg[-1]), numpy.clip(Y, yg[0], yg[-1]))
+    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline2d_mixed_backend_args(backend):
+    # X a plain scalar (NOT a backend array), Y a backend array -> the backend
+    # path selects Y as the namespace reference (the `else Y` ref-pick branch)
+    # and still matches scipy .ev.
+    xg, yg, zz = _grid_spline()
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    s = Spline2D(x=xg, y=yg, z=zz)
+    ref = spl.ev([1.5], [0.7])
+    got = _tonumpy(s(1.5, _asarray(backend, [0.7])))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-12)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1,0 +1,172 @@
+###############################################################################
+# test_backend_interpolate.py: galpy.backend.interpolate -- backend-agnostic
+# interpolation. Asserts (1) numpy path byte-identical to scipy; (2) jax/torch
+# value parity vs scipy to ~1e-9; (3) autodiff in the eval point AND -- the key
+# new capability -- in the table y-VALUES (so gradients flow to the parameters
+# that build a table, e.g. a dynamical-friction sigma_r(r)).
+###############################################################################
+import numpy
+import pytest
+import scipy.interpolate as si
+
+from galpy.backend.interpolate import (
+    Spline1D,
+    Spline2D,
+    cubic_spline_coeffs,
+    eval_cubic,
+    interp_linear,
+)
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    import array_api_compat.torch as txp
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+
+def _xp(backend):
+    return {
+        "numpy": numpy,
+        "jax": jnp if jax else None,
+        "torch": txp if torch else None,
+    }[backend]
+
+
+def _asarray(backend, x, requires_grad=False):
+    if backend == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
+
+
+def _tonumpy(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().numpy()
+    return numpy.asarray(x)
+
+
+_XG = numpy.linspace(0.3, 6.0, 25)
+_YG = numpy.sin(_XG) + 0.2 * _XG
+_RQ = numpy.array([0.3, 1.1, 2.7, 4.5, 6.0])  # in-range incl. endpoints
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline1d_frozen_parity(backend):
+    # mode 1 (frozen scipy spline, the interpRZ-like usage): build ONCE from
+    # numpy, then evaluate under each backend -> numpy byte-identical, jax/torch
+    # match the frozen scipy spline to ~1e-9.
+    s = Spline1D(_XG, _YG, k=3)  # numpy y -> mode 1
+    ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3)(_RQ)
+    got = _tonumpy(s(_asarray(backend, _RQ)))
+    rtol = 0.0 if backend == "numpy" else 1e-9  # numpy byte-identical
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline1d_mode2_self_consistent(backend):
+    # mode 2 (in-backend cubic, the differentiable usage): the SAME instance must
+    # give the same values whether queried with numpy or a backend array, and
+    # match scipy CubicSpline(natural).
+    y_b = _asarray(backend, _YG)
+    s = Spline1D(_XG, y_b, k=3, bc="natural")  # backend y -> mode 2
+    ref = si.CubicSpline(_XG, _YG, bc_type="natural")(_RQ)
+    got = _tonumpy(s(_asarray(backend, _RQ)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-12)
+    # numpy query of the same mode-2 instance agrees with the backend query
+    numpy.testing.assert_allclose(_tonumpy(s(_RQ)), got, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_cubic_and_linear_parity(backend):
+    xp = _xp(backend)
+    x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _RQ)
+    c = cubic_spline_coeffs(xp, x, y, bc="natural")
+    cub = _tonumpy(eval_cubic(xp, x, c, r))
+    refc = si.CubicSpline(_XG, _YG, bc_type="natural")(_RQ)
+    numpy.testing.assert_allclose(cub, refc, rtol=1e-9, atol=1e-12)
+    lin = _tonumpy(interp_linear(xp, x, y, r))
+    numpy.testing.assert_allclose(
+        lin, numpy.interp(_RQ, _XG, _YG), rtol=1e-12, atol=1e-12
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline2d_value_parity(backend):
+    xg = numpy.linspace(0.0, 3.0, 12)
+    yg = numpy.linspace(-1.0, 2.0, 10)
+    zz = numpy.outer(numpy.sin(xg), numpy.cos(yg)) + 0.1 * xg[:, None]
+    spl = si.RectBivariateSpline(xg, yg, zz)
+    X = numpy.array([0.2, 1.5, 2.8])
+    Y = numpy.array([-0.5, 0.7, 1.9])
+    ref = spl.ev(X, Y)
+    s = Spline2D(
+        x=_asarray(backend, xg), y=_asarray(backend, yg), z=_asarray(backend, zz)
+    )
+    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_grad_in_eval_point(backend):
+    r0 = 2.7
+    ref = si.CubicSpline(_XG, _YG, bc_type="natural").derivative()(r0)
+    xp = _xp(backend)
+    if backend == "jax":
+        ad = float(
+            jax.grad(lambda r: Spline1D(jnp.asarray(_XG), jnp.asarray(_YG), k=3)(r))(
+                jnp.asarray(r0)
+            )
+        )
+    else:
+        rt = torch.tensor(r0, requires_grad=True)
+        Spline1D(txp.asarray(_XG), txp.asarray(_YG), k=3)(rt).backward()
+        ad = float(rt.grad)
+    numpy.testing.assert_allclose(ad, ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_grad_in_table_values(backend):
+    # THE key capability: d(spline value)/d(y) -- lets gradients flow to the
+    # parameters that built a table (e.g. dynamical-friction sigma_r(r)).
+    r0 = 2.7
+    fd = numpy.empty_like(_YG)
+    for i in range(len(_XG)):
+        yp = _YG.copy()
+        yp[i] += 1e-6
+        ym = _YG.copy()
+        ym[i] -= 1e-6
+        fd[i] = (
+            si.CubicSpline(_XG, yp, bc_type="natural")(r0)
+            - si.CubicSpline(_XG, ym, bc_type="natural")(r0)
+        ) / 2e-6
+    if backend == "jax":
+        g = numpy.asarray(
+            jax.grad(lambda y: Spline1D(jnp.asarray(_XG), y, k=3)(jnp.asarray(r0)))(
+                jnp.asarray(_YG)
+            )
+        )
+    else:
+        yt = torch.tensor(_YG, requires_grad=True)
+        Spline1D(txp.asarray(_XG), yt, k=3)(txp.asarray(r0)).backward()
+        g = yt.grad.numpy()
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-8)

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -209,3 +209,103 @@ def test_semiinfinite_grad_in_limit(backend):
         ).backward()
         ga = float(at.grad)
     numpy.testing.assert_allclose(ga, -numpy.exp(-a0), rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_device_hint_explicit(backend):
+    # The device= hint anchors the node/weight tables AND the (possibly scalar)
+    # limits on a caller-supplied device, for integrands that close over arrays
+    # on a device the scalar limits cannot reveal. Exercised here on CPU; the
+    # CUDA case (where it is load-bearing) is in test_device_hint_cuda.
+    if backend == "jax":
+        xp, dev, tonp = jnp, jax.devices("cpu")[0], float
+    else:
+        xp, dev, tonp = txp, torch.device("cpu"), (lambda v: float(v.detach()))
+    e5 = 2.0 * (1.0 - numpy.exp(-5.0))
+    numpy.testing.assert_allclose(
+        tonp(fixed_quad(xp, lambda s: 2.0 * xp.exp(-s), 0.0, 5.0, n=60, device=dev)),
+        e5,
+        rtol=1e-9,
+    )
+    numpy.testing.assert_allclose(
+        tonp(
+            fixed_quad_semiinfinite(
+                xp, lambda s: 2.0 * xp.exp(-s), 0.0, n=80, device=dev
+            )
+        ),
+        2.0,
+        rtol=1e-6,
+    )
+    numpy.testing.assert_allclose(
+        tonp(
+            transformed_quad(
+                xp,
+                lambda s: 2.0 * xp.exp(-s),
+                0.0,
+                5.0,
+                n=40,
+                interior_point=1.0,
+                device=dev,
+            )
+        ),
+        e5,
+        rtol=1e-7,
+    )
+    numpy.testing.assert_allclose(
+        tonp(
+            nested_quad(
+                xp,
+                lambda x, y: xp.ones_like(x * y),
+                [[0.0, 1.0], [0.0, 2.0]],
+                n=15,
+                device=dev,
+            )
+        ),
+        2.0,
+        rtol=1e-12,
+    )
+
+
+@pytest.mark.skipif(
+    torch is None or not torch.cuda.is_available(),
+    reason="needs a CUDA torch device",
+)
+def test_device_hint_cuda():
+    # Scalar limits + a CUDA-closure integrand: without device= the CPU node
+    # tables meet the CUDA integrand and torch raises; device= fixes all four.
+    cuda = torch.device("cuda:0")
+    scale = torch.tensor(2.0, device=cuda)
+
+    def integ(s):
+        return scale * torch.exp(-s)
+
+    e5 = 2.0 * (1.0 - numpy.exp(-5.0))
+    with pytest.raises(RuntimeError):  # no hint -> mixed-device error
+        fixed_quad(txp, integ, 0.0, 5.0, n=60)
+    for out, ref in [
+        (fixed_quad(txp, integ, 0.0, 5.0, n=60, device=cuda), e5),
+        (fixed_quad_semiinfinite(txp, integ, 0.0, n=60, device=cuda), 2.0),
+        (
+            transformed_quad(
+                txp, integ, 0.0, 5.0, n=40, interior_point=1.0, device=cuda
+            ),
+            e5,
+        ),
+        (
+            nested_quad(
+                txp,
+                lambda x, y: scale * torch.ones_like(x * y),
+                [[0.0, 1.0], [0.0, 1.0]],
+                n=20,
+                device=cuda,
+            ),
+            2.0,
+        ),
+    ]:
+        assert out.device.type == "cuda"
+        numpy.testing.assert_allclose(float(out.detach().cpu()), ref, atol=1e-4)
+    sc = torch.tensor(2.0, device=cuda, requires_grad=True)
+    fixed_quad(
+        txp, lambda s: sc * torch.exp(-s), 0.0, 5.0, n=60, device=cuda
+    ).backward()
+    numpy.testing.assert_allclose(float(sc.grad.cpu()), e5 / 2.0, rtol=1e-6)

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -1,0 +1,156 @@
+###############################################################################
+# test_backend_quadrature.py: galpy.backend.quadrature -- backend-agnostic
+# fixed-order quadrature. Asserts value parity vs scipy.integrate.quad / exact,
+# autodiff in the limits AND through integrand parameters, and that the promoted
+# gauss_legendre_01 is unchanged (the special-function hyp2f1 fallback uses it).
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend.quadrature import (
+    fixed_quad,
+    fixed_quad_semiinfinite,
+    gauss_legendre_01,
+    gauss_legendre_nodes,
+    nested_quad,
+    transformed_quad,
+)
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    import array_api_compat.torch as txp
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+
+def _xp(backend):
+    return {
+        "numpy": numpy,
+        "jax": jnp if jax else None,
+        "torch": txp if torch else None,
+    }[backend]
+
+
+def test_gauss_legendre_01_unchanged():
+    # byte-identical to the leggauss [0,1] remap, and still importable from the
+    # special fallback's old path (hyp2f1 uses it).
+    for n in (8, 20, 50):
+        x, w = numpy.polynomial.legendre.leggauss(n)
+        nodes, weights = gauss_legendre_01(n)
+        numpy.testing.assert_array_equal(nodes, 0.5 * (x + 1))
+        numpy.testing.assert_array_equal(weights, 0.5 * w)
+    from galpy.backend.special._fallback._quadrature import gauss_legendre_01 as old
+
+    assert old(20)[0] is gauss_legendre_01(20)[0]  # same cached object
+
+
+def test_gauss_legendre_nodes_remap():
+    nodes, weights = gauss_legendre_nodes(30, 2.0, 5.0)
+    # integrate 1 over [2,5] -> 3
+    numpy.testing.assert_allclose(numpy.sum(weights), 3.0, rtol=1e-13)
+    numpy.testing.assert_allclose(
+        numpy.sum(weights * nodes), 0.5 * (25.0 - 4.0), rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fixed_quad_parity(backend):
+    xp = _xp(backend)
+    # int_0.5^3 exp(-s) ds = exp(-0.5) - exp(-3)
+    ref = numpy.exp(-0.5) - numpy.exp(-3.0)
+    got = float(numpy.asarray(fixed_quad(xp, lambda s: xp.exp(-s), 0.5, 3.0, n=40)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_semiinfinite_parity(backend):
+    xp = _xp(backend)
+    # int_1^inf exp(-s) ds = exp(-1); int_0^inf 1/(1+s^2) ds = pi/2
+    g1 = float(
+        numpy.asarray(
+            fixed_quad_semiinfinite(xp, lambda s: xp.exp(-s), 1.0, n=100, kind="recip")
+        )
+    )
+    numpy.testing.assert_allclose(g1, numpy.exp(-1.0), rtol=1e-7)
+    g2 = float(
+        numpy.asarray(
+            fixed_quad_semiinfinite(
+                xp, lambda s: 1.0 / (1.0 + s**2), 0.0, n=100, kind="tan"
+            )
+        )
+    )
+    numpy.testing.assert_allclose(g2, numpy.pi / 2.0, rtol=1e-7)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_nested_quad_parity(backend):
+    xp = _xp(backend)
+    # int_[0,1]^2 exp(x+y) dx dy = (e-1)^2
+    got = float(
+        numpy.asarray(
+            nested_quad(xp, lambda x, y: xp.exp(x + y), [(0.0, 1.0), (0.0, 1.0)], n=20)
+        )
+    )
+    numpy.testing.assert_allclose(got, (numpy.e - 1.0) ** 2, rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_quad_grad_in_limit_and_param(backend):
+    xp = _xp(backend)
+    a0, p0 = 0.7, 1.3
+    # d/da int_a^3 exp(-s) ds = -exp(-a)
+    if backend == "jax":
+        ga = float(
+            jax.grad(lambda a: fixed_quad(jnp, lambda s: jnp.exp(-s), a, 3.0, n=40))(
+                jnp.asarray(a0)
+            )
+        )
+        # d/dp int_0^2 exp(-p s) ds = -(d/dp)[(1-exp(-2p))/p]
+        gp = float(
+            jax.grad(
+                lambda p: fixed_quad(jnp, lambda s: jnp.exp(-p * s), 0.0, 2.0, n=60)
+            )(jnp.asarray(p0))
+        )
+    else:
+        at = torch.tensor(a0, requires_grad=True)
+        fixed_quad(txp, lambda s: txp.exp(-s), at, 3.0, n=40).backward()
+        ga = float(at.grad)
+        pt = torch.tensor(p0, requires_grad=True)
+        fixed_quad(txp, lambda s: txp.exp(-pt * s), 0.0, 2.0, n=60).backward()
+        gp = float(pt.grad)
+    numpy.testing.assert_allclose(ga, -numpy.exp(-a0), rtol=1e-6)
+    # analytic d/dp of (1-exp(-2p))/p
+    ref_gp = (2.0 * numpy.exp(-2 * p0) * p0 - (1 - numpy.exp(-2 * p0))) / p0**2
+    numpy.testing.assert_allclose(gp, ref_gp, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_transformed_quad_interior_split(backend):
+    xp = _xp(backend)
+    # int_0^2 |s-1|^0.5 ds = 4/3, with a sqrt-kink at the interior point s=1
+    got = float(
+        numpy.asarray(
+            transformed_quad(
+                xp, lambda s: xp.abs(s - 1.0) ** 0.5, 0.0, 2.0, n=60, interior_point=1.0
+            )
+        )
+    )
+    numpy.testing.assert_allclose(got, 4.0 / 3.0, rtol=1e-6)

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -154,3 +154,58 @@ def test_transformed_quad_interior_split(backend):
         )
     )
     numpy.testing.assert_allclose(got, 4.0 / 3.0, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_transformed_quad_no_interior(backend):
+    xp = _xp(backend)
+    # interior_point=None falls through to plain fixed_quad: int_0^2 exp(s) = e^2-1
+    got = float(
+        numpy.asarray(transformed_quad(xp, lambda s: xp.exp(s), 0.0, 2.0, n=40))
+    )
+    numpy.testing.assert_allclose(got, numpy.exp(2.0) - 1.0, rtol=1e-10)
+
+
+def test_boundary_layer_remap_identity():
+    # k == 1 is the identity map: nodes/weights returned unchanged (same objects).
+    from galpy.backend.quadrature import _boundary_layer_remap
+
+    x01, w01 = gauss_legendre_01(12)
+    X, wX = _boundary_layer_remap(numpy, x01, w01, 1.0)
+    assert X is x01 and wX is w01
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_nested_quad_per_dim_n(backend):
+    xp = _xp(backend)
+    # per-dimension n list: int_[0,1]x[0,2] exp(x+y) dx dy = (e-1)(e^2-1)
+    got = float(
+        numpy.asarray(
+            nested_quad(
+                xp, lambda x, y: xp.exp(x + y), [(0.0, 1.0), (0.0, 2.0)], n=[20, 30]
+            )
+        )
+    )
+    ref = (numpy.e - 1.0) * (numpy.exp(2.0) - 1.0)
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_semiinfinite_grad_in_limit(backend):
+    # d/da int_a^inf exp(-s) ds = -exp(-a), through the recip semi-infinite map.
+    a0 = 0.7
+    if backend == "jax":
+        ga = float(
+            jax.grad(
+                lambda a: fixed_quad_semiinfinite(
+                    jnp, lambda s: jnp.exp(-s), a, n=120, kind="recip"
+                )
+            )(jnp.asarray(a0))
+        )
+    else:
+        at = torch.tensor(a0, requires_grad=True)
+        fixed_quad_semiinfinite(
+            txp, lambda s: txp.exp(-s), at, n=120, kind="recip"
+        ).backward()
+        ga = float(at.grad)
+    numpy.testing.assert_allclose(ga, -numpy.exp(-a0), rtol=1e-5)


### PR DESCRIPTION
Reusable backend-agnostic **interpolation + quadrature** infrastructure (the foundation the user asked for before the friction forces). Targets `feat/backends` directly. numpy stays byte-identical (keeps calling the scipy spline / fitted PPoly); jax/torch get differentiable pure-`xp` paths.

**`galpy/backend/interpolate.py`**
- `spline_to_ppoly` / `eval_ppoly` — **promoted verbatim** from `interpSphericalPotential` (which now imports them; confirmed numpy byte-identical, 8/8 across NFW+King compute methods, in/edge/out-of-range). 1D frozen PPoly eval + `extrapolate` knob (scipy `ext` 0/3).
- `cubic_spline_coeffs` / `eval_cubic` / `interp_linear` — **new** in-backend cubic (xp tridiagonal solve) + linear, **differentiable in the y-values** so gradients flow to the parameters that build a table — e.g. `d(orbit-with-friction)/d(halo mass)` through `σ_r(r)`. `bc` natural/not-a-knot.
- `rect_bivariate_to_ppoly` / `eval_rect_ppoly` / `Spline2D` — **new** 2D tensor-product spline (`interpRZ` + spherical-DF `RectBivariateSpline` tables).
- `Spline1D`/`Spline2D` dispatch: numpy → scipy (byte-identical); backend → frozen PPoly (eval-point-diff) or in-backend cubic (mode 2, y-diff).

**`galpy/backend/quadrature.py`**
- `gauss_legendre_nodes` (promoted `gauss_legendre_01`, `[a,b]` remap; old path re-exports it so the `hyp2f1` fallback is unchanged), `fixed_quad`, `fixed_quad_semiinfinite` (the `1/s²−1` map from EllipsoidalPotential / `tan`), `transformed_quad` (interior split for near-singular points), `nested_quad` (from SCF). Fixed-order GL — a differentiable approximation, tunable `n`.

**Validation:** numpy byte-identical; jax/torch vs scipy ~1e-15 (interp) / ~1e-14 (quad); AD in eval-point, **in y-values** (1.5e-10 vs FD, gradcheck), in quad limits + integrand params (~1e-11, gradcheck); `hyp2f1` + 111 special tests unchanged; 31 new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)