### PR TITLE
Fix CUDA device-mismatch on mixed scalar/array coordinates (SCF, coords, DoubleExp)

### DIFF
--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -189,8 +189,10 @@ class DoubleExponentialDiskPotential(Potential):
         dev = device_of(R, z)
         if isinstance(R, (float, int)):
             floatIn = True
-            R = xp.atleast_1d(xp.asarray(R))
-            z = xp.atleast_1d(xp.asarray(z))
+            # anchor on dev so a scalar R does not land on CPU while z is a CUDA
+            # array (dev is None for numpy/scalars -> byte-identical)
+            R = xp.atleast_1d(asarray_on_device(xp, R, dev))
+            z = xp.atleast_1d(asarray_on_device(xp, z, dev))
         else:
             if isinstance(z, float):
                 z = z * xp.ones_like(R)

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -514,10 +514,13 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             return result
         # backend path: identical per-point evaluation, but assembled
         # functionally (stack instead of in-place writes) so it traces and
-        # differentiates under jax/torch.
-        R = xp.asarray(R) * 1.0
-        z = xp.asarray(z) * 1.0
-        phi = xp.asarray(phi) * 1.0
+        # differentiates under jax/torch. Anchor R, z, phi on one device so a
+        # CUDA array coord meeting Python-scalar siblings (which xp.asarray puts
+        # on CPU) does not mix devices; dev is None for numpy -> byte-identical.
+        dev = device_of(R, z, phi)
+        R = asarray_on_device(xp, R, dev) * 1.0
+        z = asarray_on_device(xp, z, dev) * 1.0
+        phi = asarray_on_device(xp, phi, dev) * 1.0
         shape = (R * z * phi).shape
         if shape == ():
             return self._compute_at_point(radial_func, R, z, phi)

--- a/galpy/potential/SphericalHarmonicPotentialMixin.py
+++ b/galpy/potential/SphericalHarmonicPotentialMixin.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import asarray_on_device, device_of, get_namespace, match_input_dtype
 from ..util import coords
 
 
@@ -83,10 +83,17 @@ class SphericalHarmonicPotentialMixin:
             return force
         # backend path: identical per-point evaluation, assembled functionally
         # (stack instead of in-place writes) so it traces and differentiates.
-        R = xp.asarray(R) * 1.0
-        z = xp.asarray(z) * 1.0
-        phi = xp.asarray(phi) * 1.0
-        t = xp.asarray(t) * 1.0
+        # Anchor every coordinate AND chain-rule factor on one device, so a CUDA
+        # array coord meeting Python-scalar siblings (which xp.asarray would put
+        # on CPU) does not mix devices. dev is None for numpy -> byte-identical.
+        dev = device_of(R, z, phi, t, dr_dx, dtheta_dx, dphi_dx)
+        R = asarray_on_device(xp, R, dev) * 1.0
+        z = asarray_on_device(xp, z, dev) * 1.0
+        phi = asarray_on_device(xp, phi, dev) * 1.0
+        t = asarray_on_device(xp, t, dev) * 1.0
+        dr_dx = asarray_on_device(xp, dr_dx, dev) * 1.0
+        dtheta_dx = asarray_on_device(xp, dtheta_dx, dev) * 1.0
+        dphi_dx = asarray_on_device(xp, dphi_dx, dev) * 1.0
         shape = numpy.broadcast_shapes(
             tuple(R.shape), tuple(z.shape), tuple(phi.shape), tuple(t.shape)
         )
@@ -102,11 +109,9 @@ class SphericalHarmonicPotentialMixin:
         z = xp.reshape(xp.broadcast_to(z, shape), (-1,))
         phi = xp.reshape(xp.broadcast_to(phi, shape), (-1,))
         t = xp.reshape(xp.broadcast_to(t, shape), (-1,))
-        dr_dx = xp.reshape(xp.broadcast_to(xp.asarray(dr_dx) * 1.0, shape), (-1,))
-        dtheta_dx = xp.reshape(
-            xp.broadcast_to(xp.asarray(dtheta_dx) * 1.0, shape), (-1,)
-        )
-        dphi_dx = xp.reshape(xp.broadcast_to(xp.asarray(dphi_dx) * 1.0, shape), (-1,))
+        dr_dx = xp.reshape(xp.broadcast_to(dr_dx, shape), (-1,))
+        dtheta_dx = xp.reshape(xp.broadcast_to(dtheta_dx, shape), (-1,))
+        dphi_dx = xp.reshape(xp.broadcast_to(dphi_dx, shape), (-1,))
         dPhi_dr, dPhi_dtheta, dPhi_dphi = self._compute_spher_forces_at_point(
             R, z, phi, t=t
         )
@@ -216,10 +221,13 @@ class SphericalHarmonicPotentialMixin:
                 )
             return result
         # backend path: identical per-point evaluation, assembled functionally.
-        R = xp.asarray(R) * 1.0
-        z = xp.asarray(z) * 1.0
-        phi = xp.asarray(phi) * 1.0
-        t = xp.asarray(t) * 1.0
+        # Anchor coords on one device (CUDA array meeting scalar siblings); dev
+        # is None for numpy -> byte-identical.
+        dev = device_of(R, z, phi, t)
+        R = asarray_on_device(xp, R, dev) * 1.0
+        z = asarray_on_device(xp, z, dev) * 1.0
+        phi = asarray_on_device(xp, phi, dev) * 1.0
+        t = asarray_on_device(xp, t, dev) * 1.0
         shape = numpy.broadcast_shapes(
             tuple(R.shape), tuple(z.shape), tuple(phi.shape), tuple(t.shape)
         )

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1207,7 +1207,8 @@ def cyl_to_spher(R, Z, phi):
     -----
     - 2016-05-16 - Written - Aladdin
     """
-    xp = get_namespace(R, Z)
+    xp = get_namespace(R, Z, phi)
+    R, Z, phi = _promote_scalars_for(xp, R, Z, phi)
     theta = xp.arctan2(R, Z)
     r = (R**2 + Z**2) ** 0.5
     return (r, theta, phi)

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -111,7 +111,12 @@ def _promote_scalars_for(xp, *vals):
             return v
         try:
             return xp.asarray(v, dtype=dtype, device=device)
-        except TypeError:  # pragma: no cover - namespace without device kwarg
+        except (TypeError, ValueError):
+            # namespace without a device kwarg, or one that rejects the device
+            # value (array-api jax exposes .device as the string 'cpu', which
+            # jnp.asarray(device=...) refuses with ValueError). jax tracks device
+            # automatically, so a plain asarray is correct; torch's .device is a
+            # real object and never hits this fallback.
             return xp.asarray(v, dtype=dtype)
 
     return tuple(_promote(v) for v in vals)

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -103,6 +103,31 @@ def test_doubleexp_scalar_R_array_z(backend):
     numpy.testing.assert_allclose(_np(dp(1.5, zb)), ref, rtol=1e-8, atol=1e-10)
 
 
+def test_promote_scalars_device_reject_fallback():
+    # _promote_scalars_for must fall back to a device-less asarray when the
+    # namespace rejects the ref's device value (array-api jax exposes .device as
+    # the string 'cpu', and jnp.asarray(device='cpu') raises ValueError). Driven
+    # deterministically here with a tiny stub so the fallback is covered on every
+    # CI runner regardless of the installed jax's .device behaviour.
+    from galpy.util.coords import _promote_scalars_for
+
+    class _Xp:
+        def asarray(self, v, dtype=None, device=None):
+            if device is not None:
+                raise ValueError(f"backend rejects device={device!r}")
+            return numpy.asarray(v, dtype=dtype)
+
+    class _Ref:
+        ndim = 1
+        dtype = float
+        device = "string-device-the-namespace-rejects"
+
+    ref = _Ref()
+    out = _promote_scalars_for(_Xp(), ref, 2.5)
+    assert out[0] is ref  # the array passes through untouched
+    assert float(out[1]) == 2.5  # the scalar was promoted via the fallback path
+
+
 @pytest.mark.skipif(
     torch is None or not torch.cuda.is_available(),
     reason="needs a CUDA torch device",

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -1,0 +1,129 @@
+###############################################################################
+# test_backend_device.py: device placement on mixed scalar/array coordinate
+# inputs. A Python-scalar coordinate must be anchored on the device of a sibling
+# backend-array coordinate, not left on the CPU default, or torch raises
+# "Expected all tensors to be on the same device" on CUDA. The CPU cases here
+# exercise the device-anchoring branch (a CPU torch/jax array still carries a
+# .device); the CUDA case (skipped without a GPU) is where it is load-bearing.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _np(x):
+    if torch is not None and isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return numpy.asarray(x)
+
+
+def _scf():
+    from galpy.potential import SCFPotential, scf_compute_coeffs_spherical
+
+    Acos, Asin = scf_compute_coeffs_spherical(lambda r: numpy.exp(-r), 5)
+    return SCFPotential(Acos=Acos, Asin=Asin)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_scf_mixed_scalar_array_coords(backend):
+    # SCF with scalar R,z and a backend-ARRAY phi: the scalar coords must follow
+    # phi's device. On CPU this just checks parity vs numpy (and covers the
+    # device-anchoring branch); under CUDA it is the difference between working
+    # and a mixed-device crash.
+    from galpy.potential import evaluatephitorques, evaluateRforces, evaluatezforces
+
+    scf = _scf()
+    phin = numpy.array([0.1, 0.7, 1.3])
+    phib = _arr(backend, [0.1, 0.7, 1.3])
+    for name, fn in [
+        ("pot", lambda p: scf(1.5, 0.3, phi=p)),
+        ("Rforce", lambda p: evaluateRforces(scf, 1.5, 0.3, phi=p)),
+        ("zforce", lambda p: evaluatezforces(scf, 1.5, 0.3, phi=p)),
+        ("phitorque", lambda p: evaluatephitorques(scf, 1.5, 0.3, phi=p)),
+        ("R2deriv", lambda p: scf.R2deriv(1.5, 0.3, phi=p)),
+        ("phi2deriv", lambda p: scf.phi2deriv(1.5, 0.3, phi=p)),
+    ]:
+        ref = numpy.asarray(fn(phin))
+        got = _np(fn(phib))
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-10, atol=1e-12, err_msg=f"SCF {name} ({backend})"
+        )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_cyl_to_spher_mixed(backend):
+    # array phi + scalar R,z: r, theta, phi must come back on one namespace and
+    # match the numpy values.
+    from galpy.util import coords
+
+    phib = _arr(backend, [0.1, 0.2, 0.3])
+    r, th, ph = coords.cyl_to_spher(1.5, 0.3, phib)
+    r_ref, theta_ref, phi_ref = coords.cyl_to_spher(
+        1.5, 0.3, numpy.array([0.1, 0.2, 0.3])
+    )
+    numpy.testing.assert_allclose(_np(r), numpy.broadcast_to(r_ref, (3,)), rtol=1e-12)
+    numpy.testing.assert_allclose(
+        _np(th), numpy.broadcast_to(theta_ref, (3,)), rtol=1e-12
+    )
+    numpy.testing.assert_allclose(_np(ph), phi_ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_doubleexp_scalar_R_array_z(backend):
+    # DoubleExponentialDisk._evaluate scalar-R branch with a backend-array z.
+    from galpy.potential import DoubleExponentialDiskPotential as DEDP
+
+    dp = DEDP()
+    zb = _arr(backend, [0.3, 0.6])
+    ref = numpy.asarray(dp(1.5, numpy.array([0.3, 0.6])))
+    numpy.testing.assert_allclose(_np(dp(1.5, zb)), ref, rtol=1e-8, atol=1e-10)
+
+
+@pytest.mark.skipif(
+    torch is None or not torch.cuda.is_available(),
+    reason="needs a CUDA torch device",
+)
+def test_mixed_coords_cross_device_cuda():
+    # The load-bearing case: scalar R,z + a CUDA-array phi. Pre-fix these raised
+    # "Expected all tensors to be on the same device"; now they return on CUDA.
+    from galpy.potential import DoubleExponentialDiskPotential as DEDP
+    from galpy.potential import evaluateRforces
+    from galpy.util import coords
+
+    scf = _scf()
+    phi = torch.tensor([0.1, 0.2, 0.3], device="cuda")
+    refp = numpy.asarray(scf(1.5, 0.3, phi=numpy.array([0.1, 0.2, 0.3])))
+    out = scf(1.5, 0.3, phi=phi)
+    assert out.device.type == "cuda"
+    numpy.testing.assert_allclose(out.detach().cpu().numpy(), refp, rtol=1e-10)
+    fr = evaluateRforces(scf, 1.5, 0.3, phi=phi)
+    assert fr.device.type == "cuda"
+    r, th, ph = coords.cyl_to_spher(1.5, 0.3, phi)
+    assert r.device.type == "cuda" and th.device.type == "cuda"
+    zc = torch.tensor([0.3, 0.6], device="cuda")
+    de = DEDP()(1.5, zc)
+    assert de.device.type == "cuda"


### PR DESCRIPTION
Found by a **device-placement hunt** across `galpy/backend`, the potentials, and `df`/`util` (prompted by the `galpy.backend.quadrature` device fix in #965). The sweep flagged candidates statically; I **reproduced each on a TITAN Xp** and dismissed the false positives (`interpolate.eval_ppoly`, `EllipsoidalPotential` — both correctly anchor already).

## The bug class
A compute method rebuilds a Python-scalar coordinate with bare `xp.asarray(...)` (which lands on the **CPU** default), while a sibling coordinate is a backend **array on CUDA**. torch then raises `Expected all tensors to be on the same device` (jax often auto-promotes, hiding it). Confirmed on the TITAN Xp for:

- **`SCFPotential`** `__call__` / `Rforce` / `zforce` / `phitorque` / `R2deriv` / `phi2deriv` with scalar `R,z` + a CUDA `phi` (via `SphericalHarmonicPotentialMixin._evaluate_cyl_force` / `_evaluate_cyl_2nd_deriv_core` and `SCFPotential._evaluate_expansion`);
- **`DoubleExponentialDiskPotential._evaluate`** scalar-`R` branch with a CUDA `z`;
- **`coords.cyl_to_spher`**, which dispatched the namespace on `(R, Z)` only — dropping `phi` — and returned a mixed-device `(r, theta, phi)` tuple that fed the SCF mismatch.

## Fix
Anchor every coordinate (and the SCF chain-rule factors `dr_dx/dtheta_dx/dphi_dx`) on a single device via `device_of(...)` + `asarray_on_device(...)`. `cyl_to_spher` now resolves the namespace over `(R, Z, phi)` and promotes scalars with `_promote_scalars_for`, mirroring the already-correct `cyl_to_rect`.

Since `device_of` returns `None` for numpy/scalar inputs, `asarray_on_device` reduces to plain `xp.asarray` — the **numpy path is byte-identical** (verified: SCF and DoubleExp values match the built `main` repo exactly).

## Tests
New `tests/test_backend_device.py`: CPU mixed scalar/array-input parity (jax + torch — a CPU backend array still carries a `.device`, so this exercises the anchoring branch in CI) and a CUDA-guarded cross-device check. All validated on a TITAN Xp.

## Relationship to #960
This is the **compute-layer** counterpart to #960's decorator-level coercion. #960 coerces positional args and kwargs *separately*, so it does not unify the device on the `scalar-R/z` + `CUDA-phi-kwarg` path; and wrapper `_*_nodecorator` bypasses + direct private calls skip the decorator entirely. Both layers are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)