### PR TITLE
actionAngleStaeckel: differentiable c=True actions — C value + donor gradient (Track E deriv fix, PR C)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -325,6 +325,189 @@ def _staeckel_actions(xp, R, vR, vT, z, vz, pot, delta, order):
     return jr, s["Lz"], jz
 
 
+# ------------------------------------------------- c=True backend round-trip
+# jax/torch inputs on the c=True path: the forward VALUE comes from the
+# compiled C wrapper (eager detach->numpy->C->backend round-trip; under a jax
+# trace a jax.pure_callback so the user's jit/grad stays traceable) and, under
+# AD, the ACTIONS' gradient is grafted from the in-backend t^2-substituted
+# donor quadrature (same donor as _staeckel_jr_jz's c=False graft). Lz = R*vT
+# is computed in-backend (trivially differentiable). Frequency/angle values
+# pass through UNGRAFTED (their gradients are second-order objects; Phase 2).
+
+
+def _backend_to_numpy(x):
+    """Backend array -> numpy for the C wrapper (detach + off-device)."""
+    x = stop_gradient(x)
+    if hasattr(x, "cpu"):  # torch: move off-device first
+        x = x.cpu()
+    return numpy.asarray(x)
+
+
+def _staeckel_c_value(xp, host, coords, nout):
+    """Forward `nout` (N,)-shaped outputs of a numpy-in/numpy-out C `host` for
+    backend coordinate arrays, anchored on the inputs' device/dtype."""
+    if under_jax_trace(*coords):
+        from ..backend._jax.staeckel_c import c_value as _jax_c_value
+
+        return _jax_c_value(host, coords, nout)
+    out = host(*(_backend_to_numpy(x) for x in coords))
+    dev, dt = device_of(coords[0]), coords[0].dtype
+    return tuple(asarray_on_device(xp, o, dev, dtype=dt) for o in out)
+
+
+def _staeckel_c_host_u0(pot, delta_np, useu0, u0_np, R, vR, vT, z, vz):
+    """u0 for the C wrapper, inside the numpy host (mirrors the numpy c=True
+    useu0 branches: a passed-in u0 wins, else calcu0 from E and Lz)."""
+    if not useu0:
+        return None
+    if u0_np is not None:
+        return u0_np
+    E = numpy.array(
+        [
+            _evaluatePotentials(pot, R[ii], z[ii])
+            + vR[ii] ** 2.0 / 2.0
+            + vz[ii] ** 2.0 / 2.0
+            + vT[ii] ** 2.0 / 2.0
+            for ii in range(len(R))
+        ]
+    )
+    return actionAngleStaeckel_c.actionAngleStaeckel_calcu0(E, R * vT, pot, delta_np)[0]
+
+
+def _staeckel_c_circular_freqs(pot, R, jr, jz, Omegar, Omegaphi, Omegaz):
+    """In-place close-to-circular/planar NaN-frequency substitution on the
+    numpy host side (mirrors the numpy c=True branches)."""
+    indx = numpy.isnan(Omegar) * (jr < 10.0**-3.0) + numpy.isnan(Omegaz) * (
+        jz < 10.0**-3.0
+    )
+    if numpy.sum(indx) > 0:
+        Omegar[indx] = [epifreq(pot, r, use_physical=False) for r in R[indx]]
+        Omegaphi[indx] = [omegac(pot, r, use_physical=False) for r in R[indx]]
+        Omegaz[indx] = [verticalfreq(pot, r, use_physical=False) for r in R[indx]]
+
+
+def _staeckel_t2_actions_donor(xp, R, vR, vT, z, vz, pot, delta, order):
+    """In-backend donor (jr, jz): _staeckel_prep + the t^2-substituted action
+    quadratures with the same integrand args and prefactors as the graft block
+    of _staeckel_jr_jz (only the donor's GRADIENT is used, via graft_gradient;
+    the degenerate-orbit snap zeroes the gradient as on the c=False path)."""
+    s, umin, umax, vmin, delta = _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta)
+    sqrt2 = numpy.sqrt(2.0)
+    jr_args = (s["E"], s["Lz"], s["I3U"], delta, s["u0"], s["sinh2u0"],
+               s["v0u"], s["sin2v0u"], s["potu0v0"], pot)  # fmt: skip
+    jr = (
+        _staeckel_t2_action(xp, _JRStaeckelIntegrandSquared, jr_args, umin, umax, order)
+        * sqrt2
+        * delta
+        / numpy.pi
+    )
+    jz_args = (s["E"], s["Lz"], s["I3V"], delta, s["u0"], s["cosh2u0v"],
+               s["sinh2u0v"], s["potupi2"], pot)  # fmt: skip
+    pi2 = numpy.pi / 2.0 * xp.ones_like(vmin)
+    jz = (
+        _staeckel_t2_action(xp, _JzStaeckelIntegrandSquared, jz_args, vmin, pi2, order)
+        * 2.0
+        * sqrt2
+        * delta
+        / numpy.pi
+    )
+    jr = xp.where((umax - umin) / umax < 1e-6, xp.zeros_like(jr), jr)
+    jz = xp.where((numpy.pi / 2.0 - vmin) < 1e-7, xp.zeros_like(jz), jz)
+    return jr, jz
+
+
+def _staeckel_c_graft_actions(xp, jr, jz, R, vR, vT, z, vz, pot, delta, order):
+    """Under AD (jax trace / torch grad), graft the t^2 donor's gradient onto
+    the C action values; plain forwards pay no donor cost."""
+    if not (under_jax_trace(R, vR, vT, z, vz) or under_torch_grad(R, vR, vT, z, vz)):
+        return jr, jz
+    djr, djz = _staeckel_t2_actions_donor(xp, R, vR, vT, z, vz, pot, delta, order)
+    return graft_gradient(jr, djr), graft_gradient(jz, djz)
+
+
+def _staeckel_actions_c_backend(
+    xp, R, vR, vT, z, vz, pot, delta, order, useu0=False, u0=None
+):
+    """c=True (jr, Lz, jz) for backend inputs."""
+    delta_np = _backend_to_numpy(delta) if is_backend_array(delta) else delta
+    u0_np = None if u0 is None else _backend_to_numpy(u0)
+
+    def _host(R, vR, vT, z, vz):
+        u0h = _staeckel_c_host_u0(pot, delta_np, useu0, u0_np, R, vR, vT, z, vz)
+        jr, jz, err = actionAngleStaeckel_c.actionAngleStaeckel_c(
+            pot, delta_np, R, vR, vT, z, vz, u0=u0h, order=order
+        )
+        if err != 0:  # pragma: no cover
+            raise RuntimeError(
+                "C-code for calculation actions failed; try with c=False"
+            )
+        return jr, jz
+
+    jr, jz = _staeckel_c_value(xp, _host, (R, vR, vT, z, vz), 2)
+    jr, jz = _staeckel_c_graft_actions(
+        xp, jr, jz, R, vR, vT, z, vz, pot, _coerce_delta_arraylike(delta), order
+    )
+    return jr, R * vT, jz
+
+
+def _staeckel_actions_freqs_c_backend(
+    xp, R, vR, vT, z, vz, pot, delta, order, useu0=False, u0=None
+):
+    """c=True (jr, Lz, jz, Omegar, Omegaphi, Omegaz) for backend inputs."""
+    delta_np = _backend_to_numpy(delta) if is_backend_array(delta) else delta
+    u0_np = None if u0 is None else _backend_to_numpy(u0)
+
+    def _host(R, vR, vT, z, vz):
+        u0h = _staeckel_c_host_u0(pot, delta_np, useu0, u0_np, R, vR, vT, z, vz)
+        jr, jz, Omegar, Omegaphi, Omegaz, err = (
+            actionAngleStaeckel_c.actionAngleFreqStaeckel_c(
+                pot, delta_np, R, vR, vT, z, vz, u0=u0h, order=order
+            )
+        )
+        _staeckel_c_circular_freqs(pot, R, jr, jz, Omegar, Omegaphi, Omegaz)
+        if err != 0:  # pragma: no cover
+            raise RuntimeError(
+                "C-code for calculation actions failed; try with c=False"
+            )
+        return jr, jz, Omegar, Omegaphi, Omegaz
+
+    jr, jz, Omegar, Omegaphi, Omegaz = _staeckel_c_value(
+        xp, _host, (R, vR, vT, z, vz), 5
+    )
+    jr, jz = _staeckel_c_graft_actions(
+        xp, jr, jz, R, vR, vT, z, vz, pot, _coerce_delta_arraylike(delta), order
+    )
+    return jr, R * vT, jz, Omegar, Omegaphi, Omegaz
+
+
+def _staeckel_actions_freqs_angles_c_backend(
+    xp, R, vR, vT, z, vz, phi, pot, delta, order, useu0=False, u0=None
+):
+    """c=True (jr, Lz, jz, Omegas, angles) for backend inputs."""
+    delta_np = _backend_to_numpy(delta) if is_backend_array(delta) else delta
+    u0_np = None if u0 is None else _backend_to_numpy(u0)
+
+    def _host(R, vR, vT, z, vz, phi):
+        u0h = _staeckel_c_host_u0(pot, delta_np, useu0, u0_np, R, vR, vT, z, vz)
+        jr, jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez, err = (
+            actionAngleStaeckel_c.actionAngleFreqAngleStaeckel_c(
+                pot, delta_np, R, vR, vT, z, vz, phi, u0=u0h, order=order
+            )
+        )
+        _staeckel_c_circular_freqs(pot, R, jr, jz, Omegar, Omegaphi, Omegaz)
+        if err != 0:  # pragma: no cover
+            raise RuntimeError(
+                "C-code for calculation actions failed; try with c=False"
+            )
+        return jr, jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez
+
+    out = _staeckel_c_value(xp, _host, (R, vR, vT, z, vz, phi), 8)
+    jr, jz = _staeckel_c_graft_actions(
+        xp, out[0], out[1], R, vR, vT, z, vz, pot, _coerce_delta_arraylike(delta), order
+    )
+    return (jr, R * vT, jz) + tuple(out[2:])
+
+
 # --------------------------------------------------------------- frequencies
 # The frequency derivative integrals dJ/d(E,Lz,I3) need the t^2-substitution
 # (their integrands are (factor)/sqrt(S), SINGULAR at the turning points, unlike
@@ -705,6 +888,15 @@ class actionAngleStaeckel(actionAngle):
             (self._c and not ("c" in kwargs and not kwargs["c"]))
             or (ext_loaded and ("c" in kwargs and kwargs["c"]))
         ) and _check_c(self._pot):
+            if any(is_backend_array(x) for x in (R, vR, vT, z, vz)):
+                # jax/torch inputs: forward VALUE from C, ACTION gradient (under
+                # AD) grafted from the in-backend t^2 donor. numpy is untouched.
+                xp = get_namespace(R, vR, vT, z, vz)
+                R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+                return _staeckel_actions_c_backend(
+                    xp, R, vR, vT, z, vz, self._pot, delta, order,
+                    useu0=self._useu0, u0=kwargs.pop("u0", None),
+                )  # fmt: skip
             Lz = R * vT
             if self._useu0:
                 # First calculate u0
@@ -817,6 +1009,15 @@ class actionAngleStaeckel(actionAngle):
                 vT = numpy.array([vT])
                 z = numpy.array([z])
                 vz = numpy.array([vz])
+            if any(is_backend_array(x) for x in (R, vR, vT, z, vz)):
+                # jax/torch inputs: VALUES from C; ACTION gradients grafted under
+                # AD; frequency values pass through UNGRAFTED (Phase 2).
+                xp = get_namespace(R, vR, vT, z, vz)
+                R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+                return _staeckel_actions_freqs_c_backend(
+                    xp, R, vR, vT, z, vz, self._pot, delta, order,
+                    useu0=self._useu0, u0=kwargs.pop("u0", None),
+                )  # fmt: skip
             Lz = R * vT
             if self._useu0:
                 # First calculate u0
