### PR TITLE
potential: pin SCF/Multipole construction-time setup to numpy

### DIFF
--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -22,6 +22,7 @@ from ..backend import (
     get_namespace,
     match_input_dtype,
 )
+from ..backend import use as _use_backend
 from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -389,116 +390,125 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         dumm = cls(ro=ro, vo=vo)
         internal_ro = dumm._ro
         internal_vo = dumm._vo
-        # Parse density function
-        dens_func, has_t = cls._parse_density(dens, internal_ro, internal_vo)
-        # For Potential instances with tgrid, evaluate the density at each
-        # time to create a time-dependent MultipoleExpansionPotential
-        if isinstance(dens, Potential) and tgrid is not None:
-            dens_func = lambda R, z, phi, t: dens.dens(
-                R, z, phi, t=t, use_physical=False
-            )
-            has_t = True
-        # Validate tgrid requirement
-        if has_t and tgrid is None:
-            raise ValueError(
-                "tgrid is required when the density function depends on time "
-                "(has a 't' parameter). Pass tgrid=numpy.linspace(t0, t1, Nt) "
-                "to enable time-dependent evaluation."
-            )
-        # Set L, M based on symmetry
-        if symmetry is not None and symmetry.startswith("spher"):
-            L = 1
-            M = 1
-        elif symmetry is not None and symmetry.startswith("axi"):
-            M = 1
-        else:
-            M = L
-        # Quadrature orders
-        if costheta_order is None:
-            costheta_order = max(20, L + 1)
-        if phi_order is None:
-            phi_order = max(20, 2 * L + 1)
-        if has_t:
-            # Time-dependent path: compute rho_lm at all t in tgrid
-            # using vectorized angular integration
-            tgrid = numpy.asarray(tgrid)
-            k = 3
-            beta_lm = sph_harm_normalization(L, M)
-            Nr = len(rgrid)
-            Nt = len(tgrid)
-            rho_cos_all, rho_sin_all = cls._compute_rho_lm_timedep(
-                dens_func, rgrid, tgrid, L, M, costheta_order, phi_order
-            )
-            # Build time-dependent callable splines for each (l, m)
-            # These are callables f(r, t) that return density values
-            rho_cos_funcs = [[None for _ in range(M)] for _ in range(L)]
-            rho_sin_funcs = [[None for _ in range(M)] for _ in range(L)]
-            for l in range(L):
-                for m in range(M):
-                    # beta_lm * rho_cos_all[:, :, l, m] has shape (Nt, Nr)
-                    cos_data = beta_lm[l, m] * rho_cos_all[:, :, l, m]
-                    sin_data = beta_lm[l, m] * rho_sin_all[:, :, l, m]
-                    # Build spline interpolator over t for each (l,m)
-                    cos_t_interp = make_interp_spline(tgrid, cos_data, k=3)
-                    sin_t_interp = make_interp_spline(tgrid, sin_data, k=3)
-                    # Callable f(rgrid_eval, t) that returns density on rgrid
-                    # For _precompute_radial_integrals_2d, this is called with
-                    # the full rgrid and a single t
-                    rho_cos_funcs[l][m] = lambda r, t, _interp=cos_t_interp: _interp(t)
-                    rho_sin_funcs[l][m] = lambda r, t, _interp=sin_t_interp: _interp(t)
-            # Handle astropy unit detection (following SCFPotential pattern)
-            if cls._density_has_units(dens):
-                ro = internal_ro
-                vo = internal_vo
-            return cls(
-                amp=amp,
-                rho_cos_splines=rho_cos_funcs,
-                rho_sin_splines=rho_sin_funcs,
-                rgrid=rgrid,
-                tgrid=tgrid,
-                normalize=normalize,
-                ro=ro,
-                vo=vo,
-            )
-        else:
-            # Static path
-            rho_cos, rho_sin = cls._compute_rho_lm(
-                dens_func, rgrid, L, M, costheta_order, phi_order
-            )
-            # Normalization for angular reconstruction; absorbed into splines
-            k = 3
-            beta_lm = sph_harm_normalization(L, M)
-            rho_cos_splines = [
-                [
-                    InterpolatedUnivariateSpline(
-                        rgrid, beta_lm[l, m] * rho_cos[:, l, m], k=k
-                    )
-                    for m in range(M)
+        # Construction-time numerical setup: pin to numpy so the density-arity
+        # autodetect (_parse_density) and the density-coefficient quadrature
+        # (_compute_rho_lm) run on numpy regardless of any forced backend
+        # default (byte-identical no-op on the numpy backend).
+        with _use_backend("numpy", force=True):
+            # Parse density function
+            dens_func, has_t = cls._parse_density(dens, internal_ro, internal_vo)
+            # For Potential instances with tgrid, evaluate the density at each
+            # time to create a time-dependent MultipoleExpansionPotential
+            if isinstance(dens, Potential) and tgrid is not None:
+                dens_func = lambda R, z, phi, t: dens.dens(
+                    R, z, phi, t=t, use_physical=False
+                )
+                has_t = True
+            # Validate tgrid requirement
+            if has_t and tgrid is None:
+                raise ValueError(
+                    "tgrid is required when the density function depends on time "
+                    "(has a 't' parameter). Pass tgrid=numpy.linspace(t0, t1, Nt) "
+                    "to enable time-dependent evaluation."
+                )
+            # Set L, M based on symmetry
+            if symmetry is not None and symmetry.startswith("spher"):
+                L = 1
+                M = 1
+            elif symmetry is not None and symmetry.startswith("axi"):
+                M = 1
+            else:
+                M = L
+            # Quadrature orders
+            if costheta_order is None:
+                costheta_order = max(20, L + 1)
+            if phi_order is None:
+                phi_order = max(20, 2 * L + 1)
+            if has_t:
+                # Time-dependent path: compute rho_lm at all t in tgrid
+                # using vectorized angular integration
+                tgrid = numpy.asarray(tgrid)
+                k = 3
+                beta_lm = sph_harm_normalization(L, M)
+                Nr = len(rgrid)
+                Nt = len(tgrid)
+                rho_cos_all, rho_sin_all = cls._compute_rho_lm_timedep(
+                    dens_func, rgrid, tgrid, L, M, costheta_order, phi_order
+                )
+                # Build time-dependent callable splines for each (l, m)
+                # These are callables f(r, t) that return density values
+                rho_cos_funcs = [[None for _ in range(M)] for _ in range(L)]
+                rho_sin_funcs = [[None for _ in range(M)] for _ in range(L)]
+                for l in range(L):
+                    for m in range(M):
+                        # beta_lm * rho_cos_all[:, :, l, m] has shape (Nt, Nr)
+                        cos_data = beta_lm[l, m] * rho_cos_all[:, :, l, m]
+                        sin_data = beta_lm[l, m] * rho_sin_all[:, :, l, m]
+                        # Build spline interpolator over t for each (l,m)
+                        cos_t_interp = make_interp_spline(tgrid, cos_data, k=3)
+                        sin_t_interp = make_interp_spline(tgrid, sin_data, k=3)
+                        # Callable f(rgrid_eval, t) that returns density on rgrid
+                        # For _precompute_radial_integrals_2d, this is called with
+                        # the full rgrid and a single t
+                        rho_cos_funcs[l][m] = lambda r, t, _interp=cos_t_interp: (
+                            _interp(t)
+                        )
+                        rho_sin_funcs[l][m] = lambda r, t, _interp=sin_t_interp: (
+                            _interp(t)
+                        )
+                # Handle astropy unit detection (following SCFPotential pattern)
+                if cls._density_has_units(dens):
+                    ro = internal_ro
+                    vo = internal_vo
+                return cls(
+                    amp=amp,
+                    rho_cos_splines=rho_cos_funcs,
+                    rho_sin_splines=rho_sin_funcs,
+                    rgrid=rgrid,
+                    tgrid=tgrid,
+                    normalize=normalize,
+                    ro=ro,
+                    vo=vo,
+                )
+            else:
+                # Static path
+                rho_cos, rho_sin = cls._compute_rho_lm(
+                    dens_func, rgrid, L, M, costheta_order, phi_order
+                )
+                # Normalization for angular reconstruction; absorbed into splines
+                k = 3
+                beta_lm = sph_harm_normalization(L, M)
+                rho_cos_splines = [
+                    [
+                        InterpolatedUnivariateSpline(
+                            rgrid, beta_lm[l, m] * rho_cos[:, l, m], k=k
+                        )
+                        for m in range(M)
+                    ]
+                    for l in range(L)
                 ]
-                for l in range(L)
-            ]
-            rho_sin_splines = [
-                [
-                    InterpolatedUnivariateSpline(
-                        rgrid, beta_lm[l, m] * rho_sin[:, l, m], k=k
-                    )
-                    for m in range(M)
+                rho_sin_splines = [
+                    [
+                        InterpolatedUnivariateSpline(
+                            rgrid, beta_lm[l, m] * rho_sin[:, l, m], k=k
+                        )
+                        for m in range(M)
+                    ]
+                    for l in range(L)
                 ]
-                for l in range(L)
-            ]
-            # Handle astropy unit detection (following SCFPotential pattern)
-            if cls._density_has_units(dens):
-                ro = internal_ro
-                vo = internal_vo
-            return cls(
-                amp=amp,
-                rho_cos_splines=rho_cos_splines,
-                rho_sin_splines=rho_sin_splines,
-                rgrid=rgrid,
-                normalize=normalize,
-                ro=ro,
-                vo=vo,
-            )
+                # Handle astropy unit detection (following SCFPotential pattern)
+                if cls._density_has_units(dens):
+                    ro = internal_ro
+                    vo = internal_vo
+                return cls(
+                    amp=amp,
+                    rho_cos_splines=rho_cos_splines,
+                    rho_sin_splines=rho_sin_splines,
+                    rgrid=rgrid,
+                    normalize=normalize,
+                    ro=ro,
+                    vo=vo,
+                )
 
     @staticmethod
     def _density_has_units(dens):

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -19,6 +19,7 @@ from ..backend import (
     get_namespace,
     match_input_dtype,
 )
+from ..backend import use as _use_backend
 from ..backend.special import assoc_legendre, gegenbauer
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -249,27 +250,30 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # Turn on physical outputs if input density was physical
         if _APY_LOADED:
             # First need to determine number of parameters, like in
-            # scf_compute_coeffs_spherical/axi
-            numOfParam = 0
-            try:
-                dens(0)
-                numOfParam = 1
-            except:
+            # scf_compute_coeffs_spherical/axi. Pin to numpy: the arity probe
+            # calls the (backend-aware) density on plain floats, which must
+            # dispatch on numpy regardless of any forced backend default.
+            with _use_backend("numpy", force=True):
+                numOfParam = 0
                 try:
-                    dens(0, 0)
-                    numOfParam = 2
+                    dens(0)
+                    numOfParam = 1
                 except:
-                    numOfParam = 3
-            param = [1] * numOfParam
-            try:
-                dens(*param).to(units.kg / units.m**3)
-            except (AttributeError, units.UnitConversionError):
-                # We'll just assume that unit conversion means density
-                # is scalar Quantity
-                pass
-            else:
-                ro = internal_ro
-                vo = internal_vo
+                    try:
+                        dens(0, 0)
+                        numOfParam = 2
+                    except:
+                        numOfParam = 3
+                param = [1] * numOfParam
+                try:
+                    dens(*param).to(units.kg / units.m**3)
+                except (AttributeError, units.UnitConversionError):
+                    # We'll just assume that unit conversion means density
+                    # is scalar Quantity
+                    pass
+                else:
+                    ro = internal_ro
+                    vo = internal_vo
         return cls(Acos=Acos, Asin=Asin, a=a, ro=ro, vo=vo)
 
     def _rhoTilde(self, r, N, L):
@@ -1175,43 +1179,52 @@ def scf_compute_coeffs_spherical(dens, N, a=1.0, radial_order=None):
     -----
     - 2016-05-18 - Written - Aladdin Seaifan (UofT)
     """
-    numOfParam = 0
-    try:
-        dens(0)
-        numOfParam = 1
-    except:
+    # Construction-time numerical setup: pin to numpy so the density-arity
+    # autodetect and the coefficient quadrature run on numpy regardless of any
+    # forced backend default (byte-identical no-op on the numpy backend).
+    with _use_backend("numpy", force=True):
+        numOfParam = 0
         try:
-            dens(0, 0)
-            numOfParam = 2
+            dens(0)
+            numOfParam = 1
         except:
-            numOfParam = 3
-    param = [0] * numOfParam
-    dens_kw = _scf_compute_determine_dens_kwargs(dens, param)
+            try:
+                dens(0, 0)
+                numOfParam = 2
+            except:
+                numOfParam = 3
+        param = [0] * numOfParam
+        dens_kw = _scf_compute_determine_dens_kwargs(dens, param)
 
-    def integrand(xi):
-        r = _xiToR(xi, a)
-        R = r
-        param[0] = R
-        return (
-            a**3.0
-            * dens(*param, **dens_kw)
-            * (1 + xi) ** 2.0
-            * (1 - xi) ** -3.0
-            * _C(xi, N, 1)[:, 0]
+        def integrand(xi):
+            r = _xiToR(xi, a)
+            R = r
+            param[0] = R
+            return (
+                a**3.0
+                * dens(*param, **dens_kw)
+                * (1 + xi) ** 2.0
+                * (1 - xi) ** -3.0
+                * _C(xi, N, 1)[:, 0]
+            )
+
+        Acos = numpy.zeros((N, 1, 1), float)
+        Asin = None
+
+        Ksample = [max(N + 1, 20)]
+
+        if radial_order != None:
+            Ksample[0] = radial_order
+
+        integrated = _gaussianQuadrature(integrand, [[-1.0, 1.0]], Ksample=Ksample)
+        n = numpy.arange(0, N)
+        K = (
+            16
+            * numpy.pi
+            * (n + 3.0 / 2)
+            / ((n + 2) * (n + 1) * (1 + n * (n + 3.0) / 2.0))
         )
-
-    Acos = numpy.zeros((N, 1, 1), float)
-    Asin = None
-
-    Ksample = [max(N + 1, 20)]
-
-    if radial_order != None:
-        Ksample[0] = radial_order
-
-    integrated = _gaussianQuadrature(integrand, [[-1.0, 1.0]], Ksample=Ksample)
-    n = numpy.arange(0, N)
-    K = 16 * numpy.pi * (n + 3.0 / 2) / ((n + 2) * (n + 1) * (1 + n * (n + 3.0) / 2.0))
-    Acos[n, 0, 0] = 2 * K * integrated
+        Acos[n, 0, 0] = 2 * K * integrated
     return Acos, Asin
 
 
@@ -1307,60 +1320,66 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
     -----
     - 2016-05-20 - Written - Aladdin Seaifan (UofT)
     """
-    numOfParam = 0
-    try:
-        dens(0, 0)
-        numOfParam = 2
-    except:
-        numOfParam = 3
-    param = [0] * numOfParam
-    dens_kw = _scf_compute_determine_dens_kwargs(dens, param)
+    # Construction-time numerical setup: pin to numpy (see scf_compute_coeffs_spherical).
+    with _use_backend("numpy", force=True):
+        numOfParam = 0
+        try:
+            dens(0, 0)
+            numOfParam = 2
+        except:
+            numOfParam = 3
+        param = [0] * numOfParam
+        dens_kw = _scf_compute_determine_dens_kwargs(dens, param)
 
-    def integrand(xi, costheta):
+        def integrand(xi, costheta):
+            l = numpy.arange(0, L)[numpy.newaxis, :]
+            r = _xiToR(xi, a)
+            R = r * numpy.sqrt(1 - costheta**2.0)
+            z = r * costheta
+            if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
+                PP = lpmn(0, L - 1, costheta)[0].T[numpy.newaxis, :, 0]
+            else:
+                PP = assoc_legendre_p_all(L - 1, 0, costheta, branch_cut=2)[0].T
+            dV = (1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0)
+            phi_nl = (
+                a**3
+                * (1.0 + xi) ** l
+                * (1.0 - xi) ** (l + 1.0)
+                * _C(xi, N, L)[:, :]
+                * PP
+            )
+            param[0] = R
+            param[1] = z
+            return phi_nl * dV * dens(*param, **dens_kw)
+
+        Acos = numpy.zeros((N, L, 1), float)
+        Asin = None
+
+        ##This should save us some computation time since we're only taking the double integral once, rather then L times
+        Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20)]
+        if radial_order != None:
+            Ksample[0] = radial_order
+        if costheta_order != None:
+            Ksample[1] = costheta_order
+
+        integrated = _gaussianQuadrature(
+            integrand, [[-1, 1], [-1, 1]], Ksample=Ksample
+        ) * (2 * numpy.pi)
+        n = numpy.arange(0, N)[:, numpy.newaxis]
         l = numpy.arange(0, L)[numpy.newaxis, :]
