### PR TITLE
actionAngleIsochroneApprox: one batched multi-orbit Orbit solve (~6x jax)

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -931,31 +931,24 @@ class actionAngleIsochroneApprox(actionAngle):
         z, vz, phi = xp.atleast_1d(z), xp.atleast_1d(vz), xp.atleast_1d(phi)
         no = R.shape[0]
 
-        def _integ(ic_list):
-            # ic_list: list (len no) of stacked 1-D backend IC vectors. Integrate
-            # each forward over self._tsJ with the object's integrate_method (a
-            # C-dxdv method by default -> differentiable C-STM path) and stack the
-            # (nt, phasedim) trajectories into (no, nt, phasedim).
-            os = []
-            for ic in ic_list:
-                o = Orbit(ic)
-                o.integrate(
-                    self._tsJ,
-                    pot=self._pot,
-                    method=self._integrate_method,
-                    dt=self._integrate_dt,
-                )
-                os.append(o)
-            return os
+        def _integ(ic_stack):
+            # ic_stack: (no, 6) backend ICs -> ONE Orbit integrated in a single
+            # differentiable multi-orbit solve (C-STM for a dxdv C method, else
+            # diffrax/torchdiffeq) over self._tsJ. getOrbit()/accessors return the
+            # (no, nt, ...) batch directly.
+            o = Orbit(ic_stack)
+            o.integrate(
+                self._tsJ,
+                pot=self._pot,
+                method=self._integrate_method,
+                dt=self._integrate_dt,
+            )
+            return o
 
-        # Forward integration: ICs are (R,vR,vT,z,vz,phi); stack each orbit's six
-        # coordinates into a 1-D backend vector so Orbit captures _ic_backend.
-        fwd_ics = [
-            xp.stack([R[ii], vR[ii], vT[ii], z[ii], vz[ii], phi[ii]])
-            for ii in range(no)
-        ]
-        os = _integ(fwd_ics)
-        orbs = xp.stack([o.getOrbit() for o in os], axis=0)  # (no, nt, 6)
+        # Forward integration: stack the six coordinates into a (no, 6) backend
+        # array so the one Orbit captures the whole batch in _ic_backend.
+        o = _integ(xp.stack([R, vR, vT, z, vz, phi], axis=-1))
+        orbs = o.getOrbit()  # (no, nt, 6)
         oR, ovR, ovT = orbs[:, :, 0], orbs[:, :, 1], orbs[:, :, 2]
         oz, ovz, ophi = orbs[:, :, 3], orbs[:, :, 4], orbs[:, :, 5]
         nt = oR.shape[1]
@@ -964,26 +957,20 @@ class actionAngleIsochroneApprox(actionAngle):
         # Also integrate backward in time (the requested point should not sit at
         # the edge), mirroring the numpy branch: flip the velocities, integrate
         # forward, then reverse and re-flip the velocities, and prepend.
-        bwd_ics = [
-            xp.stack([R[ii], -vR[ii], -vT[ii], z[ii], -vz[ii], phi[ii]])
-            for ii in range(no)
-        ]
-        bos = _integ(bwd_ics)
-        ts = self._tsJ
+        bo = _integ(xp.stack([R, -vR, -vT, z, -vz, phi], axis=-1))
+        borbs = bo.getOrbit()  # (no, nt, 6) at self._tsJ (== the query times, so
+        # this equals the per-orbit accessor bo.R(ts[1:]) etc. but stays batched)
 
-        def _bstack(accessor, sign=1.0):
-            # stack the backward orbits' accessor(ts[1:]), drop t=0, reverse along
-            # time (xp.flip -- array-api-compat torch rejects [::-1] negative step)
-            return sign * xp.flip(
-                xp.stack([accessor(bo)(ts[1:]) for bo in bos], axis=0), axis=1
-            )
+        def _bcol(col, sign=1.0):
+            # drop t=0, reverse along time (xp.flip -- torch rejects [::-1]).
+            return sign * xp.flip(borbs[:, 1:, col], axis=1)
 
