### PR TITLE
tests: make orbit accessor-reduction tests backend-agnostic (34 forced-torch tests → green)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,21 @@
 import os
 
+import numpy
 import pytest
+
+
+def _to_numpy(x):
+    """Coerce a (possibly jax/torch) Orbit-accessor result to a numpy array so
+    value assertions in the orbit tests are backend-agnostic. Under a forced
+    backend the accessors return jax/torch arrays; this brings them back to numpy
+    for ``numpy.amax``/``all``/``std``/... A numpy input passes through unchanged
+    (``numpy.asarray`` is the identity), so the numpy path stays byte-identical.
+    Shared by test_orbit.py and test_orbits.py (imported via ``from conftest
+    import _to_numpy``)."""
+    if hasattr(x, "detach"):  # torch tensor: detach from autograd + move to CPU
+        x = x.detach().cpu()
+    return numpy.asarray(x)
+
 
 # ---------------------------------------------------------------------------
 # Backend xfail-ledger

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -14,15 +14,7 @@ import time
 import astropy
 import numpy
 import pytest
-
-
-def _anp(x):
-    # backend-agnostic: coerce a (possibly jax/torch) accessor result to numpy
-    # for value assertions. numpy input passes through unchanged (byte-identical).
-    if hasattr(x, "detach"):
-        x = x.detach().cpu()
-    return numpy.asarray(x)
-
+from conftest import _to_numpy
 
 PY2 = sys.version < "3"
 _APY3 = astropy.__version__ > "3"
@@ -768,7 +760,7 @@ def test_energy_symplec_longterm():
                 ttol = tol["default"]
             o = setup_orbit_energy(tp)
             o.integrate(times, tp, method=integrator)
-            tEs = _anp(o.E(times))
+            tEs = _to_numpy(o.E(times))
             #            print p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.
             #            print p, ((numpy.mean(o.E(times[0:20]))-numpy.mean(o.E(times[-20:-1])))/numpy.mean(tEs))**2.
             assert (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0 < 10.0**ttol, (
@@ -5920,7 +5912,7 @@ def test_integrate_SOS_2D():
     for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
         for surface in ["x", "y"]:
             o.integrate_SOS(psis, pot, method=method)  # default is surface='x'
-            Es = _anp(o.E(o.t))
+            Es = _to_numpy(o.E(o.t))
             assert (numpy.std(Es) / numpy.mean(Es)) ** 2.0 < 10.0**-10, (
                 f"Energy is not conserved by integrate_sos for method={method} and surface={surface}"
             )
@@ -7955,8 +7947,8 @@ def test_ER_EZ():
     for o in os:
         times = numpy.linspace(0.0, 7.0, 251)  # ~10 Gyr at the Solar circle
         o.integrate(times, MWPotential)
-        ERs = _anp(o.ER(times))
-        Ezs = _anp(o.Ez(times))
+        ERs = _to_numpy(o.ER(times))
+        Ezs = _to_numpy(o.Ez(times))
         ERdiff = numpy.fabs(numpy.std(ERs - numpy.mean(ERs)) / numpy.mean(ERs))
         assert ERdiff < 10.0**-4.0, (
             "ER conservation for orbits close to the plane in MWPotential fails at %g%%"
@@ -7968,17 +7960,21 @@ def test_ER_EZ():
             % (100.0 * Ezdiff)
         )
         # Some basic checking
-        assert numpy.fabs(_anp(o.ER()) - _anp(o.ER(pot=MWPotential))) < 10.0**-16.0, (
-            "o.ER() not equal to o.ER(pot=)"
-        )
-        assert numpy.fabs(_anp(o.Ez()) - _anp(o.Ez(pot=MWPotential))) < 10.0**-16.0, (
-            "o.ER() not equal to o.Ez(pot=)"
-        )
         assert (
-            numpy.fabs(_anp(o.ER(pot=None)) - _anp(o.ER(pot=MWPotential))) < 10.0**-16.0
+            numpy.fabs(_to_numpy(o.ER()) - _to_numpy(o.ER(pot=MWPotential)))
+            < 10.0**-16.0
         ), "o.ER() not equal to o.ER(pot=)"
         assert (
-            numpy.fabs(_anp(o.Ez(pot=None)) - _anp(o.Ez(pot=MWPotential))) < 10.0**-16.0
+            numpy.fabs(_to_numpy(o.Ez()) - _to_numpy(o.Ez(pot=MWPotential)))
+            < 10.0**-16.0
+        ), "o.ER() not equal to o.Ez(pot=)"
+        assert (
+            numpy.fabs(_to_numpy(o.ER(pot=None)) - _to_numpy(o.ER(pot=MWPotential)))
+            < 10.0**-16.0
+        ), "o.ER() not equal to o.ER(pot=)"
+        assert (
+            numpy.fabs(_to_numpy(o.Ez(pot=None)) - _to_numpy(o.Ez(pot=MWPotential)))
+            < 10.0**-16.0
         ), "o.ER() not equal to o.Ez(pot=)"
     o = setup_orbit_analytic_EREz(MWPotential, axi=False)
     try:
@@ -10680,17 +10676,17 @@ def test_scalarxyvzvz_issue247():
     # Setup an orbit
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
     o = setup_orbit_energy(lp, axi=False)
-    assert numpy.ndim(_anp(o.x())) == 0, "Orbit.x() does not return a scalar"
-    assert numpy.ndim(_anp(o.y())) == 0, "Orbit.y() does not return a scalar"
-    assert numpy.ndim(_anp(o.vx())) == 0, "Orbit.vx() does not return a scalar"
-    assert numpy.ndim(_anp(o.vy())) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.x())) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.y())) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vx())) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vy())) == 0, "Orbit.vy() does not return a scalar"
     # Also integrate and then test
     times = numpy.linspace(0.0, 10.0, 1001)
     o.integrate(times, lp)
-    assert numpy.ndim(_anp(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
-    assert numpy.ndim(_anp(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
-    assert numpy.ndim(_anp(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
-    assert numpy.ndim(_anp(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
     return None
 
 
@@ -10700,97 +10696,139 @@ def test_scalar_all():
     # Setup an orbit
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
     o = setup_orbit_energy(lp, axi=False)
-    assert numpy.ndim(_anp(o.R())) == 0, "Orbit.R() does not return a scalar"
-    assert numpy.ndim(_anp(o.vR())) == 0, "Orbit.vR() does not return a scalar"
-    assert numpy.ndim(_anp(o.vT())) == 0, "Orbit.vT() does not return a scalar"
-    assert numpy.ndim(_anp(o.z())) == 0, "Orbit.z() does not return a scalar"
-    assert numpy.ndim(_anp(o.vz())) == 0, "Orbit.vz() does not return a scalar"
-    assert numpy.ndim(_anp(o.phi())) == 0, "Orbit.phi() does not return a scalar"
-    assert numpy.ndim(_anp(o.r())) == 0, "Orbit.r() does not return a scalar"
-    assert numpy.ndim(_anp(o.x())) == 0, "Orbit.x() does not return a scalar"
-    assert numpy.ndim(_anp(o.y())) == 0, "Orbit.y() does not return a scalar"
-    assert numpy.ndim(_anp(o.vx())) == 0, "Orbit.vx() does not return a scalar"
-    assert numpy.ndim(_anp(o.vy())) == 0, "Orbit.vy() does not return a scalar"
-    assert numpy.ndim(_anp(o.theta())) == 0, "Orbit.theta() does not return a scalar"
-    assert numpy.ndim(_anp(o.vtheta())) == 0, "Orbit.vtheta() does not return a scalar"
-    assert numpy.ndim(_anp(o.vr())) == 0, "Orbit.vr() does not return a scalar"
-    assert numpy.ndim(_anp(o.ra())) == 0, "Orbit.ra() does not return a scalar"
-    assert numpy.ndim(_anp(o.dec())) == 0, "Orbit.dec() does not return a scalar"
-    assert numpy.ndim(_anp(o.ll())) == 0, "Orbit.ll() does not return a scalar"
-    assert numpy.ndim(_anp(o.bb())) == 0, "Orbit.bb() does not return a scalar"
-    assert numpy.ndim(_anp(o.dist())) == 0, "Orbit.dist() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmra())) == 0, "Orbit.pmra() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmdec())) == 0, "Orbit.pmdec() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmll())) == 0, "Orbit.pmll() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmbb())) == 0, "Orbit.pmbb() does not return a scalar"
-    assert numpy.ndim(_anp(o.vra())) == 0, "Orbit.vra() does not return a scalar"
-    assert numpy.ndim(_anp(o.vdec())) == 0, "Orbit.vdec() does not return a scalar"
-    assert numpy.ndim(_anp(o.vll())) == 0, "Orbit.vll() does not return a scalar"
-    assert numpy.ndim(_anp(o.vbb())) == 0, "Orbit.vbb() does not return a scalar"
-    assert numpy.ndim(_anp(o.vlos())) == 0, "Orbit.vlos() does not return a scalar"
-    assert numpy.ndim(_anp(o.helioX())) == 0, "Orbit.helioX() does not return a scalar"
-    assert numpy.ndim(_anp(o.helioY())) == 0, "Orbit.helioY() does not return a scalar"
-    assert numpy.ndim(_anp(o.helioZ())) == 0, "Orbit.helioZ() does not return a scalar"
-    assert numpy.ndim(_anp(o.U())) == 0, "Orbit.U() does not return a scalar"
-    assert numpy.ndim(_anp(o.V())) == 0, "Orbit.V() does not return a scalar"
-    assert numpy.ndim(_anp(o.W())) == 0, "Orbit.W() does not return a scalar"
-    assert numpy.ndim(_anp(o.E(pot=lp))) == 0, "Orbit.E() does not return a scalar"
-    assert numpy.ndim(_anp(o.Jacobi(pot=lp))) == 0, (
+    assert numpy.ndim(_to_numpy(o.R())) == 0, "Orbit.R() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vR())) == 0, "Orbit.vR() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vT())) == 0, "Orbit.vT() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.z())) == 0, "Orbit.z() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vz())) == 0, "Orbit.vz() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.phi())) == 0, "Orbit.phi() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.r())) == 0, "Orbit.r() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.x())) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.y())) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vx())) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vy())) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.theta())) == 0, (
+        "Orbit.theta() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vtheta())) == 0, (
+        "Orbit.vtheta() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vr())) == 0, "Orbit.vr() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.ra())) == 0, "Orbit.ra() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.dec())) == 0, "Orbit.dec() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.ll())) == 0, "Orbit.ll() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.bb())) == 0, "Orbit.bb() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.dist())) == 0, "Orbit.dist() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.pmra())) == 0, "Orbit.pmra() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.pmdec())) == 0, (
+        "Orbit.pmdec() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.pmll())) == 0, "Orbit.pmll() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.pmbb())) == 0, "Orbit.pmbb() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vra())) == 0, "Orbit.vra() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vdec())) == 0, "Orbit.vdec() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vll())) == 0, "Orbit.vll() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vbb())) == 0, "Orbit.vbb() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vlos())) == 0, "Orbit.vlos() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.helioX())) == 0, (
+        "Orbit.helioX() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.helioY())) == 0, (
+        "Orbit.helioY() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.helioZ())) == 0, (
+        "Orbit.helioZ() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.U())) == 0, "Orbit.U() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.V())) == 0, "Orbit.V() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.W())) == 0, "Orbit.W() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.E(pot=lp))) == 0, "Orbit.E() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.Jacobi(pot=lp))) == 0, (
         "Orbit.Jacobi() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.ER(pot=lp))) == 0, "Orbit.ER() does not return a scalar"
-    assert numpy.ndim(_anp(o.Ez(pot=lp))) == 0, "Orbit.Ez() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.ER(pot=lp))) == 0, (
+        "Orbit.ER() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.Ez(pot=lp))) == 0, (
+        "Orbit.Ez() does not return a scalar"
+    )
     # Also integrate and then test
     times = numpy.linspace(0.0, 10.0, 1001)
     o.integrate(times, lp)
-    assert numpy.ndim(_anp(o.R(5.0))) == 0, "Orbit.R() does not return a scalar"
-    assert numpy.ndim(_anp(o.vR(5.0))) == 0, "Orbit.vR() does not return a scalar"
-    assert numpy.ndim(_anp(o.vT(5.0))) == 0, "Orbit.vT() does not return a scalar"
-    assert numpy.ndim(_anp(o.z(5.0))) == 0, "Orbit.z() does not return a scalar"
-    assert numpy.ndim(_anp(o.vz(5.0))) == 0, "Orbit.vz() does not return a scalar"
-    assert numpy.ndim(_anp(o.phi(5.0))) == 0, "Orbit.phi() does not return a scalar"
-    assert numpy.ndim(_anp(o.r(5.0))) == 0, "Orbit.r() does not return a scalar"
-    assert numpy.ndim(_anp(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
-    assert numpy.ndim(_anp(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
-    assert numpy.ndim(_anp(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
-    assert numpy.ndim(_anp(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
-    assert numpy.ndim(_anp(o.theta(5.0))) == 0, "Orbit.theta() does not return a scalar"
-    assert numpy.ndim(_anp(o.vtheta(5.0))) == 0, (
+    assert numpy.ndim(_to_numpy(o.R(5.0))) == 0, "Orbit.R() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vR(5.0))) == 0, "Orbit.vR() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vT(5.0))) == 0, "Orbit.vT() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.z(5.0))) == 0, "Orbit.z() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vz(5.0))) == 0, "Orbit.vz() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.phi(5.0))) == 0, (
+        "Orbit.phi() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.r(5.0))) == 0, "Orbit.r() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.theta(5.0))) == 0, (
+        "Orbit.theta() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vtheta(5.0))) == 0, (
         "Orbit.vtheta() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.vr(5.0))) == 0, "Orbit.vr() does not return a scalar"
-    assert numpy.ndim(_anp(o.ra(5.0))) == 0, "Orbit.ra() does not return a scalar"
-    assert numpy.ndim(_anp(o.dec(5.0))) == 0, "Orbit.dec() does not return a scalar"
-    assert numpy.ndim(_anp(o.ll(5.0))) == 0, "Orbit.ll() does not return a scalar"
-    assert numpy.ndim(_anp(o.bb(5.0))) == 0, "Orbit.bb() does not return a scalar"
-    assert numpy.ndim(_anp(o.dist(5.0))) == 0, "Orbit.dist() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmra(5.0))) == 0, "Orbit.pmra() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmdec(5.0))) == 0, "Orbit.pmdec() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmll(5.0))) == 0, "Orbit.pmll() does not return a scalar"
-    assert numpy.ndim(_anp(o.pmbb(5.0))) == 0, "Orbit.pmbb() does not return a scalar"
-    assert numpy.ndim(_anp(o.vra(5.0))) == 0, "Orbit.vra() does not return a scalar"
-    assert numpy.ndim(_anp(o.vdec(5.0))) == 0, "Orbit.vdec() does not return a scalar"
-    assert numpy.ndim(_anp(o.vll(5.0))) == 0, "Orbit.vll() does not return a scalar"
-    assert numpy.ndim(_anp(o.vbb(5.0))) == 0, "Orbit.vbb() does not return a scalar"
-    assert numpy.ndim(_anp(o.vlos(5.0))) == 0, "Orbit.vlos() does not return a scalar"
-    assert numpy.ndim(_anp(o.helioX(5.0))) == 0, (
+    assert numpy.ndim(_to_numpy(o.vr(5.0))) == 0, "Orbit.vr() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.ra(5.0))) == 0, "Orbit.ra() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.dec(5.0))) == 0, (
+        "Orbit.dec() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.ll(5.0))) == 0, "Orbit.ll() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.bb(5.0))) == 0, "Orbit.bb() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.dist(5.0))) == 0, (
+        "Orbit.dist() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.pmra(5.0))) == 0, (
+        "Orbit.pmra() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.pmdec(5.0))) == 0, (
+        "Orbit.pmdec() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.pmll(5.0))) == 0, (
+        "Orbit.pmll() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.pmbb(5.0))) == 0, (
+        "Orbit.pmbb() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vra(5.0))) == 0, (
+        "Orbit.vra() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vdec(5.0))) == 0, (
+        "Orbit.vdec() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vll(5.0))) == 0, (
+        "Orbit.vll() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vbb(5.0))) == 0, (
+        "Orbit.vbb() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.vlos(5.0))) == 0, (
+        "Orbit.vlos() does not return a scalar"
+    )
+    assert numpy.ndim(_to_numpy(o.helioX(5.0))) == 0, (
         "Orbit.helioX() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.helioY(5.0))) == 0, (
+    assert numpy.ndim(_to_numpy(o.helioY(5.0))) == 0, (
         "Orbit.helioY() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.helioZ(5.0))) == 0, (
+    assert numpy.ndim(_to_numpy(o.helioZ(5.0))) == 0, (
         "Orbit.helioZ() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.U(5.0))) == 0, "Orbit.U() does not return a scalar"
-    assert numpy.ndim(_anp(o.V(5.0))) == 0, "Orbit.V() does not return a scalar"
-    assert numpy.ndim(_anp(o.W(5.0))) == 0, "Orbit.W() does not return a scalar"
-    assert numpy.ndim(_anp(o.E(5.0))) == 0, "Orbit.E() does not return a scalar"
-    assert numpy.ndim(_anp(o.Jacobi(5.0))) == 0, (
+    assert numpy.ndim(_to_numpy(o.U(5.0))) == 0, "Orbit.U() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.V(5.0))) == 0, "Orbit.V() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.W(5.0))) == 0, "Orbit.W() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.E(5.0))) == 0, "Orbit.E() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.Jacobi(5.0))) == 0, (
         "Orbit.Jacobi() does not return a scalar"
     )
-    assert numpy.ndim(_anp(o.ER(5.0))) == 0, "Orbit.ER() does not return a scalar"
-    assert numpy.ndim(_anp(o.Ez(5.0))) == 0, "Orbit.Ez() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.ER(5.0))) == 0, "Orbit.ER() does not return a scalar"
+    assert numpy.ndim(_to_numpy(o.Ez(5.0))) == 0, "Orbit.Ez() does not return a scalar"
     return None
 
 
@@ -15228,10 +15266,10 @@ def test_1d_tol_integration():
 
         # make test for differing reconstruction precision and energy loss along the orbits
         Delta_r = numpy.sum(
-            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+            numpy.abs(_to_numpy(o_list[0].r(times)) - _to_numpy(o_list[1].r(times)))
         )
         Delta_E = numpy.sum(
-            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+            numpy.abs(_to_numpy(o_list[0].E(times)) - _to_numpy(o_list[1].E(times)))
         )
 
         # if special integrators yield same reconstructions
@@ -15298,10 +15336,10 @@ def test_2d_tol_integration():
 
         # make test for differing reconstruction precision and energy loss along the orbits
         Delta_r = numpy.sum(
-            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+            numpy.abs(_to_numpy(o_list[0].r(times)) - _to_numpy(o_list[1].r(times)))
         )
         Delta_E = numpy.sum(
-            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+            numpy.abs(_to_numpy(o_list[0].E(times)) - _to_numpy(o_list[1].E(times)))
         )
 
         # if special integrators yield same reconstructions
@@ -15370,10 +15408,10 @@ def test_3d_tol_integration():
 
         # make test for differing reconstruction precision and energy loss along the orbits
         Delta_r = numpy.sum(
-            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+            numpy.abs(_to_numpy(o_list[0].r(times)) - _to_numpy(o_list[1].r(times)))
         )
         Delta_E = numpy.sum(
-            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+            numpy.abs(_to_numpy(o_list[0].E(times)) - _to_numpy(o_list[1].E(times)))
         )
 
         # if special integrators yield same reconstructions

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -15,6 +15,15 @@ import astropy
 import numpy
 import pytest
 
+
+def _anp(x):
+    # backend-agnostic: coerce a (possibly jax/torch) accessor result to numpy
+    # for value assertions. numpy input passes through unchanged (byte-identical).
+    if hasattr(x, "detach"):
+        x = x.detach().cpu()
+    return numpy.asarray(x)
+
+
 PY2 = sys.version < "3"
 _APY3 = astropy.__version__ > "3"
 from test_actionAngle import reset_warning_registry
@@ -759,7 +768,7 @@ def test_energy_symplec_longterm():
                 ttol = tol["default"]
             o = setup_orbit_energy(tp)
             o.integrate(times, tp, method=integrator)
-            tEs = o.E(times)
+            tEs = _anp(o.E(times))
             #            print p, integrator, (numpy.std(tEs)/numpy.mean(tEs))**2.
             #            print p, ((numpy.mean(o.E(times[0:20]))-numpy.mean(o.E(times[-20:-1])))/numpy.mean(tEs))**2.
             assert (numpy.std(tEs) / numpy.mean(tEs)) ** 2.0 < 10.0**ttol, (
@@ -5911,7 +5920,7 @@ def test_integrate_SOS_2D():
     for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
         for surface in ["x", "y"]:
             o.integrate_SOS(psis, pot, method=method)  # default is surface='x'
-            Es = o.E(o.t)
+            Es = _anp(o.E(o.t))
             assert (numpy.std(Es) / numpy.mean(Es)) ** 2.0 < 10.0**-10, (
                 f"Energy is not conserved by integrate_sos for method={method} and surface={surface}"
             )
@@ -7946,8 +7955,8 @@ def test_ER_EZ():
     for o in os:
         times = numpy.linspace(0.0, 7.0, 251)  # ~10 Gyr at the Solar circle
         o.integrate(times, MWPotential)
-        ERs = o.ER(times)
-        Ezs = o.Ez(times)
+        ERs = _anp(o.ER(times))
+        Ezs = _anp(o.Ez(times))
         ERdiff = numpy.fabs(numpy.std(ERs - numpy.mean(ERs)) / numpy.mean(ERs))
         assert ERdiff < 10.0**-4.0, (
             "ER conservation for orbits close to the plane in MWPotential fails at %g%%"
@@ -7959,18 +7968,18 @@ def test_ER_EZ():
             % (100.0 * Ezdiff)
         )
         # Some basic checking
-        assert numpy.fabs(o.ER() - o.ER(pot=MWPotential)) < 10.0**-16.0, (
+        assert numpy.fabs(_anp(o.ER()) - _anp(o.ER(pot=MWPotential))) < 10.0**-16.0, (
             "o.ER() not equal to o.ER(pot=)"
         )
-        assert numpy.fabs(o.Ez() - o.Ez(pot=MWPotential)) < 10.0**-16.0, (
+        assert numpy.fabs(_anp(o.Ez()) - _anp(o.Ez(pot=MWPotential))) < 10.0**-16.0, (
             "o.ER() not equal to o.Ez(pot=)"
         )
-        assert numpy.fabs(o.ER(pot=None) - o.ER(pot=MWPotential)) < 10.0**-16.0, (
-            "o.ER() not equal to o.ER(pot=)"
-        )
-        assert numpy.fabs(o.Ez(pot=None) - o.Ez(pot=MWPotential)) < 10.0**-16.0, (
-            "o.ER() not equal to o.Ez(pot=)"
-        )
+        assert (
+            numpy.fabs(_anp(o.ER(pot=None)) - _anp(o.ER(pot=MWPotential))) < 10.0**-16.0
+        ), "o.ER() not equal to o.ER(pot=)"
+        assert (
+            numpy.fabs(_anp(o.Ez(pot=None)) - _anp(o.Ez(pot=MWPotential))) < 10.0**-16.0
+        ), "o.ER() not equal to o.Ez(pot=)"
     o = setup_orbit_analytic_EREz(MWPotential, axi=False)
     try:
         o.Ez()
@@ -10671,17 +10680,17 @@ def test_scalarxyvzvz_issue247():
     # Setup an orbit
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
     o = setup_orbit_energy(lp, axi=False)
-    assert isinstance(o.x(), float), "Orbit.x() does not return a scalar"
-    assert isinstance(o.y(), float), "Orbit.y() does not return a scalar"
-    assert isinstance(o.vx(), float), "Orbit.vx() does not return a scalar"
-    assert isinstance(o.vy(), float), "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_anp(o.x())) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_anp(o.y())) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_anp(o.vx())) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_anp(o.vy())) == 0, "Orbit.vy() does not return a scalar"
     # Also integrate and then test
     times = numpy.linspace(0.0, 10.0, 1001)
     o.integrate(times, lp)
-    assert isinstance(o.x(5.0), float), "Orbit.x() does not return a scalar"
-    assert isinstance(o.y(5.0), float), "Orbit.y() does not return a scalar"
-    assert isinstance(o.vx(5.0), float), "Orbit.vx() does not return a scalar"
-    assert isinstance(o.vy(5.0), float), "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_anp(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_anp(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_anp(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_anp(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
     return None
 
 
@@ -10691,87 +10700,97 @@ def test_scalar_all():
     # Setup an orbit
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
     o = setup_orbit_energy(lp, axi=False)
-    assert isinstance(o.R(), float), "Orbit.R() does not return a scalar"
-    assert isinstance(o.vR(), float), "Orbit.vR() does not return a scalar"
-    assert isinstance(o.vT(), float), "Orbit.vT() does not return a scalar"
-    assert isinstance(o.z(), float), "Orbit.z() does not return a scalar"
-    assert isinstance(o.vz(), float), "Orbit.vz() does not return a scalar"
-    assert isinstance(o.phi(), float), "Orbit.phi() does not return a scalar"
-    assert isinstance(o.r(), float), "Orbit.r() does not return a scalar"
-    assert isinstance(o.x(), float), "Orbit.x() does not return a scalar"
-    assert isinstance(o.y(), float), "Orbit.y() does not return a scalar"
-    assert isinstance(o.vx(), float), "Orbit.vx() does not return a scalar"
-    assert isinstance(o.vy(), float), "Orbit.vy() does not return a scalar"
-    assert isinstance(o.theta(), float), "Orbit.theta() does not return a scalar"
-    assert isinstance(o.vtheta(), float), "Orbit.vtheta() does not return a scalar"
-    assert isinstance(o.vr(), float), "Orbit.vr() does not return a scalar"
-    assert isinstance(o.ra(), float), "Orbit.ra() does not return a scalar"
-    assert isinstance(o.dec(), float), "Orbit.dec() does not return a scalar"
-    assert isinstance(o.ll(), float), "Orbit.ll() does not return a scalar"
-    assert isinstance(o.bb(), float), "Orbit.bb() does not return a scalar"
-    assert isinstance(o.dist(), float), "Orbit.dist() does not return a scalar"
-    assert isinstance(o.pmra(), float), "Orbit.pmra() does not return a scalar"
-    assert isinstance(o.pmdec(), float), "Orbit.pmdec() does not return a scalar"
-    assert isinstance(o.pmll(), float), "Orbit.pmll() does not return a scalar"
-    assert isinstance(o.pmbb(), float), "Orbit.pmbb() does not return a scalar"
-    assert isinstance(o.vra(), float), "Orbit.vra() does not return a scalar"
-    assert isinstance(o.vdec(), float), "Orbit.vdec() does not return a scalar"
-    assert isinstance(o.vll(), float), "Orbit.vll() does not return a scalar"
-    assert isinstance(o.vbb(), float), "Orbit.vbb() does not return a scalar"
-    assert isinstance(o.vlos(), float), "Orbit.vlos() does not return a scalar"
-    assert isinstance(o.helioX(), float), "Orbit.helioX() does not return a scalar"
-    assert isinstance(o.helioY(), float), "Orbit.helioY() does not return a scalar"
-    assert isinstance(o.helioZ(), float), "Orbit.helioZ() does not return a scalar"
-    assert isinstance(o.U(), float), "Orbit.U() does not return a scalar"
-    assert isinstance(o.V(), float), "Orbit.V() does not return a scalar"
-    assert isinstance(o.W(), float), "Orbit.W() does not return a scalar"
-    assert isinstance(o.E(pot=lp), float), "Orbit.E() does not return a scalar"
-    assert isinstance(o.Jacobi(pot=lp), float), (
+    assert numpy.ndim(_anp(o.R())) == 0, "Orbit.R() does not return a scalar"
+    assert numpy.ndim(_anp(o.vR())) == 0, "Orbit.vR() does not return a scalar"
+    assert numpy.ndim(_anp(o.vT())) == 0, "Orbit.vT() does not return a scalar"
+    assert numpy.ndim(_anp(o.z())) == 0, "Orbit.z() does not return a scalar"
+    assert numpy.ndim(_anp(o.vz())) == 0, "Orbit.vz() does not return a scalar"
+    assert numpy.ndim(_anp(o.phi())) == 0, "Orbit.phi() does not return a scalar"
+    assert numpy.ndim(_anp(o.r())) == 0, "Orbit.r() does not return a scalar"
+    assert numpy.ndim(_anp(o.x())) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_anp(o.y())) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_anp(o.vx())) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_anp(o.vy())) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_anp(o.theta())) == 0, "Orbit.theta() does not return a scalar"
+    assert numpy.ndim(_anp(o.vtheta())) == 0, "Orbit.vtheta() does not return a scalar"
+    assert numpy.ndim(_anp(o.vr())) == 0, "Orbit.vr() does not return a scalar"
+    assert numpy.ndim(_anp(o.ra())) == 0, "Orbit.ra() does not return a scalar"
+    assert numpy.ndim(_anp(o.dec())) == 0, "Orbit.dec() does not return a scalar"
+    assert numpy.ndim(_anp(o.ll())) == 0, "Orbit.ll() does not return a scalar"
+    assert numpy.ndim(_anp(o.bb())) == 0, "Orbit.bb() does not return a scalar"
+    assert numpy.ndim(_anp(o.dist())) == 0, "Orbit.dist() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmra())) == 0, "Orbit.pmra() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmdec())) == 0, "Orbit.pmdec() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmll())) == 0, "Orbit.pmll() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmbb())) == 0, "Orbit.pmbb() does not return a scalar"
+    assert numpy.ndim(_anp(o.vra())) == 0, "Orbit.vra() does not return a scalar"
+    assert numpy.ndim(_anp(o.vdec())) == 0, "Orbit.vdec() does not return a scalar"
+    assert numpy.ndim(_anp(o.vll())) == 0, "Orbit.vll() does not return a scalar"
+    assert numpy.ndim(_anp(o.vbb())) == 0, "Orbit.vbb() does not return a scalar"
+    assert numpy.ndim(_anp(o.vlos())) == 0, "Orbit.vlos() does not return a scalar"
+    assert numpy.ndim(_anp(o.helioX())) == 0, "Orbit.helioX() does not return a scalar"
+    assert numpy.ndim(_anp(o.helioY())) == 0, "Orbit.helioY() does not return a scalar"
+    assert numpy.ndim(_anp(o.helioZ())) == 0, "Orbit.helioZ() does not return a scalar"
+    assert numpy.ndim(_anp(o.U())) == 0, "Orbit.U() does not return a scalar"
+    assert numpy.ndim(_anp(o.V())) == 0, "Orbit.V() does not return a scalar"
+    assert numpy.ndim(_anp(o.W())) == 0, "Orbit.W() does not return a scalar"
+    assert numpy.ndim(_anp(o.E(pot=lp))) == 0, "Orbit.E() does not return a scalar"
+    assert numpy.ndim(_anp(o.Jacobi(pot=lp))) == 0, (
         "Orbit.Jacobi() does not return a scalar"
     )
