### PR TITLE
potential/backend: anchor construction-time scalar phi to float64 in EllipsoidalPotential

### DIFF
--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -28,12 +28,21 @@ def _anchor_phi(phi, R, xp):
     passed a backend array. torch's ``cos``/``sin`` only accept tensors, so
     such scalars are anchored as ``xp.asarray(phi, dtype=R.dtype)`` (input-
     dtype anchoring, so float32 inputs are not promoted through the backend's
-    default dtype). The numpy path returns ``phi`` untouched (byte-identical),
-    as do already-backend ``phi`` arrays (no silent cast/detach of user
-    tensors, which would break autodiff w.r.t. ``phi``)."""
+    default dtype). When ``R`` carries no dtype (a plain python scalar -- e.g.
+    the un-coerced ``Rforce(1.,0.)`` that ``normalize()`` issues from within
+    ``__init__``, before the backend-compat flag is set so the input boundary
+    does not lift the coordinates), ``phi`` is anchored to ``xp.float64``
+    (galpy's interior precision) rather than the backend default (torch's
+    float32), so the resulting amplitude does not silently drop to float32. The
+    numpy path returns ``phi`` untouched (byte-identical), as do already-backend
+    ``phi`` arrays (no silent cast/detach of user tensors, which would break
+    autodiff w.r.t. ``phi``)."""
     if xp is numpy or is_backend_array(phi):
         return phi
-    return xp.asarray(phi, dtype=getattr(R, "dtype", None))
+    dtype = getattr(R, "dtype", None)
+    if dtype is None:
+        dtype = xp.float64
+    return xp.asarray(phi, dtype=dtype)
 
 
 class EllipsoidalPotential(Potential):

--- a/tests/test_backend_ellipsoidal.py
+++ b/tests/test_backend_ellipsoidal.py
@@ -486,6 +486,45 @@ def test_mixed_backend_Rz_float_phi_t(backend_name, pot, method):
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
+# normalize() does ``numpy.fabs(self.Rforce(1., 0.))`` and ``Rforce`` here returns
+# a torch tensor; ``numpy.fabs(<torch tensor>)`` raises numpy 2.0's __array_wrap__
+# DeprecationWarning (-W error in CI). That wart is pre-existing and orthogonal to
+# the float64-amp anchoring under test, so it is ignored here (not masked globally).
+@pytest.mark.filterwarnings(
+    "ignore:__array_wrap__ must accept context:DeprecationWarning"
+)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_construct_normalize_amp_is_float64(backend_name):
+    # During __init__, normalize() issues Rforce(1., 0.) with plain python
+    # scalars BEFORE _backend_compatible is set, so the input boundary does not
+    # coerce them; under a forced backend the resolved namespace is the backend's
+    # and _anchor_phi sees a dtype-less scalar R. It must anchor the scalar phi to
+    # galpy's interior float64 -- not e.g. torch's float32 default -- so the
+    # computed _amp (and hence every later float64-coordinate evaluation) stays
+    # float64. Regression for the 6 oblate/prolate/triaxial Hernquist & Jaffe
+    # amp_mult_divide torch failures (the amplitude silently dropped to float32).
+    import galpy.backend
+
+    prev = None
+    if backend_name == "torch":
+        # Reproduce the CI torch job, which (unlike jax's x64) sets no float64
+        # default -- so a bare asarray of the scalar phi would land on float32.
+        prev = torch.get_default_dtype()
+        torch.set_default_dtype(torch.float32)
+    try:
+        with galpy.backend.use(backend_name, force=True):
+            pot = TriaxialHernquistPotential(
+                amp=1.3, a=1.5, b=0.9, c=0.7, normalize=1.0
+            )
+    finally:
+        if prev is not None:
+            torch.set_default_dtype(prev)
+    assert "float64" in str(getattr(pot._amp, "dtype", "")), (
+        f"{backend_name}: normalize() produced a non-float64 _amp "
+        f"({getattr(pot._amp, 'dtype', None)})"
+    )
+
+
 def test_evaluate_xyz_namespace_fallback():
     # _evaluate_xyz infers the backend from its (x,y,z) arguments when called
     # without an explicit ``xp`` (the public _evaluate always passes one, so this


### PR DESCRIPTION
## What

Anchor a construction-time python-scalar `phi` to `float64` in `EllipsoidalPotential._anchor_phi`.

During `__init__`, `normalize()` calls `Rforce(1., 0.)` with plain python scalars **before** `_backend_compatible` is set, so the `@potential_physical_input` boundary does not coerce them. Under a forced non-numpy backend `_anchor_phi` then saw a dtype-less scalar `R` and fell back to `xp.asarray(phi, dtype=None)` — which on torch (whose CI jobs keep the float32 default, unlike jax's x64) produced a **float32** `phi`, dropping the computed `_amp` to float32 and silently losing precision in every later float64-coordinate evaluation.

The fix: when `R` carries no dtype, anchor `phi` to `xp.float64` (galpy's interior precision).

```python
 if xp is numpy or is_backend_array(phi):
     return phi
-return xp.asarray(phi, dtype=getattr(R, "dtype", None))
+dtype = getattr(R, "dtype", None)
+if dtype is None:
+    dtype = xp.float64
+return xp.asarray(phi, dtype=dtype)
```

## Result

Fixes the **6** oblate/prolate/triaxial Hernquist & Jaffe `test_amp_mult_divide` torch failures (baseline residuals ~1e-7, i.e. float32-magnitude, vs the 1e-10 tolerance). They flip xfail→XPASS (ledger stays green via `strict=False`; the stale entries are pruned in the separate ledger-regen PR, not here).

## Safety (adversarially reviewed, CPU-forced)

- **numpy byte-identical** — the `xp is numpy` guard short-circuits before any new code; verified max abs diff `0.0` over a full evaluate/forces/2nd-deriv grid.
- **exit-cast policy preserved** — a genuine float32 `R` array still anchors `phi` to float32 (the `dtype is None` branch is only taken for a dtype-less scalar).
- **autodiff w.r.t. `phi` untouched** — a real backend `phi` array returns via the `is_backend_array` short-circuit (no cast/detach).
- jax unaffected (x64 already gives float64); no regressions across numpy/jax/torch in `test_backend_ellipsoidal.py` (687 passed).
- New test `test_construct_normalize_amp_is_float64` reproduces the CI torch float32-default condition and pins the construction-time `_amp` to float64 (fails on baseline, passes with the fix). It also covers the new branch under the coverage-uploading `test_backend*` shard.

## Notes / divergences

- Investigated under "stabilize the GL sum order", but the Gauss-Legendre quadrature was **provably not** the cause (vectorizing `_potInt` left the tests failing). The fix is a one-spot dtype anchor — the branch was renamed off `gl-stabilize` to reflect that.
- **Follow-up (separate PR):** the Ellipsoidal subclasses (PerfectEllipsoid, TwoPowerTriaxial/TriaxialHernquist/TriaxialJaffe, TriaxialGaussian, PowerTriaxial) still set `_backend_compatible=True` **after** `normalize()`, unlike the ~10 potentials #960 reordered (only TriaxialNFW was reordered). Reordering them is the root-cause cleanup; this guard is the correct, byte-identical, independently-defensible boundary fix and keeps the branch covered.
- `triaxialLogarithmicHaloPotential` / `mockRotatedAndTiltedTriaxialLogHaloPotential` torch entries are **out of scope** — LogarithmicHaloPotential is not an EllipsoidalPotential subclass (already #960-reordered; any residual float32 there is a different mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
