### PR TITLE
backend.special: harden fallback edge cases (poles, domain endpoints, AD, numpy params)

### DIFF
--- a/galpy/backend/special/_fallback/assoc_legendre.py
+++ b/galpy/backend/special/_fallback/assoc_legendre.py
@@ -55,21 +55,40 @@ def assoc_legendre(xp, L, M, x, deriv=0):
     if deriv == 0:
         return Parr
 
-    den = x * x - 1.0  # (x^2-1); singular only at the poles
+    den = x * x - 1.0  # (x^2-1); singular only at the poles |x|=1
+    pole = x * x >= 1.0  # symmetry-axis poles (cos theta = +-1)
+    den_safe = xp.where(pole, one, den)  # AD-safe: keep the dead branch finite
     dP = [[zero for _ in range(M)] for _ in range(L)]
     for m in range(M):
         for l in range(m, L):
             plm1 = P[l - 1][m] if l - 1 >= m else zero
-            dP[l][m] = (l * x * P[l][m] - (l + m) * plm1) / den
+            num = l * x * P[l][m] - (l + m) * plm1
+            if m == 0:
+                # m=0 derivative is a polynomial (finite at the poles): guard the
+                # 0/0 and substitute the closed form P_l'(+-1) = x^{l+1} l(l+1)/2.
+                dP[l][m] = xp.where(
+                    pole, x ** (l + 1) * (l * (l + 1) / 2.0), num / den_safe
+                )
+            else:
+                dP[l][m] = num / den  # m>=1 diverges at the poles, as scipy does
     dParr = _stack(dP)
     if deriv == 1:
         return Parr, dParr
 
     om = 1.0 - x * x
+    om_safe = xp.where(pole, one, om)
     d2 = [[zero for _ in range(M)] for _ in range(L)]
     for m in range(M):
         for l in range(m, L):
-            d2[l][m] = (
-                2.0 * x * dP[l][m] - l * (l + 1) * P[l][m] + (m * m) / om * P[l][m]
-            ) / om
+            if m == 0:
+                gen = (2.0 * x * dP[l][m] - l * (l + 1) * P[l][m]) / om_safe
+                # finite limit at +-1 = (l-1)l(l+1)(l+2)/8 (scipy's exact-pole
+                # convention returns this unsigned value at both poles)
+                d2[l][m] = xp.where(
+                    pole, ((l - 1) * l * (l + 1) * (l + 2) / 8.0) * one, gen
+                )
+            else:
+                d2[l][m] = (
+                    2.0 * x * dP[l][m] - l * (l + 1) * P[l][m] + (m * m) / om * P[l][m]
+                ) / om
     return Parr, dParr, _stack(d2)

--- a/galpy/backend/special/_fallback/elliptic.py
+++ b/galpy/backend/special/_fallback/elliptic.py
@@ -24,12 +24,17 @@ def _agm_KE(xp, m):
     m -> 1 (b_0 -> 0) the AGM -> 0 and K -> +inf, the correct singularity.
     """
     m = xp.asarray(m) * 1.0
-    a = xp.ones_like(m)
-    b = xp.sqrt(1.0 - m)
-    c = xp.sqrt(m)
-    # sum starts at n=0 with weight 2^{-1} and c_0^2 = m
+    one = xp.ones_like(m)
+    # At m==1 (b0=0) the AGM reaches 0 only asymptotically; run it on a safe
+    # argument and substitute the exact limits K=+inf, E=1 afterwards (AD-safe).
+    on_edge = m == 1.0
+    ms = xp.where(on_edge, 0.5 * one, m)
+    a = one
+    b = xp.sqrt(1.0 - ms)  # real for all m < 1, incl. m < 0
+    # sum starts at n=0 with weight 2^{-1} and c_0^2 = ms exactly (sqrt(ms) would
+    # be nan for m < 0, NaN-poisoning E; K depends only on b = sqrt(1-ms))
     p = 0.5
-    s = p * c * c
+    s = p * ms
     for _ in range(1, _AGM_NITER):
         an = 0.5 * (a + b)
         bn = xp.sqrt(a * b)
@@ -37,8 +42,11 @@ def _agm_KE(xp, m):
         a, b = an, bn
         p = p * 2.0
         s = s + p * c * c
-    K = xp.pi / (2.0 * a) if hasattr(xp, "pi") else 3.141592653589793 / (2.0 * a)
+    pi = xp.pi if hasattr(xp, "pi") else 3.141592653589793
+    K = pi / (2.0 * a)
     E = K * (1.0 - s)
+    K = xp.where(on_edge, xp.full_like(m, float("inf")), K)  # K(1) = +inf
+    E = xp.where(on_edge, one, E)  # E(1) = 1
     return K, E
 
 

--- a/galpy/backend/special/_fallback/gamma.py
+++ b/galpy/backend/special/_fallback/gamma.py
@@ -21,13 +21,19 @@ def gamma_fallback(xp, x):
     integers would feed a NaN back through 0*inf and poison reverse-mode
     gradients at perfectly valid inputs.
     """
