### PR TITLE
actionAngleStaeckel: C-native differentiable c=True actions — C Jacobian + custom_vjp (Track E deriv fix, PR C)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -589,6 +589,88 @@ def _staeckel_actions_freqs_angles(xp, R, vR, vT, z, vz, phi, pot, delta, order)
     return jr, s["Lz"], jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez
 
 
+def _staeckel_c_grad_actions(pot, delta, R, vR, vT, z, vz, u0, order):
+    """Differentiable (jr, jz) via the C-native Staeckel action Jacobian.
+
+    For jax/torch inputs, wraps the compiled 2x5 d(jr,jz)/d(R,vR,vT,z,vz) C entry
+    (actionAngleStaeckel_actionsJac_c) in the backend custom_vjp / autograd.Function
+    (galpy.backend._{jax,torch}.staeckel_c): the forward is the plain round-trip C
+    action value; the backward is a matvec of the C-computed Jacobian. numpy inputs
+    never reach here. delta/u0 are fixed references (no gradient). First-order only."""
+    delta_np = numpy.atleast_1d(
+        numpy.asarray(stop_gradient(delta), dtype=numpy.float64)
+    )
+    u0_np = (
+        None if u0 is None else numpy.asarray(stop_gradient(u0), dtype=numpy.float64)
+    )
+
+    def host_jac(Rn, vRn, vTn, zn, vzn):
+        jr, jz, jac, err = actionAngleStaeckel_c.actionAngleStaeckel_actionsJac_c(
+            pot, delta_np, Rn, vRn, vTn, zn, vzn, u0=u0_np, order=order
+        )
+        return jr, jz, jac
+
+    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
+    if "jax" in name:
+        from ..backend._jax.staeckel_c import actions_with_jac
+
+        return actions_with_jac(host_jac, (R, vR, vT, z, vz))
+    if "torch" in name:
+        from ..backend._torch.staeckel_c import actions_with_jac
+
+        return actions_with_jac(host_jac, R, vR, vT, z, vz)
+    raise NotImplementedError(  # pragma: no cover
+        "C-native Staeckel action gradients require a jax or torch input array."
+    )
+
+
+def _staeckel_c_forward_values(host, coords, nout):
+    """Forward numpy-in/numpy-out C `host` VALUES (frequencies/angles) under a
+    jax/torch trace, ungrafted (stop-gradient in). Phase-2: values only."""
+    name = getattr(get_namespace(*coords), "__name__", "")
+    if "jax" in name:
+        from ..backend._jax.staeckel_c import c_value
+
+        return c_value(host, coords, nout)
+    from ..backend._torch.staeckel_c import c_value
+
+    return c_value(host, coords, nout)
+
+
+def _staeckel_c_backend_refu0(pot, delta, R, vR, vT, z, vz, useu0, u0_kwarg):
+    """Fixed reference u0 (numpy, du0/dx=0) for the C-native backend path: an
+    explicit u0-kwarg or the useu0 calcu0 value; else None (C then uses ux)."""
+    if u0_kwarg is not None:
+        return numpy.asarray(stop_gradient(u0_kwarg), dtype=numpy.float64)
+    if not useu0:
+        return None
+    Rn, vRn, vTn, zn, vzn = (
+        numpy.atleast_1d(numpy.asarray(stop_gradient(c), dtype=numpy.float64))
+        for c in (R, vR, vT, z, vz)
+    )
+    E = numpy.array(
+        [
+            _evaluatePotentials(pot, Rn[ii], zn[ii])
+            + vRn[ii] ** 2.0 / 2.0
+            + vzn[ii] ** 2.0 / 2.0
+            + vTn[ii] ** 2.0 / 2.0
+            for ii in range(len(Rn))
+        ]
+    )
+    return actionAngleStaeckel_c.actionAngleStaeckel_calcu0(E, Rn * vTn, pot, delta)[0]
+
+
+def _staeckel_c_freq_circ_fix(pot, Rn, jrn, jzn, Or, Op, Oz):
+    """Close-to-circular/planar frequency substitution (numpy host mirror of the
+    C-wrapper adjustment): NaN freqs at small jr/jz -> epifreq/omegac/verticalfreq."""
+    indx = numpy.isnan(Or) * (jrn < 1e-3) + numpy.isnan(Oz) * (jzn < 1e-3)
+    if numpy.sum(indx) > 0:
+        Or[indx] = [epifreq(pot, r, use_physical=False) for r in Rn[indx]]
+        Op[indx] = [omegac(pot, r, use_physical=False) for r in Rn[indx]]
+        Oz[indx] = [verticalfreq(pot, r, use_physical=False) for r in Rn[indx]]
+    return Or, Op, Oz
+
+
 class actionAngleStaeckel(actionAngle):
     """Action-angle formalism for axisymmetric potentials using Binney (2012)'s Staeckel approximation"""
 
@@ -706,6 +788,27 @@ class actionAngleStaeckel(actionAngle):
             or (ext_loaded and ("c" in kwargs and kwargs["c"]))
         ) and _check_c(self._pot):
             Lz = R * vT
+            if any(is_backend_array(c) for c in (R, vR, vT, z, vz)):
+                # jax/torch: differentiable actions via the C-native 2x5 Jacobian
+                # (vjp/autograd.Function); numpy stays on the plain C path below.
+                xp = get_namespace(R, vR, vT, z, vz)
+                R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+                Lz = R * vT
+                u0 = _staeckel_c_backend_refu0(
+                    self._pot,
+                    delta,
+                    R,
+                    vR,
+                    vT,
+                    z,
+                    vz,
+                    self._useu0,
+                    kwargs.pop("u0", None),
+                )
+                jr, jz = _staeckel_c_grad_actions(
+                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                )
+                return (jr, Lz, jz)
             if self._useu0:
                 # First calculate u0
                 if "u0" in kwargs:
@@ -818,6 +921,52 @@ class actionAngleStaeckel(actionAngle):
                 z = numpy.array([z])
                 vz = numpy.array([vz])
             Lz = R * vT
+            if any(is_backend_array(c) for c in (R, vR, vT, z, vz)):
+                # jax/torch: differentiable actions via the C-native Jacobian;
+                # the frequency VALUES pass through ungrafted (Phase-2).
+                xp = get_namespace(R, vR, vT, z, vz)
+                R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+                Lz = R * vT
+                u0 = _staeckel_c_backend_refu0(
+                    self._pot,
+                    delta,
+                    R,
+                    vR,
+                    vT,
+                    z,
+                    vz,
+                    self._useu0,
+                    kwargs.pop("u0", None),
+                )
+                jr, jz = _staeckel_c_grad_actions(
+                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                )
+                delta_np = numpy.atleast_1d(
+                    numpy.asarray(stop_gradient(delta), dtype=numpy.float64)
+                )
+
+                def _host_freqs(Rn, vRn, vTn, zn, vzn):
+                    jrn, jzn, Or, Op, Oz, _ = (
+                        actionAngleStaeckel_c.actionAngleFreqStaeckel_c(
+                            self._pot,
+                            delta_np,
+                            Rn,
+                            vRn,
+                            vTn,
+                            zn,
+                            vzn,
+                            u0=u0,
+                            order=order,
+                        )
+                    )
+                    return _staeckel_c_freq_circ_fix(
+                        self._pot, Rn, jrn, jzn, Or, Op, Oz
+                    )
+
+                Omegar, Omegaphi, Omegaz = _staeckel_c_forward_values(
+                    _host_freqs, (R, vR, vT, z, vz), 3
+                )
+                return (jr, Lz, jz, Omegar, Omegaphi, Omegaz)
             if self._useu0:
                 # First calculate u0
                 if "u0" in kwargs:
@@ -973,6 +1122,55 @@ class actionAngleStaeckel(actionAngle):
                 vz = numpy.array([vz])
                 phi = numpy.array([phi])
             Lz = R * vT
+            if any(is_backend_array(c) for c in (R, vR, vT, z, vz)):
+                # jax/torch: differentiable actions via the C-native Jacobian; the
+                # frequency/angle VALUES pass through ungrafted (phi is forwarded
+                # through the callback, not differentiated). Phase-2.
+                xp = get_namespace(R, vR, vT, z, vz)
+                R, vR, vT, z, vz, phi = promote_scalars(xp, R, vR, vT, z, vz, phi)
+                Lz = R * vT
+                u0 = _staeckel_c_backend_refu0(
+                    self._pot,
+                    delta,
+                    R,
+                    vR,
+                    vT,
+                    z,
+                    vz,
+                    self._useu0,
+                    kwargs.pop("u0", None),
+                )
+                jr, jz = _staeckel_c_grad_actions(
+                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                )
+                delta_np = numpy.atleast_1d(
+                    numpy.asarray(stop_gradient(delta), dtype=numpy.float64)
+                )
+
+                def _host_fa(Rn, vRn, vTn, zn, vzn, phin):
+                    (jrn, jzn, Or, Op, Oz, ar, ap, az, _) = (
+                        actionAngleStaeckel_c.actionAngleFreqAngleStaeckel_c(
+                            self._pot,
+                            delta_np,
+                            Rn,
+                            vRn,
+                            vTn,
+                            zn,
+                            vzn,
+                            phin,
+                            u0=u0,
+                            order=order,
+                        )
+                    )
+                    Or, Op, Oz = _staeckel_c_freq_circ_fix(
+                        self._pot, Rn, jrn, jzn, Or, Op, Oz
+                    )
+                    return Or, Op, Oz, ar, ap, az
+
+                (Omegar, Omegaphi, Omegaz, angler, anglephi, anglez) = (
+                    _staeckel_c_forward_values(_host_fa, (R, vR, vT, z, vz, phi), 6)
+                )
+                return (jr, Lz, jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez)
             if self._useu0:
                 # First calculate u0
                 if "u0" in kwargs:

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -589,14 +589,17 @@ def _staeckel_actions_freqs_angles(xp, R, vR, vT, z, vz, phi, pot, delta, order)
     return jr, s["Lz"], jz, Omegar, Omegaphi, Omegaz, angler, anglephi, anglez
 
 
-def _staeckel_c_grad_actions(pot, delta, R, vR, vT, z, vz, u0, order):
+def _staeckel_c_grad_actions(pot, delta, R, vR, vT, z, vz, u0, order, useu0=False):
     """Differentiable (jr, jz) via the C-native Staeckel action Jacobian.
 
     For jax/torch inputs, wraps the compiled 2x5 d(jr,jz)/d(R,vR,vT,z,vz) C entry
     (actionAngleStaeckel_actionsJac_c) in the backend custom_vjp / autograd.Function
     (galpy.backend._{jax,torch}.staeckel_c): the forward is the plain round-trip C
     action value; the backward is a matvec of the C-computed Jacobian. numpy inputs
-    never reach here. delta/u0 are fixed references (no gradient). First-order only."""
+    never reach here. delta is a fixed reference (no gradient). u0 is a fixed
+    reference too when a user kwarg (useu0=False); when it is the calcu0(E,Lz)
+    reference (useu0=True) the C Jacobian adds the exact dJ/du0*du0/dx term.
+    First-order only."""
     delta_np = numpy.atleast_1d(
         numpy.asarray(stop_gradient(delta), dtype=numpy.float64)
     )
@@ -606,7 +609,7 @@ def _staeckel_c_grad_actions(pot, delta, R, vR, vT, z, vz, u0, order):
 
     def host_jac(Rn, vRn, vTn, zn, vzn):
         jr, jz, jac, err = actionAngleStaeckel_c.actionAngleStaeckel_actionsJac_c(
-            pot, delta_np, Rn, vRn, vTn, zn, vzn, u0=u0_np, order=order
+            pot, delta_np, Rn, vRn, vTn, zn, vzn, u0=u0_np, order=order, useu0=useu0
         )
         return jr, jz, jac
 
@@ -638,12 +641,15 @@ def _staeckel_c_forward_values(host, coords, nout):
 
 
 def _staeckel_c_backend_refu0(pot, delta, R, vR, vT, z, vz, useu0, u0_kwarg):
-    """Fixed reference u0 (numpy, du0/dx=0) for the C-native backend path: an
-    explicit u0-kwarg or the useu0 calcu0 value; else None (C then uses ux)."""
+    """Reference u0 (numpy) for the C-native backend path, plus a flag marking
+    whether it is the coordinate-dependent calcu0(E,Lz) reference (useu0=True,
+    no kwarg) -> the C Jacobian then adds the exact dJ/du0*du0/dx term. An
+    explicit u0-kwarg is a fixed reference (du0/dx=0); if neither, returns
+    (None, False) and the C uses ux (du0/dx=dux/dx)."""
     if u0_kwarg is not None:
-        return numpy.asarray(stop_gradient(u0_kwarg), dtype=numpy.float64)
+        return numpy.asarray(stop_gradient(u0_kwarg), dtype=numpy.float64), False
     if not useu0:
-        return None
+        return None, False
     Rn, vRn, vTn, zn, vzn = (
         numpy.atleast_1d(numpy.asarray(stop_gradient(c), dtype=numpy.float64))
         for c in (R, vR, vT, z, vz)
@@ -657,7 +663,10 @@ def _staeckel_c_backend_refu0(pot, delta, R, vR, vT, z, vz, useu0, u0_kwarg):
             for ii in range(len(Rn))
         ]
     )
-    return actionAngleStaeckel_c.actionAngleStaeckel_calcu0(E, Rn * vTn, pot, delta)[0]
+    return (
+        actionAngleStaeckel_c.actionAngleStaeckel_calcu0(E, Rn * vTn, pot, delta)[0],
+        True,
+    )
 
 
 def _staeckel_c_freq_circ_fix(pot, Rn, jrn, jzn, Or, Op, Oz):
@@ -794,7 +803,7 @@ class actionAngleStaeckel(actionAngle):
                 xp = get_namespace(R, vR, vT, z, vz)
                 R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
                 Lz = R * vT
-                u0 = _staeckel_c_backend_refu0(
+                u0, refu0_calc = _staeckel_c_backend_refu0(
                     self._pot,
                     delta,
                     R,
@@ -806,7 +815,7 @@ class actionAngleStaeckel(actionAngle):
                     kwargs.pop("u0", None),
                 )
                 jr, jz = _staeckel_c_grad_actions(
-                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                    self._pot, delta, R, vR, vT, z, vz, u0, order, useu0=refu0_calc
                 )
                 return (jr, Lz, jz)
             if self._useu0:
@@ -927,7 +936,7 @@ class actionAngleStaeckel(actionAngle):
                 xp = get_namespace(R, vR, vT, z, vz)
                 R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
                 Lz = R * vT
-                u0 = _staeckel_c_backend_refu0(
+                u0, refu0_calc = _staeckel_c_backend_refu0(
                     self._pot,
                     delta,
                     R,
@@ -939,7 +948,7 @@ class actionAngleStaeckel(actionAngle):
                     kwargs.pop("u0", None),
                 )
                 jr, jz = _staeckel_c_grad_actions(
-                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                    self._pot, delta, R, vR, vT, z, vz, u0, order, useu0=refu0_calc
                 )
                 delta_np = numpy.atleast_1d(
                     numpy.asarray(stop_gradient(delta), dtype=numpy.float64)
@@ -1129,7 +1138,7 @@ class actionAngleStaeckel(actionAngle):
                 xp = get_namespace(R, vR, vT, z, vz)
                 R, vR, vT, z, vz, phi = promote_scalars(xp, R, vR, vT, z, vz, phi)
                 Lz = R * vT
-                u0 = _staeckel_c_backend_refu0(
+                u0, refu0_calc = _staeckel_c_backend_refu0(
                     self._pot,
                     delta,
                     R,
@@ -1141,7 +1150,7 @@ class actionAngleStaeckel(actionAngle):
                     kwargs.pop("u0", None),
                 )
                 jr, jz = _staeckel_c_grad_actions(
-                    self._pot, delta, R, vR, vT, z, vz, u0, order
+                    self._pot, delta, R, vR, vT, z, vz, u0, order, useu0=refu0_calc
                 )
                 delta_np = numpy.atleast_1d(
                     numpy.asarray(stop_gradient(delta), dtype=numpy.float64)

--- a/galpy/actionAngle/actionAngleStaeckel_c.py
+++ b/galpy/actionAngle/actionAngleStaeckel_c.py
@@ -146,7 +146,9 @@ def actionAngleStaeckel_c(pot, delta, R, vR, vT, z, vz, u0=None, order=10):
     return (jr, jz, err.value)
 
 
-def actionAngleStaeckel_actionsJac_c(pot, delta, R, vR, vT, z, vz, u0=None, order=10):
+def actionAngleStaeckel_actionsJac_c(
+    pot, delta, R, vR, vT, z, vz, u0=None, order=10, useu0=False
+):
     """
     Use C to calculate Staeckel actions AND the full 2x5 Jacobian
     d(jr,jz)/d(R,vR,vT,z,vz) per object, assembled natively in C.
@@ -160,9 +162,14 @@ def actionAngleStaeckel_actionsJac_c(pot, delta, R, vR, vT, z, vz, u0=None, orde
     R, vR, vT, z, vz : numpy.ndarray
         Phase-space coordinates.
     u0 : numpy.ndarray, optional
-        If set, u0 to use (user-fixed: du0/dx=0 in the Jacobian); else u0=ux.
+        If set, u0 to use; else u0=ux (mode 0, du0/dx=dux/dx).
     order : int, optional
         Order of Gauss-Legendre integration of the relevant integrals.
+    useu0 : bool, optional
+        Only meaningful when u0 is given: if True, the passed u0 is a
+        calcu0(E,Lz) reference that depends on the coordinates (mode 2, the
+        exact useu0=True Jacobian adds dJ/du0*du0/dx); if False, u0 is a fixed
+        user kwarg (mode 1, du0/dx=0).
 
     Returns
     -------
@@ -171,7 +178,7 @@ def actionAngleStaeckel_actionsJac_c(pot, delta, R, vR, vT, z, vz, u0=None, orde
         (len(R),2,5) with jac[:,0]=d(jr)/d(R,vR,vT,z,vz), jac[:,1]=d(jz)/d(...),
         and err is non-zero if an error occurred.
     """
-    useu0 = 0 if u0 is None else 1
+    refu0mode = 0 if u0 is None else (2 if useu0 else 1)
     if u0 is None:
         u0, dummy = coords.Rz_to_uv(R, z, delta=numpy.atleast_1d(delta))
     # Parse the potential
@@ -253,7 +260,7 @@ def actionAngleStaeckel_actionsJac_c(pot, delta, R, vR, vT, z, vz, u0=None, orde
         ctypes.c_int(ndelta),
         delta,
         ctypes.c_int(order),
-        ctypes.c_int(useu0),
+        ctypes.c_int(refu0mode),
         jr,
         jz,
         jac,

--- a/galpy/actionAngle/actionAngleStaeckel_c.py
+++ b/galpy/actionAngle/actionAngleStaeckel_c.py
@@ -146,6 +146,139 @@ def actionAngleStaeckel_c(pot, delta, R, vR, vT, z, vz, u0=None, order=10):
     return (jr, jz, err.value)
 
 
+def actionAngleStaeckel_actionsJac_c(pot, delta, R, vR, vT, z, vz, u0=None, order=10):
+    """
+    Use C to calculate Staeckel actions AND the full 2x5 Jacobian
+    d(jr,jz)/d(R,vR,vT,z,vz) per object, assembled natively in C.
+
+    Parameters
+    ----------
+    pot : Potential or a combined potential formed using addition (pot1+pot2+…)
+        Potential.
+    delta : float
+        Focal length of prolate spheroidal coordinates.
+    R, vR, vT, z, vz : numpy.ndarray
+        Phase-space coordinates.
+    u0 : numpy.ndarray, optional
+        If set, u0 to use (user-fixed: du0/dx=0 in the Jacobian); else u0=ux.
+    order : int, optional
+        Order of Gauss-Legendre integration of the relevant integrals.
+
+    Returns
+    -------
+    tuple
+        (jr,jz,jac,err) where jr,jz are shape (len(R),), jac is shape
+        (len(R),2,5) with jac[:,0]=d(jr)/d(R,vR,vT,z,vz), jac[:,1]=d(jz)/d(...),
+        and err is non-zero if an error occurred.
+    """
+    useu0 = 0 if u0 is None else 1
+    if u0 is None:
+        u0, dummy = coords.Rz_to_uv(R, z, delta=numpy.atleast_1d(delta))
+    # Parse the potential
+    from ..orbit.integrateFullOrbit import _parse_pot
+    from ..orbit.integratePlanarOrbit import _prep_tfuncs
+
+    npot, pot_type, pot_args, pot_tfuncs = _parse_pot(pot, potforactions=True)
+    pot_tfuncs = _prep_tfuncs(pot_tfuncs)
+
+    # Parse delta
+    delta = numpy.atleast_1d(delta)
+    ndelta = len(delta)
+
+    # Set up result arrays
+    jr = numpy.empty(len(R))
+    jz = numpy.empty(len(R))
+    jac = numpy.empty(len(R) * 10)
+    err = ctypes.c_int(0)
+
+    # Set up the C code
+    ndarrayFlags = ("C_CONTIGUOUS", "WRITEABLE")
+    actionAngleStaeckel_actionsFunc = _lib.actionAngleStaeckel_actionsJac
+    actionAngleStaeckel_actionsFunc.argtypes = [
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ndpointer(dtype=numpy.int32, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.POINTER(ctypes.c_int),
+    ]
+
+    # Array requirements, first store old order
+    f_cont = [
+        R.flags["F_CONTIGUOUS"],
+        vR.flags["F_CONTIGUOUS"],
+        vT.flags["F_CONTIGUOUS"],
+        z.flags["F_CONTIGUOUS"],
+        vz.flags["F_CONTIGUOUS"],
+        u0.flags["F_CONTIGUOUS"],
+        delta.flags["F_CONTIGUOUS"],
+    ]
+    R = numpy.require(R, dtype=numpy.float64, requirements=["C", "W"])
+    vR = numpy.require(vR, dtype=numpy.float64, requirements=["C", "W"])
+    vT = numpy.require(vT, dtype=numpy.float64, requirements=["C", "W"])
+    z = numpy.require(z, dtype=numpy.float64, requirements=["C", "W"])
+    vz = numpy.require(vz, dtype=numpy.float64, requirements=["C", "W"])
+    u0 = numpy.require(u0, dtype=numpy.float64, requirements=["C", "W"])
+    delta = numpy.require(delta, dtype=numpy.float64, requirements=["C", "W"])
+    jr = numpy.require(jr, dtype=numpy.float64, requirements=["C", "W"])
+    jz = numpy.require(jz, dtype=numpy.float64, requirements=["C", "W"])
+    jac = numpy.require(jac, dtype=numpy.float64, requirements=["C", "W"])
+
+    # Run the C code
+    actionAngleStaeckel_actionsFunc(
+        len(R),
+        R,
+        vR,
+        vT,
+        z,
+        vz,
+        u0,
+        ctypes.c_int(npot),
+        pot_type,
+        pot_args,
+        pot_tfuncs,
+        ctypes.c_int(ndelta),
+        delta,
+        ctypes.c_int(order),
+        ctypes.c_int(useu0),
+        jr,
+        jz,
+        jac,
+        ctypes.byref(err),
+    )
+
+    # Reset input arrays
+    if f_cont[0]:
+        R = numpy.asfortranarray(R)
+    if f_cont[1]:
+        vR = numpy.asfortranarray(vR)
+    if f_cont[2]:
+        vT = numpy.asfortranarray(vT)
+    if f_cont[3]:
+        z = numpy.asfortranarray(z)
+    if f_cont[4]:
+        vz = numpy.asfortranarray(vz)
+    if f_cont[5]:
+        u0 = numpy.asfortranarray(u0)
+    if f_cont[6]:
+        delta = numpy.asfortranarray(delta)
+
+    return (jr, jz, jac.reshape((len(R), 2, 5)), err.value)
+
+
 def actionAngleStaeckel_calcu0(E, Lz, pot, delta):
     """
     Use C to calculate u0 in the Staeckel approximation

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -547,6 +547,18 @@ void actionAngleStaeckel_actions(int ndata,
   free(umax);
   free(vmin);
 }
+// Stationarity residual g(u)= df/du of f(u)= E sinh^2 u - cosh^2 u Phi(u,pi/2)
+// - Lz22delta/sinh^2 u; calcu0's reference u0 solves g=0. Used to get
+// du0/d(E,Lz) by implicit differentiation on the useu0==2 path (forces only,
+// so no R2deriv-in-C requirement; f'' is a well-conditioned central FD of g).
+static inline double staeckelU0Stationarity(double u,double E,double Lz22delta,
+					    double delta,int npot,
+					    struct potentialArg * aaArgs){
+  double s= sinh(u), c= cosh(u);
+  double P= evaluatePotentialsUV(u,0.5*M_PI,delta,npot,aaArgs);
+  double Pp= -calcRforce(delta*s,0.,0.,0.,npot,aaArgs)*delta*c;
+  return 2.*E*s*c - 2.*s*c*P - c*c*Pp + 2.*Lz22delta*c/(s*s*s);
+}
 // actions jr, jz AND the full 2x5 Jacobian d(jr,jz)/d(R,vR,vT,z,vz) per object,
 // assembled IN C: the six t^2-substituted action-derivative integrals
 // dJ/d(E,Lz,I3) + a new dJz/du0 integral, chained through the analytic
@@ -555,7 +567,9 @@ void actionAngleStaeckel_actions(int ndata,
 // (dJr/dx = djrdE dE/dx + djrdLz dLz/dx + djrdI3 dI3Utilde/dx); J_z carries the
 // extra dJz/du0*du0/dx because u0 enters its integrand via potentialStaeckel(u0,v).
 // jac layout: [ii*10 + {0..4}]=dJr/d(R,vR,vT,z,vz), [ii*10 + {5..9}]=dJz/d(...).
-// useu0!=0 -> u0 is user-fixed (du0/dx=0); else u0 tracks ux (du0/dx=dux/dx).
+// useu0 selects the reference-u0 mode: 0 -> u0 tracks ux (du0/dx=dux/dx);
+// 1 -> user-fixed u0 kwarg (du0/dx=0); 2 -> u0=calcu0(E,Lz) reference, so
+// du0/dx = du0/dE dE/dx + du0/dLz dLz/dx (exact useu0=True gradient).
 void actionAngleStaeckel_actionsJac(int ndata,
 				    double *R,
 				    double *vR,
@@ -677,12 +691,29 @@ void actionAngleStaeckel_actionsJac(int ndata,
     double dvx_dR= shx*cvx/(tdelta*D), dvx_dz= -chx*svx/(tdelta*D);
     double dux[5]= {dux_dR,0.,0.,dux_dz,0.};
     double dvx[5]= {dvx_dR,0.,0.,dvx_dz,0.};
-    double du0[5];
-    for (kk=0;kk<5;kk++) du0[kk]= useu0 ? 0. : dux[kk];
     double dE[5]= {-calcRforce(*(R+ii),*(z+ii),0.,0.,npot,actionAngleArgs),
 		   tvR,tvT,
 		   -calczforce(*(R+ii),*(z+ii),0.,0.,npot,actionAngleArgs),tvz};
     double dLz[5]= {tvT,0.,*(R+ii),0.,0.};
+    // du0/dx per reference-u0 mode (see useu0 doc above). Mode 2 chains
+    // du0/d(E,Lz) (implicit diff of the stationarity residual g=df/du=0,
+    // f''=du0 denom via central FD of g) onto the elementary dE,dLz.
+    double du0[5];
+    double du0dE= 0., du0dLz= 0.;
+    if ( useu0 == 2 ){
+      double L2= 0.5*tLz*tLz/(tdelta*tdelta);
+      double hh= 1.e-5;
+      double fpp= ( staeckelU0Stationarity(tu0+hh,tE,L2,tdelta,npot,actionAngleArgs)
+		    -staeckelU0Stationarity(tu0-hh,tE,L2,tdelta,npot,actionAngleArgs) )
+	/ ( 2.*hh );
+      du0dE= -2.*sh0*ch0/fpp;
+      du0dLz= -2.*ch0*tLz/(tdelta*tdelta*sh0*sh0*sh0)/fpp;
+    }
+    for (kk=0;kk<5;kk++){
+      if ( useu0 == 0 ) du0[kk]= dux[kk];
+      else if ( useu0 == 1 ) du0[kk]= 0.;
+      else du0[kk]= du0dE*dE[kk] + du0dLz*dLz[kk];
+    }
     // momentum derivatives
     double dpux_dux= tdelta*(tvR*shx*svx + tvz*chx*cvx);
     double dpux_dvx= tdelta*(tvR*chx*cvx - tvz*shx*svx);

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -96,6 +96,20 @@ struct u0EqArg{
   int nargs;
   struct potentialArg * actionAngleArgs;
 };
+struct dJzdU0StaeckelArg{
+  double E;
+  double Lz22delta;
+  double I3V;
+  double delta;
+  double u0;
+  double cosh2u0;
+  double sinh2u0;
+  double potupi2;
+  double vmin;
+  double dpotupi2du0; // = -calcRforce(delta*sinh(u0),0)*delta*cosh(u0)
+  int nargs;
+  struct potentialArg * actionAngleArgs;
+};
 /*
   Function Declarations
 */
@@ -118,6 +132,9 @@ EXPORT void actionAngleStaeckel_actionsFreqs(int,double *,double *,double *,doub
 				      double *,double *,int,int *,double *,tfuncs_type_arr,
 				      int,double *,int,double *,double *,
 				      double *,double *,double *,int *);
+EXPORT void actionAngleStaeckel_actionsJac(int,double *,double *,double *,double *,
+				    double *,double *,int,int *,double *,tfuncs_type_arr,
+				    int,double *,int,int,double *,double *,double *,int *);
 void calcAnglesStaeckel(int,double *,double *,double *,double *,double *,
 			double *,double *,double *,double *,double *,double *,
 			double *,double *,double *,double *,double *,double *,
@@ -144,6 +161,9 @@ void calcdJzStaeckel(int,double *,double *,double *,double *,double *,
 		     double *,double *,int,double *,double *,double *,double *,
 		     double *,int,
 		     struct potentialArg *,int);
+void calcdJzdU0Staeckel(int,double *,double *,double *,double *,double *,int,
+			double *,double *,double *,double *,double *,int,
+			struct potentialArg *,int);
 void calcUminUmax(int,double *,double *,double *,double *,double *,double *,
 		  double *,int,double *,double *,double *,double *,double *,
 		  double *,int,struct potentialArg *);
@@ -172,6 +192,9 @@ double dJzdLzHighStaeckelIntegrand(double,void *);
 double dJzdI3StaeckelIntegrand(double,void *);
 double dJzdI3LowStaeckelIntegrand(double,void *);
 double dJzdI3HighStaeckelIntegrand(double,void *);
+double dJzdU0StaeckelIntegrand(double,void *);
+double dJzdU0LowStaeckelIntegrand(double,void *);
+double dJzdU0HighStaeckelIntegrand(double,void *);
 double u0Equation(double,void *);
 double evaluatePotentials(double,double,int, struct potentialArg *);
 double evaluatePotentialsUV(double,double,double,int,struct potentialArg *);
@@ -523,6 +546,203 @@ void actionAngleStaeckel_actions(int ndata,
   free(umin);
   free(umax);
   free(vmin);
+}
+// actions jr, jz AND the full 2x5 Jacobian d(jr,jz)/d(R,vR,vT,z,vz) per object,
+// assembled IN C: the six t^2-substituted action-derivative integrals
+// dJ/d(E,Lz,I3) + a new dJz/du0 integral, chained through the analytic
+// elementary derivatives d(E,Lz,I3Utilde,I3V,u0)/d(coords). I3Utilde =
+// I3U-(sinh2u0+sin2v0)*potu0v0 makes J_R's u0/potu0v0 gauge terms drop out
+// (dJr/dx = djrdE dE/dx + djrdLz dLz/dx + djrdI3 dI3Utilde/dx); J_z carries the
+// extra dJz/du0*du0/dx because u0 enters its integrand via potentialStaeckel(u0,v).
+// jac layout: [ii*10 + {0..4}]=dJr/d(R,vR,vT,z,vz), [ii*10 + {5..9}]=dJz/d(...).
+// useu0!=0 -> u0 is user-fixed (du0/dx=0); else u0 tracks ux (du0/dx=dux/dx).
+void actionAngleStaeckel_actionsJac(int ndata,
+				    double *R,
+				    double *vR,
+				    double *vT,
+				    double *z,
+				    double *vz,
+				    double *u0,
+				    int npot,
+				    int * pot_type,
+				    double * pot_args,
+				    tfuncs_type_arr pot_tfuncs,
+				    int ndelta,
+				    double * delta,
+				    int order,
+				    int useu0,
+				    double *jr,
+				    double *jz,
+				    double *jac,
+				    int * err){
+  int ii;
+  double tdelta;
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
+  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  double *E= (double *) malloc ( ndata * sizeof(double) );
+  double *Lz= (double *) malloc ( ndata * sizeof(double) );
+  calcEL(ndata,R,vR,vT,z,vz,E,Lz,npot,actionAngleArgs);
+  double *ux= (double *) malloc ( ndata * sizeof(double) );
+  double *vx= (double *) malloc ( ndata * sizeof(double) );
+  Rz_to_uv_vec(ndata,R,z,ux,vx,ndelta,delta);
+  double *coshux= (double *) malloc ( ndata * sizeof(double) );
+  double *sinhux= (double *) malloc ( ndata * sizeof(double) );
+  double *sinvx= (double *) malloc ( ndata * sizeof(double) );
+  double *cosvx= (double *) malloc ( ndata * sizeof(double) );
+  double *pux= (double *) malloc ( ndata * sizeof(double) );
+  double *pvx= (double *) malloc ( ndata * sizeof(double) );
+  double *sinh2u0= (double *) malloc ( ndata * sizeof(double) );
+  double *cosh2u0= (double *) malloc ( ndata * sizeof(double) );
+  double *v0= (double *) malloc ( ndata * sizeof(double) );
+  double *sin2v0= (double *) malloc ( ndata * sizeof(double) );
+  double *potu0v0= (double *) malloc ( ndata * sizeof(double) );
+  double *potupi2= (double *) malloc ( ndata * sizeof(double) );
+  double *I3U= (double *) malloc ( ndata * sizeof(double) );
+  double *I3V= (double *) malloc ( ndata * sizeof(double) );
+  int delta_stride= ndelta == 1 ? 0 : 1;
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+  for (ii=0; ii < ndata; ii++){
+    tdelta= *(delta+ii*delta_stride);
+    *(coshux+ii)= cosh(*(ux+ii));
+    *(sinhux+ii)= sinh(*(ux+ii));
+    *(cosvx+ii)= cos(*(vx+ii));
+    *(sinvx+ii)= sin(*(vx+ii));
+    *(pux+ii)= tdelta * (*(vR+ii) * *(coshux+ii) * *(sinvx+ii)
+			+ *(vz+ii) * *(sinhux+ii) * *(cosvx+ii));
+    *(pvx+ii)= tdelta * (*(vR+ii) * *(sinhux+ii) * *(cosvx+ii)
+			- *(vz+ii) * *(coshux+ii) * *(sinvx+ii));
+    *(sinh2u0+ii)= sinh(*(u0+ii)) * sinh(*(u0+ii));
+    *(cosh2u0+ii)= cosh(*(u0+ii)) * cosh(*(u0+ii));
+    *(v0+ii)= 0.5 * M_PI;
+    *(sin2v0+ii)= sin(*(v0+ii)) * sin(*(v0+ii));
+    *(potu0v0+ii)= evaluatePotentialsUV(*(u0+ii),*(v0+ii),tdelta,
+					npot,actionAngleArgs);
+    *(I3U+ii)= *(E+ii) * *(sinhux+ii) * *(sinhux+ii)
+      - 0.5 * *(pux+ii) * *(pux+ii) / tdelta / tdelta
+      - 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinhux+ii) / *(sinhux+ii)
+      - ( *(sinhux+ii) * *(sinhux+ii) + *(sin2v0+ii))
+      *evaluatePotentialsUV(*(ux+ii),*(v0+ii),tdelta,
+			    npot,actionAngleArgs)
+      + ( *(sinh2u0+ii) + *(sin2v0+ii) )* *(potu0v0+ii);
+    *(potupi2+ii)= evaluatePotentialsUV(*(u0+ii),0.5 * M_PI,tdelta,
+					npot,actionAngleArgs);
+    *(I3V+ii)= - *(E+ii) * *(sinvx+ii) * *(sinvx+ii)
+      + 0.5 * *(pvx+ii) * *(pvx+ii) / tdelta / tdelta
+      + 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinvx+ii) / *(sinvx+ii)
+      - *(cosh2u0+ii) * *(potupi2+ii)
+      + ( *(sinh2u0+ii) + *(sinvx+ii) * *(sinvx+ii))
+      * evaluatePotentialsUV(*(u0+ii),*(vx+ii),tdelta,
+			     npot,actionAngleArgs);
+  }
+  double *umin= (double *) malloc ( ndata * sizeof(double) );
+  double *umax= (double *) malloc ( ndata * sizeof(double) );
+  double *vmin= (double *) malloc ( ndata * sizeof(double) );
+  calcUminUmax(ndata,umin,umax,ux,pux,E,Lz,I3U,ndelta,delta,u0,sinh2u0,v0,
+	       sin2v0,potu0v0,npot,actionAngleArgs);
+  calcVmin(ndata,vmin,vx,pvx,E,Lz,I3V,ndelta,delta,u0,cosh2u0,sinh2u0,potupi2,
+	   npot,actionAngleArgs);
+  calcJRStaeckel(ndata,jr,umin,umax,E,Lz,I3U,ndelta,delta,u0,sinh2u0,v0,sin2v0,
+		 potu0v0,npot,actionAngleArgs,order);
+  calcJzStaeckel(ndata,jz,vmin,E,Lz,I3V,ndelta,delta,u0,cosh2u0,sinh2u0,
+		 potupi2,npot,actionAngleArgs,order);
+  // Action-derivative integrals: dJ/d(E,Lz,I3) (six) + the new dJz/du0.
+  double *djrdE= (double *) malloc ( ndata * sizeof(double) );
+  double *djrdLz= (double *) malloc ( ndata * sizeof(double) );
+  double *djrdI3= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdE= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdLz= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdI3= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdU0= (double *) malloc ( ndata * sizeof(double) );
+  calcdJRStaeckel(ndata,djrdE,djrdLz,djrdI3,umin,umax,E,Lz,I3U,ndelta,delta,u0,
+		  sinh2u0,v0,sin2v0,potu0v0,npot,actionAngleArgs,order);
+  calcdJzStaeckel(ndata,djzdE,djzdLz,djzdI3,vmin,E,Lz,I3V,ndelta,delta,u0,
+		  cosh2u0,sinh2u0,potupi2,npot,actionAngleArgs,order);
+  calcdJzdU0Staeckel(ndata,djzdU0,vmin,E,Lz,I3V,ndelta,delta,u0,cosh2u0,sinh2u0,
+		     potupi2,npot,actionAngleArgs,order);
+  // Assemble the 2x5 Jacobian: chain the action-derivatives through the
+  // analytic elementary d(E,Lz,I3Utilde,I3V,u0)/d(R,vR,vT,z,vz).
+#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+  for (ii=0; ii < ndata; ii++){
+    int kk;
+    tdelta= *(delta+ii*delta_stride);
+    double shx= *(sinhux+ii), chx= *(coshux+ii);
+    double svx= *(sinvx+ii), cvx= *(cosvx+ii);
+    double tu0= *(u0+ii), sh0= sinh(tu0), ch0= cosh(tu0);
+    double tE= *(E+ii), tLz= *(Lz+ii), tpux= *(pux+ii), tpvx= *(pvx+ii);
+    double tvR= *(vR+ii), tvT= *(vT+ii), tvz= *(vz+ii);
+    double D= shx*shx + svx*svx;
+    // coordinate-transform derivatives (R = d*sinh(u)*sin(v), z = d*cosh(u)*cos(v))
+    double dux_dR= chx*svx/(tdelta*D), dux_dz= shx*cvx/(tdelta*D);
+    double dvx_dR= shx*cvx/(tdelta*D), dvx_dz= -chx*svx/(tdelta*D);
+    double dux[5]= {dux_dR,0.,0.,dux_dz,0.};
+    double dvx[5]= {dvx_dR,0.,0.,dvx_dz,0.};
+    double du0[5];
+    for (kk=0;kk<5;kk++) du0[kk]= useu0 ? 0. : dux[kk];
+    double dE[5]= {-calcRforce(*(R+ii),*(z+ii),0.,0.,npot,actionAngleArgs),
+		   tvR,tvT,
+		   -calczforce(*(R+ii),*(z+ii),0.,0.,npot,actionAngleArgs),tvz};
+    double dLz[5]= {tvT,0.,*(R+ii),0.,0.};
+    // momentum derivatives
+    double dpux_dux= tdelta*(tvR*shx*svx + tvz*chx*cvx);
+    double dpux_dvx= tdelta*(tvR*chx*cvx - tvz*shx*svx);
+    double dpvx_dux= tdelta*(tvR*chx*cvx - tvz*shx*svx);
+    double dpvx_dvx= tdelta*(-tvR*shx*svx - tvz*chx*cvx);
+    double dpux[5], dpvx[5];
+    for (kk=0;kk<5;kk++){
+      dpux[kk]= dpux_dux*dux[kk] + dpux_dvx*dvx[kk];
+      dpvx[kk]= dpvx_dux*dux[kk] + dpvx_dvx*dvx[kk];
+    }
+    dpux[1]+= tdelta*chx*svx; dpux[4]+= tdelta*shx*cvx;
+    dpvx[1]+= tdelta*shx*cvx; dpvx[4]+= -tdelta*chx*svx;
+    // I3Utilde = E*shx^2 - pux^2/(2 d^2) - Lz^2/(2 d^2 shx^2) - (shx^2+1)*Phi(ux,pi/2)
+    double Pux= evaluatePotentialsUV(*(ux+ii),0.5*M_PI,tdelta,npot,actionAngleArgs);
+    double FRux= calcRforce(tdelta*shx,0.,0.,0.,npot,actionAngleArgs);
+    double dPux_dux= -FRux*tdelta*chx; // dPhi(ux,pi/2)/dux (z-line derivative is 0)
+    double dI3Ut_dE= shx*shx;
+    double dI3Ut_dLz= -tLz/(tdelta*tdelta*shx*shx);
+    double dI3Ut_dpux= -tpux/(tdelta*tdelta);
+    double dI3Ut_dux= 2.*shx*chx*tE + tLz*tLz*chx/(tdelta*tdelta*shx*shx*shx)
+      - 2.*shx*chx*Pux - (shx*shx+1.)*dPux_dux;
+    // I3V = -E*svx^2 + pvx^2/(2 d^2) + Lz^2/(2 d^2 svx^2)
+    //       - cosh2u0*potupi2 + (sinh2u0+svx^2)*Phi(u0,vx)
+    double P0v= evaluatePotentialsUV(tu0,*(vx+ii),tdelta,npot,actionAngleArgs);
+    double FRu0= calcRforce(tdelta*sh0,0.,0.,0.,npot,actionAngleArgs);
+    double Rp= tdelta*sh0*svx, zp= tdelta*ch0*cvx;
+    double FRp= calcRforce(Rp,zp,0.,0.,npot,actionAngleArgs);
+    double Fzp= calczforce(Rp,zp,0.,0.,npot,actionAngleArgs);
+    double dPu0_du0= -FRu0*tdelta*ch0;               // dPhi(u0,pi/2)/du0
+    double dP0v_dvx= -FRp*tdelta*sh0*cvx + Fzp*tdelta*ch0*svx; // dPhi(u0,vx)/dvx
+    double dP0v_du0= -FRp*tdelta*ch0*svx - Fzp*tdelta*sh0*cvx; // dPhi(u0,vx)/du0
+    double dI3V_dE= -svx*svx;
+    double dI3V_dLz= tLz/(tdelta*tdelta*svx*svx);
+    double dI3V_dpvx= tpvx/(tdelta*tdelta);
+    double dI3V_dvx= -2.*tE*svx*cvx - tLz*tLz*cvx/(tdelta*tdelta*svx*svx*svx)
+      + 2.*svx*cvx*P0v + (sh0*sh0+svx*svx)*dP0v_dvx;
+    double dI3V_du0= -2.*ch0*sh0* *(potupi2+ii) - ch0*ch0*dPu0_du0
+      + 2.*sh0*ch0*P0v + (sh0*sh0+svx*svx)*dP0v_du0;
+    double tdjrdE= *(djrdE+ii), tdjrdLz= *(djrdLz+ii), tdjrdI3= *(djrdI3+ii);
+    double tdjzdE= *(djzdE+ii), tdjzdLz= *(djzdLz+ii), tdjzdI3= *(djzdI3+ii);
+    double tdjzdU0= *(djzdU0+ii);
+    for (kk=0;kk<5;kk++){
+      double dI3Ut= dI3Ut_dE*dE[kk] + dI3Ut_dLz*dLz[kk]
+	+ dI3Ut_dpux*dpux[kk] + dI3Ut_dux*dux[kk];
+      double dI3V= dI3V_dE*dE[kk] + dI3V_dLz*dLz[kk] + dI3V_dpvx*dpvx[kk]
+	+ dI3V_dvx*dvx[kk] + dI3V_du0*du0[kk];
+      *(jac+ii*10+kk)= tdjrdE*dE[kk] + tdjrdLz*dLz[kk] + tdjrdI3*dI3Ut;
+      *(jac+ii*10+5+kk)= tdjzdE*dE[kk] + tdjzdLz*dLz[kk] + tdjzdI3*dI3V
+	+ tdjzdU0*du0[kk];
+    }
+  }
+  free_potentialArgs(npot,actionAngleArgs);
+  free(actionAngleArgs);
+  free(E); free(Lz); free(ux); free(vx); free(coshux); free(sinhux);
+  free(sinvx); free(cosvx); free(pux); free(pvx); free(sinh2u0); free(cosh2u0);
+  free(v0); free(sin2v0); free(potu0v0); free(potupi2); free(I3U); free(I3V);
+  free(umin); free(umax); free(vmin);
+  free(djrdE); free(djrdLz); free(djrdI3); free(djzdE); free(djzdLz);
+  free(djzdI3); free(djzdU0);
+  *err= 0;
 }
 void calcJRStaeckel(int ndata,
 		    double * jr,
@@ -1205,6 +1425,83 @@ void calcdJzStaeckel(int ndata,
     (dJzInt+tid)->function = &dJzdI3HighStaeckelIntegrand;
     *(djzdI3+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdI3+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
+  }
+  free(dJzInt);
+  free(params);
+  gsl_integration_glfixed_table_free ( T );
+}
+// dJz/du0 (E,Lz,I3V held fixed): u0 enters the J_z integrand directly through
+// potentialStaeckel(u0,v) [and cosh2u0/sinh2u0/potupi2], so d(sqrt S_z)/du0 =
+// (ddV/du0)/(2 sqrt S_z) with ddV/du0 a force evaluation along the u0-line.
+// Same t^2-substituted low(vmin)+high(pi/2) GL panels and sqrt(2)*delta/pi
+// prefactor as calcdJzStaeckel; degenerate (planar/unbound) -> 0.
+void calcdJzdU0Staeckel(int ndata,
+			double * djzdU0,
+			double * vmin,
+			double * E,
+			double * Lz,
+			double * I3V,
+			int ndelta,
+			double * delta,
+			double * u0,
+			double * cosh2u0,
+			double * sinh2u0,
+			double * potupi2,
+			int nargs,
+			struct potentialArg * actionAngleArgs,
+			int order){
+  int ii, tid, nthreads;
+  double mid;
+#ifdef _OPENMP
+  nthreads = omp_get_max_threads();
+#else
+  nthreads = 1;
+#endif
+  gsl_function * dJzInt= (gsl_function *) malloc ( nthreads * sizeof(gsl_function) );
+  struct dJzdU0StaeckelArg * params= (struct dJzdU0StaeckelArg *) malloc ( nthreads * sizeof (struct dJzdU0StaeckelArg) );
+  for (tid=0; tid < nthreads; tid++){
+    (params+tid)->nargs= nargs;
+    (params+tid)->actionAngleArgs= actionAngleArgs;
+  }
+  gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
+  int delta_stride= ndelta == 1 ? 0 : 1;
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk)				\
+  private(tid,ii,mid)							\
+  shared(djzdU0,vmin,dJzInt,params,T,delta,E,Lz,I3V,u0,cosh2u0,sinh2u0,potupi2)
+  for (ii=0; ii < ndata; ii++){
+#ifdef _OPENMP
+    tid= omp_get_thread_num();
+#else
+    tid = 0;
+#endif
+    if ( *(vmin+ii) == -9999.99 ){
+      *(djzdU0+ii)= 0.;
+      continue;
+    }
+    if ( (0.5 * M_PI - *(vmin+ii)) / M_PI * 2. < 0.000001 ){//planar
+      *(djzdU0+ii) = 0.;
+      continue;
+    }
+    double td= *(delta+ii*delta_stride);
+    double ch0= cosh(*(u0+ii)), sh0= sinh(*(u0+ii));
+    (params+tid)->delta= td;
+    (params+tid)->E= *(E+ii);
+    (params+tid)->Lz22delta= 0.5 * *(Lz+ii) * *(Lz+ii) / td / td;
+    (params+tid)->I3V= *(I3V+ii);
+    (params+tid)->u0= *(u0+ii);
+    (params+tid)->cosh2u0= *(cosh2u0+ii);
+    (params+tid)->sinh2u0= *(sinh2u0+ii);
+    (params+tid)->potupi2= *(potupi2+ii);
+    (params+tid)->vmin= *(vmin+ii);
+    (params+tid)->dpotupi2du0= -calcRforce(td*sh0,0.,0.,0.,nargs,actionAngleArgs)*td*ch0;
+    (dJzInt+tid)->function = &dJzdU0LowStaeckelIntegrand;
+    (dJzInt+tid)->params = params+tid;
+    mid= sqrt( 0.5 * (M_PI/2. - *(vmin+ii) ) );
+    *(djzdU0+ii)= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
+    (dJzInt+tid)->function = &dJzdU0HighStaeckelIntegrand;
+    *(djzdU0+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
+    *(djzdU0+ii)*= sqrt(2.) * td / M_PI;
   }
   free(dJzInt);
   free(params);
@@ -1973,6 +2270,42 @@ double dJzdI3StaeckelIntegrand(double v,
   double out= JzStaeckelIntegrandSquared4dJz(v,p);
   if ( out <= 0. ) return 0.;
   else return 1./sqrt(out);
+}
+double dJzdU0LowStaeckelIntegrand(double t,
+				  void * p){
+  struct dJzdU0StaeckelArg * params= (struct dJzdU0StaeckelArg *) p;
+  double v= params->vmin + t * t;
+  return 2. * t * dJzdU0StaeckelIntegrand(v,p);
+}
+double dJzdU0HighStaeckelIntegrand(double t,
+				   void * p){
+  double v= M_PI/2. - t * t;
+  return 2. * t * dJzdU0StaeckelIntegrand(v,p);
+}
+double dJzdU0StaeckelIntegrand(double v,
+			       void * p){
+  struct dJzdU0StaeckelArg * params= (struct dJzdU0StaeckelArg *) p;
+  double sin2v= sin(v) * sin(v);
+  double phi_u0_v= evaluatePotentialsUV(params->u0,v,params->delta,
+					params->nargs,params->actionAngleArgs);
+  double dV= params->cosh2u0 * params->potupi2
+    - (params->sinh2u0+sin2v) * phi_u0_v;
+  double out= params->E * sin2v + params->I3V + dV
+    - params->Lz22delta / sin2v;
+  if ( out <= 0. ) return 0.;
+  double ch0= cosh(params->u0), sh0= sinh(params->u0);
+  double sv= sin(v), cv= cos(v);
+  double Rv= params->delta * sh0 * sv;
+  double zv= params->delta * ch0 * cv;
+  double FRv= calcRforce(Rv,zv,0.,0.,params->nargs,params->actionAngleArgs);
+  double Fzv= calczforce(Rv,zv,0.,0.,params->nargs,params->actionAngleArgs);
+  double dPhi_du0= -FRv * params->delta * ch0 * sv
+    - Fzv * params->delta * sh0 * cv; // dPhi(u0,v)/du0
+  double ddVdu0= 2. * ch0 * sh0 * params->potupi2
+    + params->cosh2u0 * params->dpotupi2du0
+    - 2. * sh0 * ch0 * phi_u0_v
+    - (params->sinh2u0+sin2v) * dPhi_du0;
+  return ddVdu0/sqrt(out);
 }
 double u0Equation(double u, void * p){
   struct u0EqArg * params= (struct u0EqArg *) p;

--- a/galpy/backend/_jax/staeckel_c.py
+++ b/galpy/backend/_jax/staeckel_c.py
@@ -1,0 +1,90 @@
+###############################################################################
+#   galpy.backend._jax.staeckel_c
+#
+#   jax wrappers for the compiled Staeckel C actions. Two entry points:
+#     * c_value: a jax.pure_callback forwarding a numpy-in/numpy-out C wrapper's
+#       VALUES under a jax trace (used for the frequency/angle values, which are
+#       not differentiated here -- their gradients are second-order objects).
+#     * actions_with_jac: a jax.custom_vjp whose forward is a pure_callback to
+#       the C entry that returns (jr, jz) AND the full 2x5 Jacobian
+#       d(jr,jz)/d(R,vR,vT,z,vz) (assembled natively in C); the backward is a
+#       matvec of that Jacobian. Registered exactly like the C-STM custom_vjp
+#       (orbit_stm), so users' jit/grad stay traceable. First-order only.
+###############################################################################
+import numpy
+
+
+def c_value(host, coords, nout):
+    """Forward a numpy-in/numpy-out C `host` under a jax trace (value only).
+
+    host : callable taking len(coords) numpy (N,) arrays, returning `nout`
+        numpy (N,) arrays. coords : tuple of traced jax (N,) arrays. The coords
+        are stop-gradient'd in, so no JVP rule is engaged (no gradient here).
+    """
+    import jax
+
+    coords = tuple(jax.lax.stop_gradient(c) for c in coords)
+    shape, dtype = coords[0].shape, coords[0].dtype
+
+    def _host_np(*args):
+        out = host(*(numpy.asarray(a, dtype=numpy.float64) for a in args))
+        return tuple(numpy.asarray(o, dtype=dtype) for o in out)
+
+    return jax.pure_callback(
+        _host_np,
+        tuple(jax.ShapeDtypeStruct(shape, dtype) for _ in range(nout)),
+        *coords,
+        vmap_method="sequential",
+    )
+
+
+def actions_with_jac(host_jac, coords):
+    """Differentiable (jr, jz) with the native-C Jacobian as the vjp residual.
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (jr, jz, jac) with jr,jz (N,) and jac (N,2,5). coords : tuple of 5
+        traced jax (N,) arrays (R,vR,vT,z,vz).
+    """
+    import jax
+    import jax.numpy as jnp
+
+    shape, dtype = coords[0].shape, coords[0].dtype
+
+    def _host(*cs):
+        jr, jz, jac = host_jac(*(numpy.asarray(c, dtype=numpy.float64) for c in cs))
+        return (
+            numpy.asarray(jr, dtype=dtype),
+            numpy.asarray(jz, dtype=dtype),
+            numpy.asarray(jac, dtype=dtype),
+        )
+
+    def _call(cs):
+        cs = tuple(jax.lax.stop_gradient(c) for c in cs)
+        return jax.pure_callback(
+            _host,
+            (
+                jax.ShapeDtypeStruct(shape, dtype),
+                jax.ShapeDtypeStruct(shape, dtype),
+                jax.ShapeDtypeStruct(shape + (2, 5), dtype),
+            ),
+            *cs,
+            vmap_method="sequential",
+        )
+
+    @jax.custom_vjp
+    def _actions(cs):
+        jr, jz, _ = _call(cs)
+        return jr, jz
+
+    def _fwd(cs):
+        jr, jz, jac = _call(cs)
+        return (jr, jz), jac  # residual = the 2x5 Jacobian
+
+    def _bwd(jac, ct):
+        ct_jr, ct_jz = ct  # each (N,)
+        # grad_k = ct_jr * dJr/dx_k + ct_jz * dJz/dx_k
+        g = ct_jr[:, None] * jac[:, 0, :] + ct_jz[:, None] * jac[:, 1, :]  # (N,5)
+        return (tuple(g[:, k] for k in range(5)),)
+
+    _actions.defvjp(_fwd, _bwd)
+    return _actions(coords)

--- a/galpy/backend/_torch/staeckel_c.py
+++ b/galpy/backend/_torch/staeckel_c.py
@@ -1,0 +1,59 @@
+###############################################################################
+#   galpy.backend._torch.staeckel_c
+#
+#   torch wrappers for the compiled Staeckel C actions. actions_with_jac is a
+#   torch.autograd.Function whose forward runs the C entry returning (jr, jz)
+#   AND the full 2x5 Jacobian d(jr,jz)/d(R,vR,vT,z,vz) (assembled natively in
+#   C), saving the Jacobian; backward is a matvec of that Jacobian. Registered
+#   exactly like the C-STM autograd.Function (orbit_stm). First-order only.
+###############################################################################
+import numpy
+import torch
+
+
+def c_value(host, coords, nout):
+    """Forward a numpy-in/numpy-out C `host` under torch (value only, no grad).
+
+    host : callable taking len(coords) numpy (N,) arrays, returning `nout` numpy
+        (N,) arrays. coords : tuple of torch (N,) tensors. Used for the
+        frequency/angle values, which are not differentiated here (their
+        gradients are second-order objects). Detached in, so no graph is built.
+    """
+    dev, dt = coords[0].device, coords[0].dtype
+    cs = [t.detach().to("cpu", torch.float64).numpy() for t in coords]
+    out = host(*cs)
+    return tuple(
+        torch.as_tensor(numpy.asarray(o, dtype=numpy.float64), dtype=dt, device=dev)
+        for o in out
+    )
+
+
+class _ActionsJacFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, host_jac, R, vR, vT, z, vz):
+        # The C entry is CPU/float64; move off-device + to numpy for the call.
+        cs = [t.detach().to("cpu", torch.float64).numpy() for t in (R, vR, vT, z, vz)]
+        jr, jz, jac = host_jac(*cs)
+        dev, dt = R.device, R.dtype
+        ctx.save_for_backward(torch.as_tensor(jac, dtype=dt, device=dev))  # (N,2,5)
+        return (
+            torch.as_tensor(jr, dtype=dt, device=dev),
+            torch.as_tensor(jz, dtype=dt, device=dev),
+        )
+
+    @staticmethod
+    def backward(ctx, g_jr, g_jz):
+        (jac,) = ctx.saved_tensors  # (N,2,5)
+        # grad_k = g_jr * dJr/dx_k + g_jz * dJz/dx_k
+        g = g_jr[:, None] * jac[:, 0, :] + g_jz[:, None] * jac[:, 1, :]  # (N,5)
+        # gradients: host_jac (non-diff) + the 5 coords
+        return (None,) + tuple(g[:, k] for k in range(5))
+
+
+def actions_with_jac(host_jac, R, vR, vT, z, vz):
+    """Differentiable (jr, jz) with the native-C Jacobian as the backward matvec.
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (jr, jz, jac) with jr,jz (N,) and jac (N,2,5).
+    """
+    return _ActionsJacFunction.apply(host_jac, R, vR, vT, z, vz)

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -325,26 +325,37 @@ def _fd_grad_aAS(aAS, orbit, eps=1e-5):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_c_useu0_grad_finite(backend):
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_staeckel_c_useu0_grad_vs_fd(backend, orbit):
     # useu0=True routes the C-native gradient through the calcu0 reference-u0
-    # branch (_staeckel_c_backend_refu0's compute path). NB: the computed
-    # reference u0=u0(E(x)) is held FIXED under AD (du0/dx=0), so this gradient
-    # OMITS the dJ/du0*du0/dx term and is only a first-order approximation for
-    # this niche numerical-stability option (it is ~20% off an FD that lets u0
-    # vary; the DEFAULT c=True path -- reference = ux -- is exact, 1.2e-12 vs the
-    # donor). Assert the grad is finite and same-order as FD, not exact.
-    coords = _ORBITS["generic"]
+    # branch. The computed reference u0=u0(E,Lz) tracks the coordinates, so the
+    # C Jacobian now adds the EXACT dJ/du0*du0/dx term (du0/d(E,Lz) by implicit
+    # differentiation of the u0 stationarity condition df/du=0; f'' via a
+    # forces-only central FD of the stationarity residual). Both d(jr,jz)/dx
+    # then match the numpy useu0 FD gold to the same plain-GL-vs-donor
+    # quadrature floor as the default path: dJr/dx is u0-independent, dJz/dx
+    # carries the full du0 chain. Pre-fix (du0/dx=0) this omitted that term and
+    # was ~20-60% off on several dJz components.
+    coords = _ORBITS[orbit]
     aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True, useu0=True)
-    fjr, _ = _fd_grad_aAS(aAS, coords)
+    fjr, fjz = _fd_grad_aAS(aAS, coords)
     if backend == "jax":
         args = [jnp.asarray([x]) for x in coords]
         gjr = jax.grad(lambda *a: jnp.sum(aAS(*a)[0]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjz = jax.grad(lambda *a: jnp.sum(aAS(*a)[2]), argnums=(0, 1, 2, 3, 4))(*args)
         gjr = [float(g[0]) for g in gjr]
+        gjz = [float(g[0]) for g in gjz]
     else:
         args = [torch.tensor([x], requires_grad=True) for x in coords]
-        gjr = [float(g[0]) for g in torch.autograd.grad(aAS(*args)[0].sum(), args)]
-    assert numpy.all(numpy.isfinite(gjr))
-    numpy.testing.assert_allclose(gjr, fjr, rtol=0.3, atol=1e-3)
+        out = aAS(*args)
+        gjr = [
+            float(g[0])
+            for g in torch.autograd.grad(out[0].sum(), args, retain_graph=True)
+        ]
+        gjz = [float(g[0]) for g in torch.autograd.grad(out[2].sum(), args)]
+    numpy.testing.assert_allclose(gjr, fjr, rtol=2e-3, atol=2e-6)
+    numpy.testing.assert_allclose(gjz, fjz, rtol=2e-3, atol=2e-6)
+    assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -398,3 +398,50 @@ def test_staeckel_c_freqs_circular_substitution(backend):
         )
         assert numpy.all(numpy.isfinite(g))
         numpy.testing.assert_allclose(g, numpy.asarray(ref[i]), rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_useu0_planar_grad_finite(backend):
+    # a planar orbit (z=vz=0 -> jz=0) exercises the C Jacobian's degenerate
+    # dJz/du0=0 guard on the useu0 path; grad must stay finite (jz and its grad
+    # are ~0).
+    planar = (1.0, 0.2, 1.1, 0.0, 0.0)
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True, useu0=True)
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in planar]
+        gjr = jax.grad(lambda *a: jnp.sum(aAS(*a)[0]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjz = jax.grad(lambda *a: jnp.sum(aAS(*a)[2]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjr, gjz = [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
+    else:
+        args = [torch.tensor([x], requires_grad=True) for x in planar]
+        out = aAS(*args)
+        gjr = [
+            float(g[0])
+            for g in torch.autograd.grad(out[0].sum(), args, retain_graph=True)
+        ]
+        gjz = [float(g[0]) for g in torch.autograd.grad(out[2].sum(), args)]
+    assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_useu0_unbound_grad_finite(backend):
+    # a vertically-unbound orbit (large vz) makes the Jz/Jr turning-point
+    # bracketing fail, so C returns the 9999.99 sentinel action; the Jacobian's
+    # vmin/umin==-9999.99 sentinel guards zero out those derivative rows. Grad
+    # must stay finite rather than differentiating through the sentinel.
+    unbound = (1.0, 0.1, 1.1, 0.2, 1.5)
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True, useu0=True)
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in unbound]
+        gjr = jax.grad(lambda *a: jnp.sum(aAS(*a)[0]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjz = jax.grad(lambda *a: jnp.sum(aAS(*a)[2]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjr, gjz = [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
+    else:
+        args = [torch.tensor([x], requires_grad=True) for x in unbound]
+        out = aAS(*args)
+        gjr = [
+            float(g[0])
+            for g in torch.autograd.grad(out[0].sum(), args, retain_graph=True)
+        ]
+        gjz = [float(g[0]) for g in torch.autograd.grad(out[2].sum(), args)]
+    assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -307,3 +307,83 @@ def test_under_torch_grad_without_torch(monkeypatch):
 
     monkeypatch.delitem(sys.modules, "torch", raising=False)
     assert under_torch_grad(numpy.array([1.0])) is False
+
+
+# --- coverage for the C-native reference-u0 host branches + circular-freq fix ---
+def _fd_grad_aAS(aAS, orbit, eps=1e-5):
+    # central-FD of a specific aAS's numpy actions (config-matched gold).
+    gjr, gjz = [], []
+    for i in range(5):
+        up, dn = list(orbit), list(orbit)
+        up[i] += eps
+        dn[i] -= eps
+        jru, _, jzu = (float(x[0]) for x in aAS(*[numpy.array([c]) for c in up]))
+        jrd, _, jzd = (float(x[0]) for x in aAS(*[numpy.array([c]) for c in dn]))
+        gjr.append((jru - jrd) / (2 * eps))
+        gjz.append((jzu - jzd) / (2 * eps))
+    return gjr, gjz
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_useu0_grad_finite(backend):
+    # useu0=True routes the C-native gradient through the calcu0 reference-u0
+    # branch (_staeckel_c_backend_refu0's compute path). NB: the computed
+    # reference u0=u0(E(x)) is held FIXED under AD (du0/dx=0), so this gradient
+    # OMITS the dJ/du0*du0/dx term and is only a first-order approximation for
+    # this niche numerical-stability option (it is ~20% off an FD that lets u0
+    # vary; the DEFAULT c=True path -- reference = ux -- is exact, 1.2e-12 vs the
+    # donor). Assert the grad is finite and same-order as FD, not exact.
+    coords = _ORBITS["generic"]
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True, useu0=True)
+    fjr, _ = _fd_grad_aAS(aAS, coords)
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in coords]
+        gjr = jax.grad(lambda *a: jnp.sum(aAS(*a)[0]), argnums=(0, 1, 2, 3, 4))(*args)
+        gjr = [float(g[0]) for g in gjr]
+    else:
+        args = [torch.tensor([x], requires_grad=True) for x in coords]
+        gjr = [float(g[0]) for g in torch.autograd.grad(aAS(*args)[0].sum(), args)]
+    assert numpy.all(numpy.isfinite(gjr))
+    numpy.testing.assert_allclose(gjr, fjr, rtol=0.3, atol=1e-3)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_u0kwarg_grad(backend):
+    # an explicit u0= kwarg routes through the fixed-u0 branch of
+    # _staeckel_c_backend_refu0 (du0/dx=0); the grad is still finite + close to FD.
+    coords = _ORBITS["generic"]
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
+    u0 = 0.8
+    fjr, _ = _fd_grad_aAS(lambda *a: aAS(*a, u0=u0), coords)
+    if backend == "jax":
+        djr = float(
+            jax.grad(
+                lambda R: jnp.sum(
+                    aAS(R, *[jnp.asarray([x]) for x in coords[1:]], u0=u0)[0]
+                )
+            )(jnp.asarray([coords[0]]))[0]
+        )
+    else:
+        args = [torch.tensor([x], requires_grad=True) for x in coords]
+        aAS(*args, u0=u0)[0].sum().backward()
+        djr = float(args[0].grad[0])
+    numpy.testing.assert_allclose(djr, fjr[0], rtol=2e-3, atol=2e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_c_freqs_circular_substitution(backend):
+    # a near-circular orbit (jr,jz -> 0) makes the C freqs NaN -> the host
+    # epifreq/omegac/verticalfreq substitution (_staeckel_c_freq_circ_fix) runs.
+    circ = (1.0, 0.0, 1.0, 0.0, 0.0)  # vR=vz=z=0, vT~vc -> jr,jz ~ 0
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
+    ref = aAS.actionsFreqs(*[numpy.array([x]) for x in circ])
+    arr = jnp.asarray if backend == "jax" else (lambda v: torch.tensor(v))
+    got = aAS.actionsFreqs(*[arr([x]) for x in circ])
+    for i in (3, 4, 5):  # Or, Op, Oz
+        g = (
+            got[i].detach().cpu().numpy()
+            if backend == "torch"
+            else numpy.asarray(got[i])
+        )
+        assert numpy.all(numpy.isfinite(g))
+        numpy.testing.assert_allclose(g, numpy.asarray(ref[i]), rtol=1e-6, atol=1e-8)

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -81,7 +81,25 @@ def _fd_grad(orbit, eps=1e-5):
     return gjr, gjz
 
 
-def _backend_grads(backend, orbit):
+def _backend_grads(backend, orbit, c=False):
+    # c=False exercises the internal vectorised donor-graft path; c=True routes
+    # through the public API to the C-native Jacobian vjp / autograd.Function.
+    if c:
+        aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
+        if backend == "jax":
+            args = [jnp.asarray([x]) for x in orbit]
+            gjr = jax.grad(lambda *a: jnp.sum(aAS(*a)[0]), argnums=(0, 1, 2, 3, 4))(
+                *args
+            )
+            gjz = jax.grad(lambda *a: jnp.sum(aAS(*a)[2]), argnums=(0, 1, 2, 3, 4))(
+                *args
+            )
+            return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
+        args = [torch.tensor([x], requires_grad=True) for x in orbit]
+        out = aAS(*args)
+        gjr = torch.autograd.grad(out[0].sum(), args, retain_graph=True)
+        gjz = torch.autograd.grad(out[2].sum(), args)
+        return [float(g[0]) for g in gjr], [float(g[0]) for g in gjz]
     if backend == "jax":
 
         def f(i, *coords):
@@ -101,17 +119,49 @@ def _backend_grads(backend, orbit):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("orbit", list(_ORBITS))
-def test_staeckel_action_grad_vs_fd(backend, orbit):
-    # d(jr,jz)/d(R,vR,vT,z,vz) via backend AD vs numpy central FD. The residual
-    # is the plain-GL-vs-donor quadrature offset (~5e-4 relative at order 10);
-    # the pre-fix failure modes were ~6e2 (naive d(sqrt S)) and ~6e0 (the
-    # (E,Lz,I3)-only chain missing the u0/v0u geometry) times larger.
+@pytest.mark.parametrize("c", [False, True])
+def test_staeckel_action_grad_vs_fd(backend, orbit, c):
+    # d(jr,jz)/d(R,vR,vT,z,vz) via backend AD vs numpy central FD, for both the
+    # c=False internal donor-graft path and the c=True C-native Jacobian. The
+    # residual is the plain-GL-vs-donor quadrature offset (~5e-4 relative at
+    # order 10); the pre-fix failure modes were ~6e2 (naive d(sqrt S)) and ~6e0
+    # (the (E,Lz,I3)-only chain missing the u0/v0u geometry) times larger.
     coords = _ORBITS[orbit]
     fjr, fjz = _fd_grad(coords)
-    gjr, gjz = _backend_grads(backend, coords)
+    gjr, gjz = _backend_grads(backend, coords, c=c)
     numpy.testing.assert_allclose(gjr, fjr, rtol=2e-3, atol=2e-6)
     numpy.testing.assert_allclose(gjz, fjz, rtol=2e-3, atol=2e-6)
     assert numpy.all(numpy.isfinite(gjr)) and numpy.all(numpy.isfinite(gjz))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_staeckel_c_native_matches_donor_grad(backend, orbit):
+    # DECISIVE cross-check: the C-native Jacobian (c=True) and the internal
+    # donor-graft gradient (c=False) use the same t^2 derivative integrals, so
+    # they must agree to ~machine precision (not merely the FD floor).
+    coords = _ORBITS[orbit]
+    gjr_c, gjz_c = _backend_grads(backend, coords, c=True)
+    gjr_d, gjz_d = _backend_grads(backend, coords, c=False)
+    numpy.testing.assert_allclose(gjr_c, gjr_d, rtol=1e-6, atol=1e-9)
+    numpy.testing.assert_allclose(gjz_c, gjz_d, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_action_value_c_true_matches_numpy(backend):
+    # c=True backend forward (no-grad and under an AD trace) == numpy c=True
+    # action values EXACTLY (the vjp forward is the plain round-trip C action).
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
+    for orbit in _ORBITS.values():
+        jr_np, _, jz_np = (float(x[0]) for x in aAS(*[numpy.array([c]) for c in orbit]))
+        if backend == "jax":
+            out = aAS(*[jnp.asarray([c]) for c in orbit])
+            jr_b, jz_b = float(out[0][0]), float(out[2][0])
+        else:
+            out = aAS(*[torch.tensor([c]) for c in orbit])
+            jr_b, jz_b = float(out[0].detach()[0]), float(out[2].detach()[0])
+        numpy.testing.assert_allclose(jr_b, jr_np, rtol=1e-15)
+        numpy.testing.assert_allclose(jz_b, jz_np, rtol=1e-15)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -146,13 +196,23 @@ def test_staeckel_action_value_unchanged(backend):
 
 
 @pytest.mark.parametrize("backend", [b for b in BACKENDS if b == "jax"])
-def test_staeckel_action_grad_jit(backend):
-    # the grafted gradient must survive the user's jit unchanged.
+@pytest.mark.parametrize("c", [False, True])
+def test_staeckel_action_grad_jit(backend, c):
+    # the gradient must survive the user's jit unchanged -- for c=False (donor
+    # graft) and c=True (the C-native Jacobian through jax.pure_callback).
     coords = _ORBITS["generic"]
+    if c:
+        aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
 
-    def djr_dR(R):
-        args = [R] + [jnp.asarray([c]) for c in coords[1:]]
-        return jnp.sum(_staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)[0])
+        def djr_dR(R):
+            args = [R] + [jnp.asarray([x]) for x in coords[1:]]
+            return jnp.sum(aAS(*args)[0])
+
+    else:
+
+        def djr_dR(R):
+            args = [R] + [jnp.asarray([x]) for x in coords[1:]]
+            return jnp.sum(_staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)[0])
 
     R0 = jnp.asarray([coords[0]])
     eager = jax.grad(djr_dR)(R0)
@@ -161,20 +221,69 @@ def test_staeckel_action_grad_jit(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_action_grad_public_api(backend):
-    # same gradients through the public actionAngleStaeckel(...) call.
+@pytest.mark.parametrize("c", [False, True])
+def test_staeckel_action_grad_public_api(backend, c):
+    # same gradients through the public actionAngleStaeckel(...) call, c in
+    # (False, True).
     coords = _ORBITS["generic"]
-    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=False)
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=c)
     fjr, _ = _fd_grad(coords)
     if backend == "jax":
         g = jax.grad(
-            lambda R: jnp.sum(aAS(R, *[jnp.asarray([c]) for c in coords[1:]])[0])
+            lambda R: jnp.sum(aAS(R, *[jnp.asarray([x]) for x in coords[1:]])[0])
         )(jnp.asarray([coords[0]]))
         djr_dR = float(g[0])
     else:
-        args = [torch.tensor([c], requires_grad=True) for c in coords]
+        args = [torch.tensor([x], requires_grad=True) for x in coords]
         aAS(*args)[0].sum().backward()
         djr_dR = float(args[0].grad[0])
+    numpy.testing.assert_allclose(djr_dR, fjr[0], rtol=2e-3, atol=2e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_actionsfreqs_c_true_backend(backend):
+    # c=True on backend arrays through actionsFreqs / actionsFreqsAngles: the
+    # freq/angle VALUES are byte-identical to numpy c=True (ungrafted, Phase-2),
+    # and the ACTIONS stay differentiable (djr matches the FD gold).
+    aAS = actionAngleStaeckel(pot=_MP, delta=_DELTA, c=True)
+    mk = (
+        (lambda c: jnp.asarray([c]))
+        if backend == "jax"
+        else (lambda c: torch.tensor([c]))
+    )
+    det = (
+        (lambda x: numpy.asarray(x))
+        if backend == "jax"
+        else (lambda x: numpy.asarray(x.detach()))
+    )
+    # freq/angle VALUES byte-identical to numpy c=True over all orbits (incl. the
+    # near-circular one, which drives the NaN->epifreq/omegac substitution).
+    for orbit in _ORBITS.values():
+        ref_f = [
+            numpy.asarray(x)
+            for x in aAS.actionsFreqs(*[numpy.array([c]) for c in orbit])
+        ]
+        ref_a = [
+            numpy.asarray(x)
+            for x in aAS.actionsFreqsAngles(*[numpy.array([c]) for c in (*orbit, 0.7)])
+        ]
+        gotf = [det(x) for x in aAS.actionsFreqs(*[mk(c) for c in orbit])]
+        gota = [det(x) for x in aAS.actionsFreqsAngles(*[mk(c) for c in (*orbit, 0.7)])]
+        for g, r in zip(gotf, ref_f):
+            numpy.testing.assert_allclose(g, r, rtol=1e-15, atol=1e-15, equal_nan=True)
+        for g, r in zip(gota, ref_a):
+            numpy.testing.assert_allclose(g, r, rtol=1e-15, atol=1e-15, equal_nan=True)
+    # the ACTIONS stay differentiable through actionsFreqs (djr matches FD gold).
+    orbit = _ORBITS["generic"]
+    fjr, _ = _fd_grad(orbit)
+    if backend == "jax":
+        af = [jnp.asarray([c]) for c in orbit]
+        g = jax.grad(lambda R: jnp.sum(aAS.actionsFreqs(R, *af[1:])[0]))(af[0])
+        djr_dR = float(g[0])
+    else:
+        gargs = [torch.tensor([c], requires_grad=True) for c in orbit]
+        aAS.actionsFreqs(*gargs)[0].sum().backward()
+        djr_dR = float(gargs[0].grad[0])
     numpy.testing.assert_allclose(djr_dR, fjr[0], rtol=2e-3, atol=2e-6)
 
 


### PR DESCRIPTION
Reworked replacement for the closed #1050 (which sourced the gradient from the Python donor). Per the design decision, the `c=True` fast path's gradient is now computed **natively in C** and tied in exactly like the C-STM — **no Python fallback in the gradient path**. First-order only (accepted).

## Design
- **New C entry `actionAngleStaeckel_actionsJac`** assembles the full 2×5 Jacobian `d(jr,jz)/d(R,vR,vT,z,vz)` from the *existing* t²-substituted derivative integrands (`dJR/dJz` w.r.t. `E,Lz,I3`) plus the elementary chain through the reference geometry:
  - **Jr** closes with the effective `Ĩ3U = I3U − (sinh²u0 + sin²v0)·potu0v0`, which removes all explicit `u0` dependence → `dJr = djrdE·dE + djrdLz·dLz + djrdI3·dĨ3U`.
  - **Jz** is a genuine `F(E,Lz,I3V,u0)`: the assembly uses the *total* `dI3V` (incl. its `du0` term) plus a **new** `∂Jz/∂u0` integrand (`calcdJzdU0Staeckel`) — no double-counting.
  - Honors the `useu0`/`u0`-kwarg gate (`du0/dx = 0` for a fixed user `u0`).
- **Registered like C-STM**: `jax.pure_callback` + `custom_vjp` (new `galpy/backend/_jax/staeckel_c.py`) and `torch.autograd.Function` (`_torch/staeckel_c.py`); saved residual is the C Jacobian, backward is a matvec. Dispatch in the `c=True` branches of `_evaluate`/`_actionsFreqs`/`_actionsFreqsAngles` routes backend arrays to the vjp path (`Lz=R·vT` in-backend); numpy path untouched. Frequency/angle **values** pass through ungrafted — their gradients are second-order (Phase 2, see #1048's xfail baselines).

## Validation
- **Decisive cross-check**: C-Jacobian vs `jax.grad` through the merged c=False donor path (#1047) = **1.2e-12** (machine precision — two fully independent true-gradient mechanisms agree), across generic + vR=0/vz=0/z=0 edge orbits, both `jr` and `jz`. vs FD gold = 1.9e-4 (the documented plain-GL-vs-donor quadrature floor).
- **numpy `c=True` byte-identical** to base: `tobytes` 0.0 over 200 orbits × {actions, freqs, angles}, MiyamotoNagai + MWPotential2014.
- Tests parametrized over `c ∈ (False, True)`: **50 passed**; `test_actionAngle.py -k staeckel` **72 passed**; jit through `pure_callback` eager==jit.

## Scope note
For the rare combination of a *traced per-object* `delta`/`u0` under `jax.jit`, the reference-geometry `stop_gradient` isn't jit-traceable (scalar `delta` — the normal case — is fully jit-safe). Acceptable; revisit in Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm