### PR TITLE
Track D: fast C-STM differentiable orbit integration (jax/torch) — PR-B (functional)

### DIFF
--- a/galpy/backend/_jax/orbit_stm.py
+++ b/galpy/backend/_jax/orbit_stm.py
@@ -1,0 +1,63 @@
+###############################################################################
+#   galpy.backend._jax.orbit_stm
+#
+#   jax.custom_vjp wrapping galpy's compiled C variational integrator for
+#   differentiable fast orbit integration. The forward is a jax.pure_callback to
+#   the (non-differentiable) C integrator, which also returns the
+#   state-transition matrix M(t)=d x(t)/d x(0); the custom vjp applies
+#   sum_t M(t)^T cotangent[t] for the IC gradient. See
+#   galpy.backend._reference.inbackend_stm for the convention (Orbit order,
+#   IC-only gradients).
+###############################################################################
+import numpy
+
+from .._reference.inbackend_stm import c_stm_forward
+
+
+def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
+    """Differentiable C-STM orbit integration under jax.
+
+    vxvv: jax array (6,) or (N,6), Orbit order. Returns (nt,6) or (N,nt,6).
+    Differentiable w.r.t. vxvv. pot/ts/method are static (closed over).
+    """
+    import jax
+    import jax.numpy as jnp
+
+    ts_np = numpy.asarray(ts, dtype=numpy.float64)
+    nt = ts_np.shape[0]
+
+    def _host(vxvv_np):
+        xt, M = c_stm_forward(
+            pot, numpy.asarray(vxvv_np, dtype=numpy.float64), ts_np, method, rtol, atol
+        )
+        return xt, M
+
+    def _call(v):
+        single = v.ndim == 1
+        n6 = (nt, 6) if single else (v.shape[0], nt, 6)
+        n66 = (nt, 6, 6) if single else (v.shape[0], nt, 6, 6)
+        return jax.pure_callback(
+            _host,
+            (jax.ShapeDtypeStruct(n6, v.dtype), jax.ShapeDtypeStruct(n66, v.dtype)),
+            v,
+            vmap_method="expand_dims",
+        )
+
+    @jax.custom_vjp
+    def _stm(v):
+        xt, _ = _call(v)
+        return xt
+
+    def _fwd(v):
+        xt, M = _call(v)
+        return xt, M  # residual = M
+
+    def _bwd(M, ct):
+        if M.ndim == 3:  # single: M (nt,6,6), ct (nt,6) -> (6,)
+            vbar = jnp.einsum("tab,ta->b", M, ct)
+        else:  # batch: M (N,nt,6,6), ct (N,nt,6) -> (N,6)
+            vbar = jnp.einsum("ntab,nta->nb", M, ct)
+        return (vbar,)
+
+    _stm.defvjp(_fwd, _bwd)
+    return _stm(vxvv)

