### PR TITLE
Track F Pdf.2: centralize backend→numpy test helper on galpy.backend.as_numpy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,15 @@ import os
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 
-def _to_numpy(x):
-    """Coerce a (possibly jax/torch) Orbit-accessor result to a numpy array so
-    value assertions in the orbit tests are backend-agnostic. Under a forced
-    backend the accessors return jax/torch arrays; this brings them back to numpy
-    for ``numpy.amax``/``all``/``std``/... A numpy input passes through unchanged
-    (``numpy.asarray`` is the identity), so the numpy path stays byte-identical.
-    Shared by test_orbit.py and test_orbits.py (imported via ``from conftest
-    import _to_numpy``)."""
-    if hasattr(x, "detach"):  # torch tensor: detach from autograd + move to CPU
-        x = x.detach().cpu()
-    return numpy.asarray(x)
+# Re-export the canonical GPU-safe backend->numpy converter under the historical
+# name used by the orbit tests (``from conftest import _to_numpy`` in
+# test_orbit.py and test_orbits.py): value assertions there are backend-agnostic
+# because as_numpy pulls a jax/torch accessor result back to numpy (detaching
+# torch grad tensors) while passing a numpy input through unchanged, so the numpy
+# path stays byte-identical.
+_to_numpy = as_numpy
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,19 @@ import os
 import numpy
 import pytest
 
-from galpy.backend import as_numpy
 
-# Re-export the canonical GPU-safe backend->numpy converter under the historical
-# name used by the orbit tests (``from conftest import _to_numpy`` in
-# test_orbit.py and test_orbits.py): value assertions there are backend-agnostic
-# because as_numpy pulls a jax/torch accessor result back to numpy (detaching
-# torch grad tensors) while passing a numpy input through unchanged, so the numpy
-# path stays byte-identical.
-_to_numpy = as_numpy
+def _to_numpy(x):
+    """Coerce a (possibly jax/torch) accessor result to numpy for backend-
+    agnostic value assertions in the orbit tests (imported as ``from conftest
+    import _to_numpy`` by test_orbit.py/test_orbits.py). Thin lazy wrapper over
+    the canonical ``galpy.backend.as_numpy``: the import is deferred to call time
+    so that merely loading conftest does NOT import galpy at session start --
+    an early galpy import here locks in the default astropy-units config before
+    tests that toggle it (e.g. test_quantity) can, making Orbit accessors return
+    plain numpy instead of Quantities. numpy input passes through unchanged."""
+    from galpy.backend import as_numpy
+
+    return as_numpy(x)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -4,19 +4,12 @@ import warnings
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.util import galpyWarning
 
 PY2 = sys.version < "3"
 # Print all galpyWarnings always for tests of warnings
 warnings.simplefilter("always", galpyWarning)
-
-
-def _to_numpy(x):
-    # Convert a possibly-backend (jax/torch) array to numpy for numpy-based test
-    # reductions; detach torch grad-tracking tensors first. Identity on numpy.
-    if hasattr(x, "detach"):
-        x = x.detach()
-    return numpy.asarray(x)
 
 
 # Test the actions of an actionAngleHarmonic
@@ -176,7 +169,7 @@ def test_actionAngleVertical_conserved_actions():
     obs.integrate(times, isopot)
     # Under a forced jax/torch backend obs.x()/vx() are backend arrays, so aAV
     # returns one too; the numpy reductions below need numpy (detach grad).
-    js = _to_numpy(aAV(obs.x(times), obs.vx(times)))
+    js = as_numpy(aAV(obs.x(times), obs.vx(times)))
     maxdj = numpy.amax(
         numpy.fabs(
             (js - numpy.tile(numpy.mean(js), (len(times), 1)).T) / numpy.mean(js)
@@ -200,8 +193,8 @@ def test_actionAngleVertical_conserved_freqs():
     times = numpy.linspace(0.0, 20.0, ntimes)
     obs.integrate(times, isopot)
     js, os = aAV.actionsFreqs(obs.x(times), obs.vx(times))
-    js = _to_numpy(js)  # backend array -> numpy for the reductions below
-    os = _to_numpy(os)
+    js = as_numpy(js)  # backend array -> numpy for the reductions below
+    os = as_numpy(os)
     maxdj = numpy.amax(
         numpy.fabs(
             (js - numpy.tile(numpy.mean(js), (len(times), 1)).T) / numpy.mean(js)
@@ -6605,10 +6598,10 @@ def test_actionAngleHarmonicInverse_wrtHarmonic():
     # Backend-agnostic reductions (identity on numpy): the orbit accessors and
     # inverse outputs are jax/torch arrays under a forced backend.
     ox, ovx, xi, vxi = (
-        _to_numpy(obs.x(times)),
-        _to_numpy(obs.vx(times)),
-        _to_numpy(xi),
-        _to_numpy(vxi),
+        as_numpy(obs.x(times)),
+        as_numpy(obs.vx(times)),
+        as_numpy(xi),
+        as_numpy(vxi),
     )
     assert numpy.amax(numpy.fabs(ox - xi)) < 10.0**-6.0, (
         "actionAngleHarmonicInverse is not the inverse of actionAngleHarmonic for an example orbit"
@@ -6657,10 +6650,10 @@ def test_actionAngleHarmonicInverse_orbit():
         omega=numpy.sqrt(4.0 * numpy.pi * ip.dens(1.2, 0.0) / 3.0)
     )
     j = 0.01
-    # First calculate frequencies and the initial x,v. _to_numpy (identity on
+    # First calculate frequencies and the initial x,v. as_numpy (identity on
     # numpy) keeps the orbit-integration plumbing below on numpy under a forced
     # backend; aAHI(j, angle) further down still runs the backend for real.
-    xvom = [_to_numpy(q) for q in aAHI.xvFreqs(j, numpy.array([0.1]))]
+    xvom = [as_numpy(q) for q in aAHI.xvFreqs(j, numpy.array([0.1]))]
     om = xvom[2:]
     # Angles along an orbit
     ts = numpy.linspace(0.0, 20.0, 1001)
@@ -6675,10 +6668,10 @@ def test_actionAngleHarmonicInverse_orbit():
     # Backend-agnostic reductions (identity on numpy): orbit accessors + inverse
     # outputs are jax/torch arrays under a forced backend.
     ox, ovx, xv0, xv1 = (
-        _to_numpy(orb.x(ts)),
-        _to_numpy(orb.vx(ts)),
-        _to_numpy(xv[0]),
-        _to_numpy(xv[1]),
+        as_numpy(orb.x(ts)),
+        as_numpy(orb.vx(ts)),
+        as_numpy(xv[0]),
+        as_numpy(xv[1]),
     )
     assert numpy.all(numpy.fabs(ox - xv0) < 10.0**tol), (
         "Integrated orbit does not agree with actionAngleHarmmonicInverse orbit in x"
@@ -6882,11 +6875,11 @@ def test_actionAngleIsochroneInverse_orbit():
     ip = IsochronePotential(normalize=1.03, b=1.2)
     aAII = actionAngleIsochroneInverse(ip=ip)
     jr, jphi, jz = 0.05, 1.1, 0.025
-    # First calculate frequencies and the initial RvR. _to_numpy (identity on
+    # First calculate frequencies and the initial RvR. as_numpy (identity on
     # numpy) keeps the orbit-integration plumbing below on numpy under a forced
     # backend; aAII(...) further down still runs the backend for real.
     RvRom = [
-        _to_numpy(q)
+        as_numpy(q)
         for q in aAII.xvFreqs(
             jr, jphi, jz, numpy.array([0.0]), numpy.array([1.0]), numpy.array([2.0])
         )
@@ -6909,14 +6902,14 @@ def test_actionAngleIsochroneInverse_orbit():
     # Backend-agnostic reductions (identity on numpy): orbit accessors + inverse
     # outputs are jax/torch arrays under a forced backend.
     oR, ovR, ovT, oz, ovz, ophi = (
-        _to_numpy(orb.R(ts)),
-        _to_numpy(orb.vR(ts)),
-        _to_numpy(orb.vT(ts)),
-        _to_numpy(orb.z(ts)),
-        _to_numpy(orb.vz(ts)),
-        _to_numpy(orb.phi(ts)),
+        as_numpy(orb.R(ts)),
+        as_numpy(orb.vR(ts)),
+        as_numpy(orb.vT(ts)),
+        as_numpy(orb.z(ts)),
+        as_numpy(orb.vz(ts)),
+        as_numpy(orb.phi(ts)),
     )
-    RvR = [_to_numpy(q) for q in RvR]
+    RvR = [as_numpy(q) for q in RvR]
     assert numpy.all(numpy.fabs(oR - RvR[0]) < 10.0**tol), (
         "Integrated orbit does not agree with torus orbit in R"
     )
@@ -7756,20 +7749,20 @@ def check_actionAngleIsochroneInverse_wrtIsochrone(
     # inverse outputs are jax/torch arrays; bring them to numpy for the
     # numpy.amax/fabs reductions below (identity on numpy).
     oR, ovR, ovT, oz, ovz, ophi = (
-        _to_numpy(obs.R(times)),
-        _to_numpy(obs.vR(times)),
-        _to_numpy(obs.vT(times)),
-        _to_numpy(obs.z(times)),
-        _to_numpy(obs.vz(times)),
-        _to_numpy(obs.phi(times)),
+        as_numpy(obs.R(times)),
+        as_numpy(obs.vR(times)),
+        as_numpy(obs.vT(times)),
+        as_numpy(obs.z(times)),
+        as_numpy(obs.vz(times)),
+        as_numpy(obs.phi(times)),
     )
     Ri, vRi, vTi, zi, vzi, phii = (
-        _to_numpy(Ri),
-        _to_numpy(vRi),
-        _to_numpy(vTi),
-        _to_numpy(zi),
-        _to_numpy(vzi),
-        _to_numpy(phii),
+        as_numpy(Ri),
+        as_numpy(vRi),
+        as_numpy(vTi),
+        as_numpy(zi),
+        as_numpy(vzi),
+        as_numpy(phii),
     )
     assert numpy.amax(numpy.fabs(oR - Ri)) < 10.0**tol, (
         "actionAngleIsochroneInverse is not the inverse of actionAngleIsochrone for an example orbit"
@@ -7834,7 +7827,7 @@ def check_actionAngle_conserved_actions(
         js = aA(obs(times))
     # Backend-agnostic: the actions are jax/torch arrays under a forced backend;
     # bring them to a numpy 2d array for the reductions (identity on numpy).
-    js = numpy.array([_to_numpy(j) for j in js])
+    js = numpy.array([as_numpy(j) for j in js])
     maxdj = numpy.amax(
         numpy.fabs(js - numpy.tile(numpy.mean(js, axis=1), (len(times), 1)).T), axis=1
     ) / numpy.mean(js, axis=1)
@@ -7925,8 +7918,8 @@ def check_actionAngle_linear_angles(
             )
     # Backend-agnostic: actionsFreqsAngles returns jax/torch arrays under a forced
     # backend; bring them to numpy for the reductions below (identity on numpy).
-    acfs = tuple(_to_numpy(a) for a in acfs)
-    acfs_init = tuple(_to_numpy(a) for a in acfs_init)
+    acfs = tuple(as_numpy(a) for a in acfs)
+    acfs_init = tuple(as_numpy(a) for a in acfs_init)
     ar = dePeriod(numpy.reshape(acfs[6], (1, len(times)))).flatten()
     ap = dePeriod(numpy.reshape(acfs[7], (1, len(times)))).flatten()
     az = dePeriod(numpy.reshape(acfs[8], (1, len(times)))).flatten()
@@ -8062,7 +8055,7 @@ def check_actionAngle_conserved_EccZmaxRperiRap(
     # Backend-agnostic: the actionAngle outputs are jax/torch arrays under a
     # forced backend; bring them to numpy for the reductions below (identity on
     # numpy, so byte-identical there).
-    es, zmaxs, rperis, raps = (_to_numpy(v) for v in (es, zmaxs, rperis, raps))
+    es, zmaxs, rperis, raps = (as_numpy(v) for v in (es, zmaxs, rperis, raps))
     assert numpy.amax(numpy.fabs(es / numpy.mean(es) - 1)) < 10.0**tole, (
         "Eccentricity conservation fails at %g%%"
         % (100.0 * numpy.amax(numpy.fabs(es / numpy.mean(es) - 1)))

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -19,6 +19,7 @@ import numpy
 import pytest
 
 from galpy import backend
+from galpy.backend import as_numpy
 from galpy.potential import IsochronePotential, PlummerPotential
 
 # This module manages backends explicitly (parametrizes over them), so it is
@@ -71,19 +72,13 @@ def _asarray(backend_name, x, requires_grad=False):
         return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("pot", POTS, ids=POT_IDS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot, method):
     # Reference is always numpy
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -162,7 +157,7 @@ def test_public_method_parity(backend_name, pot):
     # Decorator pass-through: the public Rforce (through the unit decorators and
     # _amp) must give identical values across backends.
     ref = numpy.asarray(pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(pot.Rforce(_asarray(backend_name, _RS), _asarray(backend_name, _ZS)))
+    got = as_numpy(pot.Rforce(_asarray(backend_name, _RS), _asarray(backend_name, _ZS)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -15,6 +15,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 pytestmark = pytest.mark.backend_managed
 
 BACKENDS = []
@@ -84,12 +86,6 @@ def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
 
 
-def _np(x):
-    if torch is not None and torch.is_tensor(x):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
-
-
 def _is_backend_array(backend, x):
     if backend == "jax":
         return isinstance(x, jax.Array)
@@ -111,7 +107,7 @@ def test_isochrone_parity(backend, b):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-12, atol=1e-12
+                as_numpy(g), numpy.asarray(r), rtol=1e-12, atol=1e-12
             )
 
 
@@ -123,7 +119,9 @@ def test_isochrone_ecczmaxrperirap_parity(backend, b):
     got = aAI._EccZmaxRperiRap(*[_arr(backend, v) for v in _ISO[:5]])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-12, atol=1e-12)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-12, atol=1e-12
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -140,7 +138,7 @@ def test_harmonic_parity(backend, omega):
         got = got if isinstance(got, tuple) else (got,)
         for r, g in zip(ref, got):
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-12, atol=1e-12
+                as_numpy(g), numpy.asarray(r), rtol=1e-12, atol=1e-12
             )
 
 
@@ -251,7 +249,7 @@ def test_harmonic_dangle_dt_equals_freq(backend, omega):
         return xp.stack([y[1], -(omega**2.0) * y[0]])
 
     dthdt = _flow_deriv(backend, theta, eom, y0)
-    omega_ret = float(_np(aAH._actionsFreqsAngles(*y0)[1]).ravel()[0])
+    omega_ret = float(as_numpy(aAH._actionsFreqsAngles(*y0)[1]).ravel()[0])
     assert numpy.isfinite(dthdt)
     numpy.testing.assert_allclose(dthdt, omega_ret, rtol=1e-8, atol=1e-9)
 
@@ -287,7 +285,7 @@ def test_isochrone_dangle_dt_equals_freq(backend, vT, idx_ang, idx_om):
         )
 
     dthdt = _flow_deriv(backend, theta, eom, y0)
-    om_ret = float(_np(aAI._actionsFreqsAngles(*y0)[idx_om]).ravel()[0])
+    om_ret = float(as_numpy(aAI._actionsFreqsAngles(*y0)[idx_om]).ravel()[0])
     assert numpy.isfinite(dthdt)
     numpy.testing.assert_allclose(dthdt, om_ret, rtol=1e-8, atol=1e-9)
 
@@ -310,15 +308,17 @@ def test_harmonic_inverse_roundtrip_parity(backend, omega):
     x_np, vx_np, _ = aAHi._xvFreqs(j, angle)
     # forward ∘ inverse == identity (numpy reference)
     j_np, _, a_np = aAH._actionsFreqsAngles(numpy.asarray(x_np), numpy.asarray(vx_np))
-    numpy.testing.assert_allclose(_np(j_np), j, rtol=1e-12, atol=1e-12)
-    numpy.testing.assert_allclose(_np(a_np), angle, rtol=1e-10, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(j_np), j, rtol=1e-12, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(a_np), angle, rtol=1e-10, atol=1e-10)
     # backend parity + backend-array-ness
     x_b, vx_b, _ = aAHi._xvFreqs(_arr(backend, numpy.asarray(j)), _arr(backend, angle))
     assert _is_backend_array(backend, x_b)
     assert _is_backend_array(backend, vx_b)
-    numpy.testing.assert_allclose(_np(x_b), numpy.asarray(x_np), rtol=1e-12, atol=1e-12)
     numpy.testing.assert_allclose(
-        _np(vx_b), numpy.asarray(vx_np), rtol=1e-12, atol=1e-12
+        as_numpy(x_b), numpy.asarray(x_np), rtol=1e-12, atol=1e-12
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(vx_b), numpy.asarray(vx_np), rtol=1e-12, atol=1e-12
     )
 
 
@@ -362,7 +362,9 @@ def test_isochrone_inverse_parity(backend, b):
     got = aAIi._xvFreqs(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-11, atol=1e-11)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-11, atol=1e-11
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -377,12 +379,12 @@ def test_isochrone_inverse_roundtrip(backend):
     bang = [_arr(backend, a) for a in (_II_AR, _II_AP, _II_AZ)]
     R, vR, vT, z, vz, phi = aAIi._xvFreqs(*bj, *bang)[:6]
     out = aAI._actionsFreqsAngles(R, vR, vT, z, vz, phi)
-    numpy.testing.assert_allclose(_np(out[0]), jr, rtol=1e-7, atol=1e-9)  # Jr
-    numpy.testing.assert_allclose(_np(out[1]), jphi, rtol=1e-7, atol=1e-9)  # Jphi
-    numpy.testing.assert_allclose(_np(out[2]), jz, rtol=1e-7, atol=1e-9)  # Jz
+    numpy.testing.assert_allclose(as_numpy(out[0]), jr, rtol=1e-7, atol=1e-9)  # Jr
+    numpy.testing.assert_allclose(as_numpy(out[1]), jphi, rtol=1e-7, atol=1e-9)  # Jphi
+    numpy.testing.assert_allclose(as_numpy(out[2]), jz, rtol=1e-7, atol=1e-9)  # Jz
     # angles recovered (circular difference, to be robust to the 2π wrap)
     for idx, a_in in ((6, _II_AR), (7, _II_AP), (8, _II_AZ)):
-        d = (_np(out[idx]) - a_in + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+        d = (as_numpy(out[idx]) - a_in + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
         numpy.testing.assert_allclose(d, 0.0, atol=1e-7)
 
 
@@ -451,7 +453,7 @@ def test_spherical_parity(backend, potname):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-7, atol=1e-9
+                as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-9
             )
 
 
@@ -525,7 +527,7 @@ def test_spherical_freqs_parity(backend, potname):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
             )
         # _actionsFreqsAngles (+phi); angles compared as circular differences
         ref = aAS._actionsFreqsAngles(*sph, phi)
@@ -533,11 +535,13 @@ def test_spherical_freqs_parity(backend, potname):
         for idx, (r, g) in enumerate(zip(ref, got)):
             assert _is_backend_array(backend, g)
             if idx >= 6:  # ar, ap, az: wrap-robust comparison
-                d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+                d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                    2.0 * numpy.pi
+                ) - numpy.pi
                 numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
             else:
                 numpy.testing.assert_allclose(
-                    _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                    as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
                 )
 
 
@@ -676,13 +680,15 @@ def test_spherical_edge_case_parity(backend, potname, case, prograde):
     for idx, (r, g) in enumerate(zip(ref_afa, got_afa)):
         assert _is_backend_array(backend, g)
         if idx >= 6:
-            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                2.0 * numpy.pi
+            ) - numpy.pi
             numpy.testing.assert_allclose(
                 d, 0.0, atol=2e-6, err_msg=f"{case}/{potname}/angle{idx}"
             )
         else:
             numpy.testing.assert_allclose(
-                _np(g),
+                as_numpy(g),
                 numpy.asarray(r),
                 rtol=2e-6,
                 atol=2e-6,
@@ -692,7 +698,7 @@ def test_spherical_edge_case_parity(backend, potname, case, prograde):
     for idx, (r, g) in enumerate(zip(ref_ecc, got_ecc)):
         assert _is_backend_array(backend, g)
         numpy.testing.assert_allclose(
-            _np(g),
+            as_numpy(g),
             numpy.asarray(r),
             rtol=1e-7,
             atol=1e-9,
@@ -768,11 +774,13 @@ def test_vertical_parity(backend, potname):
         for idx, (r, g) in enumerate(zip(ref, got)):
             assert _is_backend_array(backend, g)
             if len(ref) == 3 and idx == 2:  # angle: wrap-robust
-                d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+                d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                    2.0 * numpy.pi
+                ) - numpy.pi
                 numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
             else:
                 numpy.testing.assert_allclose(
-                    _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                    as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
                 )
 
 
@@ -827,7 +835,9 @@ def test_staeckel_actions_parity(backend):
     got = aA(*[_arr(backend, v) for v in _STK])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-10, atol=1e-12)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-10, atol=1e-12
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -837,8 +847,12 @@ def test_staeckel_actions_vs_c(backend):
     aC = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=True)
     jr_c, lz_c, jz_c = aC(*_STK)
     jr_b, lz_b, jz_b = aF(*[_arr(backend, v) for v in _STK])
-    numpy.testing.assert_allclose(_np(jr_b), numpy.asarray(jr_c), rtol=1e-8, atol=1e-9)
-    numpy.testing.assert_allclose(_np(jz_b), numpy.asarray(jz_c), rtol=1e-8, atol=1e-9)
+    numpy.testing.assert_allclose(
+        as_numpy(jr_b), numpy.asarray(jr_c), rtol=1e-8, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(jz_b), numpy.asarray(jz_c), rtol=1e-8, atol=1e-9
+    )
 
 
 @pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
@@ -855,14 +869,14 @@ def test_staeckel_jit_grad_rolls_direct_bisection():
     rest = tuple(jnp.asarray(v) for v in _STK[1:])
     jr_e, _, jz_e = aA(R, *rest)  # eager (Python-loop) reference
     jr_j, _, jz_j = jax.jit(lambda r: aA(r, *rest))(R)  # traced (fori_loop) value
-    numpy.testing.assert_allclose(_np(jr_j), _np(jr_e), rtol=1e-8, atol=1e-10)
-    numpy.testing.assert_allclose(_np(jz_j), _np(jz_e), rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(jr_j), as_numpy(jr_e), rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(jz_j), as_numpy(jz_e), rtol=1e-8, atol=1e-10)
     # the jaxpr is ROLLED: a loop primitive, not ~100 unrolled bisection steps.
     txt = str(jax.make_jaxpr(lambda r: aA(r, *rest)[0])(R))
     assert ("while" in txt) or ("scan" in txt)
     # grad flows through the direct-bisection turning points: finite dJr/dR.
     g = jax.grad(lambda r: jnp.sum(aA(r, *rest)[0]))(R)
-    assert numpy.all(numpy.isfinite(_np(g)))
+    assert numpy.all(numpy.isfinite(as_numpy(g)))
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -891,11 +905,15 @@ def test_staeckel_actionsfreqs_parity(backend):
     got = aF.actionsFreqs(*[_arr(backend, v) for v in _STK])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-9, atol=1e-10)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-9, atol=1e-10
+        )
     aC = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=True)
     refc = aC.actionsFreqs(*_STK)
     for g, c in zip(got, refc):  # freqs match the C path to the GL floor
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(c), rtol=1e-7, atol=1e-9)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(c), rtol=1e-7, atol=1e-9
+        )
 
 
 # A substantial grid of bound orbits (R x vR x vT x z x vz; 768 points) spanning
@@ -947,7 +965,7 @@ def test_staeckel_grid_parity(backend):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
+                as_numpy(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
             )
 
 
@@ -993,7 +1011,9 @@ def test_staeckel_turningpoint_parity(backend):
     got = tuple(aF(*bargs)) + tuple(aF.EccZmaxRperiRap(*bargs))
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-9, atol=1e-10)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-9, atol=1e-10
+        )
 
 
 # Exactly-planar orbits (z=vz=0, so J_z=0): the vertical turning point snaps to
