### PR TITLE
tests: make test_orbit energy/Jacobi conservation backend-tolerant (numpy.asarray)

### DIFF
--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -161,7 +161,7 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             o.integrate(ttimes, tp._potlist, method=integrator)
         else:
             o.integrate(ttimes, tp, method=integrator)
-        tEs = o.E(ttimes)
+        tEs = numpy.asarray(o.E(ttimes))
         # print(p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.)
         if (
             not "Bar" in pot
@@ -191,9 +191,9 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             or "RotatedAndTilted" in pot
             or "Henon" in pot
         ):
-            tJacobis = o.Jacobi(ttimes, pot=tp)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes, pot=tp))
         else:
-            tJacobis = o.Jacobi(ttimes)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes))
         #            print(p, (numpy.std(tJacobis)/numpy.mean(tJacobis))**2.)
         assert (numpy.std(tJacobis) / numpy.mean(tJacobis)) ** 2.0 < 10.0**tjactol, (
             "Jacobi integral conservation during the orbit integration fails for potential %s and integrator %s at the %g level"
@@ -201,34 +201,47 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
         )
         if firstTest or "testMWPotential" in pot:
             # Some basic checking of the energy and Jacobi functions
-            assert (o.E(pot=None) - o.E(pot=tp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=tp))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with pot=None and pot=the Potential the orbit was integrated with do not agree"
             )
-            assert (o.E() - o.E(0.0)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E()) - numpy.asarray(o.E(0.0))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with o.E() and o.E(0.) do not agree"
             )
-            assert (o.Jacobi(OmegaP=None) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.Jacobi(OmegaP=None)) - numpy.asarray(o.Jacobi())
+            ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with OmegaP=None is not equal to o.Jacobi"
             )
-            assert (o.Jacobi(pot=None) - o.Jacobi(pot=tp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.Jacobi(pot=None)) - numpy.asarray(o.Jacobi(pot=tp))
+            ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=the Potential the orbit was integrated with do not agree"
             )
             assert (
-                o.Jacobi(pot=None) - o.Jacobi(pot=potential.CompositePotential([tp]))
+                numpy.asarray(o.Jacobi(pot=None))
+                - numpy.asarray(o.Jacobi(pot=potential.CompositePotential([tp])))
             ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=[the Potential the orbit was integrated with] do not agree"
             )
             if not tp.isNonAxi:
-                assert (o.Jacobi(OmegaP=1.0) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(OmegaP=1.0)) - numpy.asarray(o.Jacobi())
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=1. for axisymmetric potential is not equal to o.Jacobi (OmegaP=1 is the default for potentials without a pattern speed"
                 )
                 assert (
-                    o.Jacobi(OmegaP=[0.0, 0.0, 1.0]) - o.Jacobi(OmegaP=1.0)
+                    numpy.asarray(o.Jacobi(OmegaP=[0.0, 0.0, 1.0]))
+                    - numpy.asarray(o.Jacobi(OmegaP=1.0))
                 ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=[0,0,1] for axisymmetric potential is not equal to o.Jacobi with OmegaP=1"
                 )
                 assert (
-                    o.Jacobi(OmegaP=numpy.array([0.0, 0.0, 1.0])) - o.Jacobi(OmegaP=1.0)
+                    numpy.asarray(o.Jacobi(OmegaP=numpy.array([0.0, 0.0, 1.0])))
+                    - numpy.asarray(o.Jacobi(OmegaP=1.0))
                 ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=[0,0,1] for axisymmetric potential is not equal to o.Jacobi with OmegaP=1"
                 )
@@ -269,14 +282,14 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
                 o.integrate(ttimes, tp._potlist, method=integrator)
             else:
                 o.integrate(ttimes, tp, method=integrator)
-            tEs = o.E(ttimes)
+            tEs = numpy.asarray(o.E(ttimes))
             #            print p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.
             assert (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0 < 10.0**ttol, (
                 "Energy conservation during the orbit integration fails for potential %s and integrator %s by %g"
                 % (pot, integrator, (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0)
             )
             # Jacobi
-            tJacobis = o.Jacobi(ttimes)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes))
             assert (
                 numpy.std(tJacobis) / numpy.mean(tJacobis)
             ) ** 2.0 < 10.0**tjactol, (
@@ -285,31 +298,43 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             )
             if firstTest or "MWPotential" in pot:
                 # Some basic checking of the energy function
-                assert (o.E(pot=None) - o.E(pot=tp)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=tp))
+                ) ** 2.0 < 10.0**ttol, (
                     "Energy calculated with pot=None and pot=the Potential the orbit was integrated with do not agree"
                 )
-                assert (o.E() - o.E(0.0)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.E()) - numpy.asarray(o.E(0.0))
+                ) ** 2.0 < 10.0**ttol, (
                     "Energy calculated with o.E() and o.E(0.) do not agree"
                 )
-                assert (o.Jacobi(OmegaP=None) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(OmegaP=None)) - numpy.asarray(o.Jacobi())
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=None is not equal to o.Jacobi"
                 )
-                assert (o.Jacobi(pot=None) - o.Jacobi(pot=tp)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(pot=None)) - numpy.asarray(o.Jacobi(pot=tp))
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=the Potential the orbit was integrated with do not agree"
                 )
                 assert (
                     (
-                        o.Jacobi(pot=None)
-                        - o.Jacobi(
-                            pot=potential.NullPotential(amp=0.0) + tp
-                        )  # get around not knowing whether we need a CompositePotential or a planarCompositePotential
+                        numpy.asarray(o.Jacobi(pot=None))
+                        - numpy.asarray(
+                            o.Jacobi(
+                                pot=potential.NullPotential(amp=0.0) + tp
+                            )  # get around not knowing whether we need a CompositePotential or a planarCompositePotential
+                        )
                     )
                     ** 2.0
                     < 10.0** ttol
                 ), (
                     "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=the Potential the orbit was integrated with do not agree"
                 )
-                assert (o.Jacobi(OmegaP=1.0) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(OmegaP=1.0)) - numpy.asarray(o.Jacobi())
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=1. for axisymmetric potential is not equal to o.Jacobi (OmegaP=1 is the default for potentials without a pattern speed"
                 )
                 o = setup_orbit_energy(tp, axi=True, henon="Henon" in pot)
@@ -349,14 +374,14 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
                 )
             else:
                 o.integrate(ttimes, ptp, method=integrator)
-            tEs = o.E(ttimes)
+            tEs = numpy.asarray(o.E(ttimes))
             #                print(p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.)
             assert (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0 < 10.0**ttol, (
                 "Energy conservation during the orbit integration fails for potential %s and integrator %s"
                 % (pot, integrator)
             )
             # Jacobi
-            tJacobis = o.Jacobi(ttimes)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes))
             assert (
                 numpy.std(tJacobis) / numpy.mean(tJacobis)
             ) ** 2.0 < 10.0**tjactol, (
@@ -365,22 +390,34 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             )
             if firstTest or "MWPotential" in pot:
                 # Some basic checking of the energy function
-                assert (o.E(pot=None) - o.E(pot=ptp)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=ptp))
+                ) ** 2.0 < 10.0**ttol, (
                     "Energy calculated with pot=None and pot=the planarPotential the orbit was integrated with do not agree for planarPotential"
                 )
-                assert (o.E(pot=None) - o.E(pot=tp)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=tp))
+                ) ** 2.0 < 10.0**ttol, (
                     "Energy calculated with pot=None and pot=the Potential the orbit was integrated with do not agree for planarPotential"
                 )
-                assert (o.E() - o.E(0.0)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.E()) - numpy.asarray(o.E(0.0))
+                ) ** 2.0 < 10.0**ttol, (
                     "Energy calculated with o.E() and o.E(0.) do not agree"
                 )
-                assert (o.Jacobi(OmegaP=None) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(OmegaP=None)) - numpy.asarray(o.Jacobi())
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=None is not equal to o.Jacobi"
                 )
-                assert (o.Jacobi(pot=None) - o.Jacobi(pot=tp)) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(pot=None)) - numpy.asarray(o.Jacobi(pot=tp))
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=the Potential the orbit was integrated with do not agree"
                 )
-                assert (o.Jacobi(OmegaP=1.0) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+                assert (
+                    numpy.asarray(o.Jacobi(OmegaP=1.0)) - numpy.asarray(o.Jacobi())
+                ) ** 2.0 < 10.0**ttol, (
                     "o.Jacobi calculated with OmegaP=1. for axisymmetric potential is not equal to o.Jacobi (OmegaP=1 is the default for potentials without a pattern speed"
                 )
                 o = setup_orbit_energy(ptp, axi=True)
@@ -408,7 +445,7 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             )
         else:
             o.integrate(ttimes, ptp, method=integrator)
-        tEs = o.E(ttimes)
+        tEs = numpy.asarray(o.E(ttimes))
         # print(p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.)
         if (
             not "Bar" in pot
@@ -431,31 +468,43 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             or "nestedListPotential" in pot
             or "WeaklyTDMultipole" in pot
         ):
-            tJacobis = o.Jacobi(ttimes, pot=tp)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes, pot=tp))
         else:
-            tJacobis = o.Jacobi(ttimes)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes))
         assert (numpy.std(tJacobis) / numpy.mean(tJacobis)) ** 2.0 < 10.0**tjactol, (
             "Jacobi integral conservation during the orbit integration fails by %g for potential %s and integrator %s"
             % ((numpy.std(tJacobis) / numpy.mean(tJacobis)) ** 2.0, pot, integrator)
         )
         if firstTest or "MWPotential" in pot:
             # Some basic checking of the energy function
-            assert (o.E(pot=None) - o.E(pot=ptp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=ptp))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with pot=None and pot=the planarPotential the orbit was integrated with do not agree for planarPotential"
             )
-            assert (o.E(pot=None) - o.E(pot=tp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=tp))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with pot=None and pot=the Potential the orbit was integrated with do not agree for planarPotential"
             )
-            assert (o.E() - o.E(0.0)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E()) - numpy.asarray(o.E(0.0))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with o.E() and o.E(0.) do not agree"
             )
-            assert (o.Jacobi(OmegaP=None) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.Jacobi(OmegaP=None)) - numpy.asarray(o.Jacobi())
+            ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with OmegaP=None is not equal to o.Jacobi"
             )
-            assert (o.Jacobi(pot=None) - o.Jacobi(pot=tp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.Jacobi(pot=None)) - numpy.asarray(o.Jacobi(pot=tp))
+            ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with pot=None is not equal to o.Jacobi with pot=the Potential the orbit was integrated with do not agree"
             )
-            assert (o.Jacobi(OmegaP=1.0) - o.Jacobi()) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.Jacobi(OmegaP=1.0)) - numpy.asarray(o.Jacobi())
+            ) ** 2.0 < 10.0**ttol, (
                 "o.Jacobi calculated with OmegaP=1. for axisymmetric potential is not equal to o.Jacobi (OmegaP=1 is the default for potentials without a pattern speed"
             )
             o = setup_orbit_energy(ptp, axi=False)
@@ -484,7 +533,7 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
                 o.integrate(ttimes, tp._potlist, method=integrator)
             else:
                 o.integrate(ttimes, tp, method=integrator)
-            tEs = o.E(ttimes)
+            tEs = numpy.asarray(o.E(ttimes))
             # print(p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.)
             assert (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0 < 10.0**ttol, (
                 "Energy conservation during the orbit integration fails for potential %s and integrator %s by %g"
@@ -497,9 +546,9 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
                 or "CorotatingRotation" in pot
                 or "GaussianAmplitudeBar" in pot
             ):
-                tJacobis = o.Jacobi(ttimes, pot=tp)
+                tJacobis = numpy.asarray(o.Jacobi(ttimes, pot=tp))
             else:
-                tJacobis = o.Jacobi(ttimes)
+                tJacobis = numpy.asarray(o.Jacobi(ttimes))
             assert (
                 numpy.std(tJacobis) / numpy.mean(tJacobis)
             ) ** 2.0 < 10.0**tjactol, (
@@ -512,7 +561,7 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             o.integrate(ttimes, tp._potlist, method=integrator)
         else:
             o.integrate(ttimes, tp, method=integrator)
-        tEs = o.E(ttimes)
+        tEs = numpy.asarray(o.E(ttimes))
         #            print p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.
         if (
             not "Bar" in pot
@@ -535,9 +584,9 @@ def test_energy_jacobi_conservation(pot, ttol, tjactol, firstTest):
             or "nestedListPotential" in pot
             or "WeaklyTDMultipole" in pot
         ):
-            tJacobis = o.Jacobi(ttimes, pot=tp)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes, pot=tp))
         else:
-            tJacobis = o.Jacobi(ttimes)
+            tJacobis = numpy.asarray(o.Jacobi(ttimes))
         assert (numpy.std(tJacobis) / numpy.mean(tJacobis)) ** 2.0 < 10.0**tjactol, (
             "Jacobi integral conservation during the orbit integration fails for potential %s and integrator %s"
             % (pot, integrator)
@@ -613,7 +662,7 @@ def test_energy_conservation_linear(pot, ttol, firstTest):
             o.integrate(ttimes, tp._potlist, method=integrator)
         else:
             o.integrate(ttimes, tp, method=integrator)
-        tEs = o.E(ttimes)
+        tEs = numpy.asarray(o.E(ttimes))
         # print(p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.)
         if (
             not "Bar" in pot
@@ -629,10 +678,14 @@ def test_energy_conservation_linear(pot, ttol, firstTest):
             )
         if firstTest or "testMWPotential" in pot or "linearMWPotential" in pot:
             # Some basic checking of the energy function
-            assert (o.E(pot=None) - o.E(pot=tp)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E(pot=None)) - numpy.asarray(o.E(pot=tp))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with pot=None and pot=the Potential the orbit was integrated with do not agree"
             )
-            assert (o.E() - o.E(0.0)) ** 2.0 < 10.0**ttol, (
+            assert (
+                numpy.asarray(o.E()) - numpy.asarray(o.E(0.0))
+            ) ** 2.0 < 10.0**ttol, (
                 "Energy calculated with o.E() and o.E(0.) do not agree"
             )
             o = setup_orbit_energy(tp, axi=False, henon="Henon" in pot)


### PR DESCRIPTION
## What
Burndown Phase-1 PR (2 of 2 test-only). Makes the energy/Jacobi conservation asserts in `tests/test_orbit.py` tolerant of a forced jax/torch backend.

## Why
`test_energy_jacobi_conservation` and `test_energy_conservation_linear` compute `numpy.std(tEs)/numpy.mean(tEs)` with `tEs = o.E(ttimes)` (and `tJacobis = o.Jacobi`). Under forced torch, `o.E()`/`o.Jacobi()` return a torch tensor (galpy computes the **correct** values), and `numpy.std(<tensor>)` dispatches to torch's `Tensor.std(ddof=,dtype=,out=,axis=)` which rejects numpy's kwargs → `TypeError`. jax passed only because numpy ufuncs auto-materialise it. Test-harness issue, not a galpy bug.

## Change (test-only)
Wrap every `o.E(...)`/`o.Jacobi(...)` output that feeds a numpy host op — the `std`/`mean` feeders and the deeper `firstTest` `(a-b)**2` arithmetic asserts — in `numpy.asarray(...)` (the #952 convention). 73 wraps; `Orbits.py` and the ledger are **not** touched.

## Byte-identity
`numpy.asarray(<numpy array>)` is an identity no-op → numpy path byte-identical. Verified: both functions give **192 passed / 0 skipped, identical** on parent (`feat/backends`) and branch (AST of the two functions is identical after stripping the wraps). Adversarially reviewed.

## Validation (CPU, CI-parity)
- numpy: 192/192 both functions, unchanged from parent.
- torch: pure-harness failures now pass — ~27/40 `energy_jacobi` + ~23/30 `energy_linear` ledger nodeids flip to pass (verified the assertions pass *numerically*, not just dodge the TypeError).

## Scope note
Nodeids that fail **earlier** — in galpy setup (`tp.normalize` scalar coercion under forced torch), in `Orbit.L()` (the `numpy.ndarray * Tensor` cross-product), or in the leapfrog integrator — are **not** fixed here and stay correctly ledgered; they're handled by the central-coercion / `Orbits.L()` / integrator source PRs. This PR only clears the `numpy.std(tensor)` harness failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)