-        bR = _bstack(lambda bo: bo.R)
-        bvR = _bstack(lambda bo: bo.vR, -1.0)
-        bvT = _bstack(lambda bo: bo.vT, -1.0)
-        bz = _bstack(lambda bo: bo.z)
-        bvz = _bstack(lambda bo: bo.vz, -1.0)
-        bphi = _bstack(lambda bo: bo.phi)
+        bR = _bcol(0)
+        bvR = _bcol(1, -1.0)
+        bvT = _bcol(2, -1.0)
+        bz = _bcol(3)
+        bvz = _bcol(4, -1.0)
+        bphi = _bcol(5)
         # full (no, 2*nt-1): [backward (reversed) | forward]
         pR = xp.concatenate([bR, oR], axis=1)
         pvR = xp.concatenate([bvR, ovR], axis=1)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1241,7 +1241,7 @@ def test_isochroneapprox_parity(backend, b):
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_isochroneapprox_scalar_parity(backend):
     # a single (scalar-array) IC: _parse_args promotes it to a 1-element batch, so
-    # the backend path's atleast_1d / per-orbit stack-and-integrate handles the
+    # the backend path's atleast_1d / one batched (1,6) Orbit solve handles the
     # batch-of-one. Exercises the scalar-vs-batch handling separately from the grid.
     aAIA = _aAIA(0.8)
     s = (1.1, 0.2, 0.9, 0.15, 0.1, 1.3)


### PR DESCRIPTION
## What

`actionAngleIsochroneApprox._parse_args_backend` (the jax/torch path) integrated the
input orbits in a **per-orbit loop** — one `Orbit` per IC, then `xp.stack` of each
orbit's `getOrbit()`/accessor outputs. Now that the C-STM path integrates many orbits
in **one differentiable solve** (#1024), this builds **one** `Orbit` from the `(no, 6)`
IC stack and reads its `getOrbit()` columns — a single stacked solve for the whole
batch, for both the forward leg and the time-reversed backward leg.

The backward leg reads `getOrbit()[:, 1:, col]` columns instead of the per-orbit
accessors (`bo.R(ts[1:])` …), which are single-orbit-only on a multi-orbit `Orbit`. For
query times `== self._tsJ` (the stored integration grid) these equal the accessor values
exactly, but stay batched.

## numpy is byte-identical

`_parse_args_backend` is only reached when `is_backend_array(args[0])` (dispatch in
`_parse_args`, line ~735). The numpy path stays on the per-orbit `_parse_args` loop and
is **untouched** — numpy output is byte-identical by construction.

## Speedup

~**6.1×** faster on an `N=8` jax `actionsFreqsAngles` batch — **47.4 s → 7.5 s** median
(CPU, `MWPotential2014`, `ntintJ=2000`) — because the per-orbit `pure_callback` C-STM
dispatch collapses to one stacked call. Scales with batch size; at `N=1` there is no
difference.

## Tests

No new tests needed — the existing `test_isochroneapprox_*` battery in
`tests/test_backend_actionAngle.py` already exercises exactly the modified path on a
3-orbit grid:
- `test_isochroneapprox_parity` — numpy↔jax↔torch parity of `_evaluate`/`_actionsFreqs`/`_actionsFreqsAngles` on a 3-orbit batch (incl. a retrograde orbit)
- `test_isochroneapprox_scalar_parity` — batch-of-one
- `test_isochroneapprox_cumul_parity`, `_planar_parity`, `_nonaxi_parity`
- `test_isochroneapprox_grad_vs_fd_wrt_vR` — AD-through-the-batched-solve gradients vs FD

All 8 jax cases pass locally (+ 4 numpy `actionAngleIsochroneApprox` tests). One stale
comment in `test_isochroneapprox_scalar_parity` updated to match the single batched solve.
torch parity runs in CI (local CUDA torch segfaults the dxdv C path).

Consumes #1024; closes the IsochroneApprox half of the optimization-phase batch work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)