### PR TITLE
Fix sdist install glob; build/test sdist on every PR (upload still release-only)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -174,8 +174,10 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: pytest -v "$GITHUB_WORKSPACE"/tests/test_orbit.py -k "test_energy_jacobi_conservation and NFW"
   build_sdist:
-    name: Build source directory for release
-    if: github.event_name == 'release' && github.event.action == 'created'
+    name: Build source distribution (sdist)
+    # Build and test the sdist on every push/PR (like the wheels), so
+    # sdist-packaging regressions are caught before release; the sdist is
+    # only uploaded to PyPI on release creation (see deploy_pypi).
     runs-on: ubuntu-latest
     steps:
       # check-out this repository
@@ -211,7 +213,11 @@ jobs:
         with:
           name: sdist
       - name: Build from sdist
-        run: python -m pip install -v "galpy*.tar.gz[test]"
+        run: |
+          # Expand the glob first, then append the [test] extras: quoting the
+          # whole "galpy*.tar.gz[test]" would stop the shell expanding the glob.
+          tarball=$(ls galpy*.tar.gz)
+          python -m pip install -v "${tarball}[test]"
       - name: Run simple test
         working-directory: ${{ runner.temp }}
         run: |


### PR DESCRIPTION
## Problem

The v1.12.0 release run's **"Test that galpy can be built from the sdist"** job failed, which gated (skipped) the **Deploy to PyPI** job — so v1.12.0 didn't publish.

Root cause is a shell-quoting bug in `wheels.yml`:

```yaml
run: python -m pip install -v "galpy*.tar.gz[test]"
```

Quoting the argument stops the shell from expanding `galpy*`, so pip receives the literal string `galpy*.tar.gz` → `FileNotFoundError: galpy*.tar.gz`. The sdist tarball downloads fine to the cwd; it's purely the glob.

This regressed in #875 (which added the `[test]` extras and quoted the arg). It went unnoticed for two releases because the `build_sdist`/`test_sdist` jobs are gated `if: github.event_name == 'release'`, so they're **skipped on PRs** — the broken line only ever runs at release time.

## Changes

1. **Fix the glob** — expand it first, then append the extras:
   ```yaml
   tarball=$(ls galpy*.tar.gz)
   python -m pip install -v "${tarball}[test]"
   ```
2. **Build + test the sdist on every push/PR** (drop the `if: release` gate on `build_sdist`), just like the wheel jobs, so sdist-packaging regressions are caught in PR CI rather than at release. **Uploading is unchanged** — `deploy_pypi` remains `if: release && created`.

Because this PR removes the release-gate, its own CI now runs the (fixed) sdist build+test — so a green **"Build source distribution (sdist)"** / sdist-test on this PR validates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eGT46rnxjijhzAcLp9RDi