@@ -972,6 +1173,15 @@ class actionAngleStaeckel(actionAngle):
                 z = numpy.array([z])
                 vz = numpy.array([vz])
                 phi = numpy.array([phi])
+            if any(is_backend_array(x) for x in (R, vR, vT, z, vz, phi)):
+                # jax/torch inputs: VALUES from C; ACTION gradients grafted under
+                # AD; frequency/angle values pass through UNGRAFTED (Phase 2).
+                xp = get_namespace(R, vR, vT, z, vz, phi)
+                R, vR, vT, z, vz, phi = promote_scalars(xp, R, vR, vT, z, vz, phi)
+                return _staeckel_actions_freqs_angles_c_backend(
+                    xp, R, vR, vT, z, vz, phi, self._pot, delta, order,
+                    useu0=self._useu0, u0=kwargs.pop("u0", None),
+                )  # fmt: skip
             Lz = R * vT
             if self._useu0:
                 # First calculate u0

--- a/galpy/backend/_jax/staeckel_c.py
+++ b/galpy/backend/_jax/staeckel_c.py
@@ -1,0 +1,42 @@
+###############################################################################
+#   galpy.backend._jax.staeckel_c
+#
+#   jax.pure_callback wrapper forwarding the compiled Staeckel C wrappers'
+#   VALUES under a jax trace (jit/grad/vmap). No JVP rule is defined here: the
+#   actions' first-order gradients are grafted from the in-backend t^2 donor
+#   quadrature in actionAngleStaeckel (graft_gradient stop-gradients this
+#   callback's outputs), and frequency/angle gradients are second-order
+#   objects (not implemented) -- differentiating them raises jax's standard
+#   pure_callback-not-differentiable error.
+###############################################################################
+import numpy
+
+
+def c_value(host, coords, nout):
+    """Forward a numpy-in/numpy-out C `host` under a jax trace.
+
+    host : callable taking len(coords) numpy (N,) arrays, returning `nout`
+        numpy (N,) arrays (the Staeckel C wrapper closure).
+    coords : tuple of traced jax (N,) coordinate arrays.
+    nout : number of outputs; all share coords[0]'s shape and dtype.
+    """
+    import jax
+
+    # Stop-gradient the coords INTO the callback: their tangents become
+    # symbolic zeros, so grad/jvp never engages pure_callback's (unsupported)
+    # JVP rule -- the actions' gradient is grafted from the t^2 donor instead.
+    coords = tuple(jax.lax.stop_gradient(c) for c in coords)
+    shape, dtype = coords[0].shape, coords[0].dtype
+
+    def _host_np(*args):
+        out = host(*(numpy.asarray(a, dtype=numpy.float64) for a in args))
+        return tuple(numpy.asarray(o, dtype=dtype) for o in out)
+
+    # vmap_method="sequential": the C wrappers are strictly 1-D (len(R) batch),
+    # so a user vmap must call the host per batch element, not add axes.
+    return jax.pure_callback(
+        _host_np,
+        tuple(jax.ShapeDtypeStruct(shape, dtype) for _ in range(nout)),
+        *coords,
+        vmap_method="sequential",
+    )

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -5,6 +5,11 @@
 # quadrature (_staeckel_t2_action), which is turning-point-regular where naive
 # d(sqrt S) is singular and carries the full (E, Lz, I3, u0/v0u geometry)
 # dependence that the dJ/d(E,Lz,I3) chain alone misses. First-order only.
