### PR TITLE
Bump version to 1.12.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.0.dev0
+current_version = 1.12.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize =
 	{major}.{minor}.{patch}.{release}{dev}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   given-names: "Jo"
   orcid: "https://orcid.org/0000-0001-6855-442X"
 title: "galpy"
-version: 1.12.0.dev0
+version: 1.12.0
 url: "https://github.com/jobovy/galpy"
 preferred-citation:
   type: article

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,7 +150,7 @@ copyright = f"2010 - {datetime.datetime.now().year}, Jo Bovy"
 # built documents.
 #
 # The short X.Y version.
-version = "1.12.0.dev0"
+version = "1.12.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"

--- a/galpy/__init__.py
+++ b/galpy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.12.0.dev0"
+__version__ = "1.12.0"
 # Check whether a new version is available
 import datetime
 import http.client

--- a/setup.py
+++ b/setup.py
@@ -387,7 +387,7 @@ class BuildExt(build_ext):
 setup(
     cmdclass=dict(build_ext=BuildExt),  # this to allow compiler check above
     name="galpy",
-    version="1.12.0.dev0",
+    version="1.12.0",
     description="Galactic Dynamics in python",
     author="Jo Bovy",
     author_email="bovy@astro.utoronto.ca",


### PR DESCRIPTION
Bump the version from `1.12.0.dev0` to `1.12.0` for the v1.12.0 release.

This is the `bumpversion release` change that was committed locally on the `release-1.12.0` branch but not pushed, so it was missed by the squash-merge of #1037 (`main` is currently still marked `1.12.0.dev0`). This restores the release version across `.bumpversion.cfg`, `CITATION.cff`, `doc/source/conf.py`, `galpy/__init__.py`, and `setup.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)