### PR TITLE
actionAngle{Staeckel,Adiabatic}Grid: jax/torch backend eval (Track E grid family)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -14,6 +14,9 @@ import numpy
 from scipy import interpolate
 
 from .. import potential
+from ..backend import get_namespace
+from ..backend import interpolate as backend_interpolate
+from ..backend import is_backend_array
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -26,7 +29,11 @@ _PRINTOUTSIDEGRID = False
 
 
 class actionAngleAdiabaticGrid(actionAngle):
-    """Action-angle formalism for axisymmetric potentials using the adiabatic approximation, grid-based interpolation"""
+    """Action-angle formalism for axisymmetric potentials using the adiabatic approximation, grid-based interpolation
+
+    jax/torch input is supported and differentiable, but evaluates the
+    interpolation grid only (no off-grid fallback): inputs must lie within the
+    grid, whereas the numpy path falls back to a per-point solve off-grid."""
 
     def __init__(
         self,
@@ -274,8 +281,33 @@ class actionAngleAdiabaticGrid(actionAngle):
         self._jrInterp = interpolate.RectBivariateSpline(
             self._Lzs, y, jr, kx=3, ky=3, s=0.0
         )
+        # Backend-agnostic eval wrappers from the SAME fitted scipy objects
+        # (numpy path is byte-identical -- the wrappers delegate to scipy).
+        self._build_backend_interp(jzEzzmax, jrERRa)
         # Check the units
         self._check_consistent_units()
+        return None
+
+    def _build_backend_interp(self, jzEzzmax, jrERRa):
+        """Wrap the fitted scipy interpolators for jax/torch evaluation."""
+        self._jzInterp_b = backend_interpolate.Spline2D(spl=self._jzInterp)
+        self._jrInterp_b = backend_interpolate.Spline2D(spl=self._jrInterp)
+        self._EzZmaxsInterp_b = backend_interpolate.Spline1D(
+            self._Rs, numpy.log(self._EzZmaxs), k=3
+        )
+        self._jzEzmaxInterp_b = backend_interpolate.Spline1D(
+            self._Rs, numpy.log(jzEzzmax + 10.0**-5.0), k=3
+        )
+        self._RLInterp_b = backend_interpolate.Spline1D(self._Lzs, self._RL, k=3)
+        self._ERRLInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(-(self._ERRL - self._ERRLmax)), k=3
+        )
+        self._ERRaInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(-(self._ERRa - self._ERRamax)), k=3
+        )
+        self._jrERRaInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(jrERRa + 10.0**-5.0), k=3
+        )
         return None
 
     def _evaluate(self, *args, **kwargs):
@@ -313,6 +345,8 @@ class actionAngleAdiabaticGrid(actionAngle):
             vT = self._eval_vT
             z = self._eval_z
             vz = self._eval_vz
+        if is_backend_array(R):  # jax/torch: vectorised, differentiable grid eval
+            return self._evaluate_backend(R, vR, vT, z, vz)
         # First work on the vertical action
         Phi = _evaluatePotentials(self._pot, R, z)
         try:
@@ -454,6 +488,35 @@ class actionAngleAdiabaticGrid(actionAngle):
                     self._jrInterp(ERLz, (ER - thisERRa) / (thisERRL - thisERRa))
                     * (numpy.exp(self._jrERRaInterp(ERLz)) - 10.0**-5.0)
                 )[0][0]
+        return (jr, R * vT, jz)
+
+    def _evaluate_backend(self, R, vR, vT, z, vz):
+        """Vectorised, differentiable on-grid action eval for jax/torch inputs.
+
+        Assumes on-grid inputs (the off-grid fallback to self._aA is numpy-only).
+        """
+        xp = get_namespace(R)
+        zero = xp.zeros_like(R)
+        # Vertical action
+        Phi = _evaluatePotentials(self._pot, R, z)
+        Phio = _evaluatePotentials(self._pot, R, zero)
+        Ez = Phi - Phio + vz**2.0 / 2.0
+        thisEzZmax = xp.exp(self._EzZmaxsInterp_b(R))
+        jz = self._jzInterp_b(R, Ez / thisEzZmax, grid=False) * (
+            xp.exp(self._jzEzmaxInterp_b(R)) - 10.0**-5.0
+        )
+        # Radial action
+        ERLz = xp.abs(R * vT) + self._gamma * jz
+        ER = Phio + vR**2.0 / 2.0 + ERLz**2.0 / 2.0 / R**2.0
+        thisERRL = -xp.exp(self._ERRLInterp_b(ERLz)) + self._ERRLmax
+        thisERRa = -xp.exp(self._ERRaInterp_b(ERLz)) + self._ERRamax
+        frac = (ER - thisERRa) / (thisERRL - thisERRa)
+        # Snap the two near-boundary cases (mirrors the numpy ER[indx]= writes).
+        ER = xp.where((frac > 1.0) & ((frac - 1.0) < 10.0**-2.0), thisERRL, ER)
+        ER = xp.where((frac < 0.0) & (frac > -(10.0**-2.0)), thisERRa, ER)
+        jr = self._jrInterp_b(
+            ERLz, (ER - thisERRa) / (thisERRL - thisERRa), grid=False
+        ) * (xp.exp(self._jrERRaInterp_b(ERLz)) - 10.0**-5.0)
         return (jr, R * vT, jz)
 
     def Jz(self, *args, **kwargs):

--- a/galpy/actionAngle/actionAngleStaeckelGrid.py
+++ b/galpy/actionAngle/actionAngleStaeckelGrid.py
@@ -14,6 +14,9 @@ import numpy
 from scipy import interpolate, ndimage, optimize
 
 from .. import potential
+from ..backend import get_namespace
+from ..backend import interpolate as backend_interpolate
+from ..backend import is_backend_array
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -27,7 +30,11 @@ _PRINTOUTSIDEGRID = False
 
 
 class actionAngleStaeckelGrid(actionAngle):
-    """Action-angle formalism for axisymmetric potentials using Binney (2012)'s Staeckel approximation, grid-based interpolation"""
+    """Action-angle formalism for axisymmetric potentials using Binney (2012)'s Staeckel approximation, grid-based interpolation
+
+    jax/torch input is supported and differentiable, but evaluates the
+    interpolation grid only (no off-grid fallback): inputs must lie within the
+    grid, whereas the numpy path falls back to a per-point solve off-grid."""
 
     def __init__(
         self,
@@ -324,8 +331,60 @@ class actionAngleStaeckelGrid(actionAngle):
             self._rapFiltered = ndimage.spline_filter(
                 numpy.log(self._rap + 10.0**-10.0), order=3
             )
+        # Backend-agnostic eval wrappers built from the SAME fitted scipy
+        # objects/filtered grids (numpy path stays byte-identical scipy).
+        self._build_backend_interp(y, interpecc)
         # Check the units
         self._check_consistent_units()
+        return None
+
+    def _build_backend_interp(self, y, interpecc):
+        """Wrap the fitted scipy interpolators for jax/torch evaluation (numpy
+        path is byte-identical -- the wrappers delegate to scipy on numpy input).
+        """
+        self._logu0Interp_b = backend_interpolate.Spline2D(spl=self._logu0Interp)
+        self._jrLzInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(self._jrLzE + 10.0**-5.0), k=3
+        )
+        self._jzLzInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(self._jzLzE + 10.0**-5.0), k=3
+        )
+        self._ERLInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(-(self._ERL - self._ERLmax)), k=3
+        )
+        self._ERaInterp_b = backend_interpolate.Spline1D(
+            self._Lzs, numpy.log(-(self._ERa - self._ERamax)), k=3
+        )
+        # The filtered grids feed the backend cubic map_coordinates (mode/order
+        # matching the scipy calls in _evaluate/_EccZmaxRperiRap).
+        self._jrMap_b = backend_interpolate.MapCoordinates(
+            numpy.log(self._jr + 10.0**-10.0)
+        )
+        self._jzMap_b = backend_interpolate.MapCoordinates(
+            numpy.log(self._jz + 10.0**-10.0)
+        )
+        if interpecc:
+            self._zmaxLzInterp_b = backend_interpolate.Spline1D(
+                self._Lzs, numpy.log(self._zmaxLzE + 10.0**-5.0), k=3
+            )
+            self._rperiLzInterp_b = backend_interpolate.Spline1D(
+                self._Lzs, numpy.log(self._rperiLzE + 10.0**-5.0), k=3
+            )
+            self._rapLzInterp_b = backend_interpolate.Spline1D(
+                self._Lzs, numpy.log(self._rapLzE + 10.0**-5.0), k=3
+            )
+            self._eccMap_b = backend_interpolate.MapCoordinates(
+                numpy.log(self._ecc + 10.0**-10.0)
+            )
+            self._zmaxMap_b = backend_interpolate.MapCoordinates(
+                numpy.log(self._zmax + 10.0**-10.0)
+            )
+            self._rperiMap_b = backend_interpolate.MapCoordinates(
+                numpy.log(self._rperi + 10.0**-10.0)
+            )
+            self._rapMap_b = backend_interpolate.MapCoordinates(
+                numpy.log(self._rap + 10.0**-10.0)
+            )
         return None
 
     def _evaluate(self, *args, **kwargs):
