### PR TITLE
actionAngle: actionAngleIsochroneInverse backend — Kepler root-find via the shared backend root-finder (Track E)

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneInverse.py
+++ b/galpy/actionAngle/actionAngleIsochroneInverse.py
@@ -10,6 +10,7 @@
 import numpy
 from scipy import optimize
 
+from ..backend import get_namespace, promote_scalars
 from ..potential import IsochronePotential
 from ..util import conversion
 from .actionAngleInverse import actionAngleInverse
@@ -131,9 +132,13 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         -----
         - 2017-11-15 - Written - Bovy (UofT).
         """
-        L = jz + numpy.fabs(jphi)  # total angular momentum
+        xp = get_namespace(jr, jphi, jz, angler, anglephi, anglez)
+        jr, jphi, jz, angler, anglephi, anglez = promote_scalars(
+            xp, jr, jphi, jz, angler, anglephi, anglez
+        )
+        L = jz + xp.abs(jphi)  # total angular momentum
         L2 = L**2.0
-        sqrtfourbkL2 = numpy.sqrt(L2 + 4.0 * self.b * self.amp)
+        sqrtfourbkL2 = xp.sqrt(L2 + 4.0 * self.b * self.amp)
         H = -2.0 * self.amp**2.0 / (2.0 * jr + L + sqrtfourbkL2) ** 2.0
         # Calculate the frequencies
         omegar = (-2.0 * H) ** 1.5 / self.amp
@@ -141,55 +146,71 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         # Start on getting the coordinates
         a = -self.amp / 2.0 / H - self.b
         ab = a + self.b
-        e = numpy.sqrt(1.0 + L2 / (2.0 * H * a**2.0))
-        # Solve Kepler's-ish equation; ar must be between 0 and 2pi
-        angler = (numpy.atleast_1d(angler) % (-2.0 * numpy.pi)) % (2.0 * numpy.pi)
-        anglephi = numpy.atleast_1d(anglephi)
-        anglez = numpy.atleast_1d(anglez)
-        eta = numpy.empty(len(angler))
-        for ii, ar in enumerate(angler):
-            try:
-                eta[ii] = optimize.newton(
-                    lambda x: x - a * e / ab * numpy.sin(x) - ar,
-                    0.0,
-                    lambda x: 1 - a * e / ab * numpy.cos(x),
-                )
-            except RuntimeError:
-                # Newton-Raphson did not converge, this has to work,
-                # bc 0 <= ra < 2pi the following start x have different signs
-                eta[ii] = optimize.brentq(
-                    lambda x: x - a * e / ab * numpy.sin(x) - ar, 0.0, 2.0 * numpy.pi
-                )
-        coseta = numpy.cos(eta)
-        r = a * numpy.sqrt((1.0 - e * coseta) * (1.0 - e * coseta + 2.0 * self.b / a))
-        vr = numpy.sqrt(self.amp / ab) * a * e * numpy.sin(eta) / r
-        taneta2 = numpy.tan(eta / 2.0)
-        tan11 = numpy.arctan(numpy.sqrt((1.0 + e) / (1.0 - e)) * taneta2)
-        tan12 = numpy.arctan(
-            numpy.sqrt((a * (1.0 + e) + 2.0 * self.b) / (a * (1.0 - e) + 2.0 * self.b))
+        e = xp.sqrt(1.0 + L2 / (2.0 * H * a**2.0))
+        # Solve Kepler's-ish equation eta - (a e/ab) sin(eta) = ar, ar in [0, 2pi)
+        angler = (xp.atleast_1d(angler) % (-2.0 * numpy.pi)) % (2.0 * numpy.pi)
+        anglephi = xp.atleast_1d(anglephi)
+        anglez = xp.atleast_1d(anglez)
+        if xp is numpy:
+            eta = numpy.empty(len(angler))
+            for ii, ar in enumerate(angler):
+                try:
+                    eta[ii] = optimize.newton(
+                        lambda x: x - a * e / ab * numpy.sin(x) - ar,
+                        0.0,
+                        lambda x: 1 - a * e / ab * numpy.cos(x),
+                    )
+                except RuntimeError:
+                    # Newton-Raphson did not converge, this has to work,
+                    # bc 0 <= ra < 2pi the following start x have different signs
+                    eta[ii] = optimize.brentq(
+                        lambda x: x - a * e / ab * numpy.sin(x) - ar,
+                        0.0,
+                        2.0 * numpy.pi,
+                    )
+        else:
+            # Differentiable, vectorised bracketed-Newton on [0, 2pi] (f is strictly
+            # monotone there since a*e/ab < 1) -- the shared backend root-finder;
+            # gradients flow to (jr,jphi,jz) via the implicit-function theorem.
+            from ..backend.optimize import brentq as _backend_brentq
+
+            _c = a * e / ab
+            eta = _backend_brentq(
+                lambda x, c, ar: x - c * xp.sin(x) - ar,
+                xp.zeros_like(angler),
+                xp.full_like(angler, 2.0 * numpy.pi),
+                args=(_c, angler),
+            )
+        coseta = xp.cos(eta)
+        r = a * xp.sqrt((1.0 - e * coseta) * (1.0 - e * coseta + 2.0 * self.b / a))
+        vr = xp.sqrt(self.amp / ab) * a * e * xp.sin(eta) / r
+        taneta2 = xp.tan(eta / 2.0)
+        tan11 = xp.arctan(xp.sqrt((1.0 + e) / (1.0 - e)) * taneta2)
+        tan12 = xp.arctan(
+            xp.sqrt((a * (1.0 + e) + 2.0 * self.b) / (a * (1.0 - e) + 2.0 * self.b))
             * taneta2
         )
-        tan11[tan11 < 0.0] += numpy.pi
-        tan12[tan12 < 0.0] += numpy.pi
+        tan11 = xp.where(tan11 < 0.0, tan11 + numpy.pi, tan11)
+        tan12 = xp.where(tan12 < 0.0, tan12 + numpy.pi, tan12)
         Lambdaeta = tan11 + L / sqrtfourbkL2 * tan12
         psi = anglez - omegaz / omegar * angler + Lambdaeta
-        lowerl = numpy.sqrt(1.0 - jphi**2.0 / L2)
-        sintheta = numpy.sin(psi) * lowerl
-        costheta = numpy.sqrt(1.0 - sintheta**2.0)
-        vtheta = L * lowerl * numpy.cos(psi) / costheta / r
+        lowerl = xp.sqrt(1.0 - jphi**2.0 / L2)
+        sintheta = xp.sin(psi) * lowerl
+        costheta = xp.sqrt(1.0 - sintheta**2.0)
+        vtheta = L * lowerl * xp.cos(psi) / costheta / r
         R = r * costheta
         z = r * sintheta
         vR = vr * costheta - vtheta * sintheta
         vz = vr * sintheta + vtheta * costheta
         sinu = sintheta / costheta * jphi / L / lowerl
-        u = numpy.arcsin(sinu)
-        u[vtheta < 0.0] = numpy.pi - u[vtheta < 0.0]
-        phi = anglephi - numpy.sign(jphi) * anglez + u
+        u = xp.arcsin(sinu)
+        u = xp.where(vtheta < 0.0, numpy.pi - u, u)
+        phi = anglephi - xp.sign(jphi) * anglez + u
         # For non-inclined orbits, phi == psi
-        phi[True ^ numpy.isfinite(phi)] = psi[True ^ numpy.isfinite(phi)]
+        phi = xp.where(xp.isfinite(phi), phi, psi)
         phi = phi % (2.0 * numpy.pi)
-        phi[phi < 0.0] += 2.0 * numpy.pi
-        return (R, vR, jphi / R, z, vz, phi, omegar, numpy.sign(jphi) * omegaz, omegaz)
+        phi = xp.where(phi < 0.0, phi + 2.0 * numpy.pi, phi)
+        return (R, vR, jphi / R, z, vz, phi, omegar, xp.sign(jphi) * omegaz, omegaz)
 
     def _Freqs(self, jr, jphi, jz, **kwargs):
         """
