### PR TITLE
Track F Pdf.2 (eddington+king): backend-migrate Eddington and King DFs

### DIFF
--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -3,10 +3,18 @@
 import numpy
 from scipy import integrate, interpolate
 
+from ..backend import as_numpy, get_namespace, resolve_namespace
+from ..backend.interpolate import Spline1D
+from ..backend.quadrature import fixed_quad
 from ..potential import CompositePotential, evaluateR2derivs
 from ..potential.Potential import _evaluatePotentials, _evaluateRforces
 from ..util import conversion
 from .sphericaldf import _handle_rmin, isotropicsphericaldf, sphericaldf
+
+# Backend Gauss-Legendre order for the two fE half-integrals; N=100 agrees with
+# scipy adaptive quad to ~6e-8 -- higher N drifts as small-r nodes cluster into
+# the r=rphi turning-point fp-cancellation zone (see tests/test_backend_eddingtondf.py).
+_QUAD_N_FE = 100
 
 
 class eddingtondf(isotropicsphericaldf):
@@ -105,11 +113,22 @@ class eddingtondf(isotropicsphericaldf):
                 )
             )
             Es4interp = (Es4interp * (self._Emin - self._potInf) + self._potInf)[::-1]
-            fE4interp = self.fE(Es4interp)
-            iindx = numpy.isfinite(fE4interp)
-            self._fE_interp = interpolate.InterpolatedUnivariateSpline(
-                Es4interp[iindx], fE4interp[iindx], k=3, ext=3
-            )
+            xp = get_namespace()  # context/forced default only (grid is numpy)
+            if xp is numpy:
+                fE4interp = self.fE(Es4interp)
+                iindx = numpy.isfinite(fE4interp)
+                self._fE_interp = interpolate.InterpolatedUnivariateSpline(
+                    Es4interp[iindx], fE4interp[iindx], k=3, ext=3
+                )
+            else:
+                # forced backend: one vectorized fE eval, pulled numpy-side for
+                # the frozen table (Spline1D queries numpy scipy / backend native);
+                # ascontiguousarray drops the [::-1] negative stride (torch rejects)
+                fE4interp = as_numpy(self.fE(numpy.ascontiguousarray(Es4interp)))
+                iindx = numpy.isfinite(fE4interp)
+                self._fE_interp = Spline1D(
+                    Es4interp[iindx], fE4interp[iindx], k=3, ext=3
+                )
 
     def fE(self, E):
         """
@@ -130,48 +149,99 @@ class eddingtondf(isotropicsphericaldf):
         - 2021-02-04 - Written - Bovy (UofT)
         """
         Eint = conversion.parse_energy(E, vo=self._vo)
-        out = numpy.zeros_like(Eint)
-        indx = (Eint < self._potInf) * (Eint >= self._Emin)
-        # Split integral at twice the lower limit to deal with divergence at
-        # the lower end and infinity at the upper end
-        out[indx] = numpy.array(
-            [
-                integrate.quad(
-                    lambda t: _fEintegrand_smallr(
-                        t, self._pot, tE, self._dnudr, self._d2nudr2, self._rphi(tE)
-                    ),
-                    0.0,
-                    numpy.sqrt(self._rphi(tE)),
-                    points=[0.0],
-                )[0]
-                for tE in Eint[indx]
-            ]
+        xp = resolve_namespace(Eint, self._potInf, self._Emin)
+        if xp is numpy:
+            out = numpy.zeros_like(Eint)
+            indx = (Eint < self._potInf) * (Eint >= self._Emin)
+            # Split integral at twice the lower limit to deal with divergence at
+            # the lower end and infinity at the upper end
+            out[indx] = numpy.array(
+                [
+                    integrate.quad(
+                        lambda t: _fEintegrand_smallr(
+                            t, self._pot, tE, self._dnudr, self._d2nudr2, self._rphi(tE)
+                        ),
+                        0.0,
+                        numpy.sqrt(self._rphi(tE)),
+                        points=[0.0],
+                    )[0]
+                    for tE in Eint[indx]
+                ]
+            )
+            out[indx] += numpy.array(
+                [
+                    integrate.quad(
+                        lambda t: _fEintegrand_larger(
+                            t, self._pot, tE, self._dnudr, self._d2nudr2
+                        ),
+                        0.0,
+                        0.5 / self._rphi(tE),
+                    )[0]
+                    for tE in Eint[indx]
+                ]
+            )
+            # Add boundary term ~ 1 / sqrt(-E) dnu / dpsi | psi=0
+            boundary_term = numpy.zeros_like(Eint)
+            boundary_term[indx] = (
+                self._dnudr(self._rInf)
+                / _evaluateRforces(self._pot, self._rInf, 0)
+                / numpy.sqrt(-Eint[indx])
+            )
+            # For some potentials, such as PowerSphericalPotential with infinite mass,
+            # the boundary term as implemented is incorrect, but we'll just set it to zero,
+            # because it essentially is
+            boundary_term[~numpy.isfinite(boundary_term)] = 0.0
+            out -= boundary_term
+            return -out / (numpy.sqrt(8.0) * numpy.pi**2.0)
+        # jax/torch: GL after the same substitutions as the numpy path -- small-r
+        # r = t^2 + rphi(E) (cancels the sqrt turning point at r=rphi(E)) on
+        # [0, sqrt(rphi(E))], large-r r = 1/t (tames r->inf) on [0, 0.5/rphi(E)];
+        # GL nodes are strictly interior so neither endpoint is evaluated.
+        Eb = xp.asarray(Eint) * 1.0
+        dead = (Eb >= self._potInf) | (Eb < self._Emin)
+        Esafe = xp.where(dead, 0.5 * (self._potInf + self._Emin), Eb)
+        rphiE = xp.asarray(self._rphi(Esafe)) * 1.0
+
+        def _raw(r, Ei):
+            # differentiable, dead-branch-guarded _fEintegrand_raw
+            Fr = _evaluateRforces(self._pot, r, 0)
+            num = Fr * self._d2nudr2(r) + self._dnudr(r) * evaluateR2derivs(
+                self._pot, r, 0, use_physical=False
+            )
+            diff = _evaluatePotentials(self._pot, r, 0) - Ei
+            diffsafe = xp.where(diff > 0.0, diff, xp.ones_like(diff))
+            return xp.where(
+                diff > 0.0,
+                num / Fr**2.0 / xp.sqrt(diffsafe),
+                xp.zeros_like(diff),
+            )
+
+        Es_b = Esafe[..., None]
+        rphi_b = rphiE[..., None]
+        small = fixed_quad(
+            xp,
+            lambda t: 2.0 * t * _raw(t**2.0 + rphi_b, Es_b),
+            0.0,
+            xp.sqrt(rphiE),
+            n=_QUAD_N_FE,
         )
-        out[indx] += numpy.array(
-            [
-                integrate.quad(
-                    lambda t: _fEintegrand_larger(
-                        t, self._pot, tE, self._dnudr, self._d2nudr2
-                    ),
-                    0.0,
-                    0.5 / self._rphi(tE),
-                )[0]
-                for tE in Eint[indx]
-            ]
+        large = fixed_quad(
+            xp,
+            lambda t: 1.0 / t**2.0 * _raw(1.0 / t, Es_b),
+            0.0,
+            0.5 / rphiE,
+            n=_QUAD_N_FE,
         )
-        # Add boundary term ~ 1 / sqrt(-E) dnu / dpsi | psi=0
-        boundary_term = numpy.zeros_like(Eint)
-        boundary_term[indx] = (
-            self._dnudr(self._rInf)
-            / _evaluateRforces(self._pot, self._rInf, 0)
-            / numpy.sqrt(-Eint[indx])
+        # boundary term ~ 1 / sqrt(-E) dnu / dpsi | psi=0 (essentially zero for
+        # the finite-mass systems here); zeroed where non-finite as in numpy
+        rInf = xp.asarray(self._rInf) * 1.0
+        boundary = (
+            self._dnudr(rInf) / _evaluateRforces(self._pot, rInf, 0) / xp.sqrt(-Esafe)
         )
-        # For some potentials, such as PowerSphericalPotential with infinite mass,
-        # the boundary term as implemented is incorrect, but we'll just set it to zero,
-        # because it essentially is
-        boundary_term[~numpy.isfinite(boundary_term)] = 0.0
-        out -= boundary_term
-        return -out / (numpy.sqrt(8.0) * numpy.pi**2.0)
+        boundary = xp.where(xp.isfinite(boundary), boundary, xp.zeros_like(Eb))
+        out = small + large - boundary
+        fE = -out / (numpy.sqrt(8.0) * numpy.pi**2.0)
+        return xp.where(dead, xp.zeros_like(fE), fE)
 
 
 def _fEintegrand_raw(r, pot, E, dnudr, d2nudr2):

--- a/galpy/df/kingdf.py
+++ b/galpy/df/kingdf.py
@@ -2,6 +2,9 @@
 import numpy
 from scipy import integrate, interpolate, special
 
+from ..backend import get_namespace, is_backend_array, resolve_namespace
+from ..backend import special as _bspecial
+from ..backend.interpolate import Spline1D
 from ..util import conversion
 from .df import df
 from .sphericaldf import isotropicsphericaldf
@@ -93,15 +96,30 @@ class kingdf(isotropicsphericaldf):
         return self._scalefree_kdf.dens(r / self._radius_scale) * self._density_scale
 
     def fE(self, E):
-        out = numpy.zeros(numpy.atleast_1d(E).shape)
-        varE = self._potInf - E
-        if numpy.sum(varE > 0.0) > 0:
-            out[varE > 0.0] = (
-                (numpy.exp(varE[varE > 0.0] / self._sigma2) - 1.0)
-                * (2.0 * numpy.pi * self._sigma2) ** -1.5
-                * self.rho1
-            )
-        return out.reshape(E.shape)  # mass density, not /self.M as for number density
+        xp = resolve_namespace(E)
+        if xp is numpy:
+            out = numpy.zeros(numpy.atleast_1d(E).shape)
+            varE = self._potInf - E
+            if numpy.sum(varE > 0.0) > 0:
+                out[varE > 0.0] = (
+                    (numpy.exp(varE[varE > 0.0] / self._sigma2) - 1.0)
+                    * (2.0 * numpy.pi * self._sigma2) ** -1.5
+                    * self.rho1
+                )
+            return out.reshape(
+                E.shape
+            )  # mass density, not /self.M as for number density
+        # jax/torch: dead-mask varE<=0 -> 0 (dummy keeps the dead branch finite)
+        Eb = xp.asarray(E) * 1.0
+        varE = self._potInf - Eb
+        live = varE > 0.0
+        varE_safe = xp.where(live, varE, xp.ones_like(varE))
+        fE = (
+            (xp.exp(varE_safe / self._sigma2) - 1.0)
+            * (2.0 * numpy.pi * self._sigma2) ** -1.5
+            * self.rho1
+        )
+        return xp.where(live, fE, xp.zeros_like(fE)).reshape(Eb.shape)
 
 
 class _scalefreekingdf:
@@ -168,8 +186,9 @@ class _scalefreekingdf:
         self._rho = self._dens_W(self._W)
         self.rt = r[-1]
         self.c = numpy.log10(self.rt / self.r0)
-        # Interpolate solution
-        self._W_from_r = interpolate.InterpolatedUnivariateSpline(self._r, self._W, k=3)
+        # Interpolate solution (backend-agnostic: numpy queries hit the scipy
+        # spline byte-identically, backend queries evaluate the frozen table)
+        self._W_from_r = Spline1D(self._r, self._W, k=3)
         # Compute the cumulative mass and store the total mass, adjust small decreases to zero
         self._cumul_mass = -self._dWdr * self._r**2.0
         for ii in range(1, npt):
@@ -182,9 +201,18 @@ class _scalefreekingdf:
 
     def _dens_W(self, W):
         """Density as a function of W"""
-        sqW = numpy.sqrt(W)
-        return numpy.exp(W) * special.erf(sqW) - _TWOOVERSQRTPI * sqW * (
-            1.0 + 2.0 / 3.0 * W
+        # data-guard: leaf consumed by numpy construction (solve_ivp, rho0/r0);
+        # only a backend-array W (dens(backend r) via _W_from_r) goes backend
+        if not is_backend_array(W):
+            sqW = numpy.sqrt(W)
+            return numpy.exp(W) * special.erf(sqW) - _TWOOVERSQRTPI * sqW * (
+                1.0 + 2.0 / 3.0 * W
+            )
+        xp = get_namespace(W)
+        Wb = xp.asarray(W) * 1.0
+        sqW = xp.sqrt(Wb)
+        return xp.exp(Wb) * _bspecial.erf(sqW) - _TWOOVERSQRTPI * sqW * (
+            1.0 + 2.0 / 3.0 * Wb
         )
 
     def dens(self, r):

--- a/tests/test_backend_eddingtondf.py
+++ b/tests/test_backend_eddingtondf.py
@@ -1,0 +1,206 @@
+###############################################################################
+# test_backend_eddingtondf.py: Track F Pdf.2 -- backend (jax/torch) coverage
+# for the Eddington-inversion isotropic DF family (eddingtondf). The numpy path
+# is byte-identical (test_sphericaldf unchanged); this exercises the
+# resolved-namespace dispatch: parity numpy<->jax<->torch of fE (the two
+# GL-substituted half-integrals) / __call__ / moments / dM/dE, grad-vs-FD of fE
+# and a moment, is-backend-array assertions, and the numpy-side sampling
+# contract (numpy RNG draws unchanged under a forced backend, Spline1D f(E)).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+import galpy.backend
+from galpy.backend import as_numpy
+from galpy.df import eddingtondf
+from galpy.potential import (
+    DehnenCoreSphericalPotential,
+    HernquistPotential,
+    NFWPotential,
+)
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(numpy.asarray(x, float))
+
+
+def _is_backend_array(backend, x):
+    if backend == "jax":
+        return isinstance(x, jax.Array)
+    return torch.is_tensor(x)
+
+
+# self-consistent DehnenCore (denspot == pot) and DehnenCore-in-NFW (denspot !=
+# pot): the two eddington test regimes in test_sphericaldf
+_DC = eddingtondf(pot=DehnenCoreSphericalPotential(amp=2.5, a=1.15))
+_DCNFW = eddingtondf(
+    pot=NFWPotential(amp=2.3, a=1.3),
+    denspot=DehnenCoreSphericalPotential(amp=2.5, a=1.15),
+)
+_DFS = {"dehnencore": _DC, "dc_in_nfw": _DCNFW}
+
+
+def _egrid(dfp):
+    # in-bounds energies (fractionally between potInf and Emin)
+    frac = numpy.linspace(0.05, 0.95, 15)
+    return frac * (dfp._Emin - dfp._potInf) + dfp._potInf
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_parity(backend):
+    # fE = the two GL-substituted half-integrals; N=100 GL agrees with scipy
+    # adaptive quad to ~6e-8 (two independent methods). Higher GL order drifts
+    # via the small-r turning-point (r=rphi, Phi-E->0) fp cancellation, so N=100
+    # is the sweet spot; rtol 1e-6 covers the ~6e-8 gap with ~17x margin.
+    for key, dfp in _DFS.items():
+        Es = _egrid(dfp)
+        ref = numpy.atleast_1d(dfp.fE(Es))
+        got = dfp.fE(_arr(backend, Es))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_out_of_bounds(backend):
+    # E > potInf (unbound) and E < Emin (below the inner cutoff) -> exactly 0 on
+    # the dead branch, NaN-free (functional dummy-then-zero)
+    dfp = _DC
+    Eoob = numpy.array([dfp._potInf + 0.05, 0.5, dfp._Emin - 0.5])
+    got = as_numpy(dfp.fE(_arr(backend, Eoob)))
+    assert numpy.all(got == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_parity(backend):
+    # __call__ (E,) tuple form routes through _call_internal -> fE
+    for key, dfp in _DFS.items():
+        Es = _egrid(dfp)
+        ref = dfp((Es,))
+        got = dfp((_arr(backend, Es),))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_moments_parity(backend):
+    # sigmar (v-moment GL over the migrated base) and the isotropic beta==0
+    rs = numpy.array([0.2, 0.5, 1.0, 2.0, 5.0])
+    for key, dfp in _DFS.items():
+        ref = numpy.array([dfp.sigmar(r) for r in rs])
+        got = numpy.array([float(as_numpy(dfp.sigmar(_arr(backend, r)))) for r in rs])
+        gotv = dfp.sigmar(_arr(backend, rs))
+        assert _is_backend_array(backend, gotv)
+        numpy.testing.assert_allclose(got, ref, rtol=1e-7)
+        numpy.testing.assert_allclose(as_numpy(gotv), ref, rtol=1e-7)
+        b = dfp.beta(_arr(backend, 1.0))
+        assert float(as_numpy(b)) == pytest.approx(0.0, abs=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_dMdE_parity(backend):
+    # dM/dE via the migrated base isotropic quadrature (r = rphi - s^2), using
+    # the eddington fE + rphi interpolator
+    for key, dfp in _DFS.items():
+        Edm = numpy.linspace(0.15, 0.85, 7) * (dfp._Emin - dfp._potInf) + dfp._potInf
+        ref = numpy.atleast_1d(dfp.dMdE(Edm))
+        got = dfp.dMdE(_arr(backend, Edm))
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+    # out-of-bounds E -> exactly zero
+    assert numpy.all(as_numpy(_DC.dMdE(_arr(backend, numpy.array([0.5])))) == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_grad_vs_fd(backend):
+    # d(fE)/dE through the two GL half-integrals (limits + Phi(r) + rphi(E)); the
+    # out-of-bounds grad is finite 0, not NaN (dead-branch guards)
+    dfp = _DC
+    E0 = 0.4 * (dfp._Emin - dfp._potInf) + dfp._potInf
+    eps = 1e-6
+    fd = (
+        dfp.fE(numpy.atleast_1d(E0 + eps))[0] - dfp.fE(numpy.atleast_1d(E0 - eps))[0]
+    ) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda E: dfp.fE(E).sum())(jnp.asarray(E0)))
+        goob = float(jax.grad(lambda E: dfp.fE(E).sum())(jnp.asarray(0.5)))
+    else:
+        t = torch.tensor(E0, requires_grad=True)
+        dfp.fE(t).sum().backward()
+        g = float(t.grad)
+        t = torch.tensor(0.5, requires_grad=True)
+        dfp.fE(t).sum().backward()
+        goob = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+    assert goob == 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sigmar_grad_vs_fd(backend):
+    # d(sigma_r)/dr through the GL moment integrals (limits + Phi(r) + fE)
+    dfp = _DC
+    r0, eps = 1.0, 1e-5
+    fd = (dfp.sigmar(r0 + eps) - dfp.sigmar(r0 - eps)) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda r: dfp.sigmar(r))(jnp.asarray(r0)))
+    else:
+        t = torch.tensor(r0, requires_grad=True)
+        dfp.sigmar(t).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_numpy_side_forced(backend):
+    # sampling is numpy-side by design: under a forced backend the numpy RNG
+    # draw sequence is unchanged and the outputs are numpy arrays; the f(E)
+    # interpolator (built via a forced-backend vectorized fE eval, pulled into a
+    # Spline1D) and the vesc/mass grids run on the backend, so draws match the
+    # pure-numpy ones to the grids' fp noise
+    ref_df = eddingtondf(pot=DehnenCoreSphericalPotential(amp=2.5, a=1.15))
+    numpy.random.seed(777)
+    ref = ref_df.sample(n=200, return_orbit=False)
+    dfb = eddingtondf(pot=DehnenCoreSphericalPotential(amp=2.5, a=1.15))
+    numpy.random.seed(777)
+    with galpy.backend.use(backend, force=True):
+        got = dfb.sample(n=200, return_orbit=False)
+    for g, r in zip(got, ref):
+        assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(g, r, rtol=1e-7, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ensure_fE_interp_forced(backend):
+    # the f(E) interpolator: numpy builds a scipy spline, a forced backend builds
+    # a Spline1D from the (backend-vectorized, numpy-pulled) fE grid; both give
+    # the same f(E) and the Spline1D evaluates natively on backend queries
+    ref_df = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3))
+    ref_df._ensure_fE_interp()
+    dfb = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3))
+    with galpy.backend.use(backend, force=True):
+        dfb._ensure_fE_interp()
+    Es = _egrid(ref_df)
+    numpy.testing.assert_allclose(dfb._fE_interp(Es), ref_df._fE_interp(Es), rtol=1e-6)
+    gb = dfb._fE_interp(_arr(backend, Es))
+    assert _is_backend_array(backend, gb)
+    numpy.testing.assert_allclose(as_numpy(gb), ref_df._fE_interp(Es), rtol=1e-6)