@@ -1079,7 +1099,9 @@ def test_staeckel_nearaxis_parity(backend):
     got = tuple(aF(*bargs)) + tuple(aF.EccZmaxRperiRap(*bargs))
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-9, atol=1e-10)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-9, atol=1e-10
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1091,11 +1113,11 @@ def test_staeckel_planar_freqs_degenerate_parity(backend):
     got = aF.actionsFreqs(*[_arr(backend, v) for v in _STK_PLANAR])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_array_equal(_kind(numpy.asarray(r)), _kind(_np(g)))
-        fin = numpy.isfinite(numpy.asarray(r)) & numpy.isfinite(_np(g))
+        numpy.testing.assert_array_equal(_kind(numpy.asarray(r)), _kind(as_numpy(g)))
+        fin = numpy.isfinite(numpy.asarray(r)) & numpy.isfinite(as_numpy(g))
         if numpy.any(fin):
             numpy.testing.assert_allclose(
-                _np(g)[fin], numpy.asarray(r)[fin], rtol=1e-8, atol=1e-9
+                as_numpy(g)[fin], numpy.asarray(r)[fin], rtol=1e-8, atol=1e-9
             )
 
 
@@ -1134,10 +1156,10 @@ def test_staeckel_grid_angles_parity(backend):
     for i, (r, g) in enumerate(zip(ref, got)):
         assert _is_backend_array(backend, g)
         if i >= 6:  # angles: wrap-aware
-            assert numpy.max(_wrapdiff(_np(g), numpy.asarray(r))) < 1e-8
+            assert numpy.max(_wrapdiff(as_numpy(g), numpy.asarray(r))) < 1e-8
         else:
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
+                as_numpy(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
             )
 
 
@@ -1153,7 +1175,7 @@ def test_staeckel_angles_numpy_phi(backend):
     ref = aF.actionsFreqsAngles(*_STK_GRID, _STK_GRID_PHI)
     for i in (6, 7, 8):  # angler, anglephi, anglez
         assert _is_backend_array(backend, got[i])
-        assert numpy.max(_wrapdiff(_np(got[i]), numpy.asarray(ref[i]))) < 1e-8
+        assert numpy.max(_wrapdiff(as_numpy(got[i]), numpy.asarray(ref[i]))) < 1e-8
 
 
 def test_actionAngleVerticalInverse_rejects_backend():
@@ -1251,24 +1273,30 @@ def test_isochroneapprox_parity(backend, b):
     got = aAIA._evaluate(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
     # _actionsFreqs: (jr,lz,jz,Or,Op,Oz)
     ref = aAIA._actionsFreqs(*_IA)
     got = aAIA._actionsFreqs(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
     # _actionsFreqsAngles: (...,ar,ap,az)
     ref = aAIA._actionsFreqsAngles(*_IA)
     got = aAIA._actionsFreqsAngles(*bargs)
     for idx, (r, g) in enumerate(zip(ref, got)):
         assert _is_backend_array(backend, g)
         if idx >= 6:  # angles: wrap-robust
-            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                2.0 * numpy.pi
+            ) - numpy.pi
             numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
         else:
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+                as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
             )
 
 
@@ -1285,7 +1313,9 @@ def test_isochroneapprox_scalar_parity(backend):
     )
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1298,7 +1328,9 @@ def test_isochroneapprox_cumul_parity(backend):
     got = aAIA._evaluate(*bargs, cumul=True)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1311,7 +1343,9 @@ def test_isochroneapprox_planar_parity(backend):
     got = aAIA._evaluate(*[_arr(backend, v) for v in planar])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1381,21 +1415,25 @@ def test_isochroneapprox_nonaxi_parity(backend):
     got = aAIA._evaluate(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+        )
     # _actionsFreqsAngles: (jr,lz,jz,Or,Op,Oz,ar,aphi,az) -- non-axi angle-fit
     ref = aAIA._actionsFreqsAngles(*_NA)
     got = aAIA._actionsFreqsAngles(*bargs)
     for idx, (r, g) in enumerate(zip(ref, got)):
         assert _is_backend_array(backend, g)
         if idx >= 6:  # angles (incl. anglephi at idx 7): wrap-robust
-            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                2.0 * numpy.pi
+            ) - numpy.pi
             numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
         else:
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
+                as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-8
             )
     # the retrograde (second) orbit must give a negative azimuthal frequency
-    assert float(_np(got[4]).ravel()[1]) < 0.0
+    assert float(as_numpy(got[4]).ravel()[1]) < 0.0
 
 
 # ------- IsochroneApprox via the in-backend diffrax/torchdiffeq integrator (#102)
@@ -1431,7 +1469,9 @@ def test_isochroneapprox_inbackend_method_parity(backend):
     got = _aAIA_small(method)._actionsFreqs(*[_arr(backend, v) for v in _IA])
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-6, atol=1e-7)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-7
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1486,14 +1526,14 @@ def test_estimateDeltaStaeckel_parity(backend):
     ref_med = numpy.asarray(estimateDeltaStaeckel(MWPotential2014, _EST_R, _EST_Z))
     got_med = estimateDeltaStaeckel(MWPotential2014, Rb, zb)
     assert _is_backend_array(backend, got_med)
-    numpy.testing.assert_allclose(_np(got_med), ref_med, rtol=1e-12, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got_med), ref_med, rtol=1e-12, atol=1e-12)
     # array, no_median: per-point deltas
     ref_all = numpy.asarray(
         estimateDeltaStaeckel(MWPotential2014, _EST_R, _EST_Z, no_median=True)
     )
     got_all = estimateDeltaStaeckel(MWPotential2014, Rb, zb, no_median=True)
     assert _is_backend_array(backend, got_all)
-    numpy.testing.assert_allclose(_np(got_all), ref_all, rtol=1e-12, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got_all), ref_all, rtol=1e-12, atol=1e-12)
     # scalar, incl. a z==0 (plane) point that hits the 1e-4 fallback
     for Rs, zs in ((1.1, 0.15), (1.2, 0.0)):
         ref = numpy.asarray(estimateDeltaStaeckel(MWPotential2014, Rs, zs))
@@ -1501,7 +1541,7 @@ def test_estimateDeltaStaeckel_parity(backend):
             MWPotential2014, _arr(backend, Rs), _arr(backend, zs)
         )
         assert _is_backend_array(backend, got)
-        numpy.testing.assert_allclose(_np(got), ref, rtol=1e-12, atol=1e-12)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12, atol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1511,12 +1551,12 @@ def test_estimateBIsochrone_parity(backend):
     ref = numpy.asarray(estimateBIsochrone(MWPotential2014, _EST_R, _EST_Z))
     got = estimateBIsochrone(MWPotential2014, Rb, zb)
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-11, atol=1e-11)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-11, atol=1e-11)
     # scalar -> single b
     ref_s = float(estimateBIsochrone(MWPotential2014, 1.1, 0.15))
     got_s = estimateBIsochrone(MWPotential2014, _arr(backend, 1.1), _arr(backend, 0.15))
     assert _is_backend_array(backend, got_s)
-    numpy.testing.assert_allclose(_np(got_s), ref_s, rtol=1e-11, atol=1e-11)
+    numpy.testing.assert_allclose(as_numpy(got_s), ref_s, rtol=1e-11, atol=1e-11)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1529,7 +1569,7 @@ def test_estimateDeltaStaeckel_grad_vs_fd_wrt_R(backend):
 
     R0 = 1.1
     g = _grad(backend, lambda t: f(backend, t), R0)
-    fd = _fd(lambda Rv: float(_np(f(backend, _arr(backend, Rv)))), R0)
+    fd = _fd(lambda Rv: float(as_numpy(f(backend, _arr(backend, Rv)))), R0)
     assert numpy.isfinite(g)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
 
@@ -1544,7 +1584,7 @@ def test_estimateBIsochrone_grad_vs_fd_wrt_R(backend):
 
     R0 = 1.1
     g = _grad(backend, lambda t: f(backend, t), R0)
-    fd = _fd(lambda Rv: float(_np(f(backend, _arr(backend, Rv)))), R0)
+    fd = _fd(lambda Rv: float(as_numpy(f(backend, _arr(backend, Rv)))), R0)
     assert numpy.isfinite(g)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
 
@@ -1581,7 +1621,9 @@ def test_adiabatic_actions_parity(backend):
     got = aA._evaluate(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-9, atol=1e-11)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-9, atol=1e-11
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1593,7 +1635,9 @@ def test_adiabatic_actionsfreqs_parity(backend):
     got = aA._actionsFreqs(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1608,11 +1652,13 @@ def test_adiabatic_actionsfreqsangles_parity(backend):
     for idx, (r, g) in enumerate(zip(ref, got)):
         assert _is_backend_array(backend, g)
         if idx >= 6:  # ar, aphi, az
-            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                2.0 * numpy.pi
+            ) - numpy.pi
             numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
         else:
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
             )
 
 
@@ -1625,7 +1671,9 @@ def test_adiabatic_ecczmaxrperirap_parity(backend):
     got = aA._EccZmaxRperiRap(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-8, atol=1e-9)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
