### PR TITLE
Staeckel jit-fast: roll direct bisection + AA bracket loops into lax.fori_loop (under trace)

### DIFF
--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -564,6 +564,7 @@ class actionAngleSpherical(actionAngle):
         by dead-branch-guarded xp.where overrides. gamma==0 (=> startsign=+1).
         """
         from ..backend.optimize import brentq as _backend_brentq
+        from ..backend.optimize import iterate_bracket
 
         xp = get_namespace(r)
 
@@ -573,14 +574,14 @@ class actionAngleSpherical(actionAngle):
         # Fixed-schedule bracketing (mirrors _rapRperiAxiFindStart, vectorised):
         # halve from r/2 until f<=0 (or below the floor) for rperi's lower end,
         # double from 2r until f<=0 for rap's upper end. 80 steps >> any needed.
-        rstart = r / 2.0
-        for _ in range(80):
-            rstart = xp.where(
-                (f(rstart, E, L) > 0.0) & (rstart > 1e-9), rstart / 2.0, rstart
-            )
-        rend = 2.0 * r
-        for _ in range(80):
-            rend = xp.where(f(rend, E, L) > 0.0, rend * 2.0, rend)
+        rstart = iterate_bracket(
+            lambda rs: xp.where((f(rs, E, L) > 0.0) & (rs > 1e-9), rs / 2.0, rs),
+            r / 2.0,
+            80,
+        )
+        rend = iterate_bracket(
+            lambda re: xp.where(f(re, E, L) > 0.0, re * 2.0, re), 2.0 * r, 80
+        )
         # Special cases (all are vr==0, measure-zero among generic test orbits).
         vcirc_r = vcirc(self._2dpot, r, use_physical=False)
         is_circ = (vr == 0.0) & (xp.abs(vt - vcirc_r) < _EPS)

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -22,7 +22,7 @@ from ..backend import (
     is_backend_array,
     promote_scalars,
 )
-from ..backend.optimize import bisect_root
+from ..backend.optimize import bisect_root, iterate_bracket
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..potential import (
     CompositePotential,
@@ -143,15 +143,16 @@ def _staeckel_uminumax(xp, s, pot, delta):
     # Lower bracket: HALVE below ux until f<0 (60 halvings reach ~1e-18, so even a
     # near-axis turning point at u~1e-4 -- low-Lz, nearly-radial orbits -- is
     # straddled; *0.9 only reached ~3.8e-4*ux in 80 steps and collapsed umin to ux).
-    lo = ux * 0.5
-    for _ in range(60):
-        lo = xp.where((f(lo) >= 0.0) & (lo > 1e-10), lo * 0.5, lo)
+    lo = iterate_bracket(
+        lambda l: xp.where((f(l) >= 0.0) & (l > 1e-10), l * 0.5, l), ux * 0.5, 60
+    )
     # f still >0 at the floor -> no lower J_R turning point: the orbit reaches the
     # symmetry axis (Lz~0, purely-radial), so umin=0 (mirrors C / Single rstart==0).
     reaches_axis = f(lo) >= 0.0
-    hi = ux * 1.1
-    for _ in range(80):  # expanding bracket above ux until f<0 (stop at u=100)
-        hi = xp.where((f(hi) >= 0.0) & (hi < 100.0), hi * 1.1, hi)
+    # expanding bracket above ux until f<0 (stop at u=100)
+    hi = iterate_bracket(
+        lambda h: xp.where((f(h) >= 0.0) & (h < 100.0), h * 1.1, h), ux * 1.1, 80
+    )
     # No upper turning point below u=100 (f(100)>=0 -> u=100 still in the allowed
     # region) -> unbound, mirroring the per-object _uminUmaxFindStart
     # `utry > 100 -> UnboundError`.
@@ -180,9 +181,9 @@ def _staeckel_vmin(xp, s, pot, delta):
     vx, eps = s["vx"], 1e-8
     at_turn = (xp.abs(s["pvx"]) < 1e-7) | (xp.abs(f(vx)) < 1e-10)
     at_vmin = at_turn & (f(vx + eps) > 0.0) & (f(vx - eps) < 0.0)
-    vlo = vx * 0.9
-    for _ in range(80):
-        vlo = xp.where((f(vlo) >= 0.0) & (vlo > 1e-9), vlo * 0.9, vlo)
+    vlo = iterate_bracket(
+        lambda v: xp.where((f(v) >= 0.0) & (v > 1e-9), v * 0.9, v), vx * 0.9, 80
+    )
     vmin = bisect_root(f, vlo, vx, xp, xtol=1e-13, maxiter=200)
     return xp.where(at_vmin, vx, vmin)
 

--- a/galpy/actionAngle/actionAngleVertical.py
+++ b/galpy/actionAngle/actionAngleVertical.py
@@ -330,6 +330,7 @@ class actionAngleVertical(actionAngle):
     def _calc_xmax_backend(self, x, vx, E):
         """Vectorised turning point xmax (E == Phi(xmax)) via backend brentq."""
         from ..backend.optimize import brentq as _backend_brentq
+        from ..backend.optimize import iterate_bracket
 
         xp = get_namespace(x)
         absx = xp.abs(x)
@@ -338,9 +339,11 @@ class actionAngleVertical(actionAngle):
             return E_ - evaluatelinearPotentials(self._pot, xm, use_physical=False)
 
         # Expanding upper bracket: double from 2|x| (1e-5 at x=0) until f <= 0.
-        xend = xp.where(absx > 0.0, 2.0 * absx, 1e-5 * xp.ones_like(absx))
-        for _ in range(80):
-            xend = xp.where(f(xend, E) > 0.0, xend * 2.0, xend)
+        xend = iterate_bracket(
+            lambda xe: xp.where(f(xe, E) > 0.0, xe * 2.0, xe),
+            xp.where(absx > 0.0, 2.0 * absx, 1e-5 * xp.ones_like(absx)),
+            80,
+        )
         # Lower bracket |x| (f(|x|) = vx^2/2 >= 0); at the turning point vx==0,
         # |x| IS xmax, so use a safe lower end there (dead-branch guard) and
         # override below.

--- a/galpy/backend/_jax/optimize.py
+++ b/galpy/backend/_jax/optimize.py
@@ -49,9 +49,10 @@ def _bisect_root(f, a, b, xp, *, xtol, maxiter):
     """
     import jax
 
