### PR TITLE
potential: backend-correct ttensor eigenvalues + zvc_range no-solution guard

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -1916,7 +1916,13 @@ class Potential(Force):
             ]
         )
         if eigenval:
-            return xp.linalg.eigvals(tij)
+            if xp is numpy:
+                return xp.linalg.eigvals(tij)
+            # jax.numpy.linalg.eigvals returns a COMPLEX array even for this
+            # symmetric (real-eigenvalue) input; take the real part so the host
+            # numpy comparison works. Real-part (not eigvalsh/sort) preserves the
+            # eigenvalue order and leaves the numpy path byte-identical.
+            return xp.real(xp.linalg.eigvals(tij))
         else:
             return tij
 
@@ -4562,7 +4568,13 @@ def ttensor(Pot, R, z, phi=0.0, t=0.0, eigenval=False):
         ]
     )
     if eigenval:
-        return xp.linalg.eigvals(tij)
+        if xp is numpy:
+            return xp.linalg.eigvals(tij)
+        # jax.numpy.linalg.eigvals returns a COMPLEX array even for this
+        # symmetric (real-eigenvalue) input; take the real part so the host
+        # numpy comparison works. Real-part (not eigvalsh/sort) preserves the
+        # eigenvalue order and leaves the numpy path byte-identical.
+        return xp.real(xp.linalg.eigvals(tij))
     else:
         return tij
 
@@ -4683,9 +4695,9 @@ def zvc_range(Pot, E, Lz, phi=0.0, t=0.0):
         # g rises to +inf as R->0 via the centrifugal barrier and as R->inf via
         # the potential). Solve each side with an implicit-diff bracketed root
         # so d{Rmin,Rmax} / d{E,Lz} (and through theta) flows, returning a
-        # stacked backend array. The numpy-only nan-nan guard (a value-branch on
-        # whether any solution exists) is not replicated -- the backend path
-        # assumes a genuine pair of roots.
+        # stacked backend array. The numpy-only nan-nan guard (the value-branch
+        # on whether any solution exists) is mirrored below with xp.where so the
+        # backend path matches numpy when there are no turning points.
         from ..backend.optimize import brentq as _bk_brentq
 
         RLz = rl(Pot, Lz, t=t, use_physical=False)
@@ -4699,7 +4711,18 @@ def zvc_range(Pot, E, Lz, phi=0.0, t=0.0):
         Rmax_hi, _ = _backend_rootbracket(g, RLz, lower_default=1e-8, hi0=2.0 * RLz)
         Rmax = _bk_brentq(g, RLz, Rmax_hi)
         xp = get_namespace(RLz)
-        return xp.stack([Rmin, Rmax])
+        # No-solution guard, mirroring the numpy branch: when the effective
+        # potential at the guiding radius exceeds E (g(RLz) > 0) there are no
+        # turning points, so return [nan, nan]. The roots are computed
+        # unconditionally above and stay finite even with no solution, so the
+        # selected (has-solution) branch is safe to evaluate eagerly. The
+        # no-solution branch MUST be a true constant (xp.full_like, NOT
+        # RLz * xp.nan): eager xp.where evaluates both branches and its VJP
+        # multiplies the unselected branch's cotangent, so RLz * nan would
+        # NaN-poison d{Rmin,Rmax}/dLz in the ordinary has-solution case.
+        no_solution = g(RLz) > 0.0
+        nan_pair = xp.stack([xp.full_like(RLz, xp.nan), xp.full_like(RLz, xp.nan)])
+        return xp.where(no_solution, nan_pair, xp.stack([Rmin, Rmax]))
     # Check whether a solution exists
     RLz = rl(Pot, Lz, t=t, use_physical=False)
     Rstart = RLz