@@ -213,10 +234,12 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         -----
         - 2017-11-15 - Written - Bovy (UofT).
         """
-        L = jz + numpy.fabs(jphi)  # total angular momentum
-        sqrtfourbkL2 = numpy.sqrt(L**2.0 + 4.0 * self.b * self.amp)
+        xp = get_namespace(jr, jphi, jz)
+        jr, jphi, jz = promote_scalars(xp, jr, jphi, jz)
+        L = jz + xp.abs(jphi)  # total angular momentum
+        sqrtfourbkL2 = xp.sqrt(L**2.0 + 4.0 * self.b * self.amp)
         H = -2.0 * self.amp**2.0 / (2.0 * jr + L + sqrtfourbkL2) ** 2.0
         # Calculate the frequencies
         omegar = (-2.0 * H) ** 1.5 / self.amp
         omegaz = (1.0 + L / sqrtfourbkL2) / 2.0 * omegar
-        return (omegar, numpy.sign(jphi) * omegaz, omegaz)
+        return (omegar, xp.sign(jphi) * omegaz, omegaz)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -261,10 +261,11 @@ def test_isochrone_dangle_dt_equals_freq(backend, vT, idx_ang, idx_om):
 
 
 # --------------------------------------------- inverse maps (J,angle) -> (x,v)
-# actionAngleHarmonicInverse is closed-form (amp=√(2J/ω); x=amp sinθ; vx=amp ω cosθ)
-# -> backend-migrated here. actionAngleIsochroneInverse solves Kepler's equation
-# (scipy Newton) -> NOT backend-traceable yet (needs a backend root-find; Track E
-# #2 with Vertical/Spherical), so only its numpy round-trip is exercised below.
+# actionAngleHarmonicInverse is closed-form (amp=√(2J/ω); x=amp sinθ; vx=amp ω cosθ).
+# actionAngleIsochroneInverse solves Kepler's equation eta-(a e/ab)sin(eta)=ar; the
+# numpy path keeps scipy.optimize.newton (byte-identical), the jax/torch path uses
+# the shared backend root-finder galpy.backend.optimize.brentq (vectorised bracketed
+# bisection + one-Newton-step implicit-diff) so gradients flow to the actions.
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("omega", [0.7, 1.3])
 def test_harmonic_inverse_roundtrip_parity(backend, omega):
@@ -311,24 +312,70 @@ def test_harmonic_inverse_grad_vs_fd(backend):
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
 
 
-def test_isochrone_inverse_roundtrip_numpy():
-    # numpy-only (scipy Newton Kepler solve not backend-traceable yet); establishes
-    # the forward∘inverse identity so the backend port (Track E #2) has a reference.
+# IsochroneInverse torus + angle batch (bound, inclined; angles inside (0,2π)).
+_II_J = (0.2, 0.8, 0.15)  # jr, jphi, jz
+_II_AR = numpy.array([0.7, 1.6, 3.1, 4.8])
+_II_AP = numpy.array([1.1, 2.3, 0.5, 5.1])
+_II_AZ = numpy.array([0.4, 1.9, 2.7, 3.6])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("b", [0.8, 1.2])
+def test_isochrone_inverse_parity(backend, b):
+    aAIi = actionAngleIsochroneInverse(b=b)
+    ref = aAIi._xvFreqs(*_II_J, _II_AR, _II_AP, _II_AZ)
+    bargs = (*[_arr(backend, numpy.asarray(j)) for j in _II_J],) + tuple(
+        _arr(backend, a) for a in (_II_AR, _II_AP, _II_AZ)
+    )
+    got = aAIi._xvFreqs(*bargs)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-11, atol=1e-11)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochrone_inverse_roundtrip(backend):
+    # forward ∘ inverse == identity, fully in-backend (the inverse Kepler solve runs
+    # via the shared backend root-finder), recovering actions and angles.
     b = 1.2
     aAIi = actionAngleIsochroneInverse(b=b)
     aAI = actionAngleIsochrone(b=b)
-    jr, jphi, jz = 0.2, 0.8, 0.15
-    ar, ap, az = 0.7, 1.1, 0.4
-    R, vR, vT, z, vz, phi = (
-        numpy.asarray(c).ravel()[0] for c in aAIi._evaluate(jr, jphi, jz, ar, ap, az)
+    jr, jphi, jz = _II_J
+    bj = [_arr(backend, numpy.asarray(j)) for j in _II_J]
+    bang = [_arr(backend, a) for a in (_II_AR, _II_AP, _II_AZ)]
+    R, vR, vT, z, vz, phi = aAIi._xvFreqs(*bj, *bang)[:6]
+    out = aAI._actionsFreqsAngles(R, vR, vT, z, vz, phi)
+    numpy.testing.assert_allclose(_np(out[0]), jr, rtol=1e-7, atol=1e-9)  # Jr
+    numpy.testing.assert_allclose(_np(out[1]), jphi, rtol=1e-7, atol=1e-9)  # Jphi
+    numpy.testing.assert_allclose(_np(out[2]), jz, rtol=1e-7, atol=1e-9)  # Jz
+    # angles recovered (circular difference, to be robust to the 2π wrap)
+    for idx, a_in in ((6, _II_AR), (7, _II_AP), (8, _II_AZ)):
+        d = (_np(out[idx]) - a_in + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+        numpy.testing.assert_allclose(d, 0.0, atol=1e-7)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochrone_inverse_grad_vs_fd(backend):
+    # d(sum R)/d jr through the Kepler root-find: AD (implicit-function theorem) vs FD.
+    aAIi = actionAngleIsochroneInverse(b=1.2)
+    _, jphi, jz = _II_J
+
+    def rsum(jr_val, xp_arr):
+        out = aAIi._xvFreqs(
+            jr_val,
+            xp_arr(jphi),
+            xp_arr(jz),
+            xp_arr(_II_AR),
+            xp_arr(_II_AP),
+            xp_arr(_II_AZ),
+        )
+        return out[0].sum()
+
+    fd = _fd(lambda j: numpy.asarray(rsum(j, lambda v: numpy.asarray(v))), _II_J[0])
+    g = _grad(
+        backend,
+        lambda jt: rsum(jt, lambda v: _arr(backend, numpy.asarray(v, float))),
+        _II_J[0],
     )
-    out = [
-        numpy.asarray(c).ravel()[0]
-        for c in aAI._actionsFreqsAngles(R, vR, vT, z, vz, phi)
-    ]
-    numpy.testing.assert_allclose(out[0], jr, rtol=1e-7, atol=1e-9)  # Jr
-    numpy.testing.assert_allclose(out[1], jphi, rtol=1e-7, atol=1e-9)  # Jphi
-    numpy.testing.assert_allclose(out[2], jz, rtol=1e-7, atol=1e-9)  # Jz
-    numpy.testing.assert_allclose(out[6], ar, rtol=1e-6, atol=1e-8)  # angler
-    numpy.testing.assert_allclose(out[7], ap, rtol=1e-6, atol=1e-8)  # anglephi
-    numpy.testing.assert_allclose(out[8], az, rtol=1e-6, atol=1e-8)  # anglez
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
Completes the **closed-form/inverse** Track E set: `actionAngleIsochroneInverse` (the (J,angle)→(x,v) map). HarmonicInverse landed in #1005; this is the harder inverse — it solves **Kepler's equation** `η − (a·e/ab)·sin η = angler` per element, so it's the **first action-angle consumer of the shared backend root-finder**.

## Approach
- `_xvFreqs`/`_Freqs`: `get_namespace` + `promote_scalars`; `numpy.*` → `xp.*`; masked writes (`tan11/tan12<0 += π`; `u[vθ<0]=π−u`; `phi` non-finite → `psi`; `phi<0 += 2π`) → `xp.where`; the double floor-modulo `(angler % −2π) % 2π` maps directly (torch/jax `%` are floor-mod, verified — **not** fmod).
- **Kepler solve branches on the namespace**:
  - **numpy** → the exact existing `scipy.optimize.newton` (+ brentq fallback) per-element loop → **byte-identical**.
  - **jax/torch** → `galpy.backend.optimize.brentq` on `[0,2π]` (the bracket is always valid: `a·e/ab < 1` ⇒ `f` strictly monotone, `f(0)≤0≤f(2π)`). That's the **shared** vectorised sign-preserving bisection + one-Newton-step **implicit-diff** helper — so the inverse is differentiable w.r.t. the actions, and every future AA root-find (Vertical, Spherical, Staeckel umin/umax) reuses the same code.

## Validation
- **numpy byte-identical** — base-vs-port over `b ∈ {0.3, 0.8, 1.5}`, prograde / retrograde / `jz=0` non-inclined, `_xvFreqs` + `_Freqs`.
- **jax/torch**: parity vs numpy ~3e-16; backend `brentq` vs `scipy.newton` ~9e-16 (near-radial `c=0.99769` ~5e-13); forward∘inverse round-trip recovers `Jr/Jphi/Jz` ~1e-16 + angles (circular) to 1e-7; `d(ΣR)/djr` AD == FD to ~5e-10 (jax + torch). `tests/test_backend_actionAngle.py` gains parity + round-trip + grad-vs-FD (replacing the numpy-only placeholder); 52 backend tests green.

## Scope
Vertical + Spherical (the remaining non-closed-form forward methods) are the next Track-E increment, reusing this same `brentq` helper + the GL-quadrature helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)