+#
+# c=True: the forward VALUE comes from the compiled C wrapper (eager numpy
+# round-trip; jax.pure_callback under a trace) and the same donor supplies the
+# ACTION gradients; frequency/angle values pass through ungrafted (Phase 2).
+# The numpy plain-GL FD gold matches C to ~4e-16, so one gold serves both.
 ###############################################################################
 import numpy
 import pytest
@@ -32,11 +37,16 @@ except ImportError:  # pragma: no cover
 
 from galpy.actionAngle import actionAngleStaeckel
 from galpy.actionAngle.actionAngleStaeckel import _staeckel_actions
+from galpy.actionAngle.actionAngleStaeckel_c import _ext_loaded
 from galpy.backend import get_namespace
 from galpy.potential import MiyamotoNagaiPotential
 
 _MP = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.0375)
 _DELTA, _ORDER = 0.45, 10
+# c=False exercises the in-backend vectorised path directly; c=True the
+# C-value + donor-graft dispatch (needs the compiled extension).
+_CS = [False] + ([True] if _ext_loaded else [])
+_AAS_C = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True) if _ext_loaded else None
 
 # (R, vR, vT, z, vz): generic / eccentric-inclined / near-circular, plus the
 # turning-point edge orbits (vR=0 at the u turning point, vz=0 at the v one,