@@ -363,6 +422,8 @@ class actionAngleStaeckelGrid(actionAngle):
             vT = self._eval_vT
             z = self._eval_z
             vz = self._eval_vz
+        if is_backend_array(R):  # jax/torch: vectorised, differentiable grid eval
+            return self._evaluate_backend(R, vR, vT, z, vz)
         Lz = R * vT
         Phi = _evaluatePotentials(self._pot, R, z)
         E = Phi + vR**2.0 / 2.0 + vT**2.0 / 2.0 + vz**2.0 / 2.0
@@ -601,6 +662,8 @@ class actionAngleStaeckelGrid(actionAngle):
             vT = self._eval_vT
             z = self._eval_z
             vz = self._eval_vz
+        if is_backend_array(R):  # jax/torch: vectorised, differentiable grid eval
+            return self._EccZmaxRperiRap_backend(R, vR, vT, z, vz)
         Lz = R * vT
         Phi = _evaluatePotentials(self._pot, R, z)
         E = Phi + vR**2.0 / 2.0 + vT**2.0 / 2.0 + vz**2.0 / 2.0
@@ -757,6 +820,76 @@ class actionAngleStaeckelGrid(actionAngle):
         rap[rap < 0.0] = 0.0
         return (ecc, zmax, rperi, rap)
 
