### PR TITLE
Support astropy ≥ 8: galcen_v_sun is now a CartesianRepresentation (.xyz)

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,12 @@
 v1.12.0 (expected around 2026-07-01)
 ====================
 
+- Fixed compatibility with astropy >= 8.0, where the ``Galactocentric``
+  ``galcen_v_sun`` frame attribute is now a ``CartesianRepresentation`` (read
+  via ``.xyz``) rather than a ``CartesianDifferential`` (``.d_xyz``); see
+  astropy/astropy#18362. Initializing an ``Orbit`` from a ``SkyCoord`` that
+  carries ``galcen_v_sun`` now works on both old and new astropy.
+
 - Added analytic planar second derivatives (R2deriv, phi2deriv, Rphideriv) of
   ``SteadyLogSpiralPotential`` and ``TransientLogSpiralPotential`` in Python
   and C, enabling the planar variational equations of ``Orbit.integrate_dxdv``

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -567,7 +567,13 @@ class Orbit:
             and isinstance(vxvv, SkyCoord)
             and not vxvv.galcen_v_sun is None
         ):
-            sc_solarmotion = vxvv.galcen_v_sun.d_xyz.to(units.km / units.s).value
+            # astropy < 8 exposes galcen_v_sun as a CartesianDifferential (.d_xyz);
+            # astropy >= 8 (astropy/astropy#18362) as a CartesianRepresentation (.xyz)
+            _galcen_v_sun = vxvv.galcen_v_sun
+            sc_solarmotion = getattr(_galcen_v_sun, "d_xyz", None)
+            if sc_solarmotion is None:
+                sc_solarmotion = _galcen_v_sun.xyz
+            sc_solarmotion = sc_solarmotion.to(units.km / units.s).value
             sc_solarmotion[0] = -sc_solarmotion[0]  # right->left
             sc_solarmotion[1] -= vo
             if solarmotion is None:

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -10752,9 +10752,15 @@ def test_SkyCoord():
     assert numpy.fabs(o.SkyCoord().z_sun.to(units.kpc).value - 1.0) < 10.0**-13.0, (
         "Orbit SkyCoord GC frame attributes are incorrect"
     )
+    # astropy < 8: galcen_v_sun is a CartesianDifferential (.d_xyz); astropy >= 8
+    # (astropy/astropy#18362) a CartesianRepresentation (.xyz)
+    _gvs = o.SkyCoord().galcen_v_sun
+    _gvs_v = getattr(_gvs, "d_xyz", None)
+    if _gvs_v is None:
+        _gvs_v = _gvs.xyz
     assert numpy.all(
         numpy.fabs(
-            o.SkyCoord().galcen_v_sun.d_xyz.to(units.km / units.s).value
+            _gvs_v.to(units.km / units.s).value
             - numpy.array([10.0, 220.0 + 34.0, 12.0])
         )
         < 10.0**-13.0


### PR DESCRIPTION
## The bug

On **astropy ≥ 8.0**, initializing an `Orbit` from a `SkyCoord` that carries `galcen_v_sun` raises:

```
AttributeError: 'CartesianRepresentation' object has no attribute 'd_xyz'
  galpy/orbit/Orbits.py:570
```

This fails **repo-wide** on every current PR (`test_SkyCoord`, `test_orbit_setup_SkyCoord`, `test_apy_sunkeywords_not_supplied`, `test_initialization_SkyCoord`).

### Cause

astropy [#18362](https://github.com/astropy/astropy/pull/18362) ("Use cartesian instead of differential attribute"), merged for **v8.0.0**, changed `Galactocentric.galcen_v_sun` from a `CartesianDifferential` (read via `.d_xyz`) to a `CartesianRepresentation` (read via `.xyz`), so it can validate velocity units. It is a **hard change with no deprecation period**.

## The fix

Read the velocity via a **capability check** (`getattr(..., "d_xyz", None)`, else `.xyz`) instead of branching on the astropy version — so galpy keeps supporting older astropy:

```python
_galcen_v_sun = vxvv.galcen_v_sun
sc_solarmotion = getattr(_galcen_v_sun, "d_xyz", None)
if sc_solarmotion is None:
    sc_solarmotion = _galcen_v_sun.xyz          # astropy >= 8
sc_solarmotion = sc_solarmotion.to(units.km / units.s).value
```

On astropy < 8 it takes the `.d_xyz` branch (**byte-identical to before**); on astropy ≥ 8 it falls back to `.xyz`. The same one-site fix is applied to the test's own `d_xyz` read.

## Verification

| | astropy 7.2.0 (`.d_xyz`) | astropy 8.0.0 (`.xyz`) |
|---|---|---|
| old code | 4 passed | **FAILS** (`d_xyz` AttributeError) |
| this PR | 4 passed | **4 passed** |

Solar-motion values identical across versions. No `astropy>=` pin is added — the fix spans the whole supported range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)