--- a/tests/test_backend_potential_convenience.py
+++ b/tests/test_backend_potential_convenience.py
@@ -252,6 +252,29 @@ def test_ttensor_eigenval_jax():
         numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-11)
 
 
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+def test_ttensor_eigenval_torch():
+    # Same as test_ttensor_eigenval_jax for torch: ttensor(eigenval=True) routes
+    # through xp.linalg.eigvals (which returns a COMPLEX tensor), so the backend
+    # path takes xp.real(...). Check the result is a REAL (non-complex) torch
+    # tensor whose (sorted) eigenvalues match the numpy reference.
+    for p in _pots():
+        ref = numpy.sort(
+            numpy.real(p.ttensor(1.0, 0.1, eigenval=True, use_physical=False))
+        )
+        out = p.ttensor(
+            torch.as_tensor(1.0, dtype=torch.float64),
+            torch.as_tensor(0.1, dtype=torch.float64),
+            eigenval=True,
+            use_physical=False,
+        )
+        assert torch.is_tensor(out), type(out)
+        # xp.real(...) must strip the imaginary part eigvals introduces
+        assert not torch.is_complex(out), out.dtype
+        got = numpy.sort(numpy.real(out.detach().numpy()))
+        numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-11)
+
+
 def test_ttensor_numpy_byte_identical_construction():
     # The migrated xp.stack construction must be byte-identical to the original
     # numpy.array([[...]]) construction on the numpy path, for both scalar and
@@ -313,6 +336,21 @@ def test_module_functional_interface_torch():
     assert isinstance(_P.rtide(p, R, z, M=1e-3, use_physical=False), torch.Tensor)
     assert isinstance(_P.tdyn(p, R, use_physical=False), torch.Tensor)
     assert isinstance(_P.ttensor(p, R, z, use_physical=False), torch.Tensor)
+    # module-level ttensor(eigenval=True): real (non-complex) torch tensor whose
+    # eigenvalues match numpy (exercises the xp.real(xp.linalg.eigvals) branch).
+    # Use float64 inputs so the value parity holds to a tight tolerance.
+    R64 = torch.as_tensor(1.1, dtype=torch.float64)
+    z64 = torch.as_tensor(0.1, dtype=torch.float64)
+    eig = _P.ttensor(p, R64, z64, eigenval=True, use_physical=False)
+    assert torch.is_tensor(eig) and not torch.is_complex(eig), type(eig)
+    numpy.testing.assert_allclose(
+        numpy.sort(eig.detach().numpy()),
+        numpy.sort(
+            numpy.real(_P.ttensor(p, 1.1, 0.1, eigenval=True, use_physical=False))
+        ),
+        rtol=1e-9,
+        atol=1e-11,
+    )
 
 
 # --- Scalar-only potentials in Potential.mass's backend quadrature dispatch ---


### PR DESCRIPTION
## What
Burndown **PR-5** (`Potential.py` only). Two galpy-source backend fixes that **complete the jax `test_potential` burndown** (these were the last 2 jax xfails):
- **`ttensor`** (class method + module function): `jax.numpy.linalg.eigvals` returns a *complex* array for the symmetric tidal tensor (numpy returns real), breaking the host-side `numpy.fabs`. Take `xp.real(...)` on the non-numpy branch only (not `eigvalsh` — that would change numpy's LAPACK routine/ordering).
- **`zvc_range`** backend branch: replicate the numpy path's no-solution `[nan,nan]` guard via `xp.where` on `g(RLz)>0`. The nan branch uses `xp.full_like(RLz, nan)` (a true constant), **not** `RLz*nan` — the latter NaN-poisons `d(zvc_range)/dLz` through the eager `xp.where` VJP (caught by adversarial review; FD-verified the gradient is now correct: AD=FD=1.3554).

## Byte-identity + review
numpy branch untouched and **bit-identical** (eigenvalues + zvc results verified via `.tobytes()`). Fixes jax `test_ttensor` + `test_zvc_range_undefined`. Adversarially reviewed (caught + fixed the AD-poisoning blocker; no-solution branch verified crash-free; condition fidelity confirmed). The torch counterparts need a separate test-side wrap / the central coercion and stay ledgered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)