-    x = xp.asarray(x)
+    x = xp.asarray(x) * 1.0
     positive = x > 0
+    # negative integer poles (-1, -2, ...): scipy.special.gamma returns nan there;
+    # the reflection formula would give a huge finite value (sin(pi*int) is ~1e-16,
+    # not 0, in float64), so mask them out. x==0 is left to the reflection branch,
+    # which yields +inf (sin(0)=0 -> pi/0), matching scipy.special.gamma(0)=inf.
+    is_pole = (x < 0) & (x == xp.round(x))
     # x>0 branch: in the dead (x<=0) region use a safe +0.5 so gammaln stays finite.
-    x_pos = xp.where(positive, x, 0.5 * xp.ones_like(x * 1.0))
+    x_pos = xp.where(positive, x, 0.5 * xp.ones_like(x))
     pos = xp.exp(gammaln(x_pos))
-    # x<=0 branch: in the dead (x>0) region use a safe -0.5 (non-integer, so
-    # sin(pi x) != 0 and gammaln(1-x) is finite).
-    x_neg = xp.where(positive, -0.5 * xp.ones_like(x * 1.0), x)
+    # x<=0 branch: keep the arg off the positive region AND the poles, so
+    # sin(pi x) != 0 and gammaln(1-x) is finite (no NaN-poisoning of AD).
+    x_neg = xp.where(positive | is_pole, -0.5 * xp.ones_like(x), x)
     refl = numpy.pi / (xp.sin(numpy.pi * x_neg) * xp.exp(gammaln(1.0 - x_neg)))
-    return xp.where(positive, pos, refl)
+    out = xp.where(positive, pos, refl)
+    return xp.where(is_pole, xp.full_like(x, numpy.nan), out)

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -78,15 +78,18 @@ def hyp2f1_fallback(xp, a, b, c, z):
     X = xg**k
     dX = k * xg ** (k - 1.0)
 
-    # Floor |z| away from exactly zero so the 1/|z| substitution is finite (and
-    # X*log1p(|z|) cannot underflow to 0, which would make T**(B-1) blow up for
-    # B<1). At |z|=0 this evaluates 2F1 at z=-1e-10, i.e. 1 to ~1e-10; the
-    # subgradient blocks gradient only at the measure-zero origin point.
-    w_safe = xp.maximum(w, xp.ones_like(w) * 1e-10)
-    L = xp.log1p(w_safe)[..., None]  # (..., 1)
-    wb = w_safe[..., None]
+    # Tiny |z|: the 1/|z| substitution is singular, so feed a safe non-zero w
+    # into the integral (double-where: the dead branch can't NaN-poison AD via
+    # 1/w / log1p(0)) and return the exact Maclaurin limit instead -- which also
+    # gives the correct gradient a*b/c at z->0 (a plain maximum-floor flattens it).
+    tiny = w < 1e-10
+    w_for_int = xp.where(tiny, xp.ones_like(w), w)
+    L = xp.log1p(w_for_int)[..., None]  # (..., 1)
+    wb = w_for_int[..., None]
     XL = X * L  # (..., N)
     T = xp.expm1(XL) / wb
     dt = xp.exp(XL) * L / wb
     integ = T ** (B - 1.0) * (1.0 - T) ** (q - 1.0) * (1.0 + wb * T) ** (-A) * dt * dX
-    return pref * xp.sum(integ * wg, axis=-1)
+    val_int = pref * xp.sum(integ * wg, axis=-1)
+    val_series = 1.0 + (a * b / c) * z  # 2F1 = 1 + (ab/c) z + O(z^2)
+    return xp.where(tiny, val_series, val_int)

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -78,15 +78,21 @@ def _dispatch(fnname, args, fallback, ns_args=None):
     if fnname not in _NEEDS_FALLBACK.get(name, frozenset()) and hasattr(sp, fnname):
         if name == "torch":
             # torch.special.* require every argument to be a Tensor (they don't