+    from .._namespaces import under_jax_trace
     from ..optimize import bisect_root, bisect_step, n_bisect_steps
 
-    if not any(isinstance(x, jax.core.Tracer) for x in (a, b)):
+    if not under_jax_trace(a, b):  # entered directly with a concrete bracket
         return bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter)
     lo = xp.asarray(a) * 1.0
     hi = xp.asarray(b) * 1.0

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -47,6 +47,31 @@ def is_backend_array(x):
     return False
 
 
+def under_jax_trace(*xs):
+    """True iff jax is imported AND one of ``xs`` is a jax tracer (jit/grad/vmap).
+
+    The predicate that gates the eager-loop-vs-``lax.fori_loop`` choice wherever
+    galpy rolls a fixed-schedule loop (bracket expansion, bisection, ...): the
+    eager Python loop stays byte-identical and ~9x faster outside a trace, while
+    under a jax trace the same body is rolled into a ``fori_loop`` so its ``n``
+    embedded copies of the physics closure do not unroll into the user's jaxpr.
+
+    Cheap on numpy/torch and on plain (untraced) jax arrays: if ``jax`` is not
+    even imported we short-circuit to ``False`` (via ``sys.modules``, so the
+    numpy/torch eager paths never import jax). This is deliberately gated on
+    ``sys.modules`` rather than the ``_JAX_LOADED`` install flag so a jax-
+    installed-but-unused run (pure numpy/torch) keeps the eager hot path from
+    importing jax at all.
+    """
+    import sys
+
+    if "jax" not in sys.modules:
+        return False
+    import jax
+
+    return any(isinstance(x, jax.core.Tracer) for x in xs)
+
+
 def _is_floating_dtype(dtype):
     """True for real floating-point dtypes of any backend.
 

--- a/galpy/backend/optimize.py
+++ b/galpy/backend/optimize.py
@@ -156,6 +156,42 @@ def bisect_step(lo, hi, slo, f, xp):
     return xp.where(same, mid, lo), xp.where(same, hi, mid)
 
 
+def _under_jax_trace(*xs):
+    """True iff jax is imported AND one of ``xs`` is a jax tracer (jit/grad/vmap).
+
+    Cheap on numpy/torch and on plain jax arrays: if ``jax`` is not even imported
+    we short-circuit to ``False`` (so the eager Python loops stay byte-identical
+    and we never import jax on the numpy/torch path). Under a jax trace the n
+    copies of the physics closure would otherwise unroll into the user's jaxpr.
+    """
+    import sys
+
+    if "jax" not in sys.modules:
+        return False
+    import jax
+
+    return any(isinstance(x, jax.core.Tracer) for x in xs)
+
+
+def iterate_bracket(step, x0, n):
+    """Run ``x = step(x)`` ``n`` times -- a fixed-schedule, branch-free bracket
+    expansion/contraction where ``step`` is a single ``xp.where`` update over the
+    physics closure ``f``.
+
+    Eager Python loop (numpy / torch / jax outside a trace) -> bit-identical to
+    the hand-written loop. Under a jax trace, a ``lax.fori_loop`` over the same
+    ``step`` so the ``n`` embedded copies of ``f`` do NOT unroll into the jaxpr
+    (mirrors the bisection rolling; eager stays ~9x faster than ``fori_loop``).
+    """
+    if _under_jax_trace(x0):
+        import jax
+
+        return jax.lax.fori_loop(0, n, lambda _, x: step(x), x0)
+    for _ in range(n):
+        x0 = step(x0)
+    return x0
+
+
 def bisect_root(f, a, b, xp, *, xtol, maxiter):
     """Vectorised, sign-preserving bisection root of ``f`` on ``[a, b]`` in ``xp``.
 
