### PR TITLE
actionAngle: actionAngleSpherical backend — frequencies + angles (Track E, PR-2 of 2)

### DIFF
--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -548,12 +548,8 @@ class actionAngleSpherical(actionAngle):
 
         xp = get_namespace(r)
 
-        def f(R_, E_, L_):
-            return (
-                E_
-                - _evaluateplanarPotentials(self._2dpot, R_)
-                - L_**2.0 / 2.0 / R_**2.0
-            )
+        def f(R_, E_, L_):  # == _rapRperiAxiEq == _radicand/2 (vr=0 root eqn)
+            return _radicand(xp, R_, E_, L_, self._2dpot) / 2.0
 
         # Fixed-schedule bracketing (mirrors _rapRperiAxiFindStart, vectorised):
         # halve from r/2 until f<=0 (or below the floor) for rperi's lower end,
@@ -604,8 +600,7 @@ class actionAngleSpherical(actionAngle):
             sin = xp.sin(theta)[None, :]
             cos = xp.cos(theta)[None, :]
             rr = rperi[:, None] + span[:, None] * sin**2.0
-            Phi = _evaluateplanarPotentials(self._2dpot, rr)
-            rad = 2.0 * (E[:, None] - Phi) - L[:, None] ** 2.0 / rr**2.0
+            rad = _radicand(xp, rr, E[:, None], L[:, None], self._2dpot)
             rad = xp.where(rad > 0.0, rad, 0.0)  # clip before sqrt (AD guard)
             return xp.sqrt(rad) * span[:, None] * 2.0 * sin * cos
 
@@ -640,8 +635,7 @@ class actionAngleSpherical(actionAngle):
         def integrand(s):  # s: (n,) GL nodes -> (N, n)
             t = lim[:, None] * s[None, :]
             rr = base[:, None] + sign * t**2.0
-            Phi = _evaluateplanarPotentials(self._2dpot, rr)
-            rad = 2.0 * (E[:, None] - Phi) - L[:, None] ** 2.0 / rr**2.0
+            rad = _radicand(xp, rr, E[:, None], L[:, None], self._2dpot)
             # clip before sqrt (AD guard); the masked-out (rad<=0) endpoint sits
             # where 2t->0 anyway, so a 0 there is harmless.
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
@@ -679,6 +673,19 @@ class actionAngleSpherical(actionAngle):
         Op = I * Or / 2.0 / numpy.pi
         return (Or, Op)
 
+    @staticmethod
+    def _assemble_angler(xp, r, Rmean, vr, wr_small_raw, wr_large_raw):
+        """Quadrant assembly for the radial angle, namespace-agnostic.
+
+        Given the raw small/large panel values (each Or*integral, or 0), apply
+        the vr/r<Rmean quadrant logic. Shared by the numpy scalar driver
+        (xp=numpy; numpy.where on scalars is byte-identical to the if/else) and
+        the backend array driver.
+        """
+        wr_small = xp.where(vr < 0.0, 2.0 * numpy.pi - wr_small_raw, wr_small_raw)
+        wr_large = xp.where(vr < 0.0, numpy.pi + wr_large_raw, numpy.pi - wr_large_raw)
+        return xp.where(r < Rmean, wr_small, wr_large)
+
     def _calc_angler_backend(self, Or, r, Rmean, rperi, rap, E, L, vr):
         """Vectorised radial angle ar (un-modded; caller takes % 2pi).
 
@@ -689,11 +696,9 @@ class actionAngleSpherical(actionAngle):
         xp = get_namespace(r)
         limS = xp.sqrt(xp.where(r > rperi, r - rperi, xp.zeros_like(r)))
         limL = xp.sqrt(xp.where(rap > r, rap - r, xp.zeros_like(r)))
-        wr_small = Or * self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
-        wr_small = xp.where(vr < 0.0, 2.0 * numpy.pi - wr_small, wr_small)
-        wr_large = Or * self._panel_backend(xp, rap, -1.0, limL, E, L, False)
-        wr_large = xp.where(vr < 0.0, numpy.pi + wr_large, numpy.pi - wr_large)
-        return xp.where(r < Rmean, wr_small, wr_large)
+        wr_small_raw = Or * self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
+        wr_large_raw = Or * self._panel_backend(xp, rap, -1.0, limL, E, L, False)
+        return self._assemble_angler(xp, r, Rmean, vr, wr_small_raw, wr_large_raw)
 
     def _calc_anglez_backend(
         self, Or, Op, ar, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
@@ -994,6 +999,11 @@ class actionAngleSpherical(actionAngle):
         return phi - u
 
     def _calc_angler(self, Or, r, Rmean, rperi, rap, E, L, vr, fixed_quad, **kwargs):
+        # Integrate only the active panel (small if r<Rmean else large) with
+        # scipy; the lim==0 guards stay here. The quadrant assembly is shared
+        # with the backend via _assemble_angler (xp.where; on numpy scalars this
+        # is byte-identical to the original if/else). The inactive panel slot is
+        # discarded by the r<Rmean select inside _assemble_angler.
         if r < Rmean:
             if r > rperi and not fixed_quad:
                 wr = (
@@ -1020,8 +1030,7 @@ class actionAngleSpherical(actionAngle):
                 )
             else:
                 wr = 0.0
-            if vr < 0.0:
-                wr = 2 * numpy.pi - wr
+            wr_small_raw, wr_large_raw = wr, 0.0
         else:
             if r < rap and not fixed_quad:
                 wr = (
@@ -1048,11 +1057,8 @@ class actionAngleSpherical(actionAngle):
                 )
             else:
                 wr = 0.0
-            if vr < 0.0:
-                wr = numpy.pi + wr
-            else:
-                wr = numpy.pi - wr
-        return wr
+            wr_small_raw, wr_large_raw = 0.0, wr
+        return self._assemble_angler(numpy, r, Rmean, vr, wr_small_raw, wr_large_raw)
 
     def _calc_anglez(
         self,
@@ -1149,34 +1155,53 @@ class actionAngleSpherical(actionAngle):
         return wz
 
 
+def _radicand(xp, r, E, L, pot):
+    """Radial-velocity^2 radicand 2*(E - Phi(r)) - L^2/r^2, namespace-agnostic.
+
+    Shared by the numpy integrands (xp=numpy, scalar r) and the backend panels
+    (xp=jax/torch, array r); byte-identical on numpy. Equals 2*_rapRperiAxiEq.
+    """
+    return 2.0 * (E - _evaluateplanarPotentials(pot, r)) - L**2.0 / r**2.0
+
+
+def _period_angle_integrand(xp, t, base, sign, E, L, pot, azimuthal):
+    """t^2-substituted period/angle integrand core, namespace-agnostic.
+
+    Builds r = base + sign*t**2 and returns 2t/sqrt(radicand) [/r**2 if
+    azimuthal]. Shared by the 4 numpy t^2 module integrands (xp=numpy). The
+    backend panel keeps its own AD-clipped sqrt, so it shares only _radicand.
+    """
+    r = base + sign * t**2.0
+    val = 2.0 * t / xp.sqrt(_radicand(xp, r, E, L, pot))
+    if azimuthal:
+        val = val / r**2.0
+    return val
+
+
 def _JrSphericalIntegrand(r, E, L, pot):
     """The J_r integrand"""
-    return numpy.sqrt(2.0 * (E - _evaluateplanarPotentials(pot, r)) - L**2.0 / r**2.0)
+    return numpy.sqrt(_radicand(numpy, r, E, L, pot))
 
 
 def _TrSphericalIntegrandSmall(t, E, L, pot, rperi):
-    r = rperi + t**2.0  # part of the transformation
-    return 2.0 * t / _JrSphericalIntegrand(r, E, L, pot)
+    return _period_angle_integrand(numpy, t, rperi, 1.0, E, L, pot, False)
 
 
 def _TrSphericalIntegrandLarge(t, E, L, pot, rap):
-    r = rap - t**2.0  # part of the transformation
-    return 2.0 * t / _JrSphericalIntegrand(r, E, L, pot)
+    return _period_angle_integrand(numpy, t, rap, -1.0, E, L, pot, False)
 
 
 def _ISphericalIntegrandSmall(t, E, L, pot, rperi):
-    r = rperi + t**2.0  # part of the transformation
-    return 2.0 * t / _JrSphericalIntegrand(r, E, L, pot) / r**2.0
+    return _period_angle_integrand(numpy, t, rperi, 1.0, E, L, pot, True)
 
 
 def _ISphericalIntegrandLarge(t, E, L, pot, rap):
-    r = rap - t**2.0  # part of the transformation
-    return 2.0 * t / _JrSphericalIntegrand(r, E, L, pot) / r**2.0
+    return _period_angle_integrand(numpy, t, rap, -1.0, E, L, pot, True)
 
 
 def _rapRperiAxiEq(R, E, L, pot):
     """The vr=0 equation that needs to be solved to find apo- and pericenter"""
-    return E - _evaluateplanarPotentials(pot, R) - L**2.0 / 2.0 / R**2.0
+    return _radicand(numpy, R, E, L, pot) / 2.0
 
 
 def _rapRperiAxiFindStart(R, E, L, pot, rap=False, startsign=1.0):

--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -202,6 +202,9 @@ class actionAngleSpherical(actionAngle):
             vz = numpy.array([vz])
         if self._c:  # pragma: no cover
             pass
+        elif is_backend_array(R):
+            # jax/torch inputs: vectorised, differentiable path (see _evaluate).
+            return self._actionsFreqs_backend(R, vR, vT, z, vz, extra_Jz)
         else:
             r = numpy.sqrt(R**2.0 + z**2.0)
             vr = (R * vR + z * vz) / r
@@ -302,6 +305,9 @@ class actionAngleSpherical(actionAngle):
             phi = numpy.array([phi])
         if self._c:  # pragma: no cover
             pass
+        elif is_backend_array(R):
+            # jax/torch inputs: vectorised, differentiable path (see _evaluate).
+            return self._actionsFreqsAngles_backend(R, vR, vT, z, vz, phi, extra_Jz)
         else:
             r = numpy.sqrt(R**2.0 + z**2.0)
             vr = (R * vR + z * vz) / r
@@ -605,6 +611,201 @@ class actionAngleSpherical(actionAngle):
 
         Jr = fixed_quad(xp, integrand, 0.0, numpy.pi / 2.0, n=25)
         return Jr / numpy.pi
+
+    # -------------------------------------------------- backend freqs + angles
+    # Vectorised, differentiable (jax/torch) Or/Op (radial+azimuthal frequency)
+    # and ar/ap/az (angles), mirroring the per-object numpy _calc_or/_calc_op/
+    # _calc_angler/_calc_anglez/_calc_long_asc. The two t^2-substituted panels
+    # of each period/angle integral are evaluated with backend.quadrature.
+    # fixed_quad on a fixed [0, 1] panel: the per-object upper limit `lim`
+    # (sqrt(Rmean-rperi) etc.) is folded INTO the integrand via t = lim*s
+    # (dt = lim ds), so fixed_quad's scalar a, b stay 0, 1 while `lim` is a
+    # shape-(N,) array. The 2t Jacobian of the substitution cancels the
+    # 1/sqrt endpoint zero; the radicand is clipped >=0 before the sqrt
+    # (sqrt'(0)=inf would NaN-poison reverse-mode AD), with the unused panel
+    # (lim==0) contributing exactly 0. The numpy path is untouched.
+
+    def _panel_backend(self, xp, base, sign, lim, E, L, azimuthal):
+        """One t^2-substituted Gauss-Legendre panel of a period/angle integral.
+
+        Integrates ``2 t / _JrSphericalIntegrand(r) [/ r**2 if azimuthal]`` over
+        ``t in [0, lim]`` with ``r = base + sign * t**2`` (sign=+1 small panel
+        with base=rperi, sign=-1 large panel with base=rap). The fixed [0, 1]
+        GL panel uses ``t = lim * s`` so the per-object ``lim`` (shape (N,))
+        multiplies inside the integrand (dt = lim ds) and fixed_quad's limits
+        stay scalar. ``lim`` is float (==0 makes this panel contribute 0).
+        """
+        from ..backend.quadrature import fixed_quad
+
+        def integrand(s):  # s: (n,) GL nodes -> (N, n)
+            t = lim[:, None] * s[None, :]
+            rr = base[:, None] + sign * t**2.0
+            Phi = _evaluateplanarPotentials(self._2dpot, rr)
+            rad = 2.0 * (E[:, None] - Phi) - L[:, None] ** 2.0 / rr**2.0
+            # clip before sqrt (AD guard); the masked-out (rad<=0) endpoint sits
+            # where 2t->0 anyway, so a 0 there is harmless.
+            rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
+            val = 2.0 * t / xp.sqrt(rad)
+            if azimuthal:
+                val = val / rr**2.0
+            return val * lim[:, None]  # dt = lim ds
+
+        return fixed_quad(xp, integrand, 0.0, 1.0, n=25)
+
+    def _calc_or_op_backend(self, Rmean, rperi, rap, E, L):
+        """Vectorised Or (radial freq) and Op (azimuthal freq magnitude).
+
+        Tr = 2*(small panel [0, sqrt(Rmean-rperi)] + large panel
+        [0, sqrt(rap-Rmean)]) of 2t/_Jr; Or = 2pi/Tr. The same panels weighted
+        by 1/r**2 give I; Op = 2*L*I * Or / (2 pi). Returns (Or, Op) with Op the
+        positive magnitude (the vT<0 sign flip is applied by the caller).
+        """
+        xp = get_namespace(rperi)
+        limS = xp.sqrt(xp.where(Rmean > rperi, Rmean - rperi, xp.zeros_like(Rmean)))
+        limL = xp.sqrt(xp.where(rap > Rmean, rap - Rmean, xp.zeros_like(Rmean)))
+        Tr = 2.0 * (
+            self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
+            + self._panel_backend(xp, rap, -1.0, limL, E, L, False)
+        )
+        Or = 2.0 * numpy.pi / Tr
+        I = (
+            2.0
+            * L
+            * (
+                self._panel_backend(xp, rperi, 1.0, limS, E, L, True)
+                + self._panel_backend(xp, rap, -1.0, limL, E, L, True)
+            )
+        )
+        Op = I * Or / 2.0 / numpy.pi
+        return (Or, Op)
+
+    def _calc_angler_backend(self, Or, r, Rmean, rperi, rap, E, L, vr):
+        """Vectorised radial angle ar (un-modded; caller takes % 2pi).
+
+        Mirrors _calc_angler: if r<Rmean integrate the small panel to
+        sqrt(r-rperi) and (vr<0) wr=2pi-wr; else integrate the large panel to
+        sqrt(rap-r) and wr = pi+wr (vr<0) / pi-wr (vr>=0).
+        """
+        xp = get_namespace(r)
+        limS = xp.sqrt(xp.where(r > rperi, r - rperi, xp.zeros_like(r)))
+        limL = xp.sqrt(xp.where(rap > r, rap - r, xp.zeros_like(r)))
+        wr_small = Or * self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
+        wr_small = xp.where(vr < 0.0, 2.0 * numpy.pi - wr_small, wr_small)
+        wr_large = Or * self._panel_backend(xp, rap, -1.0, limL, E, L, False)
+        wr_large = xp.where(vr < 0.0, numpy.pi + wr_large, numpy.pi - wr_large)
+        return xp.where(r < Rmean, wr_small, wr_large)
+
+    def _calc_anglez_backend(
+        self, Or, Op, ar, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
+    ):
+        """Vectorised vertical angle az (un-modded; caller takes % 2pi).
+
+        Mirrors _calc_anglez: psi from sinpsi=z/r/sin(inclination) (clipped,
+        vtheta>0 -> pi-psi, non-inclined -> phi), then wz = L*I-integral to the
+        same data-dependent limit (vr quadrant fixes via dpsi=Op/Or*2pi), and
+        az = -wz + psi + Op/Or*ar (ar un-modded). Op here is the magnitude.
+        """
+        xp = get_namespace(r)
+        # psi (inclination phase)
+        i_incl = xp.arccos(xp.where(xp.abs(Lz / L) < 1.0, Lz / L, xp.sign(Lz / L)))
+        sini = xp.sin(i_incl)
+        sini_safe = xp.where(sini == 0.0, xp.ones_like(sini), sini)
+        sinpsi = z / r / sini_safe
+        finite = xp.isfinite(sinpsi)
+        sinpsi_c = xp.where(
+            sinpsi > 1.0,
+            xp.ones_like(sinpsi),
+            xp.where(sinpsi < -1.0, -xp.ones_like(sinpsi), sinpsi),
+        )
+        psi = xp.arcsin(sinpsi_c)
+        psi = xp.where(vtheta > 0.0, numpy.pi - psi, psi)
+        psi = xp.where(finite, psi, phi)  # non-inclined: psi=phi
+        psi = psi % (2.0 * numpy.pi)
+        dpsi = Op / Or * 2.0 * numpy.pi  # full I integral
+        limS = xp.sqrt(xp.where(r > rperi, r - rperi, xp.zeros_like(r)))
+        limL = xp.sqrt(xp.where(rap > r, rap - r, xp.zeros_like(r)))
+        wz_small = L * self._panel_backend(xp, rperi, 1.0, limS, E, L, True)
+        wz_small = xp.where(vr < 0.0, dpsi - wz_small, wz_small)
+        wz_large = L * self._panel_backend(xp, rap, -1.0, limL, E, L, True)
+        wz_large = xp.where(vr < 0.0, dpsi / 2.0 + wz_large, dpsi / 2.0 - wz_large)
+        wz = xp.where(r < Rmean, wz_small, wz_large)
+        return -wz + psi + Op / Or * ar
+
+    def _calc_long_asc_backend(self, z, R, vtheta, phi, Lz, L):
+        """Vectorised longitude of the ascending node (mirror _calc_long_asc)."""
+        xp = get_namespace(R)
+        i = xp.arccos(Lz / L)
+        sinu = z / R / xp.tan(i)
+        sinu = xp.where(
+            (sinu > 1.0) & (sinu < 1.0 + 10.0**-7.0), xp.ones_like(sinu), sinu
+        )
+        sinu = xp.where((sinu < -1.0) & xp.isfinite(sinu), -xp.ones_like(sinu), sinu)
+        sinu_c = xp.where(
+            sinu > 1.0,
+            xp.ones_like(sinu),
+            xp.where(sinu < -1.0, -xp.ones_like(sinu), sinu),
+        )
+        u = xp.arcsin(sinu_c)
+        u = xp.where(vtheta > 0.0, numpy.pi - u, u)
+        u = xp.where(xp.isfinite(u), u, phi)  # non-inclined: Omega=0 (u=phi)
+        return phi - u
+
+    def _actionsFreqs_backend(self, R, vR, vT, z, vz, extra_Jz):
+        """Vectorised (Jr,Lz,Jz,Or,Op,Oz) for backend (jax/torch) inputs."""
+        xp = get_namespace(R)
+        r, vr, vt, E, L, Lz, L2 = self._setup_backend(R, vR, vT, z, vz, extra_Jz)
+        rperi, rap = self._calc_rperi_rap_backend(r, vr, vt, E, L)
+        Jr = self._calc_jr_backend(rperi, rap, E, L)
+        Jphi = Lz
+        Jz = L - xp.abs(Lz)
+        # Rmean = exp((log rperi + log rap)/2) if rperi>0 else rap/2 (guard log)
+        rperi_safe = xp.where(rperi > 0.0, rperi, xp.ones_like(rperi))
+        Rmean = xp.where(
+            rperi > 0.0,
+            xp.exp((xp.log(rperi_safe) + xp.log(rap)) / 2.0),
+            rap / 2.0,
+        )
+        Or, Op = self._calc_or_op_backend(Rmean, rperi, rap, E, L)
+        # Circular branch (Jr<1e-9): epifreq/omegac (backend-ready forces).
+        is_circ = Jr < 10.0**-9.0
+        Or = xp.where(is_circ, epifreq(self._2dpot, r, use_physical=False), Or)
+        Op = xp.where(is_circ, omegac(self._2dpot, r, use_physical=False), Op)
+        Oz = Op  # copy (magnitude)
+        Op = xp.where(vT < 0.0, -Op, Op)
+        return (Jr, Jphi, Jz, Or, Op, Oz)
+
+    def _actionsFreqsAngles_backend(self, R, vR, vT, z, vz, phi, extra_Jz):
+        """Vectorised (Jr,Lz,Jz,Or,Op,Oz,ar,ap,az) for backend inputs."""
+        xp = get_namespace(R)
+        r, vr, vt, E, L, Lz, L2 = self._setup_backend(R, vR, vT, z, vz, extra_Jz)
+        vtheta = (z * vR - R * vz) / r
+        rperi, rap = self._calc_rperi_rap_backend(r, vr, vt, E, L)
+        Jr = self._calc_jr_backend(rperi, rap, E, L)
+        Jphi = Lz
+        Jz = L - xp.abs(Lz)
+        rperi_safe = xp.where(rperi > 0.0, rperi, xp.ones_like(rperi))
+        Rmean = xp.where(
+            rperi > 0.0,
+            xp.exp((xp.log(rperi_safe) + xp.log(rap)) / 2.0),
+            rap / 2.0,
+        )
+        Or, Op = self._calc_or_op_backend(Rmean, rperi, rap, E, L)
+        is_circ = Jr < 10.0**-9.0
+        Or = xp.where(is_circ, epifreq(self._2dpot, r, use_physical=False), Or)
+        Op = xp.where(is_circ, omegac(self._2dpot, r, use_physical=False), Op)
+        # Angles (ar, az un-modded; Op is the magnitude here, as in numpy).
+        asc = self._calc_long_asc_backend(z, R, vtheta, phi, Lz, L)
+        ar = self._calc_angler_backend(Or, r, Rmean, rperi, rap, E, L, vr)
+        az = self._calc_anglez_backend(
+            Or, Op, ar, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
+        )
+        Oz = Op  # copy (magnitude)
+        Op = xp.where(vT < 0.0, -Op, Op)
+        ap = xp.where(vT < 0.0, asc - az, asc + az)
+        ar = ar % (2.0 * numpy.pi)
+        ap = ap % (2.0 * numpy.pi)
+        az = az % (2.0 * numpy.pi)
+        return (Jr, Jphi, Jz, Or, Op, Oz, ar, ap, az)
 
     def _calc_rperi_rap(self, r, vr, vt, E, L):
         if (

--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -25,6 +25,12 @@ from ..util import quadpack
 from .actionAngle import UnboundError, actionAngle
 
 _EPS = 10.0**-15.0
+# Gauss-Legendre order for the backend (jax/torch) action/freq/angle quadratures.
+# 50 matches scipy's adaptive quadrature to <1e-7 over the physical orbit range
+# (incl. near-radial L/Lcirc~1e-2: <1e-12 vs a tight reference); only at
+# pathological L/Lcirc<~1e-4 does scipy's own adaptive quad fail to ~1e-5, an
+# irreducible quadrature-method difference where higher order does not help.
+_BACKEND_GL_ORDER = 50
 
 
 class actionAngleSpherical(actionAngle):
@@ -587,8 +593,8 @@ class actionAngleSpherical(actionAngle):
         Substitute r = rperi + (rap-rperi) sin^2(theta), theta in [0, pi/2], so
         the sqrt's endpoint zeros are absorbed by the 2 sin cos Jacobian and the
         integrand is smooth. Fixed-order Gauss-Legendre via the shared
-        backend.quadrature.fixed_quad (n=25). The radicand is clipped >=0 before
-        the sqrt (sqrt'(0)=inf would NaN-poison reverse-mode AD).
+        backend.quadrature.fixed_quad (_BACKEND_GL_ORDER). The radicand is
+        clipped >=0 before the sqrt (sqrt'(0)=inf would NaN-poison reverse AD).
         """
         from ..backend.quadrature import fixed_quad
 
