### PR TITLE
Track F Pdf.2 (isotropic): backend-migrate isotropicNFW/Plummer/PowerLaw DFs

### DIFF
--- a/galpy/df/isotropicNFWdf.py
+++ b/galpy/df/isotropicNFWdf.py
@@ -1,6 +1,7 @@
 # Class that implements isotropic spherical NFW DF
 import numpy
 
+from ..backend import resolve_namespace
 from ..potential import NFWPotential
 from ..util import conversion
 from .sphericaldf import isotropicsphericaldf
@@ -75,28 +76,60 @@ class isotropicNFWdf(isotropicsphericaldf):
         -----
         - 2021-02-01 - Written - Bovy (UofT)
         """
-        Etilde = -conversion.parse_energy(E, vo=self._vo) / self._Etildemax
-        out = numpy.zeros_like(Etilde)
-        indx = (Etilde > self._Etildemin) * (Etilde <= 1.0)
+        Ei = conversion.parse_energy(E, vo=self._vo)
+        # resolve on _Etildemax too so backend-built potential params keep grads
+        xp = resolve_namespace(Ei, self._Etildemax)
+        if xp is numpy:
+            Etilde = -Ei / self._Etildemax
+            out = numpy.zeros_like(Etilde)
+            indx = (Etilde > self._Etildemin) * (Etilde <= 1.0)
+            if self._widrow:
+                out[indx] = (
+                    self._fEnorm
+                    * Etilde[indx] ** 1.5
+                    * (1 - Etilde[indx]) ** -2.5
+                    * (-numpy.log(Etilde[indx]) / (1.0 - Etilde[indx])) ** -2.7419
+                    * numpy.exp(
+                        0.3620 * Etilde[indx]
+                        - 0.5639 * Etilde[indx] ** 2.0
+                        - 0.0859 * Etilde[indx] ** 3.0
+                        - 0.4912 * Etilde[indx] ** 4.0
+                    )
+                )
+            else:
+                out[indx] = (
+                    self._fEnorm
+                    * Etilde[indx] ** 1.5
+                    * (1 - Etilde[indx]) ** -2.5
+                    * (-numpy.log(Etilde[indx]) / (1.0 - Etilde[indx])) ** -2.75
+                    * numpy.polyval(_COEFFS, Etilde[indx])
+                )
+            return out
+        # jax/torch: functional dead-mask (log/negative-power NaN off-domain)
+        Etilde = -xp.asarray(Ei) * 1.0 / self._Etildemax
+        dead = (Etilde <= self._Etildemin) | (Etilde > 1.0)
+        # dummy strictly inside (Etildemin, 1): keeps log/(1-Et) finite under AD
+        Es = xp.where(dead, 0.5 * (self._Etildemin + 1.0), Etilde)
         if self._widrow:
-            out[indx] = (
+            out = (
                 self._fEnorm
-                * Etilde[indx] ** 1.5
-                * (1 - Etilde[indx]) ** -2.5
-                * (-numpy.log(Etilde[indx]) / (1.0 - Etilde[indx])) ** -2.7419
-                * numpy.exp(
-                    0.3620 * Etilde[indx]
-                    - 0.5639 * Etilde[indx] ** 2.0
-                    - 0.0859 * Etilde[indx] ** 3.0
-                    - 0.4912 * Etilde[indx] ** 4.0
+                * Es**1.5
+                * (1 - Es) ** -2.5
+                * (-xp.log(Es) / (1.0 - Es)) ** -2.7419
+                * xp.exp(
+                    0.3620 * Es - 0.5639 * Es**2.0 - 0.0859 * Es**3.0 - 0.4912 * Es**4.0
                 )
             )
         else:
-            out[indx] = (
+            # Horner over the numpy-literal fit coeffs (numpy.polyval coerces off-backend)
+            poly = Es * 0.0 + _COEFFS[0]
+            for c in _COEFFS[1:]:
+                poly = poly * Es + c
+            out = (
                 self._fEnorm
-                * Etilde[indx] ** 1.5
-                * (1 - Etilde[indx]) ** -2.5
-                * (-numpy.log(Etilde[indx]) / (1.0 - Etilde[indx])) ** -2.75
-                * numpy.polyval(_COEFFS, Etilde[indx])
+                * Es**1.5
+                * (1 - Es) ** -2.5
+                * (-xp.log(Es) / (1.0 - Es)) ** -2.75
+                * poly
             )
-        return out
+        return xp.where(dead, xp.zeros_like(out), out)

--- a/galpy/df/isotropicPlummerdf.py
+++ b/galpy/df/isotropicPlummerdf.py
@@ -1,6 +1,7 @@
 # Class that implements isotropic spherical Plummer DF
 import numpy
 
+from ..backend import resolve_namespace
 from ..potential import PlummerPotential
 from ..util import conversion
 from .sphericaldf import isotropicsphericaldf
@@ -62,13 +63,27 @@ class isotropicPlummerdf(isotropicsphericaldf):
         - 2020-10-01 - Written - Bovy (UofT)
 
         """
-        Etilde = -conversion.parse_energy(E, vo=self._vo)
-        out = numpy.zeros_like(Etilde)
-        indx = (Etilde > 0) * (Etilde <= self._Etildemax)
-        out[indx] = self._fEnorm * (Etilde[indx]) ** 3.5
-        return out
+        Ei = conversion.parse_energy(E, vo=self._vo)
+        # resolve on _Etildemax too so backend-built potential params keep grads
+        xp = resolve_namespace(Ei, self._Etildemax)
+        if xp is numpy:
+            Etilde = -Ei
+            out = numpy.zeros_like(Etilde)
+            indx = (Etilde > 0) * (Etilde <= self._Etildemax)
+            out[indx] = self._fEnorm * (Etilde[indx]) ** 3.5
+            return out
+        # jax/torch: functional dead-mask (negative base -> NaN power under AD)
+        Etilde = -xp.asarray(Ei) * 1.0
+        dead = (Etilde <= 0) | (Etilde > self._Etildemax)
+        Esafe = xp.where(dead, 0.5 * self._Etildemax, Etilde)
+        out = self._fEnorm * Esafe**3.5
+        return xp.where(dead, xp.zeros_like(out), out)
 
     def _icmf(self, ms):
         """Analytic expression for the normalized inverse cumulative mass
         function. The argument ms is normalized mass fraction [0,1]"""
-        return self._pot._b / numpy.sqrt(ms ** (-2.0 / 3.0) - 1.0)
+        xp = resolve_namespace(ms)
+        if xp is numpy:
+            return self._pot._b / numpy.sqrt(ms ** (-2.0 / 3.0) - 1.0)
+        msb = xp.asarray(ms) * 1.0  # coerce: torch rejects numpy scalars
+        return self._pot._b / xp.sqrt(msb ** (-2.0 / 3.0) - 1.0)

--- a/galpy/df/isotropicPowerLawdf.py
+++ b/galpy/df/isotropicPowerLawdf.py
@@ -7,6 +7,7 @@
 import numpy
 from scipy import special
 
+from ..backend import resolve_namespace
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion
@@ -116,22 +117,43 @@ class isotropicPowerLawdf(isotropicsphericaldf):
         -----
         - 2025-03-27 - Written - Bovy (UofT)
         """
-        Eint = numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
-        eps = -Eint
-        out = numpy.zeros_like(eps)
-        valid = eps > 0.0
-        out[valid] = self._fEnorm * eps[valid] ** self._n
+        Ei = conversion.parse_energy(E, vo=self._vo)
+        # resolve on _fEnorm too so backend-built potential params keep grads
+        xp = resolve_namespace(Ei, self._fEnorm)
+        if xp is numpy:
+            Eint = numpy.atleast_1d(Ei)
+            eps = -Eint
+            out = numpy.zeros_like(eps)
+            valid = eps > 0.0
+            out[valid] = self._fEnorm * eps[valid] ** self._n
+            if hasattr(E, "shape"):
+                return out.reshape(E.shape)
+            return out[0]
+        # jax/torch: functional dead-mask (eps**n is NaN for eps<=0 when n frac)
+        eps = -xp.atleast_1d(xp.asarray(Ei) * 1.0)
+        dead = eps <= 0.0
+        epssafe = xp.where(dead, xp.ones_like(eps), eps)
+        out = self._fEnorm * epssafe**self._n
+        out = xp.where(dead, xp.zeros_like(out), out)
         if hasattr(E, "shape"):
             return out.reshape(E.shape)
         return out[0]
 
     def _vmax_at_r(self, pot, r, **kwargs):
         # For alpha > 2, Phi(inf) = 0, so v_esc = sqrt(-2*Phi(r))
-        return numpy.sqrt(-2.0 * _evaluatePotentials(self._pot, r, 0.0))
+        xp = resolve_namespace(r)
+        if xp is numpy:
+            return numpy.sqrt(-2.0 * _evaluatePotentials(self._pot, r, 0.0))
+        rb = xp.asarray(r) * 1.0  # coerce: torch potentials reject numpy coords
+        return xp.sqrt(-2.0 * _evaluatePotentials(self._pot, rb, 0.0))
 
     def _icmf(self, ms):
         """Analytic inverse cumulative mass function for the tracer density.
         The argument ms is normalized mass fraction [0,1]."""
         rmin_g = self._rmin ** (3.0 - self._gamma)
         rmax_g = self._rmax ** (3.0 - self._gamma)
-        return (ms * (rmax_g - rmin_g) + rmin_g) ** (1.0 / (3.0 - self._gamma))
+        xp = resolve_namespace(ms)
+        if xp is numpy:
+            return (ms * (rmax_g - rmin_g) + rmin_g) ** (1.0 / (3.0 - self._gamma))
+        msb = xp.asarray(ms) * 1.0  # coerce: torch rejects numpy scalars
+        return (msb * (rmax_g - rmin_g) + rmin_g) ** (1.0 / (3.0 - self._gamma))

--- a/tests/test_backend_isotropicsphericaldf.py
+++ b/tests/test_backend_isotropicsphericaldf.py
@@ -1,0 +1,244 @@
+###############################################################################
+# test_backend_isotropicsphericaldf.py: Track F Pdf.2 -- backend (jax/torch)
+# coverage for the isotropic closed-form spherical-DF family:
+# isotropicPlummerdf, isotropicNFWdf (improved + Widrow fits), and
+# isotropicPowerLawdf. The numpy path stays byte-identical (test_sphericaldf
+# unchanged); this exercises the resolved-namespace dispatch: parity
+# numpy<->jax<->torch of fE / __call__ / moments / dM/dE, grad-vs-FD of fE and
+# sigmar, is-backend-array assertions, and the numpy-side seeded-sampling
+# contract (numpy RNG draws unchanged under a forced backend).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+import galpy.backend
+from galpy.backend import as_numpy
+from galpy.df import isotropicNFWdf, isotropicPlummerdf, isotropicPowerLawdf
+from galpy.potential import (
+    NFWPotential,
+    PlummerPotential,
+    PowerSphericalPotential,
+)
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _is_backend_array(backend, x):
+    if backend == "jax":
+        return isinstance(x, jax.Array)
+    return torch.is_tensor(x)
+
+
+# --- fixtures: one instance of each closed-form DF + its energy grids --------
+_PP = PlummerPotential(amp=1.7, b=1.3)
+_PDF = isotropicPlummerdf(pot=_PP)
+_PSI0 = float(-_PP(0.0, 0.0, use_physical=False))
+_NP = NFWPotential(amp=2.0, a=1.5)
+_NDF = isotropicNFWdf(pot=_NP, rmax=1e4)
+_NDF_W = isotropicNFWdf(pot=_NP, widrow=True, rmax=1e4)
+_ETMAX_N = float(_NP._amp / _NP.a)
+_PLP = PowerSphericalPotential(amp=1.0, alpha=2.5)
+_LDF = isotropicPowerLawdf(pot=_PLP, rmax=1e4, rmin=1e-6)
+
+# fE grids: in-bounds + out-of-bounds (E>0 and E below the well floor)
+_EGRID_P = numpy.concatenate(
+    [numpy.linspace(-0.999 * _PSI0, -1e-4, 25), [0.5, -1.5 * _PSI0]]
+)
+_ETG = numpy.linspace(_NDF._Etildemin + 1e-3, 0.999, 25)
+_EGRID_N = numpy.concatenate([-_ETG * _ETMAX_N, [0.5, -2.0 * _ETMAX_N]])
+_EGRID_L = numpy.concatenate([numpy.linspace(-3.0, -1e-3, 25), [0.5, 1.0]])
+
+_RS = numpy.array([0.13, 0.5, 1.3, 5.2, 13.0])
+
+# (name, df, energy grid, an in-bounds scalar E, fE-scalar for grad-vs-FD)
+_CASES = [
+    ("plummer", _PDF, _EGRID_P, -0.4 * _PSI0),
+    ("nfw", _NDF, _EGRID_N, -0.4 * _ETMAX_N),
+    ("nfw_widrow", _NDF_W, _EGRID_N, -0.4 * _ETMAX_N),
+    ("powerlaw", _LDF, _EGRID_L, -1.3),
+]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("name,df,egrid,E0", _CASES)
+def test_fE_parity(backend, name, df, egrid, E0):
+    # closed-form fE: numpy<->backend parity on an E grid including the
+    # out-of-bounds (functional dummy-then-zero) branches
+    ref = df.fE(egrid)
+    got = df.fE(_arr(backend, egrid))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    # scalar E returns a backend array too
+    gs = df.fE(_arr(backend, E0))
+    assert _is_backend_array(backend, gs)
+    numpy.testing.assert_allclose(
+        float(as_numpy(gs)), float(df.fE(numpy.atleast_1d(E0))[0]), rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("name,df,egrid,E0", _CASES)
+def test_fE_out_of_bounds_zero(backend, name, df, egrid, E0):
+    # out-of-bounds E (E > 0) is exactly zero on the dead branch, NaN-free
+    got = as_numpy(df.fE(_arr(backend, numpy.array([0.5, 1.0, 10.0]))))
+    assert numpy.all(got == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_powerlaw_scalar_float_forced(backend):
+    # forced backend + Python-float E (no .shape) hits the scalar out[0] return
+    # on isotropicPowerLawdf's backend branch; result is a backend scalar array
+    ref = float(_LDF.fE(numpy.atleast_1d(-1.3))[0])
+    with galpy.backend.use(backend, force=True):
+        got = _LDF.fE(-1.3)
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(float(as_numpy(got)), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_parity(backend):
+    # __call__ tuple forms ((E,), (E, L)) and the 6-coordinate form (Plummer)
+    ref = _PDF((_EGRID_P,))
+    got = _PDF((_arr(backend, _EGRID_P),))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    got = _PDF((_arr(backend, _EGRID_P), _arr(backend, numpy.ones_like(_EGRID_P))))
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    R = numpy.array([0.5, 1.1, 1.7, 2.9])
+    vR = numpy.array([0.1, -0.2, 0.3, 0.0])
+    vT = numpy.array([0.3, 0.5, 0.2, 0.4])
+    z = numpy.array([0.2, -0.3, 0.5, 0.0])
+    vz = numpy.array([-0.1, 0.2, 0.0, 0.1])
+    ref = _PDF(R, vR, vT, z, vz, numpy.zeros_like(R))
+    got = _PDF(*(_arr(backend, c) for c in (R, vR, vT, z, vz)))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "name,df", [("plummer", _PDF), ("nfw", _NDF), ("powerlaw", _LDF)]
+)
+def test_moments_parity(backend, name, df):
+    # sigmar/sigmat GL-vs-adaptive quadrature parity (measured <=1.4e-10) and
+    # the exactly-isotropic beta; scalar and vectorized r
+    for mname in ("sigmar", "sigmat"):
+        f = getattr(df, mname)
+        ref = numpy.array([f(r) for r in _RS])
+        got = numpy.array([float(f(_arr(backend, r))) for r in _RS])
+        gotv = f(_arr(backend, _RS))
+        assert _is_backend_array(backend, gotv)
+        numpy.testing.assert_allclose(got, ref, rtol=1e-8)
+        numpy.testing.assert_allclose(as_numpy(gotv), ref, rtol=1e-8)
+    b = df.beta(_arr(backend, 1.3))
+    assert float(as_numpy(b)) == pytest.approx(0.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_dMdE_parity(backend):
+    # base-class quadrature dM/dE (Plummer: no closed-form _dMdE override); the
+    # r = rphi - s^2 turning-point substitution + GL matches numpy adaptive quad
+    # to 1.2e-13 (measured), no quadrature floor at these energies
+    Eneg = numpy.linspace(0.95 * (-_PSI0), 0.05 * (-_PSI0), 7)
+    ref = _PDF.dMdE(Eneg)
+    got = _PDF.dMdE(_arr(backend, Eneg))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("name,df,egrid,E0", _CASES)
+def test_fE_grad_vs_fd(backend, name, df, egrid, E0):
+    eps = 1e-6
+    fd = (
+        df.fE(numpy.atleast_1d(E0 + eps))[0] - df.fE(numpy.atleast_1d(E0 - eps))[0]
+    ) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda E: df.fE(E).reshape(()))(jnp.asarray(E0)))
+    else:
+        t = torch.tensor(E0, requires_grad=True)
+        df.fE(t).reshape(()).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-6)
+    # out-of-bounds grad is a finite 0, not NaN (dead-branch guards)
+    if backend == "jax":
+        goob = float(jax.grad(lambda E: df.fE(E).reshape(()))(jnp.asarray(0.5)))
+    else:
+        t = torch.tensor(0.5, requires_grad=True)
+        df.fE(t).reshape(()).backward()
+        goob = float(t.grad)
+    assert goob == 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "name,df", [("plummer", _PDF), ("nfw", _NDF), ("powerlaw", _LDF)]
+)
+def test_sigmar_grad_vs_fd(backend, name, df):
+    # d(sigma_r)/dr through the GL moment integrals (limits + Phi(r))
+    r0, eps = 1.3, 1e-5
+    fd = (df.sigmar(r0 + eps) - df.sigmar(r0 - eps)) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda r: df.sigmar(r))(jnp.asarray(r0)))
+    else:
+        t = torch.tensor(r0, requires_grad=True)
+        df.sigmar(t).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "name,mk,seed,rtol,atol",
+    [
+        ("plummer", lambda: isotropicPlummerdf(pot=_PP), 10, 1e-10, 1e-12),
+        # NFW has no closed-form _icmf -> interpolated CMF; the mass grid is
+        # built on the backend then pulled numpy-side into the Spline1D icdf, so
+        # jax draws differ from pure numpy at the grid's fp floor (~2e-6)
+        ("nfw", lambda: isotropicNFWdf(pot=_NP, rmax=1e4), 20, 1e-5, 1e-6),
+        (
+            "powerlaw",
+            lambda: isotropicPowerLawdf(pot=_PLP, rmax=1e4, rmin=1e-6),
+            30,
+            1e-10,
+            1e-12,
+        ),
+    ],
+)
+def test_sample_numpy_side_forced(backend, name, mk, seed, rtol, atol):
+    # sampling is numpy-side by design: under a forced backend the numpy RNG
+    # draw sequence is unchanged and outputs are numpy arrays; only the
+    # deterministic sub-steps (fE/vesc grids, closed-form icmf) run on the
+    # backend, so draws match the pure-numpy ones to fp noise
+    numpy.random.seed(seed)
+    ref = mk().sample(n=100, return_orbit=False)
+    dfb = mk()
+    numpy.random.seed(seed)
+    with galpy.backend.use(backend, force=True):
+        got = dfb.sample(n=100, return_orbit=False)
+    for g, r in zip(got, ref):
+        assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(g, r, rtol=rtol, atol=atol)

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -13,6 +13,7 @@ import pytest
 from scipy import integrate, special
 
 from galpy import potential
+from galpy.backend import as_numpy
 from galpy.df import (
     constantbetadf,
     constantbetaHernquistdf,
@@ -3440,9 +3441,12 @@ def test_constantbeta_powerlaw_beta0_equals_isotropic():
     dfiso = isotropicPowerLawdf(pot=pot, rmax=100.0, rmin=1e-4)
     dfcb = constantbetaPowerLawdf(pot=pot, beta=0.0, rmax=100.0, rmin=1e-4)
     Es = numpy.linspace(-10.0, -0.1, 21)
-    assert numpy.all(numpy.fabs(dfiso.fE(Es) / dfcb.fE(Es) - 1.0) < 1e-10), (
-        "constantbetaPowerLawdf with beta=0 does not match isotropicPowerLawdf"
-    )
+    # as_numpy: under a forced backend the migrated fE returns a backend array;
+    # pull to numpy so numpy.all/fabs work (the values match; it's a numpy.all
+    # interop crash otherwise).
+    assert numpy.all(
+        numpy.fabs(as_numpy(dfiso.fE(Es)) / as_numpy(dfcb.fE(Es)) - 1.0) < 1e-10
+    ), "constantbetaPowerLawdf with beta=0 does not match isotropicPowerLawdf"
 
 
 def test_constantbeta_powerlaw_nonself_dens_directint():


### PR DESCRIPTION
Part of the by-family Pdf.2 split. **Stacked on #1052** (base: sphericaldf + isotropicHernquist pilot + `galpy.backend` helpers); targets the base branch for a clean per-family diff. After #1052 merges to `feat/backends` I'll retarget + rebase this onto `feat/backends`, at which point the all-backend CI (`backend-tests.yml`) runs on the family-only diff.

### What's here
`isotropicNFWdf` / `isotropicPlummerdf` / `isotropicPowerLawdf` backend-migrated; generic helpers imported from `galpy.backend` (`resolve_namespace`), not from `.sphericaldf`.

### Verification (local)
- numpy byte-identical: `tests/test_sphericaldf.py -k "isotropic_nfw or isotropic_plummer or isotropic_powerlaw"` → 32 passed.
- new `tests/test_backend_isotropicsphericaldf.py`: 24 jax + 24 torch passed.

### Migration-flip ledger add (applied in one commit at retarget, to keep family PRs' files disjoint)
- `torch tests/test_sphericaldf.py::test_isotropic_plummer_energyoutofbounds` — non-backend-agnostic test (`numpy.fabs(torch tensor)`); flips because `PlummerPotential` is now backend-migrated so `pot(0,0)` is a torch scalar. Same class as the already-ledgered hernquist entry. df behavior correct.