### PR TITLE
Release 1.12.0

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,120 +1,110 @@
-v1.12.0 (expected around 2026-07-01)
+v1.12.0 (2026-07-01)
 ====================
 
-- Fixed a crash when sampling a spherical distribution function whose
-  isotropic (Eddington-inverted) form dips slightly negative over part of the
-  velocity range -- e.g. near the truncation radius of a sharply
-  exponentially-truncated NFW profile. Previously ``sample`` could fail in
-  ``sphericaldf._make_pvr_interpolator`` with an ``IndexError`` (when a
-  velocity column became entirely non-positive) or a ``ValueError: x must be
-  increasing`` (when the clamped cumulative velocity distribution was
-  non-monotonic). These regions are now clamped to be non-negative and
-  monotonic before building the inverse-CDF interpolator, so sampling succeeds
-  (still emitting the existing "DF appears to have negative regions" warning).
+- Added the full 3D variational equations (the state-transition matrix
+  dx(t)/dx0, integrated via ``Orbit.integrate_dxdv``) in C for most of the
+  potential library, the 3D analogue of the existing planar machinery. This
+  enables fast tangent-dynamics, Lyapunov-exponent (see ``Orbit.lyapunov``
+  below), and chaos calculations, and lays the groundwork for differentiable
+  orbit integration. Many potentials gained their analytic 3D Hessian in C as
+  part of this work.
+
+- Added ``Orbit.lyapunov`` to estimate the largest Lyapunov exponent of an orbit
+  from the variational equations using the renormalization method of Benettin et
+  al. (1980), for both planar and full 3D orbits (using the C variational
+  integrators when available). Setting ``spectrum=True`` computes the full
+  Lyapunov spectrum instead.
+
+- Extended the 3D variational equations in C to velocity-dependent (dissipative)
+  forces, starting with ``ChandrasekharDynamicalFrictionForce`` and
+  ``FDMDynamicalFrictionForce``.
+
+- Added the remaining C second derivatives used by these variational equations,
+  including ``NonInertialFrameForce`` (so phase-space volumes can be integrated
+  in rotating/accelerating frames), the ``OblateStaeckelWrapperPotential`` and
+  ``CylindricallySeparablePotentialWrapper`` wrappers, and the
+  ``SteadyLogSpiralPotential`` and ``TransientLogSpiralPotential`` spirals.
+
+- Added ``MultipoleExpansionPotential``, which represents the potential of an
+  arbitrary density distribution via a real spherical-harmonic multipole
+  expansion, with both Python and C evaluation of the potential, forces, second
+  derivatives, and density. Build it from a density function with the
+  ``from_density`` classmethod.
+
+- Added a ``StreamTrack`` class holding a smooth, precomputed phase-space track
+  through a tidal stream, with accessors for every standard galpy coordinate
+  system, a ``cov`` method for the 6x6 phase-space covariance along the track
+  (via analytic Jacobians), and plotting with an optional ±σ spread band. Tracks
+  can be built from a particle sample (``StreamTrack.from_particles``) or
+  directly from a ``streamdf`` or ``streamspraydf`` via their new ``streamTrack``
+  methods.
+
+- Added ``ExpTruncNFWPotential``, an NFW profile with an exponential truncation
+  ``exp(-r/rc)`` and hence finite total mass, with closed-form mass, potential,
+  force, and second derivative. Supports isotropic, Osipkov-Merritt, and
+  constant-beta distribution functions and has a C implementation (including the
+  full 3D Hessian for the variational equations). A ``from_nfw`` classmethod
+  truncates an existing ``NFWPotential``, and the total mass can alternatively be
+  set directly with the ``mass=`` keyword.
+
+- Added support for non-uniform stripping-time distributions (with a pericenter
+  helper) and callable, time-dependent ``progenitor_mass`` to the stream spray
+  DFs (``streamspraydf``).
+
+- Added support for per-orbit integration time arrays in ``Orbit.integrate``, so
+  each orbit in a multi-orbit ``Orbit`` can be integrated over its own time
+  range; this also enables batched ``streamspraydf`` integration.
+
+- Added a ``tail=`` keyword to ``fardal15spraydf`` and ``chen24spraydf`` (and
+  ``basestreamspraydf``) to select which tidal tail(s) to model (``'leading'``,
+  ``'trailing'``, or ``'both'``, the default). This replaces the now-deprecated
+  ``leading=`` keyword, which will be removed in v1.14.
+
+- Added an ``align_to_orbit`` helper (to ``galpy.util.coords`` and as an
+  ``Orbit`` method) that aligns an orbit horizontally.
+
+- Added a ``cinterp`` option (default ``True``) to ``NonInertialFrameForce``
+  that, during C integration, replaces its time-dependent inputs by cubic-spline
+  interpolations evaluated natively in C, giving large speed-ups (>100x when the
+  inputs are not ``numba``-compatible). Set ``cinterp=False`` to evaluate the
+  provided functions directly, which is required for surface-of-section
+  integration.
+
+- Vectorized ``EllipsoidalPotential`` evaluations so the triaxial ellipsoidal
+  potentials accept array inputs.
+
+- Added frequencies and angles computation for ``actionAngleStaeckel`` in pure
+  Python (``c=False``).
+
+- Rewrote the documentation tutorials as tested Jupyter notebooks with gallery
+  navigation.
+
+- Fixed a segmentation fault (or silently-dropped force) when integrating planar
+  orbits with a C integrator for potentials whose 3D version has a C
+  implementation but whose planar version does not (e.g. ``interpRZPotential``,
+  ``ChandrasekharDynamicalFrictionForce``); such potentials now fall back to
+  Python integration.
+
+- Fixed a stale-force bug in the C implementation of
+  ``RotateAndTiltWrapperPotential``, whose force cache was keyed on position only
+  and so returned stale forces when re-evaluating a time-dependent wrapped
+  potential at the same position but a different time.
+
+- Fixed an incorrect physical-unit conversion for ``phitorque`` in
+  ``DissipativeForce`` and ``planarDissipativeForce``.
 
 - Fixed compatibility with astropy >= 8.0, where the ``Galactocentric``
-  ``galcen_v_sun`` frame attribute is now a ``CartesianRepresentation`` (read
-  via ``.xyz``) rather than a ``CartesianDifferential`` (``.d_xyz``); see
-  astropy/astropy#18362. Initializing an ``Orbit`` from a ``SkyCoord`` that
-  carries ``galcen_v_sun`` now works on both old and new astropy.
+  ``galcen_v_sun`` attribute is now a ``CartesianRepresentation`` rather than a
+  ``CartesianDifferential`` (astropy/astropy#18362), so initializing an ``Orbit``
+  from a ``SkyCoord`` carrying ``galcen_v_sun`` works again.
 
-- Added ``ExpTruncNFWPotential``, an NFW profile multiplied by an exponential
-  truncation ``exp(-r/rc)`` with truncation radius ``rc``. The profile has a
-  finite total mass; the enclosed mass, potential, force, and second
-  derivative are all closed-form (via the exponential integral E_1), with a
-  small-radius Taylor expansion used to avoid catastrophic cancellation when
-  ``r`` is much smaller than ``a`` and ``rc``. The ``amp`` follows the
-  ``NFWPotential`` mass-scale convention (the two potentials coincide as
-  ``rc -> infinity``); alternatively the total mass can be set directly with
-  the ``mass=`` keyword. Also provides a ``from_nfw`` classmethod that truncates
-  an existing ``NFWPotential`` (inheriting its ``amp`` and ``a``), with the
-  truncation set by either ``rc`` or a desired total ``mass``. Supports isotropic
-  (``eddingtondf``), Osipkov-Merritt (``osipkovmerrittdf``), and constant-beta
-  (``constantbetadf``) distribution functions through closed-form ``_ddensdr``,
-  ``_d2densdr2``, and ``_ddenstwobetadr`` (and a JAX ``_rforce_jax``). Has a C
-  implementation (``hasC=True``), including the full 3D Hessian for the
-  variational equations (``hasC_dxdv3d=True``), giving fast orbit integration on
-  par with the other closed-form spherical potentials.
+- Fixed compatibility with numpy 2.5.0 (complex ``eig``/``eigvals`` results and
+  the ``chararray`` deprecation).
 
-- Added analytic planar second derivatives (R2deriv, phi2deriv, Rphideriv) of
-  ``SteadyLogSpiralPotential`` and ``TransientLogSpiralPotential`` in Python
-  and C, enabling the planar variational equations of ``Orbit.integrate_dxdv``
-  in C for these spirals (``hasC_dxdv=True``).
-
-- Added ``Orbit.lyapunov`` to estimate the largest Lyapunov exponent of an
-  orbit from the variational equations (``integrate_dxdv``) using the
-  renormalization method of Benettin et al. (1980). Works for planar
-  (phase-space dimension 4) and full 3D (phase-space dimension 6) orbits,
-  using the C variational integrators when available, and returns the running
-  estimate lambda(t) at all output times so that convergence can be assessed.
-  Setting ``spectrum=True`` computes the full Lyapunov spectrum (all
-  phase-space-dimension exponents) instead, by propagating an orthonormal set
-  of deviation vectors that is re-orthonormalized with a QR decomposition at
-  every renormalization (Benettin et al. 1980, part 2; Shimada & Nagashima
-  1979).
-
-- Extended the 3D variational equations of ``Orbit.integrate_dxdv`` in C to
-  velocity-dependent (dissipative) forces, starting with
-  ``ChandrasekharDynamicalFrictionForce`` and ``FDMDynamicalFrictionForce``
-  (analytic Jacobians; advertised via ``hasC_dxdv3d``). The pure-Python
-  ``integrate_dxdv`` methods raise a ``NotImplementedError`` for dissipative
-  forces.
-
-- Added C implementations of the second derivatives of
-  ``OblateStaeckelWrapperPotential`` and
-  ``CylindricallySeparablePotentialWrapper``, enabling both the planar and the
-  full 3D variational equations of ``Orbit.integrate_dxdv`` in C for these
-  wrappers (``hasC_dxdv`` and ``hasC_dxdv3d``, conditioned on the wrapped
-  potential's own C capabilities).
-
-- Wired the rectangular force Jacobian of ``NonInertialFrameForce`` in C for
-  the 3D variational equations (``hasC_dxdv3d=True``): the frame force is
-  linear in position and velocity, so dF/dv = -2 [Omega]_x and
-  dF/dx = |Omega|^2 I - Omega Omega^T - [Omegadot]_x are exact for every
-  supported configuration (scalar or vector Omega, constant or time-dependent
-  through tfuncs or the cinterp splines, Omegadot, and the x0/v0/a0
-  translation terms, which contribute zero). Phase-space volumes can now be
-  integrated in rotating/accelerating frames; because dF/dv is antisymmetric,
-  the frame force is phase-volume preserving (det M(t) = 1 exactly), unlike
-  dynamical friction.
-
-- Fixed a segmentation fault (or silently-dropped force) when integrating
-  planar orbits with a C integrator for potentials whose 3D version has a C
-  implementation, but whose planar version does not (e.g., interpRZPotential,
-  ChandrasekharDynamicalFrictionForce, FDMDynamicalFrictionForce). Such
-  potentials now fall back to Python integration with the usual warning, and
-  the C potential parsers now raise a clear error for any potential that
-  claims C support without having a C implementation.
-
-- Fixed a bug in the C implementation of ``RotateAndTiltWrapperPotential``
-  where the internal force cache was keyed on position only, so that
-  re-evaluating the force at the same position but a different time returned
-  stale forces when wrapping a time-dependent potential. The cache key now
-  includes the time.
-
-- Added a ``cinterp`` option (default ``True``, resolution set by ``cinterp_n``)
-  to ``NonInertialFrameForce`` that, during C orbit integration, replaces the
-  time-dependent inputs (``a0``, ``x0``, ``v0``, ``Omega``) by cubic-spline
-  interpolations built on the fly and evaluated natively in C, giving large
-  speed-ups (>100x when the inputs are not ``numba``-compatible). Set
-  ``cinterp=False`` to evaluate the provided functions directly, which is
-  required for surface-of-section integration.
-
-- Added ``tail=`` keyword to ``fardal15spraydf`` and ``chen24spraydf`` (and
-  ``basestreamspraydf``) to select which tidal tail(s) to model: ``'leading'``,
-  ``'trailing'``, or ``'both'`` (default). This replaces the ``leading=``
-  keyword, which is now deprecated and will be removed in v1.14.
-
-- Added MultipoleExpansionPotential, which computes the gravitational potential
-  of an arbitrary density distribution via a real spherical-harmonic multipole
-  expansion. The density is decomposed on a radial grid using Gauss-Legendre
-  (theta) and trapezoidal (phi) quadrature; radial integrals are stored as
-  Bernstein-polynomial splines for smooth derivatives that satisfy Poisson's
-  equation by construction. Both Python and C evaluation are supported,
-  including forces, second derivatives, and density reconstruction. The
-  constructor accepts precomputed density-coefficient splines, while the
-  from_density classmethod handles density decomposition (following the
-  SCFPotential pattern).
+- Fixed a crash when sampling a spherical distribution function whose isotropic
+  (Eddington-inverted) form dips slightly negative (e.g. near the truncation
+  radius of a sharply truncated NFW profile); such regions are now clamped to be
+  non-negative and monotonic before sampling.
 
 v1.11.2 (2026-02-27)
 ====================

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -26,10 +26,16 @@ v1.12.0 (2026-07-01)
   ``SteadyLogSpiralPotential`` and ``TransientLogSpiralPotential`` spirals.
 
 - Added ``MultipoleExpansionPotential``, which represents the potential of an
-  arbitrary density distribution via a real spherical-harmonic multipole
-  expansion, with both Python and C evaluation of the potential, forces, second
-  derivatives, and density. Build it from a density function with the
-  ``from_density`` classmethod.
+  arbitrary (and optionally time-dependent) density distribution via a real
+  spherical-harmonic multipole expansion, with both Python and C evaluation of
+  the potential, forces, second derivatives, and density. Build it from a density
+  function with the ``from_density`` classmethod.
+
+- Added ``DiskMultipoleExpansionPotential``, which represents disk+halo systems
+  by solving the Poisson equation with a multipole expansion (the analogue of
+  ``DiskSCFPotential`` built on ``MultipoleExpansionPotential``); the two now
+  share a ``KuijkenDubinskiDiskExpansionPotential`` base class, with C orbit
+  integration support.
 
 - Added a ``StreamTrack`` class holding a smooth, precomputed phase-space track
   through a tidal stream, with accessors for every standard galpy coordinate
@@ -46,6 +52,12 @@ v1.12.0 (2026-07-01)
   full 3D Hessian for the variational equations). A ``from_nfw`` classmethod
   truncates an existing ``NFWPotential``, and the total mass can alternatively be
   set directly with the ``mass=`` keyword.
+
+- Added analytic power-law spherical distribution functions for tracer densities
+  nu(r) ~ r^-gamma in power-law potentials (following Evans et al. 1997):
+  ``isotropicPowerLawdf``, ``constantbetaPowerLawdf``, and
+  ``osipkovmerrittPowerLawdf``, each supporting both the self-consistent and the
+  non-self-consistent (tracer != potential-generating density) cases.
 
 - Added support for non-uniform stripping-time distributions (with a pericenter
   helper) and callable, time-dependent ``progenitor_mass`` to the stream spray

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -5,6 +5,115 @@ This page gives some of the key improvements in each galpy
 version. See the ``HISTORY.txt`` file in the galpy source for full
 details on what is new and different in each version.
 
+v1.12
++++++
+
+Following the yearly release cycle, this entry covers all of the releases since
+v1.11.0: v1.11.1, v1.11.2, and v1.12.0. Together these contain several major new
+features alongside many smaller improvements and bug fixes. The major new
+additions are:
+
+* Full support for the **3D variational equations** (the state-transition
+  matrix) during orbit integration in C, the 3D analogue of the existing planar
+  machinery, available for most of the potential library through
+  ``Orbit.integrate_dxdv``. Building on this, the new ``Orbit.lyapunov`` method
+  estimates the largest Lyapunov exponent (or, with ``spectrum=True``, the full
+  Lyapunov spectrum) of an orbit using the renormalization method of `Benettin
+  et al. (1980)
+  <https://ui.adsabs.harvard.edu/abs/1980Mecc...15....9B/abstract>`__, making it
+  easy to quantify orbital chaos. The variational equations also support
+  velocity-dependent (dissipative) forces such as dynamical friction.
+
+* The new ``MultipoleExpansionPotential``, which represents the potential of an
+  arbitrary density distribution through a real spherical-harmonic multipole
+  expansion. Both Python and C evaluation of the potential, forces, second
+  derivatives, and density are supported, and the potential can be constructed
+  directly from a density function with the ``from_density`` classmethod.
+
+* A new ``StreamTrack`` class that holds a smooth, precomputed phase-space track
+  through a tidal stream, with accessors for every standard galpy coordinate
+  system, an analytic 6x6 phase-space covariance along the track (``cov``), and
+  built-in plotting. Tracks can be built from a particle sample or directly from
+  a ``streamdf`` or ``streamspraydf`` using their new ``streamTrack`` methods.
+
+* The new ``CompositePotential``, ``planarCompositePotential``, and
+  ``linearCompositePotential`` classes that represent combinations of potentials
+  in 3D, 2D, and 1D. These are created automatically when adding potentials with
+  ``+`` (already the recommended way to combine potentials) and provide better
+  performance and a cleaner interface than the previous lists of potentials.
+
+Other user-facing improvements and additions are:
+
+* New potentials and forces:
+
+  * ``EinastoPotential``, the potential corresponding to the Einasto density
+    profile.
+
+  * ``ExpTruncNFWPotential``, an NFW profile with an exponential truncation and
+    hence finite total mass, with closed-form properties, a C implementation,
+    and support for isotropic, Osipkov-Merritt, and constant-beta distribution
+    functions.
+
+  * Fuzzy dark matter (FDM) dynamical friction through
+    ``FDMDynamicalFrictionForce``.
+
+  * Two new wrapper potentials: ``OblateStaeckelWrapperPotential`` (turns a
+    potential into an oblate Staeckel potential) and
+    ``CylindricallySeparablePotentialWrapper``.
+
+* Faster orbit integration:
+
+  * C implementations of ``TwoPowerSphericalPotential`` (including
+    ``HernquistPotential``, ``JaffePotential``, and ``NFWPotential``) and
+    ``TwoPowerTriaxialPotential``, using fast hypergeometric-function routines.
+
+  * A ``cinterp`` option for ``NonInertialFrameForce`` that, during C
+    integration, replaces its time-dependent inputs by natively-evaluated cubic
+    splines, giving large speed-ups.
+
+  * Vectorized ``EllipsoidalPotential`` evaluations (array inputs) and C planar
+    second derivatives for the ellipsoidal potentials.
+
+* New and improved ``Orbit`` functionality:
+
+  * Orbit integrations can now be **continued or extended**: re-integrating an
+    already-integrated orbit over a time array that continues from the previous
+    one merges the two, so an orbit can be integrated forward and then backward
+    in time, or extended, without starting over.
+
+  * Orbits can be integrated **without specifying a time array** by calling
+    ``integrate(pot)``, which integrates for ten dynamical times by default
+    using the potential's dynamical time at the initial position.
+
+  * Each orbit in a multi-orbit ``Orbit`` can now be integrated over its own
+    **per-orbit time array**.
+
+  * A new ``align_to_orbit`` helper (in ``galpy.util.coords`` and as an
+    ``Orbit`` method) aligns an orbit horizontally.
+
+* Stream modeling:
+
+  * A ``tail=`` keyword for ``fardal15spraydf`` and ``chen24spraydf`` to select
+    the leading, trailing, or both tidal tails (replacing the now-deprecated
+    ``leading=`` keyword).
+
+  * Support for non-uniform stripping-time distributions and callable,
+    time-dependent progenitor masses in the stream spray DFs.
+
+* Action-angle:
+
+  * Frequencies and angles are now also computed in pure Python (``c=False``)
+    for ``actionAngleStaeckel`` and ``actionAngleAdiabatic``.
+
+* Other:
+
+  * Support for Python 3.14 (and removal of end-of-life Python 3.9).
+
+  * Enhanced ``__repr__`` methods for potential, force, and wrapper classes.
+
+  * The documentation tutorials have been rewritten as tested Jupyter notebooks
+    with gallery navigation.
+
 v1.11
 +++++
 

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -25,10 +25,13 @@ additions are:
   velocity-dependent (dissipative) forces such as dynamical friction.
 
 * The new ``MultipoleExpansionPotential``, which represents the potential of an
-  arbitrary density distribution through a real spherical-harmonic multipole
-  expansion. Both Python and C evaluation of the potential, forces, second
-  derivatives, and density are supported, and the potential can be constructed
-  directly from a density function with the ``from_density`` classmethod.
+  arbitrary, and optionally time-dependent, density distribution through a real
+  spherical-harmonic multipole expansion. Both Python and C evaluation of the
+  potential, forces, second derivatives, and density are supported, and the
+  potential can be constructed directly from a density function with the
+  ``from_density`` classmethod. The companion ``DiskMultipoleExpansionPotential``
+  uses this machinery to represent disk+halo systems by solving the Poisson
+  equation, the multipole analogue of ``DiskSCFPotential``.
 
 * A new ``StreamTrack`` class that holds a smooth, precomputed phase-space track
   through a tidal stream, with accessors for every standard galpy coordinate
@@ -41,6 +44,8 @@ additions are:
   in 3D, 2D, and 1D. These are created automatically when adding potentials with
   ``+`` (already the recommended way to combine potentials) and provide better
   performance and a cleaner interface than the previous lists of potentials.
+  Combining potentials using lists remains supported for now, but will be
+  deprecated in a future version (likely v1.14).
 
 Other user-facing improvements and additions are:
 
@@ -57,22 +62,30 @@ Other user-facing improvements and additions are:
   * Fuzzy dark matter (FDM) dynamical friction through
     ``FDMDynamicalFrictionForce``.
 
-  * Two new wrapper potentials: ``OblateStaeckelWrapperPotential`` (turns a
-    potential into an oblate Staeckel potential) and
-    ``CylindricallySeparablePotentialWrapper``.
+  * Two new wrapper potentials: ``OblateStaeckelWrapperPotential``, which turns
+    any potential into an oblate Staeckel potential, and
+    ``CylindricallySeparablePotentialWrapper``, which approximates an
+    axisymmetric potential as one that is separable in the cylindrical
+    coordinates :math:`R` and :math:`z` (built from the potential's radial and
+    vertical force profiles). Both are useful for action-angle estimation: the
+    former for the Staeckel approximation (``actionAngleStaeckel``) and the
+    latter for the adiabatic approximation (``actionAngleAdiabatic``).
 
 * Faster orbit integration:
 
-  * C implementations of ``TwoPowerSphericalPotential`` (including
-    ``HernquistPotential``, ``JaffePotential``, and ``NFWPotential``) and
-    ``TwoPowerTriaxialPotential``, using fast hypergeometric-function routines.
+  * C implementations of ``TwoPowerSphericalPotential`` instances with general
+    inner and outer exponents, and of ``TwoPowerTriaxialPotential``, using fast
+    hypergeometric-function routines (the special cases such as
+    ``HernquistPotential``, ``JaffePotential``, and ``NFWPotential`` already had
+    C implementations).
 
   * A ``cinterp`` option for ``NonInertialFrameForce`` that, during C
     integration, replaces its time-dependent inputs by natively-evaluated cubic
     splines, giving large speed-ups.
 
-  * Vectorized ``EllipsoidalPotential`` evaluations (array inputs) and C planar
-    second derivatives for the ellipsoidal potentials.
+  * Vectorized ``EllipsoidalPotential`` evaluations (array inputs), C planar
+    second derivatives for the ellipsoidal potentials, and analytic (rather than
+    numerical) second derivatives for ``SCFPotential``.
 
 * New and improved ``Orbit`` functionality:
 
@@ -90,6 +103,15 @@ Other user-facing improvements and additions are:
 
   * A new ``align_to_orbit`` helper (in ``galpy.util.coords`` and as an
     ``Orbit`` method) aligns an orbit horizontally.
+
+* Distribution functions:
+
+  * New analytic power-law spherical distribution functions for tracer densities
+    :math:`\nu(r) \propto r^{-\gamma}` in power-law potentials, following Evans
+    et al. (1997): ``isotropicPowerLawdf``, ``constantbetaPowerLawdf``, and
+    ``osipkovmerrittPowerLawdf``, each supporting both the self-consistent and
+    the non-self-consistent (tracer differs from the potential-generating
+    density) cases.
 
 * Stream modeling:
 
@@ -111,8 +133,15 @@ Other user-facing improvements and additions are:
 
   * Enhanced ``__repr__`` methods for potential, force, and wrapper classes.
 
-  * The documentation tutorials have been rewritten as tested Jupyter notebooks
-    with gallery navigation.
+Finally, there are some notable internal and documentation changes. The
+documentation tutorials have been rewritten as Jupyter notebooks with gallery
+navigation, and these notebooks are now executed as part of the test suite (and
+periodically re-rendered) so that the documentation is automatically checked
+against the current code and stays up to date. Internally, a large effort went
+into adding analytic second derivatives (Hessians) in C across the potential
+library to support the new variational equations, and the C implementations of
+the two-power potentials build on a newly-vendored copy of the ``xsf`` special-
+functions library for fast and accurate hypergeometric functions.
 
 v1.11
 +++++


### PR DESCRIPTION
Release branch for galpy v1.12.0. This PR collects all release work; please review the consolidated changelog here.

As a first step, `HISTORY.txt` has been cleaned up and expanded:

- Reordered so wide-ranging new functionality is near the top and small bug fixes near the bottom.
- Trimmed the entries to match the concise house style of prior releases.
- Filled in the release date as `2026-07-01`.
- Audited the commit log and added major features that were missing from the changelog, including:
  - `StreamTrack` (smooth phase-space stream track; `streamdf`/`streamspraydf` `streamTrack` methods)
  - the full 3D variational equations (`Orbit.integrate_dxdv` / state-transition matrix) in C across most of the potential library
  - `streamspraydf` enhancements (non-uniform stripping times, callable `progenitor_mass`)
  - per-orbit integration time arrays in `Orbit.integrate`
  - `align_to_orbit`, `EllipsoidalPotential` array inputs, pure-Python `actionAngleStaeckel` frequencies/angles, and the Jupyter-notebook tutorials
  - a few compatibility/correctness fixes (astropy ≥ 8.0, numpy 2.5.0, `phitorque` units)

Only `HISTORY.txt` is touched so far.

Later also updated "What's new".

🤖 Generated with [Claude Code](https://claude.com/claude-code)