### PR TITLE
potential/backend: anchor scalar coordinates in migrated analytic/disk compute methods

### DIFF
--- a/galpy/potential/EllipticalDiskPotential.py
+++ b/galpy/potential/EllipticalDiskPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -119,6 +119,7 @@ class EllipticalDiskPotential(planarPotential):
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             smooth * self._twophio / 2.0 * R**self._p * xp.cos(2.0 * (phi - self._phib))
@@ -126,6 +127,7 @@ class EllipticalDiskPotential(planarPotential):
 
     def _Rforce(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             -smooth
@@ -138,11 +140,13 @@ class EllipticalDiskPotential(planarPotential):
 
     def _phitorque(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return smooth * self._twophio * R**self._p * xp.sin(2.0 * (phi - self._phib))
 
     def _R2deriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             smooth
@@ -156,6 +160,7 @@ class EllipticalDiskPotential(planarPotential):
 
     def _phi2deriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             -2.0
@@ -167,6 +172,7 @@ class EllipticalDiskPotential(planarPotential):
 
     def _Rphideriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             -smooth

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -7,7 +7,7 @@ import copy
 import numpy
 from scipy import integrate
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend.special import logsumexp
 from .Potential import Potential
 
@@ -147,24 +147,51 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         # (get_namespace), so they run under numpy (byte-identical: the numpy
         # namespace IS the numpy module), jax, and torch.
         stype = Sigma.get("type", "exp")
+        # These closures are also called directly with numpy/python R (e.g. by
+        # the Sigma-derivative tests) while the resolved namespace is a forced
+        # backend, so coerce_coords R onto that backend before xp.exp(R); the
+        # numpy pass-through keeps the numpy path byte-identical.
         if stype == "exp" and not "Rhole" in Sigma:
             rd = Sigma.get("h", 1.0 / 3.0)
             ta = Sigma.get("amp", 1.0)
-            ts = lambda R, trd=rd: get_namespace(R).exp(-R / trd)
-            tds = lambda R, trd=rd: -get_namespace(R).exp(-R / trd) / trd
-            td2s = lambda R, trd=rd: get_namespace(R).exp(-R / trd) / trd**2.0
+
+            def ts(R, trd=rd):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return xp.exp(-R / trd)
+
+            def tds(R, trd=rd):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return -xp.exp(-R / trd) / trd
+
+            def td2s(R, trd=rd):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return xp.exp(-R / trd) / trd**2.0
+
         elif stype == "expwhole" or (stype == "exp" and "Rhole" in Sigma):
             rd = Sigma.get("h", 1.0 / 3.0)
             rm = Sigma.get("Rhole", 0.5)
             ta = Sigma.get("amp", 1.0)
-            ts = lambda R, trd=rd, trm=rm: get_namespace(R).exp(-trm / R - R / trd)
-            tds = lambda R, trd=rd, trm=rm: (
-                (trm / R**2.0 - 1.0 / trd) * get_namespace(R).exp(-trm / R - R / trd)
-            )
-            td2s = lambda R, trd=rd, trm=rm: (
-                ((trm / R**2.0 - 1.0 / trd) ** 2.0 - 2.0 * trm / R**3.0)
-                * get_namespace(R).exp(-trm / R - R / trd)
-            )
+
+            def ts(R, trd=rd, trm=rm):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return xp.exp(-trm / R - R / trd)
+
+            def tds(R, trd=rd, trm=rm):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return (trm / R**2.0 - 1.0 / trd) * xp.exp(-trm / R - R / trd)
+
+            def td2s(R, trd=rd, trm=rm):
+                xp = get_namespace(R)
+                (R,) = coerce_coords(xp, R)
+                return (
+                    (trm / R**2.0 - 1.0 / trd) ** 2.0 - 2.0 * trm / R**3.0
+                ) * xp.exp(-trm / R - R / trd)
+
         return (ta, ts, tds, td2s)
 
     def _parse_hz(self, hz, Hz, dHzdz):
@@ -214,20 +241,27 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         # bit-for-bit on real floats, xp.stack of same-shape inputs ==
         # numpy.array of that list, and galpy.backend.special.logsumexp routes
         # numpy to scipy.special.logsumexp -- so the numpy path is unchanged.
+        # As in _parse_Sigma_dict_indiv, these closures are also called directly
+        # with numpy/python z while the resolved namespace is a forced backend,
+        # so coerce_coords z onto that backend before xp.abs/exp/sign(z); the
+        # numpy pass-through keeps the numpy path byte-identical.
         htype = hz.get("type", "exp")
         if htype == "exp":
             zd = hz.get("h", 0.0375)
 
             def th(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return 1.0 / 2.0 / tzd * xp.exp(-xp.abs(z) / tzd)
 
             def tH(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return (xp.exp(-xp.abs(z) / tzd) - 1.0 + xp.abs(z) / tzd) * tzd / 2.0
 
             def tdH(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return 0.5 * xp.sign(z) * (1.0 - xp.exp(-xp.abs(z) / tzd))
 
         elif htype == "sech2":
@@ -236,6 +270,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             # th/tH written so as to avoid overflow in cosh
             def th(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return (
                     xp.exp(
                         -logsumexp(
@@ -250,6 +285,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
             def tH(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return tzd * (
                     logsumexp(xp.stack([z / 2.0 / tzd, -z / 2.0 / tzd]), axis=0)
                     - numpy.log(2.0)
@@ -257,6 +293,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
             def tdH(z, tzd=zd):
                 xp = get_namespace(z)
+                (z,) = coerce_coords(xp, z)
                 return xp.tanh(z / 2.0 / tzd) / 2.0
 
         return (th, tH, tdH)
@@ -265,6 +302,10 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
         # Here and below: out-of-place accumulation (out = out + ...) instead of
         # += so torch autograd never sees an in-place op; identical numpy values.
         xp = get_namespace(R, z)
+        # Coerce R/z onto the active backend so xp.sqrt and the Sigma/hz closures
+        # (xp.exp/xp.abs(...)) receive backend arrays, not numpy/python; numpy
+        # pass-through keeps this byte-identical.
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me(R, z, phi=phi, t=t, use_physical=False)
         for a, s, H in zip(self._Sigma_amp, self._Sigma, self._Hz):
@@ -273,6 +314,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _Rforce(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rforce(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, H in zip(self._Sigma_amp, self._dSigmadR, self._Hz):
@@ -281,6 +323,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _zforce(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.zforce(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, H, dH in zip(
@@ -294,6 +337,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.R2deriv(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, d2s, H in zip(
@@ -311,6 +355,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.z2deriv(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(
@@ -336,6 +381,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rzderiv(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, d2s, H, dH in zip(
@@ -354,6 +400,7 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.dens(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(
@@ -395,6 +442,7 @@ def phiME_dens(R, z, phi, dens, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz, Sigm
     """The density corresponding to phi_ME (backend-agnostic provided that the
     user-supplied ``dens`` callable accepts backend arrays)"""
     xp = get_namespace(R, z)
+    R, z = coerce_coords(xp, R, z)
     r = xp.sqrt(R**2.0 + z**2.0)
     out = dens(R, z, phi)
     for a, s, ds, d2s, h, H, dH in zip(

--- a/galpy/potential/PowerSphericalPotential.py
+++ b/galpy/potential/PowerSphericalPotential.py
@@ -11,7 +11,7 @@ import math
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -89,6 +89,7 @@ class PowerSphericalPotential(Potential):
         - Started: 2010-07-10 by Bovy (NYU)
         """
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         if self.alpha == 2.0:
             return xp.log(r2) / 2.0
@@ -281,6 +282,7 @@ class PowerSphericalPotential(Potential):
         - 2013-01-09 - Written - Bovy (IAS)
         """
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (3.0 - self.alpha) / 4.0 / math.pi / r**self.alpha
 

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -8,7 +8,7 @@
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend.special import gamma as _gamma
 from ..backend.special import gammainc as _gammainc
 from ..util import conversion
@@ -78,6 +78,7 @@ class PowerSphericalPotentialwCutoff(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         # guard r=0 in the dead branch (the 1/r term -> 0/0=NaN there) so the
         # xp.where stays finite under autodiff/jit; the value at r=0 is 0.
@@ -115,16 +116,19 @@ class PowerSphericalPotentialwCutoff(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R * R + z * z)
         return self._rforce(r) * R / r
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R * R + z * z)
         return self._rforce(r) * z / r
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R * R + z * z)
         return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
@@ -132,6 +136,7 @@ class PowerSphericalPotentialwCutoff(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R * R + z * z)
         return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
@@ -139,6 +144,7 @@ class PowerSphericalPotentialwCutoff(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R * R + z * z)
         return (
             R
@@ -224,6 +230,7 @@ class PowerSphericalPotentialwCutoff(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return 1.0 / r**self.alpha * xp.exp(-((r / self.rc) ** 2.0))
 

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -10,7 +10,7 @@ import math
 
 import numpy
 
-from ..backend import asarray_on_device, device_of, get_namespace
+from ..backend import asarray_on_device, coerce_coords, device_of, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -122,6 +122,7 @@ class SpiralArmsPotential(Potential):
 
     def _evaluate(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -143,6 +144,7 @@ class SpiralArmsPotential(Potential):
 
     def _Rforce(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         He = self._H * xp.exp(-(R - self._r_ref) / self._Rs)
@@ -186,6 +188,7 @@ class SpiralArmsPotential(Potential):
 
     def _zforce(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -208,6 +211,7 @@ class SpiralArmsPotential(Potential):
 
     def _phitorque(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -232,6 +236,7 @@ class SpiralArmsPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Rs = self._Rs
@@ -411,6 +416,7 @@ class SpiralArmsPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -436,6 +442,7 @@ class SpiralArmsPotential(Potential):
 
     def _phi2deriv(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -460,6 +467,7 @@ class SpiralArmsPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Rs = self._Rs
@@ -517,6 +525,7 @@ class SpiralArmsPotential(Potential):
 
     def _Rphideriv(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         He = self._H * xp.exp(-(R - self._r_ref) / self._Rs)
@@ -564,6 +573,7 @@ class SpiralArmsPotential(Potential):
 
     def _phizderiv(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -588,6 +598,7 @@ class SpiralArmsPotential(Potential):
 
     def _dens(self, R, z, phi=0, t=0):
         xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)


### PR DESCRIPTION
## What

Anchor scalar/numpy coordinate operands onto the active backend at the start of the migrated compute methods of 5 potentials (`SpiralArmsPotential`, `EllipticalDiskPotential`, `KuijkenDubinskiDiskExpansionPotential`, `PowerSphericalPotential`, `PowerSphericalPotentialwCutoff`), via the established per-method `coerce_coords` convention (the same one `EllipsoidalPotential._anchor_phi` uses).

These methods feed coordinates straight to `xp.<fn>` (`cos`/`sin`/`exp`/`sqrt`/`log`/`abs`/`sign`), which torch rejects on a `python-float` / `numpy.float64` / `numpy.ndarray`. #990's `potential_physical_input` boundary coercion covers the public array-evaluation path for backend-compatible potentials, but it is **bypassed** by:
- direct private-method calls (the `test_2ndDeriv` / `test_forceAsDeriv` numerical-derivative path through undecorated mock wrappers),
- the internal axisymmetric `phi = 0` reset (`mockFlatEllipticalDisk`),
- parameter/`t` forwarding (`kuijkendubinski_t_forwarding`).

## Result — 6 genuine torch reds flipped

```
test_2ndDeriv_potential[CorotatingRotation3DSpiralArmsPotential]
test_forceAsDeriv_potential[CorotatingRotation3DSpiralArmsPotential]
test_2ndDeriv_potential[mockFlatEllipticalDiskPotential]
test_amp_mult_divide[mockFlatEllipticalDiskPotential]
test_forceAsDeriv_potential[mockFlatEllipticalDiskPotential]
test_kuijkendubinski_t_forwarding
```
(verified fail-without / pass-with under forced torch, regen mode.)

`PowerSpherical` / `PowerSphericalwCutoff` flip **no** currently-red entry — #990's boundary masks their direct-compute-method gap — but they were migrated before this convention existed, so they're brought to **per-method `coerce_coords` parity** (byte-identical; closes the latent direct-call torch gap). Honest defense-in-depth, not a red-flip.

## Safety (adversarially reviewed — two independent passes)

- **numpy byte-identical** — `coerce_coords` is an object-identical pass-through when `xp is numpy`; verified identical SHA-256 output hashes across all 5 families (incl. the KuijkenDubinski lambda→def closure conversion, which is behaviorally identical).
- **jax value-identical** — worst diff `3.95e-14` across the 5 families.
- **Coverage** — the new `coerce_coords` lines execute on the numpy `test_potential` path (build.yml numpy jobs, coverage-uploaded); no backend-only line.
- **Altitude** — per-method is correct: the bypass is the mock/direct-private layer, not a galpy mixin; there is no shared choke point for these 5 potentials.
- No ledger change (the 6 become XPASS, green via `strict=False`; pruned in the separate ledger-regen PR).

File-disjoint from #991 (`_coerce.py`/`_namespaces.py`). Base is current feat/backends (#990).

## Out of scope (separate follow-ups the review surfaced)

- `expwholeDiskMultipoleExpansionPotential` 2ndDeriv — a construction-time `numpy.ndarray * Tensor` in `MultipoleExpansionPotential.from_density` (#75-adjacent).
- `specialSpiralArmsPotential` 2ndDeriv — a torch finite-difference precision mismatch, not a scalar crash.
- The larger `_backend_compatible` mock-bypass cluster (DehnenBar / Ferrers / SoftenedNeedleBar / …) — same vector, each needs its own per-method audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