--- a/galpy/backend/_reference/inbackend_stm.py
+++ b/galpy/backend/_reference/inbackend_stm.py
@@ -1,0 +1,120 @@
+###############################################################################
+#   galpy.backend._reference.inbackend_stm
+#
+#   Differentiable FAST-C orbit integration via the state-transition matrix
+#   (STM). The forward solve is galpy's compiled C variational integrator
+#   (integrate_dxdv); the gradient w.r.t. the initial conditions is the STM
+#   M(t) = d x(t) / d x(0) that the same C integration already produces, applied
+#   as M(t)^T to the output cotangent (forward-sensitivity adjoint -- a single
+#   matrix-transpose-vector product, no backward C call).
+#
+#   This is the fast first-order-differentiable orbit path for the jax/torch
+#   backends; the in-backend ODE path (inbackend_ode.py) is the independent,
+#   higher-order / parameter-gradient cross-check.
+#
+#   Convention: phase-space vectors use galpy's Orbit ordering
+#   ``[R, vR, vT, z, vz, phi]``. We assemble M directly in this frame by
+#   propagating the 6 canonical basis deviation vectors with
+#   ``integrate_dxdv(..., rectIn=False, rectOut=False)`` -- so x(t)=M(t) x(0)
+#   holds in Orbit order with no cylindrical<->rectangular Jacobian folding
+#   (verified vs finite-difference of the flow). Gradients are w.r.t. the
+#   initial conditions only; potential-parameter gradients use the in-backend
+#   ODE path (the C integrator carries no d x / d theta sensitivity).
+###############################################################################
+import numpy
+
+from .. import get_namespace
+
+# dxdv-capable C integrators (the variational RHS is wired for these).
+_C_DXDV_METHODS = ("rk4_c", "rk6_c", "dopr54_c", "dop853_c")
+
+
+def c_stm_forward(pot, vxvv, ts, method, rtol, atol):
+    """Run the C variational integrator and return (x(t), M(t)).
+
+    Pure numpy; no autodiff. This is the host-side call wrapped by the jax/torch
+    autodiff rules.
+
+    Parameters
+    ----------
+    pot : Potential (or list)
+    vxvv : numpy.ndarray, shape (6,) or (N, 6), Orbit order [R,vR,vT,z,vz,phi].
+    ts : numpy.ndarray, shape (nt,), output times (ts[0] is the initial time).
+    method : str, one of ``_C_DXDV_METHODS``.
+    rtol, atol : float
+
+    Returns
+    -------
+    xt : numpy.ndarray, (nt, 6) or (N, nt, 6) -- the orbit, Orbit order.
+    M : numpy.ndarray, (nt, 6, 6) or (N, nt, 6, 6) -- STM d x(t)/d x(0),
+        M[...,0,:,:] = identity.
+    """
+    from ...orbit import Orbit
+
+    vxvv = numpy.asarray(vxvv, dtype=numpy.float64)
+    single = vxvv.ndim == 1
+    ics = vxvv[None] if single else vxvv
+    basis = numpy.eye(6)
+    xts, Ms = [], []
+    for ic in ics:
+        cols = []
+        base = None
+        for i in range(6):
+            o = Orbit(list(ic))
+            o.integrate_dxdv(
+                basis[i],
+                ts,
+                pot,
+                method=method,
+                rectIn=False,
+                rectOut=False,
+                rtol=rtol,
+                atol=atol,
+            )
+            cols.append(o.getOrbit_dxdv())  # (nt,6): column i of M
+            if base is None:
+                base = o.getOrbit()  # (nt,6): the base orbit, Orbit order
+        xts.append(base)
+        Ms.append(numpy.asarray(cols).transpose(1, 2, 0))  # (nt,6,6)
+    xt = numpy.asarray(xts)
+    M = numpy.asarray(Ms)
+    if single:
+        return xt[0], M[0]
+    return xt, M
+
+
+def integrate_stm(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
+    """Differentiable fast-C orbit integration; dispatches on ``vxvv``'s backend.
+
+    Parameters
+    ----------
+    pot : Potential (or list).
+    vxvv : backend array, (6,) or (N, 6), Orbit order [R,vR,vT,z,vz,phi]. Its
+        namespace (jax/torch) selects the autodiff wrapper.
+    ts : array of output times (numpy or backend; ts[0] is the initial time).
+    method : one of rk4_c / rk6_c / dopr54_c / dop853_c.
+    rtol, atol : C integrator tolerances.
+
+    Returns
+    -------
+    backend array, (nt, 6) or (N, nt, 6), the orbit in Orbit order, differentiable
+    w.r.t. ``vxvv``.
+    """
+    if method not in _C_DXDV_METHODS:
+        raise ValueError(
+            f"integrate_stm needs a dxdv-capable C integrator {_C_DXDV_METHODS}, got {method!r}"
+        )
+    xp = get_namespace(vxvv)
+    name = getattr(xp, "__name__", "")
+    if "jax" in name:
+        from .._jax.orbit_stm import integrate as _integrate_jax
+
+        return _integrate_jax(pot, vxvv, ts, method=method, rtol=rtol, atol=atol)
+    if "torch" in name:
+        from .._torch.orbit_stm import integrate as _integrate_torch
+
+        return _integrate_torch(pot, vxvv, ts, method=method, rtol=rtol, atol=atol)
+    raise NotImplementedError(
+        "C-STM autodiff requires a jax or torch input array; for numpy use "
+        "Orbit.integrate (the same C integrator, non-differentiable)."
+    )

--- a/galpy/backend/_torch/orbit_stm.py
+++ b/galpy/backend/_torch/orbit_stm.py
@@ -1,0 +1,48 @@
+###############################################################################
+#   galpy.backend._torch.orbit_stm
+#
+#   torch.autograd.Function wrapping galpy's compiled C variational integrator
+#   for differentiable fast orbit integration. Forward runs the C integrator and
+#   saves the state-transition matrix M(t)=d x(t)/d x(0); backward returns the
+#   IC gradient as sum_t M(t)^T grad_out[t]. See galpy.backend._reference
+#   .inbackend_stm for the convention (Orbit order, IC-only gradients).
+###############################################################################
+import numpy
+import torch
+
+from .._reference.inbackend_stm import c_stm_forward
+
+
+class _CSTMFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, vxvv, pot, ts, method, rtol, atol):
+        # The C integrator is CPU/float64; move off-device + to numpy for the call.
+        vnp = vxvv.detach().to("cpu", torch.float64).numpy()
+        tnp = (
+            ts.detach().to("cpu", torch.float64).numpy()
+            if torch.is_tensor(ts)
+            else numpy.asarray(ts, dtype=numpy.float64)
+        )
+        xt, M = c_stm_forward(pot, vnp, tnp, method, rtol, atol)
+        ctx.save_for_backward(torch.as_tensor(M, dtype=vxvv.dtype, device=vxvv.device))
+        ctx.single = vxvv.ndim == 1
+        return torch.as_tensor(xt, dtype=vxvv.dtype, device=vxvv.device)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (M,) = ctx.saved_tensors
+        if ctx.single:  # M (nt,6,6), grad_out (nt,6) -> (6,)
+            vbar = torch.einsum("tab,ta->b", M, grad_out)
+        else:  # M (N,nt,6,6), grad_out (N,nt,6) -> (N,6)
+            vbar = torch.einsum("ntab,nta->nb", M, grad_out)
+        # gradients: vxvv only; (pot, ts, method, rtol, atol) are non-differentiable
+        return vbar, None, None, None, None, None
+
+
+def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
+    """Differentiable C-STM orbit integration under torch.
+
+    vxvv: torch tensor (6,) or (N,6), Orbit order. Returns (nt,6) or (N,nt,6).
+    Differentiable w.r.t. vxvv.
+    """
+    return _CSTMFunction.apply(vxvv, pot, ts, method, rtol, atol)

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -202,3 +202,58 @@ def test_numpy_ic_raises():
     pot = MiyamotoNagaiPotential(normalize=1.0)
     with pytest.raises(NotImplementedError):
         integrate_stm(pot, _IC, _TS, method="dop853_c")
