### PR TITLE
AA perf: Staeckel jacobian hoist + backend-agnostic recompute-elimination

### DIFF
--- a/galpy/actionAngle/actionAngleIsochrone.py
+++ b/galpy/actionAngle/actionAngleIsochrone.py
@@ -187,15 +187,14 @@ class actionAngleIsochrone(actionAngle):
             L2 = Lx * Lx + Ly * Ly + Lz * Lz
             E = self._ip(R, z) + vR**2.0 / 2.0 + vT**2.0 / 2.0 + vz**2.0 / 2.0
             L = xp.sqrt(L2)
+            sqrtL2p = xp.sqrt(L2 + 4.0 * self.amp * self.b)  # shared by Jr + Omegaz
             # Actions
             Jphi = Lz
             Jz = L - xp.abs(Lz)
-            Jr = self.amp / xp.sqrt(-2.0 * E) - 0.5 * (
-                L + xp.sqrt(L2 + 4.0 * self.amp * self.b)
-            )
+            Jr = self.amp / xp.sqrt(-2.0 * E) - 0.5 * (L + sqrtL2p)
             # Frequencies
             Omegar = (-2.0 * E) ** 1.5 / self.amp
-            Omegaz = 0.5 * (1.0 + L / xp.sqrt(L2 + 4.0 * self.amp * self.b)) * Omegar
+            Omegaz = 0.5 * (1.0 + L / sqrtL2p) * Omegar
             indx = Lz < 0.0
             Omegaphi = xp.where(indx, -Omegaz, Omegaz)
             return (Jr, Jphi, Jz, Omegar, Omegaphi, Omegaz)
@@ -252,29 +251,29 @@ class actionAngleIsochrone(actionAngle):
             L2 = Lx * Lx + Ly * Ly + Lz * Lz
             E = self._ip(R, z) + vR**2.0 / 2.0 + vT**2.0 / 2.0 + vz**2.0 / 2.0
             L = xp.sqrt(L2)
+            sqrtL2p = xp.sqrt(L2 + 4.0 * self.amp * self.b)  # shared by Jr + Omegaz
             # Actions
             Jz = L - xp.abs(Lz)
-            Jr = self.amp / xp.sqrt(-2.0 * E) - 0.5 * (
-                L + xp.sqrt(L2 + 4.0 * self.amp * self.b)
-            )
+            Jr = self.amp / xp.sqrt(-2.0 * E) - 0.5 * (L + sqrtL2p)
             # Frequencies
             Omegar = (-2.0 * E) ** 1.5 / self.amp
-            Omegaz = 0.5 * (1.0 + L / xp.sqrt(L2 + 4.0 * self.amp * self.b)) * Omegar
+            Omegaz = 0.5 * (1.0 + L / sqrtL2p) * Omegar
             indx = Lz < 0.0
             Omegaphi = xp.where(indx, -Omegaz, Omegaz)
             # Angles
             c = -self.amp / 2.0 / E - self.b
             e2 = 1.0 - L2 / self.amp / c * (1.0 + self.b / c)
             e = xp.sqrt(e2)
+            rsph = xp.sqrt(R**2.0 + z**2.0)  # shared by coseta(b==0) + cos/sintheta
             if self.b == 0.0:
-                coseta = 1 / e * (1.0 - xp.sqrt(R**2.0 + z**2.0) / c)
+                coseta = 1 / e * (1.0 - rsph / c)
             else:
                 s = 1.0 + xp.sqrt(1.0 + (R**2.0 + z**2.0) / self.b**2.0)
                 coseta = 1 / e * (1.0 - self.b / c * (s - 2.0))
             coseta = xp.clip(coseta, -1.0, 1.0)
             eta = xp.arccos(coseta)
-            costheta = z / xp.sqrt(R**2.0 + z**2.0)
-            sintheta = R / xp.sqrt(R**2.0 + z**2.0)
+            costheta = z / rsph
+            sintheta = R / rsph
             vrindx = (vR * sintheta + vz * costheta) < 0.0
             eta = xp.where(vrindx, 2.0 * numpy.pi - eta, eta)
             angler = eta - e * c / (c + self.b) * xp.sin(eta)
@@ -289,8 +288,9 @@ class actionAngleIsochrone(actionAngle):
             Lz = xp.where(Lz / L > 1.0, L, Lz)
             Lz = xp.where(Lz / L < -1.0, -L, Lz)
             Jphi = Lz
-            sini = xp.sqrt(L**2.0 - Lz**2.0) / L
-            tani = xp.sqrt(L**2.0 - Lz**2.0) / Lz
+            sqrtL2mLz2 = xp.sqrt(L**2.0 - Lz**2.0)  # shared by sini + tani
+            sini = sqrtL2mLz2 / L
+            tani = sqrtL2mLz2 / Lz
             sinpsi = costheta / sini
             sinpsi = xp.where((sinpsi > 1.0) & xp.isfinite(sinpsi), 1.0, sinpsi)
             sinpsi = xp.where((sinpsi < -1.0) & xp.isfinite(sinpsi), -1.0, sinpsi)

--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -649,19 +649,22 @@ class actionAngleSpherical(actionAngle):
     # (sqrt'(0)=inf would NaN-poison reverse-mode AD), with the unused panel
     # (lim==0) contributing exactly 0. The numpy path is untouched.
 
-    def _panel_backend(self, xp, base, sign, lim, E, L, azimuthal):
-        """One t^2-substituted Gauss-Legendre panel of a period/angle integral.
+    def _panel_backend_both(self, xp, base, sign, lim, E, L):
+        """Non-azimuthal AND azimuthal panel integrals from ONE radicand pass.
 
-        Integrates ``2 t / _JrSphericalIntegrand(r) [/ r**2 if azimuthal]`` over
+        A t^2-substituted Gauss-Legendre panel of a period/angle integral over
         ``t in [0, lim]`` with ``r = base + sign * t**2`` (sign=+1 small panel
-        with base=rperi, sign=-1 large panel with base=rap). The fixed [0, 1]
-        GL panel uses ``t = lim * s`` so the per-object ``lim`` (shape (N,))
-        multiplies inside the integrand (dt = lim ds) and fixed_quad's limits
-        stay scalar. ``lim`` is float (==0 makes this panel contribute 0).
+        base=rperi, sign=-1 large panel base=rap); the fixed [0, 1] GL panel uses
+        ``t = lim * s`` so ``lim`` (shape (N,)) folds into the integrand (dt = lim
+        ds; ``lim==0`` -> 0 contribution) and fixed_quad's limits stay scalar. The
+        radial-period/angle integral (2t/sqrt(radicand)) and the azimuthal one
+        (weighted by 1/r**2) share the SAME radicand at the same nodes, so the
+        potential is evaluated once here instead of twice. Returns
+        ``(non_azimuthal, azimuthal)``.
         """
         from ..backend.quadrature import fixed_quad
 
-        def integrand(s):  # s: (n,) GL nodes -> (N, n)
+        def integrand(s):  # -> (2, N, n): [non-azimuthal, azimuthal]
             t = lim[:, None] * s[None, :]
             rr = base[:, None] + sign * t**2.0
             rad = _radicand(xp, rr, E[:, None], L[:, None], self._2dpot)
@@ -669,13 +672,12 @@ class actionAngleSpherical(actionAngle):
             # where 2t->0 anyway, so a 0 there is harmless.
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
             val = 2.0 * t / xp.sqrt(rad)
-            if azimuthal:
-                val = val / rr**2.0
-            return val * lim[:, None]  # dt = lim ds
+            return xp.stack([val * lim[:, None], val / rr**2.0 * lim[:, None]])
 
-        return fixed_quad(
+        both = fixed_quad(
             xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(base)
         )
+        return both[0], both[1]
 
     def _calc_or_op_backend(self, Rmean, rperi, rap, E, L):
         """Vectorised Or (radial freq) and Op (azimuthal freq magnitude).
@@ -688,19 +690,13 @@ class actionAngleSpherical(actionAngle):
         xp = get_namespace(rperi)
         limS = xp.sqrt(xp.where(Rmean > rperi, Rmean - rperi, xp.zeros_like(Rmean)))
         limL = xp.sqrt(xp.where(rap > Rmean, rap - Rmean, xp.zeros_like(Rmean)))
-        Tr = 2.0 * (
-            self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
-            + self._panel_backend(xp, rap, -1.0, limL, E, L, False)
-        )
+        # Small/large panels each yield the Tr (non-azimuthal) and I (azimuthal)
+        # contributions from one shared radicand pass.
+        s_tr, s_i = self._panel_backend_both(xp, rperi, 1.0, limS, E, L)
+        l_tr, l_i = self._panel_backend_both(xp, rap, -1.0, limL, E, L)
+        Tr = 2.0 * (s_tr + l_tr)
         Or = 2.0 * numpy.pi / Tr
-        I = (
-            2.0
-            * L
-            * (
-                self._panel_backend(xp, rperi, 1.0, limS, E, L, True)
-                + self._panel_backend(xp, rap, -1.0, limL, E, L, True)
-            )
-        )
+        I = 2.0 * L * (s_i + l_i)
         Op = I * Or / 2.0 / numpy.pi
         return (Or, Op)
 
@@ -717,32 +713,30 @@ class actionAngleSpherical(actionAngle):
         wr_large = xp.where(vr < 0.0, numpy.pi + wr_large_raw, numpy.pi - wr_large_raw)
         return xp.where(r < Rmean, wr_small, wr_large)
 
-    def _calc_angler_backend(self, Or, r, Rmean, rperi, rap, E, L, vr):
-        """Vectorised radial angle ar (un-modded; caller takes % 2pi).
+    def _calc_angles_backend(
+        self, Or, Op, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
+    ):
+        """Vectorised radial + vertical angles (ar, az; un-modded, caller takes
+        % 2pi) from ONE shared radicand pass.
 
-        Mirrors _calc_angler: if r<Rmean integrate the small panel to
-        sqrt(r-rperi) and (vr<0) wr=2pi-wr; else integrate the large panel to
-        sqrt(rap-r) and wr = pi+wr (vr<0) / pi-wr (vr>=0).
+        The angler (non-azimuthal) and anglez (azimuthal) panels use the same
+        r-based limits and radicand, so the potential is evaluated once via
+        _panel_backend_both. ar: if r<Rmean integrate the small panel to
+        sqrt(r-rperi) and (vr<0) wr=2pi-wr, else the large panel with pi+/-wr.
+        az: psi from sinpsi=z/r/sin(inclination) (clipped, vtheta>0 -> pi-psi,
+        non-inclined -> phi), then wz=L*I-integral (vr quadrant via dpsi), and
+        az = -wz + psi + Op/Or*ar. Op is the magnitude here (as in numpy).
         """
         xp = get_namespace(r)
         limS = xp.sqrt(xp.where(r > rperi, r - rperi, xp.zeros_like(r)))
         limL = xp.sqrt(xp.where(rap > r, rap - r, xp.zeros_like(r)))
-        wr_small_raw = Or * self._panel_backend(xp, rperi, 1.0, limS, E, L, False)
-        wr_large_raw = Or * self._panel_backend(xp, rap, -1.0, limL, E, L, False)
-        return self._assemble_angler(xp, r, Rmean, vr, wr_small_raw, wr_large_raw)
-
-    def _calc_anglez_backend(
-        self, Or, Op, ar, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
-    ):
-        """Vectorised vertical angle az (un-modded; caller takes % 2pi).
-
-        Mirrors _calc_anglez: psi from sinpsi=z/r/sin(inclination) (clipped,
-        vtheta>0 -> pi-psi, non-inclined -> phi), then wz = L*I-integral to the
-        same data-dependent limit (vr quadrant fixes via dpsi=Op/Or*2pi), and
-        az = -wz + psi + Op/Or*ar (ar un-modded). Op here is the magnitude.
-        """
-        xp = get_namespace(r)
-        # psi (inclination phase)
+        s_nonazi, s_azi = self._panel_backend_both(xp, rperi, 1.0, limS, E, L)
+        l_nonazi, l_azi = self._panel_backend_both(xp, rap, -1.0, limL, E, L)
+        # ar (radial angle)
+        wr_small_raw = Or * s_nonazi
+        wr_large_raw = Or * l_nonazi
+        ar = self._assemble_angler(xp, r, Rmean, vr, wr_small_raw, wr_large_raw)
+        # az: psi (inclination phase)
         i_incl = xp.arccos(xp.where(xp.abs(Lz / L) < 1.0, Lz / L, xp.sign(Lz / L)))
         sini = xp.sin(i_incl)
         # Non-inclined (sin i == 0): numpy's z/r/sin(i) is non-finite -> psi=phi.
@@ -761,14 +755,13 @@ class actionAngleSpherical(actionAngle):
         psi = xp.where(finite, psi, phi)  # non-inclined: psi=phi
         psi = psi % (2.0 * numpy.pi)
         dpsi = Op / Or * 2.0 * numpy.pi  # full I integral
-        limS = xp.sqrt(xp.where(r > rperi, r - rperi, xp.zeros_like(r)))
-        limL = xp.sqrt(xp.where(rap > r, rap - r, xp.zeros_like(r)))
-        wz_small = L * self._panel_backend(xp, rperi, 1.0, limS, E, L, True)
+        wz_small = L * s_azi
         wz_small = xp.where(vr < 0.0, dpsi - wz_small, wz_small)
-        wz_large = L * self._panel_backend(xp, rap, -1.0, limL, E, L, True)
+        wz_large = L * l_azi
         wz_large = xp.where(vr < 0.0, dpsi / 2.0 + wz_large, dpsi / 2.0 - wz_large)
         wz = xp.where(r < Rmean, wz_small, wz_large)
-        return -wz + psi + Op / Or * ar
+        az = -wz + psi + Op / Or * ar
+        return ar, az
 
     def _calc_long_asc_backend(self, z, R, vtheta, phi, Lz, L):
         """Vectorised longitude of the ascending node (mirror _calc_long_asc)."""
@@ -839,9 +832,8 @@ class actionAngleSpherical(actionAngle):
         Op = xp.where(is_circ, omegac(self._2dpot, r, use_physical=False), Op)
         # Angles (ar, az un-modded; Op is the magnitude here, as in numpy).
         asc = self._calc_long_asc_backend(z, R, vtheta, phi, Lz, L)
-        ar = self._calc_angler_backend(Or, r, Rmean, rperi, rap, E, L, vr)
-        az = self._calc_anglez_backend(
-            Or, Op, ar, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
+        ar, az = self._calc_angles_backend(
+            Or, Op, z, r, Rmean, rperi, rap, E, L, Lz, vr, vtheta, phi
         )
         Oz = Op  # copy (magnitude)
         Op = xp.where(vT < 0.0, -Op, Op)

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -335,13 +335,11 @@ def _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order):
     return djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3
 
 
-def _staeckel_freqs(xp, s, umin, umax, vmin, pot, delta, order, jac=None):
+def _staeckel_freqs(xp, s, umin, umax, vmin, pot, delta, order, jac):
     """Vectorised (Omegar, Omegaphi, Omegaz); NaN for circular (caller substitutes
     epifreq/omegac/verticalfreq, mirroring the C 0/0=NaN -> close-to-circular path).
-    `jac` = precomputed _staeckel_jacobian shared with the angles; computed here
-    when None (the freqs-only callers)."""
-    if jac is None:
-        jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
+    `jac` = the _staeckel_jacobian 6-tuple, computed once by the caller and shared
+    with the angles."""
     djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = jac
     detA = djrdE * djzdI3 - djzdE * djrdI3
     circ = (umax - umin) / umax < 1e-6  # circular in R: det(A)=0 (J_R panels ->0)
@@ -367,8 +365,9 @@ def _staeckel_actions_freqs(xp, R, vR, vT, z, vz, pot, delta, order):
     Setup + turning points are computed once and shared between actions and freqs."""
     s, umin, umax, vmin, delta = _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta)
     jr, jz = _staeckel_jr_jz(xp, s, umin, umax, vmin, pot, delta, order)
+    jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
     Omegar, Omegaphi, Omegaz = _staeckel_freqs(
-        xp, s, umin, umax, vmin, pot, delta, order
+        xp, s, umin, umax, vmin, pot, delta, order, jac
     )
     return jr, s["Lz"], jz, Omegar, Omegaphi, Omegaz
 
@@ -401,17 +400,15 @@ def _staeckel_angle_partial(xp, Sfunc, sq_args, factor_fn, base, sign, mid, orde
     return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order, device=device_of(mid))
 
 
-def _staeckel_angles(xp, s, umin, umax, vmin, pot, delta, order, jac=None):
+def _staeckel_angles(xp, s, umin, umax, vmin, pot, delta, order, jac):
     """Vectorised (angler, anglephi_raw, anglez); the caller folds the azimuth phi
     into anglephi. angler/anglez are in [0, 2pi); circular orbits -> all 0.
-    `jac` = precomputed _staeckel_jacobian shared with the freqs; computed here
-    when None."""
+    `jac` = the _staeckel_jacobian 6-tuple, computed once by the caller and shared
+    with the freqs."""
     sqrt2 = numpy.sqrt(2.0)
     pi = numpy.pi
     Lz = s["Lz"]
     ux, vx, pux, pvx = s["ux"], s["vx"], s["pux"], s["pvx"]
-    if jac is None:
-        jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
     djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = jac
     detA = djrdE * djzdI3 - djzdE * djrdI3
     circ = (umax - umin) / umax < 1e-6

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -335,12 +335,14 @@ def _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order):
     return djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3
 
 
-def _staeckel_freqs(xp, s, umin, umax, vmin, pot, delta, order):
+def _staeckel_freqs(xp, s, umin, umax, vmin, pot, delta, order, jac=None):
     """Vectorised (Omegar, Omegaphi, Omegaz); NaN for circular (caller substitutes
-    epifreq/omegac/verticalfreq, mirroring the C 0/0=NaN -> close-to-circular path)."""
-    djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = _staeckel_jacobian(
-        xp, s, umin, umax, vmin, pot, delta, order
-    )
+    epifreq/omegac/verticalfreq, mirroring the C 0/0=NaN -> close-to-circular path).
+    `jac` = precomputed _staeckel_jacobian shared with the angles; computed here
+    when None (the freqs-only callers)."""
+    if jac is None:
+        jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
+    djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = jac
     detA = djrdE * djzdI3 - djzdE * djrdI3
     circ = (umax - umin) / umax < 1e-6  # circular in R: det(A)=0 (J_R panels ->0)
     planar = (numpy.pi / 2.0 - vmin) < 1e-7  # planar (J_z=0): det(A)=0 (J_z panels ->0)
@@ -399,16 +401,18 @@ def _staeckel_angle_partial(xp, Sfunc, sq_args, factor_fn, base, sign, mid, orde
     return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order, device=device_of(mid))
 
 
-def _staeckel_angles(xp, s, umin, umax, vmin, pot, delta, order):
+def _staeckel_angles(xp, s, umin, umax, vmin, pot, delta, order, jac=None):
     """Vectorised (angler, anglephi_raw, anglez); the caller folds the azimuth phi
-    into anglephi. angler/anglez are in [0, 2pi); circular orbits -> all 0."""
+    into anglephi. angler/anglez are in [0, 2pi); circular orbits -> all 0.
+    `jac` = precomputed _staeckel_jacobian shared with the freqs; computed here
+    when None."""
     sqrt2 = numpy.sqrt(2.0)
     pi = numpy.pi
     Lz = s["Lz"]
     ux, vx, pux, pvx = s["ux"], s["vx"], s["pux"], s["pvx"]
-    djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = _staeckel_jacobian(
-        xp, s, umin, umax, vmin, pot, delta, order
-    )
+    if jac is None:
+        jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
+    djrdE, djrdLz, djrdI3, djzdE, djzdLz, djzdI3 = jac
     detA = djrdE * djzdI3 - djzdE * djrdI3
     circ = (umax - umin) / umax < 1e-6
     planar = (pi / 2.0 - vmin) < 1e-7
@@ -517,11 +521,14 @@ def _staeckel_actions_freqs_angles(xp, R, vR, vT, z, vz, phi, pot, delta, order)
     setup + turning points computed once and shared. anglephi includes the azimuth."""
     s, umin, umax, vmin, delta = _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta)
     jr, jz = _staeckel_jr_jz(xp, s, umin, umax, vmin, pot, delta, order)
+    # The six Leibniz derivative panels are shared by the frequencies and the
+    # angles -- compute once and thread into both (else each recomputes all six).
+    jac = _staeckel_jacobian(xp, s, umin, umax, vmin, pot, delta, order)
     Omegar, Omegaphi, Omegaz = _staeckel_freqs(
-        xp, s, umin, umax, vmin, pot, delta, order
+        xp, s, umin, umax, vmin, pot, delta, order, jac=jac
     )
     angler, anglephi, anglez = _staeckel_angles(
-        xp, s, umin, umax, vmin, pot, delta, order
+        xp, s, umin, umax, vmin, pot, delta, order, jac=jac
     )
     anglephi = xp.remainder(anglephi + phi, 2.0 * numpy.pi)  # fold in the azimuth
     return jr, s["Lz"], jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez

--- a/galpy/actionAngle/actionAngleStaeckelGrid.py
+++ b/galpy/actionAngle/actionAngleStaeckelGrid.py
@@ -462,6 +462,9 @@ class actionAngleStaeckelGrid(actionAngle):
                     )
                 )
                 sinh2u0 = numpy.sinh(u0) ** 2.0
+                potu0pi2 = actionAngleStaeckel.potentialStaeckel(
+                    u0, numpy.pi / 2.0, self._pot, self._delta
+                )
                 thisEr = self.Er(
                     R[indxc],
                     z[indxc],
@@ -471,6 +474,7 @@ class actionAngleStaeckelGrid(actionAngle):
                     Lz[indxc],
                     sinh2u0,
                     u0,
+                    potu0pi2,
                 )
                 thisEz = self.Ez(
                     R[indxc],
@@ -481,6 +485,7 @@ class actionAngleStaeckelGrid(actionAngle):
                     Lz[indxc],
                     sinh2u0,
                     u0,
+                    potu0pi2,
                 )
                 thisv2 = self.vatu0(
                     E[indxc], Lz[indxc], u0, self._delta * numpy.sinh(u0), retv2=True
@@ -706,6 +711,9 @@ class actionAngleStaeckelGrid(actionAngle):
                     )
                 )
                 sinh2u0 = numpy.sinh(u0) ** 2.0
+                potu0pi2 = actionAngleStaeckel.potentialStaeckel(
+                    u0, numpy.pi / 2.0, self._pot, self._delta
+                )
                 thisEr = self.Er(
                     R[indxc],
                     z[indxc],
@@ -715,6 +723,7 @@ class actionAngleStaeckelGrid(actionAngle):
                     Lz[indxc],
                     sinh2u0,
                     u0,
+                    potu0pi2,
                 )
                 thisEz = self.Ez(
                     R[indxc],
@@ -725,6 +734,7 @@ class actionAngleStaeckelGrid(actionAngle):
                     Lz[indxc],
                     sinh2u0,
                     u0,
+                    potu0pi2,
                 )
                 thisv2 = self.vatu0(
                     E[indxc], Lz[indxc], u0, self._delta * numpy.sinh(u0), retv2=True
@@ -961,7 +971,7 @@ class actionAngleStaeckelGrid(actionAngle):
         logu0 = optimize.brent(_u0Eq, args=(self._delta, self._pot, E, Lz**2.0 / 2.0))
         return numpy.exp(logu0)
 
-    def Er(self, R, z, vR, vz, E, Lz, sinh2u0, u0):
+    def Er(self, R, z, vR, vz, E, Lz, sinh2u0, u0, potu0pi2=None):
         """
         Calculate the 'radial energy'
 
@@ -995,6 +1005,12 @@ class actionAngleStaeckelGrid(actionAngle):
         """
         xp = get_namespace(R) if is_backend_array(R) else numpy
         u, v = coords.Rz_to_uv(R, z, self._delta)
+        # potentialStaeckel(u0, pi/2) is identical in Er and Ez; the caller may
+        # pass it precomputed to evaluate it once per orbit instead of twice.
+        if potu0pi2 is None:
+            potu0pi2 = actionAngleStaeckel.potentialStaeckel(
+                u0, numpy.pi / 2.0, self._pot, self._delta
+            )
         pu = vR * xp.cosh(u) * xp.sin(v) + vz * xp.sinh(u) * xp.cos(
             v
         )  # no delta, bc we will divide it out
@@ -1009,16 +1025,13 @@ class actionAngleStaeckelGrid(actionAngle):
             * actionAngleStaeckel.potentialStaeckel(
                 u, numpy.pi / 2.0, self._pot, self._delta
             )
-            - (sinh2u0 + 1.0)
-            * actionAngleStaeckel.potentialStaeckel(
-                u0, numpy.pi / 2.0, self._pot, self._delta
-            )
+            - (sinh2u0 + 1.0) * potu0pi2
         )
         #              +(numpy.sinh(u)**2.+numpy.sin(v)**2.)*actionAngleStaeckel.potentialStaeckel(u,v,self._pot,self._delta)
         #              -(sinh2u0+numpy.sin(v)**2.)*actionAngleStaeckel.potentialStaeckel(u0,v,self._pot,self._delta))
         return out
 
-    def Ez(self, R, z, vR, vz, E, Lz, sinh2u0, u0):
+    def Ez(self, R, z, vR, vz, E, Lz, sinh2u0, u0, potu0pi2=None):
         """
         Calculate the 'vertical energy'
 
