### PR TITLE
actionAngleIsochroneApprox: jax/torch backend (orbit-integration path)

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -912,8 +912,8 @@ class actionAngleIsochroneApprox(actionAngle):
     # estimate runs and DIFFERENTIATES under jax/torch. The orbit integration reuses
     # the in-backend differentiable integrator (Orbit built from a STACKED backend IC
     # -> _ic_backend set -> routes to the C-STM / diffrax-torchdiffeq path); we never
-    # reinvent orbit integration here. Axisymmetric potentials only for the angle-fit
-    # (the non-axisymmetric branch is numpy-only, # pragma: no cover below).
+    # reinvent orbit integration here. Both axisymmetric and non-axisymmetric
+    # potentials are supported (non-axi: angle-averaged Lz + the 3-D-grid angle-fit).
 
     def _parse_args_backend(self, freqsAngles, _firstFlip, *args):
         """Backend counterpart of _parse_args for the float/array IC case: build,
@@ -1019,7 +1019,8 @@ class actionAngleIsochroneApprox(actionAngle):
 
         jr = sumFunc(jrI * danglerI, axis=1) / sumFunc(danglerI, axis=1)
         jz = sumFunc(jzI * danglezI, axis=1) / sumFunc(danglezI, axis=1)
-        if _isNonAxi(self._pot):  # pragma: no cover
+        if _isNonAxi(self._pot):
+            # non-axi: Lz is also angle-averaged (danglephi-weighted), not L_z(t0)
             lzI = xp.reshape(acfs[1], R.shape)[:, :-1]
             anglephiI = xp.reshape(acfs[7], R.shape)
             danglephiI = _backend_dangle(xp, anglephiI)
@@ -1052,7 +1053,8 @@ class actionAngleIsochroneApprox(actionAngle):
         danglezI = _backend_dangle(xp, anglezI)
         jr = xp.sum(jrI * danglerI, axis=1) / xp.sum(danglerI, axis=1)
         jz = xp.sum(jzI * danglezI, axis=1) / xp.sum(danglezI, axis=1)
-        if _isNonAxi(self._pot):  # pragma: no cover
+        if _isNonAxi(self._pot):
+            # non-axi: Lz is also angle-averaged (danglephi-weighted), not L_z(t0)
             lzI = xp.reshape(acfs[1], R.shape)[:, :-1]
             anglephiI = xp.reshape(acfs[7], R.shape)
             danglephiI = _backend_dangle(xp, anglephiI)
@@ -1074,32 +1076,48 @@ class actionAngleIsochroneApprox(actionAngle):
         angleZT = _backend_dePeriod(xp, xp.reshape(acfs[8], R.shape))
         nt = ts.shape[0]
         no = R.shape[0]
-        if _isNonAxi(self._pot):  # pragma: no cover
+        nonAxi = _isNonAxi(self._pot)
+        if nonAxi:
             nn = (2 * maxn - 1) ** 2 * maxn - (maxn - 1) * (2 * maxn - 1) - maxn
         else:
             nn = maxn * (2 * maxn - 1) - maxn
-        # The integer (n_R, n_Z) grid is data-independent (pure python/numpy);
-        # build it with numpy then move onto the backend (anchored on R's device).
+        # The integer n-grid is data-independent (pure python/numpy); build it with
+        # numpy then move onto the backend (anchored on R's device). For non-axi
+        # potentials the grid is 3-D (n_R, n_phi, n_Z) with the half-space mask;
+        # axisymmetric drops the n_phi axis.
         phig = list(numpy.arange(-maxn + 1, maxn, 1))
         phig.sort(key=lambda x: abs(x))
         phig = numpy.array(phig, dtype="int")
-        grid = numpy.meshgrid(numpy.arange(maxn), phig)
+        if nonAxi:
+            grid = numpy.meshgrid(numpy.arange(maxn), phig, phig)
+        else:
+            grid = numpy.meshgrid(numpy.arange(maxn), phig)
         gridR = grid[0].T.flatten()[1:]  # remove 0,0,0
         gridZ = grid[1].T.flatten()[1:]
-        mask = numpy.ones(len(gridR), dtype=bool)
-        mask[: 2 * maxn - 3 : 2] = False
+        if nonAxi:
+            gridphi = grid[2].T.flatten()[1:]
+            mask = True ^ (gridR == 0) * (
+                (gridphi < 0) + ((gridphi == 0) * (gridZ < 0))
+            )
+        else:
+            mask = numpy.ones(len(gridR), dtype=bool)
+            mask[: 2 * maxn - 3 : 2] = False
         gridR = gridR[mask]
         gridZ = gridZ[mask]
         gR = xp.asarray(numpy.asarray(gridR, dtype=float))
         gZ = xp.asarray(numpy.asarray(gridZ, dtype=float))
-        # A: (no, nt, 2+nn). A[...,0]=1, A[...,1]=ts, A[...,2:]=sin(nR aR + nZ aZ)
+        # A: (no, nt, 2+nn). A[...,0]=1, A[...,1]=ts, A[...,2:]=sin(n.angle)
         ones = xp.ones((no, nt), dtype=angleRT.dtype)
         tcol = xp.broadcast_to(ts[None, :], (no, nt))
-        # (no, nt, nn) = sin(gR*angleRT + gZ*angleZT), broadcast over the n-grid
-        sinnR = xp.sin(
+        # (no, nt, nn) = sin(gR*angleRT [+ gphi*anglephiT] + gZ*angleZT)
+        narg = (
             gR[None, None, :] * angleRT[:, :, None]
             + gZ[None, None, :] * angleZT[:, :, None]
         )
+        if nonAxi:
+            gphi = xp.asarray(numpy.asarray(gridphi[mask], dtype=float))
+            narg = narg + gphi[None, None, :] * anglephiT[:, :, None]
+        sinnR = xp.sin(narg)
         A = xp.concatenate([ones[:, :, None], tcol[:, :, None], sinnR], axis=2)
         ATt = xp.permute_dims(A, (0, 2, 1))  # (no, 2+nn, nt)
         atainv = xp.linalg.inv(xp.matmul(ATt, A))  # (no, 2+nn, 2+nn)

--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -20,6 +20,7 @@ import numpy
 from numpy import linalg
 from scipy import optimize
 
+from ..backend import get_namespace, is_backend_array
 from ..potential import IsochronePotential, MWPotential, _isNonAxi, dvcircdR, vcirc
 from ..potential.Potential import _check_potential_list_and_deprecate
 from ..util import conversion, galpyWarning, plot
@@ -143,6 +144,8 @@ class actionAngleIsochroneApprox(actionAngle):
         - 2013-09-10 - Written - Bovy (IAS).
         """
         R, vR, vT, z, vz, phi = self._parse_args(False, False, *args)
+        if is_backend_array(R):
+            return self._evaluate_backend(R, vR, vT, z, vz, phi, **kwargs)
         if self._c:  # pragma: no cover
             pass
         else:
@@ -286,6 +289,10 @@ class actionAngleIsochroneApprox(actionAngle):
             ts[self._ntintJ - 1 :] = self._tsJ
             ts[: self._ntintJ - 1] = -self._tsJ[1:][::-1]
         maxn = kwargs.get("maxn", self._maxn)
+        if is_backend_array(R):
+            return self._actionsFreqsAngles_backend(
+                R, vR, vT, z, vz, phi, ts, maxn, **kwargs
+            )
         if self._c:  # pragma: no cover
             pass
         else:
@@ -720,6 +727,13 @@ class actionAngleIsochroneApprox(actionAngle):
         """Helper function to parse the arguments to the __call__ and actionsFreqsAngles functions"""
         from ..orbit import Orbit
 
+        # Backend (jax/torch) path: when the phase-space coordinates are backend
+        # arrays, build per-orbit Orbit objects from STACKED backend ICs (so each
+        # routes to the differentiable in-backend integrator and keeps gradients),
+        # integrate, and assemble the (no, ntJ) phase-space arrays in the input
+        # namespace. The numpy per-object loop below is untouched (byte-identical).
+        if (len(args) == 6 or len(args) == 4) and is_backend_array(args[0]):
+            return self._parse_args_backend(freqsAngles, _firstFlip, *args)
         RasOrbit = False
         integrated = True  # whether the orbit was already integrated when given
         if len(args) == 5 or len(args) == 3:  # pragma: no cover
@@ -891,6 +905,260 @@ class actionAngleIsochroneApprox(actionAngle):
             return (oR, ovR, ovT, oz, ovz, ophi)
         else:
             return (R, vR, vT, z, vz, phi)
+
+    # ------------------------------------------------------------ backend (jax/torch)
+    # The numpy methods above stay byte-identical; these mirror them with the array
+    # namespace inferred from the inputs (xp), so the same isochrone-approximation
+    # estimate runs and DIFFERENTIATES under jax/torch. The orbit integration reuses
+    # the in-backend differentiable integrator (Orbit built from a STACKED backend IC
+    # -> _ic_backend set -> routes to the C-STM / diffrax-torchdiffeq path); we never
+    # reinvent orbit integration here. Axisymmetric potentials only for the angle-fit
+    # (the non-axisymmetric branch is numpy-only, # pragma: no cover below).
+
+    def _parse_args_backend(self, freqsAngles, _firstFlip, *args):
+        """Backend counterpart of _parse_args for the float/array IC case: build,
+        integrate, and assemble the (no, ntJ) phase-space arrays as backend arrays."""
+        from ..orbit import Orbit
+
+        if len(args) == 6:
+            R, vR, vT, z, vz, phi = args
+        else:  # len == 4: planar (z=vz=0)
+            R, vR, vT, phi = args
+            z, vz = 0.0 * R, 0.0 * vR
+        xp = get_namespace(R, vR, vT, z, vz, phi)
+        R = xp.atleast_1d(R)
+        vR, vT = xp.atleast_1d(vR), xp.atleast_1d(vT)
+        z, vz, phi = xp.atleast_1d(z), xp.atleast_1d(vz), xp.atleast_1d(phi)
+        no = R.shape[0]
+
+        def _integ(ic_list):
+            # ic_list: list (len no) of stacked 1-D backend IC vectors. Integrate
+            # each forward over self._tsJ with the object's integrate_method (a
+            # C-dxdv method by default -> differentiable C-STM path) and stack the
+            # (nt, phasedim) trajectories into (no, nt, phasedim).
+            os = []
+            for ic in ic_list:
+                o = Orbit(ic)
+                o.integrate(
+                    self._tsJ,
+                    pot=self._pot,
+                    method=self._integrate_method,
+                    dt=self._integrate_dt,
+                )
+                os.append(o)
+            return os
+
+        # Forward integration: ICs are (R,vR,vT,z,vz,phi); stack each orbit's six
+        # coordinates into a 1-D backend vector so Orbit captures _ic_backend.
+        fwd_ics = [
+            xp.stack([R[ii], vR[ii], vT[ii], z[ii], vz[ii], phi[ii]])
+            for ii in range(no)
+        ]
+        os = _integ(fwd_ics)
+        orbs = xp.stack([o.getOrbit() for o in os], axis=0)  # (no, nt, 6)
+        oR, ovR, ovT = orbs[:, :, 0], orbs[:, :, 1], orbs[:, :, 2]
+        oz, ovz, ophi = orbs[:, :, 3], orbs[:, :, 4], orbs[:, :, 5]
+        nt = oR.shape[1]
+        if not freqsAngles:
+            return (oR, ovR, ovT, oz, ovz, ophi)
+        # Also integrate backward in time (the requested point should not sit at
+        # the edge), mirroring the numpy branch: flip the velocities, integrate
+        # forward, then reverse and re-flip the velocities, and prepend.
+        bwd_ics = [
+            xp.stack([R[ii], -vR[ii], -vT[ii], z[ii], -vz[ii], phi[ii]])
+            for ii in range(no)
+        ]
+        bos = _integ(bwd_ics)
+        ts = self._tsJ
+
+        def _bstack(accessor, sign=1.0):
+            # stack the backward orbits' accessor(ts[1:]), drop t=0, reverse along
+            # time (xp.flip -- array-api-compat torch rejects [::-1] negative step)
+            return sign * xp.flip(
+                xp.stack([accessor(bo)(ts[1:]) for bo in bos], axis=0), axis=1
+            )
+
+        bR = _bstack(lambda bo: bo.R)
+        bvR = _bstack(lambda bo: bo.vR, -1.0)
+        bvT = _bstack(lambda bo: bo.vT, -1.0)
+        bz = _bstack(lambda bo: bo.z)
+        bvz = _bstack(lambda bo: bo.vz, -1.0)
+        bphi = _bstack(lambda bo: bo.phi)
+        # full (no, 2*nt-1): [backward (reversed) | forward]
+        pR = xp.concatenate([bR, oR], axis=1)
+        pvR = xp.concatenate([bvR, ovR], axis=1)
+        pvT = xp.concatenate([bvT, ovT], axis=1)
+        pz = xp.concatenate([bz, oz], axis=1)
+        pvz = xp.concatenate([bvz, ovz], axis=1)
+        pphi = xp.concatenate([bphi, ophi], axis=1)
+        return (pR, pvR, pvT, pz, pvz, pphi)
+
+    def _evaluate_backend(self, R, vR, vT, z, vz, phi, **kwargs):
+        """Backend counterpart of the _evaluate angle-averaged action estimate."""
+        xp = get_namespace(R, vR, vT, z, vz, phi)
+        acfs = self._aAI._actionsFreqsAngles(
+            R.reshape(-1),
+            vR.reshape(-1),
+            vT.reshape(-1),
+            z.reshape(-1),
+            vz.reshape(-1),
+            phi.reshape(-1),
+        )
+        jrI = xp.reshape(acfs[0], R.shape)[:, :-1]
+        jzI = xp.reshape(acfs[2], R.shape)[:, :-1]
+        anglerI = xp.reshape(acfs[6], R.shape)
+        anglezI = xp.reshape(acfs[8], R.shape)
+        danglerI = _backend_dangle(xp, anglerI)
+        danglezI = _backend_dangle(xp, anglezI)
+        if kwargs.get("cumul", False):
+            sumFunc = xp.cumsum
+        else:
+
+            def sumFunc(a, axis):
+                return xp.sum(a, axis=axis)
+
+        jr = sumFunc(jrI * danglerI, axis=1) / sumFunc(danglerI, axis=1)
+        jz = sumFunc(jzI * danglezI, axis=1) / sumFunc(danglezI, axis=1)
+        if _isNonAxi(self._pot):  # pragma: no cover
+            lzI = xp.reshape(acfs[1], R.shape)[:, :-1]
+            anglephiI = xp.reshape(acfs[7], R.shape)
+            danglephiI = _backend_dangle(xp, anglephiI)
+            lz = sumFunc(lzI * danglephiI, axis=1) / sumFunc(danglephiI, axis=1)
+        else:
+            lz = R[:, 0] * vT[:, 0]
+        return (jr, lz, jz)
+
+    def _actionsFreqsAngles_backend(self, R, vR, vT, z, vz, phi, ts, maxn, **kwargs):
+        """Backend counterpart of _actionsFreqsAngles (actions via angle-averaging,
+        frequencies and angles via the linear angle-fit Y=AX). Axisymmetric only."""
+        xp = get_namespace(R, vR, vT, z, vz, phi)
+        # ts is the (2*ntintJ-1) symmetric time grid (numpy from self._tsJ); move
+        # it onto the input backend for the angle-fit design matrix column A[..,1].
+        if not is_backend_array(ts):
+            ts = xp.asarray(numpy.asarray(ts, dtype=float))
+        acfs = self._aAI._actionsFreqsAngles(
+            R.reshape(-1),
+            vR.reshape(-1),
+            vT.reshape(-1),
+            z.reshape(-1),
+            vz.reshape(-1),
+            phi.reshape(-1),
+        )
+        jrI = xp.reshape(acfs[0], R.shape)[:, :-1]
+        jzI = xp.reshape(acfs[2], R.shape)[:, :-1]
+        anglerI = xp.reshape(acfs[6], R.shape)
+        anglezI = xp.reshape(acfs[8], R.shape)
+        danglerI = _backend_dangle(xp, anglerI)
+        danglezI = _backend_dangle(xp, anglezI)
+        jr = xp.sum(jrI * danglerI, axis=1) / xp.sum(danglerI, axis=1)
+        jz = xp.sum(jzI * danglezI, axis=1) / xp.sum(danglezI, axis=1)
+        if _isNonAxi(self._pot):  # pragma: no cover
+            lzI = xp.reshape(acfs[1], R.shape)[:, :-1]
+            anglephiI = xp.reshape(acfs[7], R.shape)
+            danglephiI = _backend_dangle(xp, anglephiI)
+            lz = xp.sum(lzI * danglephiI, axis=1) / xp.sum(danglephiI, axis=1)
+        else:
+            mid = ts.shape[0] // 2
+            lz = R[:, mid] * vT[:, mid]
+        # angle-fit (axisymmetric): build A and solve the per-orbit least squares
+        angleRT = _backend_dePeriod(xp, xp.reshape(acfs[6], R.shape))
+        acfs7 = xp.reshape(acfs[7], R.shape)
+        # anglephi is decreasing for retrograde orbits -> fit 2pi-anglephi instead
+        med = _backend_median(xp, acfs7 - _backend_roll1(xp, acfs7), axis=1)
+        negFreqIndx = med < 0.0
+        anglephiT = xp.where(
+            negFreqIndx[:, None],
+            _backend_dePeriod(xp, _TWOPI - acfs7),
+            _backend_dePeriod(xp, acfs7),
+        )
+        angleZT = _backend_dePeriod(xp, xp.reshape(acfs[8], R.shape))
+        nt = ts.shape[0]
+        no = R.shape[0]
+        if _isNonAxi(self._pot):  # pragma: no cover
+            nn = (2 * maxn - 1) ** 2 * maxn - (maxn - 1) * (2 * maxn - 1) - maxn
+        else:
+            nn = maxn * (2 * maxn - 1) - maxn
+        # The integer (n_R, n_Z) grid is data-independent (pure python/numpy);
+        # build it with numpy then move onto the backend (anchored on R's device).
+        phig = list(numpy.arange(-maxn + 1, maxn, 1))
+        phig.sort(key=lambda x: abs(x))
+        phig = numpy.array(phig, dtype="int")
+        grid = numpy.meshgrid(numpy.arange(maxn), phig)
+        gridR = grid[0].T.flatten()[1:]  # remove 0,0,0
+        gridZ = grid[1].T.flatten()[1:]
+        mask = numpy.ones(len(gridR), dtype=bool)
+        mask[: 2 * maxn - 3 : 2] = False
+        gridR = gridR[mask]
+        gridZ = gridZ[mask]
+        gR = xp.asarray(numpy.asarray(gridR, dtype=float))
+        gZ = xp.asarray(numpy.asarray(gridZ, dtype=float))
+        # A: (no, nt, 2+nn). A[...,0]=1, A[...,1]=ts, A[...,2:]=sin(nR aR + nZ aZ)
+        ones = xp.ones((no, nt), dtype=angleRT.dtype)
+        tcol = xp.broadcast_to(ts[None, :], (no, nt))
+        # (no, nt, nn) = sin(gR*angleRT + gZ*angleZT), broadcast over the n-grid
+        sinnR = xp.sin(
+            gR[None, None, :] * angleRT[:, :, None]
+            + gZ[None, None, :] * angleZT[:, :, None]
+        )
+        A = xp.concatenate([ones[:, :, None], tcol[:, :, None], sinnR], axis=2)
+        ATt = xp.permute_dims(A, (0, 2, 1))  # (no, 2+nn, nt)
+        atainv = xp.linalg.inv(xp.matmul(ATt, A))  # (no, 2+nn, 2+nn)
+        # ATA{R,T,Z} = sum_t A^T * angle  -> (no, 2+nn)
+        ATAR = xp.sum(ATt * angleRT[:, None, :], axis=2)
+        ATAT = xp.sum(ATt * anglephiT[:, None, :], axis=2)
+        ATAZ = xp.sum(ATt * angleZT[:, None, :], axis=2)
+        angleR = xp.sum(atainv[:, 0, :] * ATAR, axis=1)
+        OmegaR = xp.sum(atainv[:, 1, :] * ATAR, axis=1)
+        anglephi = xp.sum(atainv[:, 0, :] * ATAT, axis=1)
+        Omegaphi = xp.sum(atainv[:, 1, :] * ATAT, axis=1)
+        angleZ = xp.sum(atainv[:, 0, :] * ATAZ, axis=1)
+        OmegaZ = xp.sum(atainv[:, 1, :] * ATAZ, axis=1)
+        Omegaphi = xp.where(negFreqIndx, -Omegaphi, Omegaphi)
+        anglephi = xp.where(negFreqIndx, _TWOPI - anglephi, anglephi)
+        return (
+            jr,
+            lz,
+            jz,
+            OmegaR,
+            Omegaphi,
+            OmegaZ,
+            angleR % _TWOPI,
+            anglephi % _TWOPI,
+            angleZ % _TWOPI,
+        )
+
+
+def _backend_roll1(xp, arr):
+    """xp equivalent of numpy.roll(arr, 1, axis=1): last column wraps to front."""
+    return xp.concatenate([arr[:, -1:], arr[:, :-1]], axis=1)
+
+
+def _backend_rollm1(xp, arr):
+    """xp equivalent of numpy.roll(arr, -1, axis=1): first column wraps to back."""
+    return xp.concatenate([arr[:, 1:], arr[:, :1]], axis=1)
+
+
+def _backend_dangle(xp, angle):
+    """((roll(angle,-1) - angle) % 2pi)[:, :-1] -- the per-step angle increment."""
+    return ((_backend_rollm1(xp, angle) - angle) % _TWOPI)[:, :-1]
+
+
+def _backend_median(xp, arr, axis=1):
+    """numpy.median over axis=1 (mean of the two central order statistics for
+    even length), portable across numpy/jax/torch (xp.median's torch variant
+    returns a namedtuple and the lower median, so it is not used directly).
+    Only the axis=1 case is needed here (the per-orbit anglephi-step sign)."""
+    s = xp.sort(arr, axis=axis)
+    n = arr.shape[axis]
+    return 0.5 * (s[:, (n - 1) // 2] + s[:, n // 2])
+
+
+def _backend_dePeriod(xp, arr):
+    """Backend dePeriod: make periodic angles increase linearly (axis=1)."""
+    diff = arr - _backend_roll1(xp, arr)
+    w = diff < -6.0
+    addto = xp.cumsum(xp.astype(w, arr.dtype), axis=1)
+    return arr + _TWOPI * addto
 
 
 # coerce_backend=False: numpy-only body (isinstance/numpy.array/amin/median/amax)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1262,3 +1262,52 @@ def test_isochroneapprox_grad_vs_fd_wrt_vR(backend, which, idx):
     g = _grad(backend, f_be, 0.2)
     assert numpy.isfinite(g)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
+
+
+# Non-axisymmetric IsochroneApprox: the same orbit-integrate-and-angle-average
+# machinery, but for a potential with _isNonAxi(pot)=True. Two extra backend
+# branches fire that the axisymmetric tests never reach: (1) Lz is itself
+# angle-averaged (danglephi-weighted), not L_z(t0); and (2) the angle-fit design
+# matrix uses the 3-D (n_R, n_phi, n_Z) Fourier grid (with the half-space mask)
+# and an n_phi*anglephi term inside sin(n.angle). A mildly triaxial
+# LogarithmicHaloPotential (b=0.9 in y, q=0.8 in z) keeps the orbits bound and
+# the isochrone approximation applicable; the retrograde orbit additionally
+# exercises the negFreqIndx (2pi-anglephi / -Omegaphi) branch under non-axi.
+_NA_POT = LogarithmicHaloPotential(normalize=1.0, b=0.9, q=0.8)
+_NA_R = numpy.array([1.1, 0.9])
+_NA_VR = numpy.array([0.1, -0.05])
+_NA_VT = numpy.array([0.9, -0.8])  # second orbit retrograde -> negFreqIndx
+_NA_Z = numpy.array([0.05, 0.1])
+_NA_VZ = numpy.array([0.1, -0.07])
+_NA_PHI = numpy.array([1.3, 0.5])
+_NA = (_NA_R, _NA_VR, _NA_VT, _NA_Z, _NA_VZ, _NA_PHI)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochroneapprox_nonaxi_parity(backend):
+    # numpy <-> jax <-> torch parity for a NON-axisymmetric potential. Exercises
+    # the angle-averaged Lz (_evaluate index 1) and the 3-D-grid angle-fit
+    # (anglephi, index 7) backend branches, plus the retrograde negFreqIndx
+    # branch under non-axi. b is EXPLICIT (no estimateBIsochrone).
+    aAIA = actionAngleIsochroneApprox(pot=_NA_POT, b=0.8, tintJ=20.0, ntintJ=2000)
+    bargs = [_arr(backend, v) for v in _NA]
+    # _evaluate: (jr, lz, jz) -- lz is danglephi-weighted angle average here
+    ref = aAIA._evaluate(*_NA)
+    got = aAIA._evaluate(*bargs)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+    # _actionsFreqsAngles: (jr,lz,jz,Or,Op,Oz,ar,aphi,az) -- non-axi angle-fit
+    ref = aAIA._actionsFreqsAngles(*_NA)
+    got = aAIA._actionsFreqsAngles(*bargs)
+    for idx, (r, g) in enumerate(zip(ref, got)):
+        assert _is_backend_array(backend, g)
+        if idx >= 6:  # angles (incl. anglephi at idx 7): wrap-robust
+            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
+        else:
+            numpy.testing.assert_allclose(
+                _np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+            )
+    # the retrograde (second) orbit must give a negative azimuthal frequency
+    assert float(_np(got[4]).ravel()[1]) < 0.0

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -40,6 +40,7 @@ from galpy.actionAngle import (
     actionAngleHarmonic,
     actionAngleHarmonicInverse,
     actionAngleIsochrone,
+    actionAngleIsochroneApprox,
     actionAngleIsochroneInverse,
     actionAngleSpherical,
     actionAngleStaeckel,
@@ -1111,3 +1112,153 @@ def test_staeckel_angles_numpy_phi(backend):
     for i in (6, 7, 8):  # angler, anglephi, anglez
         assert _is_backend_array(backend, got[i])
         assert numpy.max(_wrapdiff(_np(got[i]), numpy.asarray(ref[i]))) < 1e-8
+
+
+# ====================================================================
+# actionAngleIsochroneApprox: the Bovy (2014) isochrone-approximation actions,
+# frequencies, and angles. Unlike every class above (closed-form / quadrature on
+# the INPUT phase-space point), this method INTEGRATES an orbit and angle-averages
+# the isochrone actions over it. The backend path therefore reuses TWO already-
+# migrated pieces: (1) Orbit(stacked-backend-IC).integrate(...) routes to the
+# in-backend differentiable integrator (Track D: C-STM for dopr54_c, else
+# diffrax/torchdiffeq), and (2) self._aAI._actionsFreqsAngles runs the isochrone
+# action/angle map on the integrated backend trajectory. The numpy per-object loop
+# is byte-identical (the diff is purely additive is_backend_array early-returns);
+# jax/torch ICs take the vectorised _parse_args_backend / *_backend branches.
+# Validates: numpy<->jax<->torch value parity for _evaluate (actions),
+# _actionsFreqs (+freqs), _actionsFreqsAngles (+angles), on a small bound 3D
+# MWPotential2014 grid with an EXPLICIT b (so the test does NOT depend on
+# estimateBIsochrone, migrated separately); that outputs are backend arrays; and
+# grad-vs-finite-difference of an action w.r.t. an IC under jax -- differentiating
+# THROUGH the orbit integration (orbit-STM), which is the point of the port.
+#
+# tintJ/ntintJ are reduced from the defaults (100/10000) to keep each integration
+# fast; the angle-fit still covers the full radial/vertical angle range for these
+# bound MWPotential2014 orbits. b is EXPLICIT (0.8 / 1.2); estimateBIsochrone is
+# never called. Parity tolerance ~1e-8: the in-backend integrator's trajectory
+# differs from the numpy C integrator at the ~1e-8 step level for fixed-step
+# methods (dop853_c is ~1e-12), and the angle-averaged actions inherit that.
+_IA_R = numpy.array([1.1, 0.8, 1.2])
+_IA_VR = numpy.array([0.1, -0.1, 0.05])
+_IA_VT = numpy.array([0.9, 1.0, -0.7])  # incl. a retrograde orbit (negFreqIndx)
+_IA_Z = numpy.array([0.05, -0.1, 0.1])
+_IA_VZ = numpy.array([0.1, 0.05, -0.08])
+_IA_PHI = numpy.array([1.3, 0.4, 2.0])
+_IA = (_IA_R, _IA_VR, _IA_VT, _IA_Z, _IA_VZ, _IA_PHI)
+
+
+def _aAIA(b):
+    # Explicit b (no estimateBIsochrone); short integration for test speed.
+    return actionAngleIsochroneApprox(pot=MWPotential2014, b=b, tintJ=20.0, ntintJ=2000)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("b", [0.8, 1.2])
+def test_isochroneapprox_parity(backend, b):
+    # numpy <-> jax <-> torch parity of _evaluate (jr,lz,jz), _actionsFreqs
+    # (+Or,Op,Oz), and _actionsFreqsAngles (+ar,ap,az) on a bound 3D grid (one
+    # retrograde orbit). Actions/freqs to ~1e-8 (the in-backend-vs-C integrator
+    # floor); angles compared as wrap-robust circular differences.
+    aAIA = _aAIA(b)
+    bargs = [_arr(backend, v) for v in _IA]
+    # _evaluate: (jr, lz, jz)
+    ref = aAIA._evaluate(*_IA)
+    got = aAIA._evaluate(*bargs)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+    # _actionsFreqs: (jr,lz,jz,Or,Op,Oz)
+    ref = aAIA._actionsFreqs(*_IA)
+    got = aAIA._actionsFreqs(*bargs)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+    # _actionsFreqsAngles: (...,ar,ap,az)
+    ref = aAIA._actionsFreqsAngles(*_IA)
+    got = aAIA._actionsFreqsAngles(*bargs)
+    for idx, (r, g) in enumerate(zip(ref, got)):
+        assert _is_backend_array(backend, g)
+        if idx >= 6:  # angles: wrap-robust
+            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
+        else:
+            numpy.testing.assert_allclose(
+                _np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochroneapprox_scalar_parity(backend):
+    # a single (scalar-array) IC: _parse_args promotes it to a 1-element batch, so
+    # the backend path's atleast_1d / per-orbit stack-and-integrate handles the
+    # batch-of-one. Exercises the scalar-vs-batch handling separately from the grid.
+    aAIA = _aAIA(0.8)
+    s = (1.1, 0.2, 0.9, 0.15, 0.1, 1.3)
+    ref = aAIA._evaluate(*[numpy.atleast_1d(numpy.asarray(v)) for v in s])
+    got = aAIA._evaluate(
+        *[_arr(backend, numpy.atleast_1d(numpy.asarray(v))) for v in s]
+    )
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochroneapprox_cumul_parity(backend):
+    # cumul=True returns the CUMULATIVE angle-averaged actions (convergence trace),
+    # shape (no, nt-1) rather than (no,). numpy <-> backend parity of the trace.
+    aAIA = _aAIA(0.8)
+    bargs = [_arr(backend, v) for v in _IA]
+    ref = aAIA._evaluate(*_IA, cumul=True)
+    got = aAIA._evaluate(*bargs, cumul=True)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_isochroneapprox_planar_parity(backend):
+    # 4-argument (planar) call signature R,vR,vT,phi (z=vz=0): the backend
+    # _parse_args branch builds the z=vz=0 ICs. Jz is ~0; numpy<->backend parity.
+    aAIA = _aAIA(0.8)
+    planar = (_IA_R, _IA_VR, _IA_VT, _IA_PHI)
+    ref = aAIA._evaluate(*planar)
+    got = aAIA._evaluate(*[_arr(backend, v) for v in planar])
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("which,idx", [("jr", 0), ("jz", 2)])
+def test_isochroneapprox_grad_vs_fd_wrt_vR(backend, which, idx):
+    # d(action[idx]) / d vR at a single bound point, AD vs finite-difference --
+    # differentiating THROUGH the orbit integration (the orbit-STM / in-backend
+    # ODE) and the angle-averaging. This is the whole point of the port: gradients
+    # of the isochrone-approximation actions w.r.t. the initial condition.
+    aAIA = _aAIA(0.8)
+    R, _, vT, z, vz, phi = (1.1, 0.2, 0.9, 0.15, 0.1, 1.3)
+
+    def call(vR_arr, xp_arr):
+        args = (xp_arr(R), vR_arr, xp_arr(vT), xp_arr(z), xp_arr(vz), xp_arr(phi))
+        return aAIA._evaluate(*args)[idx][0]  # scalar action
+
+    def f_np(vR_val):
+        return numpy.asarray(
+            call(
+                numpy.atleast_1d(numpy.asarray(vR_val, dtype=float)),
+                lambda v: numpy.atleast_1d(numpy.asarray(v, dtype=float)),
+            )
+        )
+
+    fd = _fd(f_np, 0.2)
+
+    def f_be(vR_t):
+        return call(
+            (jnp.atleast_1d(vR_t) if backend == "jax" else torch.atleast_1d(vR_t)),
+            lambda v: _arr(backend, numpy.atleast_1d(numpy.asarray(v, dtype=float))),
+        )
+
+    g = _grad(backend, f_be, 0.2)
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
Backend-migrates `actionAngleIsochroneApprox` — the orbit-path action-angle method (no interpolation), differentiable **through the orbit integration**.

**Approach** — purely additive (`is_backend_array` early-returns; **268 insertions, 0 deletions** → numpy byte-identical; 17 numpy tests green). The backend path:
- builds each `Orbit` from an `xp.stack`'d **1-D backend IC vector** (a *list of 0-d scalars* is silently coerced to numpy → not differentiable — a sharp edge the prereq check caught);
- integrates via the **in-backend differentiable integrator** (`dopr54_c` / C-STM), reusing it (not reinventing);
- runs the already-migrated `actionAngleIsochrone` on the backend trajectory and angle-averages with `xp` ops (linear sin-design angle fit for the axisymmetric branch; retrograde sign flips via `xp.where`).
- torch portability: `xp.flip` for `[::-1]`, concatenate-based roll, `permute_dims`, sort-based numpy-convention median.

**Validation** — numpy↔jax↔torch parity ~1.7e-11 (actions/freqs/angles); **grad-vs-FD of an action w.r.t. an IC, flowing through the orbit integration, ~3e-10** under jax *and* torch (the orbit-STM differentiability that is the whole point). 14 new tests (parity, scalar/batch, retrograde, planar 4-arg, cumul, grad). Independently adversarially verified: numpy path unchanged, verdict **solid**.

**Notes** — `estimateBIsochrone` (the `b=None` auto-estimate) is not exercised here (tests pass explicit `b`; it's migrated in #1019). Non-axisymmetric angle-fit + `c=True` paths stay numpy-only (`# pragma: no cover`, mirroring numpy). ⚠ *Perf*: the in-backend integrator is single-orbit, so the backend path integrates one `Orbit` per IC in a Python loop — correct + differentiable but not a batched solve; a future batched in-backend integrator would speed large batches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)