### PR TITLE
Add an 'all-clear' aggregate status check for auto-merge / merge queue

### DIFF
--- a/.github/workflows/all-clear.yml
+++ b/.github/workflows/all-clear.yml
@@ -24,7 +24,8 @@ jobs:
   all-clear:
     name: all-clear
     runs-on: ubuntu-latest
-    timeout-minutes: 130
+    # 5.5h, just under the 6h GitHub-hosted job hard cap; leaves margin over MAX_WAIT_SECONDS.
+    timeout-minutes: 330
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
@@ -34,8 +35,9 @@ jobs:
       # first conclude "nothing is pending" (avoids a premature pass).
       INITIAL_DELAY_SECONDS: "60"
       POLL_INTERVAL_SECONDS: "30"
-      # 2h ceiling: must exceed the slowest single check (wheels.yml ~1.5h) plus margin.
-      MAX_WAIT_SECONDS: "7200"
+      # 5h ceiling: during heavy development a full CI round can take 3-4h, partly because
+      # some wheel jobs are only scheduled after the first round and start late.
+      MAX_WAIT_SECONDS: "18000"
     steps:
       - name: Resolve head SHA
         id: sha

--- a/.github/workflows/all-clear.yml
+++ b/.github/workflows/all-clear.yml
@@ -66,17 +66,18 @@ jobs:
               "repos/$REPO/commits/$SHA/status" \
               -q '.statuses[] | {context, state}' 2>/dev/null || echo "")
 
-            pending=$(printf '%s\n' "$checks" | grep -c '"status": "\(queued\|in_progress\)"' || true)
-            pending_st=$(printf '%s\n' "$statuses" | grep -c '"state": "pending"' || true)
+            # gh --jq emits compact JSON (no space after the colon), so allow optional spaces.
+            pending=$(printf '%s\n' "$checks" | grep -c '"status": *"\(queued\|in_progress\)"' || true)
+            pending_st=$(printf '%s\n' "$statuses" | grep -c '"state": *"pending"' || true)
 
             if [ "$pending" -eq 0 ] && [ "$pending_st" -eq 0 ]; then
               echo "All sibling checks have settled. Evaluating conclusions:"
               printf '%s\n' "$checks" "$statuses"
               # Fail on any bad check-run conclusion. Treat skipped/neutral/success as OK.
               bad=$(printf '%s\n' "$checks" \
-                | grep -c '"conclusion": "\(failure\|cancelled\|timed_out\|action_required\|stale\)"' || true)
+                | grep -c '"conclusion": *"\(failure\|cancelled\|timed_out\|action_required\|stale\)"' || true)
               bad_st=$(printf '%s\n' "$statuses" \
-                | grep -c '"state": "\(failure\|error\)"' || true)
+                | grep -c '"state": *"\(failure\|error\)"' || true)
               if [ "$bad" -ne 0 ] || [ "$bad_st" -ne 0 ]; then
                 echo "::error::$bad failing check run(s) and $bad_st failing commit status(es)."
                 exit 1