@@ -57,6 +67,17 @@ def _np_actions(*orbit):
         numpy, *[numpy.array([c]) for c in orbit], _MP, _DELTA, _ORDER
     )
     return float(out[0][0]), float(out[2][0])
+
+
+def _eval_actions(backend, args, c):
+    """(jr, Lz, jz): the internal vectorised path for c=False (unit-level donor
+    coverage) or the public c=True API (C value + graft dispatch)."""
+    if c:
+        return _AAS_C(*args)
+    if backend == "jax":
+        return _staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)
+    xt = get_namespace(torch.tensor(0.0))
+    return _staeckel_actions(xt, *args, _MP, _DELTA, _ORDER)
 
 
 _FD_CACHE = {}
@@ -81,19 +102,18 @@ def _fd_grad(orbit, eps=1e-5):
     return gjr, gjz
 
 
-def _backend_grads(backend, orbit):
+def _backend_grads(backend, orbit, c):
     if backend == "jax":
 
         def f(i, *coords):
-            return jnp.sum(_staeckel_actions(jnp, *coords, _MP, _DELTA, _ORDER)[i])
+            return jnp.sum(_eval_actions("jax", coords, c)[i])
 
-        args = [jnp.asarray([c]) for c in orbit]
+        args = [jnp.asarray([x]) for x in orbit]
         gjr = jax.grad(lambda *a: f(0, *a), argnums=(0, 1, 2, 3, 4))(*args)
         gjz = jax.grad(lambda *a: f(2, *a), argnums=(0, 1, 2, 3, 4))(*args)
         return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
-    xt = get_namespace(torch.tensor(0.0))
-    args = [torch.tensor([c], requires_grad=True) for c in orbit]
-    out = _staeckel_actions(xt, *args, _MP, _DELTA, _ORDER)
+    args = [torch.tensor([x], requires_grad=True) for x in orbit]
+    out = _eval_actions("torch", args, c)
     gjr = torch.autograd.grad(out[0].sum(), args, retain_graph=True)
     gjz = torch.autograd.grad(out[2].sum(), args)
     return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
@@ -101,79 +121,179 @@ def _backend_grads(backend, orbit):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("orbit", list(_ORBITS))
-def test_staeckel_action_grad_vs_fd(backend, orbit):
+@pytest.mark.parametrize("c", _CS)
+def test_staeckel_action_grad_vs_fd(backend, orbit, c):
     # d(jr,jz)/d(R,vR,vT,z,vz) via backend AD vs numpy central FD. The residual
     # is the plain-GL-vs-donor quadrature offset (~5e-4 relative at order 10);
     # the pre-fix failure modes were ~6e2 (naive d(sqrt S)) and ~6e0 (the
     # (E,Lz,I3)-only chain missing the u0/v0u geometry) times larger.
     coords = _ORBITS[orbit]
     fjr, fjz = _fd_grad(coords)
