### PR TITLE
Track F Pdf.2 (constantbeta): backend-migrate constant-β DFs (base + Hernquist + PowerLaw)

### DIFF
--- a/galpy/df/constantbetaHernquistdf.py
+++ b/galpy/df/constantbetaHernquistdf.py
@@ -4,6 +4,8 @@ import numpy
 import scipy.integrate
 import scipy.special
 
+from ..backend import resolve_namespace
+from ..backend import special as bspecial
 from ..potential import HernquistPotential, evaluatePotentials
 from ..util import conversion
 from .constantbetadf import _constantbetadf
@@ -68,15 +70,66 @@ class constantbetaHernquistdf(_constantbetadf):
         - 2020-07-22 - Written
 
         """
-        Etilde = -numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo) / self._psi0)
-        # Handle potential E outside of bounds
-        Etilde_out = numpy.where(numpy.logical_or(Etilde < 0, Etilde > 1))[0]
-        if len(Etilde_out) > 0:
-            # Dummy variable now and 0 later, prevents numerical issues?
-            Etilde[Etilde_out] = 0.5
-        # First check algebraic solutions, all adjusted such that DF = mass den
+        Ei = conversion.parse_energy(E, vo=self._vo)
+        # resolve on _psi0 too so backend-built potential params keep gradients
+        xp = resolve_namespace(Ei, self._psi0)
+        if xp is numpy:
+            Etilde = -numpy.atleast_1d(Ei / self._psi0)
+            # Handle potential E outside of bounds
+            Etilde_out = numpy.where(numpy.logical_or(Etilde < 0, Etilde > 1))[0]
+            if len(Etilde_out) > 0:
+                # Dummy variable now and 0 later, prevents numerical issues?
+                Etilde[Etilde_out] = 0.5
+            # First check algebraic solutions, all adjusted such that DF = mass den
+            if self._beta == 0.0:  # isotropic case
+                sqrtEtilde = numpy.sqrt(Etilde)
+                fE = (
+                    self._psi0
+                    * self._pot.a
+                    / numpy.sqrt(2.0)
+                    / (2 * numpy.pi) ** 3
+                    / self._GMa**1.5
+                    * sqrtEtilde
+                    / (1 - Etilde) ** 2.0
+                    * (
+                        (1.0 - 2.0 * Etilde) * (8.0 * Etilde**2.0 - 8.0 * Etilde - 3.0)
+                        + (
+                            (3.0 * numpy.arcsin(sqrtEtilde))
+                            / numpy.sqrt(Etilde * (1.0 - Etilde))
+                        )
+                    )
+                )
+            elif self._beta == 0.5:
+                fE = (3.0 * Etilde**2.0) / (4.0 * numpy.pi**3.0 * self._pot.a)
+            elif self._beta == -0.5:
+                fE = (
+                    (20.0 * Etilde**3.0 - 20.0 * Etilde**4.0 + 6.0 * Etilde**5.0)
+                    / (1.0 - Etilde) ** 4
+                ) / (4.0 * numpy.pi**3.0 * self._GMa * self._pot.a)
+            else:
+                fE = (
+                    self._fEnorm
+                    * numpy.power(Etilde, 2.5 - self._beta)
+                    * scipy.special.hyp2f1(
+                        5.0 - 2.0 * self._beta,
+                        1.0 - 2.0 * self._beta,
+                        3.5 - self._beta,
+                        Etilde,
+                    )
+                )
+            if len(Etilde_out) > 0:
+                fE[Etilde_out] = 0.0
+            return fE.reshape(E.shape)
+        # jax/torch: functional out-of-bounds handling (dummy-then-zero, keeping
+        # the dead branch NaN-free under autodiff); beta==0 is 0/0 at Etilde==0
+        Eb = xp.asarray(Ei) * 1.0
+        Etilde = -xp.atleast_1d(Eb) / self._psi0
+        dead = (Etilde < 0) | (Etilde > 1)
+        if self._beta == 0.0:
+            dead = dead | (Etilde == 0)
+        Etilde = xp.where(dead, 0.5, Etilde)
         if self._beta == 0.0:  # isotropic case
-            sqrtEtilde = numpy.sqrt(Etilde)
+            sqrtEtilde = xp.sqrt(Etilde)
             fE = (
                 self._psi0
                 * self._pot.a
@@ -87,10 +140,7 @@ class constantbetaHernquistdf(_constantbetadf):
                 / (1 - Etilde) ** 2.0
                 * (
                     (1.0 - 2.0 * Etilde) * (8.0 * Etilde**2.0 - 8.0 * Etilde - 3.0)
-                    + (
-                        (3.0 * numpy.arcsin(sqrtEtilde))
-                        / numpy.sqrt(Etilde * (1.0 - Etilde))
-                    )
+                    + ((3.0 * xp.arcsin(sqrtEtilde)) / xp.sqrt(Etilde * (1.0 - Etilde)))
                 )
             )
         elif self._beta == 0.5:
@@ -101,21 +151,26 @@ class constantbetaHernquistdf(_constantbetadf):
                 / (1.0 - Etilde) ** 4
             ) / (4.0 * numpy.pi**3.0 * self._GMa * self._pot.a)
         else:
+            # 2F1(5-2b,1-2b;3.5-b;Etilde) with Etilde in [0,1] (positive z); the
+            # backend hyp2f1 fallback is built for z<=0, so use the Pfaff transform
+            # 2F1(a,b;c;z)=(1-z)^{-b} 2F1(c-a,b;c;z/(z-1)) to map z into (-inf,0]
+            a = 5.0 - 2.0 * self._beta
+            b = 1.0 - 2.0 * self._beta  # > 0 requires beta < 0.5 for the fallback
+            c = 3.5 - self._beta
             fE = (
                 self._fEnorm
-                * numpy.power(Etilde, 2.5 - self._beta)
-                * scipy.special.hyp2f1(
-                    5.0 - 2.0 * self._beta,
-                    1.0 - 2.0 * self._beta,
-                    3.5 - self._beta,
-                    Etilde,
-                )
+                * Etilde ** (2.5 - self._beta)
+                * (1.0 - Etilde) ** (-b)
+                * bspecial.hyp2f1(c - a, b, c, Etilde / (Etilde - 1.0))
             )
-        if len(Etilde_out) > 0:
-            fE[Etilde_out] = 0.0
-        return fE.reshape(E.shape)
+        fE = xp.where(dead, xp.zeros_like(fE), fE)
+        return fE.reshape(Eb.shape)
 
     def _icmf(self, ms):
         """Analytic expression for the normalized inverse cumulative mass
         function. The argument ms is normalized mass fraction [0,1]"""
-        return self._pot.a * numpy.sqrt(ms) / (1 - numpy.sqrt(ms))
+        xp = resolve_namespace(ms)
+        if xp is numpy:
+            return self._pot.a * numpy.sqrt(ms) / (1 - numpy.sqrt(ms))
+        sq = xp.sqrt(xp.asarray(ms) * 1.0)  # coerce: torch.sqrt rejects numpy
+        return self._pot.a * sq / (1 - sq)

--- a/galpy/df/constantbetaPowerLawdf.py
+++ b/galpy/df/constantbetaPowerLawdf.py
@@ -7,6 +7,7 @@
 import numpy
 from scipy import special
 
+from ..backend import resolve_namespace
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion
@@ -131,22 +132,40 @@ class constantbetaPowerLawdf(_constantbetadf):
         -----
         - 2025-03-27 - Written - Bovy (UofT)
         """
-        Eint = numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
-        eps = -Eint
-        out = numpy.zeros_like(eps)
+        Ei = conversion.parse_energy(E, vo=self._vo)
+        xp = resolve_namespace(Ei, self._fEnorm)
+        if xp is numpy:
+            Eint = numpy.atleast_1d(Ei)
+            eps = -Eint
+            out = numpy.zeros_like(eps)
+            valid = eps > 0.0
+            out[valid] = self._fEnorm * eps[valid] ** self._n
+            if hasattr(E, "shape"):
+                return out.reshape(E.shape)
+            return out[0]
+        # jax/torch: functional masking; eps<=0 gets a safe dummy (eps**n is
+        # NaN/complex there) that is zeroed out below
+        Eb = xp.asarray(Ei) * 1.0
+        eps = -xp.atleast_1d(Eb)
         valid = eps > 0.0
-        out[valid] = self._fEnorm * eps[valid] ** self._n
-        if hasattr(E, "shape"):
-            return out.reshape(E.shape)
-        return out[0]
+        epssafe = xp.where(valid, eps, xp.ones_like(eps))
+        fE = xp.where(valid, self._fEnorm * epssafe**self._n, xp.zeros_like(eps))
+        return fE.reshape(Eb.shape) if hasattr(Ei, "shape") else fE[0]
 
     def _vmax_at_r(self, pot, r, **kwargs):
         # For alpha > 2, Phi(inf) = 0, so v_esc = sqrt(-2*Phi(r))
-        return numpy.sqrt(-2.0 * _evaluatePotentials(self._pot, r, 0.0))
+        xp = resolve_namespace(r)
+        if xp is numpy:
+            return numpy.sqrt(-2.0 * _evaluatePotentials(self._pot, r, 0.0))
+        return xp.sqrt(-2.0 * _evaluatePotentials(self._pot, xp.asarray(r) * 1.0, 0.0))
 
     def _icmf(self, ms):
         """Analytic inverse cumulative mass function for the tracer density.
         The argument ms is normalized mass fraction [0,1]."""
         rmin_g = self._rmin ** (3.0 - self._gamma)
         rmax_g = self._rmax ** (3.0 - self._gamma)
+        xp = resolve_namespace(ms)
+        if xp is numpy:
+            return (ms * (rmax_g - rmin_g) + rmin_g) ** (1.0 / (3.0 - self._gamma))
+        ms = xp.asarray(ms) * 1.0  # coerce: torch rejects numpy sampling grids
         return (ms * (rmax_g - rmin_g) + rmin_g) ** (1.0 / (3.0 - self._gamma))

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -4,11 +4,19 @@
 import numpy
 from scipy import integrate, interpolate, special
 
+from ..backend import resolve_namespace
+from ..backend.quadrature import fixed_quad
 from ..potential import interpSphericalPotential
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion, quadpack
 from ..util._optional_deps import _JAX_LOADED
-from .sphericaldf import _handle_rmin, anisotropicsphericaldf, sphericaldf
+from .sphericaldf import (
+    _QUAD_N_DMDE,
+    _QUAD_N_VMOM,
+    _handle_rmin,
+    anisotropicsphericaldf,
+    sphericaldf,
+)
 
 if _JAX_LOADED:
     from jax import grad, vmap
@@ -74,31 +82,64 @@ class _constantbetadf(anisotropicsphericaldf):
     def _dMdE(self, E):
         if not hasattr(self, "_rphi"):
             self._rphi = self._setup_rphi_interpolator()
-        fE = self.fE(E)
-        out = numpy.zeros_like(E)
-        out[fE > 0.0] = (
+        xp = resolve_namespace(E)
+        if xp is numpy:
+            fE = self.fE(E)
+            out = numpy.zeros_like(E)
+            out[fE > 0.0] = (
+                (2.0 * numpy.pi) ** 2.5
+                * special.gamma(1.0 - self._beta)
+                / 2.0 ** (self._beta - 1.0)
+                / special.gamma(1.5 - self._beta)
+                * fE[fE > 0.0]
+                * numpy.array(
+                    [
+                        integrate.quad(
+                            lambda r: (
+                                r ** (2.0 - 2.0 * self._beta)
+                                * (tE - _evaluatePotentials(self._pot, r, 0.0))
+                                ** (0.5 - self._beta)
+                            ),
+                            0.0,
+                            self._rphi(tE),
+                        )[0]
+                        for ii, tE in enumerate(E)
+                        if fE[ii] > 0.0
+                    ]
+                )
+            )
+            return out
+        # jax/torch: GL after r = rphi(E) - s^2, which cancels the (E-Phi)^{...}
+        # turning point at r = rphi(E) so fixed-order GL converges fast
+        fE = xp.atleast_1d(self.fE(E))
+        pos = fE > 0.0
+        rphiE = xp.asarray(self._rphi(E)) * 1.0
+        # dead-branch guard: out-of-bounds E gets a safe dummy radius, zeroed below
+        rphiE = xp.where(pos, rphiE, xp.ones_like(rphiE))
+        Eb = (xp.asarray(E) * 1.0)[..., None]
+
+        def _integrand(s):
+            r = rphiE[..., None] - s**2.0
+            diff = Eb - _evaluatePotentials(self._pot, r, 0.0)
+            # guard: numerical noise can push E - Phi below 0 at the turning point
+            diffsafe = xp.where(diff > 0.0, diff, xp.ones_like(diff))
+            return (
+                r ** (2.0 - 2.0 * self._beta)
+                * xp.where(
+                    diff > 0.0, diffsafe ** (0.5 - self._beta), xp.zeros_like(diff)
+                )
+                * 2.0
+                * s
+            )
+
+        integral = fixed_quad(xp, _integrand, 0.0, xp.sqrt(rphiE), n=_QUAD_N_DMDE)
+        prefac = (
             (2.0 * numpy.pi) ** 2.5
             * special.gamma(1.0 - self._beta)
             / 2.0 ** (self._beta - 1.0)
             / special.gamma(1.5 - self._beta)
-            * fE[fE > 0.0]
-            * numpy.array(
-                [
-                    integrate.quad(
-                        lambda r: (
-                            r ** (2.0 - 2.0 * self._beta)
-                            * (tE - _evaluatePotentials(self._pot, r, 0.0))
-                            ** (0.5 - self._beta)
-                        ),
-                        0.0,
-                        self._rphi(tE),
-                    )[0]
-                    for ii, tE in enumerate(E)
-                    if fE[ii] > 0.0
-                ]
-            )
         )
-        return out
+        return xp.where(pos, prefac * fE * integral, xp.zeros_like(fE))
 
     def _sample_eta(self, r, n=1):
         """Sample the angle eta which defines radial vs tangential velocities"""
@@ -120,6 +161,12 @@ class _constantbetadf(anisotropicsphericaldf):
         return numpy.arccos(self._coseta_icmf_interp(numpy.random.uniform(size=n)))
 
     def _p_v_at_r(self, v, r):
+        xp = resolve_namespace(v, r)
+        if xp is not numpy:
+            # coerce: a forced backend sees the numpy sampling grids here and
+            # torch potentials reject numpy coords
+            v = xp.asarray(v) * 1.0
+            r = xp.asarray(r) * 1.0
         if hasattr(self, "_fE_interp"):
             return self._fE_interp(
                 _evaluatePotentials(self._pot, r, 0) + 0.5 * v**2.0
@@ -132,18 +179,42 @@ class _constantbetadf(anisotropicsphericaldf):
     def _vmomentdensity(self, r, n, m):
         if m % 2 == 1 or n % 2 == 1:
             return 0.0
+        xp = resolve_namespace(r)
+        if xp is numpy:
+            return (
+                2.0
+                * numpy.pi
+                * r ** (-2.0 * self._beta)
+                * integrate.quad(
+                    lambda v: (
+                        v ** (2.0 - 2.0 * self._beta + m + n)
+                        * self.fE(_evaluatePotentials(self._pot, r, 0) + 0.5 * v**2.0)
+                    ),
+                    0.0,
+                    self._vmax_at_r(self._pot, r),
+                )[0]
+                * special.gamma(m / 2.0 - self._beta + 1.0)
+                * special.gamma((n + 1) / 2.0)
+                / special.gamma(0.5 * (m + n - 2.0 * self._beta + 3.0))
+            )
+        # jax/torch: fixed-order GL over v, differentiable in r through Phi(r)
+        # and the vmax(r) integration limit; the node axis trails
+        rb = xp.asarray(r) * 1.0  # coerce: torch potentials reject numpy coords
+        Phir_b = (xp.asarray(_evaluatePotentials(self._pot, rb, 0)) * 1.0)[..., None]
         return (
             2.0
             * numpy.pi
-            * r ** (-2.0 * self._beta)
-            * integrate.quad(
+            * rb ** (-2.0 * self._beta)
+            * fixed_quad(
+                xp,
                 lambda v: (
                     v ** (2.0 - 2.0 * self._beta + m + n)
-                    * self.fE(_evaluatePotentials(self._pot, r, 0) + 0.5 * v**2.0)
+                    * self.fE(Phir_b + 0.5 * v**2.0)
                 ),
                 0.0,
-                self._vmax_at_r(self._pot, r),
-            )[0]
+                self._vmax_at_r(self._pot, rb),
+                n=_QUAD_N_VMOM,
+            )
             * special.gamma(m / 2.0 - self._beta + 1.0)
             * special.gamma((n + 1) / 2.0)
             / special.gamma(0.5 * (m + n - 2.0 * self._beta + 3.0))

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -193,11 +193,15 @@ jax tests/test_scf.py::test_scf_compute_axi_nbody_twopowertriaxial
 jax tests/test_scf.py::test_scf_compute_nbody_twopowertriaxial
 jax tests/test_scf.py::test_scf_compute_spherical_nbody_hernquist
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_beta
+jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dMdE_integral
+jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dens_directint
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dens_massprofile
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dens_spherically_symmetric
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_energyoutofbounds
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_sigmar
+jax tests/test_sphericaldf.py::test_constantbeta_differentpotentials_dens_directint
+jax tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
 jax tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_beta_directint
 jax tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_dens_directint
 jax tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_meanvr_directint
@@ -225,6 +229,7 @@ jax tests/test_sphericaldf.py::test_osipkovmerritt_dehnencore_in_nfw_meanvr_dire
 jax tests/test_sphericaldf.py::test_osipkovmerritt_dehnencore_in_nfw_sigmar_directint
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_Qoutofbounds
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_beta
+jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dens_massprofile
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dens_spherically_symmetric

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -1,0 +1,281 @@
+###############################################################################
+# test_backend_constantbetadf.py: Track F Pdf.2 -- backend (jax/torch)
+# coverage for the constant-beta spherical-DF family: the closed-form
+# constantbetaHernquistdf (algebraic beta=0,+-0.5 branches + the general-beta
+# hyp2f1 branch, routed through galpy.backend.special via a Pfaff transform so
+# the z<=0 fallback covers the DF's z=Etilde in [0,1] regime) and
+# constantbetaPowerLawdf, plus the shared anisotropic _constantbetadf base
+# machinery (_vmomentdensity, _dMdE, _p_v_at_r). The numpy path is
+# byte-identical (test_sphericaldf unchanged); this exercises the
+# resolved-namespace dispatch: parity numpy<->jax<->torch of fE / __call__ /
+# moments / dM/dE, grad-vs-FD, and the numpy-side sampling contract.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+import galpy.backend
+from galpy.backend import as_numpy
+from galpy.df import constantbetaHernquistdf, constantbetaPowerLawdf
+from galpy.potential import HernquistPotential, PowerSphericalPotential
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _is_backend_array(backend, x):
+    if backend == "jax":
+        return isinstance(x, jax.Array)
+    return torch.is_tensor(x)
+
+
+_HP = HernquistPotential(amp=2.3, a=1.3)
+_PSI0 = float(-_HP(0, 0, use_physical=False))
+_PP = PowerSphericalPotential(amp=1.0, alpha=2.5)
+
+# beta with closed-form (algebraic) fE and beta needing the hyp2f1 branch
+_ALG_BETAS = [-0.5, 0.0, 0.5]
+_HYP_BETAS = [-0.4, 0.3]
+
+# in-bounds E grid (Etilde in (0,1)) + out-of-bounds points (E>0, E<-psi0). E==0
+# is excluded: for beta=0 the numpy arcsin term is 0/0 -> NaN there (a known
+# 1-D numpy edge), which the backend maps to the correct fE->0 limit (tested
+# separately in test_fE_zero_edge)
+_EGRID = numpy.concatenate(
+    [numpy.linspace(0.99 * _HP(0, 0), -1e-4, 21), [0.5, -1.5 * _PSI0]]
+)
+_ENEG = numpy.linspace(-0.95 * _PSI0, -0.05 * _PSI0, 11)
+_RS = numpy.array([0.13, 0.5, 1.3, 5.2, 13.0])
+# power-law: relative energy eps=-E>0 is bound; out-of-bounds is E>=0
+_EGRIDP = numpy.concatenate([numpy.linspace(-10.0, -0.1, 21), [0.5, 0.0, 1e-8]])
+_RSP = numpy.array([0.5, 1.3, 5.0, 20.0])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_parity_hernquist(backend):
+    # algebraic branches (beta=0,+-0.5) are exact closed forms; the general-beta
+    # branch goes through the Pfaff-transformed backend hyp2f1 fallback, whose
+    # floor is ~3e-7 over Etilde in [0,1] (validated vs scipy)
+    for beta in _ALG_BETAS:
+        dfh = constantbetaHernquistdf(pot=_HP, beta=beta)
+        ref = dfh.fE(_EGRID)
+        got = dfh.fE(_arr(backend, _EGRID))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    for beta in _HYP_BETAS:
+        dfh = constantbetaHernquistdf(pot=_HP, beta=beta)
+        ref = dfh.fE(_EGRID)
+        got = dfh.fE(_arr(backend, _EGRID))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_parity_powerlaw(backend):
+    # closed-form power-law fE = eta * (-E)^n; exact on the backend
+    for beta in [-0.5, 0.0, 0.3, 0.5]:
+        dfp = constantbetaPowerLawdf(pot=_PP, beta=beta, rmax=100.0, rmin=1e-4)
+        ref = dfp.fE(_EGRIDP)
+        got = dfp.fE(_arr(backend, _EGRIDP))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    # scalar (0-d) input: numpy returns out[0]; backend returns a 0-d array
+    dfp = constantbetaPowerLawdf(pot=_PP, beta=0.3, rmax=100.0, rmin=1e-4)
+    got = dfp.fE(_arr(backend, -1.0))
+    assert float(as_numpy(got)) == pytest.approx(float(dfp.fE(-1.0)), rel=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_zero_edge(backend):
+    # E == 0 (Etilde == 0) is 0/0 in the numpy arcsin term for beta=0 (NaN in
+    # 1-D numpy); the backend branch implements the correct fE -> 0 limit,
+    # NaN-free (special-fn edge testing)
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.0)
+    got = as_numpy(dfh.fE(_arr(backend, numpy.array([0.0, -0.0, -1e-300]))))
+    assert numpy.all(got == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_outofbounds(backend):
+    # out-of-bounds E -> exactly 0 on the dead branch (functional masking)
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.3)
+    oob = as_numpy(dfh.fE(_arr(backend, numpy.array([0.5, 1.0, -1.5 * _PSI0, 0.0]))))
+    assert numpy.all(oob == 0.0)
+    dfp = constantbetaPowerLawdf(pot=_PP, beta=0.3, rmax=100.0, rmin=1e-4)
+    oobp = as_numpy(dfp.fE(_arr(backend, numpy.array([0.5, 0.0, 1e-8]))))
+    assert numpy.all(oobp == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_parity(backend):
+    # anisotropic __call__: (E, L) tuple form (f = L^{-2beta} fE) and the
+    # 6-coordinate form
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.3)
+    E = numpy.linspace(0.99 * _HP(0, 0), -1e-4, 8)
+    L = numpy.linspace(0.2, 1.5, 8)
+    ref = dfh((E, L))
+    got = dfh((_arr(backend, E), _arr(backend, L)))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+    R = numpy.array([0.5, 1.1, 1.7, 2.9])
+    vR = numpy.array([0.1, -0.2, 0.3, 0.05])
+    vT = numpy.array([0.3, 0.5, 0.2, 0.4])
+    z = numpy.array([0.2, -0.3, 0.5, 0.1])
+    vz = numpy.array([-0.1, 0.2, 0.05, 0.1])
+    ref6 = dfh(R, vR, vT, z, vz, numpy.zeros_like(R))
+    got6 = dfh(*(_arr(backend, c) for c in (R, vR, vT, z, vz)))
+    assert _is_backend_array(backend, got6)
+    numpy.testing.assert_allclose(as_numpy(got6), ref6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_moments_parity(backend):
+    # sigmar/sigmat (GL-vs-adaptive quadrature over v) and beta(r); the
+    # anisotropic constant-beta base _vmomentdensity. beta=0 hits the GL floor
+    # (~1e-9), the hyp2f1-fE betas ~1e-8 (measured); scalar + vector r
+    for pot, betas, rs, ctor in (
+        (_HP, [-0.5, 0.0, 0.3, 0.5], _RS, _mk_hern),
+        (_PP, [0.3], _RSP, _mk_pl),
+    ):
+        for beta in betas:
+            df = ctor(beta)
+            for name in ("sigmar", "sigmat"):
+                f = getattr(df, name)
+                ref = numpy.array([f(r) for r in rs])
+                got = numpy.array([float(f(_arr(backend, r))) for r in rs])
+                gotv = f(_arr(backend, rs))
+                assert _is_backend_array(backend, gotv)
+                numpy.testing.assert_allclose(got, ref, rtol=1e-7)
+                numpy.testing.assert_allclose(as_numpy(gotv), ref, rtol=1e-7)
+            refb = numpy.array([df.beta(r) for r in rs])
+            gotb = numpy.array([float(as_numpy(df.beta(_arr(backend, r)))) for r in rs])
+            numpy.testing.assert_allclose(gotb, refb, rtol=1e-7, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_dMdE_parity(backend):
+    # anisotropic constant-beta dM/dE (GL after the r = rphi - s^2 turning-point
+    # substitution). rtol 1e-5 is the numpy adaptive-quad floor at the
+    # (E-Phi)^{1/2-beta} endpoint (measured ~1.3e-6 at beta=-0.4, ~4.9e-7 at
+    # beta=0) plus the hyp2f1-fE floor; the algebraic betas hit ~1e-15
+    for beta in [-0.5, -0.4, 0.0, 0.3, 0.5]:
+        dfh = constantbetaHernquistdf(pot=_HP, beta=beta)
+        ref = dfh.dMdE(_ENEG)
+        got = dfh.dMdE(_arr(backend, _ENEG))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-5)
+    # out-of-bounds E -> exactly zero on the dead branch
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.3)
+    assert numpy.all(as_numpy(dfh.dMdE(_arr(backend, numpy.array([0.5])))) == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_grad_vs_fd(backend):
+    # d fE/dE through the closed-form and hyp2f1 branches; out-of-bounds grad
+    # is a finite 0 (dead-branch guards)
+    for pot, beta, E0, ctor in (
+        (_HP, -0.5, -0.5 * _PSI0, _mk_hern),
+        (_HP, 0.3, -0.5 * _PSI0, _mk_hern),
+        (_PP, 0.3, -2.0, _mk_pl),
+    ):
+        df = ctor(beta)
+        eps = 1e-6
+        fd = (
+            df.fE(numpy.atleast_1d(E0 + eps))[0] - df.fE(numpy.atleast_1d(E0 - eps))[0]
+        ) / (2.0 * eps)
+        if backend == "jax":
+            g = float(jax.grad(lambda E: df.fE(E))(jnp.asarray(E0)))
+            goob = float(jax.grad(lambda E: df.fE(E))(jnp.asarray(0.5)))
+        else:
+            t = torch.tensor(E0, requires_grad=True)
+            df.fE(t).backward()
+            g = float(t.grad)
+            t = torch.tensor(0.5, requires_grad=True)
+            df.fE(t).backward()
+            goob = float(t.grad)
+        numpy.testing.assert_allclose(g, fd, rtol=1e-6)
+        assert goob == 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_moment_grad_vs_fd(backend):
+    # d(sigma_r)/dr through the GL moment integrals (limits + Phi(r) + fE)
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.3)
+    r0, eps = 1.3, 1e-5
+    fd = (dfh.sigmar(r0 + eps) - dfh.sigmar(r0 - eps)) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda r: dfh.sigmar(r))(jnp.asarray(r0)))
+    else:
+        t = torch.tensor(r0, requires_grad=True)
+        dfh.sigmar(t).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_numpy_side_forced(backend):
+    # sampling is numpy-side by design: under a forced backend the numpy RNG
+    # draw sequence is unchanged and the outputs are numpy arrays; only the
+    # deterministic sub-steps (fE/vesc/pvr grids, closed-form icmf) run on the
+    # backend, so draws match the pure-numpy ones to the grids' fp noise
+    # (Hernquist's pvr grid inherits the hyp2f1 floor -> looser tol)
+    for ctor, kw, rtol, atol in (
+        (constantbetaHernquistdf, dict(pot=_HP, beta=0.3), 1e-6, 1e-8),
+        (
+            constantbetaPowerLawdf,
+            dict(pot=_PP, beta=0.3, rmax=100.0, rmin=1e-4),
+            1e-9,
+            1e-11,
+        ),
+    ):
+        ref_df = ctor(**kw)
+        numpy.random.seed(10)
+        ref = ref_df.sample(n=100, return_orbit=False)
+        dfb = ctor(**kw)
+        numpy.random.seed(10)
+        with galpy.backend.use(backend, force=True):
+            got = dfb.sample(n=100, return_orbit=False)
+        for g, r in zip(got, ref):
+            assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+            numpy.testing.assert_allclose(g, r, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_hyp2f1_domain_limit(backend):
+    # The shared galpy.backend.special.hyp2f1 fallback (Euler labeling requires
+    # a positive parameter B with c-B>=1) cannot reach the general-beta
+    # Hernquist DF for beta>=0.5 (b=1-2beta<=0 after the Pfaff transform); the
+    # numpy path (scipy) is unaffected. This locks that documented boundary.
+    dfh = constantbetaHernquistdf(pot=_HP, beta=0.7)
+    assert numpy.isfinite(dfh.fE(numpy.array([-0.5 * _PSI0]))[0])  # numpy OK
+    with pytest.raises(NotImplementedError):
+        dfh.fE(_arr(backend, numpy.array([-0.5 * _PSI0])))
+
+
+def _mk_hern(beta):
+    return constantbetaHernquistdf(pot=_HP, beta=beta)
+
+
+def _mk_pl(beta):
+    return constantbetaPowerLawdf(pot=_PP, beta=beta, rmax=100.0, rmin=1e-4)


### PR DESCRIPTION
Part of the by-family Pdf.2 split. **Stacked on #1052** (base); targets the base branch for a clean per-family diff; retarget + rebase onto `feat/backends` after #1052 merges (all-backend CI runs then).

### What's here
`constantbetadf` / `constantbetaHernquistdf` / `constantbetaPowerLawdf` backend-migrated; generic helpers from `galpy.backend` (`resolve_namespace`).

### Verification (local)
- numpy byte-identical: `tests/test_sphericaldf.py -k constantbeta` → 44 passed.
- new `tests/test_backend_constantbetadf.py`: 11 jax + 11 torch passed.

### Migration-flip ledger adds (applied in one commit at retarget)
- `torch ::test_constantbeta_powerlaw_beta0_equals_isotropic` — test-side `numpy.all(torch tensor)` interop; same class as plummer.
- `jax ::test_constantbetadf_against_hernquist` — **general-β>0.5 Hernquist**: backend `hyp2f1` fallback domain limit (`c-max(a,b)=0.8<1`); the numpy-only remnant. Liftable via the separate `hyp2f1` Pfaff/Euler β∈(0.5,1) extension PR.
- `jax ::test_constantbeta_differentpotentials_dens_directint` — direct-int quadrature floor.