--- a/.github/workflows/all-clear.yml
+++ b/.github/workflows/all-clear.yml
@@ -1,0 +1,95 @@
+name: all-clear
+
+# Single aggregate gate for branch protection / auto-merge. It runs on every PR
+# (no path filter, so it always reports a status) and succeeds only once every
+# other check on the commit has finished and passed. Make THIS the only required
+# status check: it transitively requires all CI workflows plus the external
+# Codecov / pre-commit.ci / ReadTheDocs checks without having to list any of them.
+on:
+  pull_request:
+  merge_group:
+
+# Only the latest run per PR / queue entry matters.
+concurrency:
+  group: all-clear-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  statuses: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  all-clear:
+    name: all-clear
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      # The check-run name of THIS job, so we can exclude it from the poll.
+      SELF: all-clear
+      # Initial grace period so sibling checks have time to register before we
+      # first conclude "nothing is pending" (avoids a premature pass).
+      INITIAL_DELAY_SECONDS: "60"
+      POLL_INTERVAL_SECONDS: "30"
+      # 2h ceiling: must exceed the slowest single check (wheels.yml ~1.5h) plus margin.
+      MAX_WAIT_SECONDS: "7200"
+    steps:
+      - name: Resolve head SHA
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "sha=${{ github.event.merge_group.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for all other checks to pass
+        env:
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "Aggregating checks for $REPO@$SHA (excluding '$SELF')"
+          sleep "$INITIAL_DELAY_SECONDS"
+          deadline=$(( $(date +%s) + MAX_WAIT_SECONDS ))
+
+          while :; do
+            # Check runs (GitHub Actions + apps that use the Checks API, e.g. pre-commit.ci).
+            checks=$(gh api --paginate \
+              "repos/$REPO/commits/$SHA/check-runs" \
+              -q '.check_runs[] | select(.name != env.SELF)
+                  | {name, status, conclusion}' 2>/dev/null || echo "")
+            # Legacy commit statuses (apps that use the Statuses API, e.g. Codecov, ReadTheDocs).
+            statuses=$(gh api \
+              "repos/$REPO/commits/$SHA/status" \
+              -q '.statuses[] | {context, state}' 2>/dev/null || echo "")
+
+            pending=$(printf '%s\n' "$checks" | grep -c '"status": "\(queued\|in_progress\)"' || true)
+            pending_st=$(printf '%s\n' "$statuses" | grep -c '"state": "pending"' || true)
+
+            if [ "$pending" -eq 0 ] && [ "$pending_st" -eq 0 ]; then
+              echo "All sibling checks have settled. Evaluating conclusions:"
+              printf '%s\n' "$checks" "$statuses"
+              # Fail on any bad check-run conclusion. Treat skipped/neutral/success as OK.
+              bad=$(printf '%s\n' "$checks" \
+                | grep -c '"conclusion": "\(failure\|cancelled\|timed_out\|action_required\|stale\)"' || true)
+              bad_st=$(printf '%s\n' "$statuses" \
+                | grep -c '"state": "\(failure\|error\)"' || true)
+              if [ "$bad" -ne 0 ] || [ "$bad_st" -ne 0 ]; then
+                echo "::error::$bad failing check run(s) and $bad_st failing commit status(es)."
+                exit 1
+              fi
+              echo "All checks passed."
+              exit 0
+            fi
+
+            now=$(date +%s)
+            if [ "$now" -ge "$deadline" ]; then
+              echo "::error::Timed out after ${MAX_WAIT_SECONDS}s with $pending pending check run(s) / $pending_st pending status(es)."
+              exit 1
+            fi
+            echo "Still waiting: $pending check run(s) / $pending_st status(es) pending. Sleeping ${POLL_INTERVAL_SECONDS}s..."
+            sleep "$POLL_INTERVAL_SECONDS"
+          done


### PR DESCRIPTION
## What

Adds `.github/workflows/all-clear.yml` — a single gate workflow intended to be the **only** required status check on `main`, so we can enable auto-merge without hand-listing every CI check.

It runs on every PR (and on `merge_group`) with **no path filter**, so it always reports a status. It then polls the commit for all other checks and passes only once they have **all finished and passed**:

- **Checks API** → GitHub Actions workflows + pre-commit.ci
- **Combined commit-status API** → Codecov (`codecov/project`, `codecov/patch`) and ReadTheDocs

It excludes itself, treats `skipped`/`neutral`/`success` as OK, and fails on any failing check run or commit status.

## Why

- GitHub branch protection requires you to **list each required check by name** and keep that list maintained. One `all-clear` check transitively requires everything present on the PR — including the external Codecov / pre-commit.ci / ReadTheDocs checks — without naming any of them.
- Several workflows (`build.yml`, `wheels.yml`, `build_pyodide_wheels.yml`, …) use `paths` filters. A path-filtered workflow that gets **skipped** never reports a check, so marking it individually required would block the PR forever. The aggregate gate sidesteps this — it waits only for checks that actually ran.
- **New workflows added later are captured automatically** — no change to this file or to branch protection.

## Details / tunables

- Head SHA (not `github.sha`) is used, since branch protection evaluates the PR head commit.
- 60s initial grace so sibling checks register before the first "nothing pending" evaluation.
- 2h ceiling (`timeout-minutes: 130`) to comfortably cover the slowest single check (`wheels.yml`, ~1.5h). Idle polling is free on a public repo.
- Already `merge_group`-aware. To gate a merge queue with the test suites later, add a bare `merge_group:` trigger to `build.yml` / `build_windows.yml` (inert until a queue is enabled). External app checks (Codecov/pre-commit.ci/RTD) don't run in the queue — they gate at the PR stage, which is standard.

## After merge

Make `all-clear` the sole required check, e.g.:

```bash
gh api -X PATCH repos/jobovy/galpy/branches/main/protection/required_status_checks \
  -f strict=true -f 'checks[][context]=all-clear'
```

then enable *Allow auto-merge* in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)