### PR TITLE
orbit: make Orbit.L() cross-product namespace-consistent

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -3289,10 +3289,22 @@ class Orbit:
             x = self.x(*args, **kwargs)
             y = self.y(*args, **kwargs)
             z = self.z(*args, **kwargs)
-            out = numpy.zeros(x.shape + (3,))
-            out[..., 0] = y * vz - z * vy
-            out[..., 1] = z * vx - x * vz
-            out[..., 2] = x * vy - y * vx
+            # Resolve a single namespace from all six components: under a forced
+            # backend some accessors return a backend Tensor while others stay
+            # numpy, so coerce them onto xp before the cross-product (no-op when
+            # xp is numpy -> numpy path stays byte-identical).
+            xp = get_namespace(x, y, z, vx, vy, vz)
+            if xp is not numpy:
+                x, y, z = xp.asarray(x), xp.asarray(y), xp.asarray(z)
+                vx, vy, vz = xp.asarray(vx), xp.asarray(vy), xp.asarray(vz)
+            out = xp.stack([y * vz - z * vy, z * vx - x * vz, x * vy - y * vx], axis=-1)
+            if xp is numpy:
+                # stack(axis=-1) of the F-contiguous accessor outputs is not
+                # C-contiguous for ensemble shapes; restore the historical
+                # numpy.zeros()+assign C-contiguous layout so the numpy result is
+                # byte-identical in BOTH data and flags. No-op (no copy) when the
+                # result is already C-contiguous (the common single-orbit case).
+                out = numpy.ascontiguousarray(out)
             if not old_physical is None:
                 kwargs["use_physical"] = old_physical
             else:

--- a/tests/test_backend_orbit_accessors.py
+++ b/tests/test_backend_orbit_accessors.py
@@ -340,6 +340,48 @@ def test_accessor_numpy_path_unchanged():
         numpy.testing.assert_allclose(numpy.asarray(val), _c_ref(acc), rtol=1e-12)
 
 
+# ------------------------------------------------- angular momentum L() (3-vec)
+# o.L(t) cross-multiplies x,y,z,vx,vy,vz; under a forced backend it must resolve
+# a single namespace and coerce all six onto it before the cross-product (the
+# numpy*Tensor branch in Orbits.L, phasedim==6). These exercise that branch.
+def _c_ref_L():
+    o = Orbit(list(_IC))
+    o.integrate(_TS, _POT, method="dop853_c")
+    return numpy.asarray(o.L(_TS, use_physical=False))
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_L_diffrax_matches_c_and_stays_jax():
+    o = Orbit(jnp.asarray(_IC))
+    o.integrate(jnp.asarray(_TS), _POT, method="diffrax")
+    val = o.L(jnp.asarray(_TS), use_physical=False)
+    assert isinstance(val, jax.Array), "L left the jax backend"
+    got = numpy.asarray(val)
+    assert got.shape == (*_TS.shape, 3)
+    numpy.testing.assert_allclose(got, _c_ref_L(), rtol=1e-8, atol=1e-8)
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch/torchdiffeq not installed")
+def test_L_torchdiffeq_matches_c_and_stays_torch():
+    o = Orbit(torch.as_tensor(_IC))
+    o.integrate(torch.as_tensor(_TS), _POT, method="torchdiffeq")
+    val = o.L(torch.as_tensor(_TS), use_physical=False)
+    assert isinstance(val, torch.Tensor), "L left the torch backend"
+    got = val.detach().cpu().numpy()
+    assert got.shape == (*_TS.shape, 3)
+    numpy.testing.assert_allclose(got, _c_ref_L(), rtol=1e-8, atol=1e-8)
+
+
+def test_L_numpy_path_unchanged():
+    # a numpy orbit's L() is unaffected by the backend dispatch (3-vector, ...,3)
+    o = Orbit(list(_IC))
+    o.integrate(_TS, _POT, method="dop853_c")
+    val = o.L(_TS, use_physical=False)
+    assert isinstance(val, numpy.ndarray)
+    assert val.shape == (*_TS.shape, 3)
+    numpy.testing.assert_allclose(numpy.asarray(val), _c_ref_L(), rtol=1e-12)
+
+
 @pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
 def test_accessor_diffrax_scalar_ongrid_query():
     # a scalar time landing EXACTLY on the integration grid, on a backend orbit ->


### PR DESCRIPTION
## What
Burndown **PR-6** (`Orbits.py` only). Under a forced jax/torch backend, `L()`'s position/velocity accessors were inconsistent (some returned a backend Tensor, some stayed numpy), so `out=numpy.zeros(...); out[...,0]=y*vz-z*vy` hit `numpy.ndarray * Tensor → TypeError`. Resolve one namespace from all six components, coerce onto it only when non-numpy, and assemble via `xp.stack(..., axis=-1)` (also avoids jax's immutable-array in-place assign).

## Byte-identity + review
numpy path byte-identical in **data and flags**: `get_namespace(<all numpy>)` is numpy, coercion skipped, and the result is passed through `numpy.ascontiguousarray` to restore the historical `numpy.zeros()+assign` C-contiguous layout (`xp.stack(axis=-1)` of the F-contiguous accessor outputs is otherwise non-C-contiguous for ensemble shapes — caught by adversarial review). Verified SHA-256 identical + C_CONTIGUOUS for single/ensemble/init-time `L()`. Fixes the torch `Orbit.L()` TypeError; the other L() code paths (1D/2D/phasedim-5) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)