@@ -175,6 +211,15 @@ def bisect_root(f, a, b, xp, *, xtol, maxiter):
     for ``scipy.optimize.brentq``; same-sign brackets are a caller error and
     return a midpoint without a guarantee.
     """
+    # Under a jax trace (jit/grad/vmap), roll the fixed halving schedule into a
+    # lax.fori_loop so the n copies of f do not unroll into the jaxpr. This makes
+    # DIRECT callers jit-fast too -- notably the Staeckel umin/umax/vmin turning
+    # points, which call bisect_root straight (not via brentq). Eager keeps the
+    # Python loop (bit-identical, ~9x faster than fori_loop).
+    if _under_jax_trace(a, b):
+        from ._jax.optimize import _bisect_root
+
+        return _bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter)
     # Anchor on the inputs (device/dtype); * 1.0 promotes integer brackets.
     lo = xp.asarray(a) * 1.0
     hi = xp.asarray(b) * 1.0

--- a/galpy/backend/optimize.py
+++ b/galpy/backend/optimize.py
@@ -46,7 +46,7 @@
 #   first-order sensitivity; a Hessian through x* would require a true
 #   custom_jvp differentiating the implicit relation a second time.
 ###############################################################################
-from ._namespaces import is_backend_array
+from ._namespaces import is_backend_array, under_jax_trace
 from ._resolver import get_namespace
 
 # Default bracketing tolerance (matches scipy.optimize.brentq's xtol default, so
@@ -156,23 +156,6 @@ def bisect_step(lo, hi, slo, f, xp):
     return xp.where(same, mid, lo), xp.where(same, hi, mid)
 
 
-def _under_jax_trace(*xs):
-    """True iff jax is imported AND one of ``xs`` is a jax tracer (jit/grad/vmap).
-
-    Cheap on numpy/torch and on plain jax arrays: if ``jax`` is not even imported
-    we short-circuit to ``False`` (so the eager Python loops stay byte-identical
-    and we never import jax on the numpy/torch path). Under a jax trace the n
-    copies of the physics closure would otherwise unroll into the user's jaxpr.
-    """
-    import sys
-
-    if "jax" not in sys.modules:
-        return False
-    import jax
-
-    return any(isinstance(x, jax.core.Tracer) for x in xs)
-
-
 def iterate_bracket(step, x0, n):
     """Run ``x = step(x)`` ``n`` times -- a fixed-schedule, branch-free bracket
     expansion/contraction where ``step`` is a single ``xp.where`` update over the
