### PR TITLE
actionAngleHarmonicInverse / IsochroneInverse: backend (numpy_island)

### DIFF
--- a/galpy/actionAngle/actionAngleHarmonicInverse.py
+++ b/galpy/actionAngle/actionAngleHarmonicInverse.py
@@ -9,7 +9,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace, promote_scalars
+from ..backend import get_namespace, numpy_island, promote_scalars
 from ..util import conversion
 from .actionAngleInverse import actionAngleInverse
 
@@ -43,6 +43,7 @@ class actionAngleHarmonicInverse(actionAngleInverse):
         self._omega = omega
         return None
 
+    @numpy_island
     def _evaluate(self, j, angle, **kwargs):
         """
         Evaluate the phase-space coordinates (x,v) for a number of angles on a single torus
@@ -65,6 +66,7 @@ class actionAngleHarmonicInverse(actionAngleInverse):
         """
         return self._xvFreqs(j, angle, **kwargs)[:2]
 
+    @numpy_island
     def _xvFreqs(self, j, angle, **kwargs):
         """
         Evaluate the phase-space coordinates (x,v) for a number of angles on a single torus as well as the frequency
@@ -96,6 +98,7 @@ class actionAngleHarmonicInverse(actionAngleInverse):
         vx = amp * self._omega * xp.cos(angle)
         return (x, vx, self._omega)
 
+    @numpy_island
     def _Freqs(self, j, **kwargs):
         """
         Return the frequency corresponding to a torus

--- a/galpy/actionAngle/actionAngleIsochroneInverse.py
+++ b/galpy/actionAngle/actionAngleIsochroneInverse.py
@@ -10,7 +10,7 @@
 import numpy
 from scipy import optimize
 
-from ..backend import get_namespace, promote_scalars
+from ..backend import get_namespace, numpy_island, promote_scalars
 from ..potential import IsochronePotential
 from ..util import conversion
 from .actionAngleInverse import actionAngleInverse
@@ -74,6 +74,7 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         self._check_consistent_units()
         return None
 
+    @numpy_island
     def _evaluate(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
         """
         Evaluate the phase-space coordinates (x,v) for a number of angles on a single torus.
@@ -104,6 +105,7 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         """
         return self._xvFreqs(jr, jphi, jz, angler, anglephi, anglez, **kwargs)[:6]
 
+    @numpy_island
     def _xvFreqs(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
         """
         Evaluate the phase-space coordinates (x,v) for a number of angles on a single torus as well as the frequencies.
@@ -212,6 +214,7 @@ class actionAngleIsochroneInverse(actionAngleInverse):
         phi = xp.where(phi < 0.0, phi + 2.0 * numpy.pi, phi)
         return (R, vR, jphi / R, z, vz, phi, omegar, xp.sign(jphi) * omegaz, omegaz)
 
+    @numpy_island
     def _Freqs(self, jr, jphi, jz, **kwargs):
         """
         Return the frequencies corresponding to a torus


### PR DESCRIPTION
Stacked on #1033 (needs `galpy.backend.numpy_island`).

The inverse action→coordinate mappings for the **harmonic oscillator** and the **isochrone** are closed-form (`IsochroneInverse` already uses the backend `brentq` for the eccentric-anomaly root-find), so unlike the genuinely-iterative `actionAngleVerticalInverse`, they **are** backend-migratable. They were simply missing the `@numpy_island` decorator, so under a forced jax/torch backend they returned backend arrays for numpy/scalar input and the tests' numpy comparisons mixed (`numpy.amax(Tensor)` / `ndarray - Tensor`).

- Add `@numpy_island` to `_evaluate` / `_xvFreqs` / `_Freqs` on both classes → the inverse mapping runs and returns numpy for numpy/scalar input; a real backend-array input still runs the backend-native path. numpy byte-identical; no new failures.

**No ledger change.** The `*_wrtIsochrone` / `*_wrtHarmonic` / `*_orbit` tests compare against an in-test `Pot(normalize=...)` (whose `_amp` is a backend array under a forced backend) or an `Orbit` integrated under the backend, so they stay ledgered until the eval-time param-coercion / orbit-side follow-up — the same blocker as the Staeckel/Spherical `otherIsochrone` tests. This PR makes the classes backend-aware so they flip for free once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)