+
+
+# ------------------------------------------------------------- bad method raises
+def test_integrate_stm_bad_method_raises():
+    # integrate_stm only supports the dxdv-capable C integrators
+    from galpy.backend._reference.inbackend_stm import integrate_stm
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    with pytest.raises(ValueError):
+        integrate_stm(pot, _IC, _TS, method="odeint")
+
+
+# ----------------------------------------------------- public dispatcher routing
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_integrate_stm_dispatch(backend):
+    # the public dispatcher routes a jax/torch IC to the matching backend wrapper
+    # -> identical result to calling that wrapper directly
+    from galpy.backend._reference.inbackend_stm import integrate_stm
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    v = _arr(backend, _IC)
+    got = _np(integrate_stm(pot, v, _TS, method="dop853_c"))
+    ref = _np(_integ(backend, pot, v, _TS, "dop853_c"))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-12)
+
+
+# -------------------------------------------- batch gradient (batch M^T einsum)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_batch_gradient_matches_single(backend):
+    # a gradient through a BATCHED integrate exercises the batched STM contraction
+    # ("ntab,nta->nb"); each row must equal the single-orbit IC gradient
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ics = numpy.stack([_IC, _IC * 1.01, _IC * 0.99])
+    if backend == "jax":
+        gb = _np(
+            jax.grad(
+                lambda vv: _integ("jax", pot, vv, _TS, "dop853_c")[:, -1, 0].sum()
+            )(jnp.asarray(ics))
+        )
+    else:
+        v = torch.tensor(ics, requires_grad=True)
+        _integ("torch", pot, v, _TS, "dop853_c")[:, -1, 0].sum().backward()
+        gb = _np(v.grad)
+    for j, ic in enumerate(ics):
+        if backend == "jax":
+            gj = _np(
+                jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
+                    jnp.asarray(ic)
+                )
+            )
+        else:
+            vv = torch.tensor(ic, requires_grad=True)
+            _integ("torch", pot, vv, _TS, "dop853_c")[-1, 0].backward()
+            gj = _np(vv.grad)
+        numpy.testing.assert_allclose(gb[j], gj, rtol=1e-8, atol=1e-10)

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -1,0 +1,204 @@
+###############################################################################
+# test_backend_orbit_stm.py: the fast C state-transition-matrix (STM) orbit
+# autodiff path (galpy.backend._{jax,torch}.orbit_stm + _reference.inbackend_stm).
+# Forward = galpy's compiled C variational integrator; gradient w.r.t. the
+# initial conditions = sum_t M(t)^T cotangent[t]. Validates: forward == the C
+# orbit, grad == finite-difference, jacrev == the directly-assembled STM, torch
+# gradcheck, and agreement with the independent in-backend ODE path.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.potential import (
+    DehnenBarPotential,
+    MiyamotoNagaiPotential,
+    MWPotential2014,
+)
+
+_METHODS = ["rk4_c", "rk6_c", "dop853_c"]
+_IC = numpy.array([1.0, 0.1, 0.9, 0.05, 0.1, 0.2])  # R,vR,vT,z,vz,phi
+_TS = numpy.linspace(0.0, 2.0, 9)
+
+
+def _pots():
+    return {
+        "MiyamotoNagai": MiyamotoNagaiPotential(normalize=1.0),
+        "MWPotential2014": MWPotential2014,
+        "DehnenBar": DehnenBarPotential(),  # non-axisymmetric
+    }
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _np(x):
+    if torch is not None and torch.is_tensor(x):
+        return x.detach().cpu().numpy()
+    return numpy.asarray(x)
+
+
+def _integ(backend, pot, vxvv, ts, method):
+    if backend == "jax":
+        from galpy.backend._jax.orbit_stm import integrate
+    else:
+        from galpy.backend._torch.orbit_stm import integrate
+    return integrate(pot, vxvv, ts, method=method)
+
+
+# ---------------------------------------------------------------- forward parity
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", _METHODS)
+def test_forward_matches_c(backend, method):
+    # the wrapper's forward IS galpy's C integrator -> must match Orbit.integrate
+    from galpy.orbit import Orbit
+
+    for name, pot in _pots().items():
+        o = Orbit(list(_IC))
+        o.integrate(_TS, pot, method=method)
+        ref = numpy.array(
+            [o.R(_TS), o.vR(_TS), o.vT(_TS), o.z(_TS), o.vz(_TS), o.phi(_TS)]
+        ).T
+        got = _np(_integ(backend, pot, _arr(backend, _IC), _TS, method))
+        # the wrapper's forward is the dxdv variant of the C integrator; for the
+        # fixed-step methods its shared 12-D step sequence differs from base-only
+        # Orbit.integrate at the integrator level (~1e-8), 1e-12 for dop853_c.
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-6, atol=1e-7, err_msg=f"{name} {method} {backend}"
+        )
+
+
+# ------------------------------------------------------------- grad vs finite-diff
+def _fd_grad_final_R(pot, method, eps=1e-6):
+    from galpy.orbit import Orbit
+
+    def fR(ic):
+        o = Orbit(list(ic))
+        o.integrate(_TS, pot, method=method)
+        return o.R(_TS[-1])
+
+    base = fR(_IC)
+    return numpy.array(
+        [(fR(_IC + eps * numpy.eye(6)[j]) - base) / eps for j in range(6)]
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_grad_final_R_vs_fd(backend):
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    gfd = _fd_grad_final_R(pot, "dop853_c")
+    if backend == "jax":
+        g = jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
+            jnp.asarray(_IC)
+        )
+        g = _np(g)
+    else:
+        v = torch.tensor(_IC, requires_grad=True)
+        _integ("torch", pot, v, _TS, "dop853_c")[-1, 0].backward()
+        g = _np(v.grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-4, atol=1e-5)
+
+
+# --------------------------------------------------- jacrev == assembled STM (jax)
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+@pytest.mark.parametrize("method", _METHODS)
+def test_jacrev_equals_stm(method):
+    from galpy.backend._reference.inbackend_stm import c_stm_forward
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    _, M = c_stm_forward(pot, _IC, _TS, method, 1e-10, 1e-10)
+    Jall = jax.jacrev(lambda v: _integ("jax", pot, v, _TS, method))(jnp.asarray(_IC))
+    numpy.testing.assert_allclose(_np(Jall), M, rtol=1e-10, atol=1e-10)
+
+
+# ----------------------------------------------------------------- torch gradcheck
+@pytest.mark.skipif("torch" not in BACKENDS, reason="needs torch")
+@pytest.mark.parametrize("method", ["rk4_c", "rk6_c"])
+def test_torch_gradcheck(method):
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ts = numpy.linspace(0.0, 1.0, 4)
+    v = torch.tensor(_IC, requires_grad=True)
+    assert torch.autograd.gradcheck(
+        lambda vv: _integ("torch", pot, vv, ts, method), (v,), eps=1e-6, atol=1e-4
+    )
+
+
+# ------------------------------------- C-STM vs in-backend ODE (independent check)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_cstm_grad_matches_inbackend_ode(backend):
+    # the fast C-STM IC gradient must match the diffrax/torchdiffeq AD gradient
+    from galpy.backend._reference.inbackend_ode import integrate_orbit
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    if backend == "jax":
+        g_stm = jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
+            jnp.asarray(_IC)
+        )
+        g_ode = jax.grad(lambda v: integrate_orbit(pot, v, jnp.asarray(_TS))[-1, 0])(
+            jnp.asarray(_IC)
+        )
+    else:
+        v1 = torch.tensor(_IC, requires_grad=True)
+        _integ("torch", pot, v1, _TS, "dop853_c")[-1, 0].backward()
+        g_stm = v1.grad
+        v2 = torch.tensor(_IC, requires_grad=True)
+        integrate_orbit(pot, v2, torch.tensor(_TS))[-1, 0].backward()
+        g_ode = v2.grad
+    numpy.testing.assert_allclose(_np(g_stm), _np(g_ode), rtol=1e-5, atol=1e-6)
+
+
+# --------------------------------------------------------- cross-backend agreement
+@pytest.mark.skipif(
+    "jax" not in BACKENDS or "torch" not in BACKENDS, reason="needs both"
+)
+def test_torch_grad_matches_jax():
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    g_jax = _np(
+        jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
+            jnp.asarray(_IC)
+        )
+    )
+    v = torch.tensor(_IC, requires_grad=True)
+    _integ("torch", pot, v, _TS, "dop853_c")[-1, 0].backward()
+    numpy.testing.assert_allclose(_np(v.grad), g_jax, rtol=1e-8, atol=1e-10)
+
+
+# -------------------------------------------------------------- batch / vmap (jax)
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+def test_batch_and_vmap():
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ics = jnp.asarray(numpy.stack([_IC, _IC * 1.01, _IC * 0.99]))
+    batch = _integ("jax", pot, ics, _TS, "dop853_c")
+    assert batch.shape == (3, len(_TS), 6)
+    vm = jax.vmap(lambda v: _integ("jax", pot, v, _TS, "dop853_c"))(ics)
+    numpy.testing.assert_allclose(_np(batch), _np(vm), rtol=1e-10, atol=1e-12)
+
+
+# ---------------------------------------------------------------- numpy IC raises
+def test_numpy_ic_raises():
+    from galpy.backend._reference.inbackend_stm import integrate_stm
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    with pytest.raises(NotImplementedError):
+        integrate_stm(pot, _IC, _TS, method="dop853_c")


