### PR TITLE
Orbit C-STM: multi-orbit differentiable integration (one stacked solve)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -324,6 +324,12 @@ def shapeDecorator(func):
         elif args[0].shape == ():
             return result[0]
         else:
+            newshape = args[0].shape + tuple(result.shape[1:])
+            if is_backend_array(result):
+                # numpy.reshape forwards order='C', which torch's .reshape rejects
+                # (and triggers a numpy-2 __array_wrap__ deprecation); use the
+                # array's own reshape (jax/torch), preserving the autodiff graph.
+                return result.reshape(newshape)
             return numpy.reshape(result, args[0].shape + result.shape[1:])
 
     return shape_wrapper

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2156,13 +2156,11 @@ class Orbit:
         array in self.orbit, so getOrbit()/the accessors are backend arrays
         differentiable w.r.t. the initial conditions (gradients w.r.t. potential
         PARAMETERS need the in-backend ODE path -- the C integrator carries no
-        d x / d theta sensitivity). Single orbit.
+        d x / d theta sensitivity). Single OR multiple orbits: a multi-orbit
+        backend IC is integrated in ONE stacked C-STM call (the wrapper and
+        c_stm_forward batch ``(N,6) -> (N,nt,6)``), so ``Orbit(N-backend-ICs).
+        integrate(<dxdv-C-method>)`` is differentiable w.r.t. all N ICs at once.
         """
-        if self.shape != ():
-            raise ValueError(
-                f"method='{method}' with a jax/torch initial condition supports a "
-                "single orbit only"
-            )
         ic = self._ic_backend
         xp = get_namespace(ic)
         if is_backend_array(t):
@@ -2174,17 +2172,23 @@ class Orbit:
             from ..backend._jax import orbit_stm
         else:
             from ..backend._torch import orbit_stm
-        # (nt, 6) Orbit order, differentiable backend array. Default rtol/atol =
-        # 1e-12 matches galpy's C integrators (_parse_tol).
-        result = orbit_stm.integrate(
-            pot,
-            ic,
-            ts,
-            method=method,
-            rtol=1e-12 if rtol is None else rtol,
-            atol=1e-12 if atol is None else atol,
-        )
-        self.orbit = result[None, ...]  # (1, nt, 6), matching the C layout
+        # Default rtol/atol = 1e-12 matches galpy's C integrators (_parse_tol).
+        _rtol = 1e-12 if rtol is None else rtol
+        _atol = 1e-12 if atol is None else atol
+        if self.shape == ():
+            # Single orbit: (nt, 6) -> stored as (1, nt, 6), matching the C layout.
+            result = orbit_stm.integrate(
+                pot, ic, ts, method=method, rtol=_rtol, atol=_atol
+            )
+            self.orbit = result[None, ...]
+        else:
+            # Multiple orbits: flatten to (size, 6), one stacked differentiable
+            # C-STM solve -> (size, nt, 6); getOrbit/accessors reshape on access.
+            ic2d = xp.reshape(ic, (-1, ic.shape[-1]))
+            result = orbit_stm.integrate(
+                pot, ic2d, ts, method=method, rtol=_rtol, atol=_atol
+            )
+            self.orbit = result
         self.t = t
         self._pot = pot
         self._orig_pot = pot

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -429,15 +429,55 @@ def test_orbit_integrate_cstm_fallback_inbackend(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_orbit_integrate_cstm_multiorbit_raises(backend):
-    # a multi-orbit backend IC is not yet supported by the routed C-STM (single
-    # orbit only) -> a clear error, never a silent numpy fallthrough.
+def test_orbit_integrate_cstm_multiorbit_matches_loop(backend):
+    # A multi-orbit backend IC integrates in ONE stacked, differentiable C-STM
+    # solve; getOrbit() is (N, nt, 6) and matches the per-orbit single-orbit loop.
     from galpy.orbit import Orbit
 
     pot = MiyamotoNagaiPotential(normalize=1.0)
-    o2 = Orbit(_arr(backend, numpy.tile(_IC, (2, 1))))  # (2, 6)
-    with pytest.raises(ValueError):
-        o2.integrate(_arr(backend, _TS), pot, method="dop853_c")
+    ics = numpy.array([_IC, _IC + 0.03, _IC - 0.02])  # (3, 6)
+    ts = _arr(backend, _TS)
+    om = Orbit(_arr(backend, ics))
+    om.integrate(ts, pot, method="dop853_c")
+    multi = _np(om.getOrbit())
+    assert multi.shape == (len(ics), len(_TS), 6)
+    for k in range(len(ics)):
+        ok = Orbit(_arr(backend, ics[k]))
+        ok.integrate(ts, pot, method="dop853_c")
+        numpy.testing.assert_allclose(
+            multi[k], _np(ok.getOrbit()), rtol=1e-12, atol=1e-12
+        )
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+def test_orbit_integrate_cstm_multiorbit_grad():
+    # The batched C-STM is gradient-exact: each orbit's IC jacobian equals the
+    # single-orbit jacobian (diagonal blocks) and the orbits are independent
+    # (the off-diagonal blocks of jacrev are exactly zero).
+    from galpy.orbit import Orbit
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ics = jnp.asarray(numpy.array([_IC, _IC + 0.03, _IC - 0.02]))
+    N = ics.shape[0]
+
+    def final_batch(v):  # (N,6) -> (N,6) final state
+        o = Orbit(v)
+        o.integrate(jnp.asarray(_TS), pot, method="dop853_c")
+        return o.getOrbit()[:, -1, :]
+
+    Jb = _np(jax.jacrev(final_batch)(ics))  # (N, 6, N, 6)
+
+    def final_single(v6):
+        o = Orbit(v6)
+        o.integrate(jnp.asarray(_TS), pot, method="dop853_c")
+        return o.getOrbit()[-1, :]
+
+    for i in range(N):
+        for j in range(N):
+            if i != j:
+                assert numpy.max(numpy.abs(Jb[i, :, j, :])) == 0.0  # independent
+        Js = _np(jax.jacrev(final_single)(ics[i]))  # (6, 6)
+        numpy.testing.assert_allclose(Jb[i, :, i, :], Js, rtol=1e-10, atol=1e-12)
 
 
 @pytest.mark.parametrize("method", _ROUTE_METHODS)


### PR DESCRIPTION
First optimization-phase PR after Track E breadth landed. Lifts the single-orbit restriction on the differentiable **fast-C** orbit path so a whole batch of orbits integrates (and differentiates) in **one** stacked C-STM solve.

### Change
`Orbits._integrate_cstm` raised `"single orbit only"` for a multi-orbit backend IC. But the machinery underneath already batches: `orbit_stm.integrate` (the `jax.custom_vjp` / `torch.autograd.Function` wrapper) and `c_stm_forward` accept `(N,6)` → `(N,nt,6)` with a per-orbit backward. So the fix is just to remove the guard and, for `self.shape != ()`, flatten `_ic_backend` to `(size,6)`, call `orbit_stm.integrate` once, and store `(size,nt,6)`. **The single-orbit branch is unchanged (byte-identical).**

The routing (`_integrate_impl`) already sent multi-orbit backend ICs here; only this guard blocked them.

Now: `Orbit(N×6 jax/torch ICs).integrate(t, pot, method='dop853_c')` → `getOrbit()` is `(N,nt,6)`, differentiable w.r.t. all N ICs at once (for a 6D orbit whose potential has the C 3D Hessian + a dxdv-capable C method).

### Verified (jax, MiyamotoNagai/MW2014)
- **Forward bit-identical** to the per-orbit loop: `max|Δ| = 0`.
- **Gradient-exact**: batched `jacrev` diagonal block == single-orbit `jacrev` (`max|Δ| = 0`); off-diagonal blocks **exactly 0** (orbits independent).
- **~1.65× faster** at N=8 on CPU (the multi-orbit C `numcores` parallelism; more on GPU / larger N).
- Existing single-orbit C-STM suite still green (67 passed); replaced the obsolete `test_orbit_integrate_cstm_multiorbit_raises` with parity + gradient-structure tests.

### Not in this PR (follow-ups)
- **Switch `actionAngleIsochroneApprox`** to one batched `Orbit` instead of its per-orbit loop (the consumer win — next).
- diffrax/torchdiffeq multi-orbit (the harder vmap-of-solve path) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)