### PR TITLE
backend: centralize data-coercion helpers into galpy.backend._coerce

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -6,7 +6,17 @@
 #   numpy, JAX, and PyTorch. Backend selection follows the data first (the type
 #   of the array arguments), with an explicit ``xp=`` override and a
 #   context-manager/global default as fallbacks. See ``_resolver`` for details.
+#
+#   See ``_coerce`` for the data-coercion helpers (bringing numpy/Python data
+#   onto the active backend, anchoring stored constants) and ``_namespaces``
+#   for the namespace-resolution and dtype/device primitives they build on.
 ###############################################################################
+from ._coerce import (
+    as_backend_constant,
+    coerce_coords,
+    promote_scalars,
+    zeros_like_backend,
+)
 from ._namespaces import (
     asarray_on_device,
     device_of,
@@ -33,4 +43,8 @@ __all__ = [
     "match_input_dtype",
     "device_of",
     "asarray_on_device",
+    "as_backend_constant",
+    "coerce_coords",
+    "promote_scalars",
+    "zeros_like_backend",
 ]

--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -1,0 +1,160 @@
+###############################################################################
+#   galpy.backend._coerce: backend DATA-coercion helpers.
+###############################################################################
+"""Backend data-coercion helpers: the single home for bringing numpy/Python
+data onto the active jax/torch backend.
+
+PURPOSE
+-------
+This module does two related jobs:
+
+  * it brings numpy/Python *coordinate* data onto the active backend's array
+    type (so e.g. ``torch.sqrt`` -- which rejects ``numpy.float64`` -- and
+    ``Tensor`` arithmetic see real backend arrays), and
+  * it anchors *stored numpy constants* (rotation matrices, lookup tables, a
+    zero reference coordinate) onto the dtype/device of an input array, so the
+    constant joins the computation as a same-dtype/same-device backend array.
+
+It is the single home for data-coercion. Namespace *resolution* (which backend
+a call dispatches to) and the dtype/device *primitives* it builds on live in
+``_namespaces.py`` (``is_backend_array``, ``device_of``, ``asarray_on_device``,
+``match_input_dtype``); this module only consumes those primitives.
+
+THE CORE INVARIANT
+------------------
+Every function here is a STRICT PASS-THROUGH when ``xp is numpy``: it returns
+its inputs OBJECT-IDENTICALLY (no asarray, no copy, no dtype touch). This is
+what keeps the numpy code path BYTE-IDENTICAL to galpy's historical behaviour.
+Any new coercion helper added to this module MUST preserve this invariant --
+guard the work behind ``if xp is numpy: return <inputs unchanged>`` first.
+
+WHEN TO USE EACH
+----------------
+  * ``coerce_coords(xp, *coords)`` -- at the PUBLIC INPUT BOUNDARY (the
+    ``@potential_physical_input`` decorator) to bring coordinate arguments onto
+    the backend: plain Python/int scalars become float64 (galpy's interior
+    precision), float arrays keep their dtype (so the float32 exit-cast policy
+    still applies), and ``None`` passes through.
+  * ``promote_scalars(xp, *vals)`` -- INSIDE coordinate transforms to promote
+    plain Python scalars sitting alongside array arguments, anchored on the
+    dtype/device of the first array, so mixed scalar/array inputs work on a
+    backend whose functions require arrays.
+  * ``as_backend_constant(xp, value, ref)`` -- to anchor a single STORED numpy
+    constant (a rotation matrix, an offset, a table) on a backend ``ref`` array
+    derived from the coordinate inputs.
+  * ``zeros_like_backend(xp, R)`` -- for a backend ZERO reference coordinate
+    (e.g. the ``z = 0`` plane a spherical-in-disguise wrapper feeds its wrapped
+    potential).
+
+WHY float64-INTERIOR / DEVICE-ANCHORING
+---------------------------------------
+galpy computes in float64 internally: a bare ``asarray`` of a Python float
+yields torch float32 and silently misses galpy's tolerances, so plain scalars
+are lifted to ``xp.float64`` while genuine float arrays keep their own dtype.
+Anchoring constants and promoted scalars on an input array's dtype/device keeps
+the whole computation on one device and at one precision, which is required for
+torch (cross-device / mixed-dtype ops raise) and correct for jax.
+"""
+
+import numpy
+
+from ._namespaces import (
+    _is_floating_dtype,
+    asarray_on_device,
+    device_of,
+)
+
+
+def coerce_coords(xp, *coords):
+    """Bring coordinate inputs onto the active backend's array type.
+
+    The dominant non-numpy failure mode is "the namespace resolved to a backend
+    (forced harness, or a user mixing a backend tensor with a numpy/python arg)
+    but a coordinate is still numpy/python", which torch rejects strictly
+    (``torch.sqrt(numpy.float64)`` raises; ``numpy.ndarray * Tensor`` raises).
+    Coercing the coordinates to backend arrays once, at the public input
+    boundary, fixes it for every potential at once.
+
+    Rules (applied only when the backend is NOT numpy):
+      * ``None`` is passed through (axisymmetric ``phi=None`` etc.).
+      * a coordinate that already carries a *floating* dtype (a numpy/backend
+        float32/float64 array or scalar) is moved onto the backend with its
+        dtype PRESERVED, so the float32/exit-cast policy (``match_input_dtype``)
+        still applies.
+      * a plain Python scalar (``1.0``/``1``) or an integer array is brought to
+        the backend's float64 -- galpy's interior precision; a bare ``asarray``
+        of a Python float would give torch float32 and miss the tolerances.
+
+    The numpy backend is a strict pass-through (``coords`` returned object-
+    identical) -> the numpy path stays byte-identical.
+    """
+    if xp is numpy:
+        return coords
+    dev = device_of(*coords)
+    out = []
+    for c in coords:
+        if c is None:
+            out.append(c)
+            continue
+        dt = getattr(c, "dtype", None)
+        if dt is not None and _is_floating_dtype(dt):
+            out.append(asarray_on_device(xp, c, dev))  # preserve float dtype
+        else:
+            out.append(asarray_on_device(xp, c, dev, dtype=xp.float64))
+    return tuple(out)
+
+
+def promote_scalars(xp, *vals):
+    """Promote plain Python scalars among ``vals`` to the active non-numpy
+    namespace, anchored on the dtype/device of the first array argument, so
+    that e.g. torch functions -- which require Tensors -- accept the mixed
+    scalar/array inputs that the numpy path has always supported. The numpy
+    path passes everything through untouched (byte-identical)."""
+    if xp is numpy:
+        return vals
+    ref = next((v for v in vals if hasattr(v, "ndim")), None)
+    if ref is None:
+        # Nothing to anchor on (e.g. all-scalar inputs under a forced backend
+        # default): pass through, the namespace's functions handle scalars
+        return vals
+    dtype = getattr(ref, "dtype", None)
+    device = getattr(ref, "device", None)
+
+    def _promote(v):
+        if hasattr(v, "ndim"):
+            return v
+        try:
+            return xp.asarray(v, dtype=dtype, device=device)
+        except (TypeError, ValueError):
+            # namespace without a device kwarg, or one that rejects the device
+            # value (array-api jax exposes .device as the string 'cpu', which
+            # jnp.asarray(device=...) refuses with ValueError). jax tracks device
+            # automatically, so a plain asarray is correct; torch's .device is a
+            # real object and never hits this fallback.
+            return xp.asarray(v, dtype=dtype)
+
+    return tuple(_promote(v) for v in vals)
+
+
+def as_backend_constant(xp, value, ref):
+    """Bring a stored numpy constant (rotation matrix / offset) into the active
+    namespace, anchored on the dtype/device of ``ref`` (a backend array derived
+    from the coordinate inputs). The numpy path passes the stored array through
+    untouched (byte-identical)."""
+    if xp is numpy:
+        return value
+    dtype = getattr(ref, "dtype", None)
+    device = getattr(ref, "device", None)
+    try:
+        return xp.asarray(value, dtype=dtype, device=device)
+    except TypeError:  # pragma: no cover - namespace without device= kwarg
+        return xp.asarray(value, dtype=dtype)
+
+
+def zeros_like_backend(xp, R):
+    """The numpy path passes the plain scalar through untouched
+    (byte-identical); on a non-numpy backend the z = 0 reference
+    coordinate is anchored on the inputs so the wrapped potential sees a
+    backend array (torch functions require Tensors) on the right
+    device/dtype."""
+    return 0.0 if xp is numpy else xp.zeros_like(R)

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -149,45 +149,6 @@ def asarray_on_device(xp, a, device, dtype=None):
     return xp.asarray(a, dtype=dtype, device=device)
 
 
-def coerce_coords(xp, *coords):
-    """Bring coordinate inputs onto the active backend's array type.
-
-    The dominant non-numpy failure mode is "the namespace resolved to a backend
-    (forced harness, or a user mixing a backend tensor with a numpy/python arg)
-    but a coordinate is still numpy/python", which torch rejects strictly
-    (``torch.sqrt(numpy.float64)`` raises; ``numpy.ndarray * Tensor`` raises).
-    Coercing the coordinates to backend arrays once, at the public input
-    boundary, fixes it for every potential at once.
-
-    Rules (applied only when the backend is NOT numpy):
-      * ``None`` is passed through (axisymmetric ``phi=None`` etc.).
-      * a coordinate that already carries a *floating* dtype (a numpy/backend
-        float32/float64 array or scalar) is moved onto the backend with its
-        dtype PRESERVED, so the float32/exit-cast policy (``match_input_dtype``)
-        still applies.
-      * a plain Python scalar (``1.0``/``1``) or an integer array is brought to
-        the backend's float64 -- galpy's interior precision; a bare ``asarray``
-        of a Python float would give torch float32 and miss the tolerances.
-
-    The numpy backend is a strict pass-through (``coords`` returned object-
-    identical) -> the numpy path stays byte-identical.
-    """
-    if xp is numpy:
-        return coords
-    dev = device_of(*coords)
-    out = []
-    for c in coords:
-        if c is None:
-            out.append(c)
-            continue
-        dt = getattr(c, "dtype", None)
-        if dt is not None and _is_floating_dtype(dt):
-            out.append(asarray_on_device(xp, c, dev))  # preserve float dtype
-        else:
-            out.append(asarray_on_device(xp, c, dev, dtype=xp.float64))
-    return tuple(out)
-
-
 def namespace_for_name(name):
     """Map a backend name ('numpy'|'jax'|'torch') to its array namespace module.
 

--- a/galpy/potential/KuzminLikeWrapperPotential.py
+++ b/galpy/potential/KuzminLikeWrapperPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import get_namespace, zeros_like_backend
 from ..util import conversion
 from .Potential import (
     _evaluatePotentials,
@@ -124,30 +124,22 @@ class KuzminLikeWrapperPotential(WrapperPotential):
             * ((self._a + xp.sqrt(self._b2 + z**2.0)) ** 2.0 + R**2.0) ** 1.5
         )
 
-    def _zero_like(self, xp, R):
-        # The numpy path passes the plain scalar through untouched
-        # (byte-identical); on a non-numpy backend the z = 0 reference
-        # coordinate is anchored on the inputs so the wrapped potential sees a
-        # backend array (torch functions require Tensors) on the right
-        # device/dtype.
-        return 0.0 if xp is numpy else xp.zeros_like(R)
-
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         return _evaluatePotentials(
-            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
+            self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         )
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         return _evaluateRforces(
-            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
+            self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidR(R, z)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         return _evaluateRforces(
-            self._pot, self._xi(R, z), self._zero_like(xp, R), phi=phi, t=t
+            self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidz(R, z)
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
@@ -155,7 +147,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
-        zero = self._zero_like(xp, R)
+        zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidR(R, z) ** 2.0 - _evaluateRforces(
@@ -164,7 +156,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
-        zero = self._zero_like(xp, R)
+        zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidz(R, z) ** 2.0 - _evaluateRforces(
@@ -173,7 +165,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
-        zero = self._zero_like(xp, R)
+        zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._dxidR(R, z) * self._dxidz(R, z) - _evaluateRforces(

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -10,9 +10,8 @@
 import numpy
 
 from galpy.util import conversion, coords
-from galpy.util.coords import _promote_scalars_for
 
-from ..backend import get_namespace
+from ..backend import get_namespace, promote_scalars
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -474,17 +473,17 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
 def _staeckel_prefactor(u, v):
     xp = get_namespace(u, v)
-    u, v = _promote_scalars_for(xp, u, v)
+    u, v = promote_scalars(xp, u, v)
     return xp.sinh(u) ** 2.0 + xp.sin(v) ** 2.0
 
 
 def _dstaeckel_prefactordudv(u, v):
     xp = get_namespace(u, v)
-    u, v = _promote_scalars_for(xp, u, v)
+    u, v = promote_scalars(xp, u, v)
     return (2.0 * xp.sinh(u) * xp.cosh(u), 2.0 * xp.sin(v) * xp.cos(v))
 
 
 def _dstaeckel_prefactord2ud2v(u, v):
     xp = get_namespace(u, v)
-    u, v = _promote_scalars_for(xp, u, v)
+    u, v = promote_scalars(xp, u, v)
     return (2.0 * xp.cosh(2.0 * u), 2.0 * xp.cos(2.0 * v))

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import as_backend_constant, get_namespace
 from ..util import _rotate_to_arbitrary_vector, conversion, coords
 from .Potential import (
     _evaluatephitorques,
@@ -21,21 +21,6 @@ from .Potential import (
     evaluatez2derivs,
 )
 from .WrapperPotential import WrapperPotential
-
-
-def _as_xp_constant(xp, value, ref):
-    """Bring a stored numpy constant (rotation matrix / offset) into the active
-    namespace, anchored on the dtype/device of ``ref`` (a backend array derived
-    from the coordinate inputs). The numpy path passes the stored array through
-    untouched (byte-identical)."""
-    if xp is numpy:
-        return value
-    dtype = getattr(ref, "dtype", None)
-    device = getattr(ref, "device", None)
-    try:
-        return xp.asarray(value, dtype=dtype, device=device)
-    except TypeError:  # pragma: no cover - namespace without device= kwarg
-        return xp.asarray(value, dtype=dtype)
 
 
 # Only implement 3D wrapper
@@ -194,9 +179,9 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
             x, y, z = coords.cyl_to_rect(R, phi, z)
         xyzp = xp.stack([x, y, z])
         if not self._norot:
-            xyzp = _as_xp_constant(xp, self._rot, xyzp) @ xyzp
+            xyzp = as_backend_constant(xp, self._rot, xyzp) @ xyzp
         if self._offset is not None:
-            xyzp = xyzp + _as_xp_constant(xp, self._offset, xyzp)
+            xyzp = xyzp + as_backend_constant(xp, self._offset, xyzp)
         return xyzp
 
     @check_potential_inputs_not_arrays
@@ -233,7 +218,7 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         xforcep = xp.cos(phip) * Rforcep - xp.sin(phip) * phitorquep / Rp
         yforcep = xp.sin(phip) * Rforcep + xp.cos(phip) * phitorquep / Rp
         Fxyzp = xp.stack([xforcep, yforcep, zforcep])
-        return _as_xp_constant(xp, self._inv_rot, Fxyzp) @ Fxyzp
+        return as_backend_constant(xp, self._inv_rot, Fxyzp) @ Fxyzp
 
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
@@ -342,8 +327,8 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
                 xp.stack([xzderivp, yzderivp, z2derivp]),
             ]
         )
-        inv_rot = _as_xp_constant(xp, self._inv_rot, deriv2p)
-        inv_rot_T = _as_xp_constant(xp, self._inv_rot.T, deriv2p)
+        inv_rot = as_backend_constant(xp, self._inv_rot, deriv2p)
+        inv_rot_T = as_backend_constant(xp, self._inv_rot.T, deriv2p)
         return inv_rot @ (deriv2p @ inv_rot_T)
 
     @check_potential_inputs_not_arrays

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -1144,8 +1144,7 @@ def potential_physical_input(method=None, *, coerce_backend=True):
         # targets (_check_backend_compatible); only the coordinate args/kwargs are
         # coerced, not control kwargs (dR/dphi/dz/zmax/M).
         if coerce_backend:
-            from ..backend import get_namespace
-            from ..backend._namespaces import coerce_coords
+            from ..backend import coerce_coords, get_namespace
             from ..potential import _check_backend_compatible
 
             xp = get_namespace(*args[1:])

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -80,7 +80,7 @@ from functools import wraps
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import get_namespace, promote_scalars
 from ..util import _rotate_to_arbitrary_vector
 from ..util._optional_deps import _APY_LOADED
 from ..util.config import __config__
@@ -88,38 +88,6 @@ from ..util.config import __config__
 _APY_COORDS = __config__.getboolean("astropy", "astropy-coords")
 _APY_COORDS *= _APY_LOADED
 _DEGTORAD = numpy.pi / 180.0
-
-
-def _promote_scalars_for(xp, *vals):
-    """Promote plain Python scalars among ``vals`` to the active non-numpy
-    namespace, anchored on the dtype/device of the first array argument, so
-    that e.g. torch functions -- which require Tensors -- accept the mixed
-    scalar/array inputs that the numpy path has always supported. The numpy
-    path passes everything through untouched (byte-identical)."""
-    if xp is numpy:
-        return vals
-    ref = next((v for v in vals if hasattr(v, "ndim")), None)
-    if ref is None:
-        # Nothing to anchor on (e.g. all-scalar inputs under a forced backend
-        # default): pass through, the namespace's functions handle scalars
-        return vals
-    dtype = getattr(ref, "dtype", None)
-    device = getattr(ref, "device", None)
-
-    def _promote(v):
-        if hasattr(v, "ndim"):
-            return v
-        try:
-            return xp.asarray(v, dtype=dtype, device=device)
-        except (TypeError, ValueError):
-            # namespace without a device kwarg, or one that rejects the device
-            # value (array-api jax exposes .device as the string 'cpu', which
-            # jnp.asarray(device=...) refuses with ValueError). jax tracks device
-            # automatically, so a plain asarray is correct; torch's .device is a
-            # real object and never hits this fallback.
-            return xp.asarray(v, dtype=dtype)
-
-    return tuple(_promote(v) for v in vals)
 
 
 if _APY_LOADED:
@@ -1159,7 +1127,7 @@ def rect_to_cyl(X, Y, Z):
     - 2019-06-21 - Changed such that phi in [-pi,pi] - Bovy (UofT)
     """
     xp = get_namespace(X, Y, Z)
-    X, Y, Z = _promote_scalars_for(xp, X, Y, Z)
+    X, Y, Z = promote_scalars(xp, X, Y, Z)
     return (xp.sqrt(X**2.0 + Y**2.0), xp.arctan2(Y, X), Z)
 
 
@@ -1186,7 +1154,7 @@ def cyl_to_rect(R, phi, Z):
     - 2011-02-23 - Written - Bovy (NYU)
     """
     xp = get_namespace(R, phi, Z)
-    R, phi, Z = _promote_scalars_for(xp, R, phi, Z)
+    R, phi, Z = promote_scalars(xp, R, phi, Z)
     return (R * xp.cos(phi), R * xp.sin(phi), Z)
 
 
@@ -1213,7 +1181,7 @@ def cyl_to_spher(R, Z, phi):
     - 2016-05-16 - Written - Aladdin
     """
     xp = get_namespace(R, Z, phi)
-    R, Z, phi = _promote_scalars_for(xp, R, Z, phi)
+    R, Z, phi = promote_scalars(xp, R, Z, phi)
     theta = xp.arctan2(R, Z)
     r = (R**2 + Z**2) ** 0.5
     return (r, theta, phi)
@@ -2412,7 +2380,7 @@ def Rz_to_coshucosv(R, z, delta=1.0, oblate=False):
     - 2017-10-11 - Added oblate coordinates - Bovy (UofT)
     """
     xp = get_namespace(R, z, delta)
-    R, z = _promote_scalars_for(xp, R, z)
+    R, z = promote_scalars(xp, R, z)
     if oblate:
         d12 = (R + delta) ** 2.0 + z**2.0
         d22 = (R - delta) ** 2.0 + z**2.0
@@ -2486,7 +2454,7 @@ def uv_to_Rz(u, v, delta=1.0, oblate=False):
 
     """
     xp = get_namespace(u, v, delta)
-    u, v = _promote_scalars_for(xp, u, v)
+    u, v = promote_scalars(xp, u, v)
     if oblate:
         R = delta * xp.cosh(u) * xp.sin(v)
         z = delta * xp.sinh(u) * xp.cos(v)

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -195,7 +195,7 @@ def test_check_backend_compatible_semantics():
 def test_coerce_coords_branches(backend):
     # Exercises every branch of coerce_coords: numpy pass-through, None,
     # float-dtype preservation, and python/int -> backend float64.
-    from galpy.backend._namespaces import coerce_coords
+    from galpy.backend import coerce_coords
 
     xp = _NS[backend]
     f32 = numpy.float32 if backend != "torch" else None  # torch handles below

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -112,12 +112,12 @@ def test_doubleexp_scalar_R_array_z(backend):
 
 
 def test_promote_scalars_device_reject_fallback():
-    # _promote_scalars_for must fall back to a device-less asarray when the
+    # promote_scalars must fall back to a device-less asarray when the
     # namespace rejects the ref's device value (array-api jax exposes .device as
     # the string 'cpu', and jnp.asarray(device='cpu') raises ValueError). Driven
     # deterministically here with a tiny stub so the fallback is covered on every
     # CI runner regardless of the installed jax's .device behaviour.
-    from galpy.util.coords import _promote_scalars_for
+    from galpy.backend import promote_scalars
 
     class _Xp:
         def asarray(self, v, dtype=None, device=None):
@@ -131,7 +131,7 @@ def test_promote_scalars_device_reject_fallback():
         device = "string-device-the-namespace-rejects"
 
     ref = _Ref()
-    out = _promote_scalars_for(_Xp(), ref, 2.5)
+    out = promote_scalars(_Xp(), ref, 2.5)
     assert out[0] is ref  # the array passes through untouched
     assert float(out[1]) == 2.5  # the scalar was promoted via the fallback path
 


### PR DESCRIPTION
## What
Burndown **PR-3a** (foundational refactor). Relocates the backend data-coercion helpers — which were scattered across the *wrong* modules (`util/conversion.py` = units, `util/coords.py` = coordinate systems, two potential files) — into a new **`galpy/backend/_coerce.py`** with a guiding top-level docstring (the canonical reference for how backend coercion works + the numpy-passthrough byte-identity invariant). Resolves the long-standing review note to centralize these.

Moved verbatim (renames only):
- `coerce_coords` (from `backend/_namespaces.py`)
- `promote_scalars` (was `coords.py::_promote_scalars_for`)
- `as_backend_constant` (was `RotateAndTiltWrapperPotential::_as_xp_constant`)
- `zeros_like_backend` (was `KuzminLikeWrapperPotential::_zero_like`)

Call sites (`coords.py`, `conversion.py`, RotateAndTilt/KuzminLike/OblateStaeckel wrappers, two `test_backend_*` modules) now delegate to `galpy.backend`; `_namespaces.py` keeps the namespace/dtype/device primitives; `__init__` re-exports the coercion API.

## Pure relocation — zero behavior change
Each function body is moved byte-for-byte. **No new functionality** (the new scalar-default coercion is the follow-up PR-3b).

## Byte-identity + review
numpy path byte-identical (verified: `test_coords` 97/97, `test_backend_conventions`+`test_backend_device` 47+1, RotateAndTilt/KuzminLike/OblateStaeckel/Spherical 210/210 — exact parent match; the 4 moved bodies diff to *renames only*). No circular import. **Independently adversarially reviewed** (all 6 angles refuted: verbatim-move, all-call-sites-rewired, numpy byte-identity, no-cycle, docstring accuracy, no-backend-drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)