### PR DESCRIPTION
**Draft for review** — the first half of Track D's `Pjax/Ptorch-orbit`. Design brief: `galpy-jax/logs/TrackD_orbit_integration/cstm_design.md`.

## What
Differentiable orbit integration through galpy's **compiled C variational integrator** (`integrate_dxdv`): the forward solve is the fast C code, and the gradient w.r.t. the initial conditions is the **state-transition matrix** `M(t)=dx(t)/dx(0)` — which the same C integration already produces — applied as `Σₜ M(t)ᵀ·c̄ₜ` (forward-sensitivity adjoint: one matvec, **no backward C call**).

Phase-0 finding that simplified the design: `integrate_dxdv(rectIn=False, rectOut=False)` returns M **directly in Orbit order** `[R,vR,vT,z,vz,phi]` (verified vs finite-difference of the flow), so there's **no cyl↔rect Jacobian folding** — the wrapper just does `x=M·x₀` / `Σ Mᵀc̄`.

## Files (all new, no existing code touched)
- `galpy/backend/_reference/inbackend_stm.py` — `c_stm_forward()` (assembles M from 6 canonical-basis `integrate_dxdv` calls) + `integrate_stm()` dispatcher.
- `galpy/backend/_jax/orbit_stm.py` — `jax.custom_vjp` + `jax.pure_callback`; batched ICs, `vmap`/`jit`.
- `galpy/backend/_torch/orbit_stm.py` — `torch.autograd.Function`; CUDA ICs → host for the CPU C call.

## Scope
- **Functional API only** (`integrate_stm(pot, vxvv, ts)`) — **no `Orbit.integrate` routing yet**; that's PR-C and needs your routing decisions (IC capture, selection knob, etc. — see the design brief's open questions).
- **IC gradients only.** Parameter gradients stay with the in-backend ODE path (the C integrator carries no `dx/dθ`).
- Reverse-mode (`grad`/`jacrev`); forward-mode (`jacfwd`) is a follow-up (`custom_jvp`).

## Validation — `tests/test_backend_orbit_stm.py`, 18 tests passing
forward == `Orbit.integrate`; jax `grad` and torch `grad` == finite-difference; **`jacrev` == the directly-assembled STM, exactly**; **`torch.autograd.gradcheck`**; **C-STM grad == the independent in-backend ODE grad**; torch grad == jax grad; batch/`vmap`; numpy raises. Across `rk4_c`/`rk6_c`/`dop853_c` × MiyamotoNagai / MWPotential2014 / DehnenBar (non-axi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)