### PR TITLE
potential/backend: coerce scalar coords for backend-compatible scalar-only methods

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -23,7 +23,7 @@ import numpy
 from packaging.version import Version
 from scipy import integrate, optimize
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import coerce_coords, get_namespace, is_backend_array
 from ..util import conversion, coords, galpyWarning, plot
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -74,6 +74,19 @@ def check_potential_inputs_not_arrays(func):
             raise TypeError(
                 f"Methods in {self.__class__.__name__} do not accept array inputs. Please input scalars"
             )
+        # Migrated scalar-only methods still do real backend arithmetic on the
+        # coordinates (xp.cos/sin/isinf/...), which torch rejects on a plain
+        # python float under a forced backend. Bring R, z, phi onto the active
+        # backend -- but ONLY for backend-compatible potentials, mirroring the
+        # ``potential_physical_input`` gate: an unmigrated potential (e.g.
+        # AnyAxisymmetricRazorThinDisk) keeps bare-numpy/scipy internals that
+        # reject backend arrays, so it must stay on numpy. ``t`` is left
+        # untouched (it may be used as a hashable cache key downstream). The
+        # numpy path is byte-identical regardless (coerce_coords is an
+        # object-identical pass-through when ``xp is numpy``).
+        if getattr(self, "_backend_compatible", False):
+            xp = get_namespace(R, z, phi)
+            R, z, phi = coerce_coords(xp, R, z, phi)
         return func(self, R, z, phi, t)
 
     # Marker so the mass() numerical-integration dispatch can tell that this

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -217,3 +217,22 @@ def test_coerce_coords_branches(backend):
     else:  # torch float32 tensor
         (R32_o,) = coerce_coords(xp, torch.tensor([1.0, 2.0], dtype=torch.float32))
         assert "float32" in str(R32_o.dtype)
+
+
+@pytest.mark.parametrize("backend", [b for b in _NS if b != "numpy"])
+def test_scalar_only_gate_spares_unmigrated_potential(backend):
+    # The check_potential_inputs_not_arrays decorator coerces R, z, phi onto the
+    # active backend ONLY for _backend_compatible potentials. An UNMIGRATED
+    # scalar-only potential (AnyAxisymmetricRazorThinDiskPotential: bare
+    # scipy.integrate.quad / numpy internals) must keep its plain python-float
+    # inputs even under a forced backend, or those internals crash ("'<' not
+    # supported between numpy.ndarray and Tensor"). Regression guard for the
+    # decorator's _backend_compatible gate.
+    import galpy.backend
+
+    pot = potential.AnyAxisymmetricRazorThinDiskPotential(normalize=1.0)
+    assert potential._check_backend_compatible(pot) is False
+    ref = float(pot._evaluate(0.9, 0.1, 0.0, 0.0))
+    with galpy.backend.use(backend, force=True):
+        got = float(pot._evaluate(0.9, 0.1, 0.0, 0.0))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=0.0)

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -533,3 +533,29 @@ def test_rotateandtilt_Rinf(backend_name, pot):
             )(jnp.asarray(1.1))
         )
         assert numpy.isfinite(g)
+
+
+# --- scalar-only methods accept plain python floats under a forced backend ----
+# The @check_potential_inputs_not_arrays methods do real backend arithmetic on
+# the coordinates (xp.isinf/cos/sin/...); a plain python float reaching them
+# under a forced backend used to crash torch ("isinf(): argument 'input' ... must
+# be Tensor, not float"). The decorator now coerces R, z, phi onto the active
+# backend. Pass plain python floats (NOT pre-made backend arrays) so the decorator
+# coercion -- not the caller -- is what brings them onto the backend.
+@pytest.mark.parametrize(
+    "method", ["_evaluate", "_Rforce", "_zforce", "_phitorque", "_dens"]
+)
+@pytest.mark.parametrize(
+    "pot",
+    [w[1] for w in _WRAPPERS if w[0].startswith("RotateAndTilt")],
+    ids=[w[0] for w in _WRAPPERS if w[0].startswith("RotateAndTilt")],
+)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scalar_only_python_float_inputs_forced_backend(backend_name, pot, method):
+    from galpy import backend
+
+    R, z, phi = 0.75, 0.2, 1.76
+    ref = float(getattr(pot, method)(R, z, phi=phi, t=0.0))
+    with backend.use(backend_name, force=True):
+        got = getattr(pot, method)(R, z, phi=phi, t=0.0)  # floats -> decorator coerces
+    numpy.testing.assert_allclose(float(got), ref, rtol=1e-12, atol=1e-14)


### PR DESCRIPTION
## What

Coerce scalar coordinates onto the active backend inside `check_potential_inputs_not_arrays`, for `_backend_compatible` potentials only.

The scalar-only compute methods of migrated potentials (`RotateAndTiltWrapperPotential`, `DoubleExponentialDiskPotential`) still do real backend arithmetic on their coordinates — `xp.isinf(R)`, `xp.cos(phi)`, `xp.sin(phi)` — which torch rejects on a plain python float under a forced backend:

```
TypeError: isinf(): argument 'input' (position 1) must be Tensor, not float
   at RotateAndTiltWrapperPotential.py:174  (Rinf = xp.isinf(R))
```

This was the root cause of the `mockRotatedAndTilted*` `test_amp_mult_divide` torch failures (the wrapper's `normalize()` and `_evaluate` reach the scalar-only methods with python-float `R/z/phi`).

```python
 if (... array-shape check ...):
     raise TypeError(...)
+if getattr(self, "_backend_compatible", False):
+    xp = get_namespace(R, z, phi)
+    R, z, phi = coerce_coords(xp, R, z, phi)
 return func(self, R, z, phi, t)
```

## The gate (caught by adversarial review)

An earlier *unconditional* version of this coercion regressed the **unmigrated** `AnyAxisymmetricRazorThinDiskPotential` — its bare `scipy.integrate.quad` / numpy internals reject a 0-d tensor (`'<' not supported between numpy.ndarray and Tensor`), turning ~9 currently-green forced-torch tests red. The fix mirrors the existing `potential_physical_input` gate (`conversion.py`: `if xp is not numpy and _check_backend_compatible(Pot)`): **only coerce for `_backend_compatible` potentials**, so unmigrated scalar-only potentials keep their python-float inputs. `t` is left uncoerced (it may be a hashable cache key downstream).

## Result

- Flips the RotateAndTilt-wrapped `test_amp_mult_divide` torch entries: `mockRotatedAndTiltedMWP14WrapperPotential[wInclination]` standalone; the `TriaxialLogHalo`-wrapped one composes with #987's phi-default coercion (all 4 pass on `feat/backends`+#987).
- **numpy byte-identical**: `coerce_coords` is an object-identical pass-through when `xp is numpy`, and the gate skips it entirely for unmigrated potentials.
- No regression: `test_backend_disk.py`+`test_backend_diskexpansion.py` (DoubleExp) 331✓, `test_backend_wrappers.py` 480✓, AnyAxiRazorThin forced-torch restored to baseline (the one ledgered `test_normalize_potential` xfail unchanged).
- Ledger untouched (flipped entries become XPASS, green via `strict=False`; pruned in the separate ledger-regen PR).

## Tests

- `test_scalar_only_python_float_inputs_forced_backend` (test_backend_wrappers.py): passes **plain python floats** to RotateAndTilt's `_evaluate/_Rforce/_zforce/_phitorque/_dens` under a forced backend, so the *decorator* coercion is what's under test. Fails at the `isinf` line without the fix.
- `test_scalar_only_gate_spares_unmigrated_potential` (test_backend_conventions.py): asserts `AnyAxisymmetricRazorThinDiskPotential` (not `_backend_compatible`) still evaluates under a forced backend — the regression guard for the gate.

The new coercion lines run on the numpy path too (pass-through), so they are covered by existing numpy tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
