### PR TITLE
actionAngleStaeckel: Phase-2 backend frequency gradients + action Hessians (differentiable turning points)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -135,6 +135,39 @@ def _staeckel_setup(xp, R, vR, vT, z, vz, pot, delta):
     }  # fmt: skip
 
 
+def _refine_tp(xp, f, u, skip):
+    """Differentiable turning point: one Newton step off the frozen bisection
+    root, grafted so the VALUE is byte-identical (numpy: graft_gradient is the
+    identity) but AD carries the TRUE implicit derivative du/dtheta =
+    -f_theta(u)/f_u(u). The bisection roots (backend.optimize.bisect_root) build
+    u from piecewise-constant xp.where comparisons, so their AD gradient is a
+    meaningless bracket artifact; without this the Staeckel FREQUENCY gradients
+    (dJ/d(E,Lz,I3) panels) and the action HESSIAN are finite-but-wrong (the
+    turning-point boundary term that cancels the S^-3/2 integral divergence is
+    missing). ``skip`` masks entries that are NOT simple roots (axis-reaching
+    umin=0, circular umin=umax) where f_u~0."""
+    if xp is numpy:
+        return u  # numpy path has no autodiff: keep the root EXACTLY. (Grafting
+        # here is only ~machine-eps identity, which the 1/sqrt(S) frequency panels
+        # amplify to ~1e-13 -- a byte-identity break we must not introduce.)
+    u0 = stop_gradient(u)
+    h = 1e-6
+    fu0 = f(u0)
+    fp = (f(u0 + h) - f(u0 - h)) / (2.0 * h)
+    # f(u0) can be NaN/inf AT the root (S dips <0 / divides by 0 there) while the
+    # FD slope from f(u0+/-h) is finite -> skip the Newton step there. Mask the
+    # numerator to NaN-free BEFORE dividing (dead-branch guard: eager xp.where
+    # evaluates both sides, so raw fu0/fp would still poison the value/grad).
+    good = (xp.abs(fp) > 1e-10) & xp.isfinite(fu0) & xp.isfinite(fp) & ~skip
+    fp_safe = xp.where(good, fp, xp.ones_like(fp))
+    fu0_safe = xp.where(good, fu0, xp.zeros_like(fu0))
+    donor = u0 - fu0_safe / fp_safe  # finite everywhere; == u0 where ~good
+    # Value-exact graft: donor - stop_gradient(donor) == 0 EXACTLY (finite donor),
+    # so the value is byte-exactly the bisection root (no 1/sqrt(S) amplification of
+    # a graft_gradient ~1e-16 wobble) while AD carries du/dtheta = grad(donor).
+    return u0 + (donor - stop_gradient(donor))
+
+
 def _staeckel_uminumax(xp, s, pot, delta):
     """Vectorised (umin, umax): bracket-and-bisect roots of the J_R integrand^2."""
     args = (s["E"], s["Lz"], s["I3U"], delta, s["u0"], s["sinh2u0"],
@@ -176,6 +209,9 @@ def _staeckel_uminumax(xp, s, pot, delta):
     umin = xp.where(at_umin | circular, ux, umin)
     umax = xp.where(at_umax | circular, ux, umax)
     umin = xp.where(reaches_axis, xp.zeros_like(umin), umin)  # axis-reaching -> 0
+    # differentiable turning points (value byte-identical; injects du/dtheta)
+    umin = _refine_tp(xp, f, umin, skip=reaches_axis | circular)
+    umax = _refine_tp(xp, f, umax, skip=circular)
     return umin, umax, unbound
 
 
@@ -191,7 +227,8 @@ def _staeckel_vmin(xp, s, pot, delta):
         lambda v: xp.where((f(v) >= 0.0) & (v > 1e-9), v * 0.9, v), vx * 0.9, 80
     )
     vmin = bisect_root(f, vlo, vx, xp, xtol=1e-13, maxiter=200)
-    return xp.where(at_vmin, vx, vmin)
+    vmin = xp.where(at_vmin, vx, vmin)
+    return _refine_tp(xp, f, vmin, skip=(xp.zeros_like(vmin) > 0.5))
 
 
 def _staeckel_gl_action(xp, sqfunc, args, lo, hi, order):
@@ -221,8 +258,11 @@ def _staeckel_t2_action(xp, sqfunc, args, lo, hi, order):
     dependence (E, Lz, I3, the u0/v0u reference geometry, potential parameters)."""
     a2 = tuple(x[..., None] if getattr(x, "ndim", 0) >= 1 else x for x in args)
     # Turning-point limits held fixed: the Leibniz boundary terms vanish exactly
-    # (S = 0 there), and the bisection roots' implicit gradients must not leak in.
-    lo, hi = stop_gradient(lo), stop_gradient(hi)
+    # (S = 0 there). The limits now arrive from _refine_tp carrying their TRUE
+    # implicit derivatives (needed for the action Hessian / frequency gradients);
+    # the direct boundary term still vanishes (S=0), so the action's first
+    # gradient is unchanged, while the second derivative gets its missing
+    # turning-point-motion term.
     span = hi - lo
     ok = span > 0.0  # degenerate (circular/planar) panel: 0 with 0 gradient
     mid = xp.sqrt(0.5 * xp.where(ok, span, xp.ones_like(span)))

--- a/tests/test_backend_aa_grad_probes.py
+++ b/tests/test_backend_aa_grad_probes.py
@@ -236,7 +236,11 @@ def test_batched_vertical_potential_numpy_R0_branch():
     numpy.testing.assert_allclose(got, want, rtol=1e-12)
 
 
-# ---------------------------------------------------------- Phase-2 xfail flags
+# ---- Phase-2 (LANDED): frequency gradients + action Hessians. The fix is
+# differentiable turning points (_refine_tp: one Newton step off the frozen
+# bisection root injects the true implicit du/dtheta), NOT new second-derivative
+# integrands -- the missing turning-point-motion boundary term is exactly what
+# cancels the S^-3/2 divergence in the second derivative.
 def _np_staeckel_Or(*coords):
     out = _staeckel_actions_freqs(
         numpy, *[numpy.array([c]) for c in coords], _MP, _DELTA, _ORDER
@@ -244,61 +248,79 @@ def _np_staeckel_Or(*coords):
     return float(out[3][0])
 
 
-@pytest.mark.parametrize("backend", [b for b in BACKENDS if b == "jax"])
-@pytest.mark.xfail(
-    strict=False,
-    reason="Phase 2: Staeckel FREQUENCY gradients. Omega comes from the "
-    "1/sqrt(S) Jacobian panels (_staeckel_jacobian); AD differentiates the "
-    "already ~1/t-singular integrand once more (S^(-3/2) ~ 1/t^2), a "
-    "divergent quadrature whose GL sum is finite but wrong: measured "
-    "dOmega_r/dR = 104.89 via jax.grad vs -1.9327 by FD (factor ~-54). "
-    "Flips when the Phase-2 derivative integrands land.",
-)
-def test_staeckel_freq_grad_dR_phase2(backend):
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_freq_grad_dR(backend):
+    # Frequency gradient dOmega_r/dR: Omega comes from the 1/sqrt(S) Jacobian
+    # panels, so its gradient is a SECOND derivative of the action integral.
+    # With differentiable turning points it matches FD (was ~54x off).
     coords = _ORBIT
     fd = _fd(_np_staeckel_Or, coords, 0, eps=1e-5)
-    args = [jnp.asarray([c]) for c in coords]
+    if backend == "jax":
+        args = [jnp.asarray([c]) for c in coords]
 
-    def f(R):
-        a = [R] + args[1:]
-        return jnp.sum(_staeckel_actions_freqs(jnp, *a, _MP, _DELTA, _ORDER)[3])
+        def f(R):
+            a = [R] + args[1:]
+            return jnp.sum(_staeckel_actions_freqs(jnp, *a, _MP, _DELTA, _ORDER)[3])
 
-    ad = float(jax.grad(f)(args[0])[0])
-    numpy.testing.assert_allclose(ad, fd, rtol=1e-3)
+        ad = float(jax.grad(f)(args[0])[0])
+    else:
+        args = [torch.tensor([c], requires_grad=True) for c in coords]
+        out = _staeckel_actions_freqs(torch, *args, _MP, _DELTA, _ORDER)[3].sum()
+        out.backward()
+        ad = float(args[0].grad[0])
+    # rtol is set by the FD REFERENCE, not the AD: central-diff error bottoms out
+    # ~3e-9 (jax) / ~2e-8 (torch) at eps=1e-5 for this orbit and swings to ~3e-7 at
+    # eps=1e-3 / ~1e-5 at eps=1e-7 (truncation vs round-off). 1e-5 keeps ~40x margin.
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5)
 
 
-@pytest.mark.parametrize("backend", [b for b in BACKENDS if b == "jax"])
-@pytest.mark.xfail(
-    strict=False,
-    reason="Phase 2: SECOND derivatives through the grafted actions. The "
-    "donor t^2 gradient integrand is itself ~1/t-singular under one more "
-    "differentiation, so jacfwd(grad(Jr)) w.r.t. (R,z) is finite but wrong: "
-    "measured [[-278.7, -151.9], [-151.9, -96.2]] vs the "
-    "FD-of-the-grafted-gradient reference [[0.592, 0.305], [0.305, 0.684]] "
-    "(up to ~500x off). The FD-of-grafted-grad values are the Phase-2 "
-    "baseline this must match.",
-)
-def test_staeckel_action_hessian_phase2(backend):
-    coords = _ORBIT
-    args = [jnp.asarray([c]) for c in coords]
-
-    def jr_of_Rz(Rz):
-        a = [Rz[0:1], args[1], args[2], Rz[1:2], args[4]]
-        return jnp.sum(_staeckel_actions(jnp, *a, _MP, _DELTA, _ORDER)[0])
-
-    grad_fn = jax.grad(jr_of_Rz)
-    Rz0 = jnp.asarray([coords[0], coords[3]])
-    H_ad = numpy.asarray(jax.jacfwd(grad_fn)(Rz0))
-    # FD of the (accurate, grafted) first gradient = the Phase-2 baseline
-    eps = 1e-5
-    H_fd = numpy.zeros((2, 2))
+def _hess_fd(gradf, R0, z0, eps=1e-5):
+    H = numpy.zeros((2, 2))
     for i in range(2):
-        up = numpy.array([coords[0], coords[3]])
+        up = numpy.array([R0, z0])
         dn = up.copy()
         up[i] += eps
         dn[i] -= eps
-        H_fd[:, i] = (
-            numpy.asarray(grad_fn(jnp.asarray(up)))
-            - numpy.asarray(grad_fn(jnp.asarray(dn)))
-        ) / (2.0 * eps)
-    numpy.testing.assert_allclose(H_ad, H_fd, rtol=1e-2)
+        H[:, i] = (gradf(up) - gradf(dn)) / (2.0 * eps)
+    return H
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_action_hessian(backend):
+    # Action Hessian d^2 Jr/d(R,z)^2 = jacfwd(grad(Jr)). Matches FD-of-the-
+    # accurate-first-gradient with differentiable turning points (was ~500x off).
+    coords = _ORBIT
+    if backend == "jax":
+        args = [jnp.asarray([c]) for c in coords]
+
+        def jr_of_Rz(Rz):
+            a = [Rz[0:1], args[1], args[2], Rz[1:2], args[4]]
+            return jnp.sum(_staeckel_actions(jnp, *a, _MP, _DELTA, _ORDER)[0])
+
+        grad_fn = jax.grad(jr_of_Rz)
+        H_ad = numpy.asarray(jax.jacfwd(grad_fn)(jnp.asarray([coords[0], coords[3]])))
+        gradf = lambda v: numpy.asarray(grad_fn(jnp.asarray(v)))
+    else:
+
+        def jr_of_Rz(Rz):
+            a = [Rz[0:1], torch.tensor([coords[1]]), torch.tensor([coords[2]]),
+                 Rz[1:2], torch.tensor([coords[4]])]  # fmt: skip
+            return _staeckel_actions(torch, *a, _MP, _DELTA, _ORDER)[0].sum()
+
+        Rz0 = torch.tensor([coords[0], coords[3]], requires_grad=True)
+        H_ad = torch.autograd.functional.hessian(jr_of_Rz, Rz0).detach().numpy()
+
+        def gradf(v):
+            x = torch.tensor(v, requires_grad=True)
+            (g,) = torch.autograd.grad(jr_of_Rz(x), x)
+            return g.detach().numpy()
+
+    # FD-INDEPENDENT correctness check: the true Hessian is symmetric, and AD
+    # reproduces it to ~machine eps (~3e-16) -- the FD reference only gets ~1e-10.
+    # This, not the noisy FD comparison, is what proves the AD 2nd derivative is
+    # right rather than merely close to a bad reference.
+    assert abs(H_ad[0, 1] - H_ad[1, 0]) < 1e-10
+    # FD comparison: rtol set by the FD reference (AD vs FD ~3e-9 at eps=1e-5),
+    # tightened from 1e-2 -> 1e-4 (~3e4x margin) now that both are measured.
+    H_fd = _hess_fd(gradf, coords[0], coords[3])
+    numpy.testing.assert_allclose(H_ad, H_fd, rtol=1e-4)


### PR DESCRIPTION
Completes the backend (jax/torch) half of the Track E AA gradient wave's **Phase 2**: accurate **frequency gradients** (dΩ/dx) and **action Hessians** (d²J/dx²) under autodiff. Un-xfails + extends to torch the two Phase-2 probes #1048 added.

### The finding (overturns the design framing)
Ω-gradients and action Hessians are *second* derivatives of `∫√S du`, and were finite-but-wrong under AD (~54× / ~500× off). The scoping doc framed this as needing new, turning-point-regularised **second-derivative integrands** (L-effort, research-grade). **It doesn't.**

The real cause: the turning points `umin`/`umax`/`vmin` come from `bisect_root`, built from piecewise-constant `xp.where` comparisons → their AD gradient is a **meaningless bracket artifact**. Phase 1 (#1047) hid this by `stop_gradient`-ing the panel limits — legal for the action's *first* derivative (the `√S·du_x` boundary term vanishes at `S=0`) — but that **deletes the turning-point-motion boundary term that cancels the integral's `S^{-3/2}` divergence in the second derivative**.

### The fix (~15 lines)
- `_refine_tp`: give each turning point its true implicit derivative via **one differentiable Newton step** off the frozen bisection root (`u = sg(u) − S(u,θ)/S_u(u,θ)`, θ live). Value unchanged; AD now carries `du/dθ = −S_θ/S_u`.
- Drop the `stop_gradient` on the `_staeckel_t2_action` limits so those derivatives flow into the second derivative.
- **numpy short-circuit** (`if xp is numpy: return u`) → the numpy code path is unchanged for all inputs → byte-identical (a graft here would perturb the roots at ~1e-16 and the `1/√S` panels amplify that to ~1e-13).
- Edge orbits (planar/circular/axis-reaching, `S_u≈0`) masked.

### Validation
| | jax | torch | target (FD) | was |
|---|---|---|---|---|
| dΩr/dR | −1.93268 | −1.93268 | −1.9327 | 104.89 |
| d²Jr/d(R,z)² | [[0.592,0.305],[0.305,0.684]] | same | [[0.592,…]] | [[−278,…]] |

Full Staeckel gradient suite **70 passed**; numpy byte-identical (stash-compared).

### Scope
Backend (jax/torch) only. The **c=True C-native** frequency/angle Jacobian (per the c=True-must-be-C-native directive) is a follow-up — the same implicit-function `dumin/dθ` at the already-solved root maps onto the C `actionsJac` (#1051).