### PR TITLE
DoubleExp._evaluate: treat a 0-d-array R as scalar (fix coerced-scalar reshape error on feat/backends)

### DIFF
--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -188,7 +188,11 @@ class DoubleExponentialDiskPotential(Potential):
         # for numpy/scalars, leaving the numpy path byte-identical).
         in_coords = (R, z, phi, t)
         dev = device_of(R, z)
-        if isinstance(R, (float, int)):
+        # A 0-d array counts as scalar input: the backend coercion decorator
+        # promotes a Python scalar R to a 0-d backend array, which must take the
+        # same path as a plain float (else the array branch's outShape=R.shape=()
+        # mismatches an array z and reshape fails) -> stays numpy-consistent.
+        if isinstance(R, (float, int)) or getattr(R, "ndim", 1) == 0:
             floatIn = True
             # anchor on dev so a scalar R does not land on CPU while z is a CUDA
             # array (dev is None for numpy/scalars -> byte-identical)

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -94,13 +94,21 @@ def test_cyl_to_spher_mixed(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_doubleexp_scalar_R_array_z(backend):
-    # DoubleExponentialDisk._evaluate scalar-R branch with a backend-array z.
+    # DoubleExp._evaluate's scalar-R path. The backend coercion promotes the
+    # scalar R to a 0-d array, which must still take the scalar path and return
+    # the SAME value numpy does (DoubleExp's scalar-R path returns the R-scalar
+    # result, out[0]) -- regression for the 0-d-R reshape error, and a device
+    # check (scalar R + backend-array z must not mix devices).
     from galpy.potential import DoubleExponentialDiskPotential as DEDP
 
     dp = DEDP()
     zb = _arr(backend, [0.3, 0.6])
     ref = numpy.asarray(dp(1.5, numpy.array([0.3, 0.6])))
     numpy.testing.assert_allclose(_np(dp(1.5, zb)), ref, rtol=1e-8, atol=1e-10)
+    # supported array combo (same-shape R, z) stays a full array, matching numpy
+    Rb, zb2 = _arr(backend, [1.5, 2.0]), _arr(backend, [0.3, 0.6])
+    ref2 = numpy.asarray(dp(numpy.array([1.5, 2.0]), numpy.array([0.3, 0.6])))
+    numpy.testing.assert_allclose(_np(dp(Rb, zb2)), ref2, rtol=1e-8, atol=1e-10)
 
 
 def test_promote_scalars_device_reject_fallback():


### PR DESCRIPTION
**Fixes a real red on `feat/backends`** (the `build (test_backend*.py)` job): `test_doubleexp_scalar_R_array_z[jax/torch]` fails with `cannot reshape array of shape (2,) into shape ()`.

**Root cause — an interaction that only appeared once #960 and #967 both landed:** #960's coordinate coercion promotes a scalar `R` to a **0-d backend array**, so `DoubleExp._evaluate`'s `isinstance(R, (float, int))` is now `False` → it takes the array branch, which sets `outShape = R.shape = ()` and then can't reshape a `(2,)` result (from an array `z`) into `()`. The `test_backend_device.py` test (added in #967) exercises exactly `dp(scalar_R, array_z)`, so the two PRs merging together surfaced it.

**Fix:** treat a 0-d-array `R` (`ndim == 0`) the same as a Python scalar, so a coerced scalar takes the scalar path and returns the **same value numpy does** — DoubleExp's scalar-R path returns the R-scalar result (`out[0]`), a pre-existing numpy behavior, not array-broadcasting. The normal `float` R path is untouched (**numpy byte-identical**), and same-shape array `(R, z)` still returns a full array.

Verified: the failing test passes under jax+torch; numpy `dp(1.5, 0.3)`, `dp(1.5, [0.3,0.6])` (→ scalar), `dp([1.5,2.0],[0.3,0.6])` (→ array), and 0-d-numpy-R all match. Test extended to also cover the supported same-shape array combo.

(Once merged, the stacked #962/#963 — rebased onto `feat/backends` — clear the same red.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)