@@ -604,7 +610,7 @@ class actionAngleSpherical(actionAngle):
             rad = xp.where(rad > 0.0, rad, 0.0)  # clip before sqrt (AD guard)
             return xp.sqrt(rad) * span[:, None] * 2.0 * sin * cos
 
-        Jr = fixed_quad(xp, integrand, 0.0, numpy.pi / 2.0, n=25)
+        Jr = fixed_quad(xp, integrand, 0.0, numpy.pi / 2.0, n=_BACKEND_GL_ORDER)
         return Jr / numpy.pi
 
     # -------------------------------------------------- backend freqs + angles
@@ -644,7 +650,7 @@ class actionAngleSpherical(actionAngle):
                 val = val / rr**2.0
             return val * lim[:, None]  # dt = lim ds
 
-        return fixed_quad(xp, integrand, 0.0, 1.0, n=25)
+        return fixed_quad(xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER)
 
     def _calc_or_op_backend(self, Rmean, rperi, rap, E, L):
         """Vectorised Or (radial freq) and Op (azimuthal freq magnitude).
@@ -714,9 +720,12 @@ class actionAngleSpherical(actionAngle):
         # psi (inclination phase)
         i_incl = xp.arccos(xp.where(xp.abs(Lz / L) < 1.0, Lz / L, xp.sign(Lz / L)))
         sini = xp.sin(i_incl)
+        # Non-inclined (sin i == 0): numpy's z/r/sin(i) is non-finite -> psi=phi.
+        # Test finiteness on the TRUE division (raw sini, not the safe one) so
+        # sin i==0 is caught; sini_safe is only the arcsin value (no NaN grad).
+        finite = xp.isfinite(z / r / sini)
         sini_safe = xp.where(sini == 0.0, xp.ones_like(sini), sini)
         sinpsi = z / r / sini_safe
-        finite = xp.isfinite(sinpsi)
         sinpsi_c = xp.where(
             sinpsi > 1.0,
             xp.ones_like(sinpsi),
@@ -739,12 +748,17 @@ class actionAngleSpherical(actionAngle):
     def _calc_long_asc_backend(self, z, R, vtheta, phi, Lz, L):
         """Vectorised longitude of the ascending node (mirror _calc_long_asc)."""
         xp = get_namespace(R)
-        i = xp.arccos(Lz / L)
-        sinu = z / R / xp.tan(i)
+        i = xp.arccos(xp.where(xp.abs(Lz / L) < 1.0, Lz / L, xp.sign(Lz / L)))
+        tani = xp.tan(i)
+        # Non-inclined (tan i == 0): numpy's z/R/tan(i) is non-finite -> Omega=0
+        # (u=phi). Test finiteness on the TRUE division (raw tani); tani_safe is
+        # only the arcsin value, so no NaN enters the where value/grad path.
+        finite = xp.isfinite(z / R / tani)
+        tani_safe = xp.where(tani == 0.0, xp.ones_like(tani), tani)
+        sinu = z / R / tani_safe
         sinu = xp.where(
             (sinu > 1.0) & (sinu < 1.0 + 10.0**-7.0), xp.ones_like(sinu), sinu
         )
-        sinu = xp.where((sinu < -1.0) & xp.isfinite(sinu), -xp.ones_like(sinu), sinu)
         sinu_c = xp.where(
             sinu > 1.0,
             xp.ones_like(sinu),
@@ -752,7 +766,7 @@ class actionAngleSpherical(actionAngle):
         )
         u = xp.arcsin(sinu_c)
         u = xp.where(vtheta > 0.0, numpy.pi - u, u)
-        u = xp.where(xp.isfinite(u), u, phi)  # non-inclined: Omega=0 (u=phi)
+        u = xp.where(finite, u, phi)  # non-inclined: Omega=0 (u=phi)
         return phi - u
 
     def _actionsFreqs_backend(self, R, vR, vT, z, vz, extra_Jz):

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -43,7 +43,13 @@ from galpy.actionAngle import (
     actionAngleIsochroneInverse,
     actionAngleSpherical,
 )
-from galpy.potential import LogarithmicHaloPotential, NFWPotential
+from galpy.potential import (
+    HernquistPotential,
+    IsochronePotential,
+    LogarithmicHaloPotential,
+    NFWPotential,
+    vcirc,
+)
 
 # A small batch of bound phase-space points (R,vR,vT,z,vz,phi); moderate
 # velocities so the isochrone orbits are bound (E<0) and away from the
@@ -390,7 +396,7 @@ def test_isochrone_inverse_grad_vs_fd(backend):
 # scipy brentq/quad per-object loop) while jax/torch inputs take a vectorised,
 # differentiable path -- rperi/rap via the shared backend root-finder
 # galpy.backend.optimize.brentq, Jr via galpy.backend.quadrature.fixed_quad.
-# Backend GL (n=25) vs scipy's adaptive quad differ at the ~1e-9 level, so the
+# Backend GL (n=50) vs scipy's adaptive quad differ at the ~1e-9 level, so the
 # parity tolerance is rtol~1e-7 (NOT 1e-12). PR-1 scope: only actions+ecc; the
 # frequency/angle methods (_actionsFreqs*) are PR-2 and untouched (numpy-only).
 _SPH_POTS = {
@@ -463,9 +469,9 @@ def test_spherical_grad_vs_fd_wrt_vR(backend, which):
 # per-object scipy loop is untouched (byte-identical), jax/torch inputs take the
 # vectorised, differentiable branch. The two t^2-substituted panels of each
 # radial-period / azimuthal-period / angle integral run through
-# galpy.backend.quadrature.fixed_quad (n=25) with the per-object upper limit
+# galpy.backend.quadrature.fixed_quad (n=50) with the per-object upper limit
 # folded INTO the integrand (t = lim*s on a fixed [0,1] panel), so the GL
-# (n=25) value differs from scipy's adaptive quad at the ~1e-9 level
+# (n=50) value differs from scipy's adaptive quad at the ~1e-9 level
 # (rtol~1e-6, NOT 1e-12). Azimuth phi is needed for the angles call.
 _SPH_PHI = numpy.array([1.3, 0.4, 2.1])
 # A retrograde batch (vT<0) to exercise the Op sign flip and ap = asc - az
@@ -545,3 +551,159 @@ def test_spherical_freqs_grad_vs_fd_wrt_vR(backend, which, idx):
     g = _grad(backend, f_be, _SPH_SA[1])
     assert numpy.isfinite(g)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-6)
+
+
+# ====================================================================
+# actionAngleSpherical EDGE-CASE parity. The spherical action/freq/angle map
+# has data-dependent branches that only fire at special parts of phase space:
+#   * at peri / at apo (vr=0): the radial-period bracket endpoint sits ON the
+#     turning-point root, so the panel limits collapse to 0;
+#   * exactly circular (Jr<1e-9): the epifreq/omegac fast branch;
+#   * z=0 with vz!=0 (plane-crossing but inclined): sin(psi)=0 but finite;
+#   * z=0 AND vz=0 (non-inclined, planar): numpy's z/r/sin(i) is non-finite, so
+#     psi=phi and the longitude of the ascending node is 0 by convention -- the
+#     branch the backend must reproduce EXACTLY (no xfall-through to psi=0);
+#   * near-radial (L/Lcirc~3e-3, deeply plunging) and near-circular (vT just off
+#     vcirc): the quadrature stress cases.
+# Every case must match numpy on ALL of (Jr,Lz,Jz,Or,Op,Oz,ar,ap,az,e,zmax,
+# rperi,rap), prograde AND retrograde, across Log/NFW/Hernquist/Isochrone. The
+# only non-byte-identity is the inherent GL(n=50)-vs-adaptive-quad floor (~1e-6
+# on the continuous freq/angle integrals; actions/ecc/peri/apo are ~1e-9). At
+# pathological L/Lcirc<~1e-4 scipy's OWN adaptive quad fails to ~1e-5, so that
+# extreme is excluded as an irreducible quadrature-method difference (not a
+# logic/convention divergence).
+_EDGE_POTS = {
+    "log": LogarithmicHaloPotential(normalize=1.0),
+    "nfw": NFWPotential(normalize=1.0),
+    "hernquist": HernquistPotential(normalize=1.0),
+    "isochrone": IsochronePotential(normalize=1.0),
+}
+_EDGE_CASES = [
+    "apocenter",
+    "pericenter",
+    "circular",
+    "zcross_incl",
+    "planar",
+    "near_radial",
+    "very_ecc",
+    "near_circular",
+]
+
+
+def _edge_ic(pot, case, prograde):
+    """(R,vR,vT,z,vz,phi) for a spherical action-angle edge case."""
+    sgn = 1.0 if prograde else -1.0
+    phi = 0.7
+    R = 1.0
+    vc = vcirc(pot, R, use_physical=False)
+    if case == "apocenter":  # vr=0, sub-circular vt, inclined -> r is apo
+        R, z = 0.9, 0.4
+        r = numpy.sqrt(R**2 + z**2)
+        vt = 0.6 * vcirc(pot, r, use_physical=False)
+        return (R, 0.0, sgn * vt * r / R, z, 0.0, phi)
+    if case == "pericenter":  # vr=0, super-circular vt, inclined -> r is peri
+        R, z = 0.9, 0.4
+        r = numpy.sqrt(R**2 + z**2)
+        vt = 1.4 * vcirc(pot, r, use_physical=False)
+        return (R, 0.0, sgn * vt * r / R, z, 0.0, phi)
+    if case == "circular":  # z=0,vz=0,vR=0,vT=vcirc -> Jr=0, non-inclined
+        return (1.1, 0.0, sgn * vcirc(pot, 1.1, use_physical=False), 0.0, 0.0, phi)
+    if case == "zcross_incl":  # z=0 but vz!=0: plane-crossing, inclined
+        return (R, 0.15, sgn * 0.8 * vc, 0.0, 0.3, phi)
+    if case == "planar":  # z=0 AND vz=0: non-inclined (the psi=phi branch)
+        return (R, 0.2, sgn * 0.7 * vc, 0.0, 0.0, phi)
+    if case == "near_radial":  # L/Lcirc~3e-3: deeply plunging (physical)
+        return (R, 0.6 * vc, sgn * 3e-3 * vc, 0.0, 0.05, phi)
+    if case == "very_ecc":  # bound, high ecc, inclined
+        return (R, 0.6 * vc, sgn * 0.18 * vc, 0.0, 0.05, phi)
+    if case == "near_circular":  # vT just off vcirc -> small Jr, non-inclined
+        return (R, 0.0, sgn * 1.002 * vc, 0.0, 0.0, phi)
+    raise ValueError(case)  # pragma: no cover
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("potname", list(_EDGE_POTS))
+@pytest.mark.parametrize("case", _EDGE_CASES)
+@pytest.mark.parametrize("prograde", [True, False])
+def test_spherical_edge_case_parity(backend, potname, case, prograde):
+    # numpy <-> backend parity of _actionsFreqsAngles AND _EccZmaxRperiRap at
+    # the spherical edge cases (peri/apo, circular, z-crossing, non-inclined,
+    # near-radial, near-circular), prograde + retrograde. The non-inclined cases
+    # exercise the psi=phi / Omega=0 conventions the backend must match exactly.
+    import warnings
+
+    pot = _EDGE_POTS[potname]
+    aAS = actionAngleSpherical(pot=pot)
+    R, vR, vT, z, vz, phi = _edge_ic(pot, case, prograde)
+    npargs = tuple(
+        numpy.atleast_1d(numpy.asarray(float(v))) for v in (R, vR, vT, z, vz)
+    )
+    npphi = numpy.atleast_1d(numpy.asarray(float(phi)))
+    bargs = [_arr(backend, numpy.asarray(float(v))[None]) for v in (R, vR, vT, z, vz)]
+    bphi = _arr(backend, numpy.asarray(float(phi))[None])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ref_afa = aAS._actionsFreqsAngles(*npargs, npphi)
+        got_afa = aAS._actionsFreqsAngles(*bargs, bphi)
+        ref_ecc = aAS._EccZmaxRperiRap(*npargs)
+        got_ecc = aAS._EccZmaxRperiRap(*bargs)
+    # (Jr,Lz,Jz,Or,Op,Oz,ar,ap,az): values to ~1e-6 (GL-vs-adaptive floor);
+    # angles (idx>=6) compared as wrap-robust circular differences.
+    for idx, (r, g) in enumerate(zip(ref_afa, got_afa)):
+        assert _is_backend_array(backend, g)
+        if idx >= 6:
+            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            numpy.testing.assert_allclose(
+                d, 0.0, atol=2e-6, err_msg=f"{case}/{potname}/angle{idx}"
+            )
+        else:
+            numpy.testing.assert_allclose(
+                _np(g),
+                numpy.asarray(r),
+                rtol=2e-6,
+                atol=2e-6,
+                err_msg=f"{case}/{potname}/afa{idx}",
+            )
+    # (e,zmax,rperi,rap): root-find + action quadrature, ~1e-9.
+    for idx, (r, g) in enumerate(zip(ref_ecc, got_ecc)):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(
+            _np(g),
+            numpy.asarray(r),
+            rtol=1e-7,
+            atol=1e-9,
+            err_msg=f"{case}/{potname}/ecc{idx}",
+        )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("idx,name", [(7, "ap"), (8, "az")])
+def test_spherical_noninclined_angle_grad_vs_fd(backend, idx, name):
+    # d(ap or az)/d vR for a NON-INCLINED (z=0, vz=0) orbit. numpy's psi and
+    # longitude-of-ascending-node use z/r/sin(i) and z/R/tan(i), both 0/0 (sin
+    # i==0) -> non-finite -> psi=phi / Omega=0. The backend reproduces those
+    # conventions via xp.where on a finiteness mask computed from the TRUE
+    # (un-safed) division, so NO NaN reaches the where value/grad path: the
+    # gradient stays finite and matches finite-difference (perturbing vR keeps
+    # the orbit in-plane, so the angle is smooth there). Guards against the
+    # xp.where dead-branch NaN-poisoning that a naive psi=phi guard reintroduces.
+    aAS = actionAngleSpherical(pot=_EDGE_POTS["log"])
+    pot = _EDGE_POTS["log"]
+    vc = vcirc(pot, 1.0, use_physical=False)
+    R, vT, z, vz, phi = 1.0, 0.7 * vc, 0.0, 0.0, 0.7  # non-inclined, az mid-range
+
+    def call(vR_val, xp_arr):
+        args = (xp_arr(R), vR_val, xp_arr(vT), xp_arr(z), xp_arr(vz), xp_arr(phi))
+        return aAS._actionsFreqsAngles(*args)[idx].sum()
+
+    def f_np(vR_val):
+        return numpy.asarray(call(vR_val, lambda v: numpy.atleast_1d(numpy.asarray(v))))
+
+    fd = _fd(f_np, 0.2)
+
+    def f_be(vR_t):
+        return call(vR_t, lambda v: _arr(backend, numpy.atleast_1d(v).astype(float)))
+
+    g = _grad(backend, f_be, 0.2)
+    assert numpy.isfinite(g), f"{name} grad is NaN at non-inclined point ({backend})"
+    numpy.testing.assert_allclose(g, fd, rtol=1e-4, atol=1e-6)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -455,3 +455,93 @@ def test_spherical_grad_vs_fd_wrt_vR(backend, which):
     g = _grad(backend, f_be, _SPH_S[1])
     assert numpy.isfinite(g)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
+
+
+# ====================================================================
+# actionAngleSpherical PR-2: FREQUENCIES (Or,Op,Oz via _actionsFreqs) + ANGLES
+# (ar,ap,az via _actionsFreqsAngles). Same additive backend pattern: the numpy
+# per-object scipy loop is untouched (byte-identical), jax/torch inputs take the
+# vectorised, differentiable branch. The two t^2-substituted panels of each
+# radial-period / azimuthal-period / angle integral run through
+# galpy.backend.quadrature.fixed_quad (n=25) with the per-object upper limit
+# folded INTO the integrand (t = lim*s on a fixed [0,1] panel), so the GL
+# (n=25) value differs from scipy's adaptive quad at the ~1e-9 level
+# (rtol~1e-6, NOT 1e-12). Azimuth phi is needed for the angles call.
+_SPH_PHI = numpy.array([1.3, 0.4, 2.1])
+# A retrograde batch (vT<0) to exercise the Op sign flip and ap = asc - az
+# branch; inclined and off the turning points / non-inclined kink.
+_SPH_RETRO = (
+    numpy.array([1.0, 1.2]),
+    numpy.array([0.1, -0.15]),
+    numpy.array([-0.8, -0.5]),
+    numpy.array([0.1, -0.05]),
+    numpy.array([0.05, 0.1]),
+)
+_SPH_RETRO_PHI = numpy.array([0.5, 2.0])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("potname", list(_SPH_POTS))
+def test_spherical_freqs_parity(backend, potname):
+    # numpy <-> jax <-> torch parity of _actionsFreqs (Jr,Lz,Jz,Or,Op,Oz) and
+    # _actionsFreqsAngles (+ar,ap,az) on prograde + retrograde bound ICs.
+    aAS = actionAngleSpherical(pot=_SPH_POTS[potname])
+    for sph, phi in ((_SPH, _SPH_PHI), (_SPH_RETRO, _SPH_RETRO_PHI)):
+        bargs = [_arr(backend, v) for v in sph]
+        bphi = _arr(backend, phi)
+        # _actionsFreqs (no phi)
+        ref = aAS._actionsFreqs(*sph)
+        got = aAS._actionsFreqs(*bargs)
+        for r, g in zip(ref, got):
+            assert _is_backend_array(backend, g)
+            numpy.testing.assert_allclose(
+                _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+            )
+        # _actionsFreqsAngles (+phi); angles compared as circular differences
+        ref = aAS._actionsFreqsAngles(*sph, phi)
+        got = aAS._actionsFreqsAngles(*bargs, bphi)
+        for idx, (r, g) in enumerate(zip(ref, got)):
+            assert _is_backend_array(backend, g)
+            if idx >= 6:  # ar, ap, az: wrap-robust comparison
+                d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+                numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
+            else:
+                numpy.testing.assert_allclose(
+                    _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                )
+
+
+# Scalar single-point bound IC (with phi) for clean per-component derivatives.
+_SPH_SA = (1.1, 0.2, 0.9, 0.15, 0.1, 1.3)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("which,idx", [("omegar", 3), ("angler", 6)])
+def test_spherical_freqs_grad_vs_fd_wrt_vR(backend, which, idx):
+    # d(Or or ar)/d vR at a single bound point: AD through the vectorised
+    # root-find + two-panel fixed_quad period/angle integrals vs finite-diff.
+    aAS = actionAngleSpherical(pot=_SPH_POTS["log"])
+    R, _, vT, z, vz, phi = _SPH_SA
+
+    def call(vR_val, xp_arr):
+        args = (
+            xp_arr(R),
+            vR_val,
+            xp_arr(vT),
+            xp_arr(z),
+            xp_arr(vz),
+            xp_arr(phi),
+        )
+        return aAS._actionsFreqsAngles(*args)[idx].sum()
+
+    def f_np(vR_val):
+        return numpy.asarray(call(vR_val, lambda v: numpy.atleast_1d(numpy.asarray(v))))
+
+    fd = _fd(f_np, _SPH_SA[1])
+
+    def f_be(vR_t):
+        return call(vR_t, lambda v: _arr(backend, numpy.atleast_1d(v).astype(float)))
+
+    g = _grad(backend, f_be, _SPH_SA[1])
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
**Track E — `actionAngleSpherical` backend, PR-2 of 2** (builds on #1008). This completes the Spherical migration: **frequencies** (Or, Op, Oz) + **angles** (ar, ap, az), vectorised + differentiable under jax/torch, numpy byte-identical. With #1008 (actions + ecc/peri/apo), `actionAngleSpherical` — the most complex AA method — is now fully backend-agnostic.

## Approach (purely additive — numpy byte-identical)
An `elif is_backend_array(R):` branch in `_actionsFreqs` and `_actionsFreqsAngles` routes jax/torch inputs to new vectorised helpers; the numpy per-object scipy loop is unchanged (0 deletions). Reuses #1008's verified `_calc_rperi_rap_backend` / `_calc_jr_backend` / `_setup_backend`.

- **`_panel_backend`** — one t²-substituted GL panel (`r=base±t²`); the per-object integration limit is folded into the integrand (`t=lim·s` on a fixed `[0,1]` panel) so `fixed_quad`'s a,b stay scalar; the `2t` Jacobian cancels the `1/√` endpoint singularity; radicand clipped ≥0 before `sqrt`.
- **`_calc_or_op_backend`** — `Tr=2(small+large) ⇒ Or=2π/Tr`; `I=2L(panels) ⇒ Op=I·Or/2π`; circular branch (`Jr<1e-9`) → `xp.where(is_circ, epifreq/omegac, Or/Op)`.
- **`_calc_angler`/`_anglez`/`_long_asc_backend`** — the numpy angle assembly with every `if` → `xp.where` (r<Rmean panel choice, vr<0 / vT<0 quadrant fixes, the `sinpsi` inclination + non-finite→phi fallback, `ap=asc±az`).

## Validation
- **numpy byte-identical** — base-vs-port `array_equal` over `_actionsFreqs` + `_actionsFreqsAngles`, Log/NFW/Hernquist, prograde + retrograde.
- **jax + torch** — parity vs scipy: Or ~2.8e-9, Op/Oz/angles ~1e-9 (GL(n=25)-vs-adaptive level); grad-vs-FD ~1e-7; circular-frequency branch exact. (The fully non-inclined `z=0` IC is the documented measure-zero non-smooth angle-map kink — RuntimeWarnings fire on numpy too; inclined ICs match ~1e-10.)
- Built via design→implement→**adversarial-verify** (independent agent: byte-identity, freq/angle parity, grad, numpy-unchanged → SHIP), then re-checked by me. **68 backend + 20 numpy-Spherical** tests green.

## Next (Track E)
Vertical (needs the small `linearPotential`/`verticalPotential` migration first); then the C-only Staeckel freqs/angles → pure-Python on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Update — shared-math refactor (per review: "share more, don't give up speed")
Factored the duplicated physics into namespace-agnostic helpers used by **both** paths; neither algorithm changed (numpy keeps scipy adaptive-quad+`brentq` ⇒ byte-identical; backend keeps vectorized GL+bisection ⇒ speed). The only thing that stays per-path is the quadrature/root-find **driver** — which is exactly what buys byte-identity *and* speed.
- **`_radicand(xp,r,E,L,pot)`** — the vr² radicand, written **5×** before → **once** (numpy integrand, root-find equation, + 3 backend sites).
- **`_period_angle_integrand`** — the t²-substituted core (the 4 numpy `_Tr`/`_I` integrands → one-line wrappers).
- **`_assemble_angler`** — the radial-angle quadrant logic, shared (`xp.where` is byte-identical on numpy scalars + vectorizes on arrays).
- Left **deliberately split** (prototype-verified *not* byte-identity-safe): the `_calc_anglez` psi/inclination + `_calc_long_asc` — their degenerate non-inclined branch genuinely diverges between scalar-`if` and `xp.where` (the documented measure-zero kink). The per-object-loop vs vectorized drivers also stay split.

numpy byte-identical (independent base-vs-port `array_equal`, all 4 methods, pro+retrograde); backend parity unchanged; 36 Spherical (backend+numpy) green.