+    def _grid_common_backend(self, xp, R, vR, vT, z, vz):
+        """Shared backend coordinate/energy/u0/psi math for the grid lookups.
+
+        Assumes on-grid inputs (off-grid fallback to self._aA is numpy-only);
+        clamps are xp.where guards for AD/round-off, not an off-grid dispatch.
+        Returns the map_coordinates query stacks (cos2psi- and sin2psi-based) and
+        the per-point Lz for the 1D maxima splines.
+        """
+        Lz = R * vT
+        Phi = _evaluatePotentials(self._pot, R, z)
+        E = Phi + vR**2.0 / 2.0 + vT**2.0 / 2.0 + vz**2.0 / 2.0
+        thisERL = -xp.exp(self._ERLInterp_b(Lz)) + self._ERLmax
+        thisERa = -xp.exp(self._ERaInterp_b(Lz)) + self._ERamax
+        frac = (E - thisERa) / (thisERL - thisERa)
+        # Snap the two near-boundary cases (mirrors the numpy E[indx]= writes).
+        E = xp.where((frac > 1.0) & ((frac - 1.0) < 10.0**-2.0), thisERL, E)
+        E = xp.where((frac < 0.0) & (frac > -(10.0**-2.0)), thisERa, E)
+        # u0 from the (Lz, y) RectBivariate table; y is the rescaled energy.
+        y = (_Efunc(E, thisERL) - _Efunc(thisERa, thisERL)) / (
+            _Efunc(thisERL, thisERL) - _Efunc(thisERa, thisERL)
+        )
+        u0 = xp.exp(self._logu0Interp_b(Lz, y, grid=False))
+        sinh2u0 = xp.sinh(u0) ** 2.0
+        thisEr = self.Er(R, z, vR, vz, E, Lz, sinh2u0, u0)
+        thisEz = self.Ez(R, z, vR, vz, E, Lz, sinh2u0, u0)
+        thisv2 = self.vatu0(E, Lz, u0, self._delta * xp.sinh(u0), retv2=True)
+        cos2psi = 2.0 * thisEr / thisv2 / (1.0 + sinh2u0)  # latter is cosh2u0
+        cos2psi = xp.clip(cos2psi, 0.0, 1.0)  # AD/round-off guard (numpy clamps too)
+        sin2psi = 2.0 * thisEz / thisv2 / (1.0 + sinh2u0)
+        sin2psi = xp.clip(sin2psi, 0.0, 1.0)
+        psi = xp.arccos(xp.sqrt(cos2psi))
+        psiz = xp.arcsin(xp.sqrt(sin2psi))
+        c0 = (Lz - self._Lzmin) / (self._Lzmax - self._Lzmin) * (self._nLz - 1.0)
+        c1 = y * (self._nE - 1.0)
+        coords_r = xp.stack([c0, c1, psi / numpy.pi * 2.0 * (self._npsi - 1.0)])
+        coords_z = xp.stack([c0, c1, psiz / numpy.pi * 2.0 * (self._npsi - 1.0)])
+        return Lz, coords_r, coords_z
+
+    def _evaluate_backend(self, R, vR, vT, z, vz):
+        xp = get_namespace(R)
+        Lz, coords_r, coords_z = self._grid_common_backend(xp, R, vR, vT, z, vz)
+        jr = (xp.exp(self._jrMap_b(coords_r)) - 10.0**-10.0) * (
+            xp.exp(self._jrLzInterp_b(Lz)) - 10.0**-5.0
+        )
+        jz = (xp.exp(self._jzMap_b(coords_z)) - 10.0**-10.0) * (
+            xp.exp(self._jzLzInterp_b(Lz)) - 10.0**-5.0
+        )
+        jr = xp.where(jr < 0.0, 0.0, jr)
+        jz = xp.where(jz < 0.0, 0.0, jz)
+        return (jr, Lz, jz)
+
+    def _EccZmaxRperiRap_backend(self, R, vR, vT, z, vz):
+        xp = get_namespace(R)
+        Lz, coords_r, coords_z = self._grid_common_backend(xp, R, vR, vT, z, vz)
+        ecc = xp.exp(self._eccMap_b(coords_r)) - 10.0**-10.0
+        rperi = (xp.exp(self._rperiMap_b(coords_r)) - 10.0**-10.0) * (
+            xp.exp(self._rperiLzInterp_b(Lz)) - 10.0**-5.0
+        )
+        zmax = (xp.exp(self._zmaxMap_b(coords_z)) - 10.0**-10.0) * (
+            xp.exp(self._zmaxLzInterp_b(Lz)) - 10.0**-5.0
+        )
+        rap = (xp.exp(self._rapMap_b(coords_z)) - 10.0**-10.0) * (
+            xp.exp(self._rapLzInterp_b(Lz)) - 10.0**-5.0
+        )
+        ecc = xp.where(ecc < 0.0, 0.0, ecc)
+        zmax = xp.where(zmax < 0.0, 0.0, zmax)
+        rperi = xp.where(rperi < 0.0, 0.0, rperi)
+        rap = xp.where(rap < 0.0, 0.0, rap)
+        return (ecc, zmax, rperi, rap)
+
     def vatu0(self, E, Lz, u0, R, retv2=False):
         """
         Calculate the velocity at u0.
@@ -783,6 +916,7 @@ class actionAngleStaeckelGrid(actionAngle):
         -----
         - 2012-11-29 - Written - Bovy (IAS).
         """
