### PR TITLE
Backend-agnostic orbit read-path reductions: e/rap/rperi/zmax + normalize + interp-range warning

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2119,8 +2119,9 @@ class Orbit:
         """Warn if the integrated orbit(s) visited radii outside of the
         interpolation range [rmin, rmax] of the potential potname"""
         rs = self.r(self.t, use_physical=False)
-        outside = numpy.any((rs < rmin) | (rs > rmax), axis=-1)
-        if not numpy.any(outside):
+        xp = get_namespace(rs)
+        outside = xp.any((rs < rmin) | (rs > rmax), axis=-1)
+        if not xp.any(outside):
             return
         if self.shape == ():
             warnings.warn(
@@ -3864,8 +3865,9 @@ class Orbit:
                 "Integrate the orbit first or use analytic=True for approximate eccentricity"
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
-        return (numpy.amax(rs, axis=-1) - numpy.amin(rs, axis=-1)) / (
-            numpy.amax(rs, axis=-1) + numpy.amin(rs, axis=-1)
+        xp = get_namespace(rs)
+        return (xp.max(rs, axis=-1) - xp.min(rs, axis=-1)) / (
+            xp.max(rs, axis=-1) + xp.min(rs, axis=-1)
         )
 
     @physical_conversion("position")
@@ -3913,7 +3915,8 @@ class Orbit:
                 "Integrate the orbit first or use analytic=True for approximate eccentricity"
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
-        return numpy.amax(rs, axis=-1)
+        xp = get_namespace(rs)
+        return xp.max(rs, axis=-1)
 
     @physical_conversion("position")
     @shapeDecorator
@@ -3960,7 +3963,8 @@ class Orbit:
                 "Integrate the orbit first or use analytic=True for approximate eccentricity"
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
-        return numpy.amin(rs, axis=-1)
+        xp = get_namespace(rs)
+        return xp.min(rs, axis=-1)
 
     @physical_conversion("position")
     @shapeDecorator
@@ -4192,9 +4196,9 @@ class Orbit:
             raise AttributeError(
                 "Integrate the orbit first or use analytic=True for approximate eccentricity"
             )
-        return numpy.amax(
-            numpy.fabs(self.z(self.t, use_physical=False, dontreshape=True)), axis=-1
-        )
+        zs = self.z(self.t, use_physical=False, dontreshape=True)
+        xp = get_namespace(zs)
+        return xp.max(xp.abs(zs), axis=-1)
 
     @physical_conversion("action")
     @shapeDecorator

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -978,7 +978,9 @@ class Potential(Force):
         - 2010-07-10 - Written - Bovy (NYU)
 
         """
-        self._amp *= norm / numpy.fabs(self.Rforce(1.0, 0.0, use_physical=False))
+        # abs() (via __abs__) is backend-agnostic and byte-identical to the old
+        # numpy.fabs on the numpy scalar Rforce returns.
+        self._amp *= norm / abs(self.Rforce(1.0, 0.0, use_physical=False))
 
     def toPlanar(self):
         """

--- a/tests/test_backend_orbit_accessors.py
+++ b/tests/test_backend_orbit_accessors.py
@@ -433,3 +433,54 @@ def test_accessor_diffrax_offgrid_axisymmetric(acc):
         rtol=1e-5,
         atol=1e-5,
     )
+
+
+# ----------------------------------- numeric orbit characteristics (reductions)
+# e(), rap(), rperi(), zmax() reduce over the integrated trajectory
+# (numpy.amax/amin); on a backend-integrated orbit self.r(t)/self.z(t) is a
+# backend array, so the reduction must run in the orbit's namespace -- else
+# numpy.amax(tensor) crashes (rap/rperi) or silently coerces back to numpy and
+# drops the backend/grad (zmax, via numpy.fabs).
+_CHARS = ["e", "rap", "rperi", "zmax"]
+
+
+def _c_ref_char(name):
+    o = Orbit(list(_IC))
+    o.integrate(_TS, _POT, method="dop853_c")
+    return float(numpy.asarray(getattr(o, name)(use_physical=False)))
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+@pytest.mark.parametrize("name", _CHARS)
+def test_orbit_characteristic_diffrax_matches_c_and_stays_jax(name):
+    o = Orbit(jnp.asarray(_IC))
+    o.integrate(jnp.asarray(_TS), _POT, method="diffrax")
+    val = getattr(o, name)(use_physical=False)
+    assert isinstance(val, jax.Array), f"{name} left the jax backend"
+    numpy.testing.assert_allclose(
+        float(numpy.asarray(val)), _c_ref_char(name), rtol=1e-6, atol=1e-6
+    )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch/torchdiffeq not installed")
+@pytest.mark.parametrize("name", _CHARS)
+def test_orbit_characteristic_torchdiffeq_matches_c_and_stays_torch(name):
+    o = Orbit(torch.as_tensor(_IC))
+    o.integrate(torch.as_tensor(_TS), _POT, method="torchdiffeq")
+    val = getattr(o, name)(use_physical=False)
+    assert isinstance(val, torch.Tensor), f"{name} left the torch backend"
+    numpy.testing.assert_allclose(
+        float(val.detach().cpu()), _c_ref_char(name), rtol=1e-6, atol=1e-6
+    )
+
+
+def test_orbit_characteristic_numpy_path_unchanged():
+    # a numpy orbit's e/rap/rperi/zmax are unaffected by the namespace dispatch
+    o = Orbit(list(_IC))
+    o.integrate(_TS, _POT, method="dop853_c")
+    for name in _CHARS:
+        val = getattr(o, name)(use_physical=False)
+        assert isinstance(val, (float, numpy.floating, numpy.ndarray))
+        numpy.testing.assert_allclose(
+            float(numpy.asarray(val)), _c_ref_char(name), rtol=1e-12
+        )

--- a/tests/test_backend_potential_convenience.py
+++ b/tests/test_backend_potential_convenience.py
@@ -431,3 +431,41 @@ def test_mass_scalar_only_torch_matches_numpy():
     got_sph = hp.mass(torch.as_tensor(4.2), torch.as_tensor(1.3), use_physical=False)
     assert isinstance(got_sph, torch.Tensor)
     _np.testing.assert_allclose(float(got_sph), float(ref_sph), rtol=1e-6)
+
+
+# --------------------------------------------------------------------- normalize
+# Potential.normalize() does _amp *= norm / abs(Rforce(1,0)). Under a forced
+# backend Rforce(1,0) is a backend tensor for a migrated potential (here) and a
+# python float on a scalar fast-path (e.g. RazorThin), so the magnitude uses the
+# builtin abs() -- backend-agnostic (stays float/ndarray/Tensor/jax.Array) and
+# byte-identical to the old numpy.fabs on the numpy scalar.
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("norm", [1.0, 0.6])
+def test_normalize_torch_backend(norm):
+    from galpy import backend
+
+    ref_amp = MiyamotoNagaiPotential(a=0.5, b=0.1, normalize=norm)._amp  # numpy
+    with backend.use("torch", force=True):
+        p = MiyamotoNagaiPotential(a=0.5, b=0.1, normalize=norm)
+        amp = p._amp  # construction (-> normalize) under forced torch must not crash
+        rf = p.Rforce(1.0, 0.0, use_physical=False)
+    # amp stays on-backend (differentiable) and equals the numpy amp byte-for-byte
+    assert torch.is_tensor(amp)
+    numpy.testing.assert_allclose(float(numpy.asarray(amp)), float(ref_amp), rtol=1e-12)
+    # and the normalization actually holds: |Rforce(1,0)| == norm
+    numpy.testing.assert_allclose(float(numpy.asarray(rf)), -norm, rtol=1e-10)
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="jax not installed")
+@pytest.mark.parametrize("norm", [1.0, 0.6])
+def test_normalize_jax_backend(norm):
+    from galpy import backend
+
+    ref_amp = MiyamotoNagaiPotential(a=0.5, b=0.1, normalize=norm)._amp  # numpy
+    with backend.use("jax", force=True):
+        p = MiyamotoNagaiPotential(a=0.5, b=0.1, normalize=norm)
+        amp = p._amp
+        rf = p.Rforce(1.0, 0.0, use_physical=False)
+    assert "jax" in type(amp).__module__
+    numpy.testing.assert_allclose(float(numpy.asarray(amp)), float(ref_amp), rtol=1e-12)
+    numpy.testing.assert_allclose(float(numpy.asarray(rf)), -norm, rtol=1e-10)


### PR DESCRIPTION
## What

Make the **read-path reductions** on integrated orbits and `Potential.normalize` backend-agnostic, so a jax/torch-backed orbit (e.g. integrated with `method='diffrax'`/`'torchdiffeq'`, or under a forced backend) can be queried without crashing or silently dropping the backend.

Under a forced (or in-backend) jax/torch backend, an integrated orbit's phase-space arrays are backend tensors. The numpy reductions then break:
- `Orbit.e/rap/rperi/zmax` use `numpy.amax/amin(rs)` → `TypeError: max()/min() received an invalid combination of arguments` on a Tensor (and `zmax`'s `numpy.fabs` silently coerces Tensor→numpy, dropping the backend/grad);
- `Orbit._warn_radii_outside_interpolation_range` uses `numpy.any(...)` → same crash on interp-backed potentials (King / MultipoleExpansion / interpRZ);
- `Potential.normalize` uses `numpy.fabs(self.Rforce(1,0))` → crashes when `Rforce` returns a backend tensor.

## Fix

Resolve the namespace from the data (`get_namespace`) and use `xp.max/min/any`. `normalize` uses the builtin `abs()` — backend-agnostic via `__abs__` (stays float/ndarray/Tensor/jax.Array), and byte-identical to `numpy.fabs` on the numpy scalar `Rforce` returns (this also handles the scalar-`float` fast-path that a forced-backend `Rforce` can return, e.g. RazorThin).

## numpy is byte-identical

`numpy.max==amax`, `numpy.min==amin`, and `abs`/`fabs` give identical values/dtype on the real numpy scalar — no numpy-path behavior change. Verified: the 56 numpy `e/rap/rperi/zmax` `test_orbit.py` tests pass unchanged.

## Effect (forced-torch `test_orbit.py`)

- **12 tests flip fail→pass** (verified serially, no xdist): 8× `test_energy_jacobi_conservation[*MultipoleExpansion*/KingPotential]` + 4× `test_orbinterp_reset_*` (all reaching the interp-range warning).
- **0 regressions.** (Two dxdv `*_c_vs_python` tests segfault under torch independent of this change — pre-existing, confirmed on the unmodified base — and a segfault under xdist mis-attributes blame across workers; both are reproduced identically without this PR.)

The 12 stale `backend_xfail.txt` entries are left for the next ledger-milestone regen (separate PR) per the milestone-burndown policy — they become harmless XPASS (strict=False).

## Tests added

- `test_backend_orbit_accessors.py`: `e/rap/rperi/zmax` on diffrax + torchdiffeq orbits stay on-backend and match the C reference; numpy path unchanged.
- `test_backend_potential_convenience.py`: `normalize` under forced jax/torch keeps `_amp` on-backend, byte-identical to the numpy amp, and the normalization condition `|Rforce(1,0)|==norm` holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)