+        )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1646,7 +1694,7 @@ def test_adiabatic_actions_vs_c(backend):
     jr_b, lz_b, jz_b = aF._evaluate(*[_arr(backend, v) for v in _ADB])
     for g, c in ((jr_b, jr_c), (lz_b, lz_c), (jz_b, jz_c)):
         numpy.testing.assert_allclose(
-            _np(g), numpy.asarray(c), rtol=1e-5, atol=floor + 1e-9
+            as_numpy(g), numpy.asarray(c), rtol=1e-5, atol=floor + 1e-9
         )
 
 
@@ -1725,20 +1773,22 @@ def test_adiabatic_planar_edge_parity(backend):
     for idx, (r, g) in enumerate(zip(ref, got)):
         assert _is_backend_array(backend, g)
         if idx >= 6:
-            d = (_np(g) - numpy.asarray(r) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            d = (as_numpy(g) - numpy.asarray(r) + numpy.pi) % (
+                2.0 * numpy.pi
+            ) - numpy.pi
             numpy.testing.assert_allclose(d, 0.0, atol=1e-6)
         else:
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+                as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
             )
     # planar elements: Jz==0, az==0, Oz==verticalfreq(R)
     from galpy.potential import verticalfreq
 
-    assert _np(got[2])[0] == 0.0 and _np(got[2])[2] == 0.0  # Jz
-    assert abs(_np(got[8])[0]) < 1e-12 and abs(_np(got[8])[2]) < 1e-12  # az
+    assert as_numpy(got[2])[0] == 0.0 and as_numpy(got[2])[2] == 0.0  # Jz
+    assert abs(as_numpy(got[8])[0]) < 1e-12 and abs(as_numpy(got[8])[2]) < 1e-12  # az
     for ii in (0, 2):
         numpy.testing.assert_allclose(
-            _np(got[5])[ii], verticalfreq(MWPotential2014, R[ii]), rtol=1e-12
+            as_numpy(got[5])[ii], verticalfreq(MWPotential2014, R[ii]), rtol=1e-12
         )
 
 
@@ -1764,11 +1814,11 @@ def test_adiabatic_2dpot_edge_parity(backend):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
+                as_numpy(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
             )
     # Jz (index 2 of _evaluate) and zmax (index 1 of ecc) are identically 0.
-    assert numpy.all(_np(aA._evaluate(*bargs)[2]) == 0.0)
-    assert numpy.all(_np(aA._EccZmaxRperiRap(*bargs)[1]) == 0.0)
+    assert numpy.all(as_numpy(aA._evaluate(*bargs)[2]) == 0.0)
+    assert numpy.all(as_numpy(aA._EccZmaxRperiRap(*bargs)[1]) == 0.0)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -1783,7 +1833,9 @@ def test_adiabatic_gamma0_ecczmaxrperirap_parity(backend):
     got = aA._EccZmaxRperiRap(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-6, atol=1e-8)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-6, atol=1e-8
+        )
 
 
 # ====================================================================
@@ -1826,7 +1878,7 @@ def test_staeckelgrid_parity(backend):
         for r, g in zip(ref, got):
             assert _is_backend_array(backend, g)
             numpy.testing.assert_allclose(
-                _np(g), numpy.asarray(r), rtol=1e-10, atol=1e-12
+                as_numpy(g), numpy.asarray(r), rtol=1e-10, atol=1e-12
             )
 
 
@@ -1837,7 +1889,9 @@ def test_adiabaticgrid_parity(backend):
     ref, got = _aAAG(*_GRID), _aAAG(*bargs)
     for r, g in zip(ref, got):
         assert _is_backend_array(backend, g)
-        numpy.testing.assert_allclose(_np(g), numpy.asarray(r), rtol=1e-10, atol=1e-12)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-10, atol=1e-12
+        )
 
 
 def test_staeckelgrid_numpy_byte_identity():
@@ -1918,4 +1972,4 @@ def test_staeckelgrid_vatu0_backend(backend):
         *[_arr(backend, a) for a in (E, Lz, u0, R)]
     )  # backend -> xp.where branch
     assert _is_backend_array(backend, vb)
-    numpy.testing.assert_allclose(_np(vb), vn, rtol=1e-10, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(vb), vn, rtol=1e-10, atol=1e-12)

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -9,6 +9,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 pytestmark = pytest.mark.backend_managed
 
 BACKENDS = []
@@ -33,12 +35,6 @@ except ImportError:  # pragma: no cover
 
 def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
-
-
-def _np(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
 
 
 def _scf():
@@ -68,7 +64,7 @@ def test_scf_mixed_scalar_array_coords(backend):
         ("phi2deriv", lambda p: scf.phi2deriv(1.5, 0.3, phi=p)),
     ]:
         ref = numpy.asarray(fn(phin))
-        got = _np(fn(phib))
+        got = as_numpy(fn(phib))
         numpy.testing.assert_allclose(
             got, ref, rtol=1e-10, atol=1e-12, err_msg=f"SCF {name} ({backend})"
         )
@@ -85,11 +81,13 @@ def test_cyl_to_spher_mixed(backend):
     r_ref, theta_ref, phi_ref = coords.cyl_to_spher(
         1.5, 0.3, numpy.array([0.1, 0.2, 0.3])
     )
-    numpy.testing.assert_allclose(_np(r), numpy.broadcast_to(r_ref, (3,)), rtol=1e-12)
     numpy.testing.assert_allclose(
-        _np(th), numpy.broadcast_to(theta_ref, (3,)), rtol=1e-12
+        as_numpy(r), numpy.broadcast_to(r_ref, (3,)), rtol=1e-12
     )
-    numpy.testing.assert_allclose(_np(ph), phi_ref, rtol=1e-12)
+    numpy.testing.assert_allclose(
+        as_numpy(th), numpy.broadcast_to(theta_ref, (3,)), rtol=1e-12
+    )
+    numpy.testing.assert_allclose(as_numpy(ph), phi_ref, rtol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -104,11 +102,11 @@ def test_doubleexp_scalar_R_array_z(backend):
     dp = DEDP()
     zb = _arr(backend, [0.3, 0.6])
     ref = numpy.asarray(dp(1.5, numpy.array([0.3, 0.6])))
-    numpy.testing.assert_allclose(_np(dp(1.5, zb)), ref, rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(dp(1.5, zb)), ref, rtol=1e-8, atol=1e-10)
     # supported array combo (same-shape R, z) stays a full array, matching numpy
     Rb, zb2 = _arr(backend, [1.5, 2.0]), _arr(backend, [0.3, 0.6])
     ref2 = numpy.asarray(dp(numpy.array([1.5, 2.0]), numpy.array([0.3, 0.6])))
-    numpy.testing.assert_allclose(_np(dp(Rb, zb2)), ref2, rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(dp(Rb, zb2)), ref2, rtol=1e-8, atol=1e-10)
 
 
 def test_asarray_on_device_rejecting_device_fallback():

--- a/tests/test_backend_disk.py
+++ b/tests/test_backend_disk.py
@@ -12,6 +12,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     DoubleExponentialDiskPotential,
     FlattenedPowerPotential,
@@ -138,12 +139,6 @@ def _asarray(backend_name, x, requires_grad=False):
         return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 # --- value parity ------------------------------------------------------------
 def _iter_3d_cases():
     for (pot, methods), pid in zip(_POTS_3D, _POT3D_IDS):
@@ -155,7 +150,7 @@ def _iter_3d_cases():
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity_3d(backend_name, pot, method):
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -166,7 +161,7 @@ def test_value_parity_3d(backend_name, pot, method):
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity_1d(backend_name, pot, method):
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(_XS)))
-    got = _tonumpy(getattr(pot, method)(_asarray(backend_name, _XS)))
+    got = as_numpy(getattr(pot, method)(_asarray(backend_name, _XS)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -237,7 +232,7 @@ _MASS_RS = [0.3, 1.0, 2.5]
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_mass_value_parity(backend_name, pot):
     ref = numpy.asarray(pot._mass(numpy.asarray(_MASS_RS)))
-    got = _tonumpy(pot._mass(_asarray(backend_name, _MASS_RS)))
+    got = as_numpy(pot._mass(_asarray(backend_name, _MASS_RS)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -269,7 +264,7 @@ def test_kuzmin_zkink_at_zero(backend_name, method):
     R = [0.5, 1.0, 2.0]
     z = [0.0, 0.0, 0.0]
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(R), numpy.asarray(z)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, R), _asarray(backend_name, z))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -287,7 +282,7 @@ def test_miyamoto_a0_branch_parity(backend_name, method):
     R = [0.5, 1.0, 2.0]
     z = [0.0, 0.1, 0.3]
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(R), numpy.asarray(z)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, R), _asarray(backend_name, z))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -302,7 +297,7 @@ def test_miyamoto_a0_b0_z0_finite(backend_name, method):
     R = [0.5, 1.0, 2.0]
     z = [0.0, 0.0, 0.0]
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(R), numpy.asarray(z)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, R), _asarray(backend_name, z))
     )
     assert numpy.all(numpy.isfinite(ref))
@@ -423,7 +418,7 @@ _DEXP_POINTS = [(0.5, 0.1), (1.0, 0.2), (2.0, -0.3), (1.3, 0.0), (0.7, 0.4)]
 def test_doubleexp_scalar_value_parity(backend_name, method):
     for R0, z0 in _DEXP_POINTS:
         ref = numpy.asarray(getattr(_DEXP, method)(R0, z0, 0.0, 0.0))
-        got = _tonumpy(
+        got = as_numpy(
             getattr(_DEXP, method)(
                 _asarray(backend_name, R0), _asarray(backend_name, z0), 0.0, 0.0
             )
@@ -445,12 +440,12 @@ def test_doubleexp_evaluate_zero_point(backend_name):
     # identical across backends, also as an entry of an array evaluation.
     ref = float(_DEXP._evaluate(0.0, 0.0))
     got = float(
-        _tonumpy(
+        as_numpy(
             _DEXP._evaluate(_asarray(backend_name, 0.0), _asarray(backend_name, 0.0))
         )
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-15)
-    gotarr = _tonumpy(
+    gotarr = as_numpy(
         _DEXP._evaluate(
             _asarray(backend_name, [0.0, 1.0]), _asarray(backend_name, [0.0, 0.2])
         )
@@ -528,7 +523,7 @@ def test_razorthin_scalar_value_parity(backend_name, method):
     # branches.
     for R0, z0 in _RAZOR_ZERO_POINTS + _RAZOR_ZNZ_POINTS:
         ref = numpy.asarray(getattr(_RAZOR, method)(R0, z0, 0.0, 0.0))
-        got = _tonumpy(
+        got = as_numpy(
             getattr(_RAZOR, method)(
                 _asarray(backend_name, R0), _asarray(backend_name, z0), 0.0, 0.0
             )
@@ -549,7 +544,7 @@ def test_razorthin_R2deriv_iv2_recurrence(backend_name):
     for R0 in [0.5, 1.0, 1.3, 2.0]:
         ref = float(_RAZOR._R2deriv(numpy.asarray(R0), numpy.asarray(0.0)))
         got = float(
-            _tonumpy(
+            as_numpy(
                 _RAZOR._R2deriv(_asarray(backend_name, R0), _asarray(backend_name, 0.0))
             )
         )

--- a/tests/test_backend_diskexpansion.py
+++ b/tests/test_backend_diskexpansion.py
@@ -27,7 +27,7 @@
 import numpy
 import pytest
 
-from galpy.backend import get_namespace
+from galpy.backend import as_numpy, get_namespace
 from galpy.potential import PlummerPotential
 from galpy.potential.KuijkenDubinskiDiskExpansionPotential import (
     KuijkenDubinskiDiskExpansionPotential,
@@ -64,12 +64,6 @@ def _asarray(backend_name, x, requires_grad=False):
     if backend_name == "jax":
         return jnp.asarray(x, dtype=jnp.float64)
     return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
-
-
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
 
 
 def _dens_xp(R, z):
@@ -141,7 +135,7 @@ _ZS = [-0.3, 0.05, 0.2]
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot, method):
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -156,7 +150,7 @@ def test_zkink_at_zero(backend_name, method):
     R = [0.5, 1.0, 2.0]
     z = [0.0, 0.0, 0.0]
     ref = numpy.asarray(getattr(pot, method)(numpy.asarray(R), numpy.asarray(z)))
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(_asarray(backend_name, R), _asarray(backend_name, z))
     )
     assert numpy.all(numpy.isfinite(ref))
@@ -171,7 +165,7 @@ def test_sech2_large_z_no_overflow(backend_name):
     z = [-40.0, 40.0]
     ref = numpy.asarray(pot._evaluate(numpy.asarray(R), numpy.asarray(z)))
     assert numpy.all(numpy.isfinite(ref))
-    got = _tonumpy(pot._evaluate(_asarray(backend_name, R), _asarray(backend_name, z)))
+    got = as_numpy(pot._evaluate(_asarray(backend_name, R), _asarray(backend_name, z)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -265,7 +259,7 @@ def test_force_hessian_identities(backend_name, pot):
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_phiME_dens_value_parity(backend_name, pot):
     ref = numpy.asarray(pot._phiME_dens_func(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(
+    got = as_numpy(
         pot._phiME_dens_func(_asarray(backend_name, _RS), _asarray(backend_name, _ZS))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)

--- a/tests/test_backend_ellipsoidal.py
+++ b/tests/test_backend_ellipsoidal.py
@@ -30,6 +30,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     PerfectEllipsoidPotential,
     PowerTriaxialPotential,
@@ -187,12 +188,6 @@ def _asarray(backend_name, x, requires_grad=False):
         return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("pot,method", _VALUE_PARAMS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot, method):
@@ -202,7 +197,7 @@ def test_value_parity(backend_name, pot, method):
             numpy.asarray(_RS), numpy.asarray(_ZS), numpy.asarray(_PHIS)
         )
     )
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(
             _asarray(backend_name, _RS),
             _asarray(backend_name, _ZS),
@@ -325,7 +320,7 @@ def test_mass_value_parity(backend_name, pot):
     # subclasses; numpy / jax / torch must agree.
     Rs = numpy.asarray([0.5, 1.0, 2.0])
     ref = numpy.asarray(pot.mass(Rs))
-    got = _tonumpy(pot.mass(_asarray(backend_name, [0.5, 1.0, 2.0])))
+    got = as_numpy(pot.mass(_asarray(backend_name, [0.5, 1.0, 2.0])))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -456,7 +451,7 @@ def test_axisymmetric_all_backend_inputs(backend_name, pot, ndim, method):
             numpy.asarray(R), numpy.asarray(z), phi=numpy.asarray(phi), t=t
         )
     )
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(
             _asarray(backend_name, R),
             _asarray(backend_name, z),
@@ -478,7 +473,7 @@ def test_mixed_backend_Rz_float_phi_t(backend_name, pot, method):
     ref = numpy.asarray(
         getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS), phi=phi0, t=t0)
     )
-    got = _tonumpy(
+    got = as_numpy(
         getattr(pot, method)(
             _asarray(backend_name, _RS), _asarray(backend_name, _ZS), phi=phi0, t=t0
         )

--- a/tests/test_backend_ferrers.py
+++ b/tests/test_backend_ferrers.py
@@ -18,6 +18,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import FerrersPotential
 
 # This module manages backends explicitly, so it is exempt from the global
@@ -75,12 +76,6 @@ def _asarray(backend_name, x):
         return torch.tensor(x, dtype=torch.float64)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("method", _METHODS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, method):
@@ -94,7 +89,7 @@ def test_value_parity(backend_name, method):
         )
     )
     got = float(
-        _tonumpy(
+        as_numpy(
             getattr(_FE, method)(
                 _asarray(backend_name, _R0),
                 _asarray(backend_name, _Z0),
@@ -115,7 +110,7 @@ def test_dens_inside_outside_value_parity(backend_name):
     for R0, z0, expect_zero in [(0.3, 0.05, False), (3.0, 0.5, True)]:
         ref = float(_FE._dens(numpy.asarray(R0), numpy.asarray(z0), _PHI0, _T0))
         got = float(
-            _tonumpy(
+            as_numpy(
                 _FE._dens(
                     _asarray(backend_name, R0), _asarray(backend_name, z0), _PHI0, _T0
                 )

--- a/tests/test_backend_force.py
+++ b/tests/test_backend_force.py
@@ -25,6 +25,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     ChandrasekharDynamicalFrictionForce,
     HernquistPotential,
@@ -63,12 +64,6 @@ def _asarray(backend_name, x):
         return jnp.asarray(x, dtype=jnp.float64)
     if backend_name == "torch":
         return torch.tensor(x, dtype=torch.float64)
-
-
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
 
 
 def _module_of(x):
@@ -130,7 +125,7 @@ def test_rforce_value_parity(backend_name, label, obj, needs_v, backend_ok):
         pytest.skip("force's own _Rforce not backend-clean yet (dissipative)")
     v = _V0 if needs_v else None
     ref = _rforce_np(obj, _R0, _Z0, v=v)
-    got = float(_tonumpy(_rforce_backend(backend_name, obj, _R0, _Z0, v=v)))
+    got = float(as_numpy(_rforce_backend(backend_name, obj, _R0, _Z0, v=v)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14, err_msg=label)
 
 
@@ -200,7 +195,7 @@ def test_rforce_grad_vs_finite_difference(
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_spherical_mass_value_parity(backend_name):
     ref = float(_HERN._mass(numpy.asarray(_R0)))
-    got = float(_tonumpy(_HERN._mass(_asarray(backend_name, _R0))))
+    got = float(as_numpy(_HERN._mass(_asarray(backend_name, _R0))))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 

--- a/tests/test_backend_halobar.py
+++ b/tests/test_backend_halobar.py
@@ -13,6 +13,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     CosmphiDiskPotential,
     DehnenBarPotential,
@@ -227,12 +228,6 @@ def _asarray(backend_name, x, requires_grad=False):
         return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 def _call(method, backend_name, ndim):
     R = _asarray(backend_name, _RS)
     phi = _asarray(backend_name, _PHIS)
@@ -264,7 +259,7 @@ def test_value_parity(backend_name, entry):
     for mname in methods:
         method = getattr(pot, mname)
         ref = _call_numpy(method, ndim)
-        got = _tonumpy(_call(method, backend_name, ndim))
+        got = as_numpy(_call(method, backend_name, ndim))
         numpy.testing.assert_allclose(
             got,
             ref,
@@ -279,7 +274,7 @@ def test_value_parity(backend_name, entry):
             ref = numpy.asarray(
                 method(R0, z0, phi0, _T) if ndim == 3 else method(R0, phi0, _T)
             )
-            got = _tonumpy(_call_scalar(method, backend_name, ndim, R0, z0, phi0))
+            got = as_numpy(_call_scalar(method, backend_name, ndim, R0, z0, phi0))
             numpy.testing.assert_allclose(
                 got,
                 ref,
@@ -478,7 +473,7 @@ def test_singular_branch_value_parity(backend_name, case):
             ref = numpy.asarray(
                 method(R0, z0, phi0, _T) if ndim == 3 else method(R0, phi0, _T)
             )
-            got = _tonumpy(_call_scalar(method, backend_name, ndim, R0, z0, phi0))
+            got = as_numpy(_call_scalar(method, backend_name, ndim, R0, z0, phi0))
             numpy.testing.assert_allclose(
                 got,
                 ref,
@@ -573,9 +568,9 @@ def test_time_dependence_value_parity(backend_name, case):
     phib = _asarray(backend_name, phi0)
     tgb = _asarray(backend_name, tg)
     if ndim == 3:
-        got = _tonumpy(pot._evaluate(Rb, _asarray(backend_name, z0), phib, tgb))
+        got = as_numpy(pot._evaluate(Rb, _asarray(backend_name, z0), phib, tgb))
     else:
-        got = _tonumpy(pot._evaluate(Rb, phib, tgb))
+        got = as_numpy(pot._evaluate(Rb, phib, tgb))
     numpy.testing.assert_allclose(
         got,
         ref,
@@ -669,7 +664,7 @@ def test_break_radius_inside_value_parity(backend_name, case):
     for R0 in [0.2, 0.7, pot._rb - 1e-6]:
         for mname in ["_evaluate", "_Rforce", "_phitorque", "_R2deriv", "_Rphideriv"]:
             ref = float(getattr(pot, mname)(R0, phi0))
-            got = _tonumpy(
+            got = as_numpy(
                 getattr(pot, mname)(
                     _asarray(backend_name, R0), _asarray(backend_name, phi0)
                 )
@@ -693,7 +688,7 @@ def test_break_radius_axis_no_crash(backend_name, case):
     pot, finite = case
     phi0 = 0.4
     ref = float(pot._evaluate(0.0, phi0))  # numpy scalar: must not raise
-    got = _tonumpy(
+    got = as_numpy(
         pot._evaluate(_asarray(backend_name, 0.0), _asarray(backend_name, phi0))
     )
     if finite:

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -10,6 +10,7 @@ import pytest
 import scipy.interpolate as si
 import scipy.ndimage as sndi
 
+from galpy.backend import as_numpy
 from galpy.backend.interpolate import (
     MapCoordinates,
     Spline1D,
@@ -62,12 +63,6 @@ def _asarray(backend, x, requires_grad=False):
     return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 _XG = numpy.linspace(0.3, 6.0, 25)
 _YG = numpy.sin(_XG) + 0.2 * _XG
 _RQ = numpy.array([0.3, 1.1, 2.7, 4.5, 6.0])  # in-range incl. endpoints
@@ -80,7 +75,7 @@ def test_spline1d_frozen_parity(backend):
     # match the frozen scipy spline to ~1e-9.
     s = Spline1D(_XG, _YG, k=3)  # numpy y -> mode 1
     ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3)(_RQ)
-    got = _tonumpy(s(_asarray(backend, _RQ)))
+    got = as_numpy(s(_asarray(backend, _RQ)))
     rtol = 0.0 if backend == "numpy" else 1e-9  # numpy byte-identical
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -93,10 +88,10 @@ def test_spline1d_mode2_self_consistent(backend):
     y_b = _asarray(backend, _YG)
     s = Spline1D(_XG, y_b, k=3, bc="natural")  # backend y -> mode 2
     ref = si.CubicSpline(_XG, _YG, bc_type="natural")(_RQ)
-    got = _tonumpy(s(_asarray(backend, _RQ)))
+    got = as_numpy(s(_asarray(backend, _RQ)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-12)
     # numpy query of the same mode-2 instance agrees with the backend query
-    numpy.testing.assert_allclose(_tonumpy(s(_RQ)), got, rtol=1e-9, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(s(_RQ)), got, rtol=1e-9, atol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -104,10 +99,10 @@ def test_cubic_and_linear_parity(backend):
     xp = _xp(backend)
     x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _RQ)
     c = cubic_spline_coeffs(xp, x, y, bc="natural")
-    cub = _tonumpy(eval_cubic(xp, x, c, r))
+    cub = as_numpy(eval_cubic(xp, x, c, r))
     refc = si.CubicSpline(_XG, _YG, bc_type="natural")(_RQ)
     numpy.testing.assert_allclose(cub, refc, rtol=1e-9, atol=1e-12)
-    lin = _tonumpy(interp_linear(xp, x, y, r))
+    lin = as_numpy(interp_linear(xp, x, y, r))
     numpy.testing.assert_allclose(
         lin, numpy.interp(_RQ, _XG, _YG), rtol=1e-12, atol=1e-12
     )
@@ -125,7 +120,7 @@ def test_spline2d_value_parity(backend):
     s = Spline2D(
         x=_asarray(backend, xg), y=_asarray(backend, yg), z=_asarray(backend, zz)
     )
-    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    got = as_numpy(s(_asarray(backend, X), _asarray(backend, Y)))
     rtol = 0.0 if backend == "numpy" else 1e-9
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -191,7 +186,7 @@ def test_eval_ppoly_clamp_modes(backend, ext):
     x, c = spline_to_ppoly(spl0)
     ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=3)(_ROUT)
     xp = _xp(backend)
-    got = _tonumpy(
+    got = as_numpy(
         eval_ppoly(
             xp,
             _asarray(backend, x),
@@ -213,7 +208,7 @@ def test_eval_ppoly_extrapolate_true(backend):
     x, c = spline_to_ppoly(spl0)
     ref = spl0(_ROUT)
     xp = _xp(backend)
-    got = _tonumpy(
+    got = as_numpy(
         eval_ppoly(
             xp, _asarray(backend, x), _asarray(backend, c), _asarray(backend, _ROUT)
         )
@@ -237,7 +232,7 @@ def test_cubic_not_a_knot(backend):
     xp = _xp(backend)
     x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _RQ)
     c = cubic_spline_coeffs(xp, x, y, bc="not-a-knot")
-    got = _tonumpy(eval_cubic(xp, x, c, r))
+    got = as_numpy(eval_cubic(xp, x, c, r))
     ref = si.CubicSpline(_XG, _YG)(_RQ)  # default bc_type = 'not-a-knot'
     rtol = 1e-12 if backend == "numpy" else 1e-9
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
@@ -256,7 +251,7 @@ def test_interp_linear_clamp_modes(backend, ext):
     # 'clip'/'const'/3 clamp the eval point -> edge value beyond the ends.
     xp = _xp(backend)
     x, y, r = _asarray(backend, _XG), _asarray(backend, _YG), _asarray(backend, _ROUT)
-    got = _tonumpy(interp_linear(xp, x, y, r, extrapolate=ext))
+    got = as_numpy(interp_linear(xp, x, y, r, extrapolate=ext))
     rclamp = numpy.clip(_ROUT, _XG[0], _XG[-1])
     ref = numpy.interp(rclamp, _XG, _YG)
     rtol = 1e-12 if backend == "numpy" else 1e-12
@@ -275,10 +270,10 @@ def test_spline1d_mode2_linear(backend):
     y_b = _asarray(backend, _YG)
     s = Spline1D(_XG, y_b, k=1)  # backend y, k=1 -> mode-2 linear (no scipy spline)
     ref = numpy.interp(_RQ, _XG, _YG)
-    got = _tonumpy(s(_asarray(backend, _RQ)))
+    got = as_numpy(s(_asarray(backend, _RQ)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-12)
     # numpy query of the same mode-2 k=1 instance (interp_linear numpy branch)
-    numpy.testing.assert_allclose(_tonumpy(s(_RQ)), ref, rtol=1e-12, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(s(_RQ)), ref, rtol=1e-12, atol=1e-12)
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)
@@ -294,7 +289,7 @@ def test_spline1d_ext3_const(backend):
     # jax/torch return the edge value beyond the ends.
     s = Spline1D(_XG, _YG, k=3, ext=3)
     ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3, ext=3)(_ROUT)
-    got = _tonumpy(s(_asarray(backend, _ROUT)))
+    got = as_numpy(s(_asarray(backend, _ROUT)))
     rtol = 0.0 if backend == "numpy" else 1e-9
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -320,7 +315,7 @@ def test_eval_rect_ppoly_clamp_modes(backend, ext):
     Y = numpy.array([-3.0, 0.7, 4.0])
     ref = spl.ev(numpy.clip(X, xg[0], xg[-1]), numpy.clip(Y, yg[0], yg[-1]))
     xp = _xp(backend)
-    got = _tonumpy(
+    got = as_numpy(
         eval_rect_ppoly(
             xp,
             _asarray(backend, xbr),
@@ -363,7 +358,7 @@ def test_spline2d_from_prefitted_spl(backend):
     Y = numpy.array([-0.5, 0.7, 1.9])
     ref = spl.ev(X, Y)
     s = Spline2D(spl=spl)
-    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    got = as_numpy(s(_asarray(backend, X), _asarray(backend, Y)))
     rtol = 0.0 if backend == "numpy" else 1e-9
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -377,7 +372,7 @@ def test_spline2d_ext3_const(backend):
     X = numpy.array([-1.0, 1.5, 5.0])
     Y = numpy.array([-3.0, 0.7, 4.0])
     ref = spl.ev(numpy.clip(X, xg[0], xg[-1]), numpy.clip(Y, yg[0], yg[-1]))
-    got = _tonumpy(s(_asarray(backend, X), _asarray(backend, Y)))
+    got = as_numpy(s(_asarray(backend, X), _asarray(backend, Y)))
     rtol = 0.0 if backend == "numpy" else 1e-9
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -391,7 +386,7 @@ def test_spline2d_mixed_backend_args(backend):
     spl = si.RectBivariateSpline(xg, yg, zz)
     s = Spline2D(x=xg, y=yg, z=zz)
     ref = spl.ev([1.5], [0.7])
-    got = _tonumpy(s(1.5, _asarray(backend, [0.7])))
+    got = as_numpy(s(1.5, _asarray(backend, [0.7])))
     numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-12)
 
 
@@ -420,9 +415,9 @@ def test_iuspline_value_and_deriv_vs_scipy(backend):
     s = Spline1D(_X1D, _Y1D, k=3)
     q = _asarray(backend, _Q1D)
     rtol = 0.0 if backend == "numpy" else 1e-12
-    val = _tonumpy(s(q))
+    val = as_numpy(s(q))
     numpy.testing.assert_allclose(val, ref(_Q1D), rtol=rtol, atol=1e-13)
-    dval = _tonumpy(s(q, nu=1))
+    dval = as_numpy(s(q, nu=1))
     numpy.testing.assert_allclose(dval, ref(_Q1D, nu=1), rtol=rtol, atol=1e-13)
 
 
@@ -459,7 +454,7 @@ def test_rectbivariate_pointeval_vs_scipy(backend):
     xg, yg, Z = _rect2d()
     spl = si.RectBivariateSpline(xg, yg, Z, kx=3, ky=3, s=0.0)
     s = Spline2D(x=xg, y=yg, z=Z)
-    got = _tonumpy(s(_asarray(backend, _QX2D), _asarray(backend, _QY2D), grid=False))
+    got = as_numpy(s(_asarray(backend, _QX2D), _asarray(backend, _QY2D), grid=False))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, spl.ev(_QX2D, _QY2D), rtol=rtol, atol=1e-13)
 
@@ -488,7 +483,7 @@ def test_map_coordinates_vs_scipy(backend):
     # jax/torch ~1e-12 vs scipy.ndimage.map_coordinates.
     filt = spline_filter(_MGRID, order=3)
     ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="nearest")
-    got = _tonumpy(map_coordinates(filt, _asarray(backend, _MCOORDS)))
+    got = as_numpy(map_coordinates(filt, _asarray(backend, _MCOORDS)))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13)
 
@@ -509,7 +504,7 @@ def test_mapcoordinates_class_matches_function(backend):
     ref = sndi.map_coordinates(
         mc.filtered, _MCOORDS, order=3, prefilter=False, mode="nearest"
     )
-    got = _tonumpy(mc(_asarray(backend, _MCOORDS)))
+    got = as_numpy(mc(_asarray(backend, _MCOORDS)))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13)
 
@@ -522,7 +517,7 @@ def test_grad_map_coordinates_vs_fd(backend):
     c0 = numpy.array([2.3, 3.1, 1.7])
 
     def _val(c):
-        return float(_tonumpy(mc(c.reshape(3, 1)))[0])
+        return float(as_numpy(mc(c.reshape(3, 1)))[0])
 
     fd = numpy.empty(3)
     for d in range(3):
@@ -565,7 +560,7 @@ def test_rectbivariate_grid_true_vs_scipy(backend):
     spl = si.RectBivariateSpline(xg, yg, Z, kx=3, ky=3, s=0.0)
     s = Spline2D(x=xg, y=yg, z=Z)
     ref = spl(_QX2D, _QY2D, grid=True)
-    got = _tonumpy(s(_asarray(backend, _QX2D), _asarray(backend, _QY2D), grid=True))
+    got = as_numpy(s(_asarray(backend, _QX2D), _asarray(backend, _QY2D), grid=True))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13)
 
@@ -577,14 +572,14 @@ def test_interp_linear_nu_branches(backend):
     # every backend (the function is backend-agnostic, numpy included).
     xp = _xp(backend)
     x, y, q = _asarray(backend, _X1D), _asarray(backend, _Y1D), _asarray(backend, _Q1D)
-    val = _tonumpy(interp_linear(xp, x, y, q))
+    val = as_numpy(interp_linear(xp, x, y, q))
     numpy.testing.assert_allclose(val, numpy.interp(_Q1D, _X1D, _Y1D), atol=1e-12)
-    dval = _tonumpy(interp_linear(xp, x, y, q, nu=1))
+    dval = as_numpy(interp_linear(xp, x, y, q, nu=1))
     idx = numpy.clip(numpy.searchsorted(_X1D, _Q1D, side="right") - 1, 0, len(_X1D) - 2)
     slope = (_Y1D[idx + 1] - _Y1D[idx]) / (_X1D[idx + 1] - _X1D[idx])
     numpy.testing.assert_allclose(dval, slope, atol=1e-12)
     numpy.testing.assert_allclose(
-        _tonumpy(interp_linear(xp, x, y, q, nu=2)), 0.0, atol=1e-12
+        as_numpy(interp_linear(xp, x, y, q, nu=2)), 0.0, atol=1e-12
     )
 
 
@@ -593,7 +588,7 @@ def test_spline1d_mode2_k1_deriv(backend):
     # mode-2 k=1 (backend y) Spline1D: nu=1 returns the per-interval secant slope
     # via the interp_linear path on the backend array.
     s = Spline1D(_X1D, _asarray(backend, _Y1D), k=1)
-    dval = _tonumpy(s(_asarray(backend, _Q1D), nu=1))
+    dval = as_numpy(s(_asarray(backend, _Q1D), nu=1))
     idx = numpy.clip(numpy.searchsorted(_X1D, _Q1D, side="right") - 1, 0, len(_X1D) - 2)
     slope = (_Y1D[idx + 1] - _Y1D[idx]) / (_X1D[idx + 1] - _X1D[idx])
     numpy.testing.assert_allclose(dval, slope, atol=1e-12)
@@ -610,7 +605,7 @@ def test_eval_ppoly_nu_past_degree_zero(backend):
     spl0 = si.InterpolatedUnivariateSpline(_X1D, _Y1D, k=3, ext=0)
     x, c = spline_to_ppoly(spl0)
     xp = _xp(backend)
-    got = _tonumpy(
+    got = as_numpy(
         eval_ppoly(
             xp,
             _asarray(backend, x),

--- a/tests/test_backend_interpspherical.py
+++ b/tests/test_backend_interpspherical.py
@@ -29,6 +29,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     HernquistPotential,
     KingPotential,
@@ -112,12 +113,6 @@ def _asarray(backend_name, x):
         return torch.tensor(x, dtype=torch.float64)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot):
@@ -127,7 +122,7 @@ def test_value_parity(backend_name, pot):
         ref = numpy.asarray(
             getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS))
         )
-        got = _tonumpy(getattr(pot, method)(R, z))
+        got = as_numpy(getattr(pot, method)(R, z))
         numpy.testing.assert_allclose(
             got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{type(pot).__name__}.{method}"
         )
@@ -140,7 +135,7 @@ def test_radial_value_parity(backend_name, pot):
     r = _asarray(backend_name, rs)
     for method in _ONE_D:
         ref = numpy.asarray(getattr(pot, method)(numpy.asarray(rs)))
-        got = _tonumpy(getattr(pot, method)(r))
+        got = as_numpy(getattr(pot, method)(r))
         numpy.testing.assert_allclose(
             got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{type(pot).__name__}.{method}"
         )
@@ -154,7 +149,7 @@ def test_public_value_parity(backend_name, pot):
     R = _asarray(backend_name, _RS)
     z = _asarray(backend_name, _ZS)
     ref = numpy.asarray(pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(pot.Rforce(R, z))
+    got = as_numpy(pot.Rforce(R, z))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 

--- a/tests/test_backend_jeans.py
+++ b/tests/test_backend_jeans.py
@@ -30,18 +30,13 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from galpy.backend import as_numpy
 from galpy.df import jeans
 from galpy.potential import HernquistPotential
 
 
 def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
-
-
-def _np(x):
-    if torch is not None and torch.is_tensor(x):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
 
 
 def _is_backend_array(backend, x):
@@ -64,7 +59,7 @@ def test_jeans_parity(backend, fn):
         got = f(_HP, _arr(backend, r0), use_physical=False)
         assert _is_backend_array(backend, got)
         numpy.testing.assert_allclose(
-            _np(got), numpy.asarray(ref), rtol=1e-6, atol=1e-9
+            as_numpy(got), numpy.asarray(ref), rtol=1e-6, atol=1e-9
         )
 
 
@@ -79,7 +74,7 @@ def test_jeans_sigmar_callable_beta_parity(backend):
         got = jeans.sigmar(_HP, _arr(backend, r0), beta=beta, use_physical=False)
         assert _is_backend_array(backend, got)
         numpy.testing.assert_allclose(
-            _np(got), numpy.asarray(ref), rtol=1e-6, atol=1e-9
+            as_numpy(got), numpy.asarray(ref), rtol=1e-6, atol=1e-9
         )
 
 

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -38,6 +38,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import MiyamotoNagaiPotential, MultipoleExpansionPotential
 
 # This module manages backends explicitly (parametrizes over them), so it is
@@ -121,12 +122,6 @@ def _asarray(backend_name, x):
         return torch.tensor(x, dtype=torch.float64)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot):
@@ -139,7 +134,7 @@ def test_value_parity(backend_name, pot):
                 numpy.asarray(_RS), numpy.asarray(_ZS), numpy.asarray(_PHIS)
             )
         )
-        got = _tonumpy(getattr(pot, method)(R, z, phi))
+        got = as_numpy(getattr(pot, method)(R, z, phi))
         rtol = 1e-9 if method in _SECOND_ORDER else 1e-12
         numpy.testing.assert_allclose(
             got,
@@ -157,7 +152,7 @@ def test_value_parity_scalar(backend_name, pot):
     for method in _FIRST_ORDER + _SECOND_ORDER:
         ref = float(numpy.asarray(getattr(pot, method)(1.3, 0.4, 0.7)))
         got = float(
-            _tonumpy(
+            as_numpy(
                 getattr(pot, method)(
                     _asarray(backend_name, 1.3),
                     _asarray(backend_name, 0.4),
@@ -180,7 +175,7 @@ def test_public_value_parity(backend_name, pot):
     ref = numpy.asarray(
         pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS), phi=numpy.asarray(_PHIS))
     )
-    got = _tonumpy(pot.Rforce(R, z, phi=phi))
+    got = as_numpy(pot.Rforce(R, z, phi=phi))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -403,7 +398,7 @@ def test_tdep_value_parity(backend_name, pot):
                     numpy.asarray(_RS), numpy.asarray(_ZS), numpy.asarray(_PHIS), t
                 )
             )
-            got = _tonumpy(getattr(pot, method)(R, z, phi, t))
+            got = as_numpy(getattr(pot, method)(R, z, phi, t))
             numpy.testing.assert_allclose(
                 got,
                 ref,
@@ -422,7 +417,7 @@ def test_tdep_array_t_broadcast(backend_name, pot):
     ref = numpy.asarray(
         pot._evaluate(numpy.asarray(_RS), numpy.asarray(_ZS), numpy.asarray(_PHIS), ts)
     )
-    got = _tonumpy(
+    got = as_numpy(
         pot._evaluate(
             _asarray(backend_name, _RS),
             _asarray(backend_name, _ZS),
@@ -442,7 +437,7 @@ def test_tdep_center(backend_name, pot):
     t0 = 1.21
     ref = float(numpy.asarray(pot._evaluate(0.0, 0.0, 0.3, t0)))
     got = float(
-        _tonumpy(
+        as_numpy(
             pot._evaluate(
                 _asarray(backend_name, 0.0),
                 _asarray(backend_name, 0.0),
@@ -454,7 +449,7 @@ def test_tdep_center(backend_name, pot):
     numpy.testing.assert_allclose(got, ref, rtol=1e-12)
     for meth in ["_Rforce", "_zforce", "_phitorque", "_R2deriv"]:
         val = float(
-            _tonumpy(
+            as_numpy(
                 getattr(pot, meth)(
                     _asarray(backend_name, 0.0),
                     _asarray(backend_name, 0.0),

--- a/tests/test_backend_namespaces.py
+++ b/tests/test_backend_namespaces.py
@@ -1,0 +1,57 @@
+###############################################################################
+# test_backend_namespaces.py: focused coverage for galpy.backend.as_numpy, the
+# GPU-safe backend->numpy converter that the test suite shares for value
+# assertions (it replaced ~18 duplicated per-file _tonumpy/_np/_to_numpy
+# helpers). The torch branch (.detach().cpu().numpy()) is production code, so it
+# is exercised here explicitly since the backend-tests CI job uploads no
+# coverage. The numpy path is unaffected (as_numpy is the identity on numpy
+# arrays and python scalars).
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+_SRC = [1.0, 2.5, -3.0, 4.25]
+
+
+def test_as_numpy_passthrough_numpy_and_scalars():
+    # A numpy input is returned unchanged (identity, not a copy), so the numpy
+    # path stays byte-identical; python scalars pass through unchanged too.
+    a = numpy.asarray(_SRC)
+    assert as_numpy(a) is a
+    assert as_numpy(3.5) == 3.5
+    assert as_numpy(7) == 7
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_as_numpy_roundtrip(backend):
+    src = numpy.asarray(_SRC)
+    if backend == "jax":
+        x = jnp.asarray(_SRC)
+    else:  # torch: a grad-tracking tensor exercises the .detach() branch
+        x = torch.tensor(_SRC, requires_grad=True)
+    out = as_numpy(x)
+    assert isinstance(out, numpy.ndarray)
+    numpy.testing.assert_allclose(out, src)

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -9,6 +9,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 pytestmark = pytest.mark.backend_managed
 
 BACKENDS = []
@@ -53,12 +55,6 @@ def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
 
 
-def _np(x):
-    if torch is not None and torch.is_tensor(x):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
-
-
 def _integ(backend, pot, vxvv, ts, method):
     if backend == "jax":
         from galpy.backend._jax.orbit_stm import integrate
@@ -80,7 +76,7 @@ def test_forward_matches_c(backend, method):
         ref = numpy.array(
             [o.R(_TS), o.vR(_TS), o.vT(_TS), o.z(_TS), o.vz(_TS), o.phi(_TS)]
         ).T
-        got = _np(_integ(backend, pot, _arr(backend, _IC), _TS, method))
+        got = as_numpy(_integ(backend, pot, _arr(backend, _IC), _TS, method))
         # the wrapper's forward is the dxdv variant of the C integrator; for the
         # fixed-step methods its shared 12-D step sequence differs from base-only
         # Orbit.integrate at the integrator level (~1e-8), 1e-12 for dop853_c.
@@ -112,11 +108,11 @@ def test_grad_final_R_vs_fd(backend):
         g = jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
             jnp.asarray(_IC)
         )
-        g = _np(g)
+        g = as_numpy(g)
     else:
         v = torch.tensor(_IC, requires_grad=True)
         _integ("torch", pot, v, _TS, "dop853_c")[-1, 0].backward()
-        g = _np(v.grad)
+        g = as_numpy(v.grad)
     numpy.testing.assert_allclose(g, gfd, rtol=1e-4, atol=1e-5)
 
 
@@ -129,7 +125,7 @@ def test_jacrev_equals_stm(method):
     pot = MiyamotoNagaiPotential(normalize=1.0)
     _, M = c_stm_forward(pot, _IC, _TS, method, 1e-10, 1e-10)
     Jall = jax.jacrev(lambda v: _integ("jax", pot, v, _TS, method))(jnp.asarray(_IC))
-    numpy.testing.assert_allclose(_np(Jall), M, rtol=1e-10, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(Jall), M, rtol=1e-10, atol=1e-10)
 
 
 # ----------------------------------------------------------------- torch gradcheck
@@ -165,7 +161,9 @@ def test_cstm_grad_matches_inbackend_ode(backend):
         v2 = torch.tensor(_IC, requires_grad=True)
         integrate_orbit(pot, v2, torch.tensor(_TS))[-1, 0].backward()
         g_ode = v2.grad
-    numpy.testing.assert_allclose(_np(g_stm), _np(g_ode), rtol=1e-5, atol=1e-6)
+    numpy.testing.assert_allclose(
+        as_numpy(g_stm), as_numpy(g_ode), rtol=1e-5, atol=1e-6
+    )
 
 
 # --------------------------------------------------------- cross-backend agreement
@@ -174,14 +172,14 @@ def test_cstm_grad_matches_inbackend_ode(backend):
 )
 def test_torch_grad_matches_jax():
     pot = MiyamotoNagaiPotential(normalize=1.0)
-    g_jax = _np(
+    g_jax = as_numpy(
         jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
             jnp.asarray(_IC)
         )
     )
     v = torch.tensor(_IC, requires_grad=True)
     _integ("torch", pot, v, _TS, "dop853_c")[-1, 0].backward()
-    numpy.testing.assert_allclose(_np(v.grad), g_jax, rtol=1e-8, atol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(v.grad), g_jax, rtol=1e-8, atol=1e-10)
 
 
 # -------------------------------------------------------------- batch / vmap (jax)
@@ -192,7 +190,7 @@ def test_batch_and_vmap():
     batch = _integ("jax", pot, ics, _TS, "dop853_c")
     assert batch.shape == (3, len(_TS), 6)
     vm = jax.vmap(lambda v: _integ("jax", pot, v, _TS, "dop853_c"))(ics)
-    numpy.testing.assert_allclose(_np(batch), _np(vm), rtol=1e-10, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(batch), as_numpy(vm), rtol=1e-10, atol=1e-12)
 
 
 # ---------------------------------------------------------------- numpy IC raises
@@ -223,8 +221,8 @@ def test_integrate_stm_dispatch(backend):
 
     pot = MiyamotoNagaiPotential(normalize=1.0)
     v = _arr(backend, _IC)
-    got = _np(integrate_stm(pot, v, _TS, method="dop853_c"))
-    ref = _np(_integ(backend, pot, v, _TS, "dop853_c"))
+    got = as_numpy(integrate_stm(pot, v, _TS, method="dop853_c"))
+    ref = as_numpy(_integ(backend, pot, v, _TS, "dop853_c"))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-12)
 
 
@@ -236,7 +234,7 @@ def test_batch_gradient_matches_single(backend):
     pot = MiyamotoNagaiPotential(normalize=1.0)
     ics = numpy.stack([_IC, _IC * 1.01, _IC * 0.99])
     if backend == "jax":
-        gb = _np(
+        gb = as_numpy(
             jax.grad(
                 lambda vv: _integ("jax", pot, vv, _TS, "dop853_c")[:, -1, 0].sum()
             )(jnp.asarray(ics))
@@ -244,10 +242,10 @@ def test_batch_gradient_matches_single(backend):
     else:
         v = torch.tensor(ics, requires_grad=True)
         _integ("torch", pot, v, _TS, "dop853_c")[:, -1, 0].sum().backward()
-        gb = _np(v.grad)
+        gb = as_numpy(v.grad)
     for j, ic in enumerate(ics):
         if backend == "jax":
-            gj = _np(
+            gj = as_numpy(
                 jax.grad(lambda v: _integ("jax", pot, v, _TS, "dop853_c")[-1, 0])(
                     jnp.asarray(ic)
                 )
@@ -255,7 +253,7 @@ def test_batch_gradient_matches_single(backend):
         else:
             vv = torch.tensor(ic, requires_grad=True)
             _integ("torch", pot, vv, _TS, "dop853_c")[-1, 0].backward()
-            gj = _np(vv.grad)
+            gj = as_numpy(vv.grad)
         numpy.testing.assert_allclose(gb[j], gj, rtol=1e-8, atol=1e-10)
 
 
@@ -291,7 +289,7 @@ def test_orbit_integrate_cstm_forward_parity(backend, method):
             val = getattr(o, acc)(ts, use_physical=False)
             assert _is_backend(backend, val), f"{name}.{acc} left {backend}"
             numpy.testing.assert_allclose(
-                _np(val),
+                as_numpy(val),
                 numpy.asarray(getattr(onp, acc)(_TS, use_physical=False)),
                 rtol=1e-5,
                 atol=1e-6,
@@ -330,9 +328,9 @@ def test_orbit_integrate_cstm_full_ic_jacobian_vs_fd(backend):
         return o.getOrbit()[-1]
 
     if backend == "jax":
-        jac = _np(jax.jacrev(final_b)(jnp.asarray(_IC)))
+        jac = as_numpy(jax.jacrev(final_b)(jnp.asarray(_IC)))
     else:
-        jac = _np(torch.autograd.functional.jacobian(final_b, torch.tensor(_IC)))
+        jac = as_numpy(torch.autograd.functional.jacobian(final_b, torch.tensor(_IC)))
     numpy.testing.assert_allclose(jac, jfd, rtol=1e-4, atol=1e-5)
 
 
@@ -366,11 +364,11 @@ def test_orbit_integrate_cstm_grad_accessor_vs_fd(backend, acc):
             return getattr(o, acc)(use_physical=False)
 
         if backend == "jax":
-            g = _np(jax.grad(f_b)(jnp.asarray(_IC)))
+            g = as_numpy(jax.grad(f_b)(jnp.asarray(_IC)))
         else:
             v = torch.tensor(_IC, requires_grad=True)
             f_b(v).backward()
-            g = _np(v.grad)
+            g = as_numpy(v.grad)
         numpy.testing.assert_allclose(
             g, gfd, rtol=1e-4, atol=1e-5, err_msg=f"{acc} {backend}"
         )
@@ -385,11 +383,11 @@ def test_orbit_integrate_cstm_matches_functional(backend):
     pot = MiyamotoNagaiPotential(normalize=1.0)
     o = Orbit(_arr(backend, _IC))
     o.integrate(_arr(backend, _TS), pot, method="dop853_c")
-    func = _np(_integ(backend, pot, _arr(backend, _IC), _TS, "dop853_c"))  # (nt,6)
+    func = as_numpy(_integ(backend, pot, _arr(backend, _IC), _TS, "dop853_c"))  # (nt,6)
     # identical wrapper -> identical to ~roundoff (backend-vs-numpy ts in the
     # internal numpy.asarray gives a sub-1e-11 delta; a different path would
     # differ by >>1e-9).
-    numpy.testing.assert_allclose(_np(o.getOrbit()), func, rtol=1e-9, atol=1e-9)
+    numpy.testing.assert_allclose(as_numpy(o.getOrbit()), func, rtol=1e-9, atol=1e-9)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -408,7 +406,7 @@ def test_orbit_integrate_cstm_fallback_inbackend(backend):
     onp = Orbit(list(ic5))
     onp.integrate(_TS, pot, method="dop853_c")
     numpy.testing.assert_allclose(
-        _np(o5.R(_arr(backend, _TS), use_physical=False)),
+        as_numpy(o5.R(_arr(backend, _TS), use_physical=False)),
         onp.R(_TS, use_physical=False),
         rtol=1e-6,
         atol=1e-6,
@@ -420,11 +418,11 @@ def test_orbit_integrate_cstm_fallback_inbackend(backend):
         return o.R(_arr(backend, _TS), use_physical=False)[-1]
 
     if backend == "jax":
-        g = _np(jax.grad(fR)(jnp.asarray(ic5)))[1]
+        g = as_numpy(jax.grad(fR)(jnp.asarray(ic5)))[1]
     else:
         v = torch.tensor(ic5, requires_grad=True)
         fR(v).backward()
-        g = _np(v.grad)[1]
+        g = as_numpy(v.grad)[1]
     assert numpy.isfinite(g)
 
 
@@ -439,13 +437,13 @@ def test_orbit_integrate_cstm_multiorbit_matches_loop(backend):
     ts = _arr(backend, _TS)
     om = Orbit(_arr(backend, ics))
     om.integrate(ts, pot, method="dop853_c")
-    multi = _np(om.getOrbit())
+    multi = as_numpy(om.getOrbit())
     assert multi.shape == (len(ics), len(_TS), 6)
     for k in range(len(ics)):
         ok = Orbit(_arr(backend, ics[k]))
         ok.integrate(ts, pot, method="dop853_c")
         numpy.testing.assert_allclose(
-            multi[k], _np(ok.getOrbit()), rtol=1e-12, atol=1e-12
+            multi[k], as_numpy(ok.getOrbit()), rtol=1e-12, atol=1e-12
         )
 
 
@@ -465,7 +463,7 @@ def test_orbit_integrate_cstm_multiorbit_grad():
         o.integrate(jnp.asarray(_TS), pot, method="dop853_c")
         return o.getOrbit()[:, -1, :]
 
-    Jb = _np(jax.jacrev(final_batch)(ics))  # (N, 6, N, 6)
+    Jb = as_numpy(jax.jacrev(final_batch)(ics))  # (N, 6, N, 6)
 
     def final_single(v6):
         o = Orbit(v6)
@@ -476,7 +474,7 @@ def test_orbit_integrate_cstm_multiorbit_grad():
         for j in range(N):
             if i != j:
                 assert numpy.max(numpy.abs(Jb[i, :, j, :])) == 0.0  # independent
-        Js = _np(jax.jacrev(final_single)(ics[i]))  # (6, 6)
+        Js = as_numpy(jax.jacrev(final_single)(ics[i]))  # (6, 6)
         numpy.testing.assert_allclose(Jb[i, :, i, :], Js, rtol=1e-10, atol=1e-12)
 
 
@@ -506,7 +504,7 @@ def test_orbit_integrate_cstm_numpy_times(backend):
     onp = Orbit(list(_IC))
     onp.integrate(_TS, pot, method="dop853_c")
     numpy.testing.assert_allclose(
-        _np(o.getOrbit()), onp.getOrbit(), rtol=1e-6, atol=1e-7
+        as_numpy(o.getOrbit()), onp.getOrbit(), rtol=1e-6, atol=1e-7
     )
 
 

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -23,6 +23,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import SCFPotential
 
 # This module manages backends explicitly (parametrizes over them), so it is
@@ -106,12 +107,6 @@ def _asarray(backend_name, x):
         return torch.tensor(x, dtype=torch.float64)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("name,pot", CASES, ids=CASE_IDS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity_array(backend_name, name, pot):
@@ -121,7 +116,7 @@ def test_value_parity_array(backend_name, name, pot):
     for mname in METHODS:
         method = getattr(pot, mname)
         ref = numpy.asarray(method(_RS, _ZS, _PHIS))
-        got = _tonumpy(method(R, z, phi))
+        got = as_numpy(method(R, z, phi))
         numpy.testing.assert_allclose(
             got,
             ref,
@@ -138,7 +133,7 @@ def test_value_parity_scalar(backend_name, name, pot):
         method = getattr(pot, mname)
         for R0, z0, phi0 in zip(_RS, _ZS, _PHIS):
             ref = numpy.asarray(method(R0, z0, phi0))
-            got = _tonumpy(
+            got = as_numpy(
                 method(
                     _asarray(backend_name, R0),
                     _asarray(backend_name, z0),
@@ -163,7 +158,7 @@ def test_public_value_parity(backend_name, name, pot):
     z = _asarray(backend_name, _ZS)
     phi = _asarray(backend_name, _PHIS)
     ref = numpy.asarray(pot.Rforce(_RS, _ZS, phi=_PHIS))
-    got = _tonumpy(pot.Rforce(R, z, phi=phi))
+    got = as_numpy(pot.Rforce(R, z, phi=phi))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -290,7 +285,7 @@ def test_centre_and_infinity_parity(backend_name, name, pot):
     # potential at the centre is finite (the -CC/a limit of _phiTilde)
     ref0 = float(pot._evaluate(0.0, 0.0, 0.3))
     got0 = float(
-        _tonumpy(
+        as_numpy(
             pot._evaluate(
                 _asarray(backend_name, 0.0),
                 _asarray(backend_name, 0.0),
@@ -302,7 +297,7 @@ def test_centre_and_infinity_parity(backend_name, name, pot):
     numpy.testing.assert_allclose(got0, ref0, rtol=1e-12, atol=1e-14)
     # potential at infinity -> 0, through the xi = 1 guard of _RToxi
     gotinf = float(
-        _tonumpy(
+        as_numpy(
             pot._evaluate(
                 _asarray(backend_name, numpy.inf),
                 _asarray(backend_name, 0.0),
@@ -314,7 +309,7 @@ def test_centre_and_infinity_parity(backend_name, name, pot):
     # second derivatives at the centre are defined to be 0 (numpy convention)
     refc = float(pot._R2deriv(0.0, 0.0, 0.3))
     gotc = float(
-        _tonumpy(
+        as_numpy(
             pot._R2deriv(
                 _asarray(backend_name, 0.0),
                 _asarray(backend_name, 0.0),

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -12,6 +12,7 @@ import numpy
 import pytest
 import scipy.special as scipy_special
 
+from galpy.backend import as_numpy
 from galpy.backend import special as gsp
 from galpy.backend.special._router import (
     _NATIVE_MISSING,
@@ -50,12 +51,6 @@ def _asarray(backend, x, requires_grad=False):
     return torch.tensor(x, dtype=torch.float64, requires_grad=requires_grad)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 # (router fn, scipy fn, n-args, sample points). Ranges cover what galpy uses.
 _POS = numpy.array([0.1, 0.5, 0.9, 1.3, 2.0, 3.7, 5.0])
 _REAL = numpy.array([-3.0, -1.2, -0.3, 0.0, 0.4, 1.1, 2.5])
@@ -77,7 +72,7 @@ UNARY = [
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_unary_value_parity(backend, name, fn, sp_fn, pts):
     ref = sp_fn(pts)
-    got = _tonumpy(fn(_asarray(backend, pts)))
+    got = as_numpy(fn(_asarray(backend, pts)))
     rtol = 0.0 if backend == "numpy" else 1e-12  # numpy must be byte-identical
     numpy.testing.assert_allclose(
         got, ref, rtol=rtol, atol=1e-12, err_msg=f"{name} ({backend})"
@@ -92,7 +87,7 @@ def test_gammainc_value_parity(backend):
     ]:
         for a in _A:
             ref = sp_fn(a, _XG)
-            got = _tonumpy(fn(_asarray(backend, a), _asarray(backend, _XG)))
+            got = as_numpy(fn(_asarray(backend, a), _asarray(backend, _XG)))
             rtol = 0.0 if backend == "numpy" else 1e-12
             numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -102,7 +97,7 @@ def test_xlogy_value_parity_incl_zero(backend):
     x = numpy.array([0.0, 0.0, 1.0, 2.5, 0.3])
     y = numpy.array([0.0, 5.0, 2.0, 0.7, 10.0])  # x=0 -> 0 even when y=0
     ref = scipy_special.xlogy(x, y)
-    got = _tonumpy(gsp.xlogy(_asarray(backend, x), _asarray(backend, y)))
+    got = as_numpy(gsp.xlogy(_asarray(backend, x), _asarray(backend, y)))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -113,7 +108,7 @@ def test_logsumexp_value_parity(backend):
     a = numpy.array([[-1.2, 0.3, 800.0, -800.0], [0.5, 2.0, 799.0, 0.0]])
     for axis in (0, 1, None):
         ref = scipy_special.logsumexp(a, axis=axis)
-        got = _tonumpy(gsp.logsumexp(_asarray(backend, a), axis=axis))
+        got = as_numpy(gsp.logsumexp(_asarray(backend, a), axis=axis))
         rtol = 0.0 if backend == "numpy" else 1e-12
         numpy.testing.assert_allclose(
             got, ref, rtol=rtol, atol=1e-12, err_msg=f"logsumexp axis={axis}"
@@ -198,7 +193,7 @@ def test_iv_value_parity(backend):
     pts = numpy.array([0.0, 1e-3, 1e-2, 0.3, 0.8, 1.5, 2.0, 2.5, 3.5, 5.0, 30.0])
     for n in (0, 1, 2):
         ref = scipy_special.iv(n, pts)
-        got = _tonumpy(gsp.iv(n, _asarray(backend, pts)))
+        got = as_numpy(gsp.iv(n, _asarray(backend, pts)))
         rtol = 0.0 if backend == "numpy" else 1e-10  # series/recurrence ~1e-15
         numpy.testing.assert_allclose(
             got, ref, rtol=rtol, atol=1e-12, err_msg=f"iv n={n} ({backend})"
@@ -209,7 +204,7 @@ def test_iv_value_parity(backend):
 def test_iv_zero_value_and_grad_finite(backend):
     # I_n(0)=0 for n>=2 and I_n'(0)=0: the upward recurrence divides by x, so
     # x=0 must be handled (no NaN in value OR reverse-mode gradient).
-    assert _tonumpy(gsp.iv(2, _asarray(backend, 0.0))) == 0.0
+    assert as_numpy(gsp.iv(2, _asarray(backend, 0.0))) == 0.0
     if backend == "jax":
         g = float(jax.grad(lambda x: gsp.iv(2, x))(jnp.asarray(0.0)))
     else:
@@ -238,7 +233,7 @@ def test_sici_value_parity(backend):
     pts = numpy.array([0.2, 0.8, 2.0, 5.0, 7.0, 20.0, 80.0])
     rsi, rci = scipy_special.sici(pts)
     si, ci = gsp.sici(_asarray(backend, pts))
-    si, ci = _tonumpy(si), _tonumpy(ci)
+    si, ci = as_numpy(si), as_numpy(ci)
     rtol = 0.0 if backend == "numpy" else 1e-10
     numpy.testing.assert_allclose(
         si, rsi, rtol=rtol, atol=1e-11, err_msg=f"Si ({backend})"
@@ -285,7 +280,7 @@ _HYP2F1_W = numpy.array([0.0, 1e-3, 0.05, 0.5, 0.9, 1.0, 1.7, 5.0, 12.0, 25.0, 5
 def test_hyp2f1_value_parity(backend, a, b, c):
     z = -_HYP2F1_W
     ref = scipy_special.hyp2f1(a, b, c, z)
-    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
     rtol = 0.0 if backend == "numpy" else 1e-9  # fallback quadrature at r/a<~50
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
 
@@ -297,7 +292,7 @@ def test_hyp2f1_extreme_z_bounded_error(backend, a, b, c):
     # degrades gracefully -- still ~1e-5, never diverges (unlike jax native).
     z = -numpy.array([100.0, 250.0, 500.0])
     ref = scipy_special.hyp2f1(a, b, c, z)
-    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-8)
 
 
@@ -307,7 +302,7 @@ def test_hyp1f1_value_parity(backend):
         a, b = 1.5 - alpha / 2.0, 2.5 - alpha / 2.0
         X = numpy.array([0.0, 1e-3, 0.1, 1.0, 4.0, 16.0, 64.0, 256.0])
         ref = scipy_special.hyp1f1(a, b, -X)
-        got = _tonumpy(gsp.hyp1f1(a, b, _asarray(backend, -X)))
+        got = as_numpy(gsp.hyp1f1(a, b, _asarray(backend, -X)))
         rtol = 0.0 if backend == "numpy" else 1e-9  # b=a+1 -> exact via gammainc
         numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
 
@@ -320,7 +315,7 @@ def test_elliptic_value_parity(backend):
         (gsp.ellipe, scipy_special.ellipe),
     ]:
         ref = sp_fn(m)
-        got = _tonumpy(fn(_asarray(backend, m)))
+        got = as_numpy(fn(_asarray(backend, m)))
         rtol = 0.0 if backend == "numpy" else 1e-12  # AGM is ~1e-15
         numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-12)
 
@@ -376,7 +371,7 @@ def test_gamma_fallback_agrees_and_no_nan_grad(backend):
     # Exercises the pure-backend gamma fallback (torch); on jax it routes native,
     # but we still check parity + finite gradient across the reflection at x<0.
     pts = _GAMMA_X
-    got = _tonumpy(gsp.gamma(_asarray(backend, pts)))
+    got = as_numpy(gsp.gamma(_asarray(backend, pts)))
     numpy.testing.assert_allclose(got, scipy_special.gamma(pts), rtol=1e-11, atol=1e-11)
     # gradient at a negative non-integer (reflection branch) must be finite + correct
     x0 = -1.5
@@ -411,7 +406,7 @@ def test_xlogy_fallback_direct(backend):
     x = numpy.array([0.0, 0.0, 1.0, 2.5, 0.3])
     y = numpy.array([0.0, 5.0, 2.0, 0.7, 10.0])
     ref = scipy_special.xlogy(x, y)
-    got = _tonumpy(
+    got = as_numpy(
         xlogy_fallback(_ns(backend), _asarray(backend, x), _asarray(backend, y))
     )
     numpy.testing.assert_allclose(got, ref, rtol=1e-13, atol=1e-13)
@@ -425,7 +420,7 @@ def test_hyp2f1_fallback_alt_labeling(backend):
     a, b, c = 2.0, 0.8, 2.5  # c-a=0.5 (<1), c-b=1.7 (>=1) -> labeling picks b
     z = -numpy.array([0.0, 0.1, 1.0, 5.0, 30.0])
     ref = scipy_special.hyp2f1(a, b, c, z)
-    got = _tonumpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=1e-8)
 
 
@@ -456,7 +451,7 @@ def test_bessel_k_value_parity(backend):
         ("k1", gsp.k1, scipy_special.k1),
     ]:
         ref = sp_fn(x)
-        got = _tonumpy(fn(_asarray(backend, x)))
+        got = as_numpy(fn(_asarray(backend, x)))
         rtol = 0.0 if backend == "numpy" else 1e-12  # series + scaled-trapezoid
         numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13, err_msg=name)
 
@@ -468,7 +463,7 @@ def test_bessel_kn_value_parity(backend):
     x = _BESSEL_X
     for n in (0, 1, 2, 3, 5):
         ref = scipy_special.kn(n, x)
-        got = _tonumpy(gsp.kn(n, _asarray(backend, x)))
+        got = as_numpy(gsp.kn(n, _asarray(backend, x)))
         rtol = 0.0 if backend == "numpy" else 1e-11  # recurrence amplifies a touch
         numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13, err_msg=f"kn{n}")
 
@@ -525,13 +520,13 @@ def test_assoc_legendre_value_parity(backend):
     ref = _scipy_assoc_ref(L, M, x, 2)  # P, dP/dx, d2P/dx2
     P, dP, d2 = gsp.assoc_legendre(L, M, _asarray(backend, x), deriv=2)
     if backend == "numpy":  # numpy must be byte-identical to scipy
-        assert numpy.array_equal(_tonumpy(P), ref[0])
-        assert numpy.array_equal(_tonumpy(dP), ref[1])
-        assert numpy.array_equal(_tonumpy(d2), ref[2])
+        assert numpy.array_equal(as_numpy(P), ref[0])
+        assert numpy.array_equal(as_numpy(dP), ref[1])
+        assert numpy.array_equal(as_numpy(d2), ref[2])
     else:
         for got, r, nm in [(P, ref[0], "P"), (dP, ref[1], "dP"), (d2, ref[2], "d2P")]:
             numpy.testing.assert_allclose(
-                _tonumpy(got), r, rtol=1e-11, atol=1e-11, err_msg=nm
+                as_numpy(got), r, rtol=1e-11, atol=1e-11, err_msg=nm
             )
 
 
@@ -540,9 +535,9 @@ def test_assoc_legendre_value_only_and_shape(backend):
     L, M = 5, 3
     x = numpy.array([0.3, -0.4])
     P = gsp.assoc_legendre(L, M, _asarray(backend, x))  # deriv=0 -> just P
-    assert tuple(_tonumpy(P).shape) == (2, L, M)
+    assert tuple(as_numpy(P).shape) == (2, L, M)
     numpy.testing.assert_allclose(
-        _tonumpy(P), _scipy_assoc_ref(L, M, x, 0)[0], rtol=1e-11, atol=1e-11
+        as_numpy(P), _scipy_assoc_ref(L, M, x, 0)[0], rtol=1e-11, atol=1e-11
     )
 
 
@@ -552,7 +547,7 @@ def test_assoc_legendre_autodiff_matches_analytic(backend):
     L, M = 6, 4
     x0 = 0.4
     _, dP_an = gsp.assoc_legendre(L, M, _asarray(backend, x0), deriv=1)
-    dP_an = _tonumpy(dP_an)
+    dP_an = as_numpy(dP_an)
     for ll, mm in [(3, 2), (5, 1), (4, 0), (5, 3)]:
         if backend == "jax":
             g = float(
@@ -575,7 +570,7 @@ def test_gegenbauer_value_parity(backend):
     N = 8
     x = numpy.array([-0.9, -0.3, 0.0, 0.4, 0.95])
     for alpha in (1.5, 3.5, 2 * 3 + 1.5):  # SCF uses alpha = 2l + 3/2
-        got = _tonumpy(gsp.gegenbauer(N, alpha, _asarray(backend, x)))
+        got = as_numpy(gsp.gegenbauer(N, alpha, _asarray(backend, x)))
         assert got.shape == x.shape + (N,)
         for n in range(N):
             ref = scipy_special.eval_gegenbauer(n, alpha, x)
@@ -614,7 +609,7 @@ def test_assoc_legendre_pole_derivs(backend):
     for xv in (1.0, -1.0):
         _, rdP, rd2 = gsp.assoc_legendre(L, M, numpy.asarray(xv), deriv=2)
         _, gdP, gd2 = gsp.assoc_legendre(L, M, _asarray(backend, xv), deriv=2)
-        gdP, gd2 = _tonumpy(gdP)[..., 0], _tonumpy(gd2)[..., 0]
+        gdP, gd2 = as_numpy(gdP)[..., 0], as_numpy(gd2)[..., 0]
         assert not numpy.any(numpy.isnan(gdP)) and not numpy.any(numpy.isnan(gd2))
         numpy.testing.assert_allclose(gdP, rdP[..., 0], rtol=1e-10, atol=1e-12)
         numpy.testing.assert_allclose(gd2, rd2[..., 0], rtol=1e-10, atol=1e-12)
@@ -637,7 +632,7 @@ def test_scf_spherical_zaxis_forces_finite():
         for z in (1.5, -1.5):
             ref = float(getattr(scf, meth)(0.0, z))
             for backend in AD_BACKENDS:
-                got = _tonumpy(
+                got = as_numpy(
                     getattr(scf, meth)(_asarray(backend, 0.0), _asarray(backend, z))
                 )
                 assert numpy.isfinite(got), f"{meth}(0,{z}) {backend} not finite"
@@ -653,10 +648,10 @@ def test_ellipk_ellipe_negative_m_and_unit(backend):
         (gsp.ellipk, scipy_special.ellipk),
         (gsp.ellipe, scipy_special.ellipe),
     ):
-        got = _tonumpy(fn(_asarray(backend, m)))
+        got = as_numpy(fn(_asarray(backend, m)))
         numpy.testing.assert_allclose(got, sp_fn(m), rtol=rtol, atol=1e-12)
-    assert numpy.isinf(_tonumpy(gsp.ellipk(_asarray(backend, 1.0))))
-    numpy.testing.assert_allclose(_tonumpy(gsp.ellipe(_asarray(backend, 1.0))), 1.0)
+    assert numpy.isinf(as_numpy(gsp.ellipk(_asarray(backend, 1.0))))
+    numpy.testing.assert_allclose(as_numpy(gsp.ellipe(_asarray(backend, 1.0))), 1.0)
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)
@@ -678,11 +673,11 @@ def test_gamma_negative_integer_poles_nan(backend):
     # Gamma at -1, -2, ... is nan (scipy), not a huge finite reflection value;
     # Gamma(0) is +inf (a distinct scipy convention).
     for x in (-1.0, -2.0, -3.0):
-        assert numpy.isnan(_tonumpy(gsp.gamma(_asarray(backend, x))))
-    assert numpy.isinf(_tonumpy(gsp.gamma(_asarray(backend, 0.0))))
+        assert numpy.isnan(as_numpy(gsp.gamma(_asarray(backend, x))))
+    assert numpy.isinf(as_numpy(gsp.gamma(_asarray(backend, 0.0))))
     xs = numpy.array([-2.5, -1.5, -0.5, 0.5, 2.5, 6.0])  # off-pole unchanged
     numpy.testing.assert_allclose(
-        _tonumpy(gsp.gamma(_asarray(backend, xs))), scipy_special.gamma(xs), rtol=1e-10
+        as_numpy(gsp.gamma(_asarray(backend, xs))), scipy_special.gamma(xs), rtol=1e-10
     )
 
 

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -22,6 +22,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
 from galpy.potential import (
     BurkertPotential,
     DehnenCoreSphericalPotential,
@@ -210,12 +211,6 @@ def _asarray(backend_name, x):
         return torch.tensor(x, dtype=torch.float64)
 
 
-def _tonumpy(x):
-    if torch is not None and isinstance(x, torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
-
-
 @pytest.mark.parametrize("pot,methods,_methods1d,_ad", CASES, ids=CASE_IDS)
 @pytest.mark.parametrize("backend_name", BACKENDS)
 def test_value_parity(backend_name, pot, methods, _methods1d, _ad):
@@ -225,7 +220,7 @@ def test_value_parity(backend_name, pot, methods, _methods1d, _ad):
         ref = numpy.asarray(
             getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS))
         )
-        got = _tonumpy(getattr(pot, method)(R, z))
+        got = as_numpy(getattr(pot, method)(R, z))
         numpy.testing.assert_allclose(
             got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{type(pot).__name__}.{method}"
         )
@@ -242,7 +237,7 @@ def test_public_value_parity(backend_name, pot, methods, _methods1d, _ad):
     R = _asarray(backend_name, _RS)
     z = _asarray(backend_name, _ZS)
     ref = numpy.asarray(pot.Rforce(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    got = _tonumpy(pot.Rforce(R, z))
+    got = as_numpy(pot.Rforce(R, z))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 
 
@@ -398,7 +393,7 @@ def test_surfdens_value_parity(backend_name, pot):
     Rs = [0.5, 0.9 * a, a, 1.3 * a, 2.0]
     zs = [0.3, 0.2, 0.4, 0.2, 0.3]
     ref = numpy.asarray(pot._surfdens(numpy.asarray(Rs), numpy.asarray(zs)))
-    got = _tonumpy(
+    got = as_numpy(
         pot._surfdens(_asarray(backend_name, Rs), _asarray(backend_name, zs))
     )
     numpy.testing.assert_allclose(
@@ -414,7 +409,7 @@ def test_surfdens_edge_finite(backend_name, pot):
     a = pot.a
     ref = float(numpy.asarray(pot._surfdens(numpy.asarray(a), numpy.asarray(0.3))))
     got = float(
-        _tonumpy(pot._surfdens(_asarray(backend_name, a), _asarray(backend_name, 0.3)))
+        as_numpy(pot._surfdens(_asarray(backend_name, a), _asarray(backend_name, 0.3)))
     )
     assert numpy.isfinite(ref)
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
@@ -469,11 +464,11 @@ def test_powerspherical_wcutoff_dens_parity(backend_name):
     Rs = [0.5, 1.0, 2.0]
     zs = [0.1, 0.2, 0.3]
     ref = numpy.asarray(pot._dens(numpy.asarray(Rs), numpy.asarray(zs)))
-    got = _tonumpy(pot._dens(_asarray(backend_name, Rs), _asarray(backend_name, zs)))
+    got = as_numpy(pot._dens(_asarray(backend_name, Rs), _asarray(backend_name, zs)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
     for method in ["_ddensdr", "_d2densdr2"]:
         ref = numpy.asarray(getattr(pot, method)(numpy.asarray(Rs)))
-        got = _tonumpy(getattr(pot, method)(_asarray(backend_name, Rs)))
+        got = as_numpy(getattr(pot, method)(_asarray(backend_name, Rs)))
         numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14, err_msg=method)
 
 
@@ -497,7 +492,7 @@ def test_surfdens_z0_value_parity(backend_name, pot):
     # z-guarded. The VALUE there is the generic branch's 0 and must be parity-
     # identical (and equal to numpy's 0) across backends, with no scalar crash.
     R0 = 0.6  # != a (== 1.1 for all cases)
-    val = _tonumpy(
+    val = as_numpy(
         pot._surfdens(_asarray(backend_name, R0), _asarray(backend_name, 0.0))
     )
     ref = numpy.asarray(pot._surfdens(numpy.asarray(R0), numpy.asarray(0.0)))
@@ -524,7 +519,7 @@ def test_einasto_revaluate_core_value_parity(backend_name, n):
     # grid including r == 0 (the guarded core branch) and generic points
     rs = [0.0, 0.5, 1.3]
     ref = numpy.asarray(pot._revaluate(numpy.asarray(rs)))
-    got = _tonumpy(pot._revaluate(_asarray(backend_name, rs)))
+    got = as_numpy(pot._revaluate(_asarray(backend_name, rs)))
     assert numpy.all(numpy.isfinite(ref))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
 

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -10,6 +10,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 pytestmark = pytest.mark.backend_managed
 
 BACKENDS = []
@@ -43,12 +45,6 @@ from galpy.potential import HernquistPotential
 
 def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
-
-
-def _np(x):
-    if torch is not None and torch.is_tensor(x):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
 
 
 def _is_backend_array(backend, x):
@@ -88,7 +84,7 @@ def test_fE_parity(backend):
     ref = _DF.fE(_EGRID)
     got = _DF.fE(_arr(backend, _EGRID))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -96,7 +92,7 @@ def test_fE_zero_edge(backend):
     # E == 0 exactly is 0/0 in the numpy arcsin term (masked there by a
     # historical row-quirk for 2-D grids); the backend branch implements the
     # correct fE -> 0 limit, NaN-free (special-fn edge testing)
-    got = _np(_DF.fE(_arr(backend, numpy.array([0.0, -0.0, -1e-300]))))
+    got = as_numpy(_DF.fE(_arr(backend, numpy.array([0.0, -0.0, -1e-300]))))
     assert numpy.all(got == 0.0)
 
 
@@ -106,10 +102,10 @@ def test_call_parity(backend):
     ref = _DF((_EGRID,))
     got = _DF((_arr(backend, _EGRID),))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
     # with (ignored) L: exercises the backend L-parse branch
     got = _DF((_arr(backend, _EGRID), _arr(backend, numpy.ones_like(_EGRID))))
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
     R = numpy.array([0.5, 1.1, 1.7, 2.9])
     vR = numpy.array([0.1, -0.2, 0.3, 0.0])
     vT = numpy.array([0.3, 0.5, 0.2, 0.4])
@@ -118,7 +114,7 @@ def test_call_parity(backend):
     ref = _DF(R, vR, vT, z, vz, numpy.zeros_like(R))
     got = _DF(*(_arr(backend, c) for c in (R, vR, vT, z, vz)))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -132,9 +128,9 @@ def test_moments_parity(backend):
         gotv = f(_arr(backend, _RS))
         assert _is_backend_array(backend, gotv)
         numpy.testing.assert_allclose(got, ref, rtol=1e-8)
-        numpy.testing.assert_allclose(_np(gotv), ref, rtol=1e-8)
+        numpy.testing.assert_allclose(as_numpy(gotv), ref, rtol=1e-8)
     b = _DF.beta(_arr(backend, 1.3))
-    assert float(_np(b)) == pytest.approx(0.0, abs=1e-12)
+    assert float(as_numpy(b)) == pytest.approx(0.0, abs=1e-12)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -143,9 +139,9 @@ def test_dMdE_parity(backend):
     ref = _DF.dMdE(_ENEG)
     got = _DF.dMdE(_arr(backend, _ENEG))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-11)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-11)
     # out-of-bounds E -> exactly zero on the dead branch
-    assert numpy.all(_np(_DF.dMdE(_arr(backend, numpy.array([0.5])))) == 0.0)
+    assert numpy.all(as_numpy(_DF.dMdE(_arr(backend, numpy.array([0.5])))) == 0.0)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -159,7 +155,7 @@ def test_base_isotropic_dMdE_parity(backend):
     ref = isotropicsphericaldf._dMdE(dfh, _ENEG)
     got = isotropicsphericaldf._dMdE(dfh, _arr(backend, _ENEG))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-6)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -170,7 +166,7 @@ def test_base_anisotropic_vmomentdensity_parity(backend):
         ref = sphericaldf._vmomentdensity(adf, 1.3, n, m)
         got = sphericaldf._vmomentdensity(adf, _arr(backend, 1.3), n, m)
         assert _is_backend_array(backend, got)
-        numpy.testing.assert_allclose(_np(got), ref, rtol=1e-7)
+        numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-7)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -181,10 +177,10 @@ def test_base_anisotropic_dMdE_parity(backend):
     ref = anisotropicsphericaldf._dMdE(adf, _ENEG[::3])
     got = anisotropicsphericaldf._dMdE(adf, _arr(backend, _ENEG[::3]))
     assert _is_backend_array(backend, got)
-    numpy.testing.assert_allclose(_np(got), ref, rtol=1e-7)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-7)
     # and it agrees with the isotropic base-class machinery
     iso = isotropicsphericaldf._dMdE(isotropicHernquistdf(pot=_HP), _ENEG[::3])
-    numpy.testing.assert_allclose(_np(got), iso, rtol=1e-6)
+    numpy.testing.assert_allclose(as_numpy(got), iso, rtol=1e-6)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
@@ -334,4 +330,4 @@ def test_setup_rphi_interpolator_forced(backend):
     # and the frozen table evaluates natively on backend queries
     gb = got(_arr(backend, Es))
     assert _is_backend_array(backend, gb)
-    numpy.testing.assert_allclose(_np(gb), ref(Es), rtol=1e-10)
+    numpy.testing.assert_allclose(as_numpy(gb), ref(Es), rtol=1e-10)

--- a/tests/test_backend_surfacesigma.py
+++ b/tests/test_backend_surfacesigma.py
@@ -30,17 +30,12 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from galpy.backend import as_numpy
 from galpy.df.surfaceSigmaProfile import expSurfaceSigmaProfile
 
 
 def _arr(backend, x):
     return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
-
-
-def _np(x):
-    if torch is not None and torch.is_tensor(x):
-        return x.detach().cpu().numpy()
-    return numpy.asarray(x)
 
 
 def _is_backend_array(backend, x):
@@ -71,7 +66,7 @@ def test_surfaceSigmaProfile_parity(backend):
             if (name, lg) not in _SSP_R_INDEP:
                 assert _is_backend_array(backend, got)
             numpy.testing.assert_allclose(
-                _np(got), numpy.asarray(ref), rtol=1e-12, atol=1e-14
+                as_numpy(got), numpy.asarray(ref), rtol=1e-12, atol=1e-14
             )
 
 

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -15,23 +15,13 @@ try:
 except ImportError:
     _PYNBODY_LOADED = False
 from galpy import orbit, potential
+from galpy.backend import as_numpy
 from galpy.util import _rotate_to_arbitrary_vector, coords
 
 try:
     import torch as _torch
 except ImportError:
     _torch = None
-
-
-def _tonumpy(x):
-    # Route a (possibly forced-backend) potential OUTPUT through numpy before a
-    # numpy reduction (numpy.all/fabs/max/subtract). Identity on the numpy path
-    # (numpy.asarray of an ndarray is the same array), so numpy behavior is
-    # unchanged; detaches torch tensors that may carry grad. Mirrors the
-    # _tonumpy helper in tests/test_backend_*.py.
-    if _torch is not None and isinstance(x, _torch.Tensor):
-        return x.detach().numpy()
-    return numpy.asarray(x)
 
 
 # ---- Parametrization support: build per-test potential-name lists at module level ----
@@ -3863,7 +3853,7 @@ def test_vcirc_phi_axi():
     # One at a different radius
     R = 0.5
     vcs = numpy.array([kp.vcirc(R, phi) for phi in phis])
-    assert numpy.all(numpy.fabs(vcs - _tonumpy(kp.vcirc(R))) < 10.0**-8.0), (
+    assert numpy.all(numpy.fabs(vcs - as_numpy(kp.vcirc(R))) < 10.0**-8.0), (
         "Setting phi= in vcirc for axisymmetric potential gives different answers for different phi"
     )
     return None
@@ -3882,7 +3872,7 @@ def test_vcirc_phi_nonaxi():
     # One at a different radius
     R = 0.5
     vcs = numpy.array([tnp.vcirc(R, phi) for phi in phis])
-    assert numpy.all(numpy.fabs(vcs - _tonumpy(tnp.vcirc(R, phi=0.0))) > 0.01), (
+    assert numpy.all(numpy.fabs(vcs - as_numpy(tnp.vcirc(R, phi=0.0))) > 0.01), (
         "Setting phi= in vcirc for axisymmetric potential does not give different answers for different phi"
     )
     return None
@@ -3909,14 +3899,14 @@ def test_vcirc_vesc_special():
         )
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
     assert (
-        numpy.fabs(_tonumpy(potential.calcRotcurve(lp, 0.8)) - _tonumpy(lp.vcirc(0.8)))
+        numpy.fabs(as_numpy(potential.calcRotcurve(lp, 0.8)) - as_numpy(lp.vcirc(0.8)))
         < 10.0**-16.0
     ), (
         "Circular velocity calculated with calcRotcurve not the same as that calculated with vcirc"
     )
     assert (
         numpy.fabs(
-            _tonumpy(potential.calcEscapecurve(lp, 0.8)) - _tonumpy(lp.vesc(0.8))
+            as_numpy(potential.calcEscapecurve(lp, 0.8)) - as_numpy(lp.vesc(0.8))
         )
         < 10.0**-16.0
     ), (
@@ -4011,8 +4001,8 @@ def test_rE_powervc():
     for beta in betas:
         pp = PowerSphericalPotential(alpha=2.0 - 2.0 * beta, normalize=1.0)
         rmin, rmax = 1e-8, 1e5
-        Emin = _tonumpy(pp.vcirc(rmin) ** 2.0 / 2.0 + pp(rmin, 0.0))
-        Emax = _tonumpy(pp.vcirc(rmax) ** 2.0 / 2.0 + pp(rmax, 0.0))
+        Emin = as_numpy(pp.vcirc(rmin) ** 2.0 / 2.0 + pp(rmin, 0.0))
+        Emax = as_numpy(pp.vcirc(rmax) ** 2.0 / 2.0 + pp(rmax, 0.0))
         Es = numpy.linspace(Emin, Emax, 101)
         # Test both method and function
         if beta < 0.0:
@@ -4078,8 +4068,8 @@ def test_LcE_powervc():
     for beta in betas:
         pp = PowerSphericalPotential(alpha=2.0 - 2.0 * beta, normalize=1.0)
         rmin, rmax = 1e-8, 1e5
-        Emin = _tonumpy(pp.vcirc(rmin) ** 2.0 / 2.0 + pp(rmin, 0.0))
-        Emax = _tonumpy(pp.vcirc(rmax) ** 2.0 / 2.0 + pp(rmax, 0.0))
+        Emin = as_numpy(pp.vcirc(rmin) ** 2.0 / 2.0 + pp(rmin, 0.0))
+        Emax = as_numpy(pp.vcirc(rmax) ** 2.0 / 2.0 + pp(rmax, 0.0))
         Es = numpy.linspace(Emin, Emax, 101)
         # Test both method and function
         if beta < 0.0:
@@ -4278,7 +4268,7 @@ def test_ExpDisk_special():
     zs = numpy.ones_like(rs) * 0.1
     # Potential itself
     dpevals = numpy.array([dp(r, z) for (r, z) in zip(rs, zs)])
-    assert numpy.all(numpy.fabs(_tonumpy(dp(rs, zs)) - dpevals) < 10.0**-10.0), (
+    assert numpy.all(numpy.fabs(as_numpy(dp(rs, zs)) - dpevals) < 10.0**-10.0), (
         "DoubleExppnentialDiskPotential evaluation does not work as expected for array inputs"
     )
     # Rforce
@@ -4324,173 +4314,173 @@ def test_DehnenBar_special():
     phis = numpy.ones_like(rs) * 0.1
     # Potential itself
     dpevals = numpy.array([dp(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
-    assert numpy.all(numpy.fabs(_tonumpy(dp(rs, zs, phis)) - dpevals) < 10.0**-10.0), (
+    assert numpy.all(numpy.fabs(as_numpy(dp(rs, zs, phis)) - dpevals) < 10.0**-10.0), (
         "DehnenBarPotential evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential evaluation does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential evaluation does not work as expected for array inputs"
     # Rforce
     dpevals = numpy.array([dp.Rforce(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rforce(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rforce(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rforce evaluation does not work as expected for array inputs"
     # R array, z not an array
     dpevals = numpy.array([dp.Rforce(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rforce(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rforce(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rforce does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.Rforce(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rforce(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rforce(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rforce does not work as expected for array inputs"
     # zforce
     dpevals = numpy.array([dp.zforce(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.zforce(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.zforce(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential zforce evaluation does not work as expected for array inputs"
     # R array, z not an array
     dpevals = numpy.array([dp.zforce(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.zforce(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.zforce(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential zforce does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.zforce(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.zforce(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.zforce(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential zforce does not work as expected for array inputs"
     # phitorque
     dpevals = numpy.array(
         [dp.phitorque(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)]
     )
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phitorque(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phitorque(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential zforce evaluation does not work as expected for array inputs"
     # R array, z not an array
     dpevals = numpy.array([dp.phitorque(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phitorque(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phitorque(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phitorque does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.phitorque(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phitorque(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phitorque(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phitorque does not work as expected for array inputs"
     # R2deriv
     dpevals = numpy.array([dp.R2deriv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.R2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.R2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential R2deriv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.R2deriv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.R2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.R2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential R2deriv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.R2deriv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.R2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.R2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential R2deriv does not work as expected for array inputs"
     # z2deriv
     dpevals = numpy.array([dp.z2deriv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.z2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.z2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential z2deriv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.z2deriv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.z2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.z2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential z2deriv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.z2deriv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.z2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.z2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential z2deriv does not work as expected for array inputs"
     # phi2deriv
     dpevals = numpy.array(
         [dp.phi2deriv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)]
     )
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phi2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phi2deriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential z2deriv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.phi2deriv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phi2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phi2deriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phi2deriv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.phi2deriv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phi2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phi2deriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phi2deriv does not work as expected for array inputs"
     # Rzderiv
     dpevals = numpy.array([dp.Rzderiv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rzderiv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rzderiv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential Rzderiv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.Rzderiv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rzderiv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rzderiv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rzderiv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.Rzderiv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rzderiv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rzderiv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rzderiv does not work as expected for array inputs"
     # Rphideriv
     dpevals = numpy.array(
         [dp.Rphideriv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)]
     )
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rphideriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rphideriv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential Rphideriv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.Rphideriv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rphideriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rphideriv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rphideriv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.Rphideriv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.Rphideriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.Rphideriv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential Rphideriv does not work as expected for array inputs"
     # phizderiv
     dpevals = numpy.array(
         [dp.phizderiv(r, z, phi) for (r, z, phi) in zip(rs, zs, phis)]
     )
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phizderiv(rs, zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phizderiv(rs, zs, phis)) - dpevals) < 10.0**-10.0
     ), (
         "DehnenBarPotential phizderiv evaluation does not work as expected for array inputs"
     )
     # R array, z not an array
     dpevals = numpy.array([dp.phizderiv(r, zs[0], phi) for (r, phi) in zip(rs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phizderiv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phizderiv(rs, zs[0], phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phizderiv does not work as expected for array inputs"
     # z array, R not an array
     dpevals = numpy.array([dp.phizderiv(rs[0], z, phi) for (z, phi) in zip(zs, phis)])
     assert numpy.all(
-        numpy.fabs(_tonumpy(dp.phizderiv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
+        numpy.fabs(as_numpy(dp.phizderiv(rs[0], zs, phis)) - dpevals) < 10.0**-10.0
     ), "DehnenBarPotential phizderiv does not work as expected for array inputs"
     return None
 
@@ -6558,8 +6548,8 @@ def test_DiskSCFPotential_againstDoubleExp_dens():
     # Test density
     assert numpy.all(
         numpy.fabs(
-            (_tonumpy(dp.dens(testRs, testz)) - _tonumpy(dscfp.dens(testRs, testz)))
-            / _tonumpy(dscfp.dens(testRs, testz))
+            (as_numpy(dp.dens(testRs, testz)) - as_numpy(dscfp.dens(testRs, testz)))
+            / as_numpy(dscfp.dens(testRs, testz))
         )
         < 10.0**-1.25
     ), (
@@ -6568,8 +6558,8 @@ def test_DiskSCFPotential_againstDoubleExp_dens():
     # difficult at high z
     assert numpy.all(
         numpy.fabs(
-            (_tonumpy(dp.dens(testR, testzs)) - _tonumpy(dscfp.dens(testR, testzs)))
-            / _tonumpy(dscfp.dens(testRs, testz))
+            (as_numpy(dp.dens(testR, testzs)) - as_numpy(dscfp.dens(testR, testzs)))
+            / as_numpy(dscfp.dens(testRs, testz))
         )
         < 10.0**-1.0
     ), (
@@ -7583,18 +7573,18 @@ def test_rtide_noMError():
 
 def test_ttensor():
     pmass = potential.KeplerPotential(normalize=1.0)
-    tij = _tonumpy(pmass.ttensor(1.0, 0.0, 0.0))
+    tij = as_numpy(pmass.ttensor(1.0, 0.0, 0.0))
     # Full tidal tensor here should be diag(2,-1,-1)
     assert numpy.all(numpy.fabs(tij - numpy.diag([2, -1, -1])) < 1e-10), (
         "Calculation of tidal tensor in point-mass potential fails"
     )
     # Also test eigenvalues
-    tij = _tonumpy(pmass.ttensor(1.0, 0.0, 0.0, eigenval=True))
+    tij = as_numpy(pmass.ttensor(1.0, 0.0, 0.0, eigenval=True))
     assert numpy.all(numpy.fabs(tij - numpy.array([2, -1, -1])) < 1e-10), (
         "Calculation of tidal tensor in point-mass potential fails"
     )
     # Also test function interface
-    tij = _tonumpy(
+    tij = as_numpy(
         potential.ttensor(potential.CompositePotential([pmass]), 1.0, 0.0, 0.0)
     )
     # Full tidal tensor here should be diag(2,-1,-1)
@@ -7602,7 +7592,7 @@ def test_ttensor():
         "Calculation of tidal tensor in point-mass potential fails"
     )
     # Also test eigenvalues
-    tij = _tonumpy(
+    tij = as_numpy(
         potential.ttensor(
             potential.CompositePotential([pmass]), 1.0, 0.0, 0.0, eigenval=True
         )
@@ -7611,7 +7601,7 @@ def test_ttensor():
         "Calculation of tidal tensor in point-mass potential fails"
     )
     # Also Test symmetry when y!=0 and z!=0
-    tij = _tonumpy(
+    tij = as_numpy(
         potential.ttensor(potential.CompositePotential([pmass]), 1.0, 1.0, 1.0)
     )
     assert numpy.all(numpy.fabs(tij[0][1] - tij[1][0]) < 1e-10), (
@@ -10332,22 +10322,22 @@ def test_TimeDependentAmplitudeWrapperPotential_against_DehnenSmooth():
     ott = o()
     ott.integrate(ts, lp + tp)
     tol = 1e-10
-    assert numpy.amax(numpy.fabs(_tonumpy(o.x(ts)) - _tonumpy(ott.x(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(ott.x(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.y(ts)) - _tonumpy(ott.y(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(ott.y(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.z(ts)) - _tonumpy(ott.z(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(ott.z(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.vx(ts)) - _tonumpy(ott.vx(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(ott.vx(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.vy(ts)) - _tonumpy(ott.vy(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(ott.vy(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.vz(ts)) - _tonumpy(ott.vz(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(ott.vz(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
     return None
@@ -10370,16 +10360,16 @@ def test_TimeDependentAmplitudeWrapperPotential_against_DehnenSmooth_2d():
     ott = o()
     ott.integrate(ts, lp + tp)
     tol = 1e-10
-    assert numpy.amax(numpy.fabs(_tonumpy(o.x(ts)) - _tonumpy(ott.x(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(ott.x(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.y(ts)) - _tonumpy(ott.y(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(ott.y(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.vx(ts)) - _tonumpy(ott.vx(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(ott.vx(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
-    assert numpy.amax(numpy.fabs(_tonumpy(o.vy(ts)) - _tonumpy(ott.vy(ts)))) < tol, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(ott.vy(ts)))) < tol, (
         "Integrating an orbit in a growing DehnenSmoothWrapper does not agree between DehnenSmooth and TimeDependentWrapper"
     )
     return None
@@ -10813,7 +10803,7 @@ def test_king_potential_beyond_tidal():
     r = numpy.linspace(2.1, 10.0, 1001)
     # Accuracy is limited because of the numerical solution of the King ODE and
     # the fact that interpSphericalPotential doesn't directly use the solved W potential
-    assert numpy.all(numpy.fabs(_tonumpy(kp(r, 0.0)) / mass * r + 1.0) < 1e-3), (
+    assert numpy.all(numpy.fabs(as_numpy(kp(r, 0.0)) / mass * r + 1.0) < 1e-3), (
         "King potential does not go as GM/r at r > rt"
     )
     return None
@@ -10901,7 +10891,7 @@ def test_CylindricallySeparablePotentialWrapper_separability():
     # Reconstruct potential from separable components
     phigrid_sep = phiR[:, None] + phiz[None, :]
     # Check that the difference is small
-    assert numpy.amax(numpy.fabs(_tonumpy(phigrid) - _tonumpy(phigrid_sep))) < 1e-10, (
+    assert numpy.amax(numpy.fabs(as_numpy(phigrid) - as_numpy(phigrid_sep))) < 1e-10, (
         "CylindricallySeparablePotentialWrapper does not create a separable potential for MWPotential2014"
     )
     return None


### PR DESCRIPTION
**Stacked on #1052** (which introduces `galpy.backend.as_numpy`); targets the base branch for a clean diff. Retargets to `feat/backends` after #1052 merges (like the family PRs).

Answers the #1052 review point: *"tests often have a version of the `_np` function you introduced, and it's now also in `_namespaces` — can we centralize these?"*

### What's here
Collapses ~21 duplicated per-file backend→numpy converters (`_tonumpy`×14, `_np`, `_to_numpy`) across the test suite onto the single public **`galpy.backend.as_numpy`** — the GPU-safe production helper (`detach().cpu().numpy()` for torch, `numpy.asarray` for jax, identity on numpy). The ~21 copies had three cosmetic-on-CPU inconsistencies (guard style, `.cpu()` present/absent, `.numpy()` vs `numpy.asarray`); `as_numpy` is the strict superset.

- 23 test files now `from galpy.backend import as_numpy` and call it directly.
- `conftest.py` re-exports it (`_to_numpy = as_numpy`) so the `test_orbit`/`test_orbits` importers are untouched.
- New `tests/test_backend_namespaces.py` exercises `as_numpy` under numpy/jax/torch (incl. the grad-tracking-torch `.detach()` branch) — `backend-tests.yml` uploads no coverage, so this keeps the branch covered.

numpy path unaffected (`as_numpy` is identity on numpy arrays and python scalars). Local `_np` lambdas/params (e.g. `test_backend_orbit_integrate._per_orbit_inbackend`) are correctly left alone. **Forward-looking:** adding a 4th backend is now a one-place change instead of ~21.