### PR TITLE
backend.optimize: roll bisect_root into lax.fori_loop under jax trace (P0-1)

### DIFF
--- a/galpy/backend/_jax/optimize.py
+++ b/galpy/backend/_jax/optimize.py
@@ -26,9 +26,7 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     import jax
     import jax.numpy as jnp
 
-    from ..optimize import bisect_root
-
-    x0 = jax.lax.stop_gradient(bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter))
+    x0 = jax.lax.stop_gradient(_bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter))
     # df/dx at x0 via a forward-mode directional derivative along the all-ones
     # tangent (exact df/dx for an elementwise f); the value fx0 comes for free.
     fx0, dfx0 = jax.jvp(f, (x0,), (jnp.ones_like(x0),))
@@ -36,6 +34,33 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     # constant w.r.t. theta and fx0 ~ 0 -- its theta-gradient is the implicit
     # one. Guard a (near-)singular slope so AD never sees a 0/0.
     return x0 - fx0 / _nonzero(dfx0, xp)
+
+
+def _bisect_root(f, a, b, xp, *, xtol, maxiter):
+    """Bisection root, rolling the halving loop into ``lax.fori_loop`` only when
+    tracing (user jit/grad/vmap).
+
+    Eager (concrete bracket): defer to the shared Python-loop ``bisect_root`` --
+    bit-identical and ~9x faster eagerly than ``fori_loop`` (which compiles a loop
+    primitive per call). Traced: the unrolled Python loop would bake ``n`` copies
+    of ``f`` into the user's jaxpr (the dominant compile cost for the heavier
+    closures, e.g. Staeckel turning points); ``fori_loop`` traces ``f`` once,
+    shrinking the jaxpr ~17x and the jitted compile ~4x for the same result.
+    """
+    import jax
+
+    from ..optimize import bisect_root, bisect_step, n_bisect_steps
+
+    if not any(isinstance(x, jax.core.Tracer) for x in (a, b)):
+        return bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter)
+    lo = xp.asarray(a) * 1.0
+    hi = xp.asarray(b) * 1.0
+    slo = xp.sign(f(lo))
+    n = n_bisect_steps(a, b, xtol, maxiter)  # tracer -> min(maxiter, _MAXITER)
+    lo, hi = jax.lax.fori_loop(
+        0, n, lambda _, c: bisect_step(c[0], c[1], slo, f, xp), (lo, hi)
+    )
+    return 0.5 * (lo + hi)
 
 
 def _nonzero(d, xp):

--- a/galpy/backend/optimize.py
+++ b/galpy/backend/optimize.py
@@ -142,6 +142,20 @@ def n_bisect_steps(a, b, xtol, maxiter):
     return max(1, min(n, maxiter))
 
 
