### PR TITLE
actionAngleStaeckel: accurate backend action gradients via t²-donor graft (Track E deriv fix, PR A)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -22,6 +22,12 @@ from ..backend import (
     is_backend_array,
     promote_scalars,
 )
+from ..backend._namespaces import (
+    graft_gradient,
+    stop_gradient,
+    under_jax_trace,
+    under_torch_grad,
+)
 from ..backend.optimize import bisect_root, iterate_bracket
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..potential import (
@@ -207,6 +213,34 @@ def _staeckel_gl_action(xp, sqfunc, args, lo, hi, order):
     return _backend_fixed_quad(xp, integrand, 0.0, 1.0, n=order, device=device_of(lo))
 
 
+def _staeckel_t2_action(xp, sqfunc, args, lo, hi, order):
+    """Low(lo)+High(hi) t^2-substituted panels of sqrt(sqfunc) over [lo, hi] --
+    the AD-regular gradient DONOR for the plain-GL action value: d(sqrt S) is
+    turning-point-singular under plain GL, but after u = lo + t^2 the du = 2t dt
+    Jacobian cancels the 1/sqrt(S) ~ 1/t, and AD through it carries the FULL
+    dependence (E, Lz, I3, the u0/v0u reference geometry, potential parameters)."""
+    a2 = tuple(x[..., None] if getattr(x, "ndim", 0) >= 1 else x for x in args)
+    # Turning-point limits held fixed: the Leibniz boundary terms vanish exactly
+    # (S = 0 there), and the bisection roots' implicit gradients must not leak in.
+    lo, hi = stop_gradient(lo), stop_gradient(hi)
+    span = hi - lo
+    ok = span > 0.0  # degenerate (circular/planar) panel: 0 with 0 gradient
+    mid = xp.sqrt(0.5 * xp.where(ok, span, xp.ones_like(span)))
+
+    def panel(base, sign):
+        def integ(s):  # s: (n,) -> (N, n); u = base + sign*t^2, t = mid*s
+            t = mid[..., None] * s
+            u = base[..., None] + sign * t**2.0
+            S = sqfunc(u, *a2)
+            Ssafe = xp.where(S > 0.0, S, xp.ones_like(S))  # dead-branch guard
+            g = xp.where(S > 0.0, xp.sqrt(Ssafe), xp.zeros_like(S))
+            return 2.0 * t * g * mid[..., None]
+
+        return _backend_fixed_quad(xp, integ, 0.0, 1.0, n=order, device=device_of(mid))
+
+    return xp.where(ok, panel(lo, 1.0) + panel(hi, -1.0), xp.zeros_like(span))
+
+
 def _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta):
     """Setup quantities + turning points (+ unbound check), shared by the
     vectorised actions and frequencies. Returns (setup, umin, umax, vmin, delta)."""
@@ -255,6 +289,30 @@ def _staeckel_jr_jz(xp, s, umin, umax, vmin, pot, delta, order):
         * delta
         / numpy.pi
     )
+    # Backend AD: graft the t^2-substituted donor's gradient onto the plain-GL
+    # value (naive d(sqrt S) is turning-point-singular, and the dJ/d(E,Lz,I3)
+    # chain misses the u0/v0u geometry's direct R,z dependence). Value unchanged
+    # (C parity), first-order only, no cost on plain (untraced/no-grad) forwards.
+    if is_backend_array(jr) and (under_jax_trace(jr) or under_torch_grad(jr)):
+        jr = graft_gradient(
+            jr,
+            _staeckel_t2_action(
+                xp, _JRStaeckelIntegrandSquared, jr_args, umin, umax, order
+            )
+            * sqrt2
+            * delta
+            / numpy.pi,
+        )
+        jz = graft_gradient(
+            jz,
+            _staeckel_t2_action(
+                xp, _JzStaeckelIntegrandSquared, jz_args, vmin, pi2, order
+            )
+            * 2.0
+            * sqrt2
+            * delta
+            / numpy.pi,
+        )
     jr = xp.where((umax - umin) / umax < 1e-6, xp.zeros_like(jr), jr)
     jz = xp.where((numpy.pi / 2.0 - vmin) < 1e-7, xp.zeros_like(jz), jz)
     return jr, jz

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -72,6 +72,46 @@ def under_jax_trace(*xs):
     return any(isinstance(x, jax.core.Tracer) for x in xs)
 
 
