### PR TITLE
Fix deepcopy of MultipoleExpansionPotential under scipy>=1.18

### DIFF
--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -2,7 +2,9 @@
 #   MultipoleExpansionPotential.py: Potential via multipole expansion of a
 #   given density function
 ###############################################################################
+import copy as _copy
 import inspect
+import types as _types
 
 import numpy
 from numpy.polynomial.legendre import leggauss
@@ -22,6 +24,21 @@ from .SphericalHarmonicPotentialMixin import SphericalHarmonicPotentialMixin
 
 if _APY_LOADED:
     from astropy import units
+
+# scipy>=1.18 stores references to the array-API-compat numpy *module* on its
+# PPoly-family objects (BPoly, PPoly, CubicSpline) via their ``_xp``/
+# ``_xp_internal`` attributes. ``copy.deepcopy`` has no handler for module
+# objects and falls back to pickle-style reduction, which raises
+# "cannot pickle 'module' object". This class stores such objects (the
+# precomputed radial-integral interpolants), so deep-copying one of these
+# potentials -- as ``Force.__mul__``/``__truediv__`` do when scaling the
+# amplitude -- would fail under scipy>=1.18. Modules are process-wide
+# singletons, so teach ``copy.deepcopy`` to treat any module as atomic (return
+# it unchanged); copying a module to obtain a "different" module is never
+# meaningful. Registered once on import; a no-op if scipy stops storing module
+# references (or if something else already registered a handler).
+if _types.ModuleType not in _copy._deepcopy_dispatch:  # pragma: no branch
+    _copy._deepcopy_dispatch[_types.ModuleType] = lambda module, memo: module
 
 
 class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1920,6 +1920,99 @@ def test_amp_mult_divide(potname):
     return None
 
 
+# Test that deep-copying a MultipoleExpansionPotential (as amplitude
+# multiplication/division does internally) produces an instance that is correct
+# in all ways: it must be a fully independent object whose potential, all forces,
+# all second derivatives, and density evaluate identically to the original
+# everywhere (and at all times, for the time-dependent case). This is a
+# regression test for scipy>=1.18, which stores numpy-module references on its
+# PPoly objects (BPoly/CubicSpline) -- the radial-integral interpolants stored by
+# this potential -- so that a naive copy.deepcopy raises
+# "cannot pickle 'module' object" (see MultipoleExpansionPotential.py).
+def test_MultipoleExpansion_deepcopy():
+    import copy
+
+    from galpy import potential
+
+    def _assert_same_evaluations(p1, p2, scale=1.0, ts=(0.0,)):
+        # Check Phi, every force, every second derivative, and the density match
+        # (p2's values equal scale x p1's) across a range of (R, z, phi) and t.
+        methods = [
+            "__call__",
+            "Rforce",
+            "zforce",
+            "phitorque",
+            "R2deriv",
+            "z2deriv",
+            "Rzderiv",
+            "phi2deriv",
+            "Rphideriv",
+            "dens",
+        ]
+        for R, z, phi in [
+            (0.8, 0.2, 1.1),
+            (1.3, -0.4, 4.2),
+            (0.5, 0.0, 0.0),
+            (2.0, 0.7, 3.0),
+        ]:
+            for t in ts:
+                for m in methods:
+                    func1 = p1.__call__ if m == "__call__" else getattr(p1, m)
+                    func2 = p2.__call__ if m == "__call__" else getattr(p2, m)
+                    v1 = func1(R, z, phi=phi, t=t)
+                    v2 = func2(R, z, phi=phi, t=t)
+                    # density is independent of the amplitude-scaling convention
+                    # only through _amp like the potential/forces, so scale it too
+                    assert numpy.allclose(scale * v1, v2, rtol=1e-10, atol=1e-12), (
+                        f"{m} of copied/scaled MultipoleExpansionPotential differs "
+                        f"at (R,z,phi,t)=({R},{z},{phi},{t}): "
+                        f"{scale * v1} != {v2}"
+                    )
+
+    # A representative spread: spherical, fully triaxial (phi-dependent),
+    # time-dependent, and the disk variant (which holds a MultipoleExpansion
+    # internally as ._me).
+    def triaxial_dens(R, z, phi):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        sintheta2 = R**2.0 / (r**2.0 + 1e-12)
+        return numpy.exp(-r) * (1.0 + 0.3 * numpy.cos(2.0 * phi) * sintheta2)
+
+    def timedep_dens(R, z, phi, t=0.0):
+        r = numpy.sqrt(R**2.0 + z**2.0)
+        return numpy.exp(-r) * (1.0 + 0.2 * t)
+
+    tgrid = numpy.linspace(0.0, 1.0, 5)
+    pots = [
+        potential.MultipoleExpansionPotential(amp=1.3),
+        potential.MultipoleExpansionPotential.from_density(triaxial_dens, L=4, amp=0.7),
+        potential.MultipoleExpansionPotential.from_density(
+            timedep_dens, L=2, tgrid=tgrid, symmetry="axisymmetric", amp=1.1
+        ),
+        potential.DiskMultipoleExpansionPotential(amp=0.9),
+    ]
+    for p in pots:
+        ts = (0.0, 0.25, 0.7) if getattr(p, "_tdep", False) else (0.0,)
+        # 1) copy.deepcopy is a fully independent, identical instance
+        cp = copy.deepcopy(p)
+        assert cp is not p, "deepcopy returned the same object"
+        _assert_same_evaluations(p, cp, scale=1.0, ts=ts)
+        # 2) independence: mutating the original must not affect the copy
+        orig_amp = p._amp
+        p._amp = orig_amp * 3.0
+        _assert_same_evaluations(
+            cp, cp, scale=1.0, ts=ts
+        )  # copy is internally self-consistent
+        cp_val = cp(0.8, 0.2, phi=1.1, t=ts[0])
+        p._amp = orig_amp  # restore
+        assert numpy.isclose(cp_val, cp(0.8, 0.2, phi=1.1, t=ts[0])), (
+            "copy changed when the original was mutated -- state is shared"
+        )
+        # 3) the operations that triggered the bug: multiply and divide
+        _assert_same_evaluations(p, 2.0 * p, scale=2.0, ts=ts)
+        _assert_same_evaluations(p, p / 4.0, scale=0.25, ts=ts)
+    return None
+
+
 # Test whether __repr__ works for Force, planarForce, and linearPotential classes
 def test_repr():
     # Test for 3D Potentials (inherit from Force)


### PR DESCRIPTION
## What

`copy.deepcopy` of a `MultipoleExpansionPotential` (and the `Disk*MultipoleExpansionPotential` variants, which hold one internally) fails under **scipy 1.18.0** with:

```
TypeError: cannot pickle 'module' object
```

This breaks `Force.__mul__` / `__truediv__` (amplitude scaling, e.g. `2 * pot`, `pot / 2`), which deep-copy the potential — and so it broke `tests/test_potential.py::test_amp_mult_divide` for all 9 `*MultipoleExpansionPotential` cases.

## Root cause

scipy 1.18.0 reworked its `PPoly`-family objects (`BPoly`, `PPoly`, `CubicSpline`) for array-API support. These objects now store references to the array-API-compat numpy **module** on `_xp` / `_xp_internal`:

```
'_xp': <module 'scipy._external.array_api_compat.numpy'>
```

`copy.deepcopy` has no handler for module objects, so it falls back to pickle-style reduction, which raises `cannot pickle 'module' object`. `MultipoleExpansionPotential` stores these objects as its precomputed radial-integral interpolants, so the deepcopy recurses into a module and dies. scipy ≤ 1.17 had no such attribute (hence CI was green until scipy 1.18.0 was released).

I reproduced and bisected this in an isolated env: `BPoly`/`CubicSpline`/`PPoly` deepcopy fails on 1.18.0, passes on 1.17.1; splines (`InterpolatedUnivariateSpline`, `BSpline`) are unaffected. scipy's `construct_fast` is not a usable workaround (it yields wrong `BPoly` evaluations on 1.18 and the result is still un-copyable).

## Fix

Teach `copy.deepcopy` to treat module objects as **atomic** (return them unchanged) — modules are process-wide singletons, so copying one to obtain a "different" module is never meaningful:

```python
copy._deepcopy_dispatch[types.ModuleType] = lambda module, memo: module
```

Registered once on import of `MultipoleExpansionPotential`, guarded so it won't clobber an existing handler, and a no-op once scipy stops storing module references. The copied potential shares the (read-only, singleton) module reference but gets independent coefficient arrays, so copies are correct and independent.

## Test

Adds `test_MultipoleExpansion_deepcopy`, which verifies that a deep-copied (and amplitude-scaled via `*`/`/`) instance is **correct in all ways**: a fully independent object whose potential, **every force, every second derivative, and density** evaluate identically to the original across a range of positions — and times, for the time-dependent case — covering the spherical, triaxial, time-dependent, and disk variants.

## Verification (against scipy 1.18.0)

- `test_amp_mult_divide`: **9 failures → all 142 cases pass**.
- Full Multipole suite: **64 passed, 2 skipped**.
- With the fix disabled under 1.18.0, `2 * pot` reproduces the exact `cannot pickle 'module' object` error.
- All green on scipy 1.17.1 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)