### PR TITLE
potential/backend: centrally coerce forced-backend scalar leaks

### DIFF
--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -126,15 +126,9 @@ def promote_scalars(xp, *vals):
     def _promote(v):
         if is_backend_array(v):
             return v
-        try:
-            return xp.asarray(v, dtype=dtype, device=device)
-        except (TypeError, ValueError):
-            # namespace without a device kwarg, or one that rejects the device
-            # value (array-api jax exposes .device as the string 'cpu', which
-            # jnp.asarray(device=...) refuses with ValueError). jax tracks device
-            # automatically, so a plain asarray is correct; torch's .device is a
-            # real object and never hits this fallback.
-            return xp.asarray(v, dtype=dtype)
+        # Delegate to the same helper coerce_coords uses: it places the value on
+        # the device and translates a numpy dtype to the backend dtype.
+        return asarray_on_device(xp, v, device, dtype=dtype)
 
     return tuple(_promote(v) for v in vals)
 

--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -62,6 +62,7 @@ from ._namespaces import (
     _is_floating_dtype,
     asarray_on_device,
     device_of,
+    is_backend_array,
 )
 
 
@@ -112,7 +113,9 @@ def promote_scalars(xp, *vals):
     path passes everything through untouched (byte-identical)."""
     if xp is numpy:
         return vals
-    ref = next((v for v in vals if hasattr(v, "ndim")), None)
+    # "Leave it" only for genuine backend (jax/torch) arrays: a numpy.float64
+    # (or numpy.ndarray) HAS .ndim but torch rejects it, so it must be PROMOTED.
+    ref = next((v for v in vals if is_backend_array(v)), None)
     if ref is None:
         # Nothing to anchor on (e.g. all-scalar inputs under a forced backend
         # default): pass through, the namespace's functions handle scalars
@@ -121,7 +124,7 @@ def promote_scalars(xp, *vals):
     device = getattr(ref, "device", None)
 
     def _promote(v):
-        if hasattr(v, "ndim"):
+        if is_backend_array(v):
             return v
         try:
             return xp.asarray(v, dtype=dtype, device=device)

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -136,14 +136,40 @@ def device_of(*coords):
     return None
 
 
+def _backend_dtype(xp, dtype):
+    """Map a numpy dtype to the active backend's dtype.
+
+    Some callers hand ``asarray_on_device`` a *numpy* dtype taken off a
+    coordinate (``dtype=getattr(R, "dtype", None)``); ``torch.asarray`` rejects
+    a numpy dtype (``torch.asarray(x, dtype=numpy.float64)`` raises), so it is
+    translated to ``xp``'s own same-named dtype (``torch.float64``). The numpy
+    path is a strict pass-through (``xp is numpy`` -> dtype unchanged), as is
+    ``None``; jax accepts numpy dtypes natively, so only a numpy dtype handed to
+    a backend that does not expose it as-is gets translated (``getattr`` falls
+    back to the original dtype when the backend has no same-named attribute).
+    """
+    if dtype is None or xp is numpy:
+        return dtype
+    try:
+        is_numpy_dtype = numpy.issubdtype(dtype, numpy.generic)
+    except TypeError:  # not a numpy dtype (already a torch.dtype): leave it
+        return dtype
+    if not is_numpy_dtype:
+        return dtype
+    return getattr(xp, numpy.dtype(dtype).name, dtype)
+
+
 def asarray_on_device(xp, a, device, dtype=None):
     """``xp.asarray(a, dtype=dtype)`` placed on ``device`` when one is given.
 
     ``device`` is the result of ``device_of`` on the coordinate inputs; when
     it is None (numpy arrays, plain scalars, traced values) the keyword is
     omitted so the call reduces to today's plain ``xp.asarray`` (and
-    ``dtype=None`` is the default pass-through on every backend).
+    ``dtype=None`` is the default pass-through on every backend). A numpy
+    ``dtype`` argument is translated to the backend's own dtype first so
+    ``torch.asarray(x, dtype=numpy.float64)`` (which raises) works.
     """
+    dtype = _backend_dtype(xp, dtype)
     if device is None:
         return xp.asarray(a, dtype=dtype)
     return xp.asarray(a, dtype=dtype, device=device)

--- a/galpy/potential/BurkertPotential.py
+++ b/galpy/potential/BurkertPotential.py
@@ -47,12 +47,12 @@ class BurkertPotential(SphericalPotential):
         a = conversion.parse_length(a, ro=self._ro, vo=self._vo)
         self.a = a
         self._scale = self.a
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -87,12 +87,12 @@ class EinastoPotential(SphericalPotential):
         self.h = h
         self.n = n
         self._scale = self.h
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -14,7 +14,7 @@ import numpy
 from scipy import integrate
 from scipy.special import gamma
 
-from ..backend import get_namespace
+from ..backend import get_namespace, zeros_like_backend
 from ..util import conversion, coords
 from .Potential import Potential
 
@@ -110,7 +110,7 @@ class FerrersPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(get_namespace(R, z), R)
         x, y, z = coords.cyl_to_rect(R, phi, z)
         # rotation into the aligned frame: rot(t) @ [x, y] without array stacking
         # (numpy.array([x, y]) stacking is the torch-concat backend blocker). The
@@ -140,21 +140,21 @@ class FerrersPotential(Potential):
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
         return xp.cos(phi) * Fx + xp.sin(phi) * Fy
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
         return R * (-xp.sin(phi) * Fx + xp.cos(phi) * Fy)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         _, _, Fz = self._cached_xyzforces(R, z, phi, t, xp)
         return Fz
 
@@ -237,7 +237,7 @@ class FerrersPotential(Potential):
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         phixxa = self._2ndderiv_xyz(x, y, z, 0, 0)
         phixya = self._2ndderiv_xyz(x, y, z, 0, 1)
@@ -257,7 +257,7 @@ class FerrersPotential(Potential):
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         phixza = self._2ndderiv_xyz(x, y, z, 0, 2)
         phiyza = self._2ndderiv_xyz(x, y, z, 1, 2)
@@ -270,14 +270,14 @@ class FerrersPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(get_namespace(R, z), R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         return self._2ndderiv_xyz(x, y, z, 2, 2)
 
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         Fx = self._xforce_xyz(x, y, z)
         Fy = self._yforce_xyz(x, y, z)
@@ -302,7 +302,7 @@ class FerrersPotential(Potential):
     def _Rphideriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         Fx = self._xforce_xyz(x, y, z)
         Fy = self._yforce_xyz(x, y, z)
@@ -328,7 +328,7 @@ class FerrersPotential(Potential):
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
         if not self.isNonAxi:
-            phi = 0.0
+            phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
         phixza = self._2ndderiv_xyz(x, y, z, 0, 2)
         phiyza = self._2ndderiv_xyz(x, y, z, 1, 2)

--- a/galpy/potential/FlattenedPowerPotential.py
+++ b/galpy/potential/FlattenedPowerPotential.py
@@ -73,12 +73,12 @@ class FlattenedPowerPotential(Potential):
         self.core2 = core**2.0
         # Back to old definition
         self._amp *= r1**self.alpha
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/HomogeneousSpherePotential.py
+++ b/galpy/potential/HomogeneousSpherePotential.py
@@ -47,12 +47,12 @@ class HomogeneousSpherePotential(Potential):
         self.R = R
         self._R2 = self.R**2.0
         self._R3 = self.R**3.0
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/IsochronePotential.py
+++ b/galpy/potential/IsochronePotential.py
@@ -48,12 +48,12 @@ class IsochronePotential(Potential):
         self.b = b
         self._scale = self.b
         self.b2 = self.b**2.0
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/KuzminDiskPotential.py
+++ b/galpy/potential/KuzminDiskPotential.py
@@ -47,12 +47,12 @@ class KuzminDiskPotential(Potential):
         Potential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units="mass")
         a = conversion.parse_length(a, ro=self._ro)
         self._a = a  ## a must be greater or equal to 0.
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         return None

--- a/galpy/potential/KuzminKutuzovStaeckelPotential.py
+++ b/galpy/potential/KuzminKutuzovStaeckelPotential.py
@@ -54,12 +54,12 @@ class KuzminKutuzovStaeckelPotential(Potential):
         self._Delta = Delta
         self._gamma = self._Delta**2 / (1.0 - self._ac**2)
         self._alpha = self._gamma - self._Delta**2
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
 

--- a/galpy/potential/MN3ExponentialDiskPotential.py
+++ b/galpy/potential/MN3ExponentialDiskPotential.py
@@ -130,12 +130,12 @@ class MN3ExponentialDiskPotential(Potential):
                     b=self._b,
                 ),
             ]
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         # In C this expands into three MiyamotoNagai potentials (see
         # integrateFullOrbit._parse_pot), each of which has the full 3D Hessian,

--- a/galpy/potential/MiyamotoNagaiPotential.py
+++ b/galpy/potential/MiyamotoNagaiPotential.py
@@ -56,12 +56,12 @@ class MiyamotoNagaiPotential(Potential):
         self._scale = self._a
         self._b = b
         self._b2 = self._b**2.0
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/PerfectEllipsoidPotential.py
+++ b/galpy/potential/PerfectEllipsoidPotential.py
@@ -86,12 +86,12 @@ class PerfectEllipsoidPotential(EllipsoidalPotential):
         self._scale = self.a
         # Adjust amp
         self._amp *= self.a / (numpy.pi**2 * self._b * self._c)
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian (R2deriv/z2deriv/Rzderiv/phi2deriv/Rphideriv/zphideriv)
         # in C via the EllipsoidalPotential GL angle integral; only in the aligned

--- a/galpy/potential/PlummerPotential.py
+++ b/galpy/potential/PlummerPotential.py
@@ -46,12 +46,12 @@ class PlummerPotential(Potential):
         self._b = conversion.parse_length(b, ro=self._ro)
         self._scale = self._b
         self._b2 = self._b**2.0
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/PowerSphericalPotential.py
+++ b/galpy/potential/PowerSphericalPotential.py
@@ -54,12 +54,12 @@ class PowerSphericalPotential(Potential):
         # Back to old definition
         if self.alpha != 3.0:
             self._amp *= r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -65,12 +65,12 @@ class PowerSphericalPotentialwCutoff(Potential):
         self._amp *= r1**self.alpha
         self.rc = rc
         self._scale = self.rc
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/PowerTriaxialPotential.py
+++ b/galpy/potential/PowerTriaxialPotential.py
@@ -88,12 +88,12 @@ class PowerTriaxialPotential(EllipsoidalPotential):
             self._amp *= r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
         # Multiply in constants
         self._amp *= (3.0 - self.alpha) / 4.0 / numpy.pi
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
         # (aligned frame only)

--- a/galpy/potential/RingPotential.py
+++ b/galpy/potential/RingPotential.py
@@ -44,6 +44,7 @@ class RingPotential(Potential):
         self.a = a
         self.a2 = self.a**2
         self._amp /= 2.0 * numpy.pi * self.a
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
@@ -53,7 +54,6 @@ class RingPotential(Potential):
                 )
             self.normalize(normalize)
         self.hasC = False
-        self._backend_compatible = True
         self.hasC_dxdv = False
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):

--- a/galpy/potential/SphericalShellPotential.py
+++ b/galpy/potential/SphericalShellPotential.py
@@ -46,6 +46,7 @@ class SphericalShellPotential(SphericalPotential):
         a = conversion.parse_length(a, ro=self._ro)
         self.a = a
         self.a2 = a**2
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
@@ -55,7 +56,6 @@ class SphericalShellPotential(SphericalPotential):
                 )
             self.normalize(normalize)
         self.hasC = False
-        self._backend_compatible = True
         self.hasC_dxdv = False
 
     def _revaluate(self, r, t=0.0):

--- a/galpy/potential/TriaxialGaussianPotential.py
+++ b/galpy/potential/TriaxialGaussianPotential.py
@@ -87,12 +87,12 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
         self._scale = self._sigma
         # Adjust amp
         self._amp /= (2.0 * numpy.pi) ** 1.5 * self._sigma**3.0 * self._b * self._c
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
         # (aligned frame only)

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -741,12 +741,12 @@ class JaffePotential(DehnenSphericalPotential):
         self._scale = self.a
         self.alpha = 2
         self.beta = 4
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True
@@ -907,6 +907,8 @@ class NFWPotential(TwoPowerSphericalPotential):
         """
         Potential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units="mass")
         a = conversion.parse_length(a, ro=self._ro)
+        # Flag before the (conditional) normalize() so its Rforce(1.,0.) is coerced.
+        self._backend_compatible = True
         if conc is None and rmax is None:
             self.a = a
             self.alpha = 1
@@ -940,7 +942,6 @@ class NFWPotential(TwoPowerSphericalPotential):
             self._voSet = True
         self._scale = self.a
         self.hasC = True
-        self._backend_compatible = True
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -122,12 +122,12 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
             )
         # Adjust amp
         self._amp /= 4.0 * numpy.pi * self.a**3
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
         # (aligned frame only)
@@ -277,12 +277,12 @@ class TriaxialHernquistPotential(EllipsoidalPotential):
         # Adjust amp
         self.a4 = self.a**4
         self._amp /= 4.0 * numpy.pi * self.a**3
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
         # (aligned frame only)
@@ -397,12 +397,12 @@ class TriaxialJaffePotential(EllipsoidalPotential):
         # Adjust amp
         self.a2 = self.a**2
         self._amp /= 4.0 * numpy.pi * self.a2 * self.a
+        self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover
             self.normalize(normalize)
         self.hasC = not self._glorder is None
-        self._backend_compatible = True
         self.hasC_dxdv = self.hasC and self._aligned
         # full 3D Hessian in C via the EllipsoidalPotential GL angle integral
         # (aligned frame only)

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -5,6 +5,7 @@
 #
 ###############################################################################
 import copy
+import inspect
 import math as m
 import numbers
 import warnings
@@ -1151,8 +1152,23 @@ def potential_physical_input(method=None, *, coerce_backend=True):
             if xp is not numpy and _check_backend_compatible(Pot):
                 args = (args[0],) + coerce_coords(xp, *args[1:])
                 for _key in ("phi", "t", "R", "z", "x", "v"):
-                    if kwargs.get(_key, None) is not None:
+                    if _key in kwargs:
                         (kwargs[_key],) = coerce_coords(xp, kwargs[_key])
+                # Default kwargs (B): when phi/t fall back to their SIGNATURE
+                # default (a Python float the caller never passed, so neither
+                # args nor kwargs holds it), inject the coerced default so the
+                # backend never sees a raw float (torch.sin(0.0) raises). Stays
+                # strictly inside the non-numpy + backend-compatible guard so the
+                # numpy path never rebinds/injects kwargs (byte-identical).
+                params = list(inspect.signature(method).parameters.values())
+                for _idx, _p in enumerate(params):
+                    if (
+                        _p.name in ("phi", "t")
+                        and _p.default is not inspect.Parameter.empty
+                        and _idx >= len(args)
+                        and _p.name not in kwargs
+                    ):
+                        (kwargs[_p.name],) = coerce_coords(xp, _p.default)
         return method(*args, **kwargs)
 
     return wrapper

--- a/tests/test_backend_dtype_policy.py
+++ b/tests/test_backend_dtype_policy.py
@@ -623,3 +623,49 @@ def test_torch_grad_flows_through_exit_cast():
     assert Rt.grad.dtype == torch.float32
     ref = -float(pot._Rforce(numpy.array(R0), numpy.array(z0)))
     numpy.testing.assert_allclose(float(Rt.grad), ref, rtol=1e-4)
+
+
+###############################################################################
+# _backend_dtype translation policy. asarray_on_device translates a *numpy*
+# dtype taken off a coordinate to the active backend's same-named dtype so
+# torch.asarray(x, dtype=numpy.float64) (which raises) works. A numpy dtype
+# whose scalar .type is NOT a numpy.generic subclass -- numpy's variable-width
+# StringDType, whose .type is the Python ``str`` -- is recognised as a numpy
+# dtype yet has no backend equivalent, so it must be returned unchanged rather
+# than translated (the not-a-generic branch). Covered under jax AND torch.
+###############################################################################
+# A real numpy dtype with numpy.issubdtype(d, numpy.generic) == False (StringDType
+# resolves to the Python ``str`` scalar, which is not a numpy.generic subclass);
+# numpy < 2.0 has no such dtype, so the assertion self-skips there.
+_NONGENERIC_NPDTYPE = None
+if hasattr(numpy, "dtypes") and hasattr(numpy.dtypes, "StringDType"):
+    _cand = numpy.dtypes.StringDType()
+    if numpy.issubdtype(_cand, numpy.generic) is False:
+        _NONGENERIC_NPDTYPE = _cand
+
+
+@pytest.mark.skipif(
+    _NONGENERIC_NPDTYPE is None,
+    reason="no numpy dtype with issubdtype(., generic) is False (needs numpy>=2.0)",
+)
+@pytest.mark.parametrize(
+    "backend", [b for b in ("jax", "torch") if globals()[b] is not None]
+)
+def test_backend_dtype_passes_through_nongeneric_numpy_dtype(backend):
+    # _backend_dtype must leave a recognised-but-non-generic numpy dtype
+    # untouched (no backend has a same-named equivalent to translate to), under
+    # both jax and torch. This is the only path through the not-a-generic branch.
+    from galpy.backend import get_namespace
+    from galpy.backend._namespaces import _backend_dtype
+
+    if backend == "jax":
+        arr = jnp.asarray([1.0, 2.0])
+    else:
+        arr = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    xp = get_namespace(arr)
+    out = _backend_dtype(xp, _NONGENERIC_NPDTYPE)
+    assert out is _NONGENERIC_NPDTYPE, (
+        f"{backend}: non-generic numpy dtype was not passed through unchanged"
+    )
+    # numpy stays a strict pass-through on the same input (xp is numpy guard).
+    assert _backend_dtype(numpy, _NONGENERIC_NPDTYPE) is _NONGENERIC_NPDTYPE


### PR DESCRIPTION
## What
Burndown **PR-3b** — the central scalar-coercion fix, built on #983's `galpy.backend._coerce`. Under the forced-backend all-backend suite, plain numpy/Python scalars leak into strict torch ops (`torch.cos(0.0)` / `torch.sqrt(numpy.float64)` / `numpy.ndarray*Tensor` all raise; jax is permissive). `coerce_coords` already handles *passed* coordinates; this closes the three remaining scalar-leak channels — all guarded so numpy stays byte-identical:

1. **`conversion.py`** `potential_physical_input`: also coerce the `phi`/`t` **signature defaults** (bound via `inspect.signature`) when omitted, **strictly inside** the `xp is not numpy and _check_backend_compatible` guard — so internally-derived scalars (Ferrers `_pa+_omegab*t`, DehnenBar `_smooth(t)`, CosmphiDisk/HenonHeiles/Logarithmic `sin/cos(phi)`, …) see backend tensors.
2. **`backend/_coerce.py`** `promote_scalars`: use `is_backend_array()` (not `hasattr(v,'ndim')`) as the leave-it test, so a `numpy.float64` (has `.ndim` but torch rejects) is promoted.
3. **`backend/_namespaces.py`** `asarray_on_device`: translate a numpy dtype arg to the backend dtype (`torch.asarray(dtype=numpy.float64)` raises) — fixes SpiralArms.

Plus **19 potentials**: move `self._backend_compatible=True` above `self.normalize(...)` in `__init__` (so construction-time `normalize()→Rforce(1.,0.)` is coerced); and **FerrersPotential** axisymmetric phi-reset `0.0 → zeros_like_backend(xp,R)`.

## Impact
Flips **~331 torch `test_potential` ledger entries** to pass (forceAsDeriv / evaluateAndDerivs / 2ndDeriv / poisson / normalize / toVertical_toPlanar, across the potential families). The ledger entries themselves are pruned by the separate ledger-regen PR.

## Byte-identity + review
numpy path **byte-identical** (the whole mechanism is gated on `xp is not numpy`): verified hash-matched Phi/forces/dens across the 19 reordered potentials + Ferrers + planar default-phi paths; 281/281 numpy parity; all 3325 backend unit tests pass. **Independently adversarially reviewed across 4 angles — zero blockers**: byte-identity, the `inspect.signature` default-injection correctness (every signature shape: positional/kwarg/omitted, double-decoration via `@wraps`, DF-skip, `None` defaults, no kwonly/posonly), the 19 `__init__` reorders, and regression (no previously-passing test breaks; deferred cases honestly still ledgered).

## Deferred (separate follow-ups)
- **AnySphericalPotential** — scipy interior; `test_backend_conventions` pins it as the canonical *unmigrated* potential, so it needs a coordinated source+test migration.
- **AnyAxisymmetricRazorThinDiskPotential** — scipy interior.
- **specialSpiralArmsPotential** — a torch float64 FD-precision artifact (the crash is fixed; the force matches numpy to 3.5e-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)