--- a/tests/test_backend_kingdf.py
+++ b/tests/test_backend_kingdf.py
@@ -1,0 +1,224 @@
+###############################################################################
+# test_backend_kingdf.py: Track F Pdf.2 -- backend (jax/torch) coverage for the
+# King spherical-DF family (kingdf). The numpy path is byte-identical
+# (test_sphericaldf unchanged); this exercises the resolved-namespace dispatch
+# in kingdf's own fE / dens paths and the inherited moment/dM/dE machinery:
+# parity numpy<->jax<->torch of fE / dens / __call__ / moments / dM/dE,
+# grad-vs-FD, is-backend-array assertions, and the numpy-side sampling contract
+# (seeded draws unchanged under a forced backend).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+import galpy.backend
+from galpy.backend import as_numpy
+from galpy.df import kingdf
+from galpy.df.sphericaldf import isotropicsphericaldf
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _is_backend_array(backend, x):
+    if backend == "jax":
+        return isinstance(x, jax.Array)
+    return torch.is_tensor(x)
+
+
+_DF = kingdf(W0=3.0, M=2.3, rt=1.76)
+_PI = float(_DF._potInf)  # cutoff energy; bound stars have E < _potInf
+# in-bounds E grid (E < _potInf) + out-of-bounds points (E >= _potInf) + the
+# exact boundary E == _potInf (varE == 0 -> fE == 0)
+_EGRID = numpy.concatenate(
+    [
+        numpy.linspace(_PI - abs(_PI) - 1.0, _PI - 1e-3, 21),
+        numpy.array([_PI, _PI - 1e-12, _PI + 1e-12, _PI + 0.5]),
+    ]
+)
+# radii within [0, rt] for dens/moments
+_RS = numpy.array([_DF._scale / 5.0, _DF._scale, _DF.rt * 0.3, _DF.rt * 0.7])
+_DENSRS = numpy.linspace(0.01, _DF.rt * 0.999, 12)
+# dM/dE energies strictly inside (_potInf - |_potInf|, _potInf)
+_EDM = numpy.linspace(_PI - abs(_PI) * 0.9, _PI - abs(_PI) * 0.05, 7)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_parity(backend):
+    # king fE is a smooth exp(varE/sigma^2)-1 form: numpy<->backend parity on an
+    # E grid including the out-of-bounds (functional dead-mask -> 0) branch
+    ref = _DF.fE(_EGRID)
+    got = _DF.fE(_arr(backend, _EGRID))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_dead_edge(backend):
+    # E == _potInf exactly (varE == 0) and E > _potInf are the dead branch;
+    # fE -> 0 there, NaN-free under the dummy-then-zero guard
+    got = as_numpy(_DF.fE(_arr(backend, numpy.array([_PI, _PI + 1e-9, _PI + 1.0]))))
+    assert numpy.all(got == 0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_dens_parity(backend):
+    # dens goes through the Spline1D W(r) table + the erf-based _dens_W; measured
+    # ~3e-13 (frozen-table eval + backend erf vs scipy)
+    ref = _DF.dens(_DENSRS)
+    got = _DF.dens(_arr(backend, _DENSRS))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_parity(backend):
+    # __call__ tuple form (E,) and the 6-coordinate form
+    ref = _DF((_EGRID,))
+    got = _DF((_arr(backend, _EGRID),))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    R = numpy.array([0.3, 0.6, 0.9, 1.2])
+    vR = numpy.array([0.1, -0.2, 0.3, 0.0])
+    vT = numpy.array([0.2, 0.4, 0.1, 0.3])
+    z = numpy.array([0.1, -0.2, 0.3, 0.0])
+    vz = numpy.array([-0.1, 0.1, 0.0, 0.2])
+    ref = _DF(R, vR, vT, z, vz, numpy.zeros_like(R))
+    got = _DF(*(_arr(backend, c) for c in (R, vR, vT, z, vz)))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_moments_parity(backend):
+    # sigmar/sigmat (fixed-order GL vs numpy adaptive quad): the King DF is a
+    # smooth exponential so GL matches to ~1.5e-15 (no quadrature floor here);
+    # the exactly-isotropic beta is 0. Scalar and vector r.
+    for name in ("sigmar", "sigmat"):
+        f = getattr(_DF, name)
+        ref = numpy.array([f(r) for r in _RS])
+        got = numpy.array([float(f(_arr(backend, r))) for r in _RS])
+        gotv = f(_arr(backend, _RS))
+        assert _is_backend_array(backend, gotv)
+        numpy.testing.assert_allclose(got, ref, rtol=1e-9)
+        numpy.testing.assert_allclose(as_numpy(gotv), ref, rtol=1e-9)
+    b = _DF.beta(_arr(backend, _DF.rt * 0.3))
+    assert float(as_numpy(b)) == pytest.approx(0.0, abs=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_base_dMdE_parity(backend):
+    # the inherited isotropic base-class dM/dE (GL after the r = rphi - s^2
+    # turning-point substitution + backend Spline1D rphi eval); measured ~4e-10
+    # vs the numpy adaptive quad (rtol 1e-6 leaves margin for numpy's own floor)
+    ref = isotropicsphericaldf._dMdE(_DF, _EDM)
+    got = isotropicsphericaldf._dMdE(_DF, _arr(backend, _EDM))
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fE_grad_vs_fd(backend):
+    E0, eps = _PI - 0.5 * abs(_PI), 1e-6
+    fd = (
+        _DF.fE(numpy.atleast_1d(E0 + eps))[0] - _DF.fE(numpy.atleast_1d(E0 - eps))[0]
+    ) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda E: _DF.fE(E))(jnp.asarray(E0)))
+        goob = float(jax.grad(lambda E: _DF.fE(E))(jnp.asarray(_PI + 0.5)))
+    else:
+        t = torch.tensor(E0, requires_grad=True)
+        _DF.fE(t).backward()
+        g = float(t.grad)
+        t = torch.tensor(_PI + 0.5, requires_grad=True)
+        _DF.fE(t).backward()
+        goob = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-6)
+    # out-of-bounds grad is a finite 0, not NaN (dead-branch guard)
+    assert goob == 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_dens_grad_vs_fd(backend):
+    r0, eps = _DF.rt * 0.4, 1e-6
+    fd = (
+        float(_DF.dens(numpy.atleast_1d(r0 + eps))[0])
+        - float(_DF.dens(numpy.atleast_1d(r0 - eps))[0])
+    ) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda r: _DF.dens(r))(jnp.asarray(r0)))
+    else:
+        t = torch.tensor(r0, requires_grad=True)
+        _DF.dens(t).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sigmar_grad_vs_fd(backend):
+    # d(sigma_r)/dr through the GL moment integrals (limits + Phi(r))
+    r0, eps = _DF.rt * 0.4, 1e-5
+    fd = (_DF.sigmar(r0 + eps) - _DF.sigmar(r0 - eps)) / (2.0 * eps)
+    if backend == "jax":
+        g = float(jax.grad(lambda r: _DF.sigmar(r))(jnp.asarray(r0)))
+    else:
+        t = torch.tensor(r0, requires_grad=True)
+        _DF.sigmar(t).backward()
+        g = float(t.grad)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_numpy_side_forced(backend):
+    # sampling is numpy-side by design: under a forced backend the numpy RNG
+    # draw sequence is unchanged and the outputs are numpy arrays; only the
+    # deterministic sub-steps (icmf/pvr grids built at __init__) matter, so
+    # draws match the pure-numpy ones to fp noise
+    ref_df = kingdf(W0=3.0, M=2.3, rt=1.76)
+    numpy.random.seed(10)
+    ref = ref_df.sample(n=100, return_orbit=False)
+    dfb = kingdf(W0=3.0, M=2.3, rt=1.76)
+    numpy.random.seed(10)
+    with galpy.backend.use(backend, force=True):
+        got = dfb.sample(n=100, return_orbit=False)
+    for g, r in zip(got, ref):
+        assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(g, r, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_construct_under_forced_backend(backend):
+    # _dens_W is a leaf consumed by numpy construction (solve_ivp, rho0/r0);
+    # its is_backend_array data-guard must keep scalar/numpy W on numpy even
+    # under a forced backend, so construction stays byte-identical to numpy
+    # (a backend-resolving _dens_W would make _scale a tensor and break the
+    # base class's numpy grid arithmetic)
+    ref = kingdf(W0=3.0, M=2.3, rt=1.76)
+    with galpy.backend.use(backend, force=True):
+        dfb = kingdf(W0=3.0, M=2.3, rt=1.76)
+    assert not _is_backend_array(backend, dfb._scale)
+    assert numpy.array_equal(dfb._scalefree_kdf._W, ref._scalefree_kdf._W)
+    assert numpy.array_equal(
+        dfb._scalefree_kdf._cumul_mass, ref._scalefree_kdf._cumul_mass
+    )


### PR DESCRIPTION
Part of the by-family Pdf.2 split. **Stacked on #1052** (base); targets the base branch for a clean per-family diff; retarget + rebase onto `feat/backends` after #1052 merges (all-backend CI runs then).

### What's here
`eddingtondf` / `kingdf` backend-migrated; generic helpers from `galpy.backend` (`resolve_namespace`, `as_numpy`).

### Verification (local)
- numpy byte-identical: eddington/king nodes in `tests/test_sphericaldf.py` (+ `test_quantity::test_kingdf_setup_wunits`) → 45 passed.
- new `tests/test_backend_eddingtondf.py` + `tests/test_backend_kingdf.py`: 20 jax + 20 torch passed.

### Migration-flip ledger add (applied in one commit at retarget)
- `jax ::test_isotropic_eddington_dehnencore_in_nfw_dens_directint` — **general Eddington** (denspot≠pot) direct-GL fE blows up under jax near `potInf` (numpy-only remnant). Already ledgered for torch (backend_xfail.txt:791); the jax ledger is just missing it. Not a rename bug (self-consistent DehnenCore passes under jax).