+def under_torch_grad(*xs):
+    """True iff torch is imported, grad is enabled, and some input is a grad tensor."""
+    import sys
+
+    if "torch" not in sys.modules:
+        return False
+    import torch
+
+    return torch.is_grad_enabled() and any(
+        isinstance(x, torch.Tensor) and x.requires_grad for x in xs
+    )
+
+
+def stop_gradient(x):
+    """Backend stop-gradient: identity (numpy), ``jax.lax.stop_gradient`` / ``.detach``."""
+    import sys
+
+    if "jax" in sys.modules:
+        import jax
+
+        if isinstance(x, jax.Array):
+            return jax.lax.stop_gradient(x)
+    if "torch" in sys.modules:
+        import torch
+
+        if isinstance(x, torch.Tensor):
+            return x.detach()
+    return x
+
+
+def graft_gradient(value, donor):
+    """Forward value of ``value`` with the first derivative of ``donor``.
+
+    The ``bisect_root`` stop-gradient reparameterisation:
+    ``sg(value) + donor - sg(donor)`` equals ``value`` exactly (the donor terms
+    cancel in floating point) while AD sees only ``donor``. First-order only.
+    """
+    return stop_gradient(value) + donor - stop_gradient(donor)
+
+
 def _is_floating_dtype(dtype):
     """True for real floating-point dtypes of any backend.
 

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -1,0 +1,189 @@
+###############################################################################
+# test_backend_staeckel_grad.py: accurate Staeckel ACTION gradients under
+# jax/torch AD. The plain-GL action value is kept (C parity; numpy path
+# byte-identical) while the gradient is grafted from the t^2-substituted donor
+# quadrature (_staeckel_t2_action), which is turning-point-regular where naive
+# d(sqrt S) is singular and carries the full (E, Lz, I3, u0/v0u geometry)
+# dependence that the dJ/d(E,Lz,I3) chain alone misses. First-order only.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.actionAngle import actionAngleStaeckel
+from galpy.actionAngle.actionAngleStaeckel import _staeckel_actions
+from galpy.backend import get_namespace
+from galpy.potential import MiyamotoNagaiPotential
+
+_MP = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.0375)
+_DELTA, _ORDER = 0.45, 10
+
+# (R, vR, vT, z, vz): generic / eccentric-inclined / near-circular, plus the
+# turning-point edge orbits (vR=0 at the u turning point, vz=0 at the v one,
+# z=0 in the plane) that historically hide bracketing/AD bugs.
+_ORBITS = {
+    "generic": (1.0, 0.2, 1.1, 0.1, 0.15),
+    "eccentric": (1.2, 0.35, 0.85, 0.25, -0.2),
+    "nearcirc": (1.0, 0.02, 1.0, 0.02, 0.02),
+    "edge_vR0": (1.0, 0.0, 1.1, 0.1, 0.15),
+    "edge_vz0": (1.0, 0.2, 1.1, 0.1, 0.0),
+    "edge_z0": (1.0, 0.2, 1.1, 0.0, 0.15),
+}
+_COORDS = ("R", "vR", "vT", "z", "vz")
+
+
+def _np_actions(*orbit):
+    out = _staeckel_actions(
+        numpy, *[numpy.array([c]) for c in orbit], _MP, _DELTA, _ORDER
+    )
+    return float(out[0][0]), float(out[2][0])
+
+
+_FD_CACHE = {}
+
+
+def _fd_grad(orbit, eps=1e-5):
+    # central finite differences of the numpy plain-GL actions -- the gold
+    # reference the backend AD gradients must reproduce.
+    if orbit in _FD_CACHE:
+        return _FD_CACHE[orbit]
+    gjr, gjz = [], []
+    for i in range(5):
+        up = list(orbit)
+        dn = list(orbit)
+        up[i] += eps
+        dn[i] -= eps
+        jru, jzu = _np_actions(*up)
+        jrd, jzd = _np_actions(*dn)
+        gjr.append((jru - jrd) / (2.0 * eps))
+        gjz.append((jzu - jzd) / (2.0 * eps))
+    _FD_CACHE[orbit] = (gjr, gjz)
+    return gjr, gjz
+
+
+def _backend_grads(backend, orbit):
+    if backend == "jax":
+
+        def f(i, *coords):
+            return jnp.sum(_staeckel_actions(jnp, *coords, _MP, _DELTA, _ORDER)[i])
+
+        args = [jnp.asarray([c]) for c in orbit]
+        gjr = jax.grad(lambda *a: f(0, *a), argnums=(0, 1, 2, 3, 4))(*args)
+        gjz = jax.grad(lambda *a: f(2, *a), argnums=(0, 1, 2, 3, 4))(*args)
+        return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
+    xt = get_namespace(torch.tensor(0.0))
+    args = [torch.tensor([c], requires_grad=True) for c in orbit]
+    out = _staeckel_actions(xt, *args, _MP, _DELTA, _ORDER)
+    gjr = torch.autograd.grad(out[0].sum(), args, retain_graph=True)
+    gjz = torch.autograd.grad(out[2].sum(), args)
+    return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_staeckel_action_grad_vs_fd(backend, orbit):
+    # d(jr,jz)/d(R,vR,vT,z,vz) via backend AD vs numpy central FD. The residual
+    # is the plain-GL-vs-donor quadrature offset (~5e-4 relative at order 10);
+    # the pre-fix failure modes were ~6e2 (naive d(sqrt S)) and ~6e0 (the
+    # (E,Lz,I3)-only chain missing the u0/v0u geometry) times larger.
+    coords = _ORBITS[orbit]
+    fjr, fjz = _fd_grad(coords)
+    gjr, gjz = _backend_grads(backend, coords)
+    numpy.testing.assert_allclose(gjr, fjr, rtol=2e-3, atol=2e-6)
+    numpy.testing.assert_allclose(gjz, fjz, rtol=2e-3, atol=2e-6)
+    assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_action_value_unchanged(backend):
+    # the graft must not change the forward action value: no-grad backend
+    # forward == numpy forward, and the value under an AD trace == the no-grad
+    # forward (the donor terms cancel exactly).
+    coords = _ORBITS["generic"]
+    jr_np, jz_np = _np_actions(*coords)
+    if backend == "jax":
+        args = [jnp.asarray([c]) for c in coords]
+        out = _staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)
+        jr_fwd, jz_fwd = float(out[0][0]), float(out[2][0])
+        val, _ = jax.value_and_grad(
+            lambda R: jnp.sum(
+                _staeckel_actions(jnp, R, *args[1:], _MP, _DELTA, _ORDER)[0]
+            )
+        )(args[0])
+        jr_traced = float(val)
+    else:
+        xt = get_namespace(torch.tensor(0.0))
+        args = [torch.tensor([c]) for c in coords]
+        out = _staeckel_actions(xt, *args, _MP, _DELTA, _ORDER)
+        jr_fwd, jz_fwd = float(out[0][0]), float(out[2][0])
+        gargs = [torch.tensor([c], requires_grad=True) for c in coords]
+        jr_traced = float(
+            _staeckel_actions(xt, *gargs, _MP, _DELTA, _ORDER)[0].detach()[0]
+        )
+    numpy.testing.assert_allclose(jr_fwd, jr_np, rtol=1e-14)
+    numpy.testing.assert_allclose(jz_fwd, jz_np, rtol=1e-14)
+    numpy.testing.assert_allclose(jr_traced, jr_fwd, rtol=1e-14)
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b == "jax"])
+def test_staeckel_action_grad_jit(backend):
+    # the grafted gradient must survive the user's jit unchanged.
+    coords = _ORBITS["generic"]
+
+    def djr_dR(R):
+        args = [R] + [jnp.asarray([c]) for c in coords[1:]]
+        return jnp.sum(_staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)[0])
+
+    R0 = jnp.asarray([coords[0]])
+    eager = jax.grad(djr_dR)(R0)
+    jitted = jax.jit(jax.grad(djr_dR))(R0)
+    numpy.testing.assert_allclose(float(jitted[0]), float(eager[0]), rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_action_grad_public_api(backend):
+    # same gradients through the public actionAngleStaeckel(...) call.
+    coords = _ORBITS["generic"]
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=False)
+    fjr, _ = _fd_grad(coords)
+    if backend == "jax":
+        g = jax.grad(
+            lambda R: jnp.sum(aAS(R, *[jnp.asarray([c]) for c in coords[1:]])[0])
+        )(jnp.asarray([coords[0]]))
+        djr_dR = float(g[0])
+    else:
+        args = [torch.tensor([c], requires_grad=True) for c in coords]
+        aAS(*args)[0].sum().backward()
+        djr_dR = float(args[0].grad[0])
+    numpy.testing.assert_allclose(djr_dR, fjr[0], rtol=2e-3, atol=2e-6)
+
+
+def test_graft_gradient_numpy_identity():
+    # numpy path: stop_gradient is the identity and the graft is value-neutral.
+    from galpy.backend._namespaces import graft_gradient, stop_gradient
+
+    x = numpy.array([1.5])
+    assert stop_gradient(x) is x
+    numpy.testing.assert_array_equal(
+        graft_gradient(numpy.array([2.0]), numpy.array([3.0])), numpy.array([2.0])
+    )

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -187,3 +187,14 @@ def test_graft_gradient_numpy_identity():
     numpy.testing.assert_array_equal(
         graft_gradient(numpy.array([2.0]), numpy.array([3.0])), numpy.array([2.0])
     )
+
+
+def test_under_torch_grad_without_torch(monkeypatch):
+    # the sys.modules early-out (torch never imported -> False): the test env
+    # always has torch imported, so simulate its absence.
+    import sys
+
+    from galpy.backend._namespaces import under_torch_grad
+
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    assert under_torch_grad(numpy.array([1.0])) is False


### PR DESCRIPTION
## What / why

Naive jax/torch AD through the plain-GL Staeckel actions is **turning-point-singular** (`d(√S) = dS/(2√S)`, divergent where S→0) and silently ~1–6% wrong at the production order 10, converging only algebraically with GL order. The obvious analytic fix — grafting the validated `dJ/d(E,Lz,I3)` chain from `_staeckel_jacobian` — is exact for **velocity** derivatives but badly wrong for **positions**: `_staeckel_setup` puts `u0 = ux(R,z)`, so the reference geometry (`sinh²u0`, `sin²v0u`, `potu0v0`) carries direct R,z dependence that the `(E,Lz,I3)` boundary misses (diagnosed and named term-by-term to 4e-12: `−∂Jr/∂I3U · d[(sinh²u0+sin²v0u)·potu0v0]/d(R,z)`; for Jz, u0 additionally enters the integrand directly). The old "u0 does not matter for a single action evaluation" note is true for the value, false for the gradient.

## The fix: donor graft

Keep the plain-GL **value** (C parity) and take the **gradient** from a t²-substituted value quadrature that AD differentiates correctly:

- `_staeckel_t2_action`: low/high panels `u = lo + t²` / `u = hi − t²`; the `du = 2t dt` Jacobian cancels the `1/√S ~ 1/t`, so the differentiated integrand is regular at the turning points — and it automatically carries the **full** dependence (E, Lz, I3, u0/v0u geometry, potential parameters). No hand-derived derivative integrands, nothing to go stale.
- `graft_gradient(value, donor) = sg(value) + donor − sg(donor)` (new in `galpy.backend._namespaces`, alongside `stop_gradient` and `under_torch_grad`) — the same first-order stop-gradient construction as `bisect_root`'s Newton reparameterisation. The donor terms cancel exactly in floating point, so the forward value is untouched.
- Turning-point limits are `stop_gradient`-ed (Leibniz boundary terms vanish exactly, S=0 there); degenerate circular/planar panels are dead-branch-guarded to 0 with 0 gradient.
- Gated on `is_backend_array(jr) and (under_jax_trace(jr) or under_torch_grad(jr))` inside `_staeckel_jr_jz` → zero cost on plain forwards and the forced-backend suite; the graft also covers the action outputs of `actionsFreqs`/`actionsFreqsAngles`.

## Validation

- **Gradients:** `d(jr,jz)/d(R,vR,vT,z,vz)` matches Richardson-converged central-FD gold to **1.4e-4–4.7e-4 relative** on jax and torch (the residual is the plain-GL-vs-donor quadrature offset, i.e. the donor returns the *true* action gradient). Pre-fix: naive AD 1–6%; jacobian-chain graft ~6× wrong on `∂Jr/∂R` (ruled out independently by a `∇J·flow` conservation witness, violated ~120×).
- **numpy byte-identity:** actions / actionsFreqs / actionsFreqsAngles / EccZmaxRperiRap `tobytes`-equal vs pristine base on a 24-orbit grid (incl. vR=0, z=0 edges).
- **numpy suite:** `test_actionAngle.py -k staeckel` 72/72.
- **Backend suites:** all Staeckel-adjacent backend test files (actionAngle, interpolate, wrappers, quadrature + the new file) 978 passed / 1 skipped / 0 failed; the pre-existing jit+grad test (`test_staeckel_jit_grad_rolls_direct_bisection`) exercises the donor under jit and passes.
- **New tests** (`tests/test_backend_staeckel_grad.py`, 18): grad-vs-FD over 6 orbits including the vR=0/vz=0/z=0 turning-point edges × jax+torch, value-unchanged (incl. under-trace), jit survival, public-API grads, numpy identity of the helpers.

## Scope / follow-ups

First-order only (like the C-STM and `bisect_root`): Hessians and **frequency/angle gradients** are second derivatives of the action integral and need new second-derivative integrands (Phase 2). Follow-ups: StaeckelGrid gradients (PR B), the C `c=True` path (PR C), an explicit `d(actions)/dθ` parameter-gradient test (mechanism present via the donor's potential evals), and the g17 gradient benchmark panel. torch `gradcheck` is deliberately not used: the graft makes the analytic gradient (true derivative) differ from FD-of-the-order-10-forward at the ~5e-4 quadrature-offset level by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm