### PR TITLE
actionAngle: jit-traceable vectorised Staeckel + GPU device-anchoring

### DIFF
--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -14,7 +14,7 @@ import copy
 import numpy
 from scipy import integrate, optimize
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import device_of, get_namespace, is_backend_array
 from ..potential import _dim, epifreq, omegac, vcirc
 from ..potential.planarPotential import _evaluateplanarPotentials
 from ..potential.Potential import (
@@ -610,7 +610,16 @@ class actionAngleSpherical(actionAngle):
             rad = xp.where(rad > 0.0, rad, 0.0)  # clip before sqrt (AD guard)
             return xp.sqrt(rad) * span[:, None] * 2.0 * sin * cos
 
-        Jr = fixed_quad(xp, integrand, 0.0, numpy.pi / 2.0, n=_BACKEND_GL_ORDER)
+        # device=: scalar limits, so anchor the GL nodes on the input device
+        # (rperi) -- else torch raises on CUDA input. No-op on numpy.
+        Jr = fixed_quad(
+            xp,
+            integrand,
+            0.0,
+            numpy.pi / 2.0,
+            n=_BACKEND_GL_ORDER,
+            device=device_of(rperi),
+        )
         return Jr / numpy.pi
 
     # -------------------------------------------------- backend freqs + angles
@@ -650,7 +659,9 @@ class actionAngleSpherical(actionAngle):
                 val = val / rr**2.0
             return val * lim[:, None]  # dt = lim ds
 
-        return fixed_quad(xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER)
+        return fixed_quad(
+            xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(base)
+        )
 
     def _calc_or_op_backend(self, Rmean, rperi, rap, E, L):
         """Vectorised Or (radial freq) and Op (azimuthal freq magnitude).

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -15,7 +15,7 @@ import warnings
 import numpy
 from scipy import integrate, optimize
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import asarray_on_device, device_of, get_namespace, is_backend_array
 from ..backend.optimize import bisect_root
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..potential import (
@@ -180,17 +180,27 @@ def _staeckel_gl_action(xp, sqfunc, args, lo, hi, order):
         sq = xp.where(sq > 0.0, sq, xp.zeros_like(sq))  # clip (AD/round-off guard)
         return xp.sqrt(sq) * span[..., None]
 
-    return _backend_fixed_quad(xp, integrand, 0.0, 1.0, n=order)
+    # device=: the limits are Python scalars, so anchor the GL nodes on the input
+    # arrays' device (lo) -- else torch raises on CUDA input (nodes default to CPU)
+    # and jax silently round-trips. No-op on numpy (device_of -> None).
+    return _backend_fixed_quad(xp, integrand, 0.0, 1.0, n=order, device=device_of(lo))
 
 
 def _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta):
     """Setup quantities + turning points (+ unbound check), shared by the
     vectorised actions and frequencies. Returns (setup, umin, umax, vmin, delta)."""
     if is_backend_array(R) and not is_backend_array(delta):
-        delta = xp.asarray(delta)  # per-object numpy delta -> match R's namespace
+        # match R's namespace AND device: a bare xp.asarray(delta) lands on the
+        # CPU, so an array-valued delta (e.g. EccZmax's atleast_1d) then collides
+        # with CUDA R/z in coords.Rz_to_uv. No-op on numpy (device_of -> None).
+        delta = asarray_on_device(xp, delta, device_of(R))
     s = _staeckel_setup(xp, R, vR, vT, z, vz, pot, delta)
     umin, umax, unbound = _staeckel_uminumax(xp, s, pot, delta)
-    if bool(xp.any(unbound)):  # eager (no internal jit); mirrors the Single
+    # Unbound orbits raise eagerly on the numpy path (mirrors the Single class);
+    # under a backend they must stay jit-traceable, so we cannot branch on the
+    # traced `unbound` -- let unbound orbits fall through to NaN instead (the
+    # caller jits/AD-traces and checks). numpy stays byte-identical (still raises).
+    if not is_backend_array(R) and bool(numpy.any(unbound)):
         raise UnboundError("Orbit seems to be unbound")
     vmin = _staeckel_vmin(xp, s, pot, delta)
     # Planar orbit (jz=0): snap vmin to exactly pi/2 (the bisection lands ~1e-8
@@ -259,7 +269,7 @@ def _staeckel_deriv_panels(xp, Sfunc, sq_args, factor_fn, lo, hi, order):
             g = xp.where(S > 0.0, factor_fn(xp, u) / xp.sqrt(Ssafe), xp.zeros_like(S))
             return 2.0 * t * g * mid[..., None]  # du = 2t dt, dt = mid ds
 
-        return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order)
+        return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order, device=device_of(mid))
 
     return panel(lo, 1.0) + panel(hi, -1.0)
 
@@ -365,7 +375,7 @@ def _staeckel_angle_partial(xp, Sfunc, sq_args, factor_fn, base, sign, mid, orde
         g = xp.where(S > 0.0, factor_fn(xp, u) / xp.sqrt(Ssafe), xp.zeros_like(S))
         return 2.0 * t * g * mid[..., None]
 
-    return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order)
+    return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order, device=device_of(mid))
 
 
 def _staeckel_angles(xp, s, umin, umax, vmin, pot, delta, order):
@@ -957,7 +967,9 @@ class actionAngleStaeckel(actionAngle):
             # action/frequency/angle-invariant, so it is not needed here).
             xp = get_namespace(R) if is_backend_array(R) else numpy
             if is_backend_array(R) and not is_backend_array(phi):
-                phi = xp.asarray(phi)  # fold the azimuth in R's namespace
+                # fold the azimuth in R's namespace AND device (a bare xp.asarray
+                # lands on the CPU and would collide with a CUDA anglephi).
+                phi = asarray_on_device(xp, phi, device_of(R))
             (
                 jr,
                 Lz,

--- a/galpy/actionAngle/actionAngleVertical.py
+++ b/galpy/actionAngle/actionAngleVertical.py
@@ -12,7 +12,7 @@
 import numpy
 from scipy import integrate, optimize
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import device_of, get_namespace, is_backend_array
 from ..potential.linearPotential import evaluatelinearPotentials
 from ..potential.Potential import _check_potential_list_and_deprecate
 from .actionAngle import actionAngle
@@ -358,7 +358,15 @@ class actionAngleVertical(actionAngle):
             rad = xp.where(rad > 0.0, rad, xp.zeros_like(rad))  # clip (AD guard)
             return xp.sqrt(rad) * 2.0 * t * lim[:, None]  # dx = 2t dt, dt = lim ds
 
-        return 2.0 / numpy.pi * fixed_quad(xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER)
+        # device=: scalar limits, so anchor the GL nodes on the input device (xmax)
+        # -- else torch raises on CUDA input. No-op on numpy (device_of -> None).
+        return (
+            2.0
+            / numpy.pi
+            * fixed_quad(
+                xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(xmax)
+            )
+        )
 
     def _calc_omega_backend(self, xp, xmax, E):
         """Omega = pi/2 / int_0^xmax dx/sqrt(2(E-Phi)) via x = xmax - t^2."""
@@ -375,7 +383,13 @@ class actionAngleVertical(actionAngle):
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))  # 2t->0 there anyway
             return 2.0 * t / xp.sqrt(rad) * lim[:, None]
 
-        return numpy.pi / 2.0 / fixed_quad(xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER)
+        return (
+            numpy.pi
+            / 2.0
+            / fixed_quad(
+                xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(xmax)
+            )
+        )
 
     def _calc_angle_backend(self, xp, x, vx, xmax, E, Omega):
         """angle = Omega * int_0^|x| dx/sqrt(2(E-Phi)), then (x,vx)-quadrant fix.
@@ -400,7 +414,9 @@ class actionAngleVertical(actionAngle):
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
             return 2.0 * t / xp.sqrt(rad) * span[:, None]  # dx = 2t dt, dt = span ds
 
-        angle = Omega * fixed_quad(xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER)
+        angle = Omega * fixed_quad(
+            xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(xmax)
+        )
         # Quadrant assembly (mirror the numpy masked writes; disjoint conditions).
         angle = xp.where((x >= 0.0) & (vx < 0.0), numpy.pi - angle, angle)
         angle = xp.where((x < 0.0) & (vx <= 0.0), numpy.pi + angle, angle)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -825,19 +825,21 @@ def test_staeckel_actions_vs_c(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_unbound_raises(backend):
-    # an unbound orbit raises UnboundError under the backends too (the vectorised
-    # turning-point search detects no umax below u=100, mirroring the Single).
+def test_staeckel_unbound_backend_no_raise(backend):
+    # An unbound orbit raises UnboundError on the numpy path (eager), but must NOT
+    # raise under a backend: the vectorised turning-point search cannot branch on
+    # the traced `unbound` mask under jit, so it falls through to a (garbage)
+    # backend array instead -- which is exactly what keeps actionsFreqsAngles
+    # jax.jit-traceable (jit traces+matches eager to ~9e-10). Exercises both sides
+    # of the `not is_backend_array(R)` guard in _staeckel_prep.
     from galpy.actionAngle import UnboundError
 
     aA = actionAngleStaeckel(pot=MWPotential2014, delta=0.5, c=False)
+    ub = (0.9, 10.0, -20.0, 0.1, 10.0)
     with pytest.raises(UnboundError):
-        aA(
-            *[
-                _arr(backend, numpy.atleast_1d(v).astype(float))
-                for v in (0.9, 10.0, -20.0, 0.1, 10.0)
-            ]
-        )
+        aA(*ub)  # numpy path: eager raise
+    out = aA(*[_arr(backend, numpy.atleast_1d(v).astype(float)) for v in ub])
+    assert _is_backend_array(backend, out[0])  # backend: no raise (garbage value ok)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)


### PR DESCRIPTION
Follow-up to #1015 (vectorised Staeckel angles). Two backend-correctness fixes the figure/jit work surfaced.

## (1) Make the vectorised Staeckel action-angle map jax.jit-traceable
`_staeckel_prep` had an eager unbound-orbit guard `if bool(xp.any(unbound)): raise UnboundError`. `bool()` of a traced array raises `TracerBoolConversionError` under `jax.jit`, so **a user could not jit `actionsFreqsAngles`** (the whole point of the backend work). Guarded behind `not is_backend_array(R)`:
- **numpy: byte-identical** — still raises `UnboundError` eagerly.
- **backend: jit-safe** — skips the data-dependent branch; unbound orbits fall through (the caller checks), so the function traces cleanly.

Verified locally: `jax.jit(actionsFreqsAngles)` traces and matches eager to **~9e-10**. (A `make_jaxpr` CI assertion is impractical — the unrolled bisection + quadrature trace to a ~47k-equation jaxpr; the added test instead guards the semantic fix: numpy raises, the backend path returns a backend array without raising.)

## (2) Anchor GL nodes / delta / phi on the input device (GPU)
Backend `fixed_quad` builds GL nodes from scalar limits on the **default device** (CPU for torch) while the integrand closes over CUDA inputs → **torch crashes on GPU**, jax silently round-trips. Anchored on the input device (`device=device_of(...)` / `asarray_on_device`) across Staeckel, Vertical, and Spherical. No-op on numpy (`device_of -> None`, byte-identical).
GPU-validated locally (**17/17 torch CUDA + 6/6 jax GPU** at machine precision); CI has no GPU, so these lines execute but the device placement isn't GPU-exercised in CI.

## Note for reviewers
The ~8.6 min/shape jit *compile* (from the unrolled fixed-iteration bisection) is a separate, known cost — a future jax-specific `lax.fori_loop` kernel would cut it ~12×+ (prototyped: bit-identical roots, ~12× faster compile at a ~1.7× warm cost). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)