-    gjr, gjz = _backend_grads(backend, coords)
+    gjr, gjz = _backend_grads(backend, coords, c)
     numpy.testing.assert_allclose(gjr, fjr, rtol=2e-3, atol=2e-6)
     numpy.testing.assert_allclose(gjz, fjz, rtol=2e-3, atol=2e-6)
     assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_action_value_unchanged(backend):
+@pytest.mark.parametrize("c", _CS)
+def test_staeckel_action_value_unchanged(backend, c):
     # the graft must not change the forward action value: no-grad backend
     # forward == numpy forward, and the value under an AD trace == the no-grad
     # forward (the donor terms cancel exactly).
     coords = _ORBITS["generic"]
-    jr_np, jz_np = _np_actions(*coords)
+    if c:
+        out_np = _AAS_C(*[numpy.array([x]) for x in coords])
+        jr_np, jz_np = float(out_np[0][0]), float(out_np[2][0])
+    else:
+        jr_np, jz_np = _np_actions(*coords)
     if backend == "jax":
-        args = [jnp.asarray([c]) for c in coords]
-        out = _staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)
+        args = [jnp.asarray([x]) for x in coords]
+        out = _eval_actions("jax", args, c)
         jr_fwd, jz_fwd = float(out[0][0]), float(out[2][0])
         val, _ = jax.value_and_grad(
-            lambda R: jnp.sum(
-                _staeckel_actions(jnp, R, *args[1:], _MP, _DELTA, _ORDER)[0]
-            )
+            lambda R: jnp.sum(_eval_actions("jax", (R, *args[1:]), c)[0])
         )(args[0])
         jr_traced = float(val)
     else:
-        xt = get_namespace(torch.tensor(0.0))
-        args = [torch.tensor([c]) for c in coords]
-        out = _staeckel_actions(xt, *args, _MP, _DELTA, _ORDER)
+        args = [torch.tensor([x]) for x in coords]
+        out = _eval_actions("torch", args, c)
         jr_fwd, jz_fwd = float(out[0][0]), float(out[2][0])
-        gargs = [torch.tensor([c], requires_grad=True) for c in coords]
-        jr_traced = float(
-            _staeckel_actions(xt, *gargs, _MP, _DELTA, _ORDER)[0].detach()[0]
-        )
+        gargs = [torch.tensor([x], requires_grad=True) for x in coords]
+        jr_traced = float(_eval_actions("torch", gargs, c)[0].detach()[0])
     numpy.testing.assert_allclose(jr_fwd, jr_np, rtol=1e-14)
     numpy.testing.assert_allclose(jz_fwd, jz_np, rtol=1e-14)
     numpy.testing.assert_allclose(jr_traced, jr_fwd, rtol=1e-14)
 
 
 @pytest.mark.parametrize("backend", [b for b in BACKENDS if b == "jax"])
-def test_staeckel_action_grad_jit(backend):
-    # the grafted gradient must survive the user's jit unchanged.
+@pytest.mark.parametrize("c", _CS)
+def test_staeckel_action_grad_jit(backend, c):
+    # the grafted gradient must survive the user's jit unchanged; for c=True
+    # both value and grad flow through the jax.pure_callback under jit.
     coords = _ORBITS["generic"]
 
-    def djr_dR(R):
-        args = [R] + [jnp.asarray([c]) for c in coords[1:]]
-        return jnp.sum(_staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)[0])
+    def jr_sum(R):
+        args = [R] + [jnp.asarray([x]) for x in coords[1:]]
+        return jnp.sum(_eval_actions("jax", args, c)[0])
 
     R0 = jnp.asarray([coords[0]])