-            # broadcast Python scalars like scipy/jax do), so promote any plain
-            # scalar parameters (e.g. the order `a` of gammainc(a, x)) to a
-            # Tensor on the same device/dtype as the array argument(s).
-            ref = next((a for a in args if hasattr(a, "ndim")), None)
+            # broadcast Python scalars like scipy/jax do), so promote any non-
+            # Tensor parameter (e.g. the order `a` of gammainc(a, x)) to a Tensor
+            # on the same device/dtype. Test torch.is_tensor (not hasattr ndim):
+            # numpy scalars/0-d arrays have ndim but torch.special still rejects
+            # them, so a numpy.float64 potential parameter must be promoted too.
+            import torch
+
+            ref = next((a for a in args if torch.is_tensor(a)), None)
             if ref is not None:
                 args = tuple(
                     a
-                    if hasattr(a, "ndim")
-                    else xp.asarray(a, dtype=ref.dtype, device=ref.device)
+                    if torch.is_tensor(a)
+                    else xp.asarray(
+                        numpy.asarray(a), dtype=ref.dtype, device=ref.device
+                    )
                     for a in args
                 )
         return getattr(sp, fnname)(*args)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -527,3 +527,115 @@ def test_gegenbauer_grad_vs_fd(backend):
         gsp.gegenbauer(N, alpha, xt)[n].backward()
         ad = float(xt.grad)
     numpy.testing.assert_allclose(ad, fd, rtol=1e-5)
+
+
+# --- edge-case hardening: poles, domain endpoints, AD plateaus, numpy params ---
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_assoc_legendre_pole_derivs(backend):
+    # m=0 x-derivatives are finite at the symmetry-axis poles x=+-1 (the
+    # (x^2-1) denominators must not 0/0-NaN); match the numpy/scipy reference.
+    L, M = 6, 1
+    for xv in (1.0, -1.0):
+        _, rdP, rd2 = gsp.assoc_legendre(L, M, numpy.asarray(xv), deriv=2)
+        _, gdP, gd2 = gsp.assoc_legendre(L, M, _asarray(backend, xv), deriv=2)
+        gdP, gd2 = _tonumpy(gdP)[..., 0], _tonumpy(gd2)[..., 0]
+        assert not numpy.any(numpy.isnan(gdP)) and not numpy.any(numpy.isnan(gd2))
+        numpy.testing.assert_allclose(gdP, rdP[..., 0], rtol=1e-10, atol=1e-12)
+        numpy.testing.assert_allclose(gd2, rd2[..., 0], rtol=1e-10, atol=1e-12)
+
+
+def test_scf_spherical_zaxis_forces_finite():
+    # end-to-end: spherical SCF forces / 2nd-derivs on the z-axis (cos theta=+-1)
+    # are finite and backend-consistent (regression for the assoc_legendre poles).
+    from galpy.potential import (
+        HernquistPotential,
+        SCFPotential,
+        scf_compute_coeffs_spherical,
+    )
+
+    Acos, Asin = scf_compute_coeffs_spherical(
+        HernquistPotential(amp=2.0, a=1.0).dens, 6
+    )
+    scf = SCFPotential(Acos=Acos, Asin=Asin)
+    for meth in ("Rforce", "zforce", "R2deriv", "z2deriv"):
+        for z in (1.5, -1.5):
+            ref = float(getattr(scf, meth)(0.0, z))
+            for backend in AD_BACKENDS:
+                got = _tonumpy(
+                    getattr(scf, meth)(_asarray(backend, 0.0), _asarray(backend, z))
+                )
+                assert numpy.isfinite(got), f"{meth}(0,{z}) {backend} not finite"
+                numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ellipk_ellipe_negative_m_and_unit(backend):
+    # scipy supports all real m<1 (incl. m<0); m=1 gives K=inf, E=1.
+    m = numpy.array([-5.0, -1.0, -0.5, 0.0, 0.3, 0.9, 0.999])
+    rtol = 0.0 if backend == "numpy" else 1e-9
+    for fn, sp_fn in (
+        (gsp.ellipk, scipy_special.ellipk),
+        (gsp.ellipe, scipy_special.ellipe),
+    ):
+        got = _tonumpy(fn(_asarray(backend, m)))
+        numpy.testing.assert_allclose(got, sp_fn(m), rtol=rtol, atol=1e-12)
+    assert numpy.isinf(_tonumpy(gsp.ellipk(_asarray(backend, 1.0))))
+    numpy.testing.assert_allclose(_tonumpy(gsp.ellipe(_asarray(backend, 1.0))), 1.0)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_ellipe_negative_m_grad_finite(backend):
+    # dE/dm = (E-K)/(2m) is finite for m<0 (sqrt(m) must not enter the E series).
+    ref = (scipy_special.ellipe(-1.0) - scipy_special.ellipk(-1.0)) / (2.0 * -1.0)
+    if backend == "jax":
+        g = float(jax.grad(lambda m: gsp.ellipe(m))(jnp.asarray(-1.0)))
+    else:
+        mt = torch.tensor(-1.0, dtype=torch.float64, requires_grad=True)
+        gsp.ellipe(mt).backward()
+        g = float(mt.grad)
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_gamma_negative_integer_poles_nan(backend):
+    # Gamma at -1, -2, ... is nan (scipy), not a huge finite reflection value;
+    # Gamma(0) is +inf (a distinct scipy convention).
+    for x in (-1.0, -2.0, -3.0):
+        assert numpy.isnan(_tonumpy(gsp.gamma(_asarray(backend, x))))
+    assert numpy.isinf(_tonumpy(gsp.gamma(_asarray(backend, 0.0))))
+    xs = numpy.array([-2.5, -1.5, -0.5, 0.5, 2.5, 6.0])  # off-pole unchanged
+    numpy.testing.assert_allclose(
+        _tonumpy(gsp.gamma(_asarray(backend, xs))), scipy_special.gamma(xs), rtol=1e-10
+    )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_grad_at_zero_is_abc(backend):
+    # d/dz 2F1(a,b;c;z)|_0 = a b / c (no zero-gradient plateau near z=0).
+    a, b, c = 2.0, 2.0, 3.0
+    if backend == "jax":
+        ad = float(jax.grad(lambda z: gsp.hyp2f1(a, b, c, z))(jnp.asarray(0.0)))
+    else:
+        zt = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+        gsp.hyp2f1(a, b, c, zt).backward()
+        ad = float(zt.grad)
+    numpy.testing.assert_allclose(ad, a * b / c, rtol=1e-5)
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="needs torch")
+def test_router_promotes_numpy_scalar_params_torch():
+    # numpy.float64 parameters (not only python scalars) must be promoted for
+    # torch.special, so a numpy-typed potential parameter works on the torch path.
+    x = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float64)
+    ref = scipy_special.gammainc(0.5, numpy.array([0.5, 1.0, 2.0]))
+    for a in (0.5, numpy.float64(0.5)):
+        got = gsp.gammainc(a, x)
+        assert torch.is_tensor(got)
+        numpy.testing.assert_allclose(got.detach().numpy(), ref, rtol=1e-12)
+    from galpy.potential import PowerSphericalPotentialwCutoff as PSPC
+
+    r = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    p_py = PSPC(alpha=1.3, rc=2.0)
+    p_np = PSPC(alpha=numpy.float64(1.3), rc=2.0)
+    assert torch.allclose(p_py._rforce(r), p_np._rforce(r))


### PR DESCRIPTION
Edge-case hardening of the (jax/torch-only) `galpy.backend.special` fallbacks, prompted by a Codex review of the module. Each finding was **adversarially re-verified numerically vs scipy and against galpy's real call domain** before fixing (workflow audit); refuted/unreachable items were dropped.

## Fixes

**Reachable bugs:**
- **`assoc_legendre`** — the m=0 x-derivatives divided by `(x²−1)`, so at the symmetry-axis poles `x=cosθ=±1` they returned `NaN`. **SCF/Multipole forces and 2nd-derivatives on the z-axis (R=0) were NaN under jax/torch** (numpy uses scipy and was fine). Guarded with an AD-safe double-where + the finite scipy-matching pole limits. Interior values unchanged; added an end-to-end SCF z-axis finiteness/parity test.
- **`_router`** — the torch scalar-promotion used `hasattr(a, "ndim")` to decide what to promote, but `numpy.float64`/0-d numpy scalars *have* `ndim`, so a numpy-typed potential parameter (e.g. `PowerSphericalPotentialwCutoff(alpha=numpy.float64(1.3))`) crashed `torch.special`. Now promotes anything that is not a `torch.Tensor`.

**Confirmed-but-unreachable hardening (exported infra correctness):**
- **`elliptic`** — `ellipe(m<0)` was `NaN` (`sqrt(m)`); use `c₀²=m` directly. `m==1` now returns `K=+inf, E=1` (matches scipy) via AD-safe double-where.
- **`gamma`** — negative-integer poles returned huge finite reflection values; mask to `NaN` (scipy). `Gamma(0)` stays `+inf`.
- **`hyp2f1`** — the `maximum(w, 1e-10)` floor flattened the gradient for `z∈(−1e-10, 0]`; use a double-where + analytic Maclaurin limit so `d/dz` at 0 is the correct `a·b/c`.

## Notes
- **numpy paths are untouched** (these fallbacks are jax/torch-only; numpy routes to `scipy.special`), so the numpy suite is byte-identical.
- Adds regression tests for all five (pole derivatives, SCF z-axis end-to-end, negative-m/unit-m elliptic, gamma poles, hyp2f1 grad-at-0, numpy-scalar promotion). Full `tests/test_backend_special.py`: 124 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)