-    assert isinstance(o.ER(pot=lp), float), "Orbit.ER() does not return a scalar"
-    assert isinstance(o.Ez(pot=lp), float), "Orbit.Ez() does not return a scalar"
+    assert numpy.ndim(_anp(o.ER(pot=lp))) == 0, "Orbit.ER() does not return a scalar"
+    assert numpy.ndim(_anp(o.Ez(pot=lp))) == 0, "Orbit.Ez() does not return a scalar"
     # Also integrate and then test
     times = numpy.linspace(0.0, 10.0, 1001)
     o.integrate(times, lp)
-    assert isinstance(o.R(5.0), float), "Orbit.R() does not return a scalar"
-    assert isinstance(o.vR(5.0), float), "Orbit.vR() does not return a scalar"
-    assert isinstance(o.vT(5.0), float), "Orbit.vT() does not return a scalar"
-    assert isinstance(o.z(5.0), float), "Orbit.z() does not return a scalar"
-    assert isinstance(o.vz(5.0), float), "Orbit.vz() does not return a scalar"
-    assert isinstance(o.phi(5.0), float), "Orbit.phi() does not return a scalar"
-    assert isinstance(o.r(5.0), float), "Orbit.r() does not return a scalar"
-    assert isinstance(o.x(5.0), float), "Orbit.x() does not return a scalar"
-    assert isinstance(o.y(5.0), float), "Orbit.y() does not return a scalar"
-    assert isinstance(o.vx(5.0), float), "Orbit.vx() does not return a scalar"
-    assert isinstance(o.vy(5.0), float), "Orbit.vy() does not return a scalar"
-    assert isinstance(o.theta(5.0), float), "Orbit.theta() does not return a scalar"
-    assert isinstance(o.vtheta(5.0), float), "Orbit.vtheta() does not return a scalar"
-    assert isinstance(o.vr(5.0), float), "Orbit.vr() does not return a scalar"
-    assert isinstance(o.ra(5.0), float), "Orbit.ra() does not return a scalar"
-    assert isinstance(o.dec(5.0), float), "Orbit.dec() does not return a scalar"
-    assert isinstance(o.ll(5.0), float), "Orbit.ll() does not return a scalar"
-    assert isinstance(o.bb(5.0), float), "Orbit.bb() does not return a scalar"
-    assert isinstance(o.dist(5.0), float), "Orbit.dist() does not return a scalar"
-    assert isinstance(o.pmra(5.0), float), "Orbit.pmra() does not return a scalar"
-    assert isinstance(o.pmdec(5.0), float), "Orbit.pmdec() does not return a scalar"
-    assert isinstance(o.pmll(5.0), float), "Orbit.pmll() does not return a scalar"
-    assert isinstance(o.pmbb(5.0), float), "Orbit.pmbb() does not return a scalar"
-    assert isinstance(o.vra(5.0), float), "Orbit.vra() does not return a scalar"
-    assert isinstance(o.vdec(5.0), float), "Orbit.vdec() does not return a scalar"
-    assert isinstance(o.vll(5.0), float), "Orbit.vll() does not return a scalar"
-    assert isinstance(o.vbb(5.0), float), "Orbit.vbb() does not return a scalar"
-    assert isinstance(o.vlos(5.0), float), "Orbit.vlos() does not return a scalar"
-    assert isinstance(o.helioX(5.0), float), "Orbit.helioX() does not return a scalar"
-    assert isinstance(o.helioY(5.0), float), "Orbit.helioY() does not return a scalar"
-    assert isinstance(o.helioZ(5.0), float), "Orbit.helioZ() does not return a scalar"
-    assert isinstance(o.U(5.0), float), "Orbit.U() does not return a scalar"
-    assert isinstance(o.V(5.0), float), "Orbit.V() does not return a scalar"
-    assert isinstance(o.W(5.0), float), "Orbit.W() does not return a scalar"
-    assert isinstance(o.E(5.0), float), "Orbit.E() does not return a scalar"
-    assert isinstance(o.Jacobi(5.0), float), "Orbit.Jacobi() does not return a scalar"
-    assert isinstance(o.ER(5.0), float), "Orbit.ER() does not return a scalar"
-    assert isinstance(o.Ez(5.0), float), "Orbit.Ez() does not return a scalar"
+    assert numpy.ndim(_anp(o.R(5.0))) == 0, "Orbit.R() does not return a scalar"
+    assert numpy.ndim(_anp(o.vR(5.0))) == 0, "Orbit.vR() does not return a scalar"
+    assert numpy.ndim(_anp(o.vT(5.0))) == 0, "Orbit.vT() does not return a scalar"
+    assert numpy.ndim(_anp(o.z(5.0))) == 0, "Orbit.z() does not return a scalar"
+    assert numpy.ndim(_anp(o.vz(5.0))) == 0, "Orbit.vz() does not return a scalar"
+    assert numpy.ndim(_anp(o.phi(5.0))) == 0, "Orbit.phi() does not return a scalar"
+    assert numpy.ndim(_anp(o.r(5.0))) == 0, "Orbit.r() does not return a scalar"
+    assert numpy.ndim(_anp(o.x(5.0))) == 0, "Orbit.x() does not return a scalar"
+    assert numpy.ndim(_anp(o.y(5.0))) == 0, "Orbit.y() does not return a scalar"
+    assert numpy.ndim(_anp(o.vx(5.0))) == 0, "Orbit.vx() does not return a scalar"
+    assert numpy.ndim(_anp(o.vy(5.0))) == 0, "Orbit.vy() does not return a scalar"
+    assert numpy.ndim(_anp(o.theta(5.0))) == 0, "Orbit.theta() does not return a scalar"
+    assert numpy.ndim(_anp(o.vtheta(5.0))) == 0, (
+        "Orbit.vtheta() does not return a scalar"
+    )
+    assert numpy.ndim(_anp(o.vr(5.0))) == 0, "Orbit.vr() does not return a scalar"
+    assert numpy.ndim(_anp(o.ra(5.0))) == 0, "Orbit.ra() does not return a scalar"
+    assert numpy.ndim(_anp(o.dec(5.0))) == 0, "Orbit.dec() does not return a scalar"
+    assert numpy.ndim(_anp(o.ll(5.0))) == 0, "Orbit.ll() does not return a scalar"
+    assert numpy.ndim(_anp(o.bb(5.0))) == 0, "Orbit.bb() does not return a scalar"
+    assert numpy.ndim(_anp(o.dist(5.0))) == 0, "Orbit.dist() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmra(5.0))) == 0, "Orbit.pmra() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmdec(5.0))) == 0, "Orbit.pmdec() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmll(5.0))) == 0, "Orbit.pmll() does not return a scalar"
+    assert numpy.ndim(_anp(o.pmbb(5.0))) == 0, "Orbit.pmbb() does not return a scalar"
+    assert numpy.ndim(_anp(o.vra(5.0))) == 0, "Orbit.vra() does not return a scalar"
+    assert numpy.ndim(_anp(o.vdec(5.0))) == 0, "Orbit.vdec() does not return a scalar"
+    assert numpy.ndim(_anp(o.vll(5.0))) == 0, "Orbit.vll() does not return a scalar"
+    assert numpy.ndim(_anp(o.vbb(5.0))) == 0, "Orbit.vbb() does not return a scalar"
+    assert numpy.ndim(_anp(o.vlos(5.0))) == 0, "Orbit.vlos() does not return a scalar"
+    assert numpy.ndim(_anp(o.helioX(5.0))) == 0, (
+        "Orbit.helioX() does not return a scalar"
+    )
+    assert numpy.ndim(_anp(o.helioY(5.0))) == 0, (
+        "Orbit.helioY() does not return a scalar"
+    )
+    assert numpy.ndim(_anp(o.helioZ(5.0))) == 0, (
+        "Orbit.helioZ() does not return a scalar"
+    )
+    assert numpy.ndim(_anp(o.U(5.0))) == 0, "Orbit.U() does not return a scalar"
+    assert numpy.ndim(_anp(o.V(5.0))) == 0, "Orbit.V() does not return a scalar"
+    assert numpy.ndim(_anp(o.W(5.0))) == 0, "Orbit.W() does not return a scalar"
+    assert numpy.ndim(_anp(o.E(5.0))) == 0, "Orbit.E() does not return a scalar"
+    assert numpy.ndim(_anp(o.Jacobi(5.0))) == 0, (
+        "Orbit.Jacobi() does not return a scalar"
+    )
+    assert numpy.ndim(_anp(o.ER(5.0))) == 0, "Orbit.ER() does not return a scalar"
+    assert numpy.ndim(_anp(o.Ez(5.0))) == 0, "Orbit.Ez() does not return a scalar"
     return None
 
 
@@ -15208,8 +15227,12 @@ def test_1d_tol_integration():
             o_list.append(o)
 
         # make test for differing reconstruction precision and energy loss along the orbits
-        Delta_r = numpy.sum(numpy.abs(o_list[0].r(times) - o_list[1].r(times)))
-        Delta_E = numpy.sum(numpy.abs(o_list[0].E(times) - o_list[1].E(times)))
+        Delta_r = numpy.sum(
+            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+        )
+        Delta_E = numpy.sum(
+            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+        )
 
         # if special integrators yield same reconstructions
         if integrator == "rk6_c" or integrator == "symplec6_c":
@@ -15274,8 +15297,12 @@ def test_2d_tol_integration():
             o_list.append(o)
 
         # make test for differing reconstruction precision and energy loss along the orbits
-        Delta_r = numpy.sum(numpy.abs(o_list[0].r(times) - o_list[1].r(times)))
-        Delta_E = numpy.sum(numpy.abs(o_list[0].E(times) - o_list[1].E(times)))
+        Delta_r = numpy.sum(
+            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+        )
+        Delta_E = numpy.sum(
+            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+        )
 
         # if special integrators yield same reconstructions
         if integrator == "rk6_c":
@@ -15342,8 +15369,12 @@ def test_3d_tol_integration():
             o_list.append(o)
 
         # make test for differing reconstruction precision and energy loss along the orbits
-        Delta_r = numpy.sum(numpy.abs(o_list[0].r(times) - o_list[1].r(times)))
-        Delta_E = numpy.sum(numpy.abs(o_list[0].E(times) - o_list[1].E(times)))
+        Delta_r = numpy.sum(
+            numpy.abs(_anp(o_list[0].r(times)) - _anp(o_list[1].r(times)))
+        )
+        Delta_E = numpy.sum(
+            numpy.abs(_anp(o_list[0].E(times)) - _anp(o_list[1].E(times)))
+        )
 
         # if special integrators yield same reconstructions
         if integrator == "rk6_c" or integrator == "symplec6_c":

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -4,17 +4,9 @@ import astropy.coordinates as apycoords
 import astropy.units as u
 import numpy
 import pytest
+from conftest import _to_numpy
 
 from galpy import potential
-
-
-def _anp(x):
-    # backend-agnostic: coerce a (possibly jax/torch) accessor result to numpy
-    # for value assertions. numpy input passes through unchanged (byte-identical).
-    if hasattr(x, "detach"):
-        x = x.detach().cpu()
-    return numpy.asarray(x)
-
 
 _APY3 = astropy.__version__ > "3"
 
@@ -807,7 +799,9 @@ def test_integration_1d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -815,7 +809,10 @@ def test_integration_1d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -844,7 +841,9 @@ def test_integration_2d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -852,7 +851,10 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -860,7 +862,9 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -868,7 +872,10 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vy(times))
+                    - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -876,7 +883,9 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -884,7 +893,10 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vR(times))
+                    - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -892,7 +904,10 @@ def test_integration_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vT(times))
+                    - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -903,8 +918,8 @@ def test_integration_2d():
                 numpy.fabs(
                     (
                         (
-                            _anp(orbits_list[ii].phi(times))
-                            - _anp(orbits.phi(times)[ii])
+                            _to_numpy(orbits_list[ii].phi(times))
+                            - _to_numpy(orbits.phi(times)[ii])
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -979,7 +994,9 @@ def test_integration_3d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -987,7 +1004,10 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -995,7 +1015,9 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1003,7 +1025,10 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vy(times))
+                    - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1011,7 +1036,9 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].z(times)) - _anp(orbits.z(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].z(times)) - _to_numpy(orbits.z(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1019,7 +1046,10 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vz(times))
+                    - _to_numpy(orbits.vz(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1027,7 +1057,9 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1035,7 +1067,10 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vR(times))
+                    - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1043,7 +1078,10 @@ def test_integration_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vT(times))
+                    - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1055,8 +1093,8 @@ def test_integration_3d():
                     (
                         (
                             (
-                                _anp(orbits_list[ii].phi(times))
-                                - _anp(orbits.phi(times)[ii])
+                                _to_numpy(orbits_list[ii].phi(times))
+                                - _to_numpy(orbits.phi(times)[ii])
                             )
                             + numpy.pi
                         )
@@ -1894,7 +1932,9 @@ def test_integration_forcemap_1d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1902,7 +1942,10 @@ def test_integration_forcemap_1d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1930,7 +1973,9 @@ def test_integration_forcemap_2d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1938,7 +1983,10 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1946,7 +1994,9 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1954,7 +2004,10 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vy(times))
+                    - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1962,7 +2015,9 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1970,7 +2025,10 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vR(times))
+                    - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1978,7 +2036,10 @@ def test_integration_forcemap_2d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vT(times))
+                    - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -1990,8 +2051,8 @@ def test_integration_forcemap_2d():
                     (
                         (
                             (
-                                _anp(orbits_list[ii].phi(times))
-                                - _anp(orbits.phi(times)[ii])
+                                _to_numpy(orbits_list[ii].phi(times))
+                                - _to_numpy(orbits.phi(times)[ii])
                             )
                             + numpy.pi
                         )
@@ -2026,7 +2087,9 @@ def test_integration_forcemap_3d():
     for ii in range(len(orbits)):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2034,7 +2097,10 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vx(times))
+                    - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2042,7 +2108,9 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2050,7 +2118,10 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vy(times))
+                    - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2058,7 +2129,9 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].z(times)) - _anp(orbits.z(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].z(times)) - _to_numpy(orbits.z(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2066,7 +2139,10 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vz(times))
+                    - _to_numpy(orbits.vz(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2074,7 +2150,9 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2082,7 +2160,10 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vR(times))
+                    - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2090,7 +2171,10 @@ def test_integration_forcemap_3d():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits_list[ii].vT(times))
+                    - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2102,8 +2186,8 @@ def test_integration_forcemap_3d():
                     (
                         (
                             (
-                                _anp(orbits_list[ii].phi(times))
-                                - _anp(orbits.phi(times)[ii])
+                                _to_numpy(orbits_list[ii].phi(times))
+                                - _to_numpy(orbits.phi(times)[ii])
                             )
                             + numpy.pi
                         )
@@ -2436,7 +2520,9 @@ def test_slice_singleobject():
     for ii in indices:
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2444,7 +2530,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vx(times)) - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2452,7 +2540,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2460,7 +2550,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vy(times)) - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2468,7 +2560,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].z(times)) - _anp(orbits.z(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].z(times)) - _to_numpy(orbits.z(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2476,7 +2570,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vz(times)) - _to_numpy(orbits.vz(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2484,7 +2580,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2492,7 +2590,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vR(times)) - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2500,7 +2600,9 @@ def test_slice_singleobject():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vT(times)) - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2511,7 +2613,10 @@ def test_slice_singleobject():
                 numpy.fabs(
                     (
                         (
-                            (_anp(orbits[ii].phi(times)) - _anp(orbits.phi(times)[ii]))
+                            (
+                                _to_numpy(orbits[ii].phi(times))
+                                - _to_numpy(orbits.phi(times)[ii])
+                            )
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -2544,7 +2649,9 @@ def test_slice_multipleobjects():
     for ii in range(3):
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.x()[ii]) - _anp(orbits.x()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.x()[ii]) - _to_numpy(orbits.x()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2552,7 +2659,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.vx()[ii]) - _anp(orbits.vx()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.vx()[ii]) - _to_numpy(orbits.vx()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2560,7 +2669,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.y()[ii]) - _anp(orbits.y()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.y()[ii]) - _to_numpy(orbits.y()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2568,7 +2679,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.vy()[ii]) - _anp(orbits.vy()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.vy()[ii]) - _to_numpy(orbits.vy()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2576,7 +2689,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.z()[ii]) - _anp(orbits.z()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.z()[ii]) - _to_numpy(orbits.z()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2584,7 +2699,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.vz()[ii]) - _anp(orbits.vz()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.vz()[ii]) - _to_numpy(orbits.vz()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2592,7 +2709,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.R()[ii]) - _anp(orbits.R()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.R()[ii]) - _to_numpy(orbits.R()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2600,7 +2719,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.vR()[ii]) - _anp(orbits.vR()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.vR()[ii]) - _to_numpy(orbits.vR()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2608,7 +2729,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.vT()[ii]) - _anp(orbits.vT()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.vT()[ii]) - _to_numpy(orbits.vT()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2616,7 +2739,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits_slice.phi()[ii]) - _anp(orbits.phi()[ii + 1]))
+                numpy.fabs(
+                    _to_numpy(orbits_slice.phi()[ii]) - _to_numpy(orbits.phi()[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2629,7 +2754,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.x(times)[ii]) - _anp(orbits.x(times)[ii + 1])
+                    _to_numpy(orbits_slice.x(times)[ii])
+                    - _to_numpy(orbits.x(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2639,7 +2765,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.vx(times)[ii]) - _anp(orbits.vx(times)[ii + 1])
+                    _to_numpy(orbits_slice.vx(times)[ii])
+                    - _to_numpy(orbits.vx(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2649,7 +2776,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.y(times)[ii]) - _anp(orbits.y(times)[ii + 1])
+                    _to_numpy(orbits_slice.y(times)[ii])
+                    - _to_numpy(orbits.y(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2659,7 +2787,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.vy(times)[ii]) - _anp(orbits.vy(times)[ii + 1])
+                    _to_numpy(orbits_slice.vy(times)[ii])
+                    - _to_numpy(orbits.vy(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2669,7 +2798,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.z(times)[ii]) - _anp(orbits.z(times)[ii + 1])
+                    _to_numpy(orbits_slice.z(times)[ii])
+                    - _to_numpy(orbits.z(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2679,7 +2809,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.vz(times)[ii]) - _anp(orbits.vz(times)[ii + 1])
+                    _to_numpy(orbits_slice.vz(times)[ii])
+                    - _to_numpy(orbits.vz(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2689,7 +2820,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.R(times)[ii]) - _anp(orbits.R(times)[ii + 1])
+                    _to_numpy(orbits_slice.R(times)[ii])
+                    - _to_numpy(orbits.R(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2699,7 +2831,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.vR(times)[ii]) - _anp(orbits.vR(times)[ii + 1])
+                    _to_numpy(orbits_slice.vR(times)[ii])
+                    - _to_numpy(orbits.vR(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2709,7 +2842,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.vT(times)[ii]) - _anp(orbits.vT(times)[ii + 1])
+                    _to_numpy(orbits_slice.vT(times)[ii])
+                    - _to_numpy(orbits.vT(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2719,7 +2853,8 @@ def test_slice_multipleobjects():
         assert (
             numpy.amax(
                 numpy.fabs(
-                    _anp(orbits_slice.phi(times)[ii]) - _anp(orbits.phi(times)[ii + 1])
+                    _to_numpy(orbits_slice.phi(times)[ii])
+                    - _to_numpy(orbits.phi(times)[ii + 1])
                 )
             )
             < 1e-10
@@ -2749,7 +2884,9 @@ def test_slice_singleobject_multidim():
     for ii in indices:
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].x(times)) - _anp(orbits.x(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].x(times)) - _to_numpy(orbits.x(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2757,7 +2894,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vx(times)) - _to_numpy(orbits.vx(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2765,7 +2904,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].y(times)) - _anp(orbits.y(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].y(times)) - _to_numpy(orbits.y(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2773,7 +2914,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vy(times)) - _to_numpy(orbits.vy(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2781,7 +2924,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].z(times)) - _anp(orbits.z(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].z(times)) - _to_numpy(orbits.z(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2789,7 +2934,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vz(times)) - _to_numpy(orbits.vz(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2797,7 +2944,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].R(times)) - _anp(orbits.R(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].R(times)) - _to_numpy(orbits.R(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2805,7 +2954,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vR(times)) - _to_numpy(orbits.vR(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2813,7 +2964,9 @@ def test_slice_singleobject_multidim():
         )
         assert (
             numpy.amax(
-                numpy.fabs(_anp(orbits[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+                numpy.fabs(
+                    _to_numpy(orbits[ii].vT(times)) - _to_numpy(orbits.vT(times)[ii])
+                )
             )
             < 1e-10
         ), (
@@ -2824,7 +2977,10 @@ def test_slice_singleobject_multidim():
                 numpy.fabs(
                     (
                         (
-                            (_anp(orbits[ii].phi(times)) - _anp(orbits.phi(times)[ii]))
+                            (
+                                _to_numpy(orbits[ii].phi(times))
+                                - _to_numpy(orbits.phi(times)[ii])
+                            )
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -2862,8 +3018,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.x()[ii, kk])
-                            - _anp(orbits.x()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.x()[ii, kk])
+                            - _to_numpy(orbits.x()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2873,8 +3029,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vx()[ii, kk])
-                            - _anp(orbits.vx()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vx()[ii, kk])
+                            - _to_numpy(orbits.vx()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2884,8 +3040,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.y()[ii, kk])
-                            - _anp(orbits.y()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.y()[ii, kk])
+                            - _to_numpy(orbits.y()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2895,8 +3051,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vy()[ii, kk])
-                            - _anp(orbits.vy()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vy()[ii, kk])
+                            - _to_numpy(orbits.vy()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2906,8 +3062,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.z()[ii, kk])
-                            - _anp(orbits.z()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.z()[ii, kk])
+                            - _to_numpy(orbits.z()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2917,8 +3073,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vz()[ii, kk])
-                            - _anp(orbits.vz()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vz()[ii, kk])
+                            - _to_numpy(orbits.vz()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2928,8 +3084,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.R()[ii, kk])
-                            - _anp(orbits.R()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.R()[ii, kk])
+                            - _to_numpy(orbits.R()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2939,8 +3095,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vR()[ii, kk])
-                            - _anp(orbits.vR()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vR()[ii, kk])
+                            - _to_numpy(orbits.vR()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2950,8 +3106,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vT()[ii, kk])
-                            - _anp(orbits.vT()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vT()[ii, kk])
+                            - _to_numpy(orbits.vT()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2961,8 +3117,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.phi()[ii, kk])
-                            - _anp(orbits.phi()[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.phi()[ii, kk])
+                            - _to_numpy(orbits.phi()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2978,8 +3134,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.x(times)[ii, kk])
-                            - _anp(orbits.x(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.x(times)[ii, kk])
+                            - _to_numpy(orbits.x(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2989,8 +3145,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vx(times)[ii, kk])
-                            - _anp(orbits.vx(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vx(times)[ii, kk])
+                            - _to_numpy(orbits.vx(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3000,8 +3156,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.y(times)[ii, kk])
-                            - _anp(orbits.y(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.y(times)[ii, kk])
+                            - _to_numpy(orbits.y(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3011,8 +3167,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vy(times)[ii, kk])
-                            - _anp(orbits.vy(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vy(times)[ii, kk])
+                            - _to_numpy(orbits.vy(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3022,8 +3178,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.z(times)[ii, kk])
-                            - _anp(orbits.z(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.z(times)[ii, kk])
+                            - _to_numpy(orbits.z(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3033,8 +3189,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vz(times)[ii, kk])
-                            - _anp(orbits.vz(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vz(times)[ii, kk])
+                            - _to_numpy(orbits.vz(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3044,8 +3200,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.R(times)[ii, kk])
-                            - _anp(orbits.R(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.R(times)[ii, kk])
+                            - _to_numpy(orbits.R(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3055,8 +3211,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vR(times)[ii, kk])
-                            - _anp(orbits.vR(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vR(times)[ii, kk])
+                            - _to_numpy(orbits.vR(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3066,8 +3222,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.vT(times)[ii, kk])
-                            - _anp(orbits.vT(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.vT(times)[ii, kk])
+                            - _to_numpy(orbits.vT(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3077,8 +3233,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            _anp(orbits_slice.phi(times)[ii, kk])
-                            - _anp(orbits.phi(times)[ii + 1, jj, kk])
+                            _to_numpy(orbits_slice.phi(times)[ii, kk])
+                            - _to_numpy(orbits.phi(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -3187,51 +3343,73 @@ def test_slice_physical_issue385():
             "Sliced Orbit instance that was supposed to have physical output turned does not have the right zo"
         )
         assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].x()) - _anp(orbits.x()[ii]))) < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].vx()) - _anp(orbits.vx()[ii])))
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].x()) - _to_numpy(orbits.x()[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].y()) - _anp(orbits.y()[ii]))) < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].vy()) - _anp(orbits.vy()[ii])))
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].vx()) - _to_numpy(orbits.vx()[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].z()) - _anp(orbits.z()[ii]))) < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].vz()) - _anp(orbits.vz()[ii])))
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].y()) - _to_numpy(orbits.y()[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].R()) - _anp(orbits.R()[ii]))) < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].vR()) - _anp(orbits.vR()[ii])))
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].vy()) - _to_numpy(orbits.vy()[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(_anp(orbits[ii].vT()) - _anp(orbits.vT()[ii])))
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].z()) - _to_numpy(orbits.z()[ii]))
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].vz()) - _to_numpy(orbits.vz()[ii]))
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].R()) - _to_numpy(orbits.R()[ii]))
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].vR()) - _to_numpy(orbits.vR()[ii]))
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(_to_numpy(orbits[ii].vT()) - _to_numpy(orbits.vT()[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -3240,7 +3418,10 @@ def test_slice_physical_issue385():
             numpy.amax(
                 numpy.fabs(
                     (
-                        ((_anp(orbits[ii].phi()) - _anp(orbits.phi()[ii])) + numpy.pi)
+                        (
+                            (_to_numpy(orbits[ii].phi()) - _to_numpy(orbits.phi()[ii]))
+                            + numpy.pi
+                        )
                         % (2.0 * numpy.pi)
                     )
                     - numpy.pi
@@ -3706,30 +3887,30 @@ def test_coordinate_interpolation():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time()) - _anp(list_os[ii].time())) < 1e-10
+            numpy.fabs(_to_numpy(os.time()) - _to_numpy(list_os[ii].time())) < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+            numpy.fabs(_to_numpy(os.R()[ii]) - _to_numpy(list_os[ii].R())) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+            numpy.fabs(_to_numpy(os.r()[ii]) - _to_numpy(list_os[ii].r())) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+            numpy.fabs(_to_numpy(os.vR()[ii]) - _to_numpy(list_os[ii].vR())) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+            numpy.fabs(_to_numpy(os.vT()[ii]) - _to_numpy(list_os[ii].vT())) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+            numpy.fabs(_to_numpy(os.z()[ii]) - _to_numpy(list_os[ii].z())) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+            numpy.fabs(_to_numpy(os.vz()[ii]) - _to_numpy(list_os[ii].vz())) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (_anp(os.phi()[ii]) - _anp(list_os[ii].phi()) + numpy.pi)
+                    (_to_numpy(os.phi()[ii]) - _to_numpy(list_os[ii].phi()) + numpy.pi)
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -3737,79 +3918,83 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.x()[ii]) - _anp(list_os[ii].x())) < 1e-10
+            numpy.fabs(_to_numpy(os.x()[ii]) - _to_numpy(list_os[ii].x())) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.y()[ii]) - _anp(list_os[ii].y())) < 1e-10
+            numpy.fabs(_to_numpy(os.y()[ii]) - _to_numpy(list_os[ii].y())) < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx()[ii]) - _anp(list_os[ii].vx())) < 1e-10
+            numpy.fabs(_to_numpy(os.vx()[ii]) - _to_numpy(list_os[ii].vx())) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vy()[ii]) - _anp(list_os[ii].vy())) < 1e-10
+            numpy.fabs(_to_numpy(os.vy()[ii]) - _to_numpy(list_os[ii].vy())) < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+            numpy.fabs(_to_numpy(os.vphi()[ii]) - _to_numpy(list_os[ii].vphi())) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ra()[ii]) - _anp(list_os[ii].ra())) < 1e-10
+            numpy.fabs(_to_numpy(os.ra()[ii]) - _to_numpy(list_os[ii].ra())) < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dec()[ii]) - _anp(list_os[ii].dec())) < 1e-10
+            numpy.fabs(_to_numpy(os.dec()[ii]) - _to_numpy(list_os[ii].dec())) < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dist()[ii]) - _anp(list_os[ii].dist())) < 1e-10
+            numpy.fabs(_to_numpy(os.dist()[ii]) - _to_numpy(list_os[ii].dist())) < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ll()[ii]) - _anp(list_os[ii].ll())) < 1e-10
+            numpy.fabs(_to_numpy(os.ll()[ii]) - _to_numpy(list_os[ii].ll())) < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.bb()[ii]) - _anp(list_os[ii].bb())) < 1e-10
+            numpy.fabs(_to_numpy(os.bb()[ii]) - _to_numpy(list_os[ii].bb())) < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmra()[ii]) - _anp(list_os[ii].pmra())) < 1e-10
+            numpy.fabs(_to_numpy(os.pmra()[ii]) - _to_numpy(list_os[ii].pmra())) < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmdec()[ii]) - _anp(list_os[ii].pmdec())) < 1e-10
+            numpy.fabs(_to_numpy(os.pmdec()[ii]) - _to_numpy(list_os[ii].pmdec()))
+            < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmll()[ii]) - _anp(list_os[ii].pmll())) < 1e-10
+            numpy.fabs(_to_numpy(os.pmll()[ii]) - _to_numpy(list_os[ii].pmll())) < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmbb()[ii]) - _anp(list_os[ii].pmbb())) < 1e-10
+            numpy.fabs(_to_numpy(os.pmbb()[ii]) - _to_numpy(list_os[ii].pmbb())) < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vra()[ii]) - _anp(list_os[ii].vra())) < 1e-10
+            numpy.fabs(_to_numpy(os.vra()[ii]) - _to_numpy(list_os[ii].vra())) < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vdec()[ii]) - _anp(list_os[ii].vdec())) < 1e-10
+            numpy.fabs(_to_numpy(os.vdec()[ii]) - _to_numpy(list_os[ii].vdec())) < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vll()[ii]) - _anp(list_os[ii].vll())) < 1e-10
+            numpy.fabs(_to_numpy(os.vll()[ii]) - _to_numpy(list_os[ii].vll())) < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vbb()[ii]) - _anp(list_os[ii].vbb())) < 1e-10
+            numpy.fabs(_to_numpy(os.vbb()[ii]) - _to_numpy(list_os[ii].vbb())) < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vlos()[ii]) - _anp(list_os[ii].vlos())) < 1e-10
+            numpy.fabs(_to_numpy(os.vlos()[ii]) - _to_numpy(list_os[ii].vlos())) < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioX()[ii]) - _anp(list_os[ii].helioX())) < 1e-10
+            numpy.fabs(_to_numpy(os.helioX()[ii]) - _to_numpy(list_os[ii].helioX()))
+            < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioY()[ii]) - _anp(list_os[ii].helioY())) < 1e-10
+            numpy.fabs(_to_numpy(os.helioY()[ii]) - _to_numpy(list_os[ii].helioY()))
+            < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioZ()[ii]) - _anp(list_os[ii].helioZ())) < 1e-10
+            numpy.fabs(_to_numpy(os.helioZ()[ii]) - _to_numpy(list_os[ii].helioZ()))
+            < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.U()[ii]) - _anp(list_os[ii].U())) < 1e-10
+            numpy.fabs(_to_numpy(os.U()[ii]) - _to_numpy(list_os[ii].U())) < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.V()[ii]) - _anp(list_os[ii].V())) < 1e-10
+            numpy.fabs(_to_numpy(os.V()[ii]) - _to_numpy(list_os[ii].V())) < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.W()[ii]) - _anp(list_os[ii].W())) < 1e-10
+            numpy.fabs(_to_numpy(os.W()[ii]) - _to_numpy(list_os[ii].W())) < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord().ra[ii] - list_os[ii].SkyCoord().ra).to(u.deg).value
@@ -3859,30 +4044,41 @@ def test_coordinate_interpolation():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time(times)) - _anp(list_os[ii].time(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.time(times)) - _to_numpy(list_os[ii].time(times)))
+            < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(times)[ii]) - _to_numpy(list_os[ii].R(times)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(times)[ii]) - _to_numpy(list_os[ii].r(times)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(times)[ii]) - _to_numpy(list_os[ii].vR(times)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(times)[ii]) - _to_numpy(list_os[ii].vT(times)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(times)[ii]) - _to_numpy(list_os[ii].z(times)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(times)[ii]) - _to_numpy(list_os[ii].vz(times)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times)) + numpy.pi)
+                    (
+                        _to_numpy(os.phi(times)[ii])
+                        - _to_numpy(list_os[ii].phi(times))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -3890,83 +4086,126 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.x(times)[ii]) - _anp(list_os[ii].x(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.x(times)[ii]) - _to_numpy(list_os[ii].x(times)))
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.y(times)[ii]) - _anp(list_os[ii].y(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.y(times)[ii]) - _to_numpy(list_os[ii].y(times)))
+            < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(times)[ii]) - _anp(list_os[ii].vx(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vx(times)[ii]) - _to_numpy(list_os[ii].vx(times)))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vy(times)[ii]) - _anp(list_os[ii].vy(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vy(times)[ii]) - _to_numpy(list_os[ii].vy(times)))
+            < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vphi(times)[ii]) - _to_numpy(list_os[ii].vphi(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ra(times)[ii]) - _anp(list_os[ii].ra(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.ra(times)[ii]) - _to_numpy(list_os[ii].ra(times)))
+            < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dec(times)[ii]) - _anp(list_os[ii].dec(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.dec(times)[ii]) - _to_numpy(list_os[ii].dec(times)))
+            < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dist(times)[ii]) - _anp(list_os[ii].dist(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.dist(times)[ii]) - _to_numpy(list_os[ii].dist(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ll(times)[ii]) - _anp(list_os[ii].ll(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.ll(times)[ii]) - _to_numpy(list_os[ii].ll(times)))
+            < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.bb(times)[ii]) - _anp(list_os[ii].bb(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.bb(times)[ii]) - _to_numpy(list_os[ii].bb(times)))
+            < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmra(times)[ii]) - _anp(list_os[ii].pmra(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.pmra(times)[ii]) - _to_numpy(list_os[ii].pmra(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmdec(times)[ii]) - _anp(list_os[ii].pmdec(times)))
+            numpy.fabs(
+                _to_numpy(os.pmdec(times)[ii]) - _to_numpy(list_os[ii].pmdec(times))
+            )
             < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmll(times)[ii]) - _anp(list_os[ii].pmll(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.pmll(times)[ii]) - _to_numpy(list_os[ii].pmll(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmbb(times)[ii]) - _anp(list_os[ii].pmbb(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.pmbb(times)[ii]) - _to_numpy(list_os[ii].pmbb(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vra(times)[ii]) - _anp(list_os[ii].vra(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vra(times)[ii]) - _to_numpy(list_os[ii].vra(times)))
+            < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vdec(times)[ii]) - _anp(list_os[ii].vdec(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vdec(times)[ii]) - _to_numpy(list_os[ii].vdec(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vll(times)[ii]) - _anp(list_os[ii].vll(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vll(times)[ii]) - _to_numpy(list_os[ii].vll(times)))
+            < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vbb(times)[ii]) - _anp(list_os[ii].vbb(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vbb(times)[ii]) - _to_numpy(list_os[ii].vbb(times)))
+            < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vlos(times)[ii]) - _anp(list_os[ii].vlos(times))) < 1e-9
+            numpy.fabs(
+                _to_numpy(os.vlos(times)[ii]) - _to_numpy(list_os[ii].vlos(times))
+            )
+            < 1e-9
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioX(times)[ii]) - _anp(list_os[ii].helioX(times)))
+            numpy.fabs(
+                _to_numpy(os.helioX(times)[ii]) - _to_numpy(list_os[ii].helioX(times))
+            )
             < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioY(times)[ii]) - _anp(list_os[ii].helioY(times)))
+            numpy.fabs(
+                _to_numpy(os.helioY(times)[ii]) - _to_numpy(list_os[ii].helioY(times))
+            )
             < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioZ(times)[ii]) - _anp(list_os[ii].helioZ(times)))
+            numpy.fabs(
+                _to_numpy(os.helioZ(times)[ii]) - _to_numpy(list_os[ii].helioZ(times))
+            )
             < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.U(times)[ii]) - _anp(list_os[ii].U(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.U(times)[ii]) - _to_numpy(list_os[ii].U(times)))
+            < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.V(times)[ii]) - _anp(list_os[ii].V(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.V(times)[ii]) - _to_numpy(list_os[ii].V(times)))
+            < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.W(times)[ii]) - _anp(list_os[ii].W(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.W(times)[ii]) - _to_numpy(list_os[ii].W(times)))
+            < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(times).ra[ii] - list_os[ii].SkyCoord(times).ra)
@@ -4018,36 +4257,53 @@ def test_coordinate_interpolation():
         # Also a single time in the array ...
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time(times[1])) - _anp(list_os[ii].time(times[1])))
+            numpy.fabs(
+                _to_numpy(os.time(times[1])) - _to_numpy(list_os[ii].time(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.R(times[1])[ii]) - _to_numpy(list_os[ii].R(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.r(times[1])[ii]) - _to_numpy(list_os[ii].r(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(times[1])[ii]) - _to_numpy(list_os[ii].vR(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(times[1])[ii]) - _to_numpy(list_os[ii].vT(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.z(times[1])[ii]) - _to_numpy(list_os[ii].z(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(times[1])[ii]) - _to_numpy(list_os[ii].vz(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(times[1])[ii])
-                        - _anp(list_os[ii].phi(times[1]))
+                        _to_numpy(os.phi(times[1])[ii])
+                        - _to_numpy(list_os[ii].phi(times[1]))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -4057,105 +4313,158 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.x(times[1])[ii]) - _anp(list_os[ii].x(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.x(times[1])[ii]) - _to_numpy(list_os[ii].x(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.y(times[1])[ii]) - _anp(list_os[ii].y(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.y(times[1])[ii]) - _to_numpy(list_os[ii].y(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(times[1])[ii]) - _anp(list_os[ii].vx(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vx(times[1])[ii]) - _to_numpy(list_os[ii].vx(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vy(times[1])[ii]) - _anp(list_os[ii].vy(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vy(times[1])[ii]) - _to_numpy(list_os[ii].vy(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(times[1])[ii]) - _to_numpy(list_os[ii].vphi(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ra(times[1])[ii]) - _anp(list_os[ii].ra(times[1])))
+            numpy.fabs(
+                _to_numpy(os.ra(times[1])[ii]) - _to_numpy(list_os[ii].ra(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dec(times[1])[ii]) - _anp(list_os[ii].dec(times[1])))
+            numpy.fabs(
+                _to_numpy(os.dec(times[1])[ii]) - _to_numpy(list_os[ii].dec(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dist(times[1])[ii]) - _anp(list_os[ii].dist(times[1])))
+            numpy.fabs(
+                _to_numpy(os.dist(times[1])[ii]) - _to_numpy(list_os[ii].dist(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ll(times[1])[ii]) - _anp(list_os[ii].ll(times[1])))
+            numpy.fabs(
+                _to_numpy(os.ll(times[1])[ii]) - _to_numpy(list_os[ii].ll(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.bb(times[1])[ii]) - _anp(list_os[ii].bb(times[1])))
+            numpy.fabs(
+                _to_numpy(os.bb(times[1])[ii]) - _to_numpy(list_os[ii].bb(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmra(times[1])[ii]) - _anp(list_os[ii].pmra(times[1])))
+            numpy.fabs(
+                _to_numpy(os.pmra(times[1])[ii]) - _to_numpy(list_os[ii].pmra(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmdec(times[1])[ii]) - _anp(list_os[ii].pmdec(times[1])))
+            numpy.fabs(
+                _to_numpy(os.pmdec(times[1])[ii])
+                - _to_numpy(list_os[ii].pmdec(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmll(times[1])[ii]) - _anp(list_os[ii].pmll(times[1])))
+            numpy.fabs(
+                _to_numpy(os.pmll(times[1])[ii]) - _to_numpy(list_os[ii].pmll(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmbb(times[1])[ii]) - _anp(list_os[ii].pmbb(times[1])))
+            numpy.fabs(
+                _to_numpy(os.pmbb(times[1])[ii]) - _to_numpy(list_os[ii].pmbb(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vra(times[1])[ii]) - _anp(list_os[ii].vra(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vra(times[1])[ii]) - _to_numpy(list_os[ii].vra(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vdec(times[1])[ii]) - _anp(list_os[ii].vdec(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vdec(times[1])[ii]) - _to_numpy(list_os[ii].vdec(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vll(times[1])[ii]) - _anp(list_os[ii].vll(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vll(times[1])[ii]) - _to_numpy(list_os[ii].vll(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vbb(times[1])[ii]) - _anp(list_os[ii].vbb(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vbb(times[1])[ii]) - _to_numpy(list_os[ii].vbb(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vlos(times[1])[ii]) - _anp(list_os[ii].vlos(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vlos(times[1])[ii]) - _to_numpy(list_os[ii].vlos(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioX(times[1])[ii]) - _anp(list_os[ii].helioX(times[1]))
+                _to_numpy(os.helioX(times[1])[ii])
+                - _to_numpy(list_os[ii].helioX(times[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioY(times[1])[ii]) - _anp(list_os[ii].helioY(times[1]))
+                _to_numpy(os.helioY(times[1])[ii])
+                - _to_numpy(list_os[ii].helioY(times[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioZ(times[1])[ii]) - _anp(list_os[ii].helioZ(times[1]))
+                _to_numpy(os.helioZ(times[1])[ii])
+                - _to_numpy(list_os[ii].helioZ(times[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.U(times[1])[ii]) - _anp(list_os[ii].U(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.U(times[1])[ii]) - _to_numpy(list_os[ii].U(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.V(times[1])[ii]) - _anp(list_os[ii].V(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.V(times[1])[ii]) - _to_numpy(list_os[ii].V(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.W(times[1])[ii]) - _anp(list_os[ii].W(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.W(times[1])[ii]) - _to_numpy(list_os[ii].W(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(times[1]).ra[ii] - list_os[ii].SkyCoord(times[1]).ra)
@@ -4212,29 +4521,35 @@ def test_coordinate_interpolation():
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(itimes)[ii]) - _to_numpy(list_os[ii].R(itimes)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(itimes)[ii]) - _to_numpy(list_os[ii].r(itimes)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(itimes)[ii]) - _to_numpy(list_os[ii].vR(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(itimes)[ii]) - _to_numpy(list_os[ii].vT(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(itimes)[ii]) - _to_numpy(list_os[ii].z(itimes)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(itimes)[ii]) - _to_numpy(list_os[ii].vz(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(itimes)[ii])
-                        - _anp(list_os[ii].phi(itimes))
+                        _to_numpy(os.phi(itimes)[ii])
+                        - _to_numpy(list_os[ii].phi(itimes))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -4244,90 +4559,134 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.x(itimes)[ii]) - _anp(list_os[ii].x(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.x(itimes)[ii]) - _to_numpy(list_os[ii].x(itimes)))
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.y(itimes)[ii]) - _anp(list_os[ii].y(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.y(itimes)[ii]) - _to_numpy(list_os[ii].y(itimes)))
+            < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(itimes)[ii]) - _anp(list_os[ii].vx(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vx(itimes)[ii]) - _to_numpy(list_os[ii].vx(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vy(itimes)[ii]) - _anp(list_os[ii].vy(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vy(itimes)[ii]) - _to_numpy(list_os[ii].vy(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes)[ii]) - _to_numpy(list_os[ii].vphi(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vphidoes not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ra(itimes)[ii]) - _anp(list_os[ii].ra(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.ra(itimes)[ii]) - _to_numpy(list_os[ii].ra(itimes)))
+            < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dec(itimes)[ii]) - _anp(list_os[ii].dec(itimes))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.dec(itimes)[ii]) - _to_numpy(list_os[ii].dec(itimes))
+            )
+            < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dist(itimes)[ii]) - _anp(list_os[ii].dist(itimes)))
+            numpy.fabs(
+                _to_numpy(os.dist(itimes)[ii]) - _to_numpy(list_os[ii].dist(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ll(itimes)[ii]) - _anp(list_os[ii].ll(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.ll(itimes)[ii]) - _to_numpy(list_os[ii].ll(itimes)))
+            < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.bb(itimes)[ii]) - _anp(list_os[ii].bb(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.bb(itimes)[ii]) - _to_numpy(list_os[ii].bb(itimes)))
+            < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmra(itimes)[ii]) - _anp(list_os[ii].pmra(itimes)))
+            numpy.fabs(
+                _to_numpy(os.pmra(itimes)[ii]) - _to_numpy(list_os[ii].pmra(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmdec(itimes)[ii]) - _anp(list_os[ii].pmdec(itimes)))
+            numpy.fabs(
+                _to_numpy(os.pmdec(itimes)[ii]) - _to_numpy(list_os[ii].pmdec(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmll(itimes)[ii]) - _anp(list_os[ii].pmll(itimes)))
+            numpy.fabs(
+                _to_numpy(os.pmll(itimes)[ii]) - _to_numpy(list_os[ii].pmll(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmbb(itimes)[ii]) - _anp(list_os[ii].pmbb(itimes)))
+            numpy.fabs(
+                _to_numpy(os.pmbb(itimes)[ii]) - _to_numpy(list_os[ii].pmbb(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vra(itimes)[ii]) - _anp(list_os[ii].vra(itimes))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vra(itimes)[ii]) - _to_numpy(list_os[ii].vra(itimes))
+            )
+            < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vdec(itimes)[ii]) - _anp(list_os[ii].vdec(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vdec(itimes)[ii]) - _to_numpy(list_os[ii].vdec(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vll(itimes)[ii]) - _anp(list_os[ii].vll(itimes))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vll(itimes)[ii]) - _to_numpy(list_os[ii].vll(itimes))
+            )
+            < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vbb(itimes)[ii]) - _anp(list_os[ii].vbb(itimes))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vbb(itimes)[ii]) - _to_numpy(list_os[ii].vbb(itimes))
+            )
+            < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vlos(itimes)[ii]) - _anp(list_os[ii].vlos(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vlos(itimes)[ii]) - _to_numpy(list_os[ii].vlos(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioX(itimes)[ii]) - _anp(list_os[ii].helioX(itimes)))
+            numpy.fabs(
+                _to_numpy(os.helioX(itimes)[ii]) - _to_numpy(list_os[ii].helioX(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioY(itimes)[ii]) - _anp(list_os[ii].helioY(itimes)))
+            numpy.fabs(
+                _to_numpy(os.helioY(itimes)[ii]) - _to_numpy(list_os[ii].helioY(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.helioZ(itimes)[ii]) - _anp(list_os[ii].helioZ(itimes)))
+            numpy.fabs(
+                _to_numpy(os.helioZ(itimes)[ii]) - _to_numpy(list_os[ii].helioZ(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.U(itimes)[ii]) - _anp(list_os[ii].U(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.U(itimes)[ii]) - _to_numpy(list_os[ii].U(itimes)))
+            < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.V(itimes)[ii]) - _anp(list_os[ii].V(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.V(itimes)[ii]) - _to_numpy(list_os[ii].V(itimes)))
+            < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.W(itimes)[ii]) - _anp(list_os[ii].W(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.W(itimes)[ii]) - _to_numpy(list_os[ii].W(itimes)))
+            < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(itimes).ra[ii] - list_os[ii].SkyCoord(itimes).ra)
@@ -4378,35 +4737,47 @@ def test_coordinate_interpolation():
             ), "Evaluating Orbits SkyCoord does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.R(itimes[1])[ii]) - _to_numpy(list_os[ii].R(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.r(itimes[1])[ii]) - _to_numpy(list_os[ii].r(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(itimes[1])[ii]) - _to_numpy(list_os[ii].vR(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(itimes[1])[ii]) - _to_numpy(list_os[ii].vT(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.z(itimes[1])[ii]) - _to_numpy(list_os[ii].z(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(itimes[1])[ii]) - _to_numpy(list_os[ii].vz(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(itimes[1])[ii])
-                        - _anp(list_os[ii].phi(itimes[1]))
+                        _to_numpy(os.phi(itimes[1])[ii])
+                        - _to_numpy(list_os[ii].phi(itimes[1]))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -4416,91 +4787,133 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ra(itimes[1])[ii]) - _anp(list_os[ii].ra(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.ra(itimes[1])[ii]) - _to_numpy(list_os[ii].ra(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dec(itimes[1])[ii]) - _anp(list_os[ii].dec(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.dec(itimes[1])[ii]) - _to_numpy(list_os[ii].dec(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.dist(itimes[1])[ii]) - _anp(list_os[ii].dist(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.dist(itimes[1])[ii])
+                - _to_numpy(list_os[ii].dist(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.ll(itimes[1])[ii]) - _anp(list_os[ii].ll(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.ll(itimes[1])[ii]) - _to_numpy(list_os[ii].ll(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.bb(itimes[1])[ii]) - _anp(list_os[ii].bb(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.bb(itimes[1])[ii]) - _to_numpy(list_os[ii].bb(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmra(itimes[1])[ii]) - _anp(list_os[ii].pmra(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.pmra(itimes[1])[ii])
+                - _to_numpy(list_os[ii].pmra(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.pmdec(itimes[1])[ii]) - _anp(list_os[ii].pmdec(itimes[1]))
+                _to_numpy(os.pmdec(itimes[1])[ii])
+                - _to_numpy(list_os[ii].pmdec(itimes[1]))
             )
             < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmll(itimes[1])[ii]) - _anp(list_os[ii].pmll(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.pmll(itimes[1])[ii])
+                - _to_numpy(list_os[ii].pmll(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.pmbb(itimes[1])[ii]) - _anp(list_os[ii].pmbb(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.pmbb(itimes[1])[ii])
+                - _to_numpy(list_os[ii].pmbb(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vra(itimes[1])[ii]) - _anp(list_os[ii].vra(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vra(itimes[1])[ii]) - _to_numpy(list_os[ii].vra(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vdec(itimes[1])[ii]) - _anp(list_os[ii].vdec(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vdec(itimes[1])[ii])
+                - _to_numpy(list_os[ii].vdec(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vll(itimes[1])[ii]) - _anp(list_os[ii].vll(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vll(itimes[1])[ii]) - _to_numpy(list_os[ii].vll(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vbb(itimes[1])[ii]) - _anp(list_os[ii].vbb(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vbb(itimes[1])[ii]) - _to_numpy(list_os[ii].vbb(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vlos(itimes[1])[ii]) - _anp(list_os[ii].vlos(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vlos(itimes[1])[ii])
+                - _to_numpy(list_os[ii].vlos(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioX(itimes[1])[ii]) - _anp(list_os[ii].helioX(itimes[1]))
+                _to_numpy(os.helioX(itimes[1])[ii])
+                - _to_numpy(list_os[ii].helioX(itimes[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioY(itimes[1])[ii]) - _anp(list_os[ii].helioY(itimes[1]))
+                _to_numpy(os.helioY(itimes[1])[ii])
+                - _to_numpy(list_os[ii].helioY(itimes[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                _anp(os.helioZ(itimes[1])[ii]) - _anp(list_os[ii].helioZ(itimes[1]))
+                _to_numpy(os.helioZ(itimes[1])[ii])
+                - _to_numpy(list_os[ii].helioZ(itimes[1]))
             )
             < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.U(itimes[1])[ii]) - _anp(list_os[ii].U(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.U(itimes[1])[ii]) - _to_numpy(list_os[ii].U(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.V(itimes[1])[ii]) - _anp(list_os[ii].V(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.V(itimes[1])[ii]) - _to_numpy(list_os[ii].V(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.W(itimes[1])[ii]) - _anp(list_os[ii].W(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.W(itimes[1])[ii]) - _to_numpy(list_os[ii].W(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
@@ -4579,25 +4992,25 @@ def test_coordinate_interpolation_5d():
     # Before integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+            numpy.fabs(_to_numpy(os.R()[ii]) - _to_numpy(list_os[ii].R())) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+            numpy.fabs(_to_numpy(os.r()[ii]) - _to_numpy(list_os[ii].r())) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+            numpy.fabs(_to_numpy(os.vR()[ii]) - _to_numpy(list_os[ii].vR())) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+            numpy.fabs(_to_numpy(os.vT()[ii]) - _to_numpy(list_os[ii].vT())) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+            numpy.fabs(_to_numpy(os.z()[ii]) - _to_numpy(list_os[ii].z())) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+            numpy.fabs(_to_numpy(os.vz()[ii]) - _to_numpy(list_os[ii].vz())) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+            numpy.fabs(_to_numpy(os.vphi()[ii]) - _to_numpy(list_os[ii].vphi())) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
@@ -4606,104 +5019,153 @@ def test_coordinate_interpolation_5d():
     # Test exact times of integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(times)[ii]) - _to_numpy(list_os[ii].R(times)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(times)[ii]) - _to_numpy(list_os[ii].r(times)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(times)[ii]) - _to_numpy(list_os[ii].vR(times)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(times)[ii]) - _to_numpy(list_os[ii].vT(times)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(times)[ii]) - _to_numpy(list_os[ii].z(times)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(times)[ii]) - _to_numpy(list_os[ii].vz(times)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vphi(times)[ii]) - _to_numpy(list_os[ii].vphi(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.R(times[1])[ii]) - _to_numpy(list_os[ii].R(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.r(times[1])[ii]) - _to_numpy(list_os[ii].r(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(times[1])[ii]) - _to_numpy(list_os[ii].vR(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(times[1])[ii]) - _to_numpy(list_os[ii].vT(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.z(times[1])[ii]) - _to_numpy(list_os[ii].z(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(times[1])[ii]) - _to_numpy(list_os[ii].vz(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(times[1])[ii]) - _to_numpy(list_os[ii].vphi(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(itimes)[ii]) - _to_numpy(list_os[ii].R(itimes)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(itimes)[ii]) - _to_numpy(list_os[ii].r(itimes)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(itimes)[ii]) - _to_numpy(list_os[ii].vR(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(itimes)[ii]) - _to_numpy(list_os[ii].vT(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(itimes)[ii]) - _to_numpy(list_os[ii].z(itimes)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(itimes)[ii]) - _to_numpy(list_os[ii].vz(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes)[ii]) - _to_numpy(list_os[ii].vphi(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.R(itimes[1])[ii]) - _to_numpy(list_os[ii].R(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.r(itimes[1])[ii]) - _to_numpy(list_os[ii].r(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(itimes[1])[ii]) - _to_numpy(list_os[ii].vR(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(itimes[1])[ii]) - _to_numpy(list_os[ii].vT(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.z(itimes[1])[ii]) - _to_numpy(list_os[ii].z(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(itimes[1])[ii]) - _to_numpy(list_os[ii].vz(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes[1])[ii])
+                - _to_numpy(list_os[ii].vphi(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
@@ -4728,22 +5190,22 @@ def test_coordinate_interpolation_4d():
     # Before integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+            numpy.fabs(_to_numpy(os.R()[ii]) - _to_numpy(list_os[ii].R())) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+            numpy.fabs(_to_numpy(os.r()[ii]) - _to_numpy(list_os[ii].r())) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+            numpy.fabs(_to_numpy(os.vR()[ii]) - _to_numpy(list_os[ii].vR())) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+            numpy.fabs(_to_numpy(os.vT()[ii]) - _to_numpy(list_os[ii].vT())) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.phi()[ii]) - _anp(list_os[ii].phi())) < 1e-10
+            numpy.fabs(_to_numpy(os.phi()[ii]) - _to_numpy(list_os[ii].phi())) < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+            numpy.fabs(_to_numpy(os.vphi()[ii]) - _to_numpy(list_os[ii].vphi())) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
@@ -4752,91 +5214,135 @@ def test_coordinate_interpolation_4d():
     # Test exact times of integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(times)[ii]) - _to_numpy(list_os[ii].R(times)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(times)[ii]) - _to_numpy(list_os[ii].r(times)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(times)[ii]) - _to_numpy(list_os[ii].vR(times)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(times)[ii]) - _to_numpy(list_os[ii].vT(times)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.phi(times)[ii]) - _to_numpy(list_os[ii].phi(times)))
+            < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vphi(times)[ii]) - _to_numpy(list_os[ii].vphi(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.R(times[1])[ii]) - _to_numpy(list_os[ii].R(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.r(times[1])[ii]) - _to_numpy(list_os[ii].r(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(times[1])[ii]) - _to_numpy(list_os[ii].vR(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(times[1])[ii]) - _to_numpy(list_os[ii].vT(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.phi(times[1])[ii]) - _anp(list_os[ii].phi(times[1])))
+            numpy.fabs(
+                _to_numpy(os.phi(times[1])[ii]) - _to_numpy(list_os[ii].phi(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(times[1])[ii]) - _to_numpy(list_os[ii].vphi(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(itimes)[ii]) - _to_numpy(list_os[ii].R(itimes)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(itimes)[ii]) - _to_numpy(list_os[ii].r(itimes)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(itimes)[ii]) - _to_numpy(list_os[ii].vR(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(itimes)[ii]) - _to_numpy(list_os[ii].vT(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.phi(itimes)[ii]) - _anp(list_os[ii].phi(itimes))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.phi(itimes)[ii]) - _to_numpy(list_os[ii].phi(itimes))
+            )
+            < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes)[ii]) - _to_numpy(list_os[ii].vphi(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.R(itimes[1])[ii]) - _to_numpy(list_os[ii].R(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.r(itimes[1])[ii]) - _to_numpy(list_os[ii].r(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(itimes[1])[ii]) - _to_numpy(list_os[ii].vR(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(itimes[1])[ii]) - _to_numpy(list_os[ii].vT(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.phi(itimes[1])[ii]) - _anp(list_os[ii].phi(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.phi(itimes[1])[ii]) - _to_numpy(list_os[ii].phi(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes[1])[ii])
+                - _to_numpy(list_os[ii].vphi(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
@@ -4862,19 +5368,19 @@ def test_coordinate_interpolation_3d():
     # Before integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+            numpy.fabs(_to_numpy(os.R()[ii]) - _to_numpy(list_os[ii].R())) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+            numpy.fabs(_to_numpy(os.r()[ii]) - _to_numpy(list_os[ii].r())) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+            numpy.fabs(_to_numpy(os.vR()[ii]) - _to_numpy(list_os[ii].vR())) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+            numpy.fabs(_to_numpy(os.vT()[ii]) - _to_numpy(list_os[ii].vT())) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+            numpy.fabs(_to_numpy(os.vphi()[ii]) - _to_numpy(list_os[ii].vphi())) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
@@ -4883,77 +5389,113 @@ def test_coordinate_interpolation_3d():
     # Test exact times of integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(times)[ii]) - _to_numpy(list_os[ii].R(times)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(times)[ii]) - _to_numpy(list_os[ii].r(times)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(times)[ii]) - _to_numpy(list_os[ii].vR(times)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(times)[ii]) - _to_numpy(list_os[ii].vT(times)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.vphi(times)[ii]) - _to_numpy(list_os[ii].vphi(times))
+            )
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.R(times[1])[ii]) - _to_numpy(list_os[ii].R(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.r(times[1])[ii]) - _to_numpy(list_os[ii].r(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(times[1])[ii]) - _to_numpy(list_os[ii].vR(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(times[1])[ii]) - _to_numpy(list_os[ii].vT(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(times[1])[ii]) - _to_numpy(list_os[ii].vphi(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(itimes)[ii]) - _to_numpy(list_os[ii].R(itimes)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(itimes)[ii]) - _to_numpy(list_os[ii].r(itimes)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(itimes)[ii]) - _to_numpy(list_os[ii].vR(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(itimes)[ii]) - _to_numpy(list_os[ii].vT(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes)[ii]) - _to_numpy(list_os[ii].vphi(itimes))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.R(itimes[1])[ii]) - _to_numpy(list_os[ii].R(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.r(itimes[1])[ii]) - _to_numpy(list_os[ii].r(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(itimes[1])[ii]) - _to_numpy(list_os[ii].vR(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(itimes[1])[ii]) - _to_numpy(list_os[ii].vT(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vphi(itimes[1])[ii])
+                - _to_numpy(list_os[ii].vphi(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
@@ -4985,10 +5527,10 @@ def test_coordinate_interpolation_2d():
     # Before integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.x()[ii]) - _anp(list_os[ii].x())) < 1e-10
+            numpy.fabs(_to_numpy(os.x()[ii]) - _to_numpy(list_os[ii].x())) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx()[ii]) - _anp(list_os[ii].vx())) < 1e-10
+            numpy.fabs(_to_numpy(os.vx()[ii]) - _to_numpy(list_os[ii].vx())) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
@@ -4997,35 +5539,48 @@ def test_coordinate_interpolation_2d():
     # Test exact times of integration
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.x(times)[ii]) - _anp(list_os[ii].x(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.x(times)[ii]) - _to_numpy(list_os[ii].x(times)))
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(times)[ii]) - _anp(list_os[ii].vx(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vx(times)[ii]) - _to_numpy(list_os[ii].vx(times)))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.x(times[1])[ii]) - _anp(list_os[ii].x(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.x(times[1])[ii]) - _to_numpy(list_os[ii].x(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(times[1])[ii]) - _anp(list_os[ii].vx(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vx(times[1])[ii]) - _to_numpy(list_os[ii].vx(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.x(itimes)[ii]) - _anp(list_os[ii].x(itimes))) < 1e-10
-        ), "Evaluating Orbits x does not agree with Orbit"
-        assert numpy.all(
-            numpy.fabs(_anp(os.vx(itimes)[ii]) - _anp(list_os[ii].vx(itimes))) < 1e-10
-        ), "Evaluating Orbits vx does not agree with Orbit"
-        # Also a single time in the array ...
-        assert numpy.all(
-            numpy.fabs(_anp(os.x(itimes[1])[ii]) - _anp(list_os[ii].x(itimes[1])))
+            numpy.fabs(_to_numpy(os.x(itimes)[ii]) - _to_numpy(list_os[ii].x(itimes)))
             < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vx(itimes[1])[ii]) - _anp(list_os[ii].vx(itimes[1])))
+            numpy.fabs(_to_numpy(os.vx(itimes)[ii]) - _to_numpy(list_os[ii].vx(itimes)))
+            < 1e-10
+        ), "Evaluating Orbits vx does not agree with Orbit"
+        # Also a single time in the array ...
+        assert numpy.all(
+            numpy.fabs(
+                _to_numpy(os.x(itimes[1])[ii]) - _to_numpy(list_os[ii].x(itimes[1]))
+            )
+            < 1e-10
+        ), "Evaluating Orbits x does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(
+                _to_numpy(os.vx(itimes[1])[ii]) - _to_numpy(list_os[ii].vx(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
     return None
@@ -5089,30 +5644,30 @@ def test_coordinate_interpolation_oneorbit():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time()) - _anp(list_os[ii].time())) < 1e-10
+            numpy.fabs(_to_numpy(os.time()) - _to_numpy(list_os[ii].time())) < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+            numpy.fabs(_to_numpy(os.R()[ii]) - _to_numpy(list_os[ii].R())) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+            numpy.fabs(_to_numpy(os.r()[ii]) - _to_numpy(list_os[ii].r())) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+            numpy.fabs(_to_numpy(os.vR()[ii]) - _to_numpy(list_os[ii].vR())) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+            numpy.fabs(_to_numpy(os.vT()[ii]) - _to_numpy(list_os[ii].vT())) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+            numpy.fabs(_to_numpy(os.z()[ii]) - _to_numpy(list_os[ii].z())) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+            numpy.fabs(_to_numpy(os.vz()[ii]) - _to_numpy(list_os[ii].vz())) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (_anp(os.phi()[ii]) - _anp(list_os[ii].phi()) + numpy.pi)
+                    (_to_numpy(os.phi()[ii]) - _to_numpy(list_os[ii].phi()) + numpy.pi)
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -5127,30 +5682,41 @@ def test_coordinate_interpolation_oneorbit():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time(times)) - _anp(list_os[ii].time(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.time(times)) - _to_numpy(list_os[ii].time(times)))
+            < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(times)[ii]) - _to_numpy(list_os[ii].R(times)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(times)[ii]) - _to_numpy(list_os[ii].r(times)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(times)[ii]) - _to_numpy(list_os[ii].vR(times)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(times)[ii]) - _to_numpy(list_os[ii].vT(times)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(times)[ii]) - _to_numpy(list_os[ii].z(times)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(times)[ii]) - _to_numpy(list_os[ii].vz(times)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times)) + numpy.pi)
+                    (
+                        _to_numpy(os.phi(times)[ii])
+                        - _to_numpy(list_os[ii].phi(times))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -5160,36 +5726,53 @@ def test_coordinate_interpolation_oneorbit():
         # Also a single time in the array ...
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(_anp(os.time(times[1])) - _anp(list_os[ii].time(times[1])))
+            numpy.fabs(
+                _to_numpy(os.time(times[1])) - _to_numpy(list_os[ii].time(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.R(times[1])[ii]) - _to_numpy(list_os[ii].R(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.r(times[1])[ii]) - _to_numpy(list_os[ii].r(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(times[1])[ii]) - _to_numpy(list_os[ii].vR(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(times[1])[ii]) - _to_numpy(list_os[ii].vT(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
+            numpy.fabs(
+                _to_numpy(os.z(times[1])[ii]) - _to_numpy(list_os[ii].z(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(times[1])[ii]) - _to_numpy(list_os[ii].vz(times[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(times[1])[ii])
-                        - _anp(list_os[ii].phi(times[1]))
+                        _to_numpy(os.phi(times[1])[ii])
+                        - _to_numpy(list_os[ii].phi(times[1]))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -5202,29 +5785,35 @@ def test_coordinate_interpolation_oneorbit():
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.R(itimes)[ii]) - _to_numpy(list_os[ii].R(itimes)))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.r(itimes)[ii]) - _to_numpy(list_os[ii].r(itimes)))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vR(itimes)[ii]) - _to_numpy(list_os[ii].vR(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vT(itimes)[ii]) - _to_numpy(list_os[ii].vT(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.z(itimes)[ii]) - _to_numpy(list_os[ii].z(itimes)))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
+            numpy.fabs(_to_numpy(os.vz(itimes)[ii]) - _to_numpy(list_os[ii].vz(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(itimes)[ii])
-                        - _anp(list_os[ii].phi(itimes))
+                        _to_numpy(os.phi(itimes)[ii])
+                        - _to_numpy(list_os[ii].phi(itimes))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -5235,35 +5824,47 @@ def test_coordinate_interpolation_oneorbit():
         ), "Evaluating Orbits phi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.R(itimes[1])[ii]) - _to_numpy(list_os[ii].R(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.r(itimes[1])[ii]) - _to_numpy(list_os[ii].r(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vR(itimes[1])[ii]) - _to_numpy(list_os[ii].vR(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vT(itimes[1])[ii]) - _to_numpy(list_os[ii].vT(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.z(itimes[1])[ii]) - _to_numpy(list_os[ii].z(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            numpy.fabs(
+                _to_numpy(os.vz(itimes[1])[ii]) - _to_numpy(list_os[ii].vz(itimes[1]))
+            )
             < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
                     (
-                        _anp(os.phi(itimes[1])[ii])
-                        - _anp(list_os[ii].phi(itimes[1]))
+                        _to_numpy(os.phi(itimes[1])[ii])
+                        - _to_numpy(list_os[ii].phi(itimes[1]))
                         + numpy.pi
                     )
                     % (2.0 * numpy.pi)
@@ -5344,36 +5945,50 @@ def test_output_shape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(_anp(os.time()) - _anp(list_os[ii][jj][kk].time()))
+                    numpy.fabs(
+                        _to_numpy(os.time()) - _to_numpy(list_os[ii][jj][kk].time())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.R()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].R()))
+                    numpy.fabs(
+                        _to_numpy(os.R()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].R())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.r()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].r()))
+                    numpy.fabs(
+                        _to_numpy(os.r()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].r())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vR()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vR())
+                        _to_numpy(os.vR()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vR())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vT()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vT())
+                        _to_numpy(os.vT()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vT())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.z()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].z()))
+                    numpy.fabs(
+                        _to_numpy(os.z()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].z())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vz()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vz())
+                        _to_numpy(os.vz()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vz())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
@@ -5381,8 +5996,8 @@ def test_output_shape():
                     numpy.fabs(
                         (
                             (
-                                _anp(os.phi()[ii, jj, kk])
-                                - _anp(list_os[ii][jj][kk].phi())
+                                _to_numpy(os.phi()[ii, jj, kk])
+                                - _to_numpy(list_os[ii][jj][kk].phi())
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5392,146 +6007,178 @@ def test_output_shape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.x()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].x()))
+                    numpy.fabs(
+                        _to_numpy(os.x()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].x())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.y()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].y()))
+                    numpy.fabs(
+                        _to_numpy(os.y()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].y())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vx()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vx())
+                        _to_numpy(os.vx()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vx())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vy()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vy())
+                        _to_numpy(os.vy()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vy())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vphi()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vphi())
+                        _to_numpy(os.vphi()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vphi())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ra())
+                        _to_numpy(os.ra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dec())
+                        _to_numpy(os.dec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dist()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dist())
+                        _to_numpy(os.dist()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dist())
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ll())
+                        _to_numpy(os.ll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.bb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].bb())
+                        _to_numpy(os.bb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].bb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmra())
+                        _to_numpy(os.pmra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmdec())
+                        _to_numpy(os.pmdec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmdec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmll())
+                        _to_numpy(os.pmll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmbb())
+                        _to_numpy(os.pmbb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmbb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vra())
+                        _to_numpy(os.vra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vdec())
+                        _to_numpy(os.vdec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vdec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vll())
+                        _to_numpy(os.vll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vbb())
+                        _to_numpy(os.vbb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vbb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vlos()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vlos())
+                        _to_numpy(os.vlos()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vlos())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioX()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioX())
+                        _to_numpy(os.helioX()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioX())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioY()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioY())
+                        _to_numpy(os.helioY()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioY())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioZ()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioZ())
+                        _to_numpy(os.helioZ()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioZ())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.U()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].U()))
+                    numpy.fabs(
+                        _to_numpy(os.U()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].U())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.V()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].V()))
+                    numpy.fabs(
+                        _to_numpy(os.V()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].V())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.W()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].W()))
+                    numpy.fabs(
+                        _to_numpy(os.W()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].W())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
@@ -5602,49 +6249,50 @@ def test_output_shape():
                 # .time is special, just a single array
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.time(times)) - _anp(list_os[ii][jj][kk].time(times))
+                        _to_numpy(os.time(times))
+                        - _to_numpy(list_os[ii][jj][kk].time(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.R(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].R(times))
+                        _to_numpy(os.R(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].R(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.r(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].r(times))
+                        _to_numpy(os.r(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].r(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vR(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vR(times))
+                        _to_numpy(os.vR(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vR(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vT(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vT(times))
+                        _to_numpy(os.vT(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vT(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.z(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].z(times))
+                        _to_numpy(os.z(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].z(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vz(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vz(times))
+                        _to_numpy(os.vz(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vz(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
@@ -5652,8 +6300,8 @@ def test_output_shape():
                     numpy.fabs(
                         (
                             (
-                                _anp(os.phi(times)[ii, jj, kk])
-                                - _anp(list_os[ii][jj][kk].phi(times))
+                                _to_numpy(os.phi(times)[ii, jj, kk])
+                                - _to_numpy(list_os[ii][jj][kk].phi(times))
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5664,176 +6312,176 @@ def test_output_shape():
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.x(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].x(times))
+                        _to_numpy(os.x(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].x(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.y(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].y(times))
+                        _to_numpy(os.y(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].y(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vx(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vx(times))
+                        _to_numpy(os.vx(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vx(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vy(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vy(times))
+                        _to_numpy(os.vy(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vy(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vphi(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vphi(times))
+                        _to_numpy(os.vphi(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vphi(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].ra(times))
+                        _to_numpy(os.ra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].dec(times))
+                        _to_numpy(os.dec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dist(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].dist(times))
+                        _to_numpy(os.dist(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dist(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].ll(times))
+                        _to_numpy(os.ll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.bb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].bb(times))
+                        _to_numpy(os.bb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].bb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmra(times))
+                        _to_numpy(os.pmra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmdec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmdec(times))
+                        _to_numpy(os.pmdec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmll(times))
+                        _to_numpy(os.pmll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmbb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmbb(times))
+                        _to_numpy(os.pmbb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vra(times))
+                        _to_numpy(os.vra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vdec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vdec(times))
+                        _to_numpy(os.vdec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vll(times))
+                        _to_numpy(os.vll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vbb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vbb(times))
+                        _to_numpy(os.vbb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vlos(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vlos(times))
+                        _to_numpy(os.vlos(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vlos(times))
                     )
                     < 1e-9
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioX(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioX(times))
+                        _to_numpy(os.helioX(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioX(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioY(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioY(times))
+                        _to_numpy(os.helioY(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioY(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioZ(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioZ(times))
+                        _to_numpy(os.helioZ(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioZ(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.U(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].U(times))
+                        _to_numpy(os.U(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].U(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.V(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].V(times))
+                        _to_numpy(os.V(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].V(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.W(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].W(times))
+                        _to_numpy(os.W(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].W(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
@@ -5950,36 +6598,50 @@ def test_output_reshape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(_anp(os.time()) - _anp(list_os[ii][jj][kk].time()))
+                    numpy.fabs(
+                        _to_numpy(os.time()) - _to_numpy(list_os[ii][jj][kk].time())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.R()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].R()))
+                    numpy.fabs(
+                        _to_numpy(os.R()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].R())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.r()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].r()))
+                    numpy.fabs(
+                        _to_numpy(os.r()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].r())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vR()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vR())
+                        _to_numpy(os.vR()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vR())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vT()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vT())
+                        _to_numpy(os.vT()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vT())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.z()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].z()))
+                    numpy.fabs(
+                        _to_numpy(os.z()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].z())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vz()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vz())
+                        _to_numpy(os.vz()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vz())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
@@ -5987,8 +6649,8 @@ def test_output_reshape():
                     numpy.fabs(
                         (
                             (
-                                _anp(os.phi()[ii, jj, kk])
-                                - _anp(list_os[ii][jj][kk].phi())
+                                _to_numpy(os.phi()[ii, jj, kk])
+                                - _to_numpy(list_os[ii][jj][kk].phi())
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5998,146 +6660,178 @@ def test_output_reshape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.x()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].x()))
+                    numpy.fabs(
+                        _to_numpy(os.x()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].x())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.y()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].y()))
+                    numpy.fabs(
+                        _to_numpy(os.y()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].y())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vx()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vx())
+                        _to_numpy(os.vx()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vx())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vy()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vy())
+                        _to_numpy(os.vy()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vy())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vphi()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vphi())
+                        _to_numpy(os.vphi()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vphi())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ra())
+                        _to_numpy(os.ra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dec())
+                        _to_numpy(os.dec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dist()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dist())
+                        _to_numpy(os.dist()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dist())
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ll())
+                        _to_numpy(os.ll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.bb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].bb())
+                        _to_numpy(os.bb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].bb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmra())
+                        _to_numpy(os.pmra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmdec())
+                        _to_numpy(os.pmdec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmdec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmll())
+                        _to_numpy(os.pmll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmbb())
+                        _to_numpy(os.pmbb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmbb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vra())
+                        _to_numpy(os.vra()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vra())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vdec())
+                        _to_numpy(os.vdec()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vdec())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vll())
+                        _to_numpy(os.vll()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vll())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vbb())
+                        _to_numpy(os.vbb()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vbb())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vlos()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vlos())
+                        _to_numpy(os.vlos()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vlos())
                     )
                     < 1e-10
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioX()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioX())
+                        _to_numpy(os.helioX()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioX())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioY()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioY())
+                        _to_numpy(os.helioY()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioY())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioZ()[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioZ())
+                        _to_numpy(os.helioZ()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioZ())
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.U()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].U()))
+                    numpy.fabs(
+                        _to_numpy(os.U()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].U())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.V()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].V()))
+                    numpy.fabs(
+                        _to_numpy(os.V()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].V())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(_anp(os.W()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].W()))
+                    numpy.fabs(
+                        _to_numpy(os.W()[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].W())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
@@ -6208,49 +6902,50 @@ def test_output_reshape():
                 # .time is special, just a single array
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.time(times)) - _anp(list_os[ii][jj][kk].time(times))
+                        _to_numpy(os.time(times))
+                        - _to_numpy(list_os[ii][jj][kk].time(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.R(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].R(times))
+                        _to_numpy(os.R(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].R(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.r(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].r(times))
+                        _to_numpy(os.r(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].r(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vR(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vR(times))
+                        _to_numpy(os.vR(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vR(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vT(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vT(times))
+                        _to_numpy(os.vT(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vT(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.z(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].z(times))
+                        _to_numpy(os.z(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].z(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vz(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vz(times))
+                        _to_numpy(os.vz(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vz(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
@@ -6258,8 +6953,8 @@ def test_output_reshape():
                     numpy.fabs(
                         (
                             (
-                                _anp(os.phi(times)[ii, jj, kk])
-                                - _anp(list_os[ii][jj][kk].phi(times))
+                                _to_numpy(os.phi(times)[ii, jj, kk])
+                                - _to_numpy(list_os[ii][jj][kk].phi(times))
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -6270,176 +6965,176 @@ def test_output_reshape():
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.x(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].x(times))
+                        _to_numpy(os.x(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].x(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.y(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].y(times))
+                        _to_numpy(os.y(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].y(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vx(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vx(times))
+                        _to_numpy(os.vx(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vx(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vy(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vy(times))
+                        _to_numpy(os.vy(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vy(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vphi(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vphi(times))
+                        _to_numpy(os.vphi(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vphi(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].ra(times))
+                        _to_numpy(os.ra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].dec(times))
+                        _to_numpy(os.dec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.dist(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].dist(times))
+                        _to_numpy(os.dist(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].dist(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.ll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].ll(times))
+                        _to_numpy(os.ll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].ll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.bb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].bb(times))
+                        _to_numpy(os.bb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].bb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmra(times))
+                        _to_numpy(os.pmra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmdec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmdec(times))
+                        _to_numpy(os.pmdec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmll(times))
+                        _to_numpy(os.pmll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.pmbb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].pmbb(times))
+                        _to_numpy(os.pmbb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].pmbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vra(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vra(times))
+                        _to_numpy(os.vra(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vdec(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vdec(times))
+                        _to_numpy(os.vdec(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vll(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vll(times))
+                        _to_numpy(os.vll(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vbb(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vbb(times))
+                        _to_numpy(os.vbb(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.vlos(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].vlos(times))
+                        _to_numpy(os.vlos(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].vlos(times))
                     )
                     < 1e-9
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioX(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioX(times))
+                        _to_numpy(os.helioX(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioX(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioY(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioY(times))
+                        _to_numpy(os.helioY(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioY(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.helioZ(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].helioZ(times))
+                        _to_numpy(os.helioZ(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].helioZ(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.U(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].U(times))
+                        _to_numpy(os.U(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].U(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.V(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].V(times))
+                        _to_numpy(os.V(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].V(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        _anp(os.W(times)[ii, jj, kk])
-                        - _anp(list_os[ii][jj][kk].W(times))
+                        _to_numpy(os.W(times)[ii, jj, kk])
+                        - _to_numpy(list_os[ii][jj][kk].W(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
@@ -6668,8 +7363,8 @@ def _check_energy_jacobi_angmom(os, list_os):
     for ii in range(nrand):
         assert numpy.all(
             numpy.fabs(
-                _anp(os.E(pot=MWPotential2014)[ii])
-                / _anp(list_os[ii].E(pot=MWPotential2014))
+                _to_numpy(os.E(pot=MWPotential2014)[ii])
+                / _to_numpy(list_os[ii].E(pot=MWPotential2014))
                 - 1.0
             )
             < 10.0**-10.0
@@ -6677,34 +7372,35 @@ def _check_energy_jacobi_angmom(os, list_os):
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.ER(pot=MWPotential2014)[ii])
-                    / _anp(list_os[ii].ER(pot=MWPotential2014))
+                    _to_numpy(os.ER(pot=MWPotential2014)[ii])
+                    / _to_numpy(list_os[ii].ER(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Ez(pot=MWPotential2014)[ii])
-                    / _anp(list_os[ii].Ez(pot=MWPotential2014))
+                    _to_numpy(os.Ez(pot=MWPotential2014)[ii])
+                    / _to_numpy(list_os[ii].Ez(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
+                numpy.fabs(_to_numpy(os.L()[ii]) / _to_numpy(list_os[ii].L()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                numpy.fabs(_to_numpy(os.Lz()[ii]) / _to_numpy(list_os[ii].Lz()) - 1.0)
                 < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=MWPotential2014)[ii])
-                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014))
+                    _to_numpy(os.Jacobi(pot=MWPotential2014)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6712,8 +7408,8 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=MWPotential2014, OmegaP=0.6)[ii])
-                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014, OmegaP=0.6))
+                    _to_numpy(os.Jacobi(pot=MWPotential2014, OmegaP=0.6)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=MWPotential2014, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6721,39 +7417,50 @@ def _check_energy_jacobi_angmom(os, list_os):
     # Potential for which array evaluation definitely does not work
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.E(pot=lp)[ii]) / _anp(list_os[ii].E(pot=lp)) - 1.0)
+            numpy.fabs(
+                _to_numpy(os.E(pot=lp)[ii]) / _to_numpy(list_os[ii].E(pot=lp)) - 1.0
+            )
             < 10.0**-10.0
         ), "Evaluating Orbits E does not agree with Orbit"
         if os.dim() == 3:
             assert numpy.all(
-                numpy.fabs(_anp(os.ER(pot=lp)[ii]) / _anp(list_os[ii].ER(pot=lp)) - 1.0)
+                numpy.fabs(
+                    _to_numpy(os.ER(pot=lp)[ii]) / _to_numpy(list_os[ii].ER(pot=lp))
+                    - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
-                numpy.fabs(_anp(os.Ez(pot=lp)[ii]) / _anp(list_os[ii].Ez(pot=lp)) - 1.0)
+                numpy.fabs(
+                    _to_numpy(os.Ez(pot=lp)[ii]) / _to_numpy(list_os[ii].Ez(pot=lp))
+                    - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
+                numpy.fabs(_to_numpy(os.L()[ii]) / _to_numpy(list_os[ii].L()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                numpy.fabs(_to_numpy(os.Lz()[ii]) / _to_numpy(list_os[ii].Lz()) - 1.0)
                 < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=lp)[ii]) / _anp(list_os[ii].Jacobi(pot=lp)) - 1.0
+                    _to_numpy(os.Jacobi(pot=lp)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=lp))
+                    - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=lp, OmegaP=0.6)[ii])
-                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
+                    _to_numpy(os.Jacobi(pot=lp, OmegaP=0.6)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6762,16 +7469,18 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also in 3D
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=lp, OmegaP=[0.0, 0.0, 0.6])[ii])
-                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
+                    _to_numpy(os.Jacobi(pot=lp, OmegaP=[0.0, 0.0, 0.6])[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=lp, OmegaP=numpy.array([0.0, 0.0, 0.6]))[ii])
-                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
+                    _to_numpy(
+                        os.Jacobi(pot=lp, OmegaP=numpy.array([0.0, 0.0, 0.6]))[ii]
+                    )
+                    / _to_numpy(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6789,7 +7498,8 @@ def _check_energy_jacobi_angmom(os, list_os):
         # Don't have to specify the potential or set to None
         assert numpy.all(
             numpy.fabs(
-                _anp(os.E(times)[ii]) / _anp(list_os[ii].E(times, pot=MWPotential2014))
+                _to_numpy(os.E(times)[ii])
+                / _to_numpy(list_os[ii].E(times, pot=MWPotential2014))
                 - 1.0
             )
             < 10.0**-10.0
@@ -6797,42 +7507,50 @@ def _check_energy_jacobi_angmom(os, list_os):
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.ER(times, pot=None)[ii])
-                    / _anp(list_os[ii].ER(times, pot=MWPotential2014))
+                    _to_numpy(os.ER(times, pot=None)[ii])
+                    / _to_numpy(list_os[ii].ER(times, pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Ez(times)[ii])
-                    / _anp(list_os[ii].Ez(times, pot=MWPotential2014))
+                    _to_numpy(os.Ez(times)[ii])
+                    / _to_numpy(list_os[ii].Ez(times, pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.L(times)[ii]) / _anp(list_os[ii].L(times)) - 1.0)
+                numpy.fabs(
+                    _to_numpy(os.L(times)[ii]) / _to_numpy(list_os[ii].L(times)) - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.Lz(times)[ii]) / _anp(list_os[ii].Lz(times)) - 1.0)
+                numpy.fabs(
+                    _to_numpy(os.Lz(times)[ii]) / _to_numpy(list_os[ii].Lz(times)) - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(times)[ii]) / _anp(list_os[ii].Jacobi(times)) - 1.0
+                    _to_numpy(os.Jacobi(times)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(times))
+                    - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(times, pot=MWPotential2014, OmegaP=0.6)[ii])
-                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
+                    _to_numpy(os.Jacobi(times, pot=MWPotential2014, OmegaP=0.6)[ii])
+                    / _to_numpy(
+                        list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    )
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6841,26 +7559,30 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also in 3D
             assert numpy.all(
                 numpy.fabs(
-                    _anp(
+                    _to_numpy(
                         os.Jacobi(times, pot=MWPotential2014, OmegaP=[0.0, 0.0, 0.6])[
                             ii
                         ]
                     )
-                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
+                    / _to_numpy(
+                        list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    )
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    _anp(
+                    _to_numpy(
                         os.Jacobi(
                             times,
                             pot=MWPotential2014,
                             OmegaP=numpy.array([0.0, 0.0, 0.6]),
                         )[ii]
                     )
-                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
+                    / _to_numpy(
+                        list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    )
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6872,8 +7594,8 @@ def _check_energy_jacobi_angmom(os, list_os):
     for ii in range(nrand):
         assert numpy.all(
             numpy.fabs(
-                _anp(os.E(pot=MWPotential2014 + dp + sp)[ii])
-                / _anp(list_os[ii].E(pot=MWPotential2014 + dp + sp))
+                _to_numpy(os.E(pot=MWPotential2014 + dp + sp)[ii])
+                / _to_numpy(list_os[ii].E(pot=MWPotential2014 + dp + sp))
                 - 1.0
             )
             < 10.0**-10.0
@@ -6881,34 +7603,35 @@ def _check_energy_jacobi_angmom(os, list_os):
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.ER(pot=MWPotential2014 + dp + sp)[ii])
-                    / _anp(list_os[ii].ER(pot=MWPotential2014 + dp + sp))
+                    _to_numpy(os.ER(pot=MWPotential2014 + dp + sp)[ii])
+                    / _to_numpy(list_os[ii].ER(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Ez(pot=MWPotential2014 + dp + sp)[ii])
-                    / _anp(list_os[ii].Ez(pot=MWPotential2014 + dp + sp))
+                    _to_numpy(os.Ez(pot=MWPotential2014 + dp + sp)[ii])
+                    / _to_numpy(list_os[ii].Ez(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
+                numpy.fabs(_to_numpy(os.L()[ii]) / _to_numpy(list_os[ii].L()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                numpy.fabs(_to_numpy(os.Lz()[ii]) / _to_numpy(list_os[ii].Lz()) - 1.0)
                 < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=MWPotential2014 + dp + sp)[ii])
-                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp))
+                    _to_numpy(os.Jacobi(pot=MWPotential2014 + dp + sp)[ii])
+                    / _to_numpy(list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6916,8 +7639,8 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    _anp(os.Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)[ii])
-                    / _anp(
+                    _to_numpy(os.Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)[ii])
+                    / _to_numpy(
                         list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)
                     )
                     - 1.0
@@ -7518,33 +8241,33 @@ def test_flip():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.x()) - _to_numpy(of.x())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vx()) + _to_numpy(of.vx())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         else:
-            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.R()) - _to_numpy(of.R())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vR()) + _to_numpy(of.vR())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vT()) + _to_numpy(of.vT())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.phi()) - _to_numpy(of.phi())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii < 2:
-            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.z()) - _to_numpy(of.z())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vz()) + _to_numpy(of.vz())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
     return None
 
 
@@ -7600,33 +8323,33 @@ def test_flip_inplace():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.x()) - _to_numpy(of.x())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vx()) + _to_numpy(of.vx())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         else:
-            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.R()) - _to_numpy(of.R())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vR()) + _to_numpy(of.vR())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vT()) + _to_numpy(of.vT())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.phi()) - _to_numpy(of.phi())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii < 2:
-            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.z()) - _to_numpy(of.z())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vz()) + _to_numpy(of.vz())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
     return None
 
 
@@ -7695,33 +8418,33 @@ def test_flip_inplace_integrated():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.x()) - _to_numpy(of.x())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vx()) + _to_numpy(of.vx())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         else:
-            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.R()) - _to_numpy(of.R())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vR()) + _to_numpy(of.vR())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vT()) + _to_numpy(of.vT())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.phi()) - _to_numpy(of.phi())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii < 2:
-            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.z()) - _to_numpy(of.z())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vz()) + _to_numpy(of.vz())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
     return None
 
 
@@ -7760,7 +8483,7 @@ def test_flip_inplace_integrated_evaluated():
             o.integrate(ts, llp)
             of.integrate(ts, llp)
         # Evaluate, make sure it is at an interpolated time!
-        dumb = _anp(of.R(0.52))
+        dumb = _to_numpy(of.R(0.52))
         # Now flip
         of.flip(inplace=True)
         # Just check one time, allows code duplication!
@@ -7796,33 +8519,33 @@ def test_flip_inplace_integrated_evaluated():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.x()) - _to_numpy(of.x())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vx()) + _to_numpy(of.vx())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         else:
-            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.R()) - _to_numpy(of.R())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vR()) + _to_numpy(of.vR())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vT()) + _to_numpy(of.vT())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.phi()) - _to_numpy(of.phi())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
         if ii < 2:
-            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
-            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
-                "o.flip() did not work as expected"
-            )
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.z()) - _to_numpy(of.z())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
+            assert numpy.all(
+                numpy.abs(_to_numpy(o.vz()) + _to_numpy(of.vz())) < 10.0**-10.0
+            ), "o.flip() did not work as expected"
     return None
 
 
@@ -7929,13 +8652,14 @@ def test_EccZmaxRperiRap_num_againstorbit_2d():
     [o.integrate(times, MWPotential2014) for o in list_os]
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(_anp(os.e()[ii]) - _anp(list_os[ii].e())) < 1e-10
+            numpy.fabs(_to_numpy(os.e()[ii]) - _to_numpy(list_os[ii].e())) < 1e-10
         ), "Evaluating Orbits e does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.rperi()[ii]) - _anp(list_os[ii].rperi())) < 1e-10
+            numpy.fabs(_to_numpy(os.rperi()[ii]) - _to_numpy(list_os[ii].rperi()))
+            < 1e-10
         ), "Evaluating Orbits rperi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(_anp(os.rap()[ii]) - _anp(list_os[ii].rap())) < 1e-10
+            numpy.fabs(_to_numpy(os.rap()[ii]) - _to_numpy(list_os[ii].rap())) < 1e-10
         ), "Evaluating Orbits rap does not agree with Orbit"
     return None
 
@@ -9129,19 +9853,19 @@ def test_toLinear():
     obs = Orbit([[1.0, 0.1, 1.1, 0.3, 0.0, 2.0], [1.0, -0.2, 1.3, -0.3, 0.0, 5.0]])
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinear does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
+    assert numpy.all(_to_numpy(obsl.x()) == _to_numpy(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
+    assert numpy.all(_to_numpy(obsl.vx()) == _to_numpy(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     obs = Orbit([[1.0, 0.1, 1.1, 0.3, 0.0], [1.0, -0.2, 1.3, -0.3, 0.0]])
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinear does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
+    assert numpy.all(_to_numpy(obsl.x()) == _to_numpy(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
+    assert numpy.all(_to_numpy(obsl.vx()) == _to_numpy(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     obs = Orbit([[1.0, 0.1, 1.1, 0.3], [1.0, -0.2, 1.3, -0.3]])
@@ -9160,10 +9884,10 @@ def test_toLinear():
     )
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinwar does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
+    assert numpy.all(_to_numpy(obsl.x()) == _to_numpy(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
+    assert numpy.all(_to_numpy(obsl.vx()) == _to_numpy(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     assert numpy.fabs(obs._ro - obsl._ro) < 10.0**-15.0, (

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -7,6 +7,15 @@ import pytest
 
 from galpy import potential
 
+
+def _anp(x):
+    # backend-agnostic: coerce a (possibly jax/torch) accessor result to numpy
+    # for value assertions. numpy input passes through unchanged (byte-identical).
+    if hasattr(x, "detach"):
+        x = x.detach().cpu()
+    return numpy.asarray(x)
+
+
 _APY3 = astropy.__version__ > "3"
 
 
@@ -797,13 +806,17 @@ def test_integration_1d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -830,43 +843,57 @@ def test_integration_2d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].y(times) - orbits.y(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vy(times) - orbits.vy(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].R(times) - orbits.R(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vR(times) - orbits.vR(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vT(times) - orbits.vT(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -875,7 +902,11 @@ def test_integration_2d():
             numpy.amax(
                 numpy.fabs(
                     (
-                        (orbits_list[ii].phi(times) - orbits.phi(times)[ii] + numpy.pi)
+                        (
+                            _anp(orbits_list[ii].phi(times))
+                            - _anp(orbits.phi(times)[ii])
+                            + numpy.pi
+                        )
                         % (2.0 * numpy.pi)
                     )
                     - numpy.pi
@@ -947,55 +978,73 @@ def test_integration_3d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].y(times) - orbits.y(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vy(times) - orbits.vy(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].z(times) - orbits.z(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].z(times)) - _anp(orbits.z(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vz(times) - orbits.vz(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].R(times) - orbits.R(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vR(times) - orbits.vR(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vT(times) - orbits.vT(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -1005,7 +1054,10 @@ def test_integration_3d():
                 numpy.fabs(
                     (
                         (
-                            (orbits_list[ii].phi(times) - orbits.phi(times)[ii])
+                            (
+                                _anp(orbits_list[ii].phi(times))
+                                - _anp(orbits.phi(times)[ii])
+                            )
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -1841,13 +1893,17 @@ def test_integration_forcemap_1d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -1873,43 +1929,57 @@ def test_integration_forcemap_2d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].y(times) - orbits.y(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vy(times) - orbits.vy(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].R(times) - orbits.R(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vR(times) - orbits.vR(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vT(times) - orbits.vT(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -1919,7 +1989,10 @@ def test_integration_forcemap_2d():
                 numpy.fabs(
                     (
                         (
-                            (orbits_list[ii].phi(times) - orbits.phi(times)[ii])
+                            (
+                                _anp(orbits_list[ii].phi(times))
+                                - _anp(orbits.phi(times)[ii])
+                            )
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -1952,55 +2025,73 @@ def test_integration_forcemap_3d():
     # Compare
     for ii in range(len(orbits)):
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].x(times) - orbits.x(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vx(times) - orbits.vx(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].y(times) - orbits.y(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vy(times) - orbits.vy(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].z(times) - orbits.z(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].z(times)) - _anp(orbits.z(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vz(times) - orbits.vz(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].R(times) - orbits.R(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vR(times) - orbits.vR(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_list[ii].vT(times) - orbits.vT(times)[ii]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_list[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -2010,7 +2101,10 @@ def test_integration_forcemap_3d():
                 numpy.fabs(
                     (
                         (
-                            (orbits_list[ii].phi(times) - orbits.phi(times)[ii])
+                            (
+                                _anp(orbits_list[ii].phi(times))
+                                - _anp(orbits.phi(times)[ii])
+                            )
                             + numpy.pi
                         )
                         % (2.0 * numpy.pi)
@@ -2341,47 +2435,74 @@ def test_slice_singleobject():
     indices = [0, 1, -1]
     for ii in indices:
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].x(times) - orbits.x(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vx(times) - orbits.vx(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].y(times) - orbits.y(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vy(times) - orbits.vy(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].z(times) - orbits.z(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].z(times)) - _anp(orbits.z(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vz(times) - orbits.vz(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].R(times) - orbits.R(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vR(times) - orbits.vR(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vT(times) - orbits.vT(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
@@ -2389,7 +2510,10 @@ def test_slice_singleobject():
             numpy.amax(
                 numpy.fabs(
                     (
-                        ((orbits[ii].phi(times) - orbits.phi(times)[ii]) + numpy.pi)
+                        (
+                            (_anp(orbits[ii].phi(times)) - _anp(orbits.phi(times)[ii]))
+                            + numpy.pi
+                        )
                         % (2.0 * numpy.pi)
                     )
                     - numpy.pi
@@ -2419,52 +2543,81 @@ def test_slice_multipleobjects():
     orbits_slice = orbits[1:4]
     for ii in range(3):
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.x()[ii] - orbits.x()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.x()[ii]) - _anp(orbits.x()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.vx()[ii] - orbits.vx()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.vx()[ii]) - _anp(orbits.vx()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.y()[ii] - orbits.y()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.y()[ii]) - _anp(orbits.y()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.vy()[ii] - orbits.vy()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.vy()[ii]) - _anp(orbits.vy()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.z()[ii] - orbits.z()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.z()[ii]) - _anp(orbits.z()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.vz()[ii] - orbits.vz()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.vz()[ii]) - _anp(orbits.vz()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.R()[ii] - orbits.R()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.R()[ii]) - _anp(orbits.R()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.vR()[ii] - orbits.vR()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.vR()[ii]) - _anp(orbits.vR()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.vT()[ii] - orbits.vT()[ii + 1])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.vT()[ii]) - _anp(orbits.vT()[ii + 1]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.phi()[ii] - orbits.phi()[ii + 1]))
+            numpy.amax(
+                numpy.fabs(_anp(orbits_slice.phi()[ii]) - _anp(orbits.phi()[ii + 1]))
+            )
             < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
@@ -2474,56 +2627,10 @@ def test_slice_multipleobjects():
     orbits_slice = orbits[1:4]
     for ii in range(3):
         assert (
-            numpy.amax(numpy.fabs(orbits_slice.x(times)[ii] - orbits.x(times)[ii + 1]))
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
             numpy.amax(
-                numpy.fabs(orbits_slice.vx(times)[ii] - orbits.vx(times)[ii + 1])
-            )
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(orbits_slice.y(times)[ii] - orbits.y(times)[ii + 1]))
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(
-                numpy.fabs(orbits_slice.vy(times)[ii] - orbits.vy(times)[ii + 1])
-            )
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(orbits_slice.z(times)[ii] - orbits.z(times)[ii + 1]))
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(
-                numpy.fabs(orbits_slice.vz(times)[ii] - orbits.vz(times)[ii + 1])
-            )
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(numpy.fabs(orbits_slice.R(times)[ii] - orbits.R(times)[ii + 1]))
-            < 1e-10
-        ), (
-            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
-        )
-        assert (
-            numpy.amax(
-                numpy.fabs(orbits_slice.vR(times)[ii] - orbits.vR(times)[ii + 1])
+                numpy.fabs(
+                    _anp(orbits_slice.x(times)[ii]) - _anp(orbits.x(times)[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2531,7 +2638,9 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(orbits_slice.vT(times)[ii] - orbits.vT(times)[ii + 1])
+                numpy.fabs(
+                    _anp(orbits_slice.vx(times)[ii]) - _anp(orbits.vx(times)[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2539,7 +2648,79 @@ def test_slice_multipleobjects():
         )
         assert (
             numpy.amax(
-                numpy.fabs(orbits_slice.phi(times)[ii] - orbits.phi(times)[ii + 1])
+                numpy.fabs(
+                    _anp(orbits_slice.y(times)[ii]) - _anp(orbits.y(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.vy(times)[ii]) - _anp(orbits.vy(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.z(times)[ii]) - _anp(orbits.z(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.vz(times)[ii]) - _anp(orbits.vz(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.R(times)[ii]) - _anp(orbits.R(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.vR(times)[ii]) - _anp(orbits.vR(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.vT(times)[ii]) - _anp(orbits.vT(times)[ii + 1])
+                )
+            )
+            < 1e-10
+        ), (
+            "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
+        )
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    _anp(orbits_slice.phi(times)[ii]) - _anp(orbits.phi(times)[ii + 1])
+                )
             )
             < 1e-10
         ), (
@@ -2567,47 +2748,74 @@ def test_slice_singleobject_multidim():
     indices = [(0, 0, 0), (1, 0, 2), (-1, 0, 1)]
     for ii in indices:
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].x(times) - orbits.x(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].x(times)) - _anp(orbits.x(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vx(times) - orbits.vx(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vx(times)) - _anp(orbits.vx(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].y(times) - orbits.y(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].y(times)) - _anp(orbits.y(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vy(times) - orbits.vy(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vy(times)) - _anp(orbits.vy(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].z(times) - orbits.z(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].z(times)) - _anp(orbits.z(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vz(times) - orbits.vz(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vz(times)) - _anp(orbits.vz(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].R(times) - orbits.R(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].R(times)) - _anp(orbits.R(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vR(times) - orbits.vR(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vR(times)) - _anp(orbits.vR(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
-            numpy.amax(numpy.fabs(orbits[ii].vT(times) - orbits.vT(times)[ii])) < 1e-10
+            numpy.amax(
+                numpy.fabs(_anp(orbits[ii].vT(times)) - _anp(orbits.vT(times)[ii]))
+            )
+            < 1e-10
         ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
@@ -2615,7 +2823,10 @@ def test_slice_singleobject_multidim():
             numpy.amax(
                 numpy.fabs(
                     (
-                        ((orbits[ii].phi(times) - orbits.phi(times)[ii]) + numpy.pi)
+                        (
+                            (_anp(orbits[ii].phi(times)) - _anp(orbits.phi(times)[ii]))
+                            + numpy.pi
+                        )
                         % (2.0 * numpy.pi)
                     )
                     - numpy.pi
@@ -2651,7 +2862,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.x()[ii, kk] - orbits.x()[ii + 1, jj, kk]
+                            _anp(orbits_slice.x()[ii, kk])
+                            - _anp(orbits.x()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2661,7 +2873,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vx()[ii, kk] - orbits.vx()[ii + 1, jj, kk]
+                            _anp(orbits_slice.vx()[ii, kk])
+                            - _anp(orbits.vx()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2671,7 +2884,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.y()[ii, kk] - orbits.y()[ii + 1, jj, kk]
+                            _anp(orbits_slice.y()[ii, kk])
+                            - _anp(orbits.y()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2681,7 +2895,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vy()[ii, kk] - orbits.vy()[ii + 1, jj, kk]
+                            _anp(orbits_slice.vy()[ii, kk])
+                            - _anp(orbits.vy()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2691,7 +2906,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.z()[ii, kk] - orbits.z()[ii + 1, jj, kk]
+                            _anp(orbits_slice.z()[ii, kk])
+                            - _anp(orbits.z()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2701,7 +2917,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vz()[ii, kk] - orbits.vz()[ii + 1, jj, kk]
+                            _anp(orbits_slice.vz()[ii, kk])
+                            - _anp(orbits.vz()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2711,7 +2928,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.R()[ii, kk] - orbits.R()[ii + 1, jj, kk]
+                            _anp(orbits_slice.R()[ii, kk])
+                            - _anp(orbits.R()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2721,7 +2939,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vR()[ii, kk] - orbits.vR()[ii + 1, jj, kk]
+                            _anp(orbits_slice.vR()[ii, kk])
+                            - _anp(orbits.vR()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2731,7 +2950,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vT()[ii, kk] - orbits.vT()[ii + 1, jj, kk]
+                            _anp(orbits_slice.vT()[ii, kk])
+                            - _anp(orbits.vT()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2741,7 +2961,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.phi()[ii, kk] - orbits.phi()[ii + 1, jj, kk]
+                            _anp(orbits_slice.phi()[ii, kk])
+                            - _anp(orbits.phi()[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2757,8 +2978,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.x(times)[ii, kk]
-                            - orbits.x(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.x(times)[ii, kk])
+                            - _anp(orbits.x(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2768,8 +2989,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vx(times)[ii, kk]
-                            - orbits.vx(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.vx(times)[ii, kk])
+                            - _anp(orbits.vx(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2779,8 +3000,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.y(times)[ii, kk]
-                            - orbits.y(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.y(times)[ii, kk])
+                            - _anp(orbits.y(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2790,8 +3011,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vy(times)[ii, kk]
-                            - orbits.vy(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.vy(times)[ii, kk])
+                            - _anp(orbits.vy(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2801,8 +3022,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.z(times)[ii, kk]
-                            - orbits.z(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.z(times)[ii, kk])
+                            - _anp(orbits.z(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2812,8 +3033,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vz(times)[ii, kk]
-                            - orbits.vz(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.vz(times)[ii, kk])
+                            - _anp(orbits.vz(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2823,8 +3044,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.R(times)[ii, kk]
-                            - orbits.R(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.R(times)[ii, kk])
+                            - _anp(orbits.R(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2834,8 +3055,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vR(times)[ii, kk]
-                            - orbits.vR(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.vR(times)[ii, kk])
+                            - _anp(orbits.vR(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2845,8 +3066,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.vT(times)[ii, kk]
-                            - orbits.vT(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.vT(times)[ii, kk])
+                            - _anp(orbits.vT(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2856,8 +3077,8 @@ def test_slice_multipleobjects_multidim():
                 assert (
                     numpy.amax(
                         numpy.fabs(
-                            orbits_slice.phi(times)[ii, kk]
-                            - orbits.phi(times)[ii + 1, jj, kk]
+                            _anp(orbits_slice.phi(times)[ii, kk])
+                            - _anp(orbits.phi(times)[ii + 1, jj, kk])
                         )
                     )
                     < 1e-10
@@ -2965,38 +3186,61 @@ def test_slice_physical_issue385():
         ), (
             "Sliced Orbit instance that was supposed to have physical output turned does not have the right zo"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].x() - orbits.x()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].x()) - _anp(orbits.x()[ii]))) < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].vx() - orbits.vx()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].vx()) - _anp(orbits.vx()[ii])))
+            < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].y() - orbits.y()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].y()) - _anp(orbits.y()[ii]))) < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].vy() - orbits.vy()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].vy()) - _anp(orbits.vy()[ii])))
+            < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].z() - orbits.z()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].z()) - _anp(orbits.z()[ii]))) < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].vz() - orbits.vz()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].vz()) - _anp(orbits.vz()[ii])))
+            < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].R() - orbits.R()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].R()) - _anp(orbits.R()[ii]))) < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].vR() - orbits.vR()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].vR()) - _anp(orbits.vR()[ii])))
+            < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
-        assert numpy.amax(numpy.fabs(orbits[ii].vT() - orbits.vT()[ii])) < 1e-10, (
+        assert (
+            numpy.amax(numpy.fabs(_anp(orbits[ii].vT()) - _anp(orbits.vT()[ii])))
+            < 1e-10
+        ), (
             "Integration of multiple orbits as Orbits does not agree with integrating multiple orbits"
         )
         assert (
             numpy.amax(
                 numpy.fabs(
                     (
-                        ((orbits[ii].phi() - orbits.phi()[ii]) + numpy.pi)
+                        ((_anp(orbits[ii].phi()) - _anp(orbits.phi()[ii])) + numpy.pi)
                         % (2.0 * numpy.pi)
                     )
                     - numpy.pi
@@ -3461,109 +3705,112 @@ def test_coordinate_interpolation():
     # Before integration
     for ii in range(nrand):
         # .time is special, just a single array
-        assert numpy.all(numpy.fabs(os.time() - list_os[ii].time()) < 1e-10), (
-            "Evaluating Orbits time does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.R()[ii] - list_os[ii].R()) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r()[ii] - list_os[ii].r()) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vR()[ii] - list_os[ii].vR()) < 1e-10), (
-            "Evaluating Orbits vR does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vT()[ii] - list_os[ii].vT()) < 1e-10), (
-            "Evaluating Orbits vT does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.z()[ii] - list_os[ii].z()) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vz()[ii] - list_os[ii].vz()) < 1e-10), (
-            "Evaluating Orbits vz does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.time()) - _anp(list_os[ii].time())) < 1e-10
+        ), "Evaluating Orbits time does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+        ), "Evaluating Orbits vR does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+        ), "Evaluating Orbits vT does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+        ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                ((os.phi()[ii] - list_os[ii].phi() + numpy.pi) % (2.0 * numpy.pi))
+                (
+                    (_anp(os.phi()[ii]) - _anp(list_os[ii].phi()) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
                 - numpy.pi
             )
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.x()[ii] - list_os[ii].x()) < 1e-10), (
-            "Evaluating Orbits x does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.y()[ii] - list_os[ii].y()) < 1e-10), (
-            "Evaluating Orbits y does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vx()[ii] - list_os[ii].vx()) < 1e-10), (
-            "Evaluating Orbits vx does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vy()[ii] - list_os[ii].vy()) < 1e-10), (
-            "Evaluating Orbits vy does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vphi()[ii] - list_os[ii].vphi()) < 1e-10), (
-            "Evaluating Orbits vphi does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.ra()[ii] - list_os[ii].ra()) < 1e-10), (
-            "Evaluating Orbits ra  does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.dec()[ii] - list_os[ii].dec()) < 1e-10), (
-            "Evaluating Orbits dec does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.dist()[ii] - list_os[ii].dist()) < 1e-10), (
-            "Evaluating Orbits dist does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.ll()[ii] - list_os[ii].ll()) < 1e-10), (
-            "Evaluating Orbits ll does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.bb()[ii] - list_os[ii].bb()) < 1e-10), (
-            "Evaluating Orbits bb  does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.pmra()[ii] - list_os[ii].pmra()) < 1e-10), (
-            "Evaluating Orbits pmra does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.pmdec()[ii] - list_os[ii].pmdec()) < 1e-10), (
-            "Evaluating Orbits pmdec does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.pmll()[ii] - list_os[ii].pmll()) < 1e-10), (
-            "Evaluating Orbits pmll does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.pmbb()[ii] - list_os[ii].pmbb()) < 1e-10), (
-            "Evaluating Orbits pmbb does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vra()[ii] - list_os[ii].vra()) < 1e-10), (
-            "Evaluating Orbits vra does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vdec()[ii] - list_os[ii].vdec()) < 1e-10), (
-            "Evaluating Orbits vdec does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vll()[ii] - list_os[ii].vll()) < 1e-10), (
-            "Evaluating Orbits vll does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vbb()[ii] - list_os[ii].vbb()) < 1e-10), (
-            "Evaluating Orbits vbb does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vlos()[ii] - list_os[ii].vlos()) < 1e-10), (
-            "Evaluating Orbits vlos does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.helioX()[ii] - list_os[ii].helioX()) < 1e-10), (
-            "Evaluating Orbits helioX does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.helioY()[ii] - list_os[ii].helioY()) < 1e-10), (
-            "Evaluating Orbits helioY does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.helioZ()[ii] - list_os[ii].helioZ()) < 1e-10), (
-            "Evaluating Orbits helioZ does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.U()[ii] - list_os[ii].U()) < 1e-10), (
-            "Evaluating Orbits U does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.V()[ii] - list_os[ii].V()) < 1e-10), (
-            "Evaluating Orbits V does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.W()[ii] - list_os[ii].W()) < 1e-10), (
-            "Evaluating Orbits W does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.x()[ii]) - _anp(list_os[ii].x())) < 1e-10
+        ), "Evaluating Orbits x does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.y()[ii]) - _anp(list_os[ii].y())) < 1e-10
+        ), "Evaluating Orbits y does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vx()[ii]) - _anp(list_os[ii].vx())) < 1e-10
+        ), "Evaluating Orbits vx does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vy()[ii]) - _anp(list_os[ii].vy())) < 1e-10
+        ), "Evaluating Orbits vy does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+        ), "Evaluating Orbits vphi does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.ra()[ii]) - _anp(list_os[ii].ra())) < 1e-10
+        ), "Evaluating Orbits ra  does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.dec()[ii]) - _anp(list_os[ii].dec())) < 1e-10
+        ), "Evaluating Orbits dec does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.dist()[ii]) - _anp(list_os[ii].dist())) < 1e-10
+        ), "Evaluating Orbits dist does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.ll()[ii]) - _anp(list_os[ii].ll())) < 1e-10
+        ), "Evaluating Orbits ll does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.bb()[ii]) - _anp(list_os[ii].bb())) < 1e-10
+        ), "Evaluating Orbits bb  does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.pmra()[ii]) - _anp(list_os[ii].pmra())) < 1e-10
+        ), "Evaluating Orbits pmra does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.pmdec()[ii]) - _anp(list_os[ii].pmdec())) < 1e-10
+        ), "Evaluating Orbits pmdec does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.pmll()[ii]) - _anp(list_os[ii].pmll())) < 1e-10
+        ), "Evaluating Orbits pmll does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.pmbb()[ii]) - _anp(list_os[ii].pmbb())) < 1e-10
+        ), "Evaluating Orbits pmbb does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vra()[ii]) - _anp(list_os[ii].vra())) < 1e-10
+        ), "Evaluating Orbits vra does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vdec()[ii]) - _anp(list_os[ii].vdec())) < 1e-10
+        ), "Evaluating Orbits vdec does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vll()[ii]) - _anp(list_os[ii].vll())) < 1e-10
+        ), "Evaluating Orbits vll does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vbb()[ii]) - _anp(list_os[ii].vbb())) < 1e-10
+        ), "Evaluating Orbits vbb does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vlos()[ii]) - _anp(list_os[ii].vlos())) < 1e-10
+        ), "Evaluating Orbits vlos does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.helioX()[ii]) - _anp(list_os[ii].helioX())) < 1e-10
+        ), "Evaluating Orbits helioX does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.helioY()[ii]) - _anp(list_os[ii].helioY())) < 1e-10
+        ), "Evaluating Orbits helioY does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.helioZ()[ii]) - _anp(list_os[ii].helioZ())) < 1e-10
+        ), "Evaluating Orbits helioZ does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.U()[ii]) - _anp(list_os[ii].U())) < 1e-10
+        ), "Evaluating Orbits U does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.V()[ii]) - _anp(list_os[ii].V())) < 1e-10
+        ), "Evaluating Orbits V does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.W()[ii]) - _anp(list_os[ii].W())) < 1e-10
+        ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord().ra[ii] - list_os[ii].SkyCoord().ra).to(u.deg).value
             < 1e-10
@@ -3612,111 +3859,115 @@ def test_coordinate_interpolation():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(os.time(times) - list_os[ii].time(times)) < 1e-10
+            numpy.fabs(_anp(os.time(times)) - _anp(list_os[ii].time(times))) < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.R(times)[ii] - list_os[ii].R(times)) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r(times)[ii] - list_os[ii].r(times)) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vR(times)[ii] - list_os[ii].vR(times)) < 1e-10
+            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times)[ii] - list_os[ii].vT(times)) < 1e-10
+            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.z(times)[ii] - list_os[ii].z(times)) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vz(times)[ii] - list_os[ii].vz(times)) < 1e-10
+            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(times)[ii] - list_os[ii].phi(times) + numpy.pi)
+                    (_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times)) + numpy.pi)
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
             )
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.x(times)[ii] - list_os[ii].x(times)) < 1e-10), (
-            "Evaluating Orbits x does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.y(times)[ii] - list_os[ii].y(times)) < 1e-10), (
-            "Evaluating Orbits y does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vx(times)[ii] - list_os[ii].vx(times)) < 1e-10
+            numpy.fabs(_anp(os.x(times)[ii]) - _anp(list_os[ii].x(times))) < 1e-10
+        ), "Evaluating Orbits x does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.y(times)[ii]) - _anp(list_os[ii].y(times))) < 1e-10
+        ), "Evaluating Orbits y does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vx(times)[ii]) - _anp(list_os[ii].vx(times))) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vy(times)[ii] - list_os[ii].vy(times)) < 1e-10
+            numpy.fabs(_anp(os.vy(times)[ii]) - _anp(list_os[ii].vy(times))) < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times)[ii] - list_os[ii].vphi(times)) < 1e-10
+            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ra(times)[ii] - list_os[ii].ra(times)) < 1e-10
+            numpy.fabs(_anp(os.ra(times)[ii]) - _anp(list_os[ii].ra(times))) < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dec(times)[ii] - list_os[ii].dec(times)) < 1e-10
+            numpy.fabs(_anp(os.dec(times)[ii]) - _anp(list_os[ii].dec(times))) < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dist(times)[ii] - list_os[ii].dist(times)) < 1e-10
+            numpy.fabs(_anp(os.dist(times)[ii]) - _anp(list_os[ii].dist(times))) < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ll(times)[ii] - list_os[ii].ll(times)) < 1e-10
+            numpy.fabs(_anp(os.ll(times)[ii]) - _anp(list_os[ii].ll(times))) < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.bb(times)[ii] - list_os[ii].bb(times)) < 1e-10
+            numpy.fabs(_anp(os.bb(times)[ii]) - _anp(list_os[ii].bb(times))) < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmra(times)[ii] - list_os[ii].pmra(times)) < 1e-10
+            numpy.fabs(_anp(os.pmra(times)[ii]) - _anp(list_os[ii].pmra(times))) < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmdec(times)[ii] - list_os[ii].pmdec(times)) < 1e-10
+            numpy.fabs(_anp(os.pmdec(times)[ii]) - _anp(list_os[ii].pmdec(times)))
+            < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmll(times)[ii] - list_os[ii].pmll(times)) < 1e-10
+            numpy.fabs(_anp(os.pmll(times)[ii]) - _anp(list_os[ii].pmll(times))) < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmbb(times)[ii] - list_os[ii].pmbb(times)) < 1e-10
+            numpy.fabs(_anp(os.pmbb(times)[ii]) - _anp(list_os[ii].pmbb(times))) < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vra(times)[ii] - list_os[ii].vra(times)) < 1e-10
+            numpy.fabs(_anp(os.vra(times)[ii]) - _anp(list_os[ii].vra(times))) < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vdec(times)[ii] - list_os[ii].vdec(times)) < 1e-10
+            numpy.fabs(_anp(os.vdec(times)[ii]) - _anp(list_os[ii].vdec(times))) < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vll(times)[ii] - list_os[ii].vll(times)) < 1e-10
+            numpy.fabs(_anp(os.vll(times)[ii]) - _anp(list_os[ii].vll(times))) < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vbb(times)[ii] - list_os[ii].vbb(times)) < 1e-10
+            numpy.fabs(_anp(os.vbb(times)[ii]) - _anp(list_os[ii].vbb(times))) < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vlos(times)[ii] - list_os[ii].vlos(times)) < 1e-9
+            numpy.fabs(_anp(os.vlos(times)[ii]) - _anp(list_os[ii].vlos(times))) < 1e-9
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioX(times)[ii] - list_os[ii].helioX(times)) < 1e-10
+            numpy.fabs(_anp(os.helioX(times)[ii]) - _anp(list_os[ii].helioX(times)))
+            < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioY(times)[ii] - list_os[ii].helioY(times)) < 1e-10
+            numpy.fabs(_anp(os.helioY(times)[ii]) - _anp(list_os[ii].helioY(times)))
+            < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioZ(times)[ii] - list_os[ii].helioZ(times)) < 1e-10
+            numpy.fabs(_anp(os.helioZ(times)[ii]) - _anp(list_os[ii].helioZ(times)))
+            < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.U(times)[ii] - list_os[ii].U(times)) < 1e-10), (
-            "Evaluating Orbits U does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.V(times)[ii] - list_os[ii].V(times)) < 1e-10), (
-            "Evaluating Orbits V does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.W(times)[ii] - list_os[ii].W(times)) < 1e-10), (
-            "Evaluating Orbits W does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.U(times)[ii]) - _anp(list_os[ii].U(times))) < 1e-10
+        ), "Evaluating Orbits U does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.V(times)[ii]) - _anp(list_os[ii].V(times))) < 1e-10
+        ), "Evaluating Orbits V does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.W(times)[ii]) - _anp(list_os[ii].W(times))) < 1e-10
+        ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(times).ra[ii] - list_os[ii].SkyCoord(times).ra)
             .to(u.deg)
@@ -3767,30 +4018,38 @@ def test_coordinate_interpolation():
         # Also a single time in the array ...
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(os.time(times[1]) - list_os[ii].time(times[1])) < 1e-10
+            numpy.fabs(_anp(os.time(times[1])) - _anp(list_os[ii].time(times[1])))
+            < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.R(times[1])[ii] - list_os[ii].R(times[1])) < 1e-10
+            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(times[1])[ii] - list_os[ii].r(times[1])) < 1e-10
+            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(times[1])[ii] - list_os[ii].vR(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times[1])[ii] - list_os[ii].vT(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(times[1])[ii] - list_os[ii].z(times[1])) < 1e-10
+            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(times[1])[ii] - list_os[ii].vz(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(times[1])[ii] - list_os[ii].phi(times[1]) + numpy.pi)
+                    (
+                        _anp(os.phi(times[1])[ii])
+                        - _anp(list_os[ii].phi(times[1]))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -3798,79 +4057,105 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.x(times[1])[ii] - list_os[ii].x(times[1])) < 1e-10
+            numpy.fabs(_anp(os.x(times[1])[ii]) - _anp(list_os[ii].x(times[1]))) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.y(times[1])[ii] - list_os[ii].y(times[1])) < 1e-10
+            numpy.fabs(_anp(os.y(times[1])[ii]) - _anp(list_os[ii].y(times[1]))) < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vx(times[1])[ii] - list_os[ii].vx(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vx(times[1])[ii]) - _anp(list_os[ii].vx(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vy(times[1])[ii] - list_os[ii].vy(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vy(times[1])[ii]) - _anp(list_os[ii].vy(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times[1])[ii] - list_os[ii].vphi(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ra(times[1])[ii] - list_os[ii].ra(times[1])) < 1e-10
+            numpy.fabs(_anp(os.ra(times[1])[ii]) - _anp(list_os[ii].ra(times[1])))
+            < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dec(times[1])[ii] - list_os[ii].dec(times[1])) < 1e-10
+            numpy.fabs(_anp(os.dec(times[1])[ii]) - _anp(list_os[ii].dec(times[1])))
+            < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dist(times[1])[ii] - list_os[ii].dist(times[1])) < 1e-10
+            numpy.fabs(_anp(os.dist(times[1])[ii]) - _anp(list_os[ii].dist(times[1])))
+            < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ll(times[1])[ii] - list_os[ii].ll(times[1])) < 1e-10
+            numpy.fabs(_anp(os.ll(times[1])[ii]) - _anp(list_os[ii].ll(times[1])))
+            < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.bb(times[1])[ii] - list_os[ii].bb(times[1])) < 1e-10
+            numpy.fabs(_anp(os.bb(times[1])[ii]) - _anp(list_os[ii].bb(times[1])))
+            < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmra(times[1])[ii] - list_os[ii].pmra(times[1])) < 1e-10
+            numpy.fabs(_anp(os.pmra(times[1])[ii]) - _anp(list_os[ii].pmra(times[1])))
+            < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmdec(times[1])[ii] - list_os[ii].pmdec(times[1])) < 1e-10
+            numpy.fabs(_anp(os.pmdec(times[1])[ii]) - _anp(list_os[ii].pmdec(times[1])))
+            < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmll(times[1])[ii] - list_os[ii].pmll(times[1])) < 1e-10
+            numpy.fabs(_anp(os.pmll(times[1])[ii]) - _anp(list_os[ii].pmll(times[1])))
+            < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmbb(times[1])[ii] - list_os[ii].pmbb(times[1])) < 1e-10
+            numpy.fabs(_anp(os.pmbb(times[1])[ii]) - _anp(list_os[ii].pmbb(times[1])))
+            < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vra(times[1])[ii] - list_os[ii].vra(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vra(times[1])[ii]) - _anp(list_os[ii].vra(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vdec(times[1])[ii] - list_os[ii].vdec(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vdec(times[1])[ii]) - _anp(list_os[ii].vdec(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vll(times[1])[ii] - list_os[ii].vll(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vll(times[1])[ii]) - _anp(list_os[ii].vll(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vbb(times[1])[ii] - list_os[ii].vbb(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vbb(times[1])[ii]) - _anp(list_os[ii].vbb(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vlos(times[1])[ii] - list_os[ii].vlos(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vlos(times[1])[ii]) - _anp(list_os[ii].vlos(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioX(times[1])[ii] - list_os[ii].helioX(times[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioX(times[1])[ii]) - _anp(list_os[ii].helioX(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioY(times[1])[ii] - list_os[ii].helioY(times[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioY(times[1])[ii]) - _anp(list_os[ii].helioY(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioZ(times[1])[ii] - list_os[ii].helioZ(times[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioZ(times[1])[ii]) - _anp(list_os[ii].helioZ(times[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.U(times[1])[ii] - list_os[ii].U(times[1])) < 1e-10
+            numpy.fabs(_anp(os.U(times[1])[ii]) - _anp(list_os[ii].U(times[1]))) < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.V(times[1])[ii] - list_os[ii].V(times[1])) < 1e-10
+            numpy.fabs(_anp(os.V(times[1])[ii]) - _anp(list_os[ii].V(times[1]))) < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.W(times[1])[ii] - list_os[ii].W(times[1])) < 1e-10
+            numpy.fabs(_anp(os.W(times[1])[ii]) - _anp(list_os[ii].W(times[1]))) < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(times[1]).ra[ii] - list_os[ii].SkyCoord(times[1]).ra)
@@ -3927,27 +4212,31 @@ def test_coordinate_interpolation():
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.R(itimes)[ii] - list_os[ii].R(itimes)) < 1e-10
+            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes)[ii] - list_os[ii].r(itimes)) < 1e-10
+            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes)[ii] - list_os[ii].vR(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes)[ii] - list_os[ii].vT(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes)[ii] - list_os[ii].z(itimes)) < 1e-10
+            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes)[ii] - list_os[ii].vz(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(itimes)[ii] - list_os[ii].phi(itimes) + numpy.pi)
+                    (
+                        _anp(os.phi(itimes)[ii])
+                        - _anp(list_os[ii].phi(itimes))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -3955,79 +4244,90 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.x(itimes)[ii] - list_os[ii].x(itimes)) < 1e-10
+            numpy.fabs(_anp(os.x(itimes)[ii]) - _anp(list_os[ii].x(itimes))) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.y(itimes)[ii] - list_os[ii].y(itimes)) < 1e-10
+            numpy.fabs(_anp(os.y(itimes)[ii]) - _anp(list_os[ii].y(itimes))) < 1e-10
         ), "Evaluating Orbits y does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vx(itimes)[ii] - list_os[ii].vx(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vx(itimes)[ii]) - _anp(list_os[ii].vx(itimes))) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vy(itimes)[ii] - list_os[ii].vy(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vy(itimes)[ii]) - _anp(list_os[ii].vy(itimes))) < 1e-10
         ), "Evaluating Orbits vy does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes)[ii] - list_os[ii].vphi(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vphidoes not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ra(itimes)[ii] - list_os[ii].ra(itimes)) < 1e-10
+            numpy.fabs(_anp(os.ra(itimes)[ii]) - _anp(list_os[ii].ra(itimes))) < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dec(itimes)[ii] - list_os[ii].dec(itimes)) < 1e-10
+            numpy.fabs(_anp(os.dec(itimes)[ii]) - _anp(list_os[ii].dec(itimes))) < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dist(itimes)[ii] - list_os[ii].dist(itimes)) < 1e-10
+            numpy.fabs(_anp(os.dist(itimes)[ii]) - _anp(list_os[ii].dist(itimes)))
+            < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ll(itimes)[ii] - list_os[ii].ll(itimes)) < 1e-10
+            numpy.fabs(_anp(os.ll(itimes)[ii]) - _anp(list_os[ii].ll(itimes))) < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.bb(itimes)[ii] - list_os[ii].bb(itimes)) < 1e-10
+            numpy.fabs(_anp(os.bb(itimes)[ii]) - _anp(list_os[ii].bb(itimes))) < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmra(itimes)[ii] - list_os[ii].pmra(itimes)) < 1e-10
+            numpy.fabs(_anp(os.pmra(itimes)[ii]) - _anp(list_os[ii].pmra(itimes)))
+            < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmdec(itimes)[ii] - list_os[ii].pmdec(itimes)) < 1e-10
+            numpy.fabs(_anp(os.pmdec(itimes)[ii]) - _anp(list_os[ii].pmdec(itimes)))
+            < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmll(itimes)[ii] - list_os[ii].pmll(itimes)) < 1e-10
+            numpy.fabs(_anp(os.pmll(itimes)[ii]) - _anp(list_os[ii].pmll(itimes)))
+            < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmbb(itimes)[ii] - list_os[ii].pmbb(itimes)) < 1e-10
+            numpy.fabs(_anp(os.pmbb(itimes)[ii]) - _anp(list_os[ii].pmbb(itimes)))
+            < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vra(itimes)[ii] - list_os[ii].vra(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vra(itimes)[ii]) - _anp(list_os[ii].vra(itimes))) < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vdec(itimes)[ii] - list_os[ii].vdec(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vdec(itimes)[ii]) - _anp(list_os[ii].vdec(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vll(itimes)[ii] - list_os[ii].vll(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vll(itimes)[ii]) - _anp(list_os[ii].vll(itimes))) < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vbb(itimes)[ii] - list_os[ii].vbb(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vbb(itimes)[ii]) - _anp(list_os[ii].vbb(itimes))) < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vlos(itimes)[ii] - list_os[ii].vlos(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vlos(itimes)[ii]) - _anp(list_os[ii].vlos(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioX(itimes)[ii] - list_os[ii].helioX(itimes)) < 1e-10
+            numpy.fabs(_anp(os.helioX(itimes)[ii]) - _anp(list_os[ii].helioX(itimes)))
+            < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioY(itimes)[ii] - list_os[ii].helioY(itimes)) < 1e-10
+            numpy.fabs(_anp(os.helioY(itimes)[ii]) - _anp(list_os[ii].helioY(itimes)))
+            < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioZ(itimes)[ii] - list_os[ii].helioZ(itimes)) < 1e-10
+            numpy.fabs(_anp(os.helioZ(itimes)[ii]) - _anp(list_os[ii].helioZ(itimes)))
+            < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.U(itimes)[ii] - list_os[ii].U(itimes)) < 1e-10
+            numpy.fabs(_anp(os.U(itimes)[ii]) - _anp(list_os[ii].U(itimes))) < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.V(itimes)[ii] - list_os[ii].V(itimes)) < 1e-10
+            numpy.fabs(_anp(os.V(itimes)[ii]) - _anp(list_os[ii].V(itimes))) < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.W(itimes)[ii] - list_os[ii].W(itimes)) < 1e-10
+            numpy.fabs(_anp(os.W(itimes)[ii]) - _anp(list_os[ii].W(itimes))) < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(os.SkyCoord(itimes).ra[ii] - list_os[ii].SkyCoord(itimes).ra)
@@ -4078,27 +4378,37 @@ def test_coordinate_interpolation():
             ), "Evaluating Orbits SkyCoord does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(itimes[1])[ii] - list_os[ii].R(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes[1])[ii] - list_os[ii].r(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes[1])[ii] - list_os[ii].vR(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes[1])[ii] - list_os[ii].vT(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes[1])[ii] - list_os[ii].z(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes[1])[ii] - list_os[ii].vz(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(itimes[1])[ii] - list_os[ii].phi(itimes[1]) + numpy.pi)
+                    (
+                        _anp(os.phi(itimes[1])[ii])
+                        - _anp(list_os[ii].phi(itimes[1]))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -4106,64 +4416,92 @@ def test_coordinate_interpolation():
             < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ra(itimes[1])[ii] - list_os[ii].ra(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.ra(itimes[1])[ii]) - _anp(list_os[ii].ra(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits ra  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dec(itimes[1])[ii] - list_os[ii].dec(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.dec(itimes[1])[ii]) - _anp(list_os[ii].dec(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits dec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.dist(itimes[1])[ii] - list_os[ii].dist(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.dist(itimes[1])[ii]) - _anp(list_os[ii].dist(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits dist does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.ll(itimes[1])[ii] - list_os[ii].ll(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.ll(itimes[1])[ii]) - _anp(list_os[ii].ll(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits ll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.bb(itimes[1])[ii] - list_os[ii].bb(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.bb(itimes[1])[ii]) - _anp(list_os[ii].bb(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits bb  does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmra(itimes[1])[ii] - list_os[ii].pmra(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.pmra(itimes[1])[ii]) - _anp(list_os[ii].pmra(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits pmra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmdec(itimes[1])[ii] - list_os[ii].pmdec(itimes[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.pmdec(itimes[1])[ii]) - _anp(list_os[ii].pmdec(itimes[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits pmdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmll(itimes[1])[ii] - list_os[ii].pmll(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.pmll(itimes[1])[ii]) - _anp(list_os[ii].pmll(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits pmll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.pmbb(itimes[1])[ii] - list_os[ii].pmbb(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.pmbb(itimes[1])[ii]) - _anp(list_os[ii].pmbb(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits pmbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vra(itimes[1])[ii] - list_os[ii].vra(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vra(itimes[1])[ii]) - _anp(list_os[ii].vra(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vra does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vdec(itimes[1])[ii] - list_os[ii].vdec(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vdec(itimes[1])[ii]) - _anp(list_os[ii].vdec(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vdec does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vll(itimes[1])[ii] - list_os[ii].vll(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vll(itimes[1])[ii]) - _anp(list_os[ii].vll(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vll does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vbb(itimes[1])[ii] - list_os[ii].vbb(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vbb(itimes[1])[ii]) - _anp(list_os[ii].vbb(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vbb does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vlos(itimes[1])[ii] - list_os[ii].vlos(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vlos(itimes[1])[ii]) - _anp(list_os[ii].vlos(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vlos does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioX(itimes[1])[ii] - list_os[ii].helioX(itimes[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioX(itimes[1])[ii]) - _anp(list_os[ii].helioX(itimes[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioX does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioY(itimes[1])[ii] - list_os[ii].helioY(itimes[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioY(itimes[1])[ii]) - _anp(list_os[ii].helioY(itimes[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioY does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.helioZ(itimes[1])[ii] - list_os[ii].helioZ(itimes[1])) < 1e-10
+            numpy.fabs(
+                _anp(os.helioZ(itimes[1])[ii]) - _anp(list_os[ii].helioZ(itimes[1]))
+            )
+            < 1e-10
         ), "Evaluating Orbits helioZ does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.U(itimes[1])[ii] - list_os[ii].U(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.U(itimes[1])[ii]) - _anp(list_os[ii].U(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits U does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.V(itimes[1])[ii] - list_os[ii].V(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.V(itimes[1])[ii]) - _anp(list_os[ii].V(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits V does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.W(itimes[1])[ii] - list_os[ii].W(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.W(itimes[1])[ii]) - _anp(list_os[ii].W(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits W does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
@@ -4240,121 +4578,133 @@ def test_coordinate_interpolation_5d():
     ]
     # Before integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R()[ii] - list_os[ii].R()) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r()[ii] - list_os[ii].r()) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vR()[ii] - list_os[ii].vR()) < 1e-10), (
-            "Evaluating Orbits vR does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vT()[ii] - list_os[ii].vT()) < 1e-10), (
-            "Evaluating Orbits vT does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.z()[ii] - list_os[ii].z()) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vz()[ii] - list_os[ii].vz()) < 1e-10), (
-            "Evaluating Orbits vz does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vphi()[ii] - list_os[ii].vphi()) < 1e-10), (
-            "Evaluating Orbits vphi does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+        ), "Evaluating Orbits vR does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+        ), "Evaluating Orbits vT does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+        ), "Evaluating Orbits vz does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+        ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
     os.integrate(times, MWPotential2014)
     [o.integrate(times, MWPotential2014) for o in list_os]
     # Test exact times of integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R(times)[ii] - list_os[ii].R(times)) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r(times)[ii] - list_os[ii].r(times)) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vR(times)[ii] - list_os[ii].vR(times)) < 1e-10
+            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times)[ii] - list_os[ii].vT(times)) < 1e-10
+            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.z(times)[ii] - list_os[ii].z(times)) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vz(times)[ii] - list_os[ii].vz(times)) < 1e-10
+            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times)[ii] - list_os[ii].vphi(times)) < 1e-10
+            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(times[1])[ii] - list_os[ii].R(times[1])) < 1e-10
+            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(times[1])[ii] - list_os[ii].r(times[1])) < 1e-10
+            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(times[1])[ii] - list_os[ii].vR(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times[1])[ii] - list_os[ii].vT(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(times[1])[ii] - list_os[ii].z(times[1])) < 1e-10
+            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(times[1])[ii] - list_os[ii].vz(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times[1])[ii] - list_os[ii].vphi(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.R(itimes)[ii] - list_os[ii].R(itimes)) < 1e-10
+            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes)[ii] - list_os[ii].r(itimes)) < 1e-10
+            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes)[ii] - list_os[ii].vR(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes)[ii] - list_os[ii].vT(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes)[ii] - list_os[ii].z(itimes)) < 1e-10
+            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes)[ii] - list_os[ii].vz(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes)[ii] - list_os[ii].vphi(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(itimes[1])[ii] - list_os[ii].R(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes[1])[ii] - list_os[ii].r(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes[1])[ii] - list_os[ii].vR(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes[1])[ii] - list_os[ii].vT(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes[1])[ii] - list_os[ii].z(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes[1])[ii] - list_os[ii].vz(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes[1])[ii] - list_os[ii].vphi(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
         os.phi()
@@ -4377,106 +4727,117 @@ def test_coordinate_interpolation_4d():
     list_os = [Orbit([R, vR, vT, phi]) for R, vR, vT, phi in zip(Rs, vRs, vTs, phis)]
     # Before integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R()[ii] - list_os[ii].R()) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r()[ii] - list_os[ii].r()) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vR()[ii] - list_os[ii].vR()) < 1e-10), (
-            "Evaluating Orbits vR does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vT()[ii] - list_os[ii].vT()) < 1e-10), (
-            "Evaluating Orbits vT does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.phi()[ii] - list_os[ii].phi()) < 1e-10), (
-            "Evaluating Orbits phi does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vphi()[ii] - list_os[ii].vphi()) < 1e-10), (
-            "Evaluating Orbits vphi does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+        ), "Evaluating Orbits vR does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+        ), "Evaluating Orbits vT does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.phi()[ii]) - _anp(list_os[ii].phi())) < 1e-10
+        ), "Evaluating Orbits phi does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+        ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
     os.integrate(times, MWPotential2014)
     [o.integrate(times, MWPotential2014) for o in list_os]
     # Test exact times of integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R(times)[ii] - list_os[ii].R(times)) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r(times)[ii] - list_os[ii].r(times)) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vR(times)[ii] - list_os[ii].vR(times)) < 1e-10
+            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times)[ii] - list_os[ii].vT(times)) < 1e-10
+            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.phi(times)[ii] - list_os[ii].phi(times)) < 1e-10
+            numpy.fabs(_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times))) < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times)[ii] - list_os[ii].vphi(times)) < 1e-10
+            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(times[1])[ii] - list_os[ii].R(times[1])) < 1e-10
+            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(times[1])[ii] - list_os[ii].r(times[1])) < 1e-10
+            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(times[1])[ii] - list_os[ii].vR(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times[1])[ii] - list_os[ii].vT(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.phi(times[1])[ii] - list_os[ii].phi(times[1])) < 1e-10
+            numpy.fabs(_anp(os.phi(times[1])[ii]) - _anp(list_os[ii].phi(times[1])))
+            < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times[1])[ii] - list_os[ii].vphi(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.R(itimes)[ii] - list_os[ii].R(itimes)) < 1e-10
+            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes)[ii] - list_os[ii].r(itimes)) < 1e-10
+            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes)[ii] - list_os[ii].vR(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes)[ii] - list_os[ii].vT(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.phi(itimes)[ii] - list_os[ii].phi(itimes)) < 1e-10
+            numpy.fabs(_anp(os.phi(itimes)[ii]) - _anp(list_os[ii].phi(itimes))) < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes)[ii] - list_os[ii].vphi(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(itimes[1])[ii] - list_os[ii].R(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes[1])[ii] - list_os[ii].r(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes[1])[ii] - list_os[ii].vR(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes[1])[ii] - list_os[ii].vT(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.phi(itimes[1])[ii] - list_os[ii].phi(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.phi(itimes[1])[ii]) - _anp(list_os[ii].phi(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits phi does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes[1])[ii] - list_os[ii].vphi(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
         os.z()
@@ -4500,91 +4861,100 @@ def test_coordinate_interpolation_3d():
     list_os = [Orbit([R, vR, vT]) for R, vR, vT in zip(Rs, vRs, vTs)]
     # Before integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R()[ii] - list_os[ii].R()) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r()[ii] - list_os[ii].r()) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vR()[ii] - list_os[ii].vR()) < 1e-10), (
-            "Evaluating Orbits vR does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vT()[ii] - list_os[ii].vT()) < 1e-10), (
-            "Evaluating Orbits vT does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vphi()[ii] - list_os[ii].vphi()) < 1e-10), (
-            "Evaluating Orbits vphi does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+        ), "Evaluating Orbits vR does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+        ), "Evaluating Orbits vT does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vphi()[ii]) - _anp(list_os[ii].vphi())) < 1e-10
+        ), "Evaluating Orbits vphi does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
     os.integrate(times, MWPotential2014)
     [o.integrate(times, MWPotential2014) for o in list_os]
     # Test exact times of integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.R(times)[ii] - list_os[ii].R(times)) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r(times)[ii] - list_os[ii].r(times)) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vR(times)[ii] - list_os[ii].vR(times)) < 1e-10
+            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times)[ii] - list_os[ii].vT(times)) < 1e-10
+            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times)[ii] - list_os[ii].vphi(times)) < 1e-10
+            numpy.fabs(_anp(os.vphi(times)[ii]) - _anp(list_os[ii].vphi(times))) < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(times[1])[ii] - list_os[ii].R(times[1])) < 1e-10
+            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(times[1])[ii] - list_os[ii].r(times[1])) < 1e-10
+            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(times[1])[ii] - list_os[ii].vR(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times[1])[ii] - list_os[ii].vT(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(times[1])[ii] - list_os[ii].vphi(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(times[1])[ii]) - _anp(list_os[ii].vphi(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.R(itimes)[ii] - list_os[ii].R(itimes)) < 1e-10
+            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes)[ii] - list_os[ii].r(itimes)) < 1e-10
+            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes)[ii] - list_os[ii].vR(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes)[ii] - list_os[ii].vT(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes)[ii] - list_os[ii].vphi(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes)[ii]) - _anp(list_os[ii].vphi(itimes)))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(itimes[1])[ii] - list_os[ii].R(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes[1])[ii] - list_os[ii].r(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes[1])[ii] - list_os[ii].vR(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes[1])[ii] - list_os[ii].vT(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vphi(itimes[1])[ii] - list_os[ii].vphi(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vphi(itimes[1])[ii]) - _anp(list_os[ii].vphi(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vphi does not agree with Orbit"
     with pytest.raises(AttributeError):
         os.phi()
@@ -4614,46 +4984,49 @@ def test_coordinate_interpolation_2d():
     list_os = [Orbit([z, vz]) for z, vz in zip(zs, vzs)]
     # Before integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.x()[ii] - list_os[ii].x()) < 1e-10), (
-            "Evaluating Orbits x does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vx()[ii] - list_os[ii].vx()) < 1e-10), (
-            "Evaluating Orbits vx does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.x()[ii]) - _anp(list_os[ii].x())) < 1e-10
+        ), "Evaluating Orbits x does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vx()[ii]) - _anp(list_os[ii].vx())) < 1e-10
+        ), "Evaluating Orbits vx does not agree with Orbit"
     # Integrate all
     times = numpy.linspace(0.0, 10.0, 1001)
     os.integrate(times, MWPotential2014)
     [o.integrate(times, MWPotential2014) for o in list_os]
     # Test exact times of integration
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.x(times)[ii] - list_os[ii].x(times)) < 1e-10), (
-            "Evaluating Orbits x does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vx(times)[ii] - list_os[ii].vx(times)) < 1e-10
+            numpy.fabs(_anp(os.x(times)[ii]) - _anp(list_os[ii].x(times))) < 1e-10
+        ), "Evaluating Orbits x does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vx(times)[ii]) - _anp(list_os[ii].vx(times))) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.x(times[1])[ii] - list_os[ii].x(times[1])) < 1e-10
+            numpy.fabs(_anp(os.x(times[1])[ii]) - _anp(list_os[ii].x(times[1]))) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vx(times[1])[ii] - list_os[ii].vx(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vx(times[1])[ii]) - _anp(list_os[ii].vx(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
     # Test actual interpolated
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.x(itimes)[ii] - list_os[ii].x(itimes)) < 1e-10
+            numpy.fabs(_anp(os.x(itimes)[ii]) - _anp(list_os[ii].x(itimes))) < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vx(itimes)[ii] - list_os[ii].vx(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vx(itimes)[ii]) - _anp(list_os[ii].vx(itimes))) < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.x(itimes[1])[ii] - list_os[ii].x(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.x(itimes[1])[ii]) - _anp(list_os[ii].x(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits x does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vx(itimes[1])[ii] - list_os[ii].vx(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vx(itimes[1])[ii]) - _anp(list_os[ii].vx(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vx does not agree with Orbit"
     return None
 
@@ -4715,30 +5088,33 @@ def test_coordinate_interpolation_oneorbit():
     # Before integration
     for ii in range(nrand):
         # .time is special, just a single array
-        assert numpy.all(numpy.fabs(os.time() - list_os[ii].time()) < 1e-10), (
-            "Evaluating Orbits time does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.R()[ii] - list_os[ii].R()) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r()[ii] - list_os[ii].r()) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vR()[ii] - list_os[ii].vR()) < 1e-10), (
-            "Evaluating Orbits vR does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vT()[ii] - list_os[ii].vT()) < 1e-10), (
-            "Evaluating Orbits vT does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.z()[ii] - list_os[ii].z()) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.vz()[ii] - list_os[ii].vz()) < 1e-10), (
-            "Evaluating Orbits vz does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.time()) - _anp(list_os[ii].time())) < 1e-10
+        ), "Evaluating Orbits time does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.R()[ii]) - _anp(list_os[ii].R())) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r()[ii]) - _anp(list_os[ii].r())) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR()[ii]) - _anp(list_os[ii].vR())) < 1e-10
+        ), "Evaluating Orbits vR does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vT()[ii]) - _anp(list_os[ii].vT())) < 1e-10
+        ), "Evaluating Orbits vT does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.z()[ii]) - _anp(list_os[ii].z())) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz()[ii]) - _anp(list_os[ii].vz())) < 1e-10
+        ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
-                ((os.phi()[ii] - list_os[ii].phi() + numpy.pi) % (2.0 * numpy.pi))
+                (
+                    (_anp(os.phi()[ii]) - _anp(list_os[ii].phi()) + numpy.pi)
+                    % (2.0 * numpy.pi)
+                )
                 - numpy.pi
             )
             < 1e-10
@@ -4751,30 +5127,30 @@ def test_coordinate_interpolation_oneorbit():
     for ii in range(nrand):
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(os.time(times) - list_os[ii].time(times)) < 1e-10
+            numpy.fabs(_anp(os.time(times)) - _anp(list_os[ii].time(times))) < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.R(times)[ii] - list_os[ii].R(times)) < 1e-10), (
-            "Evaluating Orbits R does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.r(times)[ii] - list_os[ii].r(times)) < 1e-10), (
-            "Evaluating Orbits r does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vR(times)[ii] - list_os[ii].vR(times)) < 1e-10
+            numpy.fabs(_anp(os.R(times)[ii]) - _anp(list_os[ii].R(times))) < 1e-10
+        ), "Evaluating Orbits R does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.r(times)[ii]) - _anp(list_os[ii].r(times))) < 1e-10
+        ), "Evaluating Orbits r does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vR(times)[ii]) - _anp(list_os[ii].vR(times))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times)[ii] - list_os[ii].vT(times)) < 1e-10
+            numpy.fabs(_anp(os.vT(times)[ii]) - _anp(list_os[ii].vT(times))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
-        assert numpy.all(numpy.fabs(os.z(times)[ii] - list_os[ii].z(times)) < 1e-10), (
-            "Evaluating Orbits z does not agree with Orbit"
-        )
         assert numpy.all(
-            numpy.fabs(os.vz(times)[ii] - list_os[ii].vz(times)) < 1e-10
+            numpy.fabs(_anp(os.z(times)[ii]) - _anp(list_os[ii].z(times))) < 1e-10
+        ), "Evaluating Orbits z does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.vz(times)[ii]) - _anp(list_os[ii].vz(times))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(times)[ii] - list_os[ii].phi(times) + numpy.pi)
+                    (_anp(os.phi(times)[ii]) - _anp(list_os[ii].phi(times)) + numpy.pi)
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -4784,30 +5160,38 @@ def test_coordinate_interpolation_oneorbit():
         # Also a single time in the array ...
         # .time is special, just a single array
         assert numpy.all(
-            numpy.fabs(os.time(times[1]) - list_os[ii].time(times[1])) < 1e-10
+            numpy.fabs(_anp(os.time(times[1])) - _anp(list_os[ii].time(times[1])))
+            < 1e-10
         ), "Evaluating Orbits time does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.R(times[1])[ii] - list_os[ii].R(times[1])) < 1e-10
+            numpy.fabs(_anp(os.R(times[1])[ii]) - _anp(list_os[ii].R(times[1]))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(times[1])[ii] - list_os[ii].r(times[1])) < 1e-10
+            numpy.fabs(_anp(os.r(times[1])[ii]) - _anp(list_os[ii].r(times[1]))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(times[1])[ii] - list_os[ii].vR(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(times[1])[ii]) - _anp(list_os[ii].vR(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(times[1])[ii] - list_os[ii].vT(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(times[1])[ii]) - _anp(list_os[ii].vT(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(times[1])[ii] - list_os[ii].z(times[1])) < 1e-10
+            numpy.fabs(_anp(os.z(times[1])[ii]) - _anp(list_os[ii].z(times[1]))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(times[1])[ii] - list_os[ii].vz(times[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(times[1])[ii]) - _anp(list_os[ii].vz(times[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(times[1])[ii] - list_os[ii].phi(times[1]) + numpy.pi)
+                    (
+                        _anp(os.phi(times[1])[ii])
+                        - _anp(list_os[ii].phi(times[1]))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -4818,27 +5202,31 @@ def test_coordinate_interpolation_oneorbit():
     itimes = times[:-2] + (times[1] - times[0]) / 2.0
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.R(itimes)[ii] - list_os[ii].R(itimes)) < 1e-10
+            numpy.fabs(_anp(os.R(itimes)[ii]) - _anp(list_os[ii].R(itimes))) < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes)[ii] - list_os[ii].r(itimes)) < 1e-10
+            numpy.fabs(_anp(os.r(itimes)[ii]) - _anp(list_os[ii].r(itimes))) < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes)[ii] - list_os[ii].vR(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes)[ii]) - _anp(list_os[ii].vR(itimes))) < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes)[ii] - list_os[ii].vT(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes)[ii]) - _anp(list_os[ii].vT(itimes))) < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes)[ii] - list_os[ii].z(itimes)) < 1e-10
+            numpy.fabs(_anp(os.z(itimes)[ii]) - _anp(list_os[ii].z(itimes))) < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes)[ii] - list_os[ii].vz(itimes)) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes)[ii]) - _anp(list_os[ii].vz(itimes))) < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(itimes)[ii] - list_os[ii].phi(itimes) + numpy.pi)
+                    (
+                        _anp(os.phi(itimes)[ii])
+                        - _anp(list_os[ii].phi(itimes))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -4847,27 +5235,37 @@ def test_coordinate_interpolation_oneorbit():
         ), "Evaluating Orbits phi does not agree with Orbit"
         # Also a single time in the array ...
         assert numpy.all(
-            numpy.fabs(os.R(itimes[1])[ii] - list_os[ii].R(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.R(itimes[1])[ii]) - _anp(list_os[ii].R(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits R does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.r(itimes[1])[ii] - list_os[ii].r(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.r(itimes[1])[ii]) - _anp(list_os[ii].r(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits r does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vR(itimes[1])[ii] - list_os[ii].vR(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vR(itimes[1])[ii]) - _anp(list_os[ii].vR(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vR does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vT(itimes[1])[ii] - list_os[ii].vT(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vT(itimes[1])[ii]) - _anp(list_os[ii].vT(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vT does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.z(itimes[1])[ii] - list_os[ii].z(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.z(itimes[1])[ii]) - _anp(list_os[ii].z(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits z does not agree with Orbit"
         assert numpy.all(
-            numpy.fabs(os.vz(itimes[1])[ii] - list_os[ii].vz(itimes[1])) < 1e-10
+            numpy.fabs(_anp(os.vz(itimes[1])[ii]) - _anp(list_os[ii].vz(itimes[1])))
+            < 1e-10
         ), "Evaluating Orbits vz does not agree with Orbit"
         assert numpy.all(
             numpy.fabs(
                 (
-                    (os.phi(itimes[1])[ii] - list_os[ii].phi(itimes[1]) + numpy.pi)
+                    (
+                        _anp(os.phi(itimes[1])[ii])
+                        - _anp(list_os[ii].phi(itimes[1]))
+                        + numpy.pi
+                    )
                     % (2.0 * numpy.pi)
                 )
                 - numpy.pi
@@ -4946,32 +5344,45 @@ def test_output_shape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(os.time() - list_os[ii][jj][kk].time()) < 1e-10
+                    numpy.fabs(_anp(os.time()) - _anp(list_os[ii][jj][kk].time()))
+                    < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.R()[ii, jj, kk] - list_os[ii][jj][kk].R()) < 1e-10
+                    numpy.fabs(_anp(os.R()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].R()))
+                    < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.r()[ii, jj, kk] - list_os[ii][jj][kk].r()) < 1e-10
+                    numpy.fabs(_anp(os.r()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].r()))
+                    < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vR()[ii, jj, kk] - list_os[ii][jj][kk].vR()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vR()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vR())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vT()[ii, jj, kk] - list_os[ii][jj][kk].vT()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vT()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vT())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.z()[ii, jj, kk] - list_os[ii][jj][kk].z()) < 1e-10
+                    numpy.fabs(_anp(os.z()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].z()))
+                    < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vz()[ii, jj, kk] - list_os[ii][jj][kk].vz()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vz()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vz())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
                         (
                             (
-                                os.phi()[ii, jj, kk]
-                                - list_os[ii][jj][kk].phi()
+                                _anp(os.phi()[ii, jj, kk])
+                                - _anp(list_os[ii][jj][kk].phi())
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -4981,90 +5392,147 @@ def test_output_shape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.x()[ii, jj, kk] - list_os[ii][jj][kk].x()) < 1e-10
+                    numpy.fabs(_anp(os.x()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].x()))
+                    < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.y()[ii, jj, kk] - list_os[ii][jj][kk].y()) < 1e-10
+                    numpy.fabs(_anp(os.y()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].y()))
+                    < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vx()[ii, jj, kk] - list_os[ii][jj][kk].vx()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vx()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vx())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vy()[ii, jj, kk] - list_os[ii][jj][kk].vy()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vy()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vy())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vphi()[ii, jj, kk] - list_os[ii][jj][kk].vphi())
+                    numpy.fabs(
+                        _anp(os.vphi()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vphi())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ra()[ii, jj, kk] - list_os[ii][jj][kk].ra()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.ra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ra())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.dec()[ii, jj, kk] - list_os[ii][jj][kk].dec()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.dec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dec())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.dist()[ii, jj, kk] - list_os[ii][jj][kk].dist())
+                    numpy.fabs(
+                        _anp(os.dist()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dist())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ll()[ii, jj, kk] - list_os[ii][jj][kk].ll()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.ll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ll())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.bb()[ii, jj, kk] - list_os[ii][jj][kk].bb()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.bb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].bb())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmra()[ii, jj, kk] - list_os[ii][jj][kk].pmra())
+                    numpy.fabs(
+                        _anp(os.pmra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmra())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmdec()[ii, jj, kk] - list_os[ii][jj][kk].pmdec())
+                    numpy.fabs(
+                        _anp(os.pmdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmdec())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmll()[ii, jj, kk] - list_os[ii][jj][kk].pmll())
+                    numpy.fabs(
+                        _anp(os.pmll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmll())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmbb()[ii, jj, kk] - list_os[ii][jj][kk].pmbb())
+                    numpy.fabs(
+                        _anp(os.pmbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmbb())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vra()[ii, jj, kk] - list_os[ii][jj][kk].vra()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vra())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vdec()[ii, jj, kk] - list_os[ii][jj][kk].vdec())
+                    numpy.fabs(
+                        _anp(os.vdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vdec())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vll()[ii, jj, kk] - list_os[ii][jj][kk].vll()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vll())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vbb()[ii, jj, kk] - list_os[ii][jj][kk].vbb()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vbb())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vlos()[ii, jj, kk] - list_os[ii][jj][kk].vlos())
+                    numpy.fabs(
+                        _anp(os.vlos()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vlos())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioX()[ii, jj, kk] - list_os[ii][jj][kk].helioX())
+                    numpy.fabs(
+                        _anp(os.helioX()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioX())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioY()[ii, jj, kk] - list_os[ii][jj][kk].helioY())
+                    numpy.fabs(
+                        _anp(os.helioY()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioY())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioZ()[ii, jj, kk] - list_os[ii][jj][kk].helioZ())
+                    numpy.fabs(
+                        _anp(os.helioZ()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioZ())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.U()[ii, jj, kk] - list_os[ii][jj][kk].U()) < 1e-10
+                    numpy.fabs(_anp(os.U()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].U()))
+                    < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.V()[ii, jj, kk] - list_os[ii][jj][kk].V()) < 1e-10
+                    numpy.fabs(_anp(os.V()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].V()))
+                    < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.W()[ii, jj, kk] - list_os[ii][jj][kk].W()) < 1e-10
+                    numpy.fabs(_anp(os.W()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].W()))
+                    < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
@@ -5133,38 +5601,59 @@ def test_output_shape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(os.time(times) - list_os[ii][jj][kk].time(times)) < 1e-10
+                    numpy.fabs(
+                        _anp(os.time(times)) - _anp(list_os[ii][jj][kk].time(times))
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.R(times)[ii, jj, kk] - list_os[ii][jj][kk].R(times))
+                    numpy.fabs(
+                        _anp(os.R(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].R(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.r(times)[ii, jj, kk] - list_os[ii][jj][kk].r(times))
+                    numpy.fabs(
+                        _anp(os.r(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].r(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vR(times)[ii, jj, kk] - list_os[ii][jj][kk].vR(times))
+                    numpy.fabs(
+                        _anp(os.vR(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vR(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vT(times)[ii, jj, kk] - list_os[ii][jj][kk].vT(times))
+                    numpy.fabs(
+                        _anp(os.vT(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vT(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.z(times)[ii, jj, kk] - list_os[ii][jj][kk].z(times))
+                    numpy.fabs(
+                        _anp(os.z(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].z(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vz(times)[ii, jj, kk] - list_os[ii][jj][kk].vz(times))
+                    numpy.fabs(
+                        _anp(os.vz(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vz(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
                         (
                             (
-                                os.phi(times)[ii, jj, kk]
-                                - list_os[ii][jj][kk].phi(times)
+                                _anp(os.phi(times)[ii, jj, kk])
+                                - _anp(list_os[ii][jj][kk].phi(times))
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5174,133 +5663,178 @@ def test_output_shape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.x(times)[ii, jj, kk] - list_os[ii][jj][kk].x(times))
+                    numpy.fabs(
+                        _anp(os.x(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].x(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.y(times)[ii, jj, kk] - list_os[ii][jj][kk].y(times))
+                    numpy.fabs(
+                        _anp(os.y(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].y(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vx(times)[ii, jj, kk] - list_os[ii][jj][kk].vx(times))
+                    numpy.fabs(
+                        _anp(os.vx(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vx(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vy(times)[ii, jj, kk] - list_os[ii][jj][kk].vy(times))
+                    numpy.fabs(
+                        _anp(os.vy(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vy(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vphi(times)[ii, jj, kk] - list_os[ii][jj][kk].vphi(times)
+                        _anp(os.vphi(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vphi(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ra(times)[ii, jj, kk] - list_os[ii][jj][kk].ra(times))
+                    numpy.fabs(
+                        _anp(os.ra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].ra(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.dec(times)[ii, jj, kk] - list_os[ii][jj][kk].dec(times)
+                        _anp(os.dec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].dec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.dist(times)[ii, jj, kk] - list_os[ii][jj][kk].dist(times)
+                        _anp(os.dist(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].dist(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ll(times)[ii, jj, kk] - list_os[ii][jj][kk].ll(times))
+                    numpy.fabs(
+                        _anp(os.ll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].ll(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.bb(times)[ii, jj, kk] - list_os[ii][jj][kk].bb(times))
+                    numpy.fabs(
+                        _anp(os.bb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].bb(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmra(times)[ii, jj, kk] - list_os[ii][jj][kk].pmra(times)
+                        _anp(os.pmra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmdec(times)[ii, jj, kk] - list_os[ii][jj][kk].pmdec(times)
+                        _anp(os.pmdec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmll(times)[ii, jj, kk] - list_os[ii][jj][kk].pmll(times)
+                        _anp(os.pmll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmbb(times)[ii, jj, kk] - list_os[ii][jj][kk].pmbb(times)
+                        _anp(os.pmbb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vra(times)[ii, jj, kk] - list_os[ii][jj][kk].vra(times)
+                        _anp(os.vra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vdec(times)[ii, jj, kk] - list_os[ii][jj][kk].vdec(times)
+                        _anp(os.vdec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vll(times)[ii, jj, kk] - list_os[ii][jj][kk].vll(times)
+                        _anp(os.vll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vbb(times)[ii, jj, kk] - list_os[ii][jj][kk].vbb(times)
+                        _anp(os.vbb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vlos(times)[ii, jj, kk] - list_os[ii][jj][kk].vlos(times)
+                        _anp(os.vlos(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vlos(times))
                     )
                     < 1e-9
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioX(times)[ii, jj, kk] - list_os[ii][jj][kk].helioX(times)
+                        _anp(os.helioX(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioX(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioY(times)[ii, jj, kk] - list_os[ii][jj][kk].helioY(times)
+                        _anp(os.helioY(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioY(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioZ(times)[ii, jj, kk] - list_os[ii][jj][kk].helioZ(times)
+                        _anp(os.helioZ(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioZ(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.U(times)[ii, jj, kk] - list_os[ii][jj][kk].U(times))
+                    numpy.fabs(
+                        _anp(os.U(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].U(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.V(times)[ii, jj, kk] - list_os[ii][jj][kk].V(times))
+                    numpy.fabs(
+                        _anp(os.V(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].V(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.W(times)[ii, jj, kk] - list_os[ii][jj][kk].W(times))
+                    numpy.fabs(
+                        _anp(os.W(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].W(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
@@ -5416,32 +5950,45 @@ def test_output_reshape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(os.time() - list_os[ii][jj][kk].time()) < 1e-10
+                    numpy.fabs(_anp(os.time()) - _anp(list_os[ii][jj][kk].time()))
+                    < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.R()[ii, jj, kk] - list_os[ii][jj][kk].R()) < 1e-10
+                    numpy.fabs(_anp(os.R()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].R()))
+                    < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.r()[ii, jj, kk] - list_os[ii][jj][kk].r()) < 1e-10
+                    numpy.fabs(_anp(os.r()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].r()))
+                    < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vR()[ii, jj, kk] - list_os[ii][jj][kk].vR()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vR()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vR())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vT()[ii, jj, kk] - list_os[ii][jj][kk].vT()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vT()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vT())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.z()[ii, jj, kk] - list_os[ii][jj][kk].z()) < 1e-10
+                    numpy.fabs(_anp(os.z()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].z()))
+                    < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vz()[ii, jj, kk] - list_os[ii][jj][kk].vz()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vz()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vz())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
                         (
                             (
-                                os.phi()[ii, jj, kk]
-                                - list_os[ii][jj][kk].phi()
+                                _anp(os.phi()[ii, jj, kk])
+                                - _anp(list_os[ii][jj][kk].phi())
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5451,90 +5998,147 @@ def test_output_reshape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.x()[ii, jj, kk] - list_os[ii][jj][kk].x()) < 1e-10
+                    numpy.fabs(_anp(os.x()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].x()))
+                    < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.y()[ii, jj, kk] - list_os[ii][jj][kk].y()) < 1e-10
+                    numpy.fabs(_anp(os.y()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].y()))
+                    < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vx()[ii, jj, kk] - list_os[ii][jj][kk].vx()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vx()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vx())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vy()[ii, jj, kk] - list_os[ii][jj][kk].vy()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vy()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vy())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vphi()[ii, jj, kk] - list_os[ii][jj][kk].vphi())
+                    numpy.fabs(
+                        _anp(os.vphi()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vphi())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ra()[ii, jj, kk] - list_os[ii][jj][kk].ra()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.ra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ra())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.dec()[ii, jj, kk] - list_os[ii][jj][kk].dec()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.dec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dec())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.dist()[ii, jj, kk] - list_os[ii][jj][kk].dist())
+                    numpy.fabs(
+                        _anp(os.dist()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].dist())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ll()[ii, jj, kk] - list_os[ii][jj][kk].ll()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.ll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].ll())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.bb()[ii, jj, kk] - list_os[ii][jj][kk].bb()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.bb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].bb())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmra()[ii, jj, kk] - list_os[ii][jj][kk].pmra())
+                    numpy.fabs(
+                        _anp(os.pmra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmra())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmdec()[ii, jj, kk] - list_os[ii][jj][kk].pmdec())
+                    numpy.fabs(
+                        _anp(os.pmdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmdec())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmll()[ii, jj, kk] - list_os[ii][jj][kk].pmll())
+                    numpy.fabs(
+                        _anp(os.pmll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmll())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.pmbb()[ii, jj, kk] - list_os[ii][jj][kk].pmbb())
+                    numpy.fabs(
+                        _anp(os.pmbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].pmbb())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vra()[ii, jj, kk] - list_os[ii][jj][kk].vra()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vra()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vra())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vdec()[ii, jj, kk] - list_os[ii][jj][kk].vdec())
+                    numpy.fabs(
+                        _anp(os.vdec()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vdec())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vll()[ii, jj, kk] - list_os[ii][jj][kk].vll()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vll()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vll())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vbb()[ii, jj, kk] - list_os[ii][jj][kk].vbb()) < 1e-10
+                    numpy.fabs(
+                        _anp(os.vbb()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vbb())
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vlos()[ii, jj, kk] - list_os[ii][jj][kk].vlos())
+                    numpy.fabs(
+                        _anp(os.vlos()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].vlos())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioX()[ii, jj, kk] - list_os[ii][jj][kk].helioX())
+                    numpy.fabs(
+                        _anp(os.helioX()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioX())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioY()[ii, jj, kk] - list_os[ii][jj][kk].helioY())
+                    numpy.fabs(
+                        _anp(os.helioY()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioY())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.helioZ()[ii, jj, kk] - list_os[ii][jj][kk].helioZ())
+                    numpy.fabs(
+                        _anp(os.helioZ()[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioZ())
+                    )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.U()[ii, jj, kk] - list_os[ii][jj][kk].U()) < 1e-10
+                    numpy.fabs(_anp(os.U()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].U()))
+                    < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.V()[ii, jj, kk] - list_os[ii][jj][kk].V()) < 1e-10
+                    numpy.fabs(_anp(os.V()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].V()))
+                    < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.W()[ii, jj, kk] - list_os[ii][jj][kk].W()) < 1e-10
+                    numpy.fabs(_anp(os.W()[ii, jj, kk]) - _anp(list_os[ii][jj][kk].W()))
+                    < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
@@ -5603,38 +6207,59 @@ def test_output_reshape():
             for kk in range(nrand[2]):
                 # .time is special, just a single array
                 assert numpy.all(
-                    numpy.fabs(os.time(times) - list_os[ii][jj][kk].time(times)) < 1e-10
+                    numpy.fabs(
+                        _anp(os.time(times)) - _anp(list_os[ii][jj][kk].time(times))
+                    )
+                    < 1e-10
                 ), "Evaluating Orbits time does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.R(times)[ii, jj, kk] - list_os[ii][jj][kk].R(times))
+                    numpy.fabs(
+                        _anp(os.R(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].R(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits R does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.r(times)[ii, jj, kk] - list_os[ii][jj][kk].r(times))
+                    numpy.fabs(
+                        _anp(os.r(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].r(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits r does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vR(times)[ii, jj, kk] - list_os[ii][jj][kk].vR(times))
+                    numpy.fabs(
+                        _anp(os.vR(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vR(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vR does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vT(times)[ii, jj, kk] - list_os[ii][jj][kk].vT(times))
+                    numpy.fabs(
+                        _anp(os.vT(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vT(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vT does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.z(times)[ii, jj, kk] - list_os[ii][jj][kk].z(times))
+                    numpy.fabs(
+                        _anp(os.z(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].z(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits z does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vz(times)[ii, jj, kk] - list_os[ii][jj][kk].vz(times))
+                    numpy.fabs(
+                        _anp(os.vz(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vz(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vz does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
                         (
                             (
-                                os.phi(times)[ii, jj, kk]
-                                - list_os[ii][jj][kk].phi(times)
+                                _anp(os.phi(times)[ii, jj, kk])
+                                - _anp(list_os[ii][jj][kk].phi(times))
                                 + numpy.pi
                             )
                             % (2.0 * numpy.pi)
@@ -5644,133 +6269,178 @@ def test_output_reshape():
                     < 1e-10
                 ), "Evaluating Orbits phi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.x(times)[ii, jj, kk] - list_os[ii][jj][kk].x(times))
+                    numpy.fabs(
+                        _anp(os.x(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].x(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits x does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.y(times)[ii, jj, kk] - list_os[ii][jj][kk].y(times))
+                    numpy.fabs(
+                        _anp(os.y(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].y(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits y does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vx(times)[ii, jj, kk] - list_os[ii][jj][kk].vx(times))
+                    numpy.fabs(
+                        _anp(os.vx(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vx(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vx does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.vy(times)[ii, jj, kk] - list_os[ii][jj][kk].vy(times))
+                    numpy.fabs(
+                        _anp(os.vy(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vy(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits vy does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vphi(times)[ii, jj, kk] - list_os[ii][jj][kk].vphi(times)
+                        _anp(os.vphi(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vphi(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vphi does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ra(times)[ii, jj, kk] - list_os[ii][jj][kk].ra(times))
+                    numpy.fabs(
+                        _anp(os.ra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].ra(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits ra  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.dec(times)[ii, jj, kk] - list_os[ii][jj][kk].dec(times)
+                        _anp(os.dec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].dec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.dist(times)[ii, jj, kk] - list_os[ii][jj][kk].dist(times)
+                        _anp(os.dist(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].dist(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits dist does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.ll(times)[ii, jj, kk] - list_os[ii][jj][kk].ll(times))
+                    numpy.fabs(
+                        _anp(os.ll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].ll(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits ll does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.bb(times)[ii, jj, kk] - list_os[ii][jj][kk].bb(times))
+                    numpy.fabs(
+                        _anp(os.bb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].bb(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits bb  does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmra(times)[ii, jj, kk] - list_os[ii][jj][kk].pmra(times)
+                        _anp(os.pmra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmdec(times)[ii, jj, kk] - list_os[ii][jj][kk].pmdec(times)
+                        _anp(os.pmdec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmll(times)[ii, jj, kk] - list_os[ii][jj][kk].pmll(times)
+                        _anp(os.pmll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.pmbb(times)[ii, jj, kk] - list_os[ii][jj][kk].pmbb(times)
+                        _anp(os.pmbb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].pmbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits pmbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vra(times)[ii, jj, kk] - list_os[ii][jj][kk].vra(times)
+                        _anp(os.vra(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vra(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vra does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vdec(times)[ii, jj, kk] - list_os[ii][jj][kk].vdec(times)
+                        _anp(os.vdec(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vdec(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vdec does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vll(times)[ii, jj, kk] - list_os[ii][jj][kk].vll(times)
+                        _anp(os.vll(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vll(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vll does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vbb(times)[ii, jj, kk] - list_os[ii][jj][kk].vbb(times)
+                        _anp(os.vbb(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vbb(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits vbb does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.vlos(times)[ii, jj, kk] - list_os[ii][jj][kk].vlos(times)
+                        _anp(os.vlos(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].vlos(times))
                     )
                     < 1e-9
                 ), "Evaluating Orbits vlos does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioX(times)[ii, jj, kk] - list_os[ii][jj][kk].helioX(times)
+                        _anp(os.helioX(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioX(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioX does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioY(times)[ii, jj, kk] - list_os[ii][jj][kk].helioY(times)
+                        _anp(os.helioY(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioY(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioY does not agree with Orbit"
                 assert numpy.all(
                     numpy.fabs(
-                        os.helioZ(times)[ii, jj, kk] - list_os[ii][jj][kk].helioZ(times)
+                        _anp(os.helioZ(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].helioZ(times))
                     )
                     < 1e-10
                 ), "Evaluating Orbits helioZ does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.U(times)[ii, jj, kk] - list_os[ii][jj][kk].U(times))
+                    numpy.fabs(
+                        _anp(os.U(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].U(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits U does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.V(times)[ii, jj, kk] - list_os[ii][jj][kk].V(times))
+                    numpy.fabs(
+                        _anp(os.V(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].V(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits V does not agree with Orbit"
                 assert numpy.all(
-                    numpy.fabs(os.W(times)[ii, jj, kk] - list_os[ii][jj][kk].W(times))
+                    numpy.fabs(
+                        _anp(os.W(times)[ii, jj, kk])
+                        - _anp(list_os[ii][jj][kk].W(times))
+                    )
                     < 1e-10
                 ), "Evaluating Orbits W does not agree with Orbit"
                 assert numpy.all(
@@ -5998,38 +6668,43 @@ def _check_energy_jacobi_angmom(os, list_os):
     for ii in range(nrand):
         assert numpy.all(
             numpy.fabs(
-                os.E(pot=MWPotential2014)[ii] / list_os[ii].E(pot=MWPotential2014) - 1.0
+                _anp(os.E(pot=MWPotential2014)[ii])
+                / _anp(list_os[ii].E(pot=MWPotential2014))
+                - 1.0
             )
             < 10.0**-10.0
         ), "Evaluating Orbits E does not agree with Orbit"
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    os.ER(pot=MWPotential2014)[ii] / list_os[ii].ER(pot=MWPotential2014)
+                    _anp(os.ER(pot=MWPotential2014)[ii])
+                    / _anp(list_os[ii].ER(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    os.Ez(pot=MWPotential2014)[ii] / list_os[ii].Ez(pot=MWPotential2014)
+                    _anp(os.Ez(pot=MWPotential2014)[ii])
+                    / _anp(list_os[ii].Ez(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.L()[ii] / list_os[ii].L() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Lz()[ii] / list_os[ii].Lz() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=MWPotential2014)[ii]
-                    / list_os[ii].Jacobi(pot=MWPotential2014)
+                    _anp(os.Jacobi(pot=MWPotential2014)[ii])
+                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6037,8 +6712,8 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=MWPotential2014, OmegaP=0.6)[ii]
-                    / list_os[ii].Jacobi(pot=MWPotential2014, OmegaP=0.6)
+                    _anp(os.Jacobi(pot=MWPotential2014, OmegaP=0.6)[ii])
+                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6046,35 +6721,39 @@ def _check_energy_jacobi_angmom(os, list_os):
     # Potential for which array evaluation definitely does not work
     for ii in range(nrand):
         assert numpy.all(
-            numpy.fabs(os.E(pot=lp)[ii] / list_os[ii].E(pot=lp) - 1.0) < 10.0**-10.0
+            numpy.fabs(_anp(os.E(pot=lp)[ii]) / _anp(list_os[ii].E(pot=lp)) - 1.0)
+            < 10.0**-10.0
         ), "Evaluating Orbits E does not agree with Orbit"
         if os.dim() == 3:
             assert numpy.all(
-                numpy.fabs(os.ER(pot=lp)[ii] / list_os[ii].ER(pot=lp) - 1.0)
+                numpy.fabs(_anp(os.ER(pot=lp)[ii]) / _anp(list_os[ii].ER(pot=lp)) - 1.0)
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
-                numpy.fabs(os.Ez(pot=lp)[ii] / list_os[ii].Ez(pot=lp) - 1.0)
+                numpy.fabs(_anp(os.Ez(pot=lp)[ii]) / _anp(list_os[ii].Ez(pot=lp)) - 1.0)
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.L()[ii] / list_os[ii].L() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Lz()[ii] / list_os[ii].Lz() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Jacobi(pot=lp)[ii] / list_os[ii].Jacobi(pot=lp) - 1.0)
+                numpy.fabs(
+                    _anp(os.Jacobi(pot=lp)[ii]) / _anp(list_os[ii].Jacobi(pot=lp)) - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=lp, OmegaP=0.6)[ii]
-                    / list_os[ii].Jacobi(pot=lp, OmegaP=0.6)
+                    _anp(os.Jacobi(pot=lp, OmegaP=0.6)[ii])
+                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6083,16 +6762,16 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also in 3D
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=lp, OmegaP=[0.0, 0.0, 0.6])[ii]
-                    / list_os[ii].Jacobi(pot=lp, OmegaP=0.6)
+                    _anp(os.Jacobi(pot=lp, OmegaP=[0.0, 0.0, 0.6])[ii])
+                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=lp, OmegaP=numpy.array([0.0, 0.0, 0.6]))[ii]
-                    / list_os[ii].Jacobi(pot=lp, OmegaP=0.6)
+                    _anp(os.Jacobi(pot=lp, OmegaP=numpy.array([0.0, 0.0, 0.6]))[ii])
+                    / _anp(list_os[ii].Jacobi(pot=lp, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6110,43 +6789,50 @@ def _check_energy_jacobi_angmom(os, list_os):
         # Don't have to specify the potential or set to None
         assert numpy.all(
             numpy.fabs(
-                os.E(times)[ii] / list_os[ii].E(times, pot=MWPotential2014) - 1.0
+                _anp(os.E(times)[ii]) / _anp(list_os[ii].E(times, pot=MWPotential2014))
+                - 1.0
             )
             < 10.0**-10.0
         ), "Evaluating Orbits E does not agree with Orbit"
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    os.ER(times, pot=None)[ii]
-                    / list_os[ii].ER(times, pot=MWPotential2014)
+                    _anp(os.ER(times, pot=None)[ii])
+                    / _anp(list_os[ii].ER(times, pot=MWPotential2014))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    os.Ez(times)[ii] / list_os[ii].Ez(times, pot=MWPotential2014) - 1.0
+                    _anp(os.Ez(times)[ii])
+                    / _anp(list_os[ii].Ez(times, pot=MWPotential2014))
+                    - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.L(times)[ii] / list_os[ii].L(times) - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.L(times)[ii]) / _anp(list_os[ii].L(times)) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Lz(times)[ii] / list_os[ii].Lz(times) - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.Lz(times)[ii]) / _anp(list_os[ii].Lz(times)) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Jacobi(times)[ii] / list_os[ii].Jacobi(times) - 1.0)
+                numpy.fabs(
+                    _anp(os.Jacobi(times)[ii]) / _anp(list_os[ii].Jacobi(times)) - 1.0
+                )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(times, pot=MWPotential2014, OmegaP=0.6)[ii]
-                    / list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    _anp(os.Jacobi(times, pot=MWPotential2014, OmegaP=0.6)[ii])
+                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6155,18 +6841,26 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also in 3D
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(times, pot=MWPotential2014, OmegaP=[0.0, 0.0, 0.6])[ii]
-                    / list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    _anp(
+                        os.Jacobi(times, pot=MWPotential2014, OmegaP=[0.0, 0.0, 0.6])[
+                            ii
+                        ]
+                    )
+                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Jacobi does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(
-                        times, pot=MWPotential2014, OmegaP=numpy.array([0.0, 0.0, 0.6])
-                    )[ii]
-                    / list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6)
+                    _anp(
+                        os.Jacobi(
+                            times,
+                            pot=MWPotential2014,
+                            OmegaP=numpy.array([0.0, 0.0, 0.6]),
+                        )[ii]
+                    )
+                    / _anp(list_os[ii].Jacobi(times, pot=MWPotential2014, OmegaP=0.6))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6178,8 +6872,8 @@ def _check_energy_jacobi_angmom(os, list_os):
     for ii in range(nrand):
         assert numpy.all(
             numpy.fabs(
-                os.E(pot=MWPotential2014 + dp + sp)[ii]
-                / list_os[ii].E(pot=MWPotential2014 + dp + sp)
+                _anp(os.E(pot=MWPotential2014 + dp + sp)[ii])
+                / _anp(list_os[ii].E(pot=MWPotential2014 + dp + sp))
                 - 1.0
             )
             < 10.0**-10.0
@@ -6187,33 +6881,34 @@ def _check_energy_jacobi_angmom(os, list_os):
         if os.dim() == 3:
             assert numpy.all(
                 numpy.fabs(
-                    os.ER(pot=MWPotential2014 + dp + sp)[ii]
-                    / list_os[ii].ER(pot=MWPotential2014 + dp + sp)
+                    _anp(os.ER(pot=MWPotential2014 + dp + sp)[ii])
+                    / _anp(list_os[ii].ER(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits ER does not agree with Orbit"
             assert numpy.all(
                 numpy.fabs(
-                    os.Ez(pot=MWPotential2014 + dp + sp)[ii]
-                    / list_os[ii].Ez(pot=MWPotential2014 + dp + sp)
+                    _anp(os.Ez(pot=MWPotential2014 + dp + sp)[ii])
+                    / _anp(list_os[ii].Ez(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
             ), "Evaluating Orbits Ez does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.L()[ii] / list_os[ii].L() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.L()[ii]) / _anp(list_os[ii].L()) - 1.0) < 10.0**-10.0
             ), "Evaluating Orbits L does not agree with Orbit"
         if os.dim() != 1:
             assert numpy.all(
-                numpy.fabs(os.Lz()[ii] / list_os[ii].Lz() - 1.0) < 10.0**-10.0
+                numpy.fabs(_anp(os.Lz()[ii]) / _anp(list_os[ii].Lz()) - 1.0)
+                < 10.0**-10.0
             ), "Evaluating Orbits Lz does not agree with Orbit"
         if os.phasedim() % 2 == 0 and os.dim() != 1:
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=MWPotential2014 + dp + sp)[ii]
-                    / list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp)
+                    _anp(os.Jacobi(pot=MWPotential2014 + dp + sp)[ii])
+                    / _anp(list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp))
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6221,8 +6916,10 @@ def _check_energy_jacobi_angmom(os, list_os):
             # Also explicitly set OmegaP
             assert numpy.all(
                 numpy.fabs(
-                    os.Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)[ii]
-                    / list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)
+                    _anp(os.Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)[ii])
+                    / _anp(
+                        list_os[ii].Jacobi(pot=MWPotential2014 + dp + sp, OmegaP=0.6)
+                    )
                     - 1.0
                 )
                 < 10.0**-10.0
@@ -6821,31 +7518,31 @@ def test_flip():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(o.x() - of.x()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vx() + of.vx()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         else:
-            assert numpy.all(numpy.abs(o.R() - of.R()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vR() + of.vR()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vT() + of.vT()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(o.phi() - of.phi()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii < 2:
-            assert numpy.all(numpy.abs(o.z() - of.z()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vz() + of.vz()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
     return None
@@ -6903,31 +7600,31 @@ def test_flip_inplace():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(o.x() - of.x()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vx() + of.vx()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         else:
-            assert numpy.all(numpy.abs(o.R() - of.R()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vR() + of.vR()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vT() + of.vT()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(o.phi() - of.phi()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii < 2:
-            assert numpy.all(numpy.abs(o.z() - of.z()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vz() + of.vz()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
     return None
@@ -6998,31 +7695,31 @@ def test_flip_inplace_integrated():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(o.x() - of.x()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vx() + of.vx()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         else:
-            assert numpy.all(numpy.abs(o.R() - of.R()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vR() + of.vR()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vT() + of.vT()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(o.phi() - of.phi()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii < 2:
-            assert numpy.all(numpy.abs(o.z() - of.z()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vz() + of.vz()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
     return None
@@ -7063,7 +7760,7 @@ def test_flip_inplace_integrated_evaluated():
             o.integrate(ts, llp)
             of.integrate(ts, llp)
         # Evaluate, make sure it is at an interpolated time!
-        dumb = of.R(0.52)
+        dumb = _anp(of.R(0.52))
         # Now flip
         of.flip(inplace=True)
         # Just check one time, allows code duplication!
@@ -7099,31 +7796,31 @@ def test_flip_inplace_integrated_evaluated():
             "o.flip() did not conserve physical scales and coordinate-transformation parameters"
         )
         if ii == 4:
-            assert numpy.all(numpy.abs(o.x() - of.x()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.x()) - _anp(of.x())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vx() + of.vx()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vx()) + _anp(of.vx())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         else:
-            assert numpy.all(numpy.abs(o.R() - of.R()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.R()) - _anp(of.R())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vR() + of.vR()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vR()) + _anp(of.vR())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vT() + of.vT()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vT()) + _anp(of.vT())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii % 2 == 1:
-            assert numpy.all(numpy.abs(o.phi() - of.phi()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.phi()) - _anp(of.phi())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
         if ii < 2:
-            assert numpy.all(numpy.abs(o.z() - of.z()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.z()) - _anp(of.z())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
-            assert numpy.all(numpy.abs(o.vz() + of.vz()) < 10.0**-10.0), (
+            assert numpy.all(numpy.abs(_anp(o.vz()) + _anp(of.vz())) < 10.0**-10.0), (
                 "o.flip() did not work as expected"
             )
     return None
@@ -7231,15 +7928,15 @@ def test_EccZmaxRperiRap_num_againstorbit_2d():
     os.integrate(times, MWPotential2014)
     [o.integrate(times, MWPotential2014) for o in list_os]
     for ii in range(nrand):
-        assert numpy.all(numpy.fabs(os.e()[ii] - list_os[ii].e()) < 1e-10), (
-            "Evaluating Orbits e does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.rperi()[ii] - list_os[ii].rperi()) < 1e-10), (
-            "Evaluating Orbits rperi does not agree with Orbit"
-        )
-        assert numpy.all(numpy.fabs(os.rap()[ii] - list_os[ii].rap()) < 1e-10), (
-            "Evaluating Orbits rap does not agree with Orbit"
-        )
+        assert numpy.all(
+            numpy.fabs(_anp(os.e()[ii]) - _anp(list_os[ii].e())) < 1e-10
+        ), "Evaluating Orbits e does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.rperi()[ii]) - _anp(list_os[ii].rperi())) < 1e-10
+        ), "Evaluating Orbits rperi does not agree with Orbit"
+        assert numpy.all(
+            numpy.fabs(_anp(os.rap()[ii]) - _anp(list_os[ii].rap())) < 1e-10
+        ), "Evaluating Orbits rap does not agree with Orbit"
     return None
 
 
@@ -8432,19 +9129,19 @@ def test_toLinear():
     obs = Orbit([[1.0, 0.1, 1.1, 0.3, 0.0, 2.0], [1.0, -0.2, 1.3, -0.3, 0.0, 5.0]])
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinear does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(obsl.x() == obs.z()), (
+    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(obsl.vx() == obs.vz()), (
+    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     obs = Orbit([[1.0, 0.1, 1.1, 0.3, 0.0], [1.0, -0.2, 1.3, -0.3, 0.0]])
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinear does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(obsl.x() == obs.z()), (
+    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(obsl.vx() == obs.vz()), (
+    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     obs = Orbit([[1.0, 0.1, 1.1, 0.3], [1.0, -0.2, 1.3, -0.3]])
@@ -8463,10 +9160,10 @@ def test_toLinear():
     )
     obsl = obs.toLinear()
     assert obsl.dim() == 1, "toLinwar does not generate an Orbit w/ dim=1 for FullOrbit"
-    assert numpy.all(obsl.x() == obs.z()), (
+    assert numpy.all(_anp(obsl.x()) == _anp(obs.z())), (
         "Linear orbit generated w/ toLinear does not have the correct z"
     )
-    assert numpy.all(obsl.vx() == obs.vz()), (
+    assert numpy.all(_anp(obsl.vx()) == _anp(obs.vz())), (
         "Linear orbit generated w/ toLinear does not have the correct vx"
     )
     assert numpy.fabs(obs._ro - obsl._ro) < 10.0**-15.0, (


### PR DESCRIPTION
## What

Under the forced-torch all-backend fixture (`backend.use("torch", force=True)`), `Orbit` accessors (`o.E()`, `o.x()`, `o.r()`, `o.e()`, `o.L()`, `os.x()[ii]`, …) **correctly** return torch tensors — the namespace-coerce in `_resolve_accessor_namespace` is load-bearing so the *derived* accessors (`x`/`y`/`vx` via `cos`/`sin`) evaluate on torch (`torch.cos(numpy)` would fail). 34 existing comparison / energy / scalar tests then called numpy reductions (`numpy.all/amax/sum/std/fabs`, `isinstance(..., float)`) on those tensors and raised `TypeError`.

This is a **test-harness** gap, not an orbit-code bug (the accessors are right). The fix makes the affected tests backend-agnostic:
- add a small `_anp(x)` helper (`detach().cpu()` for torch, then `numpy.asarray`; **identity on numpy**) to each of `tests/test_orbit.py` and `tests/test_orbits.py`;
- wrap the accessor-call outputs at the reduction sites inside the 34 affected functions;
- `isinstance(o.r(), float)` → `numpy.ndim(_anp(o.r())) == 0` (numpy.float64 has ndim 0, so numpy behavior is unchanged).

## Scope & safety

- **numpy byte-identical**: `numpy.asarray(ndarray)` is the identity; verified **34/34 pass unchanged under numpy**.
- **green under torch**: verified **34/34 pass under `--backend=torch`** (CPU torch, matches CI).
- **strictly scoped**: `git diff` touches only the 34 listed functions + the `_anp` helper (+ the shared `_check_energy_jacobi_angmom` helper, called only by `test_energy_jacobi_angmom`). No other test changed.

`test_orbit.py` (8): `test_1d/2d/3d_tol_integration`, `test_ER_EZ`, `test_energy_symplec_longterm`, `test_integrate_SOS_2D`, `test_scalar_all`, `test_scalarxyvzvz_issue247`.
`test_orbits.py` (26): the slice / flip / coordinate-interpolation / integration / output comparison tests + `test_energy_jacobi_angmom` + `test_EccZmaxRperiRap_num_againstorbit_2d`.

The diff is large but uniform (1 accessor wrap per reduction operand) and mechanical — it's the honest cost of making these comparison-heavy tests backend-agnostic without restructuring them.

## Out of scope (stay ledgered)

Orbit tests still red under torch hit deeper galpy issues unrelated to the test body — Python-eager integrators (`leung_dop853`/`leapfrog` stepping numpy into torch potentials), the staeckel actionAngle setup (`numpy.sum(indx)` on a torch mask), and non-migrated potentials — and remain xfail for Track A / Track E. The 2 `*_issue322` cases are a genuine `_helioXYZ` observer-coercion bug (separate small follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)