+def bisect_step(lo, hi, slo, f, xp):
+    """One sign-preserving bisection halving of ``[lo, hi]`` (branch-free).
+
+    Returns the updated ``(lo, hi)``. Root in ``[lo, mid]`` iff ``f(mid)`` keeps
+    the sign of ``f(lo)`` on ``[mid, hi]`` (``sign(f(mid)) == slo`` -> the sign
+    change is in ``[mid, hi]``: move ``lo`` up). The shared per-step kernel so the
+    Python-loop (eager/torch) and the jax ``lax.fori_loop`` body run identical
+    arithmetic.
+    """
+    mid = 0.5 * (lo + hi)
+    same = xp.sign(f(mid)) == slo
+    return xp.where(same, mid, lo), xp.where(same, hi, mid)
+
+
 def bisect_root(f, a, b, xp, *, xtol, maxiter):
     """Vectorised, sign-preserving bisection root of ``f`` on ``[a, b]`` in ``xp``.
 
@@ -153,6 +167,10 @@ def bisect_root(f, a, b, xp, *, xtol, maxiter):
     reparameterises it through one Newton step for the implicit-function
     gradient. Shared by both backend paths so the logic lives in one place.
 
+    This is the eager Python-loop form (torch, and jax outside a trace); the jax
+    path swaps in a ``lax.fori_loop`` over the same ``bisect_step`` only when
+    tracing (see ``_jax.optimize``), keeping the jaxpr small under the user's jit.
+
     ``f`` must change sign on ``[a, b]`` (``f(a)``, ``f(b)`` opposite sign), as
     for ``scipy.optimize.brentq``; same-sign brackets are a caller error and
     return a midpoint without a guarantee.
@@ -163,10 +181,5 @@ def bisect_root(f, a, b, xp, *, xtol, maxiter):
     slo = xp.sign(f(lo))  # sign of f at the low endpoint
     n = n_bisect_steps(a, b, xtol, maxiter)
     for _ in range(n):
-        mid = 0.5 * (lo + hi)
-        # Root in [lo, mid] iff f(mid) keeps the sign of f(lo) on [mid, hi],
-        # i.e. sign(f(mid)) == slo -> the sign change is in [mid, hi]: move lo up.
-        same = xp.sign(f(mid)) == slo
-        lo = xp.where(same, mid, lo)
-        hi = xp.where(same, hi, mid)
+        lo, hi = bisect_step(lo, hi, slo, f, xp)
     return 0.5 * (lo + hi)

--- a/tests/test_backend_optimize.py
+++ b/tests/test_backend_optimize.py
@@ -222,6 +222,35 @@ def test_vectorized_array_theta(backend):
     )
 
 
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_jax_jit_rolls_bisection():
+    # Under a trace (jax.jit/grad) the bisection halving loop is rolled into
+    # lax.fori_loop instead of unrolling ~n copies of f into the jaxpr: same root,
+    # but a small jaxpr with a loop primitive (the eager path keeps the Python
+    # loop -- see test_backend_optimize's eager tests). Covers the traced branch
+    # of galpy.backend._jax.optimize._bisect_root.
+    f = lambda x: x * x - 2.0  # root sqrt(2) on [0, 5]
+    a, b = jnp.asarray(0.0), jnp.asarray(5.0)
+    # eager value (Python-loop branch)
+    r_eager = float(brentq(f, a, b))
+    numpy.testing.assert_allclose(r_eager, numpy.sqrt(2.0), rtol=1e-9)
+    # jit value (fori_loop branch): a correct root
+    r_jit = float(jax.jit(lambda a, b: brentq(f, a, b))(a, b))
+    numpy.testing.assert_allclose(r_jit, numpy.sqrt(2.0), rtol=1e-9)
+    # the jaxpr is ROLLED: a loop primitive + far fewer eqns than an unrolled
+    # ~100-step bisection (which would be 700+ lines).
+    txt = str(jax.make_jaxpr(lambda a, b: brentq(f, a, b))(a, b))
+    assert ("while" in txt) or ("scan" in txt)
+    assert txt.count("\n") < 300
+
+    # jit gradient still exact: d sqrt(c)/dc = 1/(2 sqrt(c)) via implicit theorem
+    def root_of_c(c):
+        return brentq(lambda x: x * x - c, a, b)
+
+    g = float(jax.jit(jax.grad(root_of_c))(jnp.asarray(2.0)))
+    numpy.testing.assert_allclose(g, 1.0 / (2.0 * numpy.sqrt(2.0)), rtol=1e-6)
+
+
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_vectorized_grad_jacobian(backend):
     # Per-element gradient of the vector root w.r.t. the vector theta: a diagonal


### PR DESCRIPTION
## What

The shared `bisect_root` (every backend turning-point/root solve goes through it
— Staeckel ×2, Spherical `rperi/rap`, Vertical `xmax`, `Potential.rl/rE/zmaxgrid`,
IsochroneInverse `eta`) runs its sign-preserving halving as a Python `for _ in
range(n)` over a branch-free `xp.where` step. Under a user `jax.jit`/`grad` that
**unrolls `n` (up to 100) copies of the closure `f`** into the jaxpr — the
dominant compile cost for the heavier closures (the roadmap's "Staeckel actions =
47,528-eqn jaxpr, ~8.6 min compile").

This rolls the loop into `jax.lax.fori_loop` **only when tracing**. galpy's own
**eager** path (and torch) keep the Python loop — byte-identical to today, and
~9× faster eagerly than `fori_loop` (which compiles a loop primitive per call).
The jax path detects a tracer (`isinstance(x, jax.core.Tracer)`) and swaps in
`fori_loop` over the same `bisect_step` kernel.

## Why eager stays on the Python loop

`lax.fori_loop` is a win for *jitted user code* but a **regression for eager
execution** — which is exactly what galpy's CI runs. Measured (N=64 vectorised
bracket, representative `f`):

| | eager (CI) | jit compile | jaxpr eqns |
|---|---|---|---|
| Python for-loop (today) | **16 ms** | 592 ms | 717 |
| naive `lax.fori_loop` | 137 ms (9× slower) | 152 ms | 41 |
| **this PR** (eager Python / traced fori) | **16 ms** (unchanged) | **152 ms** | **41** |

Best of both: eager untouched, jitted user code compiles ~4× faster with a ~17×
smaller graph.

## Correctness

- **numpy untouched** (`scipy.optimize.brentq`).
- **Traced result bit-identical** to the unrolled loop at the same step count
  (`max|rolled − unrolled| = 0`); `fori_loop` runs the identical arithmetic.
- Eager jax/torch path **unchanged** (delegates to the shared `bisect_root`).
- Eager-vs-jit differ by ULPs *as they already did* — eager uses the concrete
  halving count (~50), a tracer falls back to `n=100` (pre-existing
  `n_bisect_steps` behavior, unchanged here).

## Tests

`test_jax_jit_rolls_bisection` (new) covers the traced branch: correct root under
`jit`, exact jitted gradient (implicit-function theorem), and a rolled-jaxpr
assertion (loop primitive + ≪ unrolled size). Verified green: all 110
`test_backend_optimize.py` + `test_backend_potential_rootfind.py` tests, plus
Staeckel turning-point / actions-vs-C and Spherical grad jax consumers.

Roadmap lever **P0-1**. The broader sub-part — threading a static step count
through the callers so jitted code uses ~50 not 100 halvings — is a deferred
follow-up (and composes with the per-subsystem #93 Staeckel bracket loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)