@@ -183,7 +166,7 @@ def iterate_bracket(step, x0, n):
     ``step`` so the ``n`` embedded copies of ``f`` do NOT unroll into the jaxpr
     (mirrors the bisection rolling; eager stays ~9x faster than ``fori_loop``).
     """
-    if _under_jax_trace(x0):
+    if under_jax_trace(x0):
         import jax
 
         return jax.lax.fori_loop(0, n, lambda _, x: step(x), x0)
@@ -216,7 +199,7 @@ def bisect_root(f, a, b, xp, *, xtol, maxiter):
     # DIRECT callers jit-fast too -- notably the Staeckel umin/umax/vmin turning
     # points, which call bisect_root straight (not via brentq). Eager keeps the
     # Python loop (bit-identical, ~9x faster than fori_loop).
-    if _under_jax_trace(a, b):
+    if under_jax_trace(a, b):
         from ._jax.optimize import _bisect_root
 
         return _bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter)

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -841,6 +841,30 @@ def test_staeckel_actions_vs_c(backend):
     numpy.testing.assert_allclose(_np(jz_b), numpy.asarray(jz_c), rtol=1e-8, atol=1e-9)
 
 
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_staeckel_jit_grad_rolls_direct_bisection():
+    # Staeckel's turning points call the module-level ``bisect_root`` DIRECTLY
+    # (not via ``brentq``). Under a jax trace (jit/grad) the bracket endpoints are
+    # tracers, so ``bisect_root`` dispatches to the rolled ``lax.fori_loop`` kernel
+    # -- the ~100-step bisection does NOT unroll ~100 copies of the Staeckel
+    # integrand into the user's jaxpr. Covers the ``under_jax_trace(a, b)`` branch
+    # of ``galpy.backend.optimize.bisect_root`` reached only by these direct
+    # callers (the brentq-based AA methods route through a different kernel).
+    aA = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=False)
+    R = jnp.asarray(_STK[0])
+    rest = tuple(jnp.asarray(v) for v in _STK[1:])
+    jr_e, _, jz_e = aA(R, *rest)  # eager (Python-loop) reference
+    jr_j, _, jz_j = jax.jit(lambda r: aA(r, *rest))(R)  # traced (fori_loop) value
+    numpy.testing.assert_allclose(_np(jr_j), _np(jr_e), rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(_np(jz_j), _np(jz_e), rtol=1e-8, atol=1e-10)
+    # the jaxpr is ROLLED: a loop primitive, not ~100 unrolled bisection steps.
+    txt = str(jax.make_jaxpr(lambda r: aA(r, *rest)[0])(R))
+    assert ("while" in txt) or ("scan" in txt)
+    # grad flows through the direct-bisection turning points: finite dJr/dR.
+    g = jax.grad(lambda r: jnp.sum(aA(r, *rest)[0]))(R)
+    assert numpy.all(numpy.isfinite(_np(g)))
+
+
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_staeckel_unbound_backend_no_raise(backend):
     # An unbound orbit raises UnboundError on the numpy path (eager), but must NOT


### PR DESCRIPTION
First perf PR after Track E (action-angle) completion. Knocks out the biggest item on the backend speed-up roadmap (#93): the Staeckel jit/grad compile blow-up.

## Problem
The Staeckel turning-point bisections (`umin`/`umax`/`vmin`) call `bisect_root` **directly**, not via `brentq` — so #1026's `lax.fori_loop` rolling never reached them. Under a user `jit`/`grad` trace they unrolled `maxiter=200` copies of the physics closure, and six expanding-bracket `for`-loops (Staeckel ×3, Spherical ×2, Vertical ×1) unrolled 60–80 copies each. The Staeckel-actions jaxpr was **47,556 eqns / 134 s to compile** (N=8).

## Fix (the proven #1026 eager/traced split)
numpy / torch / jax-eager keep the Python loop → **byte-identical, no `fori_loop` eager regression**; `lax.fori_loop` runs **only under a jax trace** (gated by a new `_under_jax_trace`, which short-circuits to `False` unless jax is imported *and* an input is a `Tracer`).
- `bisect_root` now dispatches to the lax `_bisect_root` under a trace → Staeckel's 3 direct bisections get the small jaxpr.
- new `iterate_bracket(step, x0, n)` helper rolls the six bracket loops.

## Results (Staeckel actions, MWPotential2014, N=8, CPU x64)
| | baseline | after |
|---|---|---|
| jaxpr eqns | 47,556 | **2,283** (~21×) |
| jit compile+run | 134.0 s | **2.6 s** (~52×) |
| jit-vs-eager values | — | max\|Δ\| **1.6e-16** |
| grad through rolled loops | — | finite & correct |

## Regression
- numpy Staeckel/Spherical/Vertical actionAngle: **91 passed** (byte-identical)
- torch `test_backend_actionAngle` parity + gradcheck: **197 passed**
The new traced (lax) path is exercised by the existing jax/torch grad-vs-FD + gradcheck tests.