@@ -1052,6 +1065,12 @@ class actionAngleStaeckelGrid(actionAngle):
         """
         xp = get_namespace(R) if is_backend_array(R) else numpy
         u, v = coords.Rz_to_uv(R, z, self._delta)
+        # potentialStaeckel(u0, pi/2) is identical in Er and Ez; the caller may
+        # pass it precomputed to evaluate it once per orbit instead of twice.
+        if potu0pi2 is None:
+            potu0pi2 = actionAngleStaeckel.potentialStaeckel(
+                u0, numpy.pi / 2.0, self._pot, self._delta
+            )
         pv = vR * xp.sinh(u) * xp.cos(v) - vz * xp.cosh(u) * xp.sin(
             v
         )  # no delta, bc we will divide it out
@@ -1059,10 +1078,7 @@ class actionAngleStaeckelGrid(actionAngle):
             pv**2.0 / 2.0
             + Lz**2.0 / 2.0 / self._delta**2.0 * (1.0 / xp.sin(v) ** 2.0 - 1.0)
             - E * (xp.sin(v) ** 2.0 - 1.0)
-            - (sinh2u0 + 1.0)
-            * actionAngleStaeckel.potentialStaeckel(
-                u0, numpy.pi / 2.0, self._pot, self._delta
-            )
+            - (sinh2u0 + 1.0) * potu0pi2
             + (sinh2u0 + xp.sin(v) ** 2.0)
             * actionAngleStaeckel.potentialStaeckel(u0, v, self._pot, self._delta)
         )


### PR DESCRIPTION
Backend-agnostic action-angle performance pass, from a full audit of every AA
method (workflow, one auditor per method). Built with a byte-identity gold
reference (numpy AA outputs on a fixed grid, `numpy.array_equal` before/after
each edit). **The numpy path is byte-identical throughout** (verified per
commit); jax/torch parity + grad unchanged.

## What's here

- **Staeckel `_staeckel_jacobian` hoist** (the real win). The six t²-substituted
  Leibniz derivative panels (dJr/dJz d{E,Lz,I3}, each a singular-integrand GL
  quadrature) were computed **twice** per orbit in `actionsFreqsAngles` — once
  in `_staeckel_freqs`, once in `_staeckel_angles`. Compute once and thread into
  both via a `jac=` param (default `None` → freqs-only callers unchanged).
  Halves the derivative-panel quadrature across **all** backends (numpy byte-id,
  eager, and a smaller jit trace graph).
- **Isochrone sqrt hoists.** `sqrt(L²+4·amp·b)`, `sqrt(R²+z²)`, `sqrt(L²−Lz²)`
  each evaluated 2–3× → computed once. Only *literally-identical* expressions are
  hoisted (the `1/sqrt(1+4·amp·b/L²)` angle term is a distinct float op and is
  left untouched), so it stays byte-identical.
- **StaeckelGrid `potentialStaeckel(u0,π/2)` dedup.** `Er` and `Ez` each
  evaluated the identical `(sinh2u0+1)·potentialStaeckel(u0,π/2)`; both run per
  on-grid orbit → the potential was evaluated twice. Compute once, pass to both.
- **Spherical radicand-share (eager-only).** The radial and azimuthal
  frequency/angle integrals share the same radicand at the same GL nodes;
  `_panel_backend_both` returns both from one pass, and `_calc_angles_backend`
  merges angler+anglez. Bit-identical backend output (exact op order preserved);
  the win is eager-only (jit CSE already dedups). numpy path untouched (scipy).

## Deliberately not done

- **IsochroneApprox tile→broadcast** — the audit flagged it byte-identical, but
  `numpy.sum`'s pairwise grouping depends on array contiguity, so tile+transpose
  vs broadcast differ at ~1e-13, amplified through `inv(AᵀA)` into the angles.
  Not byte-identical → dropped.
- **`_grid_common_numpy` extraction / AdiabaticGrid `Jz` setup** — pure
  cross-method DRY (separate entry points each run their setup once), so it
  dedups *code*, not per-call *compute* — no speedup for real byte-identity risk
  on branchy masked-assignment numpy. Skipped.

## Verification

- Byte-identity gold reference: byte-identical across Staeckel/Isochrone/
  StaeckelGrid/Spherical numpy outputs.
- `test_actionAngle.py` (numpy, affected classes): **166 passed**.
- `test_backend_actionAngle.py` (full jax+torch parity + grad): **300 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)