-    eager = jax.grad(djr_dR)(R0)
-    jitted = jax.jit(jax.grad(djr_dR))(R0)
+    eager_val = jr_sum(R0)
+    jit_val = jax.jit(jr_sum)(R0)
+    numpy.testing.assert_allclose(float(jit_val), float(eager_val), rtol=1e-15)
+    eager = jax.grad(jr_sum)(R0)
+    jitted = jax.jit(jax.grad(jr_sum))(R0)
     numpy.testing.assert_allclose(float(jitted[0]), float(eager[0]), rtol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_action_grad_public_api(backend):
+@pytest.mark.parametrize("c", _CS)
+def test_staeckel_action_grad_public_api(backend, c):
     # same gradients through the public actionAngleStaeckel(...) call.
     coords = _ORBITS["generic"]
-    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=False)
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=c)
     fjr, _ = _fd_grad(coords)
     if backend == "jax":
         g = jax.grad(
-            lambda R: jnp.sum(aAS(R, *[jnp.asarray([c]) for c in coords[1:]])[0])
+            lambda R: jnp.sum(aAS(R, *[jnp.asarray([x]) for x in coords[1:]])[0])
         )(jnp.asarray([coords[0]]))
         djr_dR = float(g[0])
     else:
-        args = [torch.tensor([c], requires_grad=True) for c in coords]
+        args = [torch.tensor([x], requires_grad=True) for x in coords]
         aAS(*args)[0].sum().backward()
+        djr_dR = float(args[0].grad[0])
+    numpy.testing.assert_allclose(djr_dR, fjr[0], rtol=2e-3, atol=2e-6)
+
+
+@pytest.mark.skipif(not _ext_loaded, reason="C extension not available")
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_staeckel_c_backend_forward_matches_numpy(backend, orbit):
+    # c=True backend forward == numpy c=True forward: the value is the SAME C
+    # computation on the same float64s either way (round-trip is exact).
+    coords = _ORBITS[orbit]
+    np_out = _AAS_C(*[numpy.array([x]) for x in coords])
+    assert isinstance(np_out[0], numpy.ndarray)  # numpy in -> numpy out
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in coords]
+    else:
+        args = [torch.tensor([x]) for x in coords]
+    out = _AAS_C(*args)
+    for a, b in zip(out, np_out):
+        numpy.testing.assert_allclose(float(a[0]), float(b[0]), rtol=1e-15)
+
+
+@pytest.mark.skipif(not _ext_loaded, reason="C extension not available")
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", ["generic", "circular"])
+def test_staeckel_c_backend_freqs_angles_forward(backend, orbit):
+    # c=True actionsFreqs / actionsFreqsAngles with backend inputs: all values
+    # (actions grafted, freqs/angles pass-through) match the numpy C outputs.
+    # The exactly-circular orbit exercises the NaN-frequency -> epifreq/omegac/
+    # verticalfreq substitution inside the numpy host.
+    coords = (1.0, 0.0, 1.0, 0.0, 0.0) if orbit == "circular" else _ORBITS["generic"]
+    phi0 = 0.3
+    np6 = _AAS_C.actionsFreqs(*[numpy.array([x]) for x in coords])
+    assert numpy.all(numpy.isfinite(numpy.array(np6)))
+    np9 = _AAS_C.actionsFreqsAngles(
+        *([numpy.array([x]) for x in coords] + [numpy.array([phi0])])
+    )
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in coords]
+        phi = jnp.asarray([phi0])
+    else:
+        args = [torch.tensor([x]) for x in coords]
+        phi = torch.tensor([phi0])
+    b6 = _AAS_C.actionsFreqs(*args)
+    b9 = _AAS_C.actionsFreqsAngles(*(args + [phi]))
+    for a, b in zip(b6, np6):
+        numpy.testing.assert_allclose(float(a[0]), float(b[0]), rtol=1e-15)
+    for a, b in zip(b9, np9):
+        numpy.testing.assert_allclose(float(a[0]), float(b[0]), rtol=1e-15)
+
+
+@pytest.mark.skipif(not _ext_loaded, reason="C extension not available")
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_backend_useu0_u0_delta(backend):
+    # useu0=True (u0 computed on the numpy host), an explicit backend-array u0
+    # kwarg, and a backend-array delta override all match the numpy C outputs.
+    coords = _ORBITS["generic"]
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True, useu0=True)
+    np_args = [numpy.array([x]) for x in coords]
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in coords]
+        u0, delta = jnp.asarray([1.1]), jnp.asarray([0.4])
+    else:
+        args = [torch.tensor([x]) for x in coords]
+        u0, delta = torch.tensor([1.1]), torch.tensor([0.4])
+    for kw_np, kw_b in (
+        ({}, {}),
+        ({"u0": numpy.array([1.1])}, {"u0": u0}),
+        ({"u0": numpy.array([1.1]), "delta": numpy.array([0.4])},
+         {"u0": u0, "delta": delta}),
+    ):  # fmt: skip
+        np_out = aAS(*np_args, **kw_np)
+        out = aAS(*args, **kw_b)
+        for a, b in zip(out, np_out):
+            numpy.testing.assert_allclose(float(a[0]), float(b[0]), rtol=1e-15)
+
+
+@pytest.mark.skipif(not _ext_loaded, reason="C extension not available")
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_backend_freqs_action_grad(backend):
+    # the ACTION outputs of c=True actionsFreqs carry the grafted gradient too.
+    coords = _ORBITS["generic"]
+    fjr, _ = _fd_grad(coords)
+    if backend == "jax":
+        g = jax.grad(
+            lambda R: jnp.sum(
+                _AAS_C.actionsFreqs(R, *[jnp.asarray([x]) for x in coords[1:]])[0]
+            )
+        )(jnp.asarray([coords[0]]))
+        djr_dR = float(g[0])
+    else:
+        args = [torch.tensor([x], requires_grad=True) for x in coords]
+        _AAS_C.actionsFreqs(*args)[0].sum().backward()
         djr_dR = float(args[0].grad[0])
     numpy.testing.assert_allclose(djr_dR, fjr[0], rtol=2e-3, atol=2e-6)
 