+        xp = get_namespace(E) if is_backend_array(E) else numpy
         v2 = (
             2.0
             * (
@@ -795,6 +929,8 @@ class actionAngleStaeckelGrid(actionAngle):
         )
         if retv2:
             return v2
+        if is_backend_array(v2):  # masked clip -> xp.where (no in-place write)
+            return xp.sqrt(xp.where((v2 < 0.0) & (v2 > -(10.0**-7.0)), 0.0, v2))
         v2[(v2 < 0.0) * (v2 > -(10.0**-7.0))] = 0.0
         return numpy.sqrt(v2)
 
@@ -853,8 +989,9 @@ class actionAngleStaeckelGrid(actionAngle):
         -----
         - 2012-11-29 - Written - Bovy (IAS).
         """
+        xp = get_namespace(R) if is_backend_array(R) else numpy
         u, v = coords.Rz_to_uv(R, z, self._delta)
-        pu = vR * numpy.cosh(u) * numpy.sin(v) + vz * numpy.sinh(u) * numpy.cos(
+        pu = vR * xp.cosh(u) * xp.sin(v) + vz * xp.sinh(u) * xp.cos(
             v
         )  # no delta, bc we will divide it out
         out = (
@@ -862,9 +999,9 @@ class actionAngleStaeckelGrid(actionAngle):
             + Lz**2.0
             / 2.0
             / self._delta**2.0
-            * (1.0 / numpy.sinh(u) ** 2.0 - 1.0 / sinh2u0)
-            - E * (numpy.sinh(u) ** 2.0 - sinh2u0)
-            + (numpy.sinh(u) ** 2.0 + 1.0)
+            * (1.0 / xp.sinh(u) ** 2.0 - 1.0 / sinh2u0)
+            - E * (xp.sinh(u) ** 2.0 - sinh2u0)
+            + (xp.sinh(u) ** 2.0 + 1.0)
             * actionAngleStaeckel.potentialStaeckel(
                 u, numpy.pi / 2.0, self._pot, self._delta
             )
@@ -909,19 +1046,20 @@ class actionAngleStaeckelGrid(actionAngle):
         -----
         - 2012-12-23 - Written - Bovy (IAS)
         """
+        xp = get_namespace(R) if is_backend_array(R) else numpy
         u, v = coords.Rz_to_uv(R, z, self._delta)
-        pv = vR * numpy.sinh(u) * numpy.cos(v) - vz * numpy.cosh(u) * numpy.sin(
+        pv = vR * xp.sinh(u) * xp.cos(v) - vz * xp.cosh(u) * xp.sin(
             v
         )  # no delta, bc we will divide it out
         out = (
             pv**2.0 / 2.0
-            + Lz**2.0 / 2.0 / self._delta**2.0 * (1.0 / numpy.sin(v) ** 2.0 - 1.0)
-            - E * (numpy.sin(v) ** 2.0 - 1.0)
+            + Lz**2.0 / 2.0 / self._delta**2.0 * (1.0 / xp.sin(v) ** 2.0 - 1.0)
+            - E * (xp.sin(v) ** 2.0 - 1.0)
             - (sinh2u0 + 1.0)
             * actionAngleStaeckel.potentialStaeckel(
                 u0, numpy.pi / 2.0, self._pot, self._delta
             )
-            + (sinh2u0 + numpy.sin(v) ** 2.0)
+            + (sinh2u0 + xp.sin(v) ** 2.0)
             * actionAngleStaeckel.potentialStaeckel(u0, v, self._pot, self._delta)
         )
         return out
@@ -939,7 +1077,8 @@ def _u0Eq(logu, delta, pot, E, Lz22):
 def _Efunc(E, *args):
     """Function to apply to the energy in building the grid (e.g., if this is a log, then the grid will be logarithmic"""
     #    return ((E-args[0]))**0.5
-    return numpy.log(E - args[0] + 10.0**-10.0)
+    xp = get_namespace(E) if is_backend_array(E) else numpy
+    return xp.log(E - args[0] + 10.0**-10.0)
 
 
 def _invEfunc(Ef, *args):

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -38,6 +38,7 @@ except ImportError:  # pragma: no cover
 
 from galpy.actionAngle import (
     actionAngleAdiabatic,
+    actionAngleAdiabaticGrid,
     actionAngleHarmonic,
     actionAngleHarmonicInverse,
     actionAngleIsochrone,
@@ -45,6 +46,7 @@ from galpy.actionAngle import (
     actionAngleIsochroneInverse,
     actionAngleSpherical,
     actionAngleStaeckel,
+    actionAngleStaeckelGrid,
     actionAngleVertical,
     estimateBIsochrone,
     estimateDeltaStaeckel,
@@ -1678,3 +1680,138 @@ def test_adiabatic_gamma0_ecczmaxrperirap_parity(backend):
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
         numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8)
+
+
+# ====================================================================
+# actionAngleStaeckelGrid / actionAngleAdiabaticGrid: GRID-INTERPOLATED actions.
+# The grid SETUP (scipy spline/RectBivariate fits + ndimage.spline_filter) stays
+# numpy-only and BYTE-IDENTICAL; only the EVALUATION (interpolation lookups +
+# the surrounding coordinate/energy/u0/psi math) gets an additive backend branch.
+# At __init__ the SAME fitted scipy objects / filtered grids are wrapped with the
+# galpy.backend.interpolate helpers (Spline1D / Spline2D / MapCoordinates -- the
+# latter cubic map_coordinates off a setup-time prefilter), so the numpy path is
+# a literal scipy passthrough and jax/torch inputs evaluate natively and
+# differentiably. ICs are chosen well inside the grid (the off-grid fallback to
+# self._aA is numpy-only), so the backend path is the pure on-grid interpolation.
+# Parity is at machine precision (~1e-13) because the wrappers reuse scipy's own
+# coefficients; grad-vs-FD validates the differentiability that is the point.
+_GRID_R = numpy.array([1.1, 0.8, 1.3])
+_GRID_VR = numpy.array([0.1, -0.2, 0.05])
+_GRID_VT = numpy.array([0.9, 0.6, 1.0])
+_GRID_Z = numpy.array([0.1, -0.15, 0.08])
+_GRID_VZ = numpy.array([0.08, 0.1, -0.05])
+_GRID = (_GRID_R, _GRID_VR, _GRID_VT, _GRID_Z, _GRID_VZ)
+
+# Built once (grid construction is the expensive part); small grids for speed.
+_aASG = actionAngleStaeckelGrid(
+    pot=MWPotential2014, delta=0.45, nE=15, npsi=15, nLz=18, interpecc=True
+)
+_aAAG = actionAngleAdiabaticGrid(pot=MWPotential2014, nR=12, nEz=12, nEr=20, nLz=20)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_parity(backend):
+    # numpy <-> jax <-> torch parity of the grid-interpolated (Jr,Lz,Jz) and
+    # (ecc,zmax,rperi,rap). The backend wrappers reuse scipy's fitted
+    # coefficients, so parity is at machine precision (rtol~1e-10).
+    bargs = [_arr(backend, v) for v in _GRID]
+    for ref, got in (
+        (_aASG(*_GRID), _aASG(*bargs)),
+        (_aASG.EccZmaxRperiRap(*_GRID), _aASG.EccZmaxRperiRap(*bargs)),
+    ):
+        for r, g in zip(ref, got):
+            assert _is_backend_array(backend, g)
+            numpy.testing.assert_allclose(
+                _np(g), numpy.asarray(r), rtol=1e-10, atol=1e-12
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabaticgrid_parity(backend):
+    # numpy <-> jax <-> torch parity of the grid-interpolated (Jr,Lz,Jz).
+    bargs = [_arr(backend, v) for v in _GRID]
+    ref, got = _aAAG(*_GRID), _aAAG(*bargs)
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-10, atol=1e-12)
+
+
+def test_staeckelgrid_numpy_byte_identity():
+    # A numpy-array input takes the untouched scipy interpolation path; the
+    # backend dispatch is is_backend_array(R) == False, so the result is the
+    # EXACT pre-migration output. We verify the numpy-array path equals the
+    # scalar-loop path bit-for-bit (the scalar branch recurses to the array
+    # branch, so this pins the array path to per-point evaluation).
+    act = _aASG(*_GRID)
+    ecc = _aASG.EccZmaxRperiRap(*_GRID)
+    for ii in range(len(_GRID_R)):
+        sact = _aASG(*[v[ii] for v in _GRID])
+        secc = _aASG.EccZmaxRperiRap(*[v[ii] for v in _GRID])
+        for comp, s in zip(act, sact):
+            numpy.testing.assert_array_equal(comp[ii], s)
+        for comp, s in zip(ecc, secc):
+            numpy.testing.assert_array_equal(comp[ii], s)
+
+
+def test_adiabaticgrid_numpy_byte_identity():
+    # As above for the adiabatic grid: numpy-array path == scalar-loop path,
+    # confirming the numpy output is unchanged by the additive backend branch.
+    act = _aAAG(*_GRID)
+    for ii in range(len(_GRID_R)):
+        sact = _aAAG(*[v[ii] for v in _GRID])
+        for comp, s in zip(act, sact):
+            numpy.testing.assert_array_equal(comp[ii], s)
+
+
+# Single-point bound IC well inside both grids, away from turning points / edges.
+_GRID_S = (1.1, 0.15, 0.9, 0.12, 0.13)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "aa,idx", [("staeckel", 2), ("adiabatic", 2)]
+)  # Jz vs vz through both grids
+def test_grid_jz_grad_vs_fd_wrt_vz(backend, aa, idx):
+    # d Jz / d vz at a single on-grid point: AD through the cubic-spline
+    # interpolation (map_coordinates for Staeckel, RectBivariate for adiabatic)
+    # vs central finite difference. The interpolation lookups carry the gradient.
+    grid = _aASG if aa == "staeckel" else _aAAG
+    R, vR, vT, z, _ = _GRID_S
+    vz0 = _GRID_S[4]
+
+    def call(vz_arr, xp_arr):
+        args = (xp_arr(R), xp_arr(vR), xp_arr(vT), xp_arr(z), vz_arr)
+        return grid(*args)[idx].sum()
+
+    def f_np(vz_val):
+        # FD reference: vz is a plain numpy 1-element array (numpy array path).
+        return numpy.asarray(
+            call(numpy.atleast_1d(vz_val), lambda v: numpy.atleast_1d(numpy.asarray(v)))
+        )
+
+    fd = _fd(f_np, vz0)
+
+    def f_be(vz_t):
+        # AD: vz_t is the differentiated rank-0 backend scalar (kept raw so grad
+        # sees a scalar); the backend grid path is fully vectorised on rank-0.
+        return call(vz_t, lambda v: _arr(backend, numpy.atleast_1d(v).astype(float)))
+
+    g = _grad(backend, f_be, vz0)
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_vatu0_backend(backend):
+    # vatu0(retv2=False) backend branch: the grid eval path only calls
+    # vatu0(retv2=True), so its masked-sqrt xp.where branch is otherwise untested.
+    u0 = numpy.array([0.6, 0.8])
+    E = numpy.array([-0.9, -0.8])
+    Lz = numpy.array([0.3, 0.4])
+    R = _aASG._delta * numpy.sinh(u0)
+    vn = _aASG.vatu0(E, Lz, u0, R)  # numpy
+    vb = _aASG.vatu0(
+        *[_arr(backend, a) for a in (E, Lz, u0, R)]
+    )  # backend -> xp.where branch
+    assert _is_backend_array(backend, vb)
+    numpy.testing.assert_allclose(_np(vb), vn, rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
Adds an **additive, differentiable jax/torch evaluation path** to the two action-angle *grid* classes — the last breadth item in Track E (action-angle backends). Builds on #1021 (`galpy.backend.interpolate` `map_coordinates` + spline derivative/point-eval), which it uses as the backend interpolation engine.

### Design (numpy stays byte-identical)
Grid **construction** (`__init__`, the scipy fits + `ndimage.spline_filter`) is untouched and numpy-only. At the end of `__init__`, `_build_backend_interp` wraps the **same fitted scipy objects / filtered grids** into backend-eval wrappers (`Spline1D`, `Spline2D(spl=...)`, `MapCoordinates`) — reusing scipy's coefficients, no refit of new data.

Each eval method gets an early `if is_backend_array(R): return self._..._backend(...)` dispatch; the numpy/scalar path is the existing code, unchanged. The surrounding coordinate/energy/`u0`/`psi` math (`Er`, `Ez`, `vatu0`, `_Efunc`, the `frac` boundary snaps, the `j<0`/`v2<0` clamps) is made namespace-agnostic (`get_namespace`, masked writes → `xp.where`, clamps → `xp.clip`, device/dtype follow the input).

- **StaeckelGrid**: `_evaluate` (JR, Jz), `_EccZmaxRperiRap` (ecc/zmax/rperi/rap when `interpecc=True`).
- **AdiabaticGrid**: `_evaluate` (JR, Jz).

### On-grid only (documented)
The backend path evaluates the interpolation grid only — it does **not** replicate numpy's per-point off-grid fallback (`self._aA(...)`, an iterative scipy solve that is inherently non-traceable). Inputs must lie within the grid; this is noted in both class docstrings. This mirrors the established jit-compat contract (numpy does the eager thing off the fast path; the backend stays traceable).

`actionAngleStaeckelSingle` is **not** removed — it is still used by the grid setup and by `actionAngleStaeckel` itself.

### Validation
- **numpy byte-identical** — independently verified: pristine (pre-migration) vs migrated files on 40 random ICs, `numpy.testing.assert_array_equal` (exact) on all 8 outputs (StaeckelGrid JR/Jz + ecc/zmax/rperi/rap, AdiabaticGrid JR/Jz). Existing `tests/test_actionAngle.py -k Grid` (12 tests) still pass under numpy.
- **Parity** numpy↔jax↔torch at `rtol=1e-10, atol=1e-12` (wrappers reuse scipy's exact coefficients — no quadrature floor).
- **grad-vs-FD** (jax.grad + torch autograd vs central FD): dJz/dvz — StaeckelGrid 2.6e-10, AdiabaticGrid 1.7e-11.
- 10 new tests (parity / numpy-byte-identity / grad-vs-FD for both classes); 16 grid backend tests pass under default + `--backend=jax` + `--backend=torch`.

Stacked on #1021 — retarget to `feat/backends` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)