-        r = _xiToR(xi, a)
-        R = r * numpy.sqrt(1 - costheta**2.0)
-        z = r * costheta
-        if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
-            PP = lpmn(0, L - 1, costheta)[0].T[numpy.newaxis, :, 0]
-        else:
-            PP = assoc_legendre_p_all(L - 1, 0, costheta, branch_cut=2)[0].T
-        dV = (1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0)
-        phi_nl = (
-            a**3 * (1.0 + xi) ** l * (1.0 - xi) ** (l + 1.0) * _C(xi, N, L)[:, :] * PP
+        K = 0.5 * n * (n + 4 * l + 3) + (l + 1) * (2 * l + 1)
+        # I = -K*(4*numpy.pi)/(2.**(8*l + 6)) * gamma(n + 4*l + 3)/(gamma(n + 1)*(n + 2*l + 3./2)*gamma(2*l + 3./2)**2)
+        ##Taking the ln of I will allow bigger size coefficients
+        lnI = (
+            -(8 * l + 6) * numpy.log(2)
+            + gammaln(n + 4 * l + 3)
+            - gammaln(n + 1)
+            - numpy.log(n + 2 * l + 3.0 / 2)
+            - 2 * gammaln(2 * l + 3.0 / 2)
         )
-        param[0] = R
-        param[1] = z
-        return phi_nl * dV * dens(*param, **dens_kw)
-
-    Acos = numpy.zeros((N, L, 1), float)
-    Asin = None
-
-    ##This should save us some computation time since we're only taking the double integral once, rather then L times
-    Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20)]
-    if radial_order != None:
-        Ksample[0] = radial_order
-    if costheta_order != None:
-        Ksample[1] = costheta_order
-
-    integrated = _gaussianQuadrature(integrand, [[-1, 1], [-1, 1]], Ksample=Ksample) * (
-        2 * numpy.pi
-    )
-    n = numpy.arange(0, N)[:, numpy.newaxis]
-    l = numpy.arange(0, L)[numpy.newaxis, :]
-    K = 0.5 * n * (n + 4 * l + 3) + (l + 1) * (2 * l + 1)
-    # I = -K*(4*numpy.pi)/(2.**(8*l + 6)) * gamma(n + 4*l + 3)/(gamma(n + 1)*(n + 2*l + 3./2)*gamma(2*l + 3./2)**2)
-    ##Taking the ln of I will allow bigger size coefficients
-    lnI = (
-        -(8 * l + 6) * numpy.log(2)
-        + gammaln(n + 4 * l + 3)
-        - gammaln(n + 1)
-        - numpy.log(n + 2 * l + 3.0 / 2)
-        - 2 * gammaln(2 * l + 3.0 / 2)
-    )
-    I = -K * (4 * numpy.pi) * numpy.e ** (lnI)
-    constants = -(2.0 ** (-2 * l)) * (2 * l + 1.0) ** 0.5
-    Acos[:, :, 0] = 2 * I**-1 * integrated * constants
+        I = -K * (4 * numpy.pi) * numpy.e ** (lnI)
+        constants = -(2.0 ** (-2 * l)) * (2 * l + 1.0) ** 0.5
+        Acos[:, :, 0] = 2 * I**-1 * integrated * constants
     return Acos, Asin
 
 
@@ -1477,80 +1496,86 @@ def scf_compute_coeffs(
     - 2016-05-27 - Written - Aladdin Seaifan (UofT)
 
     """
-    dens_kw = _scf_compute_determine_dens_kwargs(dens, [0.1, 0.1, 0.1])
+    # Construction-time numerical setup: pin to numpy (see scf_compute_coeffs_spherical).
+    with _use_backend("numpy", force=True):
+        dens_kw = _scf_compute_determine_dens_kwargs(dens, [0.1, 0.1, 0.1])
 
-    def integrand(xi, costheta, phi):
+        def integrand(xi, costheta, phi):
+            l = numpy.arange(0, L)[numpy.newaxis, :, numpy.newaxis]
+            m = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :]
+            r = _xiToR(xi, a)
+            R = r * numpy.sqrt(1 - costheta**2.0)
+            z = r * costheta
+            if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
+                PP = lpmn(L - 1, L - 1, costheta)[0].T[numpy.newaxis, :, :]
+            else:
+                PP = numpy.swapaxes(
+                    assoc_legendre_p_all(L - 1, L - 1, costheta, branch_cut=2)[0][
+                        :, :L
+                    ],
+                    0,
+                    1,
+                ).T[numpy.newaxis, :, :]
+            dV = (1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0)
+
+            phi_nl = (
+                -(a**3)
+                * (1.0 + xi) ** l
+                * (1.0 - xi) ** (l + 1.0)
+                * _C(xi, N, L)[:, :, numpy.newaxis]
+                * PP
+            )
+
+            return (
+                dens(R, z, phi, **dens_kw)
+                * phi_nl[numpy.newaxis, :, :, :]
+                * numpy.array([numpy.cos(m * phi), numpy.sin(m * phi)])
+                * dV
+            )
+
+        Acos = numpy.zeros((N, L, L), float)
+        Asin = numpy.zeros((N, L, L), float)
+
+        Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20), max(L + 1, 20)]
+        if radial_order != None:
+            Ksample[0] = radial_order
+        if costheta_order != None:
+            Ksample[1] = costheta_order
+        if phi_order != None:
+            Ksample[2] = phi_order
+        integrated = _gaussianQuadrature(
+            integrand, [[-1.0, 1.0], [-1.0, 1.0], [0, 2 * numpy.pi]], Ksample=Ksample
+        )
+        n = numpy.arange(0, N)[:, numpy.newaxis, numpy.newaxis]
         l = numpy.arange(0, L)[numpy.newaxis, :, numpy.newaxis]
         m = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :]
-        r = _xiToR(xi, a)
-        R = r * numpy.sqrt(1 - costheta**2.0)
-        z = r * costheta
-        if _SCIPY_VERSION < parse_version("1.15"):  # pragma: no cover
-            PP = lpmn(L - 1, L - 1, costheta)[0].T[numpy.newaxis, :, :]
-        else:
-            PP = numpy.swapaxes(
-                assoc_legendre_p_all(L - 1, L - 1, costheta, branch_cut=2)[0][:, :L],
-                0,
-                1,
-            ).T[numpy.newaxis, :, :]
-        dV = (1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0)
+        K = 0.5 * n * (n + 4 * l + 3) + (l + 1) * (2 * l + 1)
 
-        phi_nl = (
-            -(a**3)
-            * (1.0 + xi) ** l
-            * (1.0 - xi) ** (l + 1.0)
-            * _C(xi, N, L)[:, :, numpy.newaxis]
-            * PP
+        Nln = (
+            0.5 * gammaln(l - m + 1) - 0.5 * gammaln(l + m + 1) - (2 * l) * numpy.log(2)
+        )
+        NN = numpy.e ** (Nln)
+
+        NN[numpy.where(NN == numpy.inf)] = (
+            0  ## To account for the fact that m can't be bigger than l
         )
 
-        return (
-            dens(R, z, phi, **dens_kw)
-            * phi_nl[numpy.newaxis, :, :, :]
-            * numpy.array([numpy.cos(m * phi), numpy.sin(m * phi)])
-            * dV
+        constants = NN * (2 * l + 1.0) ** 0.5
+
+        lnI = (
+            -(8 * l + 6) * numpy.log(2)
+            + gammaln(n + 4 * l + 3)
+            - gammaln(n + 1)
+            - numpy.log(n + 2 * l + 3.0 / 2)
+            - 2 * gammaln(2 * l + 3.0 / 2)
         )
-
-    Acos = numpy.zeros((N, L, L), float)
-    Asin = numpy.zeros((N, L, L), float)
-
-    Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20), max(L + 1, 20)]
-    if radial_order != None:
-        Ksample[0] = radial_order
-    if costheta_order != None:
-        Ksample[1] = costheta_order
-    if phi_order != None:
-        Ksample[2] = phi_order
-    integrated = _gaussianQuadrature(
-        integrand, [[-1.0, 1.0], [-1.0, 1.0], [0, 2 * numpy.pi]], Ksample=Ksample
-    )
-    n = numpy.arange(0, N)[:, numpy.newaxis, numpy.newaxis]
-    l = numpy.arange(0, L)[numpy.newaxis, :, numpy.newaxis]
-    m = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :]
-    K = 0.5 * n * (n + 4 * l + 3) + (l + 1) * (2 * l + 1)
-
-    Nln = 0.5 * gammaln(l - m + 1) - 0.5 * gammaln(l + m + 1) - (2 * l) * numpy.log(2)
-    NN = numpy.e ** (Nln)
-
-    NN[numpy.where(NN == numpy.inf)] = (
-        0  ## To account for the fact that m can't be bigger than l
-    )
-
-    constants = NN * (2 * l + 1.0) ** 0.5
-
-    lnI = (
-        -(8 * l + 6) * numpy.log(2)
-        + gammaln(n + 4 * l + 3)
-        - gammaln(n + 1)
-        - numpy.log(n + 2 * l + 3.0 / 2)
-        - 2 * gammaln(2 * l + 3.0 / 2)
-    )
-    I = -K * (4 * numpy.pi) * numpy.e ** (lnI)
-    Acos[:, :, :], Asin[:, :, :] = (
-        2
-        * (I**-1.0)[numpy.newaxis, :, :, :]
-        * integrated
-        * constants[numpy.newaxis, :, :, :]
-    )
+        I = -K * (4 * numpy.pi) * numpy.e ** (lnI)
+        Acos[:, :, :], Asin[:, :, :] = (
+            2
+            * (I**-1.0)[numpy.newaxis, :, :, :]
+            * integrated
+            * constants[numpy.newaxis, :, :, :]
+        )
 
     return Acos, Asin
 


### PR DESCRIPTION
## What
Burndown **PR-4** (`SCFPotential.py` + `MultipoleExpansionPotential.py`). Constructing SCF/Multipole/DiskSCF/DiskMultipole/KuijkenDubinski potentials ran their pure-numpy coefficient/density-grid quadrature + density-lambda arity autodetect while the forced backend default was torch/jax, so `get_namespace(<plain scalar>)` returned the backend and torch rejected the mixed ops (`numpy.ndarray * Tensor`; a swallowed `TypeError` mis-detecting a Multipole density lambda's arity). Wrap the construction-time numerical setup in `with use("numpy", force=True):`. This is non-differentiable host setup that builds the stored numpy coefficient tables; **evaluation stays backend-aware** (the jax/torch eval tables are built lazily, outside the wrap).

## Byte-identity + review
numpy byte-identical (forced-numpy is a no-op on the numpy default): **118 stored coefficient/table attributes bit-identical** parent vs branch; `test_scf`/`test_MultipoleExpansionPotential`/`test_amp_mult_divide` counts unchanged. Under torch these families now construct and **12 `test_amp_mult_divide` entries flip to pass**; the 3 remaining (`expwhole*`/`nonaxiDiskSCF`) fail for the separate `Potential.normalize`-stores-Tensor central-coercion reason (PR-3b). Adversarially reviewed (byte-identity, eval-path-not-pinned, context-manager exception/nesting safety, no missed/double-wrapped paths — all refuted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)