### PR TITLE
orbit/coords: pin the 3D variational dxdv driver's host-side coords to numpy

### DIFF
--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -928,7 +928,7 @@ def integrateFullOrbit_dxdv(
         yo[:, 4],
         yo[:, 5],
     )
-    X, Y, Z = coords.cyl_to_rect(R, phi, z)
+    X, Y, Z = coords.cyl_to_rect(R, phi, z, xp=numpy)
     vX, vY, vZ = coords.cyl_to_rect_vec(vR, vT, vz, phi)
     this_yo = numpy.array([X, Y, Z, vX, vY, vZ]).T
     if not rectIn:
@@ -997,9 +997,17 @@ def integrateFullOrbit_dxdv(
     # Go back to the cylindrical frame: base state out[...,:6] is rectangular
     # (x,y,z,vx,vy,vz); convert to (R,vR,vT,z,vz,phi) and (optionally) the
     # deviation out[...,6:] from rectangular to cylindrical.
-    Rout, phiout, Zout = coords.rect_to_cyl(out[..., 0], out[..., 1], out[..., 2])
+    Rout, phiout, Zout = coords.rect_to_cyl(
+        out[..., 0], out[..., 1], out[..., 2], xp=numpy
+    )
     vRout, vTout, vzout = coords.rect_to_cyl_vec(
-        out[..., 3], out[..., 4], out[..., 5], out[..., 0], out[..., 1], out[..., 2]
+        out[..., 3],
+        out[..., 4],
+        out[..., 5],
+        out[..., 0],
+        out[..., 1],
+        out[..., 2],
+        xp=numpy,
     )
     # rect_to_cyl/rect_to_cyl_vec pass Z/vz through BY REFERENCE, so Zout and
     # vzout are views into out[...,2]/out[...,5]; copy them before the in-place

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1103,7 +1103,7 @@ def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
         return out
 
 
-def rect_to_cyl(X, Y, Z):
+def rect_to_cyl(X, Y, Z, *, xp=None):
     """
     Convert from rectangular to cylindrical coordinates
 
@@ -1115,6 +1115,9 @@ def rect_to_cyl(X, Y, Z):
         Y coordinate.
     Z : float or numpy.ndarray
         Z coordinate.
+    xp : module or str, optional
+        Explicit array-namespace override forwarded to get_namespace (e.g.
+        ``numpy`` to pin host-side bookkeeping regardless of the forced default).
 
     Returns
     -------
@@ -1126,12 +1129,12 @@ def rect_to_cyl(X, Y, Z):
     - 2010-09-24 - Written - Bovy (NYU)
     - 2019-06-21 - Changed such that phi in [-pi,pi] - Bovy (UofT)
     """
-    xp = get_namespace(X, Y, Z)
+    xp = get_namespace(X, Y, Z, xp=xp)
     X, Y, Z = promote_scalars(xp, X, Y, Z)
     return (xp.sqrt(X**2.0 + Y**2.0), xp.arctan2(Y, X), Z)
 
 
-def cyl_to_rect(R, phi, Z):
+def cyl_to_rect(R, phi, Z, *, xp=None):
     """
     Convert from cylindrical to rectangular coordinates
 
@@ -1143,6 +1146,9 @@ def cyl_to_rect(R, phi, Z):
         Cylindrical phi coordinate.
     Z : float or numpy.ndarray
         Cylindrical Z coordinate.
+    xp : module or str, optional
+        Explicit array-namespace override forwarded to get_namespace (e.g.
+        ``numpy`` to pin host-side bookkeeping regardless of the forced default).
 
     Returns
     -------
@@ -1153,7 +1159,7 @@ def cyl_to_rect(R, phi, Z):
     -----
     - 2011-02-23 - Written - Bovy (NYU)
     """
-    xp = get_namespace(R, phi, Z)
+    xp = get_namespace(R, phi, Z, xp=xp)
     R, phi, Z = promote_scalars(xp, R, phi, Z)
     return (R * xp.cos(phi), R * xp.sin(phi), Z)
 
@@ -1574,7 +1580,7 @@ def spher_to_cyl_vec(vr, vT, vtheta, theta):
     return (vR, vT, vz)
 
 
-def rect_to_cyl_vec(vx, vy, vz, X, Y, Z, cyl=False):
+def rect_to_cyl_vec(vx, vy, vz, X, Y, Z, cyl=False, *, xp=None):
     """
     Transform vectors from rectangular to cylindrical coordinates vectors.
 
@@ -1594,6 +1600,10 @@ def rect_to_cyl_vec(vx, vy, vz, X, Y, Z, cyl=False):
         Z-coordinate.
     cyl : bool, optional
         If True, X, Y, Z are already cylindrical (i.e., [X,Y,Z] == [R,phi,Z]), by default False.
+    xp : module or str, optional
+        Explicit array-namespace override forwarded to the internal rect_to_cyl
+        call (e.g. ``numpy`` to pin host-side bookkeeping regardless of the
+        forced default).
 
     Returns
     -------
@@ -1606,7 +1616,7 @@ def rect_to_cyl_vec(vx, vy, vz, X, Y, Z, cyl=False):
 
     """
     if not cyl:
-        R, phi, Z = rect_to_cyl(X, Y, Z)
+        R, phi, Z = rect_to_cyl(X, Y, Z, xp=xp)
     else:
         phi = Y
     vr = +vx * numpy.cos(phi) + vy * numpy.sin(phi)


### PR DESCRIPTION
## What
Burndown **PR-7**. `integrateFullOrbit_dxdv` (the 3D variational/STM driver) builds a pure-numpy base state and converts it via `coords.cyl_to_rect`/`rect_to_cyl`/`rect_to_cyl_vec` around the C integrator. Each does `xp = get_namespace(...)`, which under the forced all-backend harness returns torch even for the numpy data → `torch.cos(numpy_array)` raises. This is host-side numpy bookkeeping, not a backend/autodiff path (the planar twin already uses literal `numpy.cos/sin`).

- Add an **inert `xp=None` keyword** to `coords.cyl_to_rect`/`rect_to_cyl`/`rect_to_cyl_vec` (forwarded to `get_namespace`, which already takes an explicit `xp=` override; `rect_to_cyl_vec` forwards to its internal `rect_to_cyl`).
- Pass `xp=numpy` at the 3 dxdv-driver call sites in `integrateFullOrbit.py`.

## Impact
Flips **37/41 `test_liouville_3d_2d_bridge`** torch entries (the `dop853_c` C path). The remaining 4 + `test_liouville_3d`/`test_dxdv_3d_c_vs_python` need the central scalar-coercion (#987) for their pure-Python `_EOM_dxdv` force eval (and one test-side coords call) — they flip once #987 lands.

## Byte-identity + review
The `xp=None` default is **inert** for every existing caller, so numpy AND data-first jax/torch dispatch are unchanged. Verified byte-identical: coords + dxdv-driver output hashes identical parent vs branch; `test_coords.py` 97/97 and the orbit liouville/dxdv slice 288/3 identical. **Adversarially reviewed (4 angles, all refuted)** — including a full audit of every caller of these widely-used coords functions (no positional-arg collisions with the keyword-only boundary), the load-bearing-and-complete numpy-pin, and no decorator interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)