### PR TITLE
c_stm_forward: stacked single integrate_dxdv for all STM columns (perf)

### DIFF
--- a/galpy/backend/_reference/inbackend_stm.py
+++ b/galpy/backend/_reference/inbackend_stm.py
@@ -54,30 +54,28 @@ def c_stm_forward(pot, vxvv, ts, method, rtol, atol):
     vxvv = numpy.asarray(vxvv, dtype=numpy.float64)
     single = vxvv.ndim == 1
     ics = vxvv[None] if single else vxvv
-    basis = numpy.eye(6)
-    xts, Ms = [], []
-    for ic in ics:
-        cols = []
-        base = None
-        for i in range(6):
-            o = Orbit(list(ic))
-            o.integrate_dxdv(
-                basis[i],
-                ts,
-                pot,
-                method=method,
-                rectIn=False,
-                rectOut=False,
-                rtol=rtol,
-                atol=atol,
-            )
-            cols.append(o.getOrbit_dxdv())  # (nt,6): column i of M
-            if base is None:
-                base = o.getOrbit()  # (nt,6): the base orbit, Orbit order
-        xts.append(base)
-        Ms.append(numpy.asarray(cols).transpose(1, 2, 0))  # (nt,6,6)
-    xt = numpy.asarray(xts)
-    M = numpy.asarray(Ms)
+    n = ics.shape[0]
+    # Propagate all 6 canonical basis deviation vectors of all N initial
+    # conditions in ONE stacked C integrate_dxdv call (6N independent orbits)
+    # instead of 6N separate calls each re-integrating the same base orbit.
+    # Orbit row 6k+i = IC k carrying basis vector i (repeat ICs x6, tile eye(6)).
+    o = Orbit(numpy.repeat(ics, 6, axis=0))
+    o.integrate_dxdv(
+        numpy.tile(numpy.eye(6), (n, 1)),
+        ts,
+        pot,
+        method=method,
+        progressbar=False,
+        rectIn=False,
+        rectOut=False,
+        rtol=rtol,
+        atol=atol,
+    )
+    nt = numpy.asarray(ts).shape[0]
+    # cols[k,i] = column i of M for IC k -> (N,nt,6,6) with the last axis the column.
+    M = o.getOrbit_dxdv().reshape(n, 6, nt, 6).transpose(0, 2, 3, 1)
+    # The 6 stacked copies share one base orbit; keep the first per IC.
+    xt = o.getOrbit().reshape(n, 6, nt, 6)[:, 0]
     if single:
         return xt[0], M[0]
     return xt, M

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -132,6 +132,24 @@ def test_jacrev_equals_stm(method):
     numpy.testing.assert_allclose(_np(Jall), M, rtol=1e-10, atol=1e-10)
 
 
+# ------------------------------------------ c_stm_forward batch == stacked singles
+@pytest.mark.parametrize("method", _METHODS)
+def test_c_stm_forward_batch_matches_singles(method):
+    # The batched host call (one stacked integrate_dxdv over 6N orbits) must return
+    # (N,nt,6)/(N,nt,6,6) and match the per-orbit single calls.
+    from galpy.backend._reference.inbackend_stm import c_stm_forward
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ics = numpy.array([_IC, _IC + 0.03, _IC - 0.02])  # (3, 6)
+    xt_b, M_b = c_stm_forward(pot, ics, _TS, method, 1e-10, 1e-10)  # batch -> (N,...)
+    assert xt_b.shape == (len(ics), len(_TS), 6)
+    assert M_b.shape == (len(ics), len(_TS), 6, 6)
+    for k in range(len(ics)):
+        xt_s, M_s = c_stm_forward(pot, ics[k], _TS, method, 1e-10, 1e-10)  # single
+        numpy.testing.assert_allclose(xt_b[k], xt_s, rtol=1e-12, atol=1e-12)
+        numpy.testing.assert_allclose(M_b[k], M_s, rtol=1e-12, atol=1e-12)
+
+
 # ----------------------------------------------------------------- torch gradcheck
 @pytest.mark.skipif("torch" not in BACKENDS, reason="needs torch")
 @pytest.mark.parametrize("method", ["rk4_c", "rk6_c"])


### PR DESCRIPTION
**P0-3 from the backend speed-up roadmap.** The differentiable fast-C orbit path (`galpy.backend._reference.inbackend_stm.c_stm_forward`, wrapped by the jax/torch C-STM autodiff rules) built the state-transition matrix `M(t)=∂x(t)/∂x(0)` by calling `Orbit.integrate_dxdv` **6N times** — once per canonical basis deviation vector per IC — each constructing a fresh `Orbit` and entering the C integrator separately.

This stacks all 6 basis vectors of all N ICs into **one** `integrate_dxdv` on 6N orbits (`numpy.repeat(ics, 6)` + `numpy.tile(eye(6), (N,1))`), keeping `rectIn=False, rectOut=False` so `M` stays in Orbit order, then reshapes `getOrbit_dxdv()`/`getOrbit()` back to `(N,nt,6,6)` / `(N,nt,6)`.

### Correctness
**Bit-identical** `x(t)` and `M(t)` to the per-column loop: 24/24 cases exact (`max|Δx|=max|ΔM|=0`) across MW2014 / triaxial-Log / MiyamotoNagai × rk4_c/rk6_c/dopr54_c/dop853_c × single+batch. The full C-STM/integrate suite (`tests/test_backend_orbit_stm.py` + `tests/test_backend_orbit_integrate.py`) passes — **117 tests** under numpy/jax/torch.

### Performance (N=20 ICs, dop853_c, 101 output times)
| | time |
|---|---|
| old (6N separate calls) | 881 ms |
| new (one call, `numcores`=1) | 750 ms (~1.2×, call-overhead) |
| new (one call, `numcores`=8) | 480 ms (~1.8×, parallel) |

The win is (a) collapsing 6N `Orbit` constructions + C entries into one and (b) letting the existing multi-orbit `numcores` parallelism span the 6N independent integrations (the per-call loop integrated one orbit at a time, so it couldn't). It uses galpy's default `numcores`, so this is automatic.

### Not in scope (noted for the optimization phase)
This does **not** eliminate the redundant base-orbit integration (each of the 6 stacked copies re-integrates the same base trajectory) — that is inherent to `integrate_dxdv`'s base+1-deviation design. The true ~6× would require a base+6-deviation **augmented** (42-state) C variational integrator; tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)