### PR DESCRIPTION
Follow-on to #1047, completing the "not just in Python but also C" half: the fast **`c=True` path now accepts backend arrays and carries accurate action gradients**.

## Design
Backend-array inputs in the `c=True` branches of `_evaluate` / `_actionsFreqs` / `_actionsFreqsAngles` route to backend helpers:
- **Forward value from C** (unchanged numerics): torch / eager jax via detach/asarray round-trip; jax **under trace** via `jax.pure_callback` (new `galpy/backend/_jax/staeckel_c.py`, mirroring `orbit_stm.py`). One subtlety: the callback has no JVP rule, so the coords are `lax.stop_gradient`-ed *into* it — intended semantics, since the gradient comes from the graft, not the callback.
- **Gradient under AD** from the same t²-donor graft as #1047 (`_staeckel_prep` + `_staeckel_t2_action` in-backend). `Lz = R·vT` stays in-backend (no round-trip). Freqs/angles **values** pass through ungrafted — their gradients are Phase-2 second-order objects (see #1048's xfail baselines).

## Validation
- **c=True backend forward == numpy c=True exactly** (0.0 relative — same C computation), eager == jit.
- **numpy path byte-identical**: 72/72 arrays `tobytes`-equal vs pristine base — 10 orbits (incl. vR=0/vz=0/z=0 edges) × {actions, actionsFreqs, actionsFreqsAngles, EccZmaxRperiRap} × {MiyamotoNagai, MN+useu0, MWPotential2014} + delta-array + u0-kwarg.
- **Gradients**: 4.6e-4 relative of FD gold (the known donor-vs-plain-GL quadrature offset from #1047), both backends, through `_evaluate` and through `actionsFreqs`' action outputs; jit-stable through the pure_callback.
- Tests parametrized over `c ∈ (False, True)` + new c=True-specific parity/jit/useu0 tests → **56 passed**; numpy Staeckel suite 72/72.

`_uminumaxvmin` (EccZmax backend path) deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm