### PR TITLE
orbit: backend-agnostic SOS / dissipative-minr / multi-orbit interp-range-warning reductions

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1946,7 +1946,8 @@ class Orbit:
                     dtype="bool",
                 )
             ][0]
-            if numpy.any(self.r(self.t, use_physical=False) < pot[cdf_indx]._minr):
+            _cdf_r = self.r(self.t, use_physical=False)
+            if get_namespace(_cdf_r).any(_cdf_r < pot[cdf_indx]._minr):
                 warnings.warn(
                     """Orbit integration with """
                     """ChandrasekharDynamicalFrictionForce """
@@ -1973,7 +1974,8 @@ class Orbit:
                     dtype="bool",
                 )
             ][0]
-            if numpy.any(self.r(self.t, use_physical=False) < pot[cdf_indx]._minr):
+            _cdf_r = self.r(self.t, use_physical=False)
+            if get_namespace(_cdf_r).any(_cdf_r < pot[cdf_indx]._minr):
                 warnings.warn(
                     """Orbit integration with """
                     """FDMDynamicalFrictionForce """
@@ -2136,11 +2138,11 @@ class Orbit:
             warnings.warn(
                 f"Orbit integration with {potname} visited radii "
                 f"outside of the interpolation range for "
-                f"{numpy.sum(outside)} out of {self.size} orbits; "
+                f"{int(xp.sum(outside))} out of {self.size} orbits; "
                 f"initialize {potname} with a wider radial range to "
                 f"avoid this if you wish (min/max r = "
-                f"{numpy.amin(self.rperi()):.3f},"
-                f"{numpy.amax(self.rap()):.3f}, which is the full "
+                f"{float(xp.min(self.rperi())):.3f},"
+                f"{float(xp.max(self.rap())):.3f}, which is the full "
                 f"range over all orbits)",
                 galpyWarning,
             )
@@ -6406,50 +6408,44 @@ class Orbit:
 
         """
         if self.dim() == 3:
-            init_psis = numpy.arctan2(
-                self.z(use_physical=False), self.vz(use_physical=False)
-            )
+            _sos_q, _sos_v = self.z(use_physical=False), self.vz(use_physical=False)
         elif self.phasedim() == 4:
             if not surface is None and surface.lower() == "y":
-                init_psis = numpy.arctan2(
-                    self.y(use_physical=False), self.vy(use_physical=False)
-                )
+                _sos_q, _sos_v = self.y(use_physical=False), self.vy(use_physical=False)
             else:
-                init_psis = numpy.arctan2(
-                    self.x(use_physical=False), self.vx(use_physical=False)
-                )
+                _sos_q, _sos_v = self.x(use_physical=False), self.vx(use_physical=False)
         else:
             raise NotImplementedError(
                 "SOS not implemented for 1D orbits or 2D orbits without phi"
             )
+        # build init_psis in the orbit's own namespace; coerce the IC accessor
+        # values onto it (under a forced backend the no-time accessors can return
+        # numpy). numpy.atan2 == arctan2 byte-for-byte; xp.asarray is a no-op on numpy.
+        xp = get_namespace(_sos_q, _sos_v)
+        _sos_q, _sos_v = xp.asarray(_sos_q), xp.asarray(_sos_v)
+        init_psis = xp.atan2(_sos_q, _sos_v)
         # Let's check that v(x/y/z) != 0 for orbits that are already on the SOS
         if (
             (
                 self.dim() == 3
-                and not numpy.all(
-                    (self.vz() != 0.0) + (numpy.fabs(init_psis % numpy.pi) > 1e-10)
-                )
+                and not xp.all((_sos_v != 0.0) + (xp.abs(init_psis % numpy.pi) > 1e-10))
             )
             or (
                 self.dim() == 2
                 and not surface is None
                 and surface.lower() == "y"
-                and not numpy.all(
-                    (self.vy() != 0.0) + (numpy.fabs(init_psis % numpy.pi) > 1e-10)
-                )
+                and not xp.all((_sos_v != 0.0) + (xp.abs(init_psis % numpy.pi) > 1e-10))
             )
             or (
                 self.dim() == 2
                 and (surface is None or surface.lower() == "x")
-                and not numpy.all(
-                    (self.vx() != 0.0) + (numpy.fabs(init_psis % numpy.pi) > 1e-10)
-                )
+                and not xp.all((_sos_v != 0.0) + (xp.abs(init_psis % numpy.pi) > 1e-10))
             )
         ):
             raise RuntimeError(
                 "An orbit appears to be within the SOS surface. Refusing to perform specialized SOS integration, please use normal integration instead"
             )
-        if numpy.any(numpy.fabs(init_psis) > 1e-10):
+        if xp.any(xp.abs(init_psis) > 1e-10):
             # Integrate to the next crossing
             init_psis = numpy.atleast_1d(
                 (init_psis + 2.0 * numpy.pi) % (2.0 * numpy.pi)


### PR DESCRIPTION
## What

Three more orbit read-path sites called `numpy.<reduction>` on a backend tensor under a forced jax/torch backend (the `FIX_ORBIT_INFRA` cluster from the orbit-failure triage). Same shape as #1001 — resolve the namespace from the data and reduce in it.

- **`Orbit.SOS()`** — `init_psis` is built in the orbit's own namespace (`xp.atan2`, with the IC accessor values coerced onto `xp`; the *no-time* accessors can return numpy even under a forced backend, which `numpy.arctan2` then propagated). The on-surface checks use `xp.all`/`xp.abs` on the captured velocity `_sos_v` (which **is** `self.vz/vy/vx()` for that dim → byte-identical) instead of `numpy.all`/`numpy.fabs` + a second accessor call.
- **Chandrasekhar / FDM dynamical-friction `minr` guards** — `get_namespace(...).any` instead of `numpy.any(self.r(...) < minr)`.
- **multi-orbit branch of `_warn_radii_outside_interpolation_range`** — formats `int(xp.sum(outside))` / `float(xp.min/max(...))` instead of `numpy.sum/amin/amax` (the single-orbit branch was already done in #1001).

## Safety

**numpy byte-identical**: `numpy.atan2 == arctan2`, `numpy.min/max == amin/amax`, `numpy.asarray` is the identity, and `int()/float()` format the same scalar. Verified **118 numpy** SOS/dxdv/dynamfric/interp-range tests unchanged.

**Flips 13 forced-torch tests green** (verified serially): 5 dissipative-dxdv (`chandrasekhar_dxdv_*`, `fdm_dxdv_*`), `plotSOS`/`SOS_2Dx`/`SOS_2Dy`/`SOS_onsurfaceerror_2D` (test_orbit.py + test_orbits.py), and the multi-orbit MultipoleExpansion interp-range warning.

## Out of scope (deferred follow-ups)

- **`bruteSOS`** — mutates the numpy `self.orbit` in place while `cross` comes from the torch accessor; needs a type reconciliation, not a reduction swap.
- **`test_SOS_3D`** — a *separate* `sqrt`-on-numpy in the SOS-3D integration path (my SOS fix lets it get further but it then fails there). Single-file diff: `Orbits.py` +23/−21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)