### PR TITLE
Fix numpy 2.5.0 compatibility (eig/eigvals complex + chararray deprecation)

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -41,6 +41,18 @@ _USEINTERP = True
 _USESIMPLE = True
 # cast a wide net
 _TWOPIWRAPS = numpy.arange(-4, 5) * 2.0 * numpy.pi
+
+
+def _real_eig(a):
+    # numpy>=2.5 returns a complex result from numpy.linalg.eig even for input
+    # with real eigenvalues (e.g. the symmetric dO/dJ = d^2H/dJ^2 and covariance
+    # matrices used here); return the real part so the downstream real-valued
+    # math (fabs/sqrt/argsort) works. No-op (byte-identical) on numpy<2.5, where
+    # eig already returns real arrays for these inputs.
+    w, v = numpy.linalg.eig(a)
+    return numpy.real(w), numpy.real(v)
+
+
 _labelDict = {
     "x": r"$X$",
     "y": r"$Y$",
@@ -316,7 +328,7 @@ class streamdf(df):
                 self._progenitor.vxvv[0], self._aA, dxv=None, dOdJ=True, _initacfs=acfs
             )
         self._dOdJpInv = numpy.linalg.inv(self._dOdJp)
-        self._dOdJpEig = numpy.linalg.eig(self._dOdJp)
+        self._dOdJpEig = _real_eig(self._dOdJp)
         return None
 
     def _offset_setup(self, sigangle, leading, deltaAngleTrack):
@@ -335,7 +347,7 @@ class streamdf(df):
             self._dOdJp, numpy.dot(self._sigjmatrix, self._dOdJp.T)
         )
         # Estimate angle spread as the ratio of the largest to the middle eigenvalue
-        self._sigomatrixEig = numpy.linalg.eig(self._sigomatrix)
+        self._sigomatrixEig = _real_eig(self._sigomatrix)
         self._sigomatrixEigsortIndx = numpy.argsort(self._sigomatrixEig[0])
         self._sortedSigOEig = sorted(self._sigomatrixEig[0])
         if sigangle is None:
@@ -1040,7 +1052,7 @@ class streamdf(df):
             out = numpy.empty((self._nTrackChunks, 2))
             eigDir = numpy.array([1.0, 0.0])
             for ii in range(self._nTrackChunks):
-                covEig = numpy.linalg.eig(cov[ii])
+                covEig = _real_eig(cov[ii])
                 minIndx = numpy.argmin(covEig[0])
                 minEigvec = covEig[1][
                     :, minIndx
@@ -1056,7 +1068,7 @@ class streamdf(df):
             allEigvec = numpy.empty((self._nTrackChunks, 2))
             eigDir = numpy.array([1.0, 0.0])
             for ii in range(self._nTrackChunks):
-                covEig = numpy.linalg.eig(cov[ii])
+                covEig = _real_eig(cov[ii])
                 minIndx = numpy.argmin(covEig[0])
                 minEigvec = covEig[1][
                     :, minIndx
@@ -1557,7 +1569,7 @@ class streamdf(df):
         for ii in range(nC):
             tjac = coords.cyl_to_rect_jac(*self._ObsTrack[ii])
             allErrCovsXY[ii] = numpy.dot(tjac, numpy.dot(chunk_covs[ii], tjac.T))
-            teig = numpy.linalg.eig(allErrCovsXY[ii])
+            teig = _real_eig(allErrCovsXY[ii])
             sortIndx = numpy.argsort(teig[0])
             eigvals[ii] = teig[0][sortIndx]
             # Keep eigenvectors continuous along the stream by sign-aligning
@@ -1660,7 +1672,7 @@ class streamdf(df):
                 tjac, numpy.dot(self._allErrCovsXY[ii], tjac.T)
             )
             # Eigen decomposition for interpolation
-            teig = numpy.linalg.eig(allErrCovsLB[ii])
+            teig = _real_eig(allErrCovsLB[ii])
             # Sort them to match them up later
             sortIndx = numpy.argsort(teig[0])
             allErrCovsEigvalLB[ii] = teig[0][sortIndx]

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -921,7 +921,9 @@ class Orbit:
                 zo=obs[2],
                 solarmotion=obs[3],
             )
-        out._name = numpy.asarray(name)
+        # ndmin=1 matches numpy.char.array's scalar->1-d promotion (name may be a
+        # single string), so the name property's shape_wrapper indexing still works.
+        out._name = numpy.array(name, ndmin=1)
         return out
 
     @property

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -359,7 +359,7 @@ class Orbit:
         if vxvv is None:  # Assume one wants the Sun
             vxvv = numpy.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
             radec = True
-            self._name = numpy.char.array(["Sun"])
+            self._name = numpy.array(["Sun"])
         elif isinstance(vxvv, (list, tuple)):
             # Robust way to check for None in case of a list of arrays (None in
             # doesn't work then for some reason)
@@ -921,7 +921,7 @@ class Orbit:
                 zo=obs[2],
                 solarmotion=obs[3],
             )
-        out._name = numpy.char.array(name)
+        out._name = numpy.asarray(name)
         return out
 
     @property

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -1835,7 +1835,9 @@ class Potential(Force):
         tzz = z2deriv
         tij = -numpy.array([[txx, txy, txz], [tyx, tyy, tyz], [tzx, tzy, tzz]])
         if eigenval:
-            return numpy.linalg.eigvals(tij)
+            # numpy>=2.5 returns complex from eigvals even for this symmetric
+            # (real-eigenvalue) tidal tensor; take the real part (no-op on numpy<2.5).
+            return numpy.real(numpy.linalg.eigvals(tij))
         else:
             return tij
 
@@ -4348,7 +4350,9 @@ def ttensor(Pot, R, z, phi=0.0, t=0.0, eigenval=False):
     tzz = z2deriv
     tij = -numpy.array([[txx, txy, txz], [tyx, tyy, tyz], [tzx, tzy, tzz]])
     if eigenval:
-        return numpy.linalg.eigvals(tij)
+        # numpy>=2.5 returns complex from eigvals even for this symmetric
+        # (real-eigenvalue) tidal tensor; take the real part (no-op on numpy<2.5).
+        return numpy.real(numpy.linalg.eigvals(tij))
     else:
         return tij
 

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -8896,12 +8896,12 @@ def test_from_name_name():
     assert Orbit.from_name("LMC").name == "LMC", (
         "Orbit.from_name does not appear to set the name attribute correctly"
     )
-    assert numpy.char.equal(Orbit.from_name(["LMC"]).name, numpy.char.array("LMC")), (
+    assert numpy.char.equal(Orbit.from_name(["LMC"]).name, numpy.array("LMC")), (
         "Orbit.from_name does not appear to set the name attribute correctly"
     )
     assert numpy.all(
         numpy.char.equal(
-            Orbit.from_name(["LMC", "SMC"]).name, numpy.char.array(["LMC", "SMC"])
+            Orbit.from_name(["LMC", "SMC"]).name, numpy.array(["LMC", "SMC"])
         )
     ), "Orbit.from_name does not appear to set the name attribute correctly"
     # Also slice
@@ -8911,7 +8911,7 @@ def test_from_name_name():
     assert numpy.all(
         numpy.char.equal(
             Orbit.from_name(["LMC", "SMC", "Fornax"])[:2].name,
-            numpy.char.array(["LMC", "SMC"]),
+            numpy.array(["LMC", "SMC"]),
         )
     ), "Orbit.from_name does not appear to set the name attribute correctly"
     return None


### PR DESCRIPTION
## What

numpy **2.5.0** (released 2026-06-21 20:56 UTC) broke galpy CI **repo-wide** (numpy build jobs, notebooks, and the backend shards across every open PR / `feat/backends` / `main`). The galpy code is byte-identical to the last green run; only numpy changed (2.4.6 → 2.5.0). Two upstream changes, both fixed here. **Byte-identical on numpy <2.5.**

### 1. `numpy.linalg.eig`/`eigvals` now return **complex** even for real (symmetric) input
numpy 2.5 returns `complex128` eigenvalues/vectors even when they are real, so downstream `fabs`/`sqrt`/`argsort` raised `TypeError` / `_UFuncOutputCastingError`:
- **`Potential.ttensor`** (method + module function): `numpy.real(eigvals(tij))` of the symmetric tidal tensor.
- **`streamdf`**: new `_real_eig()` helper (`numpy.real` of both outputs) at the 6 `numpy.linalg.eig` sites (`dO/dJ = d²H/dJ²` and covariance matrices — all symmetric, real eigenvalues). Also fixes **streamgapdf** (builds on streamdf setup).

`numpy.real` is a no-op on the real arrays numpy<2.5 returned → numpy<2.5 path unchanged.

### 2. `numpy.char.array` deprecated (→ `chararray`)
Under the suite's `-W error` this failed **every named Orbit**. `Orbits.py` built `Orbit._name` via `numpy.char.array(...)`; replaced with a plain string ndarray (`numpy.array`/`asarray`). `_name` is only stored / indexed / returned, so behavior is unchanged.

## Verification
Per-file under numpy 2.5.0 (matching CI shard isolation): **test_potential 1201 passed**, **test_quantity 239 passed**, **test_streamgapdf 30 passed**, conversion / coords / jeans / dynamfric green. Residual local failures are environment-only (astroquery not installed; the Torus C library absent from the single-ext build) — neither a numpy issue.

Merging this to `main` unblocks `main` + every open PR; `feat/backends` then rebases to consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)