### PR TITLE
Cover EllipsoidalPotential _anchor_phi dtype-less-R branch (line 44)

### DIFF
--- a/tests/test_backend_ellipsoidal.py
+++ b/tests/test_backend_ellipsoidal.py
@@ -525,6 +525,35 @@ def test_construct_normalize_amp_is_float64(backend_name):
     )
 
 
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_anchor_phi_dtypeless_scalar_R_anchors_float64(backend_name):
+    # _anchor_phi's dtype-less-R branch: a scalar phi with a plain-python-scalar R
+    # (no .dtype) is anchored to the backend's float64 -- galpy's interior
+    # precision -- not the backend default (torch's float32). Tested directly on
+    # the helper so the branch stays covered regardless of when __init__ sets
+    # _backend_compatible: the construction-time normalize() path that used to
+    # reach it now coerces R to a typed array first, so it no longer exercises
+    # the dtype-less branch. Also pins the numpy short-circuit (returned untouched).
+    import galpy.backend
+    from galpy.potential.EllipsoidalPotential import _anchor_phi
+
+    prev = None
+    if backend_name == "torch":
+        prev = torch.get_default_dtype()
+        torch.set_default_dtype(torch.float32)  # worst case: backend default float32
+    try:
+        with galpy.backend.use(backend_name, force=True):
+            xp = galpy.backend.get_namespace()
+            out = _anchor_phi(0.0, 1.0, xp)  # R=1. is dtype-less -> anchor to float64
+    finally:
+        if prev is not None:
+            torch.set_default_dtype(prev)
+    assert "float64" in str(out.dtype), (
+        f"{backend_name}: dtype-less R should anchor phi to float64, got {out.dtype}"
+    )
+    assert _anchor_phi(0.5, 1.0, numpy) == 0.5  # numpy short-circuit, untouched
+
+
 def test_evaluate_xyz_namespace_fallback():
     # _evaluate_xyz infers the backend from its (x,y,z) arguments when called
     # without an explicit ``xp`` (the public _evaluate always passes one, so this


### PR DESCRIPTION
`EllipsoidalPotential.py:44` (`dtype = xp.float64`, the anchor for a dtype-less
scalar `R` under a non-numpy backend) is uncovered on `feat/backends`.

**Why it regressed:** the existing regression test
`test_construct_normalize_amp_is_float64` reached line 44 via the construction-time
`normalize()` → `Rforce(1.,0.)` path. The `_backend_compatible`-before-`normalize()`
reorder now coerces `R` to a typed array before `_anchor_phi` sees it, so
`getattr(R, "dtype", None)` is no longer `None` and the dtype-less branch isn't
hit at construct time. (It's a backend-only branch — line 40 short-circuits under
numpy — so the numpy coverage job can only reach it via a forced-backend
`test_backend_*` test.)

**Fix:** a direct unit test of `_anchor_phi(0., 1., xp)` under jax and torch (torch
with a float32 default — the worst case the branch defends against), asserting the
result is float64, plus the numpy short-circuit. It deterministically exercises
line 44 and is immune to when `__init__` sets `_backend_compatible`. Verified line
44 leaves the coverage Missing list; 2 passed (jax, torch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)