### PR TITLE
Add SCFPotential.from_nbody for N-body / particle initialization

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -11,6 +11,13 @@ v1.12.1 (expected around 2026-11-01)
   and builds a time-dependent potential from a density that depends on time
   (analogous to the time-dependent ``MultipoleExpansionPotential``).
 
+- Added ``SCFPotential.from_nbody`` to initialize an ``SCFPotential`` directly
+  from an N-body / particle representation (positions and masses), using the
+  ``scf_compute_coeffs_*_nbody`` machinery. Multiple snapshots (``pos`` of shape
+  ``[3,n,nt]`` together with a ``tgrid``) build a time-dependent potential, and
+  the particle sum is accumulated in batches so building from a very large number
+  of particles stays memory-bounded.
+
 v1.12.0 (2026-07-01)
 ====================
 

--- a/doc/source/reference/potentialscf.rst
+++ b/doc/source/reference/potentialscf.rst
@@ -4,4 +4,4 @@ Hernquist & Ostriker Self-Consistent-Field-type potential
 ===========================================================
 
 .. autoclass:: galpy.potential.SCFPotential
-   :members: __init__, from_density
+   :members: __init__, from_density, from_nbody

--- a/doc/source/tutorials/potentials/scf_and_multipole.ipynb
+++ b/doc/source/tutorials/potentials/scf_and_multipole.ipynb
@@ -5,10 +5,10 @@
    "id": "a1b2c3d4e5f6a7b8",
    "metadata": {
     "papermill": {
-     "duration": 0.01353,
-     "end_time": "2026-07-04T00:25:45.397190+00:00",
+     "duration": 0.013939,
+     "end_time": "2026-07-04T01:06:19.032100+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:25:45.383660+00:00",
+     "start_time": "2026-07-04T01:06:19.018161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
    "id": "b1c2d3e4f5a6b7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:25:45.423548Z",
-     "iopub.status.busy": "2026-07-04T00:25:45.423087Z",
-     "iopub.status.idle": "2026-07-04T00:25:50.229081Z",
-     "shell.execute_reply": "2026-07-04T00:25:50.227878Z"
+     "iopub.execute_input": "2026-07-04T01:06:19.058179Z",
+     "iopub.status.busy": "2026-07-04T01:06:19.057905Z",
+     "iopub.status.idle": "2026-07-04T01:06:23.210603Z",
+     "shell.execute_reply": "2026-07-04T01:06:23.209373Z"
     },
     "papermill": {
-     "duration": 4.821855,
-     "end_time": "2026-07-04T00:25:50.231131+00:00",
+     "duration": 4.170426,
+     "end_time": "2026-07-04T01:06:23.214915+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:25:45.409276+00:00",
+     "start_time": "2026-07-04T01:06:19.044489+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,10 +74,10 @@
    "id": "c2d3e4f5a6b7c8d9",
    "metadata": {
     "papermill": {
-     "duration": 0.008401,
-     "end_time": "2026-07-04T00:25:50.248797+00:00",
+     "duration": 0.015299,
+     "end_time": "2026-07-04T01:06:23.248978+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:25:50.240396+00:00",
+     "start_time": "2026-07-04T01:06:23.233679+00:00",
      "status": "completed"
     },
     "tags": []
@@ -94,16 +94,16 @@
    "id": "d3e4f5a6b7c8d9e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:25:50.267561Z",
-     "iopub.status.busy": "2026-07-04T00:25:50.267057Z",
-     "iopub.status.idle": "2026-07-04T00:27:03.545802Z",
-     "shell.execute_reply": "2026-07-04T00:27:03.544408Z"
+     "iopub.execute_input": "2026-07-04T01:06:23.281904Z",
+     "iopub.status.busy": "2026-07-04T01:06:23.281307Z",
+     "iopub.status.idle": "2026-07-04T01:07:34.518076Z",
+     "shell.execute_reply": "2026-07-04T01:07:34.515598Z"
     },
     "papermill": {
-     "duration": 73.289928,
-     "end_time": "2026-07-04T00:27:03.547299+00:00",
+     "duration": 71.256246,
+     "end_time": "2026-07-04T01:07:34.519784+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:25:50.257371+00:00",
+     "start_time": "2026-07-04T01:06:23.263538+00:00",
      "status": "completed"
     },
     "tags": []
@@ -122,10 +122,10 @@
    "id": "e4f5a6b7c8d9e0f1",
    "metadata": {
     "papermill": {
-     "duration": 0.0054,
-     "end_time": "2026-07-04T00:27:03.560188+00:00",
+     "duration": 0.005361,
+     "end_time": "2026-07-04T01:07:34.532343+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:03.554788+00:00",
+     "start_time": "2026-07-04T01:07:34.526982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -142,16 +142,16 @@
    "id": "f5a6b7c8d9e0f1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:03.573373Z",
-     "iopub.status.busy": "2026-07-04T00:27:03.573162Z",
-     "iopub.status.idle": "2026-07-04T00:27:16.771011Z",
-     "shell.execute_reply": "2026-07-04T00:27:16.769573Z"
+     "iopub.execute_input": "2026-07-04T01:07:34.569946Z",
+     "iopub.status.busy": "2026-07-04T01:07:34.569699Z",
+     "iopub.status.idle": "2026-07-04T01:07:47.506237Z",
+     "shell.execute_reply": "2026-07-04T01:07:47.504327Z"
     },
     "papermill": {
-     "duration": 13.206447,
-     "end_time": "2026-07-04T00:27:16.772117+00:00",
+     "duration": 12.946121,
+     "end_time": "2026-07-04T01:07:47.507390+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:03.565670+00:00",
+     "start_time": "2026-07-04T01:07:34.561269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "a6b7c8d9e0f1a2b3",
    "metadata": {
     "papermill": {
-     "duration": 0.006129,
-     "end_time": "2026-07-04T00:27:16.785063+00:00",
+     "duration": 0.006197,
+     "end_time": "2026-07-04T01:07:47.520232+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:16.778934+00:00",
+     "start_time": "2026-07-04T01:07:47.514035+00:00",
      "status": "completed"
     },
     "tags": []
@@ -213,16 +213,16 @@
    "id": "b7c8d9e0f1a2b3c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:16.805641Z",
-     "iopub.status.busy": "2026-07-04T00:27:16.805421Z",
-     "iopub.status.idle": "2026-07-04T00:27:21.493449Z",
-     "shell.execute_reply": "2026-07-04T00:27:21.492091Z"
+     "iopub.execute_input": "2026-07-04T01:07:47.534799Z",
+     "iopub.status.busy": "2026-07-04T01:07:47.534603Z",
+     "iopub.status.idle": "2026-07-04T01:07:52.355240Z",
+     "shell.execute_reply": "2026-07-04T01:07:52.352802Z"
     },
     "papermill": {
-     "duration": 4.700656,
-     "end_time": "2026-07-04T00:27:21.494734+00:00",
+     "duration": 4.830557,
+     "end_time": "2026-07-04T01:07:52.356957+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:16.794078+00:00",
+     "start_time": "2026-07-04T01:07:47.526400+00:00",
      "status": "completed"
     },
     "tags": []
@@ -239,10 +239,10 @@
    "id": "c8d9e0f1a2b3c4d5",
    "metadata": {
     "papermill": {
-     "duration": 0.006073,
-     "end_time": "2026-07-04T00:27:21.507643+00:00",
+     "duration": 0.006397,
+     "end_time": "2026-07-04T01:07:52.373589+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:21.501570+00:00",
+     "start_time": "2026-07-04T01:07:52.367192+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "d9e0f1a2b3c4d5e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:21.522136Z",
-     "iopub.status.busy": "2026-07-04T00:27:21.521892Z",
-     "iopub.status.idle": "2026-07-04T00:27:35.020576Z",
-     "shell.execute_reply": "2026-07-04T00:27:35.019209Z"
+     "iopub.execute_input": "2026-07-04T01:07:52.397241Z",
+     "iopub.status.busy": "2026-07-04T01:07:52.396916Z",
+     "iopub.status.idle": "2026-07-04T01:08:05.525328Z",
+     "shell.execute_reply": "2026-07-04T01:08:05.523691Z"
     },
     "papermill": {
-     "duration": 13.507981,
-     "end_time": "2026-07-04T00:27:35.021790+00:00",
+     "duration": 13.144598,
+     "end_time": "2026-07-04T01:08:05.526799+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:21.513809+00:00",
+     "start_time": "2026-07-04T01:07:52.382201+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,10 +299,10 @@
    "id": "a2b3c4d5e6f7a8b9",
    "metadata": {
     "papermill": {
-     "duration": 0.006424,
-     "end_time": "2026-07-04T00:27:35.035257+00:00",
+     "duration": 0.00671,
+     "end_time": "2026-07-04T01:08:05.541160+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:35.028833+00:00",
+     "start_time": "2026-07-04T01:08:05.534450+00:00",
      "status": "completed"
     },
     "tags": []
@@ -319,16 +319,16 @@
    "id": "6c7c334f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:35.050102Z",
-     "iopub.status.busy": "2026-07-04T00:27:35.049891Z",
-     "iopub.status.idle": "2026-07-04T00:27:38.445967Z",
-     "shell.execute_reply": "2026-07-04T00:27:38.444245Z"
+     "iopub.execute_input": "2026-07-04T01:08:05.559413Z",
+     "iopub.status.busy": "2026-07-04T01:08:05.559225Z",
+     "iopub.status.idle": "2026-07-04T01:08:08.942182Z",
+     "shell.execute_reply": "2026-07-04T01:08:08.940544Z"
     },
     "papermill": {
-     "duration": 3.405101,
-     "end_time": "2026-07-04T00:27:38.447292+00:00",
+     "duration": 3.39574,
+     "end_time": "2026-07-04T01:08:08.943486+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:35.042191+00:00",
+     "start_time": "2026-07-04T01:08:05.547746+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "papermill": {
-     "duration": 0.010196,
-     "end_time": "2026-07-04T00:27:38.469148+00:00",
+     "duration": 0.016465,
+     "end_time": "2026-07-04T01:08:08.971567+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:38.458952+00:00",
+     "start_time": "2026-07-04T01:08:08.955102+00:00",
      "status": "completed"
     },
     "tags": []
@@ -382,11 +382,14 @@
     "\n",
     "To illustrate this, we draw an isotropic sample from a spherical NFW halo with\n",
     "`isotropicNFWdf`, build an `SCFPotential` from the samples, and compare its rotation\n",
-    "curve to the `from_density` build of the same halo (the \"direct\" calculation) and to\n",
-    "the exact result. We compare the circular velocity rather than the density because,\n",
-    "like any basis-function expansion truncated at a modest order, the SCF reproduces\n",
-    "the potential and forces of a cuspy NFW profile much more accurately than its\n",
-    "density."
+    "curve to a `from_density` build (the \"direct\" calculation) and to the exact result.\n",
+    "Because `isotropicNFWdf` samples the halo out to a finite truncation radius `rmax`,\n",
+    "we build `from_density` from the *same* density truncated at `rmax`, so the two\n",
+    "represent the same mass distribution. We compare the circular velocity rather than\n",
+    "the density because, like any basis-function expansion truncated at a modest order,\n",
+    "the SCF reproduces the potential and forces of a cuspy NFW profile much more\n",
+    "accurately than its density; representing the *full*, formally infinite-mass NFW\n",
+    "this well would require a larger `N`."
    ]
   },
   {
@@ -395,16 +398,16 @@
    "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:38.491314Z",
-     "iopub.status.busy": "2026-07-04T00:27:38.491087Z",
-     "iopub.status.idle": "2026-07-04T00:27:40.288627Z",
-     "shell.execute_reply": "2026-07-04T00:27:40.286985Z"
+     "iopub.execute_input": "2026-07-04T01:08:08.996285Z",
+     "iopub.status.busy": "2026-07-04T01:08:08.996092Z",
+     "iopub.status.idle": "2026-07-04T01:08:10.888278Z",
+     "shell.execute_reply": "2026-07-04T01:08:10.886370Z"
     },
     "papermill": {
-     "duration": 1.810062,
-     "end_time": "2026-07-04T00:27:40.289622+00:00",
+     "duration": 1.90508,
+     "end_time": "2026-07-04T01:08:10.889399+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:38.479560+00:00",
+     "start_time": "2026-07-04T01:08:08.984319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -412,9 +415,9 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk0AAAGGCAYAAABmPbWyAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjDBJREFUeJzs3Xd0FFUbwOHfbnovBBISUui9Q0JAeqhKURSQjoKKogIW4FOqJQiIqKAoShMVLBQBDUoJNXSQ3hMCpJDe6+58f6wsrEkgYJLdkPc5Z8/Zmblz550Qdt/ce+delaIoCkIIIYQQ4p7Uxg5ACCGEEKI8kKRJCCGEEKIYJGkSQgghhCgGSZqEEEIIIYpBkiYhhBBCiGKQpEkIIYQQohgkaRJCCCGEKAZJmoQQQgghisHc2AE8CrRaLVFRUTg4OKBSqYwdjhBCCCEegKIopKWl4enpiVpddHuSJE0lICoqCm9vb2OHIYQQQoj/4Pr161SrVq3I45I0lQAHBwdA98N2dHQ0cjRCCCGEeBCpqal4e3vrv8+LIklTCbjdJefo6ChJkxBCCFFO3W+IjQwEF0IIIYQoBkmahBBCCCGKQZImIYQQQohikDFNQgghSoRGoyEvL8/YYQhRgIWFBWZmZv+5HkmahBBC/CeKohATE0NycrKxQxGiSM7Oznh4ePyn+RQlaRJCCPGf3E6YqlSpgq2trUzyK0yKoihkZmZy69YtAKpWrfrQdUnSJIQQ4qFpNBp9wlSpUiVjhyNEoWxsbAC4desWVapUeeiuOhkILoQQ4qHdHsNka2tr5EiEuLfbv6P/ZdydJE1CCCH+M+mSE6auJH5HJWkSQgghhCgGSZpEicvO07D7Yhx/nIo2dihCCCFEiZGkSZSofI2WUcsPMWLZIV5fe6LA8Vup2ZyPSS37wIQQ4i6dOnViwoQJRo9BpVKxZs0ag/0LFy7Ez89Pv71ixQpUKlWB1zfffMP58+dRqVQcOHDAoI42bdpgbW1Ndna2fl92djbW1tZ8++23pXpfjzJJmkSJ+vivixy4mghAbr6WnHyN/phWq/DmLyfp+/k+vtlzFa1WMVaYQghxX4qikJ+fX6rXsLa25t13373v4GRHR0eio6MNXkOHDqVevXp4eHgQGhqqL5uWlsaxY8eoXLmyQTIVFhZGTk4OXbp0Ka3beeRJ0iRKzM7zt/gy9Ip+e0iAj8HxdcdvsvtiHLkaLe9vOcfI5YeITc3+dzV35OfA9cOQn1v48Zy0kghbCFHBjBo1il27dvHpp5/qW20iIiIIDQ1FpVLxxx9/0LJlS6ysrNi7dy+jRo2if//+BnVMmDCBTp066be1Wi3BwcFUr14dGxsbmjZtyi+//HLfWJ599lmSk5NZunTpPcupVCo8PDwMXrcfo+/cubNB0rR3717q1KlDnz59DPaHhobi6+tL9erV7xuXKJzM0yRKRFRyFpN+OqHffqd3fcZ2qGFQpk/TqpyPTuWbveEA7LkUT5/P97J6TAB13B3uFDyzHo4sh+sHIT8b3rgIDu6GF9TkwdwaYFsJqtSH+n2g1XOldXtCiGJKSUnh1KlTRrt+48aNcXJyumeZTz/9lIsXL9KoUSNmz54NQOXKlYmIiABgypQpzJ8/nxo1auDi4lKs6wYHB7N69WqWLFlC7dq12b17N8OGDaNy5cp07NixyPMcHR155513mD17NiNHjsTOzq54N3qXzp07M3HiRPLz8zE3N2fnzp106tSJ9u3b88UXXzBz5kwAdu7cSefOnR+4fnGHJE3iP8vTaHn1x+MkZeqal4PquzOmfcG/ZKzMzXj3iQZ0qluFN34+QWxqDrfSchiweA8jfFLJjr5EbGwsHSxOMdDphP68SRPGozhWw9XVlUqVKuHm5kbDKuY01ORCWrTu5fdYWd2uEOIeTp06Rfv27Y12/T179vDYY/f+PHBycsLS0hJbW1s8PDwKHJ89ezbdunUr9jVzcnL48MMP2bZtG4GBgQDUqFGDvXv38tVXX90zaQJ4+eWX+fTTT1mwYAHTpk0rtExKSgr29vb6bXt7e2JiYgBd0pSRkcHhw4cJDAwkNDSUt956i8cee4yRI0eSnZ2NoigcOnSIMWPGFPu+REGSNIn/bP7WCxy9lgSAl7MNHz/TtMj5MG7cuMH5XSG4H9tOsnNLctzqk5ar8PkZM279spacG2fY56Fm4It3Phy2bFzHxQStQT1PNzDn52fuTKY3fc1RfC58Q+vWrWnYsCHm5v/8al/6C3zagJUDQghRHK1atXqg8pcvXyYzM7NAopWbm0vz5s3ve76VlRWzZ8/m1VdfZdy4cYWWcXBw4NixY/pttfrO6JpatWpRrVo1QkNDadiwIcePH6djx45UqVIFHx8fwsLCUBSFnJwcaWn6jyRpEv/JwasJfLX7KgAWZioWD22Bk62FQZno6Gi++OILNm7cyKlTp3Cxhlmdrfmu1hba3pxAhlcAaitbqgycRdz6D/k7/BgHb2g4HqNhZ0Q+kSnaAtf9O0bLW39l06iyGlsLFe/98iPwI6CbLr958+Y80b45k62/R2Vph6rFcGjzMjh7l/rPRAhRvv27i0ytVqMohg+u3D1wOz09HYAtW7bg5eVlUM7KyqpY1xw2bBjz58/n/fffN3hy7u4YatWqVeT5nTp1YufOnTRp0oTatWtTpUoVADp27MjOnTtRFIVatWrh7S2fgf+FySVNixcvZt68ecTExNC0aVM+//xz/P39Cy27bt06PvzwQy5fvkxeXh61a9fmjTfeYPjw4YDul/rdd9/l999/5+rVqzg5OREUFMScOXPw9PTU1+Pn58e1a9cM6g4ODmbKlCmld6OPiPXHb+rfT+5Zj2bezvrtq1evMnfuXJYvX05urm4wdytPNb8PsaWyne6vpMFRH7Mo521sarRCbWGNW0B/zJVEhu+2wNLSEgsLC7yrZ5CQkEBSUpL+g+tSopb5+wsfIJ6VlcX+/ft5wuYo6sesIDcNDnzBygOx1O/9Eq1atTL4K00IUXIaN27Mnj17jHr94rC0tESj0dy/ILrxTqdPnzbYd+LECSwsdH8gNmjQACsrKyIjI+/bFVcUtVpNcHAwTz31VJGtTffSuXNnXnvtNRo0aGAwQL1Dhw4sXboURVGklakEmFTStHbtWiZNmsSSJUsICAhg4cKF9OjRgwsXLuiz5ru5urryzjvvUK9ePSwtLdm8eTOjR4+mSpUq9OjRg8zMTI4dO8a0adNo2rQpSUlJvP766/Tt25cjR44Y1DV79mzGjh2r33ZwkO6c4ni/fyN6NvLgj1MxjGzrB8D58+d57733WLNmDVqtYSvR2TgtWXc9wftWBweaN23Emmg7crDgu/f+h7VF4X36Go2GlJQUoqOjuXTpEpcuXeLixYtcuHCBEydOkJZm+DRdnzp3fr1PxWoYtWQ5zFqOu7s7vXv35oknnqB79+4G4wQKo9UqZOZpyMzNJzNHg5lahberrLMlRGGcnJzuO6bIFPj5+XHw4EEiIiKwt7fH1dW1yLJdunRh3rx5rFq1isDAQFavXs3p06f1XW8ODg68+eabTJw4Ea1Wy2OPPUZKSgr79u3D0dGRkSNHFiumxx9/nICAAL766ivc3d3vf8Jdbo9rWrZsmcGTeB07dtSPY3r55ZcfqE5RCMWE+Pv7K6+88op+W6PRKJ6enkpwcHCx62jevLny7rvvFnn80KFDCqBcu3ZNv8/X11f55JNPHipmRVGUlJQUBVBSUlIeuo5HgVarVT777DPFyspKAQq86tevr0ybNk05v+4jRZnhqCiftVCUCyGKotUqefkaJSMnr9A6i0Oj0Shnz55VVq5cqYwfP15p0aKFYmWuUoY1sVAOj7VTnm9uUWhM/j42ymuDg5TVq1crkTHxyr5LccqyvVeVKb/+rTy5eK/SeEaI4jt5s8FrzMrDBa7/zZ6ryndhEcqFmFRFoylezEI8CrKyspSzZ88qWVlZxg7lgVy4cEFp06aNYmNjowBKeHi4snPnTgVQkpKSCpSfPn264u7urjg5OSkTJ05Uxo8fr3Ts2FF/XKvVKgsXLlTq1q2rWFhYKJUrV1Z69Oih7Nq1q8gYOnbsqLz++usG+/bv368Aiq+vr37f8uXLFScnp/vek6+vrwIo0dHRBvv9/PwUQImKirpvHY+ye/2uFvd7XKUoiknMMJibm4utrS2//PKLwXwYI0eOJDk5mY0bN97zfEVR2LFjB3379mXDhg1FPvmwbds2unfvTnJyMo6OjoDuL47s7Gzy8vLw8fFhyJAhTJw48c5g4vtITU3FycmJlJQUfZ0VTUxMDKNHjyYkJAQAtQra+5ix65qGNm3aMHXqVJ544gldt5iiwKlfoEE/MLcsss4rcelMXHuCj59pSm33B2/5S0pKYteuXezcuYMd27dz+szZAmX2jLalrbcZP57K5wvXN7npFnDfeocG+PDBk3e6ABRFoeX720jM0HUXOtta0MrXhe4NPOjV2AMHa4uiqhKi3MvOziY8PJzq1atjbW1t7HCEKNK9fleL+z1uMt1z8fHxaDSaAk2S7u7unD9/vsjzUlJS8PLyIicnBzMzM7744osiE6bs7GwmT57Ms88+a/BDee2112jRogWurq7s37+fqVOnEh0dzYIFCwqtJycnh5ycHP12amrFWxZEURT9E3KbN2/mueeeIy4uDoB23mZ82tOa5lXNON5yPi36jDF8mk6lgibP3LP+1Ow8xq46wtW4DB7/bC+D/b15uVMtPJyK/6Hs4uJC//799Un4tWvX+HFjCBsOXeZqYg4tL33JYz66/wJDm1igitnA/zBMmlytwKeKE/ZWFthYmmFnaUb72pUNylyJS9cnTADJmXlsO3eLbeduMW3jabo39OCpFl60r+WGuZmMpRJCiPLKZJKmh+Xg4MCJEydIT09n+/btTJo0iRo1ahgMhAPdoPCBAweiKApffvmlwbFJkybp3zdp0gRLS0tefPFFgoODC33yITg4mFmzZpXK/ZQXn2y7xPHIJCxuHGPF+xNQ/pm129NBRegoW8zVuiSpZcwPoDyvS5QeQEZOPlbmZgDkarSsCrvGmsPXGRrgw7hONaniULzkKSUrj6PXEjl4NZFdF+M4H1MNqlXDthp81CMGkrYCkKdReG9XFqnVNpN36yq58dfIi4/kWm4WNypXZujQoYwaNYqmTZsWuIZvJTvWv9yWwxGJHI5I4khEon7Oqpx8LZv+jmLT31FUcbBi2ajWNPK698R7QgghTNMj0z1325gxY7h+/Tpbt27V77udMF29epUdO3ZQqVKle9Zx5swZGjVqxPnz56lbt26B44W1NHl7e1eY7jmtVqH93J3cTM5C0Wq4+cUoNBm6eZqaNm1K6IT6OEf8rits6QDP/wnuDR74Opm5+SzacZkV+yPIzL3zlIuluZpGno7U9XCkQVUHhrXxNWjJ+i4sgitxGRwKT+RcTCpF/YZ/8GQjhnpEod02m8hsG2YccmD9+vUGA8rtLMDeUkVshq6SZs2aMWrUKIYOHYqbm1uh9SqKwt83Ulh/7Aa//R2lT6Dc7C3ZO7kL1hZmD/yzEMJUSfecKC9KonvOZPoKLC0tadmyJdu3b9fv02q1bN++XT/DanFotVqDhOZ2wnTp0iW2bdt234QJdI+SqtXqQp/YA928G46OjgaviuRAeAI3kzPxVcWQHX5cnzBNmjSJgwcP4tznfVBbQJNB8OqRh0qYAGwtzXm7Zz32vN2ZFzvUwNpC9+uam6/lWGQyPx6K5Ju94QUm0ly6J5wV+yM4G22YMKlU0MzbmUnd6rD51ccY4u8DvoGon/sdvxd/ZOXKlcTGxvLTTz/Rr18/LCwseL2NJVdft2dBDyuq2qs4ceIEEyZMwMvLi8GDB7Nt27YCTwiqVCqaeTszq18jDv4viK+Ht6RbA3fGtq9RIGHacymOtOx7L9QphBDCNJhU99ykSZMYOXIkrVq1wt/fn4ULF5KRkcHo0aMBGDFiBF5eXgQHBwO6brJWrVpRs2ZNcnJy+P333/nuu+/03W95eXk8/fTTHDt2jM2bN6PRaPTTzru6umJpaUlYWBgHDx6kc+fOODg4EBYWxsSJExk2bFix1xyqUDT57F0dzB+Wf+KliqfOed36cgsWLGDixIm6MlY1YeKZguvFPaRK9lZM7V2fMe1r8PXuK/x+KoabyVkA1C1kgHgle0siEzNRqaC+hyP+1V0JqO5K6+quuNkXMtGcSgXmuv02NjY888wzPPPMMyTHRGDzVRuslCwmtrGiR01zGn6RAehaRteuXcvatWvx8/Pj+eef5/nnn6dq1aoGVVuaq+ne0IPuDT0KTI53MzmLMSuP4GBtzhvd6zKwlTdm6gfrxhRCCFF2TCppGjRoEHFxcUyfPp2YmBiaNWtGSEiIfnB4ZGSkwaSEGRkZvPzyy9y4cQMbGxvq1avH6tWrGTRoEAA3b97kt99+A3TdKne7vaChlZUVa9asYebMmeTk5FC9enUmTpxoMM5J3HF5XlfeVk7o2yhHOB/HNTj4TsJ0WwklTHer7GDFO4834J3HG5CWncfF2DQsChlYPbVXffK1Whp6OuFk8/BPrjlHhICSpd8+79IVL6+j3Lx506BcREQE06ZNY9asWfTt25eXXnqJrl27FphA898tYh//eYGcfC056blMXXeKlfsjmP5EA9rWKrzbTwghhHGZzJim8qyiTDmwY8cOxk+dzo6eN/BQ6brkknHAefo1UD+C43S0Wji3EXbNg5xUePUYGpUZW7du5ZtvvmHTpk3k5+fTsLKaM3GGXXQ1a9bkxRdfZPTo0UWOfbqemMmcP86z5VS0wf4+TT2Z0adB4a1iQpgYGdMkyouSGNMkSVMJqAhJU1JSEk2aNCG33TiaVXdhheVczmhr0vXNFaicqhk7vNKl1ULqDXD2MdgdExPD9uUfMDRnFaER+Sw8kMumi/lo7/ofZWVlxaBBg3j55Zfx9/cvdCHjQ+GJvLf5LKdupuj3Odta8E7v+jzdslqRix8LYQokaRLlxSM1EFyYtvHjxxOVlI61b2MuKD50z3yfLrP+fPQTJgC1ukDCBODh4cFQv3gAOvmZ8+sgO3ycDbsDc3JyWLVqFW3atKF169YsX76crKwsgzL+1V3Z+Eo75j7dBOd/FjtOzszjrV9OMuzbg8SmZpfSjQkhhHgQkjSJop3fAqnRrFmzhh9++AHbWgGoVLpfmWc7NpFFb1NuwsUQ/aZZw76EnY3kgw8+wMenYJJ19OhRnnvuOby9vZkyZYrBItFqtYqBrbzZNqkj/ZrdWUz6alwGdlYmNfRQCPEfZWZmMmDAABwdHVGpVCQnJxs7pHtasWIFzs7OZXa9iIgIVCrd08qmpoJ/64ki5aTBhnHkLu/L5NdfAsCisp/+8BPNvI0UmAlx8oKXD0Dz4WBuDQEv4eHhwf/+9z+uXr3Kb7/9Ro8ePXjV35LnmlvwTyMSCQkJfPTRR9SoUYMnn3ySnTt36p+sc7O34tPBzVk+ujVezja8378R9pI0CVHi4uLiGDduHD4+PlhZWeHh4UGPHj3Yt2+fQbnjx4/zzDPP4O7ujrW1NbVr12bs2LFcvHgRuPMF/+/XsGHDirz2ypUr2bNnD/v37yc6OhonJ5nw9m7e3t5ER0fTqFEjAEJDQ00muZSkSRTu2HeQnYJl0kVW9crD0QqStn3F01Ynea9/IxrLrNY6letCv0Uw6Rz43JlPzMzMjD59+hCyaT2f9KvMt31tiH7DkdcC7qy1p9Vq2bBhA126dKFJkyZ8/fXXZGZmAtC5bhW2v9GRrvUNn0KMTc3mt7+jCkxfIIR4MAMGDOD48eOsXLmSixcv8ttvv9GpUycSEhL0ZTZv3kybNm3Iycnh+++/59y5c6xevRonJyemTZtmUN+2bduIjo7WvxYvXlzkta9cuUL9+vVp1KgRHh4ehY5bzM3NLeTMisHMzAwPD49ir/9apkpq9eCKrLirI5cb+bmKsqChosxwVJQZjkrUJHvF0gzF399fyc3NNXZ05cvx7/U/R2WGo7J94UtK48aNFaDQl4uLi/LWW28pERERBarSarXKyGUHFd/Jm5XxPxxTkjPl30IY371WjjdVSUlJCqCEhoYWWSYjI0Nxc3NT+vfvX2QdiqIo4eHhCqAcP368WNfu2LGjwf/5jh07KoqiKL6+vsrs2bOV4cOHKw4ODsrIkSMVRVGUX375RWnQoIFiaWmp+Pr6KvPnzzeoz9fXV3nvvfeU4cOHK3Z2doqPj4+yceNG5datW0rfvn0VOzs7pXHjxsrhw4eLFZ+iKMry5csVb29vxcbGRunfv78yf/58xcnJyaDMhg0blObNmytWVlZK9erVlZkzZyp5eXn644CydOlSpX///oqNjY1Sq1YtZePGjfrjiYmJypAhQxQ3NzfF2tpaqVWrlrJs2bICP9Pb7+9+jRw5Ulm5cqXi6uqqZGdnG8TVr18/ZdiwYYXe171+V4v7PS5JUwl45JImrVZJObZe2THKQVFmOCqT21kqtra2yoULF4wdWflz8GtFmeOrS5o+8FKUnAxFq9UqoaGhytNPP62YmZkp5mqUUc0sFCerOx8KarVaeeqpp5Rdu3YpWq1WURRF2XMxTvGdvFn/ahu8XTkSkWDc+xMVXnlMmvLy8hR7e3tlwoQJBb50b1u3bp0CKPv3779nXQ+aNCUkJChjx45VAgMDlejoaCUhQfd/2NfXV3F0dFTmz5+vXL58Wbl8+bJy5MgRRa1WK7Nnz1YuXLigLF++XLGxsVGWL1+ur8/X11dxdXVVlixZoly8eFEZN26c4ujoqPTs2VP56aeflAsXLij9+/dX6tevr/8suZcDBw4oarVa+eijj5QLFy4on376qeLs7GyQNO3evVtxdHRUVqxYoVy5ckX5888/FT8/P2XmzJn6MoBSrVo15YcfflAuXbqkvPbaa4q9vb3+fl955RWlWbNmyuHDh5Xw8HDlr7/+Un777bcCP9P8/Hzl119/VQDlwoULSnR0tJKcnKxkZmYqTk5Oyk8//aS/ZmxsrGJubq7s2LGj0HsriaRJphwoAY/ilAPvvvsuH3zwAc091FxN0vL+/M8ZP368scMqn/Ky4dwmyIyHNuMMDl2/fp3tS6YwymIz2fkKWy7m88af2VxLufPfslmzZrz++usMHjyYvy4k8s76U6Rm5wOgVsHrXevwSueamBcy0acQpa2ox7i/2XOVb/aE3/f8Rl6OfDOytcG+MSsPc/pm6n3PHdO+OmPa13jwoIFff/2VsWPHkpWVRYsWLejYsSODBw+mSZMmAMydO5fJkyeTmJh4z9UhIiIiqF69OjY2NgYPx+zZs4fmzZsXes6ECRM4ceIEoaGh+n1+fn40b96c9evX6/cNHTqUuLg4/vzzT/2+t99+my1btnDmzBn9ee3bt+e7774DdFOhVK1alWnTpjF79mwADhw4QGBgINHR0Xh4eNzz5zJkyBBSUlLYsmWLft/gwYMJCQnRjykKCgqia9euTJ06VV9m9erVvP3220RFRQG6yXzfffdd3nvvPUA3GbW9vT1//PEHPXv2pG/fvri5ubFs2bIif6bHjx+nWbNmhIaG0rlzZ5KSkgwGpL/88stERETw+++6tU4XLFjA4sWLuXz5cqFdnjLlgCgVCQkJfPrppwAcj9Hi2qI367IbMeeP81y+lW7k6MohC2to8kyBhAl0Ax5HtbABwNpcRZ+6FiRnG/4dc+LECUaPHo2vry9H1n3FqiH1ae2n+xDXKvDJtos8u/SAfmkZIUxBWnY+ManZ930lZBQcu5OQkVusc9P++ePhYQwYMICoqCh+++03evbsSWhoKC1atGDFihUADzxucO3atZw4cUL/atDgwdfcbNWqlcH2uXPnaNeuncG+du3acenSJTSaO4uY3070AP0KGo0bNy6w79atW/eN4dy5cwQEBBjs+/f6r3///TezZ8/G3t5e/xo7dizR0dH6cZn/jsvOzg5HR0d9DOPGjWPNmjU0a9aMt99+m/379983tn8bO3Ysf/75p36VhhUrVjBq1KhSndtOkiZRwMcff0x6+p3kqGW/0VyNz2DJritcjE0zYmSPIK0GIg/oNy0a9GLj1lCeeuopg79aG1VR09IxkeD3Z+PfqBY2YV8zuKG9fq26wxFJ9P50DyGnY8r8FoQojIO1OR6O1vd9VbKzLHBuJTvLYp3rYP3fBgpbW1vTrVs3pk2bxv79+xk1ahQzZswAoE6dOgCcP3++WHV5e3tTq1Yt/cvK6sFn9Lezs3vgcwAsLO7MD3c7YShs378XF39Y6enpzJo1yyBJPHXqFJcuXTJowbk7httx3I6hV69eXLt2jYkTJxIVFUXXrl158803HyiO5s2b07RpU1atWsXRo0c5c+YMo0aN+s/3dy8mODRdGFN8fDyff/65frtW7TpEapyBHCzN1HSoU9losT2S1Gbw6jG4sh1O/oSqYX86NuhIx44diYiIYPHixSxdupRX/XN4oaUlSVkKv5zL44VVK2HVSvx7Dya35VCSclWkZOXx0uqjrH+5Lc19ZLFpYVxj2td46K6zf3fXlZUGDRqwYcMGALp3746bmxtz58416DK7LTk5udTnLqpfv36BKRD27dtHnTp1MDMrnaWr6tevz8GDBw32HThwwGC7RYsWXLhwgVq1av2na1WuXJmRI0cycuRI2rdvz1tvvcX8+fMLlLO01CXWd7eu3TZmzBgWLlzIzZs3CQoKwtu7dKfDkZYmcceuufy54CWyMu60Mj335gxiU3MAaFerkswZVBrMLaFuL3hmOTTop9/t5+fHvHnzuHEtnOGtnAFwsVHh43jnv+2h39fw99zBcP04AE80qiwJkxD3kZCQQJcuXVi9ejUnT54kPDycn3/+mblz59Kvn+7/oJ2dHd988w1btmyhb9++bNu2jYiICI4cOcLbb7/NSy+9VOpxvvHGG2zfvp333nuPixcvsnLlShYtWvTALTIP4rXXXiMkJIT58+dz6dIlFi1aREhIiEGZ6dOns2rVKmbNmsWZM2c4d+4ca9as4d133y32daZPn87GjRu5fPkyZ86cYfPmzdSvX7/Qsr6+vqhUKjZv3kxcXJxBT8iQIUO4ceMGS5cu5bnnnnu4m34AkjQJneTrKKFzGGL5F5deteeJOubUqVMHtfedgYzdG957AKEoHfaZkdio8vTb51S1DY4rORlc+2EaXU++Q9wnvZj02itcunSprMMUotywt7cnICCATz75hA4dOtCoUSOmTZvG2LFjWbRokb5cv3792L9/PxYWFgwZMoR69erx7LPPkpKSwvvvv1/qcbZo0YKffvqJNWvW0KhRI6ZPn87s2bNLtQuqTZs2LF26lE8//ZSmTZvy559/FkiGevTowebNm/nzzz9p3bo1bdq04ZNPPsHX17fY17G0tGTq1Kk0adKEDh06YGZmxpo1awot6+XlxaxZs5gyZQru7u4GDyU5OTkxYMAA7O3t6d+//0Pd84OQp+dKwCPx9NzuebDjzodA0KoMRr+3khWx1bh0Kx2VCg7+rytVHGRBTqPISoILf8CZDdD/S85ExPDZZ5+xatUqsrOzUQE3Jtnj6aAmNUfho325nHTqRvshr3FT5cYHTzaWVkJRKmTBXmFsXbt2pWHDhnz22Wf3LCdPz4kSkxV1Z7DjpQQNN61qERDUh0v/PC3XwsdFEiZjsnGBZkNg6E9gV4mGDRvy1VdfcePGDT788EP6tXDH00H339nRSkVqjpY/dh9i0cFENp6IosP7Wzhy9f5PzgghRHmRlJTE+vXrCQ0N5ZVXXimTa0rSJACYd9GXyvPSGPBTJu/uzGH69BlsPXvnS7Z7A/d7nC2MpVKlSkydOpWfv3gfjUrXkqRVFH49m4+Fqyf889RMYp45A77cz8ZpjxN/cC1o8u5VrRDiEdWrVy+DqQLufn344YfGDu+BNG/enFGjRvHRRx9Rt27dMrmmdM+VgPLePacoCrVr1+bKlSsA1K5dm0PHT9L5490kZeq+XEPf7ISf28M9DivKSHYqXAzhxvFtvPlHKr/88gsqezfc+k7GyrMOjVVX2WSlG5uQqrEkJnAmdXqXzV9n4tEl3XPly82bN8nKKnxON1dXV1xdXcs4orJTEt1zMshBcODAAX3CBDBq1CiiUnJxsLYgKTOPfs08JWEqD6wdoclAqjUZyJqRutnGFy9ezNfffEh24z480S5bX9TRLJeAyUtw/eAHJkyYwJNPPmmai2MKIUqUl5eXsUMo16R7TrBq1SqD7aFDh9LA05Ftkzoyu19D3uhWNs2eomR5e3szZ84crl+LIHiQP86xx8hTdP/lT2hrkvX4HM5a1WPgs0OoUaMGH330EcnhJyB0DiReNW7wQghhgqR7rgSU5+65nJwcqlatSlJSEgCdOnVi586dRo5KlAatVstvG9dxbM9mYq192ar1R5ORTNSy8WgzkwF4r6sd7z72z6R51VrD0J91g9CFKIJ0z4nyQp6eE//Z3l+/4s3mmXSrYYadBQwfPtzYIYlSolar6f/k08ycvxzflr1QKxrSd3ylT5gABt01t9y1i6fY9NeeQmfhFUKIikiSpgouetcK/tfeij+H25E02QGNR10uyfpyjzS1WsX/BrQh7J3uXN27kXnz5uHr60sVOxX5d30kfBWWTN9+/ahTpw6ffPKJfoVzIvZB1HGQRmohRAUj3XMloDx2z+VrtPz1dwQWX7YlyEv3JEVUngNtNV+hVsELHWoypVc9I0cpykp+fj4bN/7GtJBwfB019I5eyvzfrxCZcufjwc7OjpEjRzK/7jFsEs9ClYbQZhy0kNbJiky650R5Id1z4qF9+Pt5xv10FseqPmgV3Vw++9QtAdAq4OUsH34Vibm5Oarq/mRWqsc5i4Z87LOQnK7voLZ10pfJyMhgx09LdAkTwK0zKLFnjRSxEOVXZmYmAwYMwNHREZVKdacVt5wYNWpUqSxZEhoaavI/D0maKqDY1GxWH7gGqBiYO4NmOV8xJvcNVuUHAeBXyZbB/j7GDVKUuc51q9C3qad+27p2G2q/tgKvgMfvlPEzXFm997s/sGDBgoIfchnxpRmqEP9ZXFwc48aNw8fHBysrKzw8POjRowf79u0zKHf8+HGeeeYZ3N3dsba2pnbt2owdO5aLFy8CEBERgUqlKvAaNmxYkddeuXIle/bsYf/+/URHR+Pk5FRkWWFaJGmqgL4/cI1cjRaA7MhTxFw8xeH8OlyzqoOLrQUfPtUYCzP51ahoXOws+ezZ5nwxtAWudpYAZCsWmHcaxxPBGwjo2I0vj+RR+/N0PtiTw4bzeYQci+SNN97Ay8uLl156idOnT0NaLHxcD1b1gzPrIT/XyHcmREEDBgzg+PHjrFy5kosXL/Lbb7/RqVMnEhIS9GU2b95MmzZtyMnJ4fvvv+fcuXOsXr0aJycnpk2bZlDftm3biI6O1r8WL15c5LWvXLlC/fr1adSoER4eHqj+mbn/brm58v/GJCniP0tJSVEAJSUlxdihFEtmTr4y8J1FiueYLxUzOxcFUI4ePaooiqJotVojRydMwa3UbGXsysOK7+TN+leTmVuVeb/sUUaMHKlYWloqQKGvJcPrKcoMxzuvS38Z+3ZEKcrKylLOnj2rZGVlGTuUYktKSlIAJTQ0tMgyGRkZipubm9K/f/8i61AURQkPD1cA5fjx48W6dseOHQ3+v3Ts2FFRFEXx9fVVZs+erQwfPlxxcHBQRo4cqSiKovzyyy9KgwYNFEtLS8XX11eZP3++QX2+vr7Ke++9pwwfPlyxs7NTfHx8lI0bNyq3bt1S+vbtq9jZ2SmNGzdWDh8+XKz4li9frjg5OSkhISFKvXr1FDs7O6VHjx5KVFSUvszIkSOVfv36KTNnzlTc3NwUBwcH5cUXX1RycnL0ZbKzs5VXX31VqVy5smJlZaW0a9dOOXTokMG1tmzZotSuXVuxtrZWOnXqpCxfvlwBlKSkJCU9PV1xcHBQfv75Z4Nz1q9fr9ja2iqpqanFup+73et3tbjf49KcUAFZW6g58uMCor4ZhyYjiQYNGtC8eXOAQv/iERVPZQcrvhrekk8HN9O3OqVk5bHocArjpn/M9evXef/99wudXbiT43X9+2QcueXQqMziFiYk+TpcC9O9Ig8UXiYz8U6Za2GQm1GwTH6uYZn0IhaeTostdmi311rbsGEDOTk5hZbZunUr8fHxvP3224Ued3Z2Lvb17rZu3TrGjh1LYGAg0dHRrFu3Tn9s/vz5NG3alOPHjzNt2jSOHj3KwIEDGTx4MKdOnWLmzJlMmzaNFStWGNT5ySef0K5dO44fP87jjz/O8OHDGTFiBMOGDePYsWPUrFmTESNGoBTzua/MzEzmz5/Pd999x+7du4mMjOTNN980KLN9+3bOnTtHaGgoP/74I+vWrWPWrFn642+//Ta//vorK1eu5NixY9SqVYsePXqQmJgI6FYseOqpp+jTpw8nTpxgzJgxTJkyRX++nZ0dgwcPZvny5QbXXb58OU8//TQODg7FupcS98CpWilbtGiR4uvrq1hZWSn+/v7KwYMHiyz766+/Ki1btlScnJwUW1tbpWnTpsqqVasMymi1WmXatGmKh4eHYm1trXTt2lW5ePGiQZmEhARlyJAhioODg+Lk5KQ899xzSlpaWrFjLm8tTWfOnDH4Syc4ONjYIQkTFp+Wrbz24zHFd/Jm5aXvjhgcy83NVX766SelQ4cO+t+nAC8zZWkfayV9qoPyv/aWiqWlpTJ06FBl//79d1oyz/+uKNtmK0rSNSPckShJRf71vuPDO62Ns90KP/n8H4atkjFnCpZJjTYsc2x14XUdWf5Acf/yyy+Ki4uLYm1trbRt21aZOnWq8vfff+uPf/TRRwqgJCYm3rOe2y1NNjY2ip2dnf517NixIs95/fXX9S1Mt/n6+hZo1RoyZIjSrVs3g31vvfWW0qBBA4Pzhg0bpt+Ojo5WAGXatGn6fWFhYQqgREdH3/NeFEXRt/ZcvnxZv2/x4sWKu7u7fnvkyJGKq6urkpGRod/35ZdfKvb29opGo1HS09MVCwsL5fvvv9cfz83NVTw9PZW5c+cqiqIoU6dONbgPRVGUyZMn61uaFEVRDh48qJiZmelbuWJjYxVzc/N7thDeyyPX0rR27VomTZrEjBkzOHbsGE2bNqVHjx7culX4Xxaurq688847hIWFcfLkSUaPHs3o0aPZunWrvszcuXP57LPPWLJkCQcPHsTOzo4ePXqQnX1nHa6hQ4dy5swZ/vrrLzZv3szu3bt54YUXSv1+y5pGq/srY/v27QxuZM6cICt61TKnf6+uRo5MmLJK9lZ8Org5y0a1Yla/hgbHzM3Nqd+2O7t27eLEiROMHTuWk4mWjN2UTdWP01h0KJfc3Fy+//572rZtS8uWLfn222/R7P0U9syHT5vCL8/LnE+izA0YMICoqCh+++03evbsSWhoKC1atNC34igP+Du5du1aTpw4oX81aNDggWNq1aqVwfa5c+do166dwb527dpx6dIlg0lnmzRpon/v7u4OQOPGjQvsK+q79N9sbW2pWbOmfrtq1aoFzm3atCm2trb67cDAQNLT07l+/TpXrlwhLy/PIHYLCwv8/f05d+6c/t4CAgIM6gwMDDTY9vf3p2HDhqxcuRKA1atX4+vrS4cOHYp1H6XBpJKmBQsWMHbsWEaPHk2DBg1YsmQJtra2LFu2rNDynTp14sknn6R+/frUrFmT119/nSZNmrB3715A90u/cOFC3n33Xfr160eTJk1YtWoVUVFRbNiwAdD9w4WEhPDNN98QEBDAY489xueff86aNWuIiooqq1svdYqi0G/xXib/cpIte44wtLEFk9tZ8ftQW+qGjjF2eKIc6FLPnSoOhlNRbDoZzROf72Xi2hNUrV6Xr7/+mhs3bvDxxx9TuVoNUv/V83H8+HHmT3kBs+thuh2KFqzsQbqFhRFYW1vTrVs3pk2bxv79+xk1ahQzZswAoE6dOgCcP3++WHV5e3tTq1Yt/cvKyuqB47Gze7iF0S0sLPTvbw+xKGyfVqt94Ppun/+gSWRJGTNmjD6RXb58OaNHjzbqMBKTSZpyc3M5evQoQUFB+n1qtZqgoCDCwsLue76iKGzfvp0LFy7os9Dw8HBiYmIM6nRyciIgIEBfZ1hYGM7OzgYZflBQEGq1moMHD5bU7Rld6IU4Tt9MZe2R65y1aUR7nzsr2qt8Au9xphCFS8vO473Nunma1h+/Sef5oXwRehlbBycmTZrEpUuX2LJlC7179zb4kHOzVXHm1p2/kl/69gjr168nPz/f8AIpN8rkPkQpaT4MRofoXiM3FV7G2/9OmdEh4OJbsIyNq2GZ2t0Kr6tOr/8ccoMGDcjI0I2r6t69O25ubsydO7fQsmUxl1D9+vULTIGwb98+6tSpg5mZWRFnlY2///6brKws/faBAwewt7fH29ubmjVrYmlpaRB7Xl4ehw8f1rfA1a9fn0OHDhnUeeBAwbFvw4YN49q1a3z22WecPXuWkSNHltIdFY/5/YuUjfj4eDQajb4Z8TZ3d/d7ZvopKSl4eXmRk5ODmZkZX3zxBd266f5TxcTE6Ov4d523j8XExFClShWD4+bm5ri6uurL/FtOTo7B4MHU1NRi3qXxLNl1Rf/e4vgabthpcbBSo1apwLetESMT5ZWdpTkTgmozN+QCKVl5ZORqmBtygTWHrvPO4/Xp3sCd3r1707t3b65cucKSJUtYtmwZeyMTafRlBu19zAiqYc5Xofv5auNTeHl58cILLzBmzBg8na3h85bg3gj8X4CG/cH8wf9yF0bk7K173YutK/je5482c8v7lwFwcL9/mX8kJCTwzDPP8Nxzz9GkSRMcHBw4cuQIc+fOpV+/foCu1eebb77hmWeeoW/fvrz22mvUqlWL+Ph4fvrpJyIjI1mzZk2xr/kw3njjDVq3bs17773HoEGDCAsLY9GiRXzxxRelet3iyM3N5fnnn+fdd98lIiKCGTNmMH78eNRqNXZ2dowbN4633noLV1dXfHx8mDt3LpmZmTz//PMAvPTSS3z88ce89dZbjBkzhqNHjxYY4A7g4uLCU089xVtvvUX37t2pVq1aGd+pIZNpaXpYDg4OnDhxgsOHD/PBBx8wadIkQkNDS/WawcHBODk56V/e3vf5YDCyc9GpHAzXPbHgrM7m6qnjNPoyA6c5acT0/Bbq9DRyhKI8UqtVDA3wZeebnRjexhf1P41JkYmZvPjdUQZ/fYAT15MBqFmzJvPmzePGjRssX76cVq1asSdSw4zQO3983Lx5kxkzZuDj48PKid0hPxtuHoH1L8DFrYVEIMTDsbe3JyAggE8++YQOHTrQqFEjpk2bxtixY1m0aJG+XL9+/di/fz8WFhYMGTKEevXq8eyzz5KSksL7779f6nG2aNGCn376iTVr1tCoUSOmT5/O7NmzGTVqVKlf+366du1K7dq16dChA4MGDaJv377MnDlTf3zOnDkMGDCA4cOH06JFCy5fvszWrVtxcXEBwMfHh19//ZUNGzbQtGlTlixZwocffljotZ5//nlyc3N57rnnyuLW7slk1p7Lzc3F1taWX375xWB69pEjR5KcnMzGjRuLVc+YMWO4fv06W7du5erVq9SsWZPjx4/TrFkzfZmOHTvSrFkzPv30U5YtW8Ybb7xBUlKS/nh+fj7W1tb8/PPPPPnkkwWuUVhLk7e3t8muPbfh+E0mrD0BQKUbezj2/UeA7ovs8uXLRoxMPErOx6Qye9NZ9l9JMNjfp6knnw5qhlptOA7h8OHDfPnll/z4448GD2YAXBxvR+1Kuu6HNJUjuS8foVLl4rckiLIja8+J0vbdd98xceJEoqKisLS0fOh6Hqm15ywtLWnZsiXbt2/X79NqtWzfvr3AiPp70Wq1+oSmevXqeHh4GNSZmprKwYMH9XUGBgaSnJzM0aNH9WV27NiBVqstMLL/NisrKxwdHQ1epiw29c4X0pWTd/qQu3aVp+ZEyann4cj3YwJYMqwl1d3uDGi1NlcXSJgAWrduzbJly7h58yYLFiygdu3a+mNP/JjFpwdzSM1RmLP9Fl7evgwbNoy9e/feGZAasQ+OrYK8rAJ1CyHKv8zMTK5cucKcOXN48cUX/1PCVGIearKDUrJmzRrFyspKWbFihXL27FnlhRdeUJydnZWYmBhFURRl+PDhypQpU/TlP/zwQ+XPP/9Urly5opw9e1aZP3++Ym5urixdulRfZs6cOYqzs7OyceNG5eTJk0q/fv2U6tWrG8zT0LNnT6V58+bKwYMHlb179yq1a9dWnn322WLHberzNM367Yx+Vmcrrwb6+XTWrl1r7NDEIyo3X6Os2h+utA3ertxMyjQ4lpWbr8SmFpwnRaPRKH/99ZcyYMAAxczMTAEUe0sUB0vDGccbNGigfPrpp0rut4/r5u2Z46so298vozsT/1YeZwSvyHr27Gkwn9Tdrw8++MDY4RmYMWOGYm5urnTp0uWB5k4sSknM02QyA8EBBg0aRFxcHNOnTycmJoZmzZoREhKiH8gdGRmJWn2ncSwjI4OXX36ZGzduYGNjQ7169Vi9ejWDBg3Sl3n77bfJyMjghRdeIDk5mccee4yQkBCDprnvv/+e8ePH07VrV9RqNQMGDOCzzz4ruxsvZbfS7rQ0adLvdJ107tzZGOGICsDCTM3wQD+GBPhi9q9Wph8PRfJRyHlGBPrxQocauNnrBnjfflo2KCiIqKgovv32W/0UBnc7e/YsX8yeyGvj7XU7spJQUiKRSQuEuL9vvvnG4Km3u7m6upZxNPc2c+ZMg3FSpsBkxjSVZ8XtCzWWgUvCOBShGwjebNPTBFRVuGXhzSdrd4Gj533OFqLkZOdpaD93J3Fpui50aws1g1p5M7ZDDaq52BYon5+fzx9//MGSJUv4448/9F1zfeuas7yfDa42ulRp4DZ3Hhs4nmHDhhl+8Gu1oDaZUQiPJBnTJMqLR2pMkyg9sf+0NGmz0xlQB6Y+ZsUnAbdgSXuZiVmUqVyNlr5NPbEy1330ZOdpWRl2jY7zQpm09gQXY9MMypubm9OnTx+2bNlCeHg477zzDh4eHvx2IZ9qC9IY81sW3x7P5ed9l3j99dfx9PRk+PDh7N69GyU7FT5vDttmyZxPZUD+/hamriR+R6WlqQSYekvTvsvxbNkZxudffMnhdrup5/bPpGi1u8PQn40bnKiQYlOz+Xr3VX44GElWnsbgWKe6lXmuXXXa13YrdObfvLw8Nm/ezNdff83WrVuL/CCc/bgX01r9k4SpzHQTLPq1K7SseHgajYaLFy9SpUoVKlWqZOxwhChSQkICt27dKnRy0OJ+j5vUmCZROtrVcuOnz7eRc/IPsvztyNcqmKtV4NXS2KGJCsrd0ZppTzRgfOdarNgfwcqwCJIz8wDd7PWHwxM58L+uOFhbFDjXwsKCJ598kieffJKIiAi++eYbli1bRnR0tL6MChhUPRnQfTAm5Zpx8Ewi3bw1Rp9J+VFjZmaGs7Ozfm0yW1tboy5zIcS/KYpCZmYmt27dwtnZ+T99BkhLUwkw9ZYmgEaNGnHmzBkAurYPZNt3H4ODB7hWN3JkQkBGTj4/Hopk+b4IbiZnMbqdHzP6GC4OnJCeQyX7wmcFz8/PZ8uWLSxdupQ//vgDNVpGN7PgtQBLGlUxY/rObN7bnUu1atX0C3tXr14d4i/r1r5z8CiL23xkKYpCTExMmSwtIsTDcnZ2xsPDo9Ckvrjf45I0lQBTT5piYmKoWrWqfnvatGnMnj3biBEJUbh8jZa/zsbSyMsJb9c7A8OTMnJpE7ydlr4uDGvjS1B9dyzNCx+Sef36dZYvX863335LZGQkXaqbcSpWS1ym4Udd165dWdkjG8+sc6gaPgkB46CatL7+FxqNhry8PGOHIUQBFhYW92xhkqSpDJly0nQ9MZMVv2xi9tQ30KTGoeTnEhoaSseOHY0dmhDF9s2eq7y/5Zx+29XOkv7NvHimVTXqVy38/5xGo2Hbtm188803bNy4scCXeU0XFRdftdetvwgkenXBZcw66VoSogKSp+cEAFtORfPtVXu8xn6FTc3W2NjY0KZNG2OHJcQDcbG1xLfSnZanxIxclu0Lp9ene3ji8z2s2BdOfHqOwTlmZmb06NGDn3/+mZs3b/Lxxx9Tv359/fEhjS30CRNA71mbaN68OZ9++inx8fGlf1NCiHJHWppKgCm3NM3adIbl+yIAiFn9JoG1Pdi5c6dxgxLiIWi1CvuuxLP28HX+PBNLrkZrcNxMrWJM++pM7VW/iBp0Y28OHDjAt99+y9o1a2jrkc1r/pa42app822GvpyFhQV9+vRhzIhn6aHsRN1qNFRrVWr3JoQwLnl6TgAQk6Kb+bWl6gJtm92iUv26kHQNnH1AuiFEOaJWq2hfuzLta1cmOTOX3/6O4ucjNzh1MwUAjVahmrONwTlarUJ2vgZbS91HnUqlIjAwkMDAQBYuXMjPP//MnGXLOBy21+C8vLw81q1bR+Vrm+j1hA2cWE2mS31sh/8oD08IUYFJS1MJMOWWpscXbOPMrRzeMP+JV8036Haq1DDluu6pISHKufMxqWw4HsXvp6JZ/3JbgyfsDl5NYOTyQ3SuW4XejavSqW7lQqcxuHjxIsuXL2fVqlVERUXp958eZ0fDKrrBo3EZWp7cU5dnh49m8ODBMieREI8QGQhehkw5aWoxfROJuWpWmr1PR4uzup1VGsDLYcYNTIgSpihKgUHcMzaeZmXYNf22hZmKwJpudGvgTrf67ng4GS6lkJ+fz19//cXy5cvZtXUjy58wo3dtXZL1/u4cpu3UjZu63X03cuRIenV5DAs7F2m5FaIck+45gaIopOTqcmKVJpc8tYKFmQq8Whg5MiFKXmFPvTlYW+BqZ0liRi4AeRqF3Rfj2H0xjmkbTtPIy5EudavQo5EHDT2dMDc3p1evXvTq1YuEhAR+/PFHnvp5KR1sLrDkSK6+3tvdd+vWrWPzcCea+TiT32I0Po+/gUpacIV4ZElLUwkw1ZamlMw8ms7+E4Cs8GN4X/iJI5uXg4UNuDe8z9lCPBryNVoOhSfy59lY/joby83kgiu8FzaZ5t1Onz7NypUr+e6774iNjdXv93FScfU1e8zUuoRtQ4QtF+pPYOjQoVSrVq3kb0YIUSpkygHBrX8W6gXQpCdSv3Ez3RNAkjCJCsTcTE3bWm7M7NuQvZM7s+W1x3i9a20aet75YOxSr4rBOTeTs3j8sz3M+eM8+y/HU6tufebNm8eNGzfYsmULAwcOxMrKinGtLPUJE8DHO+OYMmUKPj4+dO3alRUrVpCWZrgIsRCi/JKWphJgqi1Nm49cZvwvFwBICfuJd/o05s033zRyVEKYjtjUbHaev8WTLbywMr8zW/CaQ5FMWXdKv21lrqaVnwtta7rRtmYlGns5kZaawu8/LEE5tJSe7nFEpSk0XZJR4BqVHG34bFgjqnSfSMfeT2NhUXAguhDCuGRMk+D0hSsomjxUZhZo0hNp2rSpsUMSwqS4O1oz2N+nwP6r8YbJT06+ln2XE9h3OQEAeytzWvu50LnFs4x4ZSpXLpwh9IevqF59M+Hh4Qbn9q+Zz5DKF8g98iK/rX2Zo24D6Dd0LP7+/jL7uBDljLQ0lQBTbWn6+OOPefPNN1HbOKJo8oi5HkGVKlXuf6IQgvj0HPZeimff5Xj2X0kodCxU57qVWT7aX7+tKAo//r6LHb+t5def1pCcnMyxF+xoXlXXihWfqaXagnRyNFCrVi2GDBnC0KFDqVOnTpndlxCiIJlyoAyZatI0fPhw4g+s4ekG5hxNtOeL30+Dg7uxwxKi3FEUhWsJmey/ksD+K/EcuJpIfHoOU3vV48WONfXl8jVamsz6k3ytQmNPB7yzr/J2wlQ8LdIBmLc/h7f/yilQfzv/FgwYPIxBgwbh6elZZvclhNCRpKkMmWrS1KRJE17xvcSLLS11O8xtYEokmFsaNzAhyjlFUbgSl4GjjTlVHO7M9fT39WT6Ld5nUFaFlo7qv3nO4i+Cb7Zmz6G/ybl5jvzEm/oy6wbaUM1RzVdH84iuFMhTg4fz1FNP4eLiUmb3JERFJklTGTLFpCknJwd7e3vOjbOmlus/D0lW7wgjfzNuYEI8wi7EpLF0z1UORyRyLSHznmWt/3yfC8cP4Omg4toEe8z/eQpv5YlcRm3MxtLSkl69evHss8/Sp08fbG1t71mfEOLhyUDwCu7cuXNU7jKKCHZTNf8WduZaqNHR2GEJ8Uir6+HA/Gd0D1zcSsvmaEQShyOSOHItkbNRqeRrdX+jejpZs+/ofk6ePEns2kmYq4/o61hn+QR2jVPIjb7Axo2/sXHjRuzs7OjXrx+DBw+mR48eWFpKa7EQxiAtTSXAFFuaVqxYyYzTjqjMLVFuXWLXyCr4NW0Pzt7GDk2ICikrV8PJG8kcjUzCXK3ihQ7/jIVKuIJy+FvSDqwgQWtP59wFgK7VSZuTQU70JcxjzjDdcx/LDqZwKUnFk08+xeDBg+ncuTPm5vK3rxD/lXTPlSFTTJrGT3qbzZa6lqWciONcXz1FPlyFMFFarcLAL0JJjbrMRW3BgeDPmIUyz+JrAE6m2vPUimiuJClUrlyZp59+mkGDBvHYY49hZmZW4FwhxP1J91wFd+JiBDTSJU2OlkjCJIQJU6tV/DK+M5m57Tl1I4Xj15M5HpnEsWtJxKXnMthsp75sNatMbqTq/taNi4tj6dpNrM+si/nCLbT0c2Vw90AGdHsMC3NJoIQoafJN+ghSFIVL12OxaaTbrupkY9yAhBDFYmtpTkCNSgTUqATo/i/HxCdi8VMliLsEwK5kT/JJAzQAWHnWwcqjFjWr2nBLsWLKrnQm/7WeymZZBNatyuNtGtLcxwV3R+uiLiuEKCZJmh5BUVFRZGjNuZ0q1fB0M2o8QoiHo1KpqFq5EryyFRKuwPHveLLxQGLeq8K6detYs2YNx3LdURQtb1uspZv6KHu1jfhB3ZUQrT+bLuew6fIxAHwdzdg5pTtqtSw5KsTDkjFNJcDUxjRt2bKF2HVv4+RZnX2ahtRt2JIXhw40dlhCiFIQExPDhrWrGJPwIeZq3cf5xuwWvI7hOpNZV49gsX8pAwYM4Omnn6Zdu3a8s+E0igLNvJ1p5uNM7SoOBgsQC1FRyEDwMmRqSVPwB+/zStZCHM3zAIj1eRz3534wclRCiFJzdAVsel2/OfGoL5+HRmFZtQ5WVetg5VmHrKtHUU6sIy1XV6aqpyc2w75Ao7rT4WBnaUbjak4093Ghmbczzb2dqSLdeqICKO73uMm10y5evBg/Pz+sra0JCAjg0KFDRZZdunQp7du3x8XFBRcXF4KCggqUV6lUhb7mzZunL+Pn51fg+Jw5c0rtHktb2sU9+oQJwLJukBGjEUKUuhYj4bk/oflwqFyPTzYeJ+LcCYJfGURDzWVi17xD/vF1XJ/owJ/DbBnWxILMfIV8xbBVKSNXw4GriXwZeoUXvzuK/4fbaTdnB0ciEo10Y0KYFpNqaVq7di0jRoxgyZIlBAQEsHDhQn7++WcuXLhQ6EKzQ4cOpV27drRt2xZra2s++ugj1q9fz5kzZ/Dy8gJ0Tdd3++OPP3j++ee5fPkyNWrUAHRJ0/PPP8/YsWP15RwcHLCzsytW3KbW0vRM2xq80M6VQNvr2KuyyR3/N5ZufsYOSwhRFrRa+Ne4pZs3b3L6h+n0yPhFv+/ZXzNZe8EMS/daWHnWwbJqXaw862DuWPCzds/bnfF2vTMj+f4r8fx5JpbmPs608HGhmosNKpV064nyq1x2zwUEBNC6dWsWLVoEgFarxdvbm1dffZUpU6bc93yNRoOLiwuLFi1ixIgRhZbp378/aWlpbN++Xb/Pz8+PCRMmMGHChIeK25SSpszMTBwcHHAIHIRNZW9613fk2w/fMWpMQggTsKo/XNVNXZCjsqLPrnps37UPrVZrUMzM3lWfQNl6N8C+ijczWsITTzyu/3z78PdzfL37qv6cyg5WNPd2poWvCy18XGhSzQlrC5nyQJQf5W6eptzcXI4ePcrUqVP1+9RqNUFBQYSFhRWrjszMTPLy8nB1dS30eGxsLFu2bGHlypUFjs2ZM4f33nsPHx8fhgwZwsSJE8vl3EZnz55Fq9WSsu9HUoDew3657zlCiAqg0xRw9oEz67Fq0I8/ZywiNjaWDRs28Ouvv7Jjxw5611TxQZccfjh9lB9OHCByl+5v6qGApaUlXbt25amnnuJgVm2DquPScvjzbCx/no0FwFytoqGnI08292JUu+plfadClBqTyQri4+PRaDS4u7sb7Hd3d+f8+fPFqmPy5Ml4enoSFFT4GJ6VK1fi4ODAU089ZbD/tddeo0WLFri6urJ//36mTp1KdHQ0CxYsKLSenJwccnJy9NupqanFiq8shIeHG2zXq1fPSJEIIUyKTxvdq9dHkJMO6D5fX3zxRV588UUSEhJI/XYA1TOPE+xuxvQOVrjNSyPzn+GRubm5/PHHH/zxxx+Y2zrSrGt/qrfqgtbVlwvxOaRl5+svla9V+PtGin6+qdsUReH7g5E0qeZE/aqOWJiZ3LBaIe7JZJKm/2rOnDmsWbOG0NBQrK0Lf9pj2bJlDB06tMDxSZMm6d83adIES0tLXnzxRYKDg7GysipQT3BwMLNmzSrZGyghERERBtu+vr7GCUQIYZosbHSvf6lkb0ml3HP67XjXljzevzK///47GRkZBmXzM1M5smkVRzatAqBxk6b07TuYak0fIx4HjkUmc/lWOi18nA3Ou5GUxbsbTgNgY2FGk2pOtPZzpaWfrlvPycaihG9WiJJlMkmTm5sbZmZmxMbGGuyPjY3Fw8PjnufOnz+fOXPmsG3bNpo0aVJomT179nDhwgXWrl1731gCAgLIz88nIiKCunXrFjg+depUg0QrNTUVb2/TWAg3IiICVGpQtLi5uWFvb2/skIQQ5YE2H9q+Bqd+gqQIvHtP4qc3+pCdnc22bdtYt24dv/32GzP8M/CwU7HmTB6/X8onOx9OnfybUyf/BsDHx4d+/frxau++tK3uYnCJo9eS9O+z8jQcDE/kYLjuyTyVCupUcaCVnwut/Vzp1dgDK1kKRpgYkxsI7u/vz+effw7oBoL7+Pgwfvz4IgeCz507lw8++ICtW7fSpk2bIuseNWoUp0+f5siRI/eN4/vvv2fEiBHEx8fj4uJy3/KmNBB8yejmqPLTueXVmct5lXh29Gv0bFTVqDEJIcoRRYEbR6BqEzA3bGnPz86AebUx1+hantafy+Opn7KKrMrJyYnevXvTr18/evbsSarGgp0XbnH0WhJHIpK4mVz4ubaWZpyc0R3zu7rvkjJycbSxkMk3RakodwPBQddNNnLkSFq1aoW/vz8LFy4kIyOD0aNHAzBixAi8vLwIDg4G4KOPPmL69On88MMP+Pn56acXsLe3N2hhSU1N5eeff+bjjz8ucM2wsDAOHjxI586dcXBwICwsjIkTJzJs2LBiJUymprnNTQKq5ABrOWhZj2TV6/c9Rwgh9FQq8G5d6CHziFDQ3Omqaz5kGu/WyWTjxo2cOnWqQPmUlBR+/PFHfvzxRywsLOjUqRN9+/ZlUp8++A5uTkxKNkeuJXIkIomj15I4G52KRqvQwsfFIGECmPTTCY5cS6Klr64lqrWfqzylJ8qcSbU0ASxatIh58+YRExNDs2bN+OyzzwgICACgU6dO+Pn5sWLFCkA3VcC1a9cK1DFjxgxmzpyp3/7666+ZMGEC0dHRODk5GZQ9duwYL7/8MufPnycnJ4fq1aszfPhwJk2aVOh4psKYSkuToihETnLC10n3l9ivmvbUGPsdzX3KX/InhDBBN45A2CK4EAKKBt66DNa6z9QrV66wceNGNm1cz1dNThB2PZ+fz+bz19V8cjUFq2ratCl9+vShT58+tGrVCrVaTUZOPieuJ6NWqQiseWcQuVar0HT2nwaDzQEszdU0reaEf3VX/KtXoqWvC/ZWJtUWIMqJcjlPU3llKklT3K1bXPlfdep42OFqnsPC/KcY+OYXeDoXHPQphBAPLScdov8Gv3YFj10NhVX99Jsvh2j48mBGwXJ38fDw4IknnqBPnz507dq1wMTCKZl5TFl3ksMRicSn5xZZj1oFi4e0oFdjGZIgHowkTWXIVJKmw4cP4+/vj8fw+bh5+qBCy9EPnpHHeoUQZWfT67q18ABUZmSNP8n2sBNs2rSJ3377jZiYGNQqsLNAvw7e3aytrenSpQtPPPEEjz/+OD4+PvpjiqIQkZDJ4X8GkB+OSCQyMdPg/B1vdKRG5TvDM45eS2TD8Sj8q7sSUMOVKg6ylp4oqFyOaRL/ze3pBswcKpOGLc7WakmYhBBlq0ZnSIuBKzvAJxCbStV44olqPPHEE3z55ZccPXqUv3/7khH8yp9X8lh/Pp+fzuRxuwEpOzub33//nd9//x3QTQPz+OOP8/jjj9OmTRuqu9lR3c2Oga11TyzHpmZzKDyRQ+GJXLqVRnU3w1aq7edu8d2Ba3x3QDeUo4abHQE1XAmoXomAGq5UdZKWeFF8kjQ9QiIiIlBZ2mDuoBsL4Ocm0w0IIcpYw/66V3YKZMQbHFKr1bRu3ZrW8b/AQXiijgWP17Ekw6sF6//cR25uwaankydPcvLkSYKDg6lUqRI9e/bk8ccfp0ePHri6uuLuaE2fpp70aepZaDiH/7XY8NX4DK7GZ/DjoesA+FaypU31SvRs5EHnegXX3RPibpI0PULCw8OxcLnzwVHb3fiLBwshKihrJ/0gcQOKAuc26TdV3gGsmbmVtLQ0tm3bxqZNm9iyZQt2uXE4W6s4HnNnbbyEhAS+//57vv/+e9RqNYGBgfTu3ZvHH3+cJk2aFLpo8PLR/hyJ0HXnHbyawMkbKeRr74xKuZaQybWETKwt1AWSplup2VRxlO48cYckTY+QiIgIzF2r6bdrVpGWJiGEiVG00Hs+nPsNLvwB9Z8AwMHBgSeffJInn3wSrVZL7HdjqBr+KzFZZvx8KovX/8jm7gG4Wq2Wffv2sW/fPt555x08PT3p1asXvXv3JigoSD8uxd7KnE51q9Cpri4hyszN59i1ZA5cTeBgeAInrieTp1Fo868lX26lZuP/4XZ9S1RgTd3LXZKoCk0GgpcAUxkIPqe/D0k21Yiv3pMLijfTh/Wie8N7z6YuhBBGo8nTvSxtDfcrCnzWDJIiAMh1b8Yqi+Fs3ryZbdu2FVjW5d/Mzc1p164dvXr1olevXjRu3LjQViiArFwNxyOTaOjlZLCMy8YTN3l9zYkC5au72dGmxj9JVI1KVHYo3tQ0wrTJ03NlyBSSJkVRiHvbiSp2ug+GrXmtaD55izQtCyHKn/hLsKjVne2uM6C9bumqnJwcdu/ezZYtW3C59AvZqXFsvpjP6VvaIioDLy8vevbsSc+ePQkKCsLZ2fm+IWw7G8vXu69y4noyuZqi627o6cim8Y+hlpnKyzVJmsqQKSRNcTfDqby0mX57v11P2r51/3X2hBDCJCVe1XXfXfgDHv8YKhdcB5TPWkDiFQD2JrgStDSanJyce1ZrZmZGYGAgPXv2pEePHrRo0QK1uuinjG+3RIVdTeDA1TvdebcFVHdl7YuBBuf8cvQGLrYWtK7uiqO1LEJcHkjSVIZMIWn6e+d6qv85Ekcr3V87x2q9Toths40SixBClLr4y7Co5Z3trtPJbDmOnTt38vvvv/PHH38QHh6OszUkZxddjZubG926daNHjx50796dqlXvPTFmZm4+RyJ0SVTYlQSC6ldhfJfa+uNarUKrD7aRmJGLWgWNqznTtmYl2tasRCtfV2wsZdkXUyRJUxkyhaTpp59+YtCgQbjaqKjhomL15r3UbR54/xOFEKI8Ct8Dm17TtUgBvLQPPBrpDyuKwqVLl6iypgcZGZlsPJPByhPZHLpZyJoud2nSpIk+gXrsscewtn6wIQ7nY1LpuXBPoccszFQ093GhXU032taqRNNqzliay1x6pkCSpjJkCknT3LlzeWfu51j7NCE/4QaXj+7Cy83ZKLEIIUSZib+kW7ql9RjdYsN3S7gCn7fQb17wHsKXp6wICQnhwoUL963axsaGjh070r17d7p3706DBg2KHFB+W0ZOPnsvxxN2RdcSdSE2rciyv7/WngaeMjWMKZAZwSuYiIgIbHyb4drtJQD2hqcySJImIcSjzq227lWYS38abNZ9/GUWPt8Y0H1mbt26la1bQ+iUu5094Vlsu5pv0JWXlZVFSEgIISEhAHh6etKtWze6detGUFAQ7u7uBS5pZ2VOj4Ye9PjnyeW4tBx9V97+K/FcS9At++JqZ0k9DweDc5ftDedQeCJta1WibU03ala2u2+SJsqWtDSVAFNoaerduzcH8nxxbKmb8+TnlwJp7edqlFiEEMIkxF+Gcxvh0l+QcgMmnCrYGnXXk3paRcXMv915/7dLFOersUmTJvokqn379tja2t73nBtJmYRdSSAzV8PItn4GxwZ/HcaBq3dmMHd3tKJtTTfa1XKjXa1KsuRLKZLuuTJkCklTgwYNSGgyFBu/ZgAcfTeISvYyf4gQQgCQnwvmlgX3H1gCIZPvbI/bT7yZO9u3b2fr1q389ddf3Lhxg/puas7FFz31gKWlJe3atdO3QrVo0QIzs+IP+s7XaGk7Zwe30op++q+Gmx1ta1ViYCtvmlRzLnbd4v4kaSpDxk6aFK2W1x9zJNH/FaJsahGrdeb0nKelWVcIIe5n54ew71PIzwZ7d3jjgkFrlKIoXD34OzVDhpCQa8nWS9nM3pnJhYSiEygAZ2dnunTpQteuXQkKCqJ27dr3/UzWaBXORaey73I8+64kcDg8kay8ggPXFw5qRv/mXvrtnHwNWi3yZN5/IElTGTJ20nQr/CxVVt55Um6+dhhvzl5c5nEIIUS5lJcF1/ZDVhI0frrg8QNfQsgU/eZh/8Vs3H+ev/76iyNHjqDV3juBAvD29tYnUV27dsXTs/AFhu+Wm6/lxPVk9l2OZ/+VeI5HJpOvVTj0v64GExdvPRPDqz8cp4WvM+1qutGuthtNvJwwN5Mn84pLkqYyZOyk6fTWFTQKe12//ZHtW0x++90yj0MIIR5JPwyCi7rB4Nh7wBvn9a1RiYmJhIaGcj70J/rzFyEXMtgRrmFHeD5Z+UVXWa9ePX0S1alTJ1xd7z8GNSMnn79vJNO2ppvB/ukbT7Mq7JrBPgcrcwJquP4zHsqN2lXspffhHuTpuQokNfK0wbZ91SKeJBFCCPHgur0HNTrD1Z3g6GXQfefq6spTTz0FHlHw5x80CLRiUiC8frUTP4aEERcXV2iV58+f5/z583zxxReoVCqaNWtG165d6dy5M+3bt8fBwaHAOXZW5gUSJgA3eyt8XG2JTMzU70vLyWfbuVtsO3cLgMoOVgwN8GFCUJ3/+tOo0KSlqQQYu6Xpozlz+PbPQzQKaI+36hbdnhzNE63lP4YQQpSZ7wfCpa26947VYOJptIrC6dOn2bZtG9u3byf+zC6erJXPrmsa9kbmk55beFVmZma0bt2azp0706VLF9q2bVusJ/OuJ2bqx0PtvxxPQobhBcZ1qsnknvX024qisOP8LVr5uuJkW7GXe5HuuTJk7KRp3Lhx/HLTAbsGHQH4a2IHarsX/CtFCCFEKdk9X9eFd/MYNH4GnvqqQBHNro8x26lb3ipfC36fZ3MzuYjM6S4WFhYEBATQuXNnOnfuTGBg4H1nKtdqFS7EpumSqMvxHAxPZOmIVrSrdaelKiI+g07zQ1GpoLGXk64rr6YbrfxcsLaoWIPKJWkqQ8ZOmnr16sWB7KrY1GyNpUtVLgT3wcq8Yv3CCyGESchOhdx0cCxkoPfqp+HyX7r3zr5kvnCA/fv3s2PHDrZv386RI0eo6QxNPdTsuaYhNqPwr2crKyvatGlDp06d6NSpE23atLlvEpWbr0WtwmBw+OoD13h3w+kCZS3N1bTyddGPh2rs5YSZ+tEeDyVJUxkydtJUv359zp8/D8DAQYNZu+bHMo9BCCHEfax4Aq7tA0ULzYZC/y8MDqekpBCzdhJ1o34B4GKCluZfpZOZd+9qbydRHTt21CdRNjb3nwjz1I0UNp64yd7L8ZyPKXq5Fy9nG/ZO7vxIDySXgeAVhKIoRERE6Ler+/kaLxghhBBFG7UZslMg8gDYFRzQ7eTkhJN1gn67Zs2arF47g507d7Jz505On9a1Cvk6qXCzVXEiRotGgZycHHbt2sWuXbuYPXs2lpaW+Pv707FjRzp27EhgYCD29vYFrte4mhONqzkBEJ+ew/4rCey7FM/ey/HcTM7Sl6vn4VAgYfpmz1Vc7SxpV8sNd8cHW9S4PJOWphJgzJamW5GXebZTPcKTtFxPVfh88Ze89NJLZRqDEEKIEqDVwryakPXPUiotRkDfz/WHb926xe7du7E7tJBetqdIz1UIu66h1/eZaO7xTW5ubk7Lli3p2LEjHTp0oF27djg7OxdZXlEUIhMz2Xs5nv2XE+hQx41BrX30x3PztTSb/SeZubqJN2tVsaddzUq0q+VGm5qVcLQuf4PKpXuuDBkzaTr3+1fUP/Q2APlahSON36PNM6/f5ywhhBAmKS8boo7puvG8WkHNzgXLrHgCIvYAkGLlxTs3u7Br1y59SxRANUcVlmZwNangV7xKpaJp06Z06NCBDh060L59e6pUqVLsEA9HJPLMkrBCj6lV0LiaM4/VqkS7mm609HMpF2NsJWkqQ8ZMmg599Sr+0av02we6/EKbDt3KNAYhhBBlRJMHc3wg7585mVo9B098AkBcXBy7d+9m165dNItfz3N1UolN17L7moZBv2Rxry/7unXr6hOo9u3b4+vrW+QYppx8DceuJbP/iq4r7+SNFDTawmvf/VZnfCrdf7oEY5OkqQwZM2na/34v2ubvByBPMSPm5ct4u99/ZlkhhBDlkKJAUgRcPwiRYVD3cajTvWC5Zb0gUvfdcF1TiSf/cOX48eMGS754O6owU0NEcsE0oFq1avoEqn379jRo0AC1uvBlWVKz8zh4NVG/3MvF2HRd/a427Hm7i0HZz7df4tTNlH+ezKtEzcqmMVO5JE1lyJhJ05vjRhFuUQ0/+zycNIlMm/O1SfwCCiGEMJL8XJjjrVuEGMD/Beg9j9TUVPbv369vjXrG8QQTAsyJTdey65/WqKK4uLjQrl07HnvsMR577DFatWqFlZVVoWVvpWaz/0oCeRotz7TyNjj2xOd7OH0zVb/t7mhF25putP1nTJSn8/2f+isN5TZpWrx4MfPmzSMmJoamTZvy+eef4+/vX2jZpUuXsmrVKn0/bsuWLfnwww8Nyo8aNYqVK1canNejRw9CQkL024mJibz66qts2rQJtVrNgAED+PTTTwt92qAwxkyauvd6gotNxwFgkXqDS1+8WKbXF0IIYWK0Woj5G64f0rVINR4IdXsWLPZ1F9RRRwE4m2qH/9epZGRkGJSp5arGxhzOxmkNBptbWVnRunVrfSLVtm3b+66fl52nod2cHQVmKr9bdTc7AmtWYoi/D428nB7gpv+bcpk0rV27lhEjRrBkyRICAgJYuHAhP//8MxcuXCh0kNrQoUNp164dbdu2xdramo8++oj169dz5swZvLy8AF3SFBsby/Lly/XnWVlZ4eLiot/u1asX0dHRfPXVV+Tl5TF69Ghat27NDz/8UKy4jZk0NWzXnYz2uoHfldIuc3SxDAIXQghxH/k5EFwNNP8kMG1eJq/rbI4fP86ePXvYs2cPe/fuZVZABq+0tiQ9V2H3tXwe/6Ho1qgGDRrQrl07/atmzZoFej60WoWz0ansvxLPvssJHApPJCtPU6Cub0a0IqiBu347K1eDVlGwsyqdmZLKZdIUEBBA69atWbRoEQBarRZvb29effVVpkyZct/zNRoNLi4uLFq0iBEjRgC6pCk5OZkNGzYUes65c+do0KABhw8fplWrVgCEhITQu3dvbty4gadnIbO6/osxkyavNn2w6KSbYqBuzgW2fjKpTK8vhBCiHNJqIPpvuHFY92o8sMDYKK1WS87ngdgk6SZPPhRrTsCSxAJVNfdQ426v5vBNDQlZd1KKKlWq0LZtW30S1aJFiwJdern5Wo5HJrHvSgJhV+I5HpmMApyY3g2Hu6Yu+OXoDab8epKXOtbkzR51S/AHoVPuJrfMzc3l6NGjTJ06Vb9PrVYTFBREWFjhjzb+W2ZmJnl5eQWaCENDQ6lSpQouLi506dKF999/n0qVKgEQFhaGs7OzPmECCAoKQq1Wc/DgQZ588skC18nJySEnJ0e/nZqaWqBMWVAUhUy1DbcbMD3sCh+kJ4QQQhhQm4FXC90roPBhHWpNLjYpl/Xb/k+O48a749i3bx979+5l7969/P3337zUypIXWloCcDxaQ4uvdV18t27dYsOGDfpGC0tLS1q1akXbtm31L3d3dwJqVCKgRiXoVoeMnHzORacaJEwA+6/Ek69V8HAy7kSaJpM0xcfHo9FocHd3N9jv7u6uXyLkfiZPnoynpydBQUH6fT179uSpp56ievXqXLlyhf/973/06tWLsLAwzMzMiImJKdD1Z25ujqurKzExMYVeJzg4mFmzZj3gHZa8lKQEHO1sAAVQUdXFztghCSGEeFSYWcK4MLh5BG4ehVpBeHl5MXDgQAYOHAjoGg1UX7WHjAgAUnIL/+M9qIYZDSrDkesH+eLT/cyfr9tfvXp12rZtS2BgIG3btqVx48a08is4NsrbxZYale1oW7NSqdxqcZlM0vRfzZkzhzVr1hAaGmqwcOHgwYP17xs3bkyTJk2oWbMmoaGhdO3a9aGuNXXqVCZNutMNlpqaire39z3OKB0pV49xrd0G8pRNJOHAfttRZR6DEEKIR5RaDZXr6F7NhhRaxNHGErJu6Lc7PDuBo6/2Z//+/ezbt499+/Zx/fp1hja2YFQzXWtUTLqWqh/rpiUIDw8nPDyc77//HgA7Oztat25NYGAggYGBtGnThsqVKzOxWx0mdqtTyjd8fyaTNLm5uWFmZkZsbKzB/tjYWDw8PO557vz585kzZw7btm2jSZMm9yxbo0YN3NzcuHz5Ml27dsXDw4Nbt24ZlMnPzycxMbHI61pZWRX5qGVZSouNAMBCpaEKybhVkvmZhBBClCELa3jrMkSdgKhjqP060MK7BS1atGD8+PEAXL9+HcfV3SEnCoATMdpCqxra2IJuNTQci9nP7tV7CA7WDRCvWbOmPoEKDAykcePGWFgYZ6kWkxkEY2lpScuWLdm+fbt+n1arZfv27QQGBhZ53ty5c3nvvfcICQkxGJdUlBs3bpCQkEDVqlUBCAwMJDk5maNHj+rL7NixA61WS0BAwH+4o9KXlXDDYNvNw6eIkkIIIUQpsXHRLffS/g3wbl3gsLenB04WdxKlLsPfJDQ0lODgYPr06YObm27x4p61zBjZzJJPe1rz0zN35mu6cuUKq1evZvz48bRs2RInJyc2b95c+vdVCJNpaQKYNGkSI0eOpFWrVvj7+7Nw4UIyMjIYPXo0ACNGjMDLy4vg4GAAPvroI6ZPn84PP/yAn5+ffgySvb099vb2pKenM2vWLAYMGICHhwdXrlzh7bffplatWvTo0QOA+vXr07NnT8aOHcuSJUvIy8tj/PjxDB48uFhPzhlTRJY9K3/Pws1WjZutigEj6xk7JCGEEMKQmQW8cR5SoyDqOJaVatGxSj06duwI6B5qunz5MpV/ehzydL1Nx6ILb41ytobkrCxq1qxZZuHfzaSSpkGDBhEXF8f06dOJiYmhWbNmhISE6AeHR0ZGGkzj/uWXX5Kbm8vTTz9tUM+MGTOYOXMmZmZmnDx5kpUrV5KcnIynpyfdu3fnvffeM+he+/777xk/fjxdu3bVT2752Weflc1N/wfhKbD4cJ5+e6xnDSNGI4QQQhRBpQInL92rwCEVtWvWAL9mugHnmfF0G/Em28d05MCBA4SFhXHgwAHi4+MBcHZ2pm7dkp92oDhMap6m8spY8zS99dZbzP/nEQRHR0dSUlLK7NpCCCFEiVMUXYuU2hwc3O/arXDlyhWO7dvBrbRc/XipklLq8zTl5eURExNDZmYmlStXvu/06aLkxSQkYelRG01mCpWquNz/BCGEEMKU3W6RKrBbRa2aNanl5w3mxnsQ64GSprS0NFavXs2aNWs4dOgQubm5KIqCSqWiWrVqdO/enRdeeIHWrQsOBBMl70Y6VB35CQDW1w8YORohhBCiFKlURk2Y4AGenluwYAF+fn4sX76coKAgNmzYwIkTJ7h48SJhYWHMmDGD/Px8unfvTs+ePbl06VJpxi2ApMx8/XsH4zx9KYQQQlQYxW5pOnz4MLt376Zhw4aFHvf39+e5555jyZIlLF++nD179lC7du0SC1QUtKxOKPaWh0jCgaOuVY0djhBCCPFIK3bS9OOPPwK6RXE3bdpE165dcXBwKFDOysqKl156qeQiFEWqaZuOkzoJgHibsl0oWAghhKhoHnhySzMzM5599lni4uJKIx5RTDmZ6TiZ35luAGunogsLIYQQ4j97qKfnWrduTXh4ODVqyLxAxpIYH8uWuEZUcXXAhTQ0LmW/9p0QQghRkTxU0vTqq6/yv//9j19++cUoC9UKuJWUzruJT2DtoFtrb75v4bOnCiGEEKJkPFTSNGjQIAAaNmxI37596dSpE82bN6dx48ZYWlqWaICicPHx8ajtdF1y2twsvNwLzmshhBBCiJLzUElTeHg4f//9NydOnODvv/8mODiYiIgIzM3NqVu3LidPnizpOMW/xMXFYWbrDIAmM4XKlZsZNR4hhBDiUfdQSZOvry++vr707dtXvy8tLY0TJ05IwlRGbsXFo7b2AUCbmaxfJVoIIYQQpaPEFux1cHCgffv2tG/fvqSqFPeQEB9H5IKJmNk6YW5pg9PKScYOSQghhHikFTtpioyMxMfHp9gV37x5Ey8vGWdTWhqk7+PXARbEZ2aQqNGtyyOEEEKI0lPseZpat27Niy++yOHDh4ssk5KSwtKlS2nUqBG//vpriQQoCuehuclT9S14oaUlg+srxg5HCCGEeOQVu6Xp7NmzfPDBB3Tr1g1ra2tatmyJp6cn1tbWJCUlcfbsWc6cOUOLFi2YO3cuvXv3Ls24Kzxrbbr+fYZi3AUMhRBCiIpApSjKAzVTZGVlsWXLFvbu3cu1a9fIysrCzc2N5s2b06NHDxo1alRasZqs1NRUnJycSElJwdGxbJYzWT2mIY2d0nA1zyYy3412H58tk+sKIYQQj5rifo8/8EBwGxsbnn76aZ5++mn9vhs3buDh4YG5eYmNKxf3MSWqA+ZuTwDgn3eIdkaORwghhHjUPfDac4Xp3bs3GRkZ+u2kpCQOHTpUElWLQiiKQg53JhH1cLY1YjRCCCFExVAiSZO5uTlOTncWjHVycmLcuHElUbUoREpKCiprB/22Z6Wy6RIUQgghKrISSZqqVavGnj177lSqVpObm1sSVYtC6JZQcdZv+7i7Gi8YIYQQooIokUFIixYtonfv3gQGBuLv78+pU6ceaE4n8WB0S6joWvY0Wam4V65i5IiEEEKIR99DtTRdu3bNYNvHx4fjx4/TrVs3IiMjqVOnDmvXri2RAEVBWTdO8j+X7Yw128zTbMfDSaYcEEIIIUrbQ7U01atXj3HjxvHuu+/i6qrrGrKwsGDgwIEMHDiwRAMUBeVHn+UV6z90Gy5wy3aUUeMRQgghKoKHamnavXs3f//9NzVq1ODDDz8kKyurpOMS95CVGm+w7exZ00iRCCGEEBXHQyVNrVu3Zvv27axdu5Zff/2VWrVq8fXXX6PVaks6PlGIjIwMMv+ZBVyrgKWjjGkSQgghStt/enquR48eHD16lPnz5zNv3jwaNGjAunXrSio2UYT18X5UP/sKNSLe4bHjvUFtZuyQhBBCiEdeiTw9169fP/z8/HjjjTd45pln0Gg0JVGtKEJW9GVubdkCQJWAACNHI4QQQlQMD5U0LVu2jLNnz+pfN27cAHRP0T3xxBMlGqAoKD7+zpimypUrGzESIYQQouJ4qO65qVOncuLECerUqcO0adPYt28fKSkpXL16lY0bN/6ngBYvXoyfnx/W1tYEBATcczmWpUuX0r59e1xcXHBxcSEoKMigfF5eHpMnT6Zx48bY2dnh6enJiBEjiIqKMqjHz88PlUpl8JozZ85/uo/SFBcXp3/v5uZmxEiEEEKIiuOhWppiY2NLOg4A1q5dy6RJk1iyZAkBAQEsXLiQHj16cOHCBapUKTjYOTQ0lGeffZa2bdtibW3NRx99RPfu3Tlz5gxeXl5kZmZy7Ngxpk2bRtOmTUlKSuL111+nb9++HDlyxKCu2bNnM3bsWP22g4PDvy9nMqSlSQghhCh7KkVRFGMHcVtAQACtW7dm0aJFAGi1Wry9vXn11VeZMmXKfc/XaDS4uLiwaNEiRowYUWiZw4cP4+/vz7Vr1/Szlvv5+TFhwgQmTJjwUHGnpqbi5ORESkoKjo6luw5cTk4OE18cSIadD/GZWoLqVmbilJmlek0hhBDiUVbc7/ESWXuuJOTm5nL06FGCgoL0+9RqNUFBQYSFhRWrjszMTPLy8vQTbhYmJSUFlUqFs7Ozwf45c+ZQqVIlmjdvzrx588jPzy+yjpycHFJTUw1eZSXhVjRf+IWysvIqtviu5jHry2V2bSGEEKIiK5Gn50pCfHw8Go0Gd3d3g/3u7u6cP3++WHVMnjwZT09Pg8TrbtnZ2UyePJlnn33WIJN87bXXaNGiBa6uruzfv5+pU6cSHR3NggULCq0nODiYWbNmFfPOSlZS1BU879q2cPIwShxCCCFERWMySdN/NWfOHNasWUNoaCjW1tYFjufl5TFw4EAUReHLL780ODZp0iT9+yZNmmBpacmLL75IcHAwVlYF13WbOnWqwTmpqal4e3uX4N0ULTUmwmDbxtWz8IJCCCGEKFEmkzS5ublhZmZWYJB5bGwsHh73bk2ZP38+c+bMYdu2bTRp0qTA8dsJ07Vr19ixY8d9xx0FBASQn59PREQEdevWLXDcysqq0GSqLFxMs2Zi9ue4qNKxiz3O3KfbGyUOIYQQoqIxmTFNlpaWtGzZku3bt+v3abVatm/fTmBgYJHnzZ07l/fee4+QkBBatWpV4PjthOnSpUts27aNSpUq3TeWEydOoFarC31iz9gi49KIoRLnFF92xTlTybuOsUMSQgghKgSTaWkCXTfZyJEjadWqFf7+/ixcuJCMjAxGjx4NwIgRI/Dy8iI4OBiAjz76iOnTp/PDDz/g5+dHTEwMAPb29tjb25OXl8fTTz/NsWPH2Lx5MxqNRl/G1dUVS0tLwsLCOHjwIJ07d8bBwYGwsDAmTpzIsGHDcHFxMc4P4h6iEtP075Xs1FJ/Wk8IIYQQOiaVNA0aNIi4uDimT59OTEwMzZo1IyQkRD84PDIyErX6TuPYl19+SW5uLk8//bRBPTNmzGDmzJncvHmT3377DYBmzZoZlNm5cyedOnXCysqKNWvWMHPmTHJycqhevToTJ040GLNkSm6lZoGN7r21Kh+VSmXcgIQQQogKwqTmaSqvynKepk7Pv0tEZV13pfXJXzn/+7JSvZ4QQgjxqCvu97hJtTSJ+3PSJlJdFU2i4oCtjckMSRNCCCEeeZI0lTNv2m2mvdX3AJypdf9B7UIIIYQoGdJUUc44aO8MBM9X2xgxEiGEEKJikaSpHFEUBSfLO8u7aKycjReMEEIIUcFI91w5kpKSwsj1WXjYq3CzVdFjiD8tjB2UEEIIUUFI0lSOxMXFcTCvJtqoVDSZKXR8s42xQxJCCCEqDEmaypFbcXF4DJ+PSqUmJ/oilStXNnZIQgghRIUhY5rKkcjoeFQq3T+ZNisNNzc3I0ckhBBCVBySNJUjMYkp+vfa7DRcXV2NGI0QQghRsUjSVI4kpmfr32uz03FwcDBiNEIIIUTFImOaypF66fs5b7WJTKzIbKHBTjUTcDJ2WEIIIUSFIElTOaLNzcbaLA9r8nC1BqxsjR2SEEIIUWFI91x5osk23LaQpEkIIYQoK9LSVI4cz6lGkro/NuRiGXWckWozY4ckhBBCVBiSNJUjh7J9WWdRHwDLi6mMNHI8QgghREUi3XPlSJb2zj+XraS7QgghRJmSr95yxOXqX/y9733U1vb4NKpl7HCEEEKICkVamsqRrPRUNBlJ5CVcx8HOxtjhCCGEEBWKJE3lSEZGhv69nZ2dESMRQgghKh7pnitHJjeMxrOZLZl5kFM50tjhCCGEEBWKJE3lSP2qtjSz183VdDInzcjRCCGEEBWLdM+VExqtgo3tnckstebWRoxGCCGEqHikpamcSMnM5bC2LrGKC5bZiWTbuxs7JCGEEKJCkaSpnIhLyeDd/OcByDgfytTOVelk3JCEEEKICkW658qJ6MRU/XtNdro8PSeEEEKUMUmayom45HT9e21OOvb29kaMRgghhKh4JGkqJ+JTM/XvtVlp0tIkhBBClDFJmsqJhLQs/XutdM8JIYQQZc7kkqbFixfj5+eHtbU1AQEBHDp0qMiyS5cupX379ri4uODi4kJQUFCB8oqiMH36dKpWrYqNjQ1BQUFcunTJoExiYiJDhw7F0dERZ2dnnn/+edLT0zEl2anxvGe+jP+Zf887dcKprI0zdkhCCCFEhWJSSdPatWuZNGkSM2bM4NixYzRt2pQePXpw69atQsuHhoby7LPPsnPnTsLCwvD29qZ79+7cvHlTX2bu3Ll89tlnLFmyhIMHD2JnZ0ePHj3Izs7Wlxk6dChnzpzhr7/+YvPmzezevZsXXnih1O/3QWgyExluvo0XzLcwtXE8LpI0CSGEEGVLMSH+/v7KK6+8ot/WaDSKp6enEhwcXKzz8/PzFQcHB2XlypWKoiiKVqtVPDw8lHnz5unLJCcnK1ZWVsqPP/6oKIqinD17VgGUw4cP68v88ccfikqlUm7evFms66akpCiAkpKSUqzyDyN4wQJFmeGof0XtWlFq1xJCCCEqkuJ+j5tMS1Nubi5Hjx4lKChIv0+tVhMUFERYWFix6sjMzCQvLw9XV1cAwsPDiYmJMajTycmJgIAAfZ1hYWE4OzvTqlUrfZmgoCDUajUHDx4s9Do5OTmkpqYavEpbfZtUbqRqScxSyM5XsLJzLvVrCiGEEOIOk0ma4uPj0Wg0uLsbznTt7u5OTExMseqYPHkynp6e+iTp9nn3qjMmJoYqVaoYHDc3N8fV1bXI6wYHB+Pk5KR/eXt7Fyu+/+Jargven6RTaW4aNh+kYVGnS6lfUwghhBB3mEzS9F/NmTOHNWvWsH79eqytS3ddtqlTp5KSkqJ/Xb9+vVSvB5CRkWGwbXvXOnRCCCGEKH0ms4yKm5sbZmZmxMbGGuyPjY3Fw8PjnufOnz+fOXPmsG3bNpo0aaLff/u82NhYqlatalBns2bN9GX+PdA8Pz+fxMTEIq9rZWWFlZVVse+tJNydNNnY2GBmZlam1xdCCCEqOpNpabK0tKRly5Zs375dv0+r1bJ9+3YCAwOLPG/u3Lm89957hISEGIxLAqhevToeHh4GdaampnLw4EF9nYGBgSQnJ3P06FF9mR07dqDVagkICCip2/vPtuQ2wH3IR7gEvSRzNAkhhBBGYDItTQCTJk1i5MiRtGrVCn9/fxYuXEhGRgajR48GYMSIEXh5eREcHAzARx99xPTp0/nhhx/w8/PTj0Gyt7fH3t4elUrFhAkTeP/996lduzbVq1dn2rRpeHp60r9/fwDq169Pz549GTt2LEuWLCEvL4/x48czePBgPD09jfJz+Lc8jZYktRPW3k6gVmMtSZMQQghR5kwqaRo0aBBxcXFMnz6dmJgYmjVrRkhIiH4gd2RkJGr1ncaxL7/8ktzcXJ5++mmDembMmMHMmTMBePvtt8nIyOCFF14gOTmZxx57jJCQEINxT99//z3jx4+na9euqNVqBgwYwGeffVb6N1xMqVl5NFSF00B9jSTLG1jVlq45IYQQoqypFEVRjB1EeZeamoqTkxMpKSk4OjqWeP1X4tLZ/Ol4XjdfD0CORoXVe8klfh0hhBCiIiru97jJjGkSRUvJysOWHP12tlb+2YQQQoiyJt++5UBKVh42dyVNuYp0zwkhhBBlTZKmciA1K48P8ofSOnsxzXb6M+dmG2OHJIQQQlQ4kjSVAylZeWRhTRwuXE7UkmLhfv+ThBBCCFGiJGkqB1Iy8/TvtdnpMk+TEEIIYQSSNJUDKVl3J00ZkjQJIYQQRiBJUznQuW5lknatJOXgr+SnxGBvb2/skIQQQogKx6QmtxSFa+Zpi/eVX1GATDMFFxvJdYUQQoiyJklTOZCRkcGmZ22p7qJLls7n7wCmGDcoIYQQooKRJotyID09HVuLO9sqC1vjBSOEEEJUUJI0lQNXY1OwtVDpt9XWMqZJCCGEKGvSPVcOvLI5ilaq/2EZf4PsXV8x8YNOxg5JCCGEqHAkaTJxuflacjSwj8ZkJ6uJPZ3PBPfGxg5LCCGEqHCke87E/XuOJkDmaRJCCCGMQJImE2eYNKUDyDxNQgghhBFI0mTiCkuapKVJCCGEKHsypsnEpWbloUILgDY7DZCkSQghhDAGSZpMXEpWHi1Ul/jVahaZndVktrXHJuE02PobOzQhhBCiQpGkycSlZOVhq8oBwNZMi62tGtTyzyaEEEKUNRnTZOKSM/OwIcdwp8wILoQQQpQ5abIwcSlZeVxRPJmbNxDt6d+pbJXP83aVjR2WEEIIUeFIS5OJe71rbWyvH2H6yn38LySJT8+7g10lY4clhBBCVDjS0mTinGwtUJKjyLl5DpA5moQQQghjkZamciAjI0P/XqYbEEIIIYxDkqZyID09Xf9ekiYhhBDCOCRpMnHfHbhGSqUGWFdvAUjSJIQQQhiLjGkycR9sOctLLc3p0iKL5ChbrKqcNnZIQgghRIVkci1Nixcvxs/PD2trawICAjh06FCRZc+cOcOAAQPw8/NDpVKxcOHCAmVuH/v365VXXtGX6dSpU4HjL730Umnc3gPJydeQnafFVx1DM8ubdPIzp4ZVkrHDEkIIISokk0qa1q5dy6RJk5gxYwbHjh2jadOm9OjRg1u3bhVaPjMzkxo1ajBnzhw8PDwKLXP48GGio6P1r7/++guAZ555xqDc2LFjDcrNnTu3ZG/uIdxerNeGXP0+jdrSWOEIIYQQFZpJdc8tWLCAsWPHMnr0aACWLFnCli1bWLZsGVOmTClQvnXr1rRu3Rqg0OMAlSsbTgQ5Z84catasSceOHQ3229raFpl4GUvqP0nT39qaKKkxWCRexa1ONTyNHJcQQghREZlMS1Nubi5Hjx4lKChIv0+tVhMUFERYWFiJXWP16tU899xzqFQqg2Pff/89bm5uNGrUiKlTp5KZmVki1/wvbrc0faXpw/DTbeixOpP9Lk8bOSohhBCiYjKZlqb4+Hg0Gg3u7u4G+93d3Tl//nyJXGPDhg0kJyczatQog/1DhgzB19cXT09PTp48yeTJk7lw4QLr1q0rtJ6cnBxycu6sB5eamloi8f1bcmae/r02WzftgDw9J4QQQhiHySRNZeHbb7+lV69eeHoadnC98MIL+veNGzematWqdO3alStXrlCzZs0C9QQHBzNr1qxSj/d2SxNI0iSEEEIYm8l0z7m5uWFmZkZsbKzB/tjY2BIZa3Tt2jW2bdvGmDFj7ls2ICAAgMuXLxd6fOrUqaSkpOhf169f/8/xFUaSJiGEEMJ0mEzSZGlpScuWLdm+fbt+n1arZfv27QQGBv7n+pcvX06VKlV4/PHH71v2xIkTAFStWrXQ41ZWVjg6Ohq8SsPdSZPmn6RJ1p4TQgghjMOkuucmTZrEyJEjadWqFf7+/ixcuJCMjAz903QjRozAy8uL4OBgQDew++zZs/r3N2/e5MSJE9jb21OrVi19vVqtluXLlzNy5EjMzQ1v+cqVK/zwww/07t2bSpUqcfLkSSZOnEiHDh1o0qRJGd154eytzKliA69lfUF6ixuk1bTCI/M80PG+5wohhBCiZJlU0jRo0CDi4uKYPn06MTExNGvWjJCQEP3g8MjISNTqO41jUVFRNG/eXL89f/585s+fT8eOHQkNDdXv37ZtG5GRkTz33HMFrmlpacm2bdv0CZq3tzcDBgzg3XffLb0bLaYx7Wvgeus4/U/uQd1QBVhxK/OKscMSQgghKiSVoiiKsYMo71JTU3FyciIlJaXEu+p+WPktQ8In6beT/N/CpbfxEzohhBDiUVHc73GTamkSBWVnpHIpQYOthQo7SxWW9q7GDkkIIYSokCRpMnFJWVrqLMrQb2fPet6I0QghhBAVl8k8PScKl56ern9vZmaGpaWsPSeEEEIYgyRNJi4j404rk52dXYHlX4QQQghRNiRpMnF3J00yR5MQQghhPJI0mbh/tzQJIYQQwjhkILiJs8+NZVwrCzLzoLKXAjnpYCUtTkIIIURZk6TJxHmr45j8uM0/W7cgK1GSJiGEEMIIpHvOxKnyswx3WNgaJxAhhBCigpOkycSp87MNd1jYFF5QCCGEEKVKkiYTt/y0Gc5zUvH8OI03I7tKS5MQQghhJDKmycSlpGeSkgMpOQoZVu4g8zQJIYQQRiEtTSZO5mkSQgghTIMkTSZO5mkSQgghTIMkTSYsNzeXvLw8/bYkTUIIIYTxyJgmE5aRkUF9NzW2Fugmt7TWGDskIYQQosKSpMmEZWRk8HF3a3rV1v0zxWb8BEwxblBCCCFEBSXdcyYsIyMDO8s724q5zNEkhBBCGIskTSYsPT0dW4u7phiQiS2FEEIIo5HuOROWkZHBhE1ZVLJVYWehYua8gXgYOyghhBCigpKkyYRlZGRwPEar355RrbURoxFCCCEqNumeM2F3z9EEMuWAEEIIYUySNJmw9PR0g21JmoQQQgjjkaTJhElLkxBCCGE6JGkyYRnp6VjfNepMkiYhhBDCeGQguAnTZiaQ9Y4jABm5ChZnfoZmQ4wclRBCCFExSUuTCcvLSNG/t7NUgcrMiNEIIYQQFZskTSYsPyvNcIdMbimEEEIYjcklTYsXL8bPzw9ra2sCAgI4dOhQkWXPnDnDgAED8PPzQ6VSsXDhwgJlZs6ciUqlMnjVq1fPoEx2djavvPIKlSpVwt7engEDBhAbG1vSt/bAbqXnM3FrNu/syOars/ZQua6xQxJCCCEqLJNKmtauXcukSZOYMWMGx44do2nTpvTo0YNbt24VWj4zM5MaNWowZ84cPDyKniu7YcOGREdH61979+41OD5x4kQ2bdrEzz//zK5du4iKiuKpp54q0Xt7GLFp+Sw8kMuHe3JZerWqJE1CCCGEEZlU0rRgwQLGjh3L6NGjadCgAUuWLMHW1pZly5YVWr5169bMmzePwYMHY2VlVWS95ubmeHh46F9ubm76YykpKXz77bcsWLCALl260LJlS5YvX87+/fs5cOBAid/jg7h7niZ5ck4IIYQwLpNJmnJzczl69ChBQUH6fWq1mqCgIMLCwv5T3ZcuXcLT05MaNWowdOhQIiMj9ceOHj1KXl6ewXXr1auHj4/Pf77uf3X3PE2SNAkhhBDGZTJJU3x8PBqNBnd3d4P97u7uxMTEPHS9AQEBrFixgpCQEL788kvCw8Np3749aWm6QdYxMTFYWlri7Oxc7Ovm5OSQmppq8CoNdydN9vb2pXINIYQQQhTPIz9PU69evfTvmzRpQkBAAL6+vvz00088//zzD1VncHAws2bNKqkQiyQtTUIIIYTpMJmWJjc3N8zMzAo8tRYbG3vPQd4PytnZmTp16nD58mUAPDw8yM3NJTk5udjXnTp1KikpKfrX9evXSyy+uz3ulcypcXYcHGPH1Kr7ID+3VK4jhBBCiPszmaTJ0tKSli1bsn37dv0+rVbL9u3bCQwMLLHrpKenc+XKFapWrQpAy5YtsbCwMLjuhQsXiIyMLPK6VlZWODo6GrxKg4t5Do2qmOHvZUYdy1gwsyiV6wghhBDi/kyqe27SpEmMHDmSVq1a4e/vz8KFC8nIyGD06NEAjBgxAi8vL4KDgwHd4PGzZ8/q39+8eZMTJ05gb29PrVq1AHjzzTfp06cPvr6+REVFMWPGDMzMzHj22WcBcHJy4vnnn2fSpEm4urri6OjIq6++SmBgIG3atDHCT0FHURTsrcwALQC5mGOpUhktHiGEEKKiM6mkadCgQcTFxTF9+nRiYmJo1qwZISEh+sHhkZGRqNV3GseioqJo3ry5fnv+/PnMnz+fjh07EhoaCsCNGzd49tlnSUhIoHLlyjz22GMcOHCAypUr68/75JNPUKvVDBgwgJycHHr06MEXX3xRNjddBJVKxRsffYNy/ne0OemYqU3qn0oIIYSocFSKoijGDqK8S01NxcnJiZSUlFLrqhNCCCFE6Sju97jJjGkSQgghhDBlkjQJIYQQQhSDJE1CCCGEEMUgSZMQQgghRDHII1mmbNtMSI8DCxuo1gqaDjZ2REIIIUSFJUmTKTu/BeIv6t7npErSJIQQQhiRdM+ZsrysO+8tbIwXhxBCCCGkpcmkOfuC2lyXPNlWMnY0QgghRIUmSZMpG73F2BEIIYQQ4h/SPSeEEEIIUQySNAkhhBBCFIMkTUIIIYQQxSBJkxBCCCFEMUjSJIQQQghRDJI0CSGEEEIUgyRNQgghhBDFIEmTEEIIIUQxSNIkhBBCCFEMkjQJIYQQQhSDJE1CCCGEEMUgSZMQQgghRDFI0iSEEEIIUQzmxg7gUaAoCgCpqalGjkQIIYQQD+r29/ft7/OiSNJUAtLS0gDw9vY2ciRCCCGEeFhpaWk4OTkVeVyl3C+tEvel1WqJiorCwcEBlUr1n+tLTU3F29ub69ev4+joWAIRPtrk5/Vg5Of1YOTn9WDk51V88rN6MKX581IUhbS0NDw9PVGrix65JC1NJUCtVlOtWrUSr9fR0VH+Iz0A+Xn9v717C2ky7uMA/jVfNytNXZpzxebUmpQHwnKN0CIlNbCTF3a4sANGNSOTDhSUBZGhNx2QugjqJq2M7ARRYWkEamRMM0pqKBJpkqDWyjT9vxfRYB3s8YX6P759PzDYnue5+PLjd/F1ezZHh/MaHc5rdDgv5Tir0flT8xrpHaZveCM4ERERkQIsTUREREQKsDSpkFarRWFhIbRarewoYwLnNTqc1+hwXqPDeSnHWY2OGubFG8GJiIiIFOA7TUREREQKsDQRERERKcDSRERERKQAS5PKlJaWIjw8HL6+vrBarXj06JHsSKp08OBBeHl5eTyio6Nlx1KNBw8eIDMzEwaDAV5eXrh69arHeSEEDhw4gLCwMIwfPx6pqal4+fKlnLAq8Lt5rVu37od9S09PlxNWBYqKijB37lz4+/tjypQpWL58OVpaWjyu6e/vh91ux+TJk+Hn54esrCy8fftWUmK5lMxr4cKFP+zY5s2bJSWW69SpU4iLi3P/HpPNZsOtW7fc52XuFkuTily8eBEFBQUoLCzEkydPEB8fj7S0NHR1dcmOpkqzZs1CR0eH+/Hw4UPZkVTD5XIhPj4epaWlPz1fXFyMEydO4PTp06ivr8fEiRORlpaG/v7+v5xUHX43LwBIT0/32Lfy8vK/mFBdampqYLfbUVdXh7t372JwcBCLFy+Gy+VyX7Njxw7cuHEDFRUVqKmpwZs3b7By5UqJqeVRMi8AyM3N9dix4uJiSYnlmjZtGo4ePYqGhgY8fvwYixYtwrJly/Ds2TMAkndLkGokJiYKu93ufj00NCQMBoMoKiqSmEqdCgsLRXx8vOwYYwIAUVlZ6X49PDws9Hq9KCkpcR/r6ekRWq1WlJeXS0ioLt/PSwghcnJyxLJly6TkGQu6uroEAFFTUyOE+LpPPj4+oqKiwn3N8+fPBQBRW1srK6ZqfD8vIYRYsGCB2L59u7xQKhcUFCTOnDkjfbf4TpNKDAwMoKGhAampqe5j48aNQ2pqKmprayUmU6+XL1/CYDAgIiICa9euRXt7u+xIY0Jrays6Ozs9di0gIABWq5W7NoLq6mpMmTIFFosFW7ZsQXd3t+xIqtHb2wsA0Ol0AICGhgYMDg567Fh0dDSMRiN3DD/O65vz588jODgYMTEx2Lt3Lz5+/CgjnqoMDQ3hwoULcLlcsNls0neL/3tOJd69e4ehoSGEhoZ6HA8NDcWLFy8kpVIvq9WKc+fOwWKxoKOjA4cOHUJSUhKam5vh7+8vO56qdXZ2AsBPd+3bOfKUnp6OlStXwmw2w+l0Yt++fcjIyEBtbS28vb1lx5NqeHgY+fn5mD9/PmJiYgB83TGNRoPAwECPa7ljP58XAKxZswYmkwkGgwFNTU3Ys2cPWlpacOXKFYlp5Xn69ClsNhv6+/vh5+eHyspKzJw5Ew6HQ+pusTTRmJSRkeF+HhcXB6vVCpPJhEuXLmHjxo0Sk9H/o1WrVrmfx8bGIi4uDpGRkaiurkZKSorEZPLZ7XY0NzfznkKFfjWvTZs2uZ/HxsYiLCwMKSkpcDqdiIyM/NsxpbNYLHA4HOjt7cXly5eRk5ODmpoa2bF4I7haBAcHw9vb+4dvALx9+xZ6vV5SqrEjMDAQM2bMwKtXr2RHUb1v+8Rd+99FREQgODj4n9+3vLw83Lx5E/fv38e0adPcx/V6PQYGBtDT0+Nx/b++Y7+a189YrVYA+Gd3TKPRICoqCgkJCSgqKkJ8fDyOHz8ufbdYmlRCo9EgISEBVVVV7mPDw8OoqqqCzWaTmGxs+PDhA5xOJ8LCwmRHUT2z2Qy9Xu+xa319faivr+euKfT69Wt0d3f/s/smhEBeXh4qKytx7949mM1mj/MJCQnw8fHx2LGWlha0t7f/kzv2u3n9jMPhAIB/dse+Nzw8jM+fP0vfLX48pyIFBQXIycnBnDlzkJiYiGPHjsHlcmH9+vWyo6nOzp07kZmZCZPJhDdv3qCwsBDe3t5YvXq17Giq8OHDB4+/UFtbW+FwOKDT6WA0GpGfn4/Dhw9j+vTpMJvN2L9/PwwGA5YvXy4vtEQjzUun0+HQoUPIysqCXq+H0+nE7t27ERUVhbS0NImp5bHb7SgrK8O1a9fg7+/vvpckICAA48ePR0BAADZu3IiCggLodDpMmjQJ27Ztg81mw7x58ySn//t+Ny+n04mysjIsWbIEkydPRlNTE3bs2IHk5GTExcVJTv/37d27FxkZGTAajXj//j3KyspQXV2N27dvy9+tP/79PBqVkydPCqPRKDQajUhMTBR1dXWyI6lSdna2CAsLExqNRkydOlVkZ2eLV69eyY6lGvfv3xcAfnjk5OQIIb7+7MD+/ftFaGio0Gq1IiUlRbS0tMgNLdFI8/r48aNYvHixCAkJET4+PsJkMonc3FzR2dkpO7Y0P5sVAHH27Fn3NZ8+fRJbt24VQUFBYsKECWLFihWio6NDXmiJfjev9vZ2kZycLHQ6ndBqtSIqKkrs2rVL9Pb2yg0uyYYNG4TJZBIajUaEhISIlJQUcefOHfd5mbvlJYQQf76aEREREY1tvKeJiIiISAGWJiIiIiIFWJqIiIiIFGBpIiIiIlKApYmIiIhIAZYmIiIiIgVYmoiIiIgUYGkiIiIiUoCliYiIiEgBliYiIiIiBViaiIhG6cuXL7IjEJEELE1ERCNoa2uDl5cXLl26hKSkJGi1Wly/fl12LCKS4D+yAxARqVljYyMAoKSkBEeOHIHZbEZISIjkVEQkA0sTEdEIHA4HJk6ciIqKCoSHh8uOQ0QS8eM5IqIRNDY2YunSpSxMRMTSREQ0EofDgYULF8qOQUQqwNJERPQLfX19aGtrw+zZs2VHISIVYGkiIvqFxsZGeHt7IzY2VnYUIlIBliYiol9obGyExWKBr6+v7ChEpAJeQgghOwQRERGR2vGdJiIiIiIFWJqIiIiIFGBpIiIiIlKApYmIiIhIAZYmIiIiIgVYmoiIiIgUYGkiIiIiUoCliYiIiEgBliYiIiIiBViaiIiIiBRgaSIiIiJSgKWJiIiISIH/AnRc6e8TD0eWAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6sAAAGGCAYAAACdTxdEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2BFJREFUeJzs3Xd8E+UfwPFPkjbdky5auoCyZ9m7QBmiLAER2VNQZMpS2coSFJClIEPRH4ggIiB7Q9l7lU2BDkpL90qT+/1xkBLaQpG2aeF5v155mbt77u57sVzyvWcpJEmSEARBEARBEARBEIQCRGnsAARBEARBEARBEATheSJZFQRBEARBEARBEAockawKgiAIgiAIgiAIBY5IVgVBEARBEARBEIQCRySrgiAIgiAIgiAIQoEjklVBEARBEARBEAShwBHJqiAIgiAIgiAIglDgiGRVEARBEARBEARBKHBMjB3Am0Cn0xEaGoqNjQ0KhcLY4QiCIAh5QJIk4uPjcXd3R6kUz3rzivhOFQRBePPl9DtVJKu5IDQ0FE9PT2OHIQiCIOSDe/fuUaxYMWOH8cYS36mCIAhvj5d9p4pkNRfY2NgA8odta2tr5GgEQRCEvBAXF4enp6f+ni/kDfGdKgiC8ObL6XeqSFZzwdNmSra2tuKLVRAE4Q0nmqbmLfGdKgiC8PZ42Xeq6HQjCIIgCIIgCIIgFDgiWRUEQRAEQRAEQRAKHJGsCoIgCIIgCIIgCAWO6LMqCEK+0mq1aDQaY4chCFlSq9ViWhpBEARBKCBEsioIQr6QJInw8HBiYmKMHYogZEupVOLr64tarTZ2KIIgCILw1hPJqiAI+eJpouri4oKlpaUYUVUocHQ6HaGhoYSFheHl5SX+RgVBEATByESyKghCntNqtfpEtUiRIsYORxCy5ezsTGhoKOnp6Ziamho7HEEQBEF4q4mOOYIg5LmnfVQtLS2NHIkgvNjT5r9ardbIkQiCIAiCIJJVQRDyjWhWKRR04m9UEARBEAoOkawKgiAIgiAIgiAIBY7osyrkvl2T4co/oE0FB19o/yPYFjV2VIIgCIIgCIIg/EeSJHHxQRwmKgVli9rmyzlFzarwn20+H8rUfy4y7Z/z/LDtPCt2n2fbyWtoYsMh6jrEhEDIUbAUA+oIhVdAQADDhg0zegwKhYI1a9YYrJ87dy4+Pj765ZUrV6JQKDK9li1bxtWrV1EoFBw9etTgGLVr18bc3JyUlBT9upSUFMzNzfn555/z9LoEQRAEQSj4YpM0fL35Mg1m7aX1gkMs3Hsj384talaFHNHpJEDi4MGDHD2wmzIRf7M1vSrb7TtlKjtRGUnvJ1MUXkywY9OsOVSr5k+1atVwcnKSN8SEQNh5KPMuiD5iQiEnSRJarRYTk7y7pZqbm/PVV1/RoUOHF45Sa2trS3BwsME6Ozs7LCwscHNzY9++fdSuXRuA+Ph4Tp8+jaurK0ePHiUgIACAoKAgUlNTadKkSZ5djyAIgiAIhYOFWsUfJ+8Rl5IOwN6rD0nRaDE3VeX5uUXNqvBCUQmpDPs1iBpfrqN4iZJ893EgXaK/p63THSY4/IsVyZn2OYcf67X1Wa+tz58mLZl3VkPLli1xdnbG39+fsWPHEvLnl7C2K6xqDeEXjHBlgvByvXr1Yv/+/cybN09fS3nnzh327duHQqHg33//pVq1apiZmXHo0CF69epFu3btDI4xbNgwfRII8lye06dPx9fXFwsLCypXrsyff/750li6dOlCTEwMS5cufWE5hUKBm5ubwcvCwgKAxo0bs2/fPn3ZQ4cOUapUKVq3bm2wft++fXh7e+Pr6/vSuARBEARBeDPcfpTI3F3XmLr5ssF6tYmSFuXdMFEqaODnxJfvlkOS8icmUbMqZGvf+dt8/OtJUlWWgBURSkd6Vg7Hy05+xuFhlsKAi8MZe8YVlYUdSks71M5erCtWno0O9fXHSQlZqX9/5swZrl08w9gRtmAO3DlIyvI2mIy8jImZRf5eoGBUsbGxXLhgnAcVFStWxM7O7qXl5s2bx7Vr16hQoQJTpkwB5Hk479y5A8DYsWOZPXs2xYsXx8HBIUfnnj59OqtXr2bJkiX4+flx4MABunXrhrOzM40aNcp2P1tbW7788kumTJlCz549sbKyytH5ntW4cWOGDx9Oeno6JiYm7N27l4CAABo0aMCiRYuYNGkSAHv37qVx48avfHxBEARBEAqXx4lpbD4fyvrTDzh7LwYAtUrJkKZ+2FlktOQa0bwUX75bFntLdb7GV+CS1YULF/Ltt98SHh5O5cqV+eGHH6hZs2aWZTds2MC0adO4ceMGGo0GPz8/Ro4cSffu3QF5bsevvvqKrVu3cuvWLezs7AgMDGTGjBm4u7vrj+Pj48Pdu3cNjj19+nTGjh2bdxdagEmSxNB5a/n7gTkKlTwvpi4tBRNbF3ptPEU5ZyVlnFREppnhUiGAOU3qYGZmhrm5OampqYSHh3Mn4hpXH0uE6IqQFHzI4Pg1y7hhYZYGyE0JBq0LZes8H3r06EG/fv0oXbp0fl+yYAQXLlygQYMGRjn3wYMHqV+//kvL2dnZoVarsbS0xM3NLdP2KVOm0KxZsxyfNzU1lWnTprFr1y7q1KkDQPHixTl06BA//vjjC5NVgE8++YR58+bx3XffMX78+CzLxMbGYm1trV+2trYmPDwckJPVxMRETpw4QZ06ddi3bx+jRo2ifv369OzZk5SUFCRJ4vjx4/Tr1y/H1yUIgiAIQuGRrtWxLziSdafusefqQzRaw2pSjU7HidvRBJZz1a8ramecSqUClayuXbuWESNGsGTJEmrVqsXcuXNp0aIFwcHBuLi4ZCrv6OjIl19+SZkyZVCr1WzevJnevXvj4uJCixYtSEpK4vTp04wfP57KlSvz+PFjhg4dSps2bTh58qTBsaZMmUL//v31yzY2Nnl+vQXRw8hIAscsJc6lMoonzdBT7l3i0d8z8PN0pffUmRR5ry6E7sK5wed0MbN+8QGBqKgBnD59mr1797J9+3bO2FameVo9vjT5DVfFY3bV+oSUczv5btFSZs+eTYMGDRg0aBAdO3Z8Yd88QTC26tWrv1L5GzdukJSUlCnBTUtLo2rVqi/d38zMjClTpvDZZ58xaNCgLMvY2Nhw+vRp/bJSmdHbo2TJkhQrVox9+/ZRvnx5zpw5Q6NGjXBxccHLy4ugoCAkSSI1NVXUrArCy2jTITYEVGqwK2bsaARBEF4qNV3LdzuuseHMAyLjUzNtL1vUlvZV3Wld2d1oyenzClSy+t1339G/f3969+4NwJIlS9iyZQvLly/Pspbz2X5gAEOHDmXVqlUcOnSIFi1aYGdnx86dOw3KLFiwgJo1axISEoKXl5d+vY2NTZY1J2+T0NBQGn32HRq/xoBECUUoZ06cwv3hMdZs3kCjRo1QPB0MqdzLa6WeKlKkCM2aNaNZs2ZMmzaN+dsvsOzgbQZoRmJFMip7Cxwa9cS+3kckBh/i2Okt3Py4K3sWDMP33aEMGDAgY2AmQShAnm+Kq1QqkZ7rxKHRaPTvExISANiyZQseHh4G5czMzHJ0zm7dujF79my+/vprg5GAn42hZMmS2e4fEBDA3r17qVSpEn5+fvoHgY0aNWLv3r1IkkTJkiXx9PTMUTyC8FZaXB8eXgZJC7U/hZbTjB2RIAjCS6lVSvYFRxokqs42ZrSr4s77/sXybTqaV1FgktW0tDROnTrFuHHj9OuUSiWBgYEEBQW9dH9JktizZw/BwcHMnDkz23KxsbEoFArs7e0N1s+YMYOpU6fi5eXFRx99xPDhw/N0ZM+C5vbt2zTpPwGp+oeYkcZUk+W0URxkTeMedB19IldrOIe0qMgngeXZGxzJioPXOXI7BlCgMDHFunxjrMsHsEKaSGOLG6w+OZWKs6bSoVtfPv/88yx/nAuFU8WKFTl48KDRzp1TarUarVabo7LOzs5cvHjRYN3Zs2f1/37KlSuHmZkZISEhL23ymx2lUsn06dN5//33s61dfZHGjRszZMgQypUrZ/DAr2HDhixduhRJkkStqiBkJ/wCOBYHJDlRBXh826ghCYIgZOXGw3j2BUfSr0Fx/TqFQkGn6sWYue0qgWVd6VS9GA39nDFRFdwxdwtMNvbo0SO0Wi2urq4G611dXbl69Wq2+8XGxuLh4UFqaioqlYpFixZl24csJSWFMWPG0KVLF2xtM54cDBkyBH9/fxwdHTly5Ajjxo0jLCyM7777LsvjpKamkpqa8UQiLi7uVS61wLl69SqB3T5D1eQzzNCwVj2FKspbAPSy2AWpMWDqnKvnNFEpaVbOlWblXAmJSuK343f5PegO8Wk6uqp209hUnr+pWyU11moN7RcuZMmSJXTp0oWxY8dSvnz5XI1HyH92dnY56jdqbD4+Phw7dow7d+5gbW2No6NjtmWbNGnCt99+yy+//EKdOnVYvXo1Fy9e1DfxtbGx4fPPP2f48OHodDrq169PbGwshw8fxtbWlp49e+YopnfffZdatWrx448/ZrpnvszTfqvLly83GFm4UaNG+n6qn3zyySsdUxDeCjod/K8LJD+GtISM9Y/vGC0kQRCEZ2m0OrZfCmf10bscvRUNQN0STpRzz8h7Otfw5H3/Yjha5e9ASf9VwU2jc8jGxoazZ89y4sQJvvnmG0aMGGEwBcNTGo2GDz74AEmSWLx4scG2ESNGEBAQQKVKlRg4cCBz5szhhx9+MEhInzV9+nTs7Oz0r8LcXO7x48e0bNmS8Gtn0DwKIQ1TLj1+pjlifDiEHMnTGLyKWDLunbKcGN+cOZ0qU8omDa0kNzdO1kiM2y3/f1A5F2f90WtUrFSZDz74IFMNliDkhc8//xyVSkW5cuVwdnYmJCQk27ItWrRg/PjxjB49mho1ahAfH0+PHj0MykydOpXx48czffp0ypYtS8uWLdmyZcsrTxMzc+ZMUlJSXvl6fH198fb2Jj4+3qB218vLC3d3d9LS0jJ1sRAEAbh7CGLvZSSqJhbQbjG0nm/cuARBeOtFxKXw/c5r1Juxh8G/n9EnqgD/O274u8XG3LTQJKoACun5DlZGkpaWhqWlJX/++afBPIU9e/YkJiaGv//+O0fH6devH/fu3WP79u36dU8T1Vu3brFnzx6KFCnywmNcunSJChUqcPXq1SxHps2qZtXT05PY2FiDGtuCTpIkOnXqxPr16wFQqC0o/W5/9s0bguufbUGTDJ1Wgm/+j9gac+0wdts+47xZTfotO8XJkydxfv8rLP1qkx4bQfzprSSc30GH1i2ZNGkS5cqVy/cYhZxLSUnh9u3b+Pr6Ym5ubuxwBCFbL/pbjYuLw87OrtDd6wubAvs5b/oMTv8iv1eoYMRlsHm7x7oQBMG4Toc8ZuXhO2y9EEa6zjClK+5sRdda3nTw98j36WZyIqf3+gLTDFitVlOtWjV2796tT1Z1Oh27d+9m8ODBOT6OTqczSCSfJqrXr19n7969L01UQe5jplQqsxyBGOSBUHI6GEpBtnTxD2z9e71+uaR3MY78PEmeL7LTKrBxNdoIh/al6oHPISqbmHN8gIJ1W3Yz+mAyACZ2rgQ0acC1+u3Zc+UEm5q25YNmdZg0aRLFixd/yZEFQRAE4T94Zxb4NoKzv8sjAItEVRAEI5r8zyVWHL5jsE6pgGblXOlRx4e6JYpkDIxaiBWYZBXk5rg9e/akevXq1KxZk7lz55KYmKgfHbhHjx54eHgwffp0QG6OW716dUqUKEFqaipbt27l119/1Tfz1Wg0dOzYkdOnT7N582a0Wq1+vkFHR0fUajVBQUEcO3aMxo0bY2NjQ1BQEMOHD6dbt25y0vaGurVrOU2vT+DrphaM3J6MWq1mzZo1GddcrJpxAwRQy3O8KoCOrZriXDKSuVvPcP9hFCvUs0hSmzOuSj8OVprLjnuX+Kt1b7o2qsCkCePf+pGdBUEQhFxmagEVO8ovXc4GXRMKkes7Ye80eeAscztoNhXcqxg7KkHIVgM/J32y6mBpSpeaXnSt7Y2HfcGYcia3FKhktXPnzkRGRjJhwgTCw8OpUqUK27Zt0w8gEhISYjBnYGJiIp988gn379/HwsKCMmXKsHr1ajp37gzAgwcP2LRpEwBVqlQxONfevXsJCAjAzMyMNWvWMGnSJFJTU/H19WX48OGMGDEify7aCFJOr8Hn4HCUdjC0lpo1dx3pNmg0/v7+xg4tW0qlgsZlXGhcpgWJq7thdSMBRxL4VT2DXmmj2OdZFXPP8myOe8jqCv6M+KQfn3/+ecFqQiYIgiC8GZQqY0cgvKrY+3BpI6hModbHmbcnx0BoxhzVZFcjdfsAeNWRjyMI+eBedBI/H7pNYFlX6vtlTOUYUMqFFuVdaVrGlTZV3DE3fTPvSwWmz2phVmD712Tj/MSaVFIE65f3ppWj0deHDR4EFFhJ0fBjI3kidiBM7UtA2GekWsk1qamhwYT/OhIAJycnJkyYwMCBA3N16h3h1Yk+q0JhIfqsGl+h+5x1WkiJBcvsRwoXjEiS4I8ecEWuvMDGHYZfgud/81xcD3/2yVgecxcs7A3LxEfAnFJg5QyVOkP1PlCkRJ6GL7y9zt+P4ccDt/j3Qhg6CeqVLMJv/WobO6xck9N7fSHIToTcFBkZSaMVsSzQtAFgQ3pdbD78uXAkqiD/GPgkCGp+DAoVRXss48q83gypCCYPrxB34i990UePHjFkyBBKdxrF3F/+QjyXEQRBEHLN7ikw3x++doXfP8ibc9w7Djf3Zr0t8RGcX5c3532TKBSGCWV8KNw7lrmcrQeUfhfKvAclmmZOVEGuVQVIjISgBRB2Lk9CFt5ekiSx/1okHy09SpsFh9lyXk5UAU7fjSEi7tVnASjsClQzYCHvzZgxA9ManZmtrcVhqSIWDl4sr1TIRtI1s4ZWs6DuYLD3QgmM6Pouw7q8w++/u/HVVyF09Qrn13MaHtqWQ1emGXMvw+JBixj1XmX6vlvvjehwLgiCIGQWGpPMD3uuExabQp3iRfi4US7UfGnTQfXcT6akaIi+Kb+Pvv3653he8mO5pi/2PtQfBo2/lJue6nRwdjXsnCDX6DqVBPequX/+N0ndIXDiZ0iNA9tikPQocxmv2vLrRW7vz3hvbg+lW+VqmMLbS6uT2HohjMX7bnI5LM5gm5O1mp51fOhW2xuHQjTlTG4Ryepb5N69e/y0cS9FOk0F4GiiBxcnvG/kqF6DvZfBolKppFu3bnSubIXp+l581dCcpZEOLCOROKxItffh60OxzN3zK+PaVKVLwwoolSJpFQRBeJNodRL/O34PAEt1LvXhmlNanl9VbQ01B0DAGHB8Zm7kpEeQGg9mNrlzPkmSp8qJla+DQ9+DqRU0GiXXCm76LKPsP0Oh357MyfTbKPwiOJUCk+d+0Fs6QpsfwKYoFKuRuQlwTjV/MujSmd/Awx9Ms+jWEh8BCeFQtPJ/O4fw1olN0tB24SHuRCUZrPd1sqJ/g+K87+/xxvZHzYlC0vZTyA1Tpk7Ful43/XLnclZYmb9hT2jSUzHdMxkACxMY5HYJ3aEf0UQ/0BdJUBfhy20hVPtiHRtO3EanE82DBUEQ3hQuthlTy4XF5lKTudR4SE+Rk1KdRl7n7g/l34cGI+VESJGLP6l06WDtmrHsWAJqD5Lfe9eBcu0ytmnTIfFh7p27MJIkOPgd/NQIDszKukz5duBV678nqgAWDlCjHwzYCy1nZF1mz1R5bI2/P4WEt/z/i5AjdpamFLXLGMG3UjE7Fnf1Z9eIRnxUy+utTlRBJKtvhwenuXNqF2sOXcXMvTQAqoQIvu7XxsiB5YHER/LAB0+Y1h3E5tU/0yB+H5F/zyAt4pZ+22OsGLH+MrUmbeLQ9UgjBCsIgiDkNjMTFU7W8oPYiNxIVtNTQZsxf7u+9tS3AXRaAU0ngH8PUFu9/rmeUpnCu3Og82o5ae20Qu4C81TLGfL6wMnw8X6wdc+9c+cTjVbHrcgEdl+J4Ny9mEzbj92K4uy9GOJSNC8+kCTB34Nh92Q5yT84R+7rm9eyGg047BycWQ1I8n9/6yjHJwhPxKdo+O3Y3UzjqHzSuMSTAZRq8fen9XinYlFUovUfIJoBvx12jMfn7iGOtPfgf+zmd21TPqnnjonqDXxWYecBfXfApb/gyHxoMBIfS0fW/O93eQ7dESM4fyCdFk3rcNWxEcmYE5lmwiefDGLRxGHUr1/f2FcgCHpJSUl0796dnTt3Eh8fz+PHj7G3tzd2WNlauXIlw4YNIyYmJl/Od+fOHXx9fTlz5kym6cmEt5urrTmPEtKIiE9Fq5Ne/0dfsyly7WpqfP72Dy3bGko2y9zc1LYoDD2fdTPUAiwyPpWdlyPYfimcoJtRpGl1AHxYw5PKnvYGZSf8fYngiHgAijlY0MDPmYDSztQtUQQb82cSRYUC3CpmLEs6uPw3eNbM68vJLHgb8EwS0nRi9lPgCG+V2CQNyw/fZsXh28SlpONuZ0HjMi767Q38nGng5/yCI7y93sBsRTAQF4p09zAAFU0fUFoRgnlsCMM7NzdyYHlIoYAK70P/vQZTCdSpU4egI0f4bXJ/fndZxUH6MSjxR8zuHePCrvU0aNCADz/8kJCQEBJS0414AUJBEhkZyaBBg/Dy8sLMzAw3NzdatGjB4cOHDcqdOXOGTp064erqirm5OX5+fvTv359r164BcmKlUCgyvbp165bVaQFYtWoVBw8e5MiRI4SFhWFnZ5en11rYeHp6EhYWRoUKFQDYt28fCoUi35JloeAqaicncVqdxKOE1JeUfgkTM6g3FJp8Be/MBN+GuRDhK8guIS0kiaokSRy+8Yhuy45Rc9ouvvjrAvuvReoTVYBbkYkG+2h1ErejMtbdf5zM/46H8PGvp6g6ZScDfjnJ3qsP0T7txlN7INT+FJSm0GYBNP86X64tk4Ax0PMfcK0AlbtAyabGiUMoMB4npvHt9qvUm7mHebuvE5ci/75cvO+mkSMrPETN6pvuxi4UzzzlW3fDgs8/KFF4pqp5HVk8zVQoFLR3vgs3wMJExxjz/RzZs4drT7avXbuWv//+m4rDVlDS14sv3i1PBQ+RILzNOnToQFpaGqtWraJ48eJERESwe/duoqKi9GU2b95Mhw4daNGiBb/99hslSpTg4cOHrFu3jvHjx7N27Vp92V27dlG+fHn9soWFBdm5efMmZcuW1SdjWUlLS0OtfsP6nueQSqXCzc3N2GEIBZCrbUYiFx6bYrAs5J+Td6KZtvUKp0NiMm1ztzOnqpcDvk5WVPAwnGNRo9XxefNS3IpM5MbDBM7fj9Unt+k6iR2XI9hxOQJ3O3N++Kgq1bwd5QS18odQtFJ+XFr2fBvCgH1yH+esRN2Um4zbiHvXmywqIZWlB2/za9AdEtO0+vUmSgXtq3rwSeOSRoyucHkLMpa3m1SlG+23uzD9UCoH7qZz6egB+rQLNHZYxqPVwJV/9Isah5I4VDccEVnhUYmHkg1Hbj3mvR8OMeR/p7kXnfT8kYS3QExMDAcPHmTmzJk0btwYb29vatasybhx42jTRu7znZSURO/evWnVqhWbNm0iMDAQX19fatWqxezZs/nxxx8NjlmkSBHc3Nz0r+xqSwMCApgzZw4HDhxAoVAQEBAAgI+PD1OnTqVHjx7Y2toyYMAAANavX0/58uUxMzPDx8eHOXPmGBzPx8eHr7/+mh49emBtbY23tzebNm0iMjKStm3bYm1tTaVKlTh58mSOP5+VK1fi5eWFpaUl7du3N0jgn/r777/x9/fH3Nyc4sWLM3nyZNLTM1ouKBQKli1bRvv27bG0tMTPz49Nmzbptz9+/JiuXbvi7OyMhYUFfn5+rFixAsiorT579ix37tyhcePGADg4OKBQKOjVqxe//PILRYoUITXVsHatXbt2dO/ePcfXKhQuT2tWIRcHWXqZ3Oib+LrHeHwHUuJeWiy/RCWmGSSqXo6WfNq4BP8Mrs/hsU1Y2NWfz1uUpmWFogb7mZuqGNCwBDM6VOLPQXU5O7EZy3tVp0cdb4paZ9SzRCak4l3kSV9hpdL4iepTKtOsR4ZOT4N1PWFRHbiyOf/jEvJcdGIaM/69SoNZe1my/6Y+UTVVKehS04u9nwfwbafK+DrlYh/3N5xIVt9wx0+cYOPRG3yxO5VGK5Po0bPX21Grmh2VKXx6TB64wt4L04DRrFz1C8eOHaNOnTpyGUlHzaSDBCjPoEDHpnNhNJ69l2lbrxCb9JKBHoQ3irW1NdbW1mzcuDFTsvPU9u3befToEaNHj85y+3/tY7phwwb69+9PnTp1CAsLY8OGDfpts2fPpnLlypw5c4bx48dz6tQpPvjgAz788EMuXLjApEmTGD9+PCtXrjQ45vfff0+9evU4c+YM7777Lt27d6dHjx5069aN06dPU6JECXr06JFp4IesHDt2jL59+zJ48GDOnj1L48aN+fprw6Z3Bw8epEePHgwdOpTLly/z448/snLlSr755huDcpMnT+aDDz7g/PnztGrViq5duxIdHQ3A+PHjuXz5Mv/++y9Xrlxh8eLFODk5ZYrH09OT9evXAxAcHExYWBjz5s2jU6dOaLVagwT44cOHbNmyhT59+rz0OoXCye2ZkTUj4vIwWb2+C37vDAtqwvRi8gPRVxQZn8q+4IfyyPQHZ8PylhC0EB7fzdkBdDq4sRt+/xDmVXkywE/B0KysK2XcbCjlas38LlXZ+3kAo1qUoWIxu1ea79xSbUKTMq5MaV6MIy4z2FL/Nk3LuNCyQlGcrM0Myl58EFtwu/LsmwbhFyA5GtZ2heNLjR2RkMtCopNYsv8mSU+SVLVKSffa3uwf1Zjp71fE09HSyBEWPqIZ8Bvu5xUrDZZ79epllDgKFFMLeeh5/56A/GVZs2ZNDh8+zO+//86YMaMZlbKAGo4qrmvdWKxtxwZdQ346cIs1x+8yollputb2xvRNHKDKCJYdvMWyg7dfWq6Chy3LetYwWNdv1QkuPnh5LUK/Br70a1D8lWMzMTFh5cqV9O/fnyVLluDv70+jRo348MMPqVRJfoJ//fp1AMqUKZOjY9atW9fggdHBgwepWjXzgC2Ojo5YWlqiVqszNXVt0qQJI0eO1C937dqVpk2bMn78eABKlSrF5cuX+fbbbw3+zbdq1YqPP/4YgAkTJrB48WJq1KhBp06dABgzZgx16tQhIiLipc1r582bR8uWLfVJeqlSpThy5Ajbtm3Tl5k8eTJjx46lZ8+eABQvXpypU6cyevRoJk6cqC/Xq1cvunTpAsC0adOYP38+x48fp2XLloSEhFC1alWqV68OyDXEWVGpVDg6yn3UXVxcDB4SfPTRR6xYsUJ/natXr8bLy0tfWy28edxsX79mNSIuB82HEyPhWsbfPLH3wPHV7jX/Ox7Cdzuv4V3EkvWKdTglBENIEJxaBYNzMKqtpIWNn8hzewKcWAq1Br7eFC3/QURcCpvPh9G3fsb8s0qlglV9auJsbfb685prUuD3zihCT1M+9DQ/vzMLXY0BBkWS07T0W3WSdJ3E581L0am6Z8EZUTU9DW7tz1i2cIDS7xgvHiFXSJJk8OCliqc9jUs7c/hmFF1qeDIooCRudqIbwusQv7bfYMnJyWy6o8Ct51ysKgbSsHFTfH19X77j20JlajCJukKhoGvXrlzb9Qs13OU5rfxU4ZSM2IlOI9eqxaVomfTPZVp8f4Djt6ONEvabJj4lnfC4lJe+ohLTMu0blZiWo33jU/77U/YOHToQGhrKpk2baNmyJfv27cPf319fa5mTWshnrV27lrNnz+pf5cqVe+WYniZuT125coV69eoZrKtXrx7Xr19Hq83oK/M0wQZwdZXncKxYsWKmdQ8fvnxuwCtXrlCrVi2DdfrWCU+cO3eOKVOm6Guora2t6d+/P2FhYSQlZTStfzYuKysrbG1t9TEMGjSINWvWUKVKFUaPHs2RI0deGtvz+vfvz44dO3jwQJ5veeXKlfTq1euVanaEwsXHyZL3/T34tHEJ6pfMqIm/Gh7HgWuR3H+c9MI5tq+ExVF7+m4+WnqUSztWwJIGsKKVXIuaGp9R0MHHcMfoFz94238tkhRNxr/JdK2O34+FAKCLvi0nqk+Vfe/lFwryd1n1Z1oJRN+CkFf/d/I6Tt6J5r0fDjF182UO33hksM3V1vz1E1WAUyvg3tGM5YPfoUwzfFi59OAtwuNSeJSQytgNF3h3/kFO3S0g39UmauizXR6sCwW0/xHsihk7KuE/ikmSB07qtCQo071kYuvyHBjVmMltK4hENReImtU32Nr1f2FaphEqc2vUzT/hw3IJxg6pULCMuyWPKKjToJNg9oazhGo/xr5hD6wrNAHg1qNEjh8/Tk3flkaOtvCzMTcxqAXJThGrzIMIFbFS52hfG/PXu9WZm5vTrFkzmjVrxvjx4+nXrx8TJ06kV69elCpVCoCrV69mStay4unpScmSrzewgpXVf+vrYmqaMd3D00Qtq3U6nY7ckJCQwOTJk3n//fczbTM3z/j/9mwMT+N4GsM777zD3bt32bp1Kzt37qRp06Z8+umnzJ49O8dxVK1alcqVK/PLL7/QvHlzLl26xJYtW/7jVQmFQTEHS777oEqm9WtP3GPF4TsA/N6/FnVLZG5SDvDnqftIEhy5GUWKVQiEn8/YqHrmXuRYXJ42xcEXHH3B1iPbmO5FJ/HxrycZ0LAEI5rJ9w2FQsGkNuVZffQut248Ynl6S1qoTuChiEJbujWqnF5wtV5weJ5cU1dzQL5N2yJJEquP3mXyP5dJf/KD/Yc916lXMuvP9bXU/BgSIuDQ92DhCD3+BnPDPv9tq7hzNTyOrRfkWuar4fF0WBxEl5pejG1ZBjvLLOZGzU8mankapKrdwcnPuLEI/0lssoafD91mxaHbxD9pbr7tUjitKmb0u/YR/VFzlUhW31R3jxC8fy0lnVpzR7Ik9UYQPSZPfPl+AtTsL89td2IZyoQIlq1vz9ChQ7m45TviT2/GoWl/HJNDKBf2M9M2V6LTVyvwK52zJqBCZv0aFP9PTXSBTM2C80u5cuXYuHEjAM2bN8fJyYlZs2bx119/ZSobExOT53Ojli1bNtNUOocPH6ZUqVKoVDn+ufvK5zx27JjBuqNHjxos+/v7Exwc/NrJubOzMz179qRnz540aNCAUaNGZZmsPh0V+dna5Kf69evH3LlzefDgAYGBgXh6er5WTELhdOdhHB2UB7BXJFDculqmJnwgj0S78YxcC69WKSlf5JntKrU8lc1TNq4w8NBLzytJEpM2XSJFo2PJ/pu0rlQUP1cbVEoFLSu40bKCG6dDStF9mStTUrtTQXGbqidMmOKROb4s2bjCyKtgbvvysrlEq5Ov6dejGX1r65Yowg9d8mgeWqUSAieBcxmw9waXzN+73kWsWNS1GifuRDNp0yUuhco1r/87HsLOy+FMbF2e9yoVNX6riuwS1dj7sGM8tPoWrPIg4Rf+s/gUDSsP32HpwVv66WdAHjjpbpQYhDMviWT1DZWwfwHTPfYB+7ilc2OsW+v/XBvzVrJxk+fUA5ogz6H5008/MX78eCJWj+KTplY0qWBCEy5zc1ENvjHvxs3SPXm3cjHaV/XInSZPgtFFRUXRqVMn+vTpQ6VKlbCxseHkyZPMmjWLtm3bAnIt57Jly+jUqRNt2rRhyJAhlCxZkkePHvHHH38QEhLCmjVr8jTOkSNHUqNGDaZOnUrnzp0JCgpiwYIFLFq0KM/OOWTIEOrVq8fs2bNp27Yt27dvN+ivCnK/2Pfeew8vLy86duyIUqnk3LlzXLx4MdNgTNmZMGEC1apVo3z58qSmprJ582bKli2bZVlvb28UCgWbN2+mVatWWFhYYG1tDcj9Vj///HOWLl3KL7/88noXLxRaZSP+ZrR6CQDrF96j5rA1mQY82Rccqe920KycK/HWvly3a0R6UhxVvBz4L3f3nZcj2H1VbtruYGmaZdNAfy8HFnerRp+VJ7ioK87FYyG42VvwaU6nuMjHRDU1XcvwtWf1NZgA/Rv4MqZlGUzyejyHyh++tEgNH0f+/rQevwTdZc6OYBLTtDxKSOOz/51h8/lQvm5XEWcbs5ceJ1+lp8IfPeHBSbh/Aj78DYpWNnZUb73E1HRWBd3hpwO3iHlmkE0TpYJO1T35tHEJijmIQZPykuiz+oZKuJ0x/cStFGuGdm9vxGgKPxMTEz755BOuXbvG0E8HMrBqxs8VrU5ixpZg9lyLYuS6c3RacoRLobFGjFbILdbW1tSqVYvvv/+ehg0bUqFCBcaPH0///v1ZsGCBvlzbtm05cuQIpqamfPTRR5QpU4YuXboQGxub46Tsdfj7+/PHH3+wZs0aKlSowIQJE5gyZUqeDqhWu3Ztli5dyrx586hcuTI7duzgq6++MijTokULNm/ezI4dO6hRowa1a9fm+++/x9vbO8fnUavVjBs3jkqVKtGwYUNUKlW2yb+Hh4d+UCdXV1cGDx6s32ZnZ0eHDh2wtramXbt2/+mahcJHo9Vx/3ESaek6UjRaPkv9Wb+tg3I/18NjMu3z56l7+vcdqxVj4PkStI74mPbxo9hTfckrx5CUls7kfy7rl8e/Vw4b86ybozYs5cysjhl9uL/dHsze4Jf3Ic9PCanp9F5xQp+omigVzOlUmS/fLZf3ieorMFEp6VPfl10jG9GivKt+/f5rkSQWxNGCd02SE1WQB+ra8nnuTIck/Ge7LkfQcNZeZm0L1ieqKqWCTtWKsffzAKa/X1EkqvlAIb3q6CBCJnFxcdjZ2REbG4utbf492cxWehqpU9wwU8pN4RbcK8Wny44bv9nLmyIpmqh1w7C+sQkzlcSgLcn84dgfm6qt9EUUQK9a7gxrWQE7CyP3kSkAUlJSuH37Nr6+vgZ9FQUhPzVt2pTy5cszf/78bMu86G+1wN3rc8HChQv59ttvCQ8Pp3Llyvzwww/UrJl9f8d169Yxfvx47ty5g5+fHzNnzqRVq4x7nyRJTJw4kaVLlxITE0O9evVYvHgxfn4575+XW5/z5H8usfLIHSQJtg5pgEqpYN0PY/jK9Dd9mT9qruODVs31y1EJqdSatpt0nYSLjRlHxjZhb3Ak/X+Rkwh/L3vWD6r7St+n0/+9wo/7bwHQwM+JX/rUfOn+C/fe4Nvt8mBL5YrasmVI/QLxHf44MY0ey49z4YH8QNbcVMnibtVoXNold08kSfDPUPBrnvOBpl5iy/kwJvx9kUEBJf5z15M8FXlNns7m0TW5T+6AfeCQ8wd7Qu67Gh5Hy7kHAVAqoF0VD4Y09RN9UnNJTu/1BecRmJBrkjVaSt8ayXupXzNa058wizIF4kvujWHpSJGev6Aee4OLbh3ZH+NO9I5FRPwxAU3UfQAkIPD0p5yd2YJ9Oze98oixgiDknsePH/PXX3+xb98+Pv30U2OHU2CsXbuWESNGMHHiRE6fPk3lypVp0aJFtqNBHzlyhC5dutC3b1/OnDlDu3btaNeuHRcvXtSXmTVrFvPnz2fJkiUcO3YMKysrWrRoQUpKHs51mg0bMxN9xVREXAq3IhPYo6vKDm01Zmk+oGvaOM7EGw7Qs+lcqH6goPb+HpiolDQt40JpVxsATofEvNJI8DcexvPzk6m51CZKpratkPX38XODmn0SUIJGpZxpVs6VX/u+PLnNJDUBzvwG+2a+2n4vcTsqkRsP5cEa7SxM+a1f7dxPVAFO/gynV8nJ27Zx8rQvr+ndSkXZNaIRvesZzoqQotGy/1rkax//tTmXgn675TEzOq0UiWo+S03XcvtRosG6Mm62tK7sTuvK7uwY3ojvOlcRiaoRiGT1DbR97wGkohW4KBXnt8jSVA1oa+yQ3kgKKycqDPyZ0xeu8s0336CMuEro8sE83reCiumXqae6RCNOEXC4O2tnD+ZaRPzLDyoIBcQ777xjMOXMs69p06YZO7xXUrVqVXr16sXMmTMpXbq0scMpML777jv69+9P7969KVeuHEuWLMHS0pLly5dnWf7p3LqjRo2ibNmyTJ06FX9/f32TeEmSmDt3Ll999RVt27alUqVK/PLLL4SGhuoHJMtPbnYW+vdhsSncjEzgluTOAM1IFmnbcVhXkcuPDJuDrjt5X/++o788rYhSqWBgQEZN3J+n7hvsQ8w92P4lrOkKi+vBg9P6TfN339Anv4Malcj6h25SNMz0hl/awt7pEHUThULB4m7+/NS9GkWsX7Fv5YllMLsU/P0JHJwtHz+X+Hs5sLxXDbyLWLJuYB2qeTvk2rH1Hl6RE9Snji+FyKu5cmgHK3WmeVdnbw+m5/LjjFp3jgRjNw82t4XOq6F4o6y3awtg8+VCTqPVseZ4CE1m76fPyhOkaw0fHM3tXIUfulSlpIu1kSIURLL6Blqz9yyKJ/OHptw+SZMmTYwc0ZvN3NycL774gmvXrtG1S2fijq2nd5jhj/mfoyvxztz93H8sRowTCodly5YZzAf77GvgwIHGDu+V3Llzh9jYWD7//HNjh1JgpKWlcerUKQIDA/XrlEolgYGBBAUFZblPUFCQQXmQ+yU/LX/79m3Cw8MNytjZ2VGrVq1sj5mXij4ziFF4XAq3IhMzlbkREa9v+XIlLI7LYfLosZU97fF7UpsK8E6Folibyd+r2y6GG8yVSnoKBC2Aq5sh4qI8zylwNyqRzedDAXC0UjOwUYmsA713HFLj4NY+2D8DYuTRdS3VJv+tVZSdJ2ieXKs2DS6se/VjvECdEkXYNaIRpZ75fHJVkZJQe1DGcvOpULRS9uVfw+XQOH4+LNd8rzt1n3fmHeDEnQIyL+vzYh/AoloQvO3lZYWX0mh1/HHiHk3m7GPshgs8iEnm9qNENp4NNSj3/MMNIf+J0YDfQKdvhCKVKodCocTLJB5HR0djh/RW8PDwYPXq1Xz66af8OGEAOs1N3i9ryrbUClynGAnnd/JR21nMmzePqlWrys2alCr5JQgFjIdH9vNFCoXfo0eP0Gq1uLq6Gqx3dXXl6tWsa7HCw8OzLB8eHq7f/nRddmWykpqaSmpqqn45Lk5OGM+ePasfzfm/iI7JGLnz0q37hMTKtVIKoKKLmvMP00hM07Lj0EmcrVRciUyjjJMp16I01HTScfq0XENa7MJ8FDots6yU/KHxY19qVZb/e5TaxeSaW4U2jSooUCAnvaGXjhCuKc5Pp2J5UqlKS181Vy6eyzJO98t/4/bkvYSSc1FqdLGnM5WLSdHyz7VEPqpg8+If0DpHKpgVQZ0aRbqpNeF3b/HQNPPxcuJxspYj91Jo5WeZv92JirTDtpYb9mEHCTGtCaf/W/wvI0kSn1S3Y/mZOJLTJe5FJ/PBkiDal7Gic3kbTFUFI1FRaFMpdWgIVrE3kP73IaFl+xNR8kMQXbxemVYncSAkmXWXEwhPMJzmzL+oGcQ84PTpgjWo2ZsqISEhR+VEsvqGCQ0N5frG+SgtVmLh60+3Dtk0JRHyTJ06dai1/Ry//vorDaeP5mH0SR6X/IWEs9s4mBxHtWrV6N27N991LoXVlbWYBIyGCh1BJf45CoLw9pk+fTqTJ0/OtL5Ro9f7/lKa2+A59H8AbN5zGFezNIq7unI/UcXBo8exq90RgHY9B5Jy+7TBfuN16XyVlgxAzBgb7MwVtAJClO+xT1eVics38+jvGfp9Ln9ihUYHtx7rWPPnD6y99D1KC1tsqr2HdYWmzOjXmempmWt2AVqUUNGhnCn1PFWkpGupVqtBpjJmXhVxbj0albUDK35eSuyh31947T0rm5KkkdgUHEeqdhYw61U+OgBUVg64dpmGaRFP5iz8kdhDv718pzyRt1N/AZjYuVLk3RGYe5ZHAjZcTWTN/vM82vwdmkd3X7p/XhtdT83MQLmlgAKJiD2Lqdt1NqmZp5QWsqNQYlUuALu6H2Lq6G6wKfn2aWIO/cZfocFkni1dMDbx6/gNc3DbBjqXN+FseALXr+zjnRZ5P22GkJlSqaRnz568//77TJ8+nTlz5qBLkweIkCSJ31Yt5xtnJ+zM0+Cvj9Gd+Bll3x3iKakgCPnCyckJlUpFRESEwfqIiAjc3Nyy3MfNze2F5Z/+NyIigqJFixqUqVKlSraxjBs3jhEjRuiX4+Li8PT0ZP/+/a9VsypJEh+uD0ejg1KVa7KmxA48rnwJVpBc1JpKie2wJ4HhE8fQoGI2c5lKErb/NIUntaYalSWkg325+vw17gSWpnJvquQnxb2A0U9eT2l1Eqr+B14abwpyLe2pj9WZtgVHpfHlnih0EjjW/4gFX31GOefM5Z439qUlshadrGXivigexMvZkF+zbsz5dhjW6je395hWJ/F3cCJrLsWTrgO1awm8+i+ka0UbWpeyQmnM72edloeXFuJy+y80agdMuy/myMeuL99P0PvlXBwbgw0fGFVyUdO5gg1lnd6FMe8aKbK3V0JCQo4eSopk9Q0TenQDazrKcz4lacDUJ4/6lAg5YmNjw7Rp0+jXrx+jRo1iw4YNAPStZYubecbohgvvF6fu3cdU8xFNtgVByHtqtZpq1aqxe/du/byzOp2O3bt3G8xP+6w6deqwe/duhg0bpl+3c+dO6tSpA4Cvry9ubm7s3r1bn5zGxcVx7NgxBg0alMURZWZmZpiZZR5EqEqVKq89RZD7nr3cjUoiJg08nsl7LbQJ7DMbjociinPRTajsn019iiYZjpaG1HhIjaeEszvcACcbc+w8/KhYzC7r/XKZPxClus7sHdfQSbDodCL/Dq2GnWXuT40WGpPM58uO6RNVD3sL1gyojadjHs0nKUkQfh6KVs6b47+CGtWhS2gsw9ee5VpEAuk6WHUungp+vnSq5mnc4KqvhFONMXUuTUWv2saNpRBy9Erkn+v70eok6pYowrDAUtT0Fb+5jOlpl4+XEcnqG0Sn05H+4Aw8ad1gZgIq52yeFgv5qnjx4qxfv559+/YxfPhw/rh0jeJlKvFxsVsko2ZRanPmLAki0NecOd0b5skPEEEQhGeNGDGCnj17Ur16dWrWrMncuXNJTEykd+/eAPTo0QMPDw+mT58OwNChQ2nUqBFz5szh3XffZc2aNZw8eZKffvoJAIVCwbBhw/j666/x8/PD19eX8ePH4+7urk+I85ubrTl3o5KIT0kn/fF9gx89HoooACpwg3vRSRRzsMjcL9PUAj49pl8sE5nA2vhUavg4osym36hWJ+XJoCyDAkpy8Pojjt2OJjQ2hXF/nWfhR/652pf0VmQC3ZYdIzRWnmqomIMF/+ufh4kqyFPU/DMU6gyGJuPB1LhzcZd3t2PT4PrM3h7Mz4dvU6mYPe2rFpA+/NV6Zr8t8RFYOeVfLAVUarqWP0/dx9rMhLZVMv6/+ThZMaZlaSoXs6dW8SJGjFB4VSJZfYMcOHaaihXLAfKcd3Emzjio8/ALRnhlAQEBnDx5kpUrV/LFF18w28KaWi3akOwgfznvup1C9YmbGNeyFL2rWKLY+Ak0/iL7YewFQRD+o86dOxMZGcmECRMIDw+nSpUqbNu2TT9AUkhICEplRrPPunXr8vvvv/PVV1/xxRdf4Ofnx8aNG6lQoYK+zOjRo0lMTGTAgAHExMRQv359tm3bhrm5cRIQt2dGBA6rNgLPKp0h7gGc+Bkey6PAqmJD6DJ3MxpzR9pXLcbYd8pke7ziztYUd86+afKdR4l8+NNR2lX1oG99X5xtXnHamRdQKRV837kK78w7SGyyhq0Xwvlu5zVGNs/hdEzJMWBhn+3miw9i6bn8OFGJcqsfnyKWrO5Xi2IOefg74vFdedofkEdUvntYnmvUyAMPmpuq+Oq9cjQt64qzjRkmKsPmzwmp6frRoQuEmBD4qTFU6gzNpryVY2Akp2lZeyKEJftvER6XgrudOe9UKIraJOP/3YCG2YzILRRoCunpmO3CfxYXF4ednR2xsbGv3WTpdfSdspiDSUUpqXiAz+31TOrTBpfmw4wWj/BicXFxTJ8+ne/nzkNdPhD7Bt1RmmX8KFhiOpeWquPyQvEA+OAXMM+fJme5LSUlhdu3b+Pr62u0H62FUVJSEt27d2fnzp3Ex8fz+PFj7O3tjR1WjvXq1YuYmJhcn2Nz3759NG7cOE8+jxf9rRaUe/2bLjc/56vhcSSlaVm09yYgUdLFhmGBfpiHn5KTI49qnJdK0HFzOmmY8r6/B999UOU/nSstXUfHJUc4fz8WgO61vZnarkL2O0gS6NJB9WotabZfCmfg6lM8/fU2qXU5etXzzbqwTgs398i1l9e2w+AT4OCTqdjhG48Y+Osp4p/MM1rGzYZf+tbExSaP79dHFsCOLzOWm38NdT/L23O+pjMhj+m5/Dhj3ilDlxpe2daw55u0RFjeAsIvyMu+jeCDVWCRB3PgFkBxKRp+DbrL8kO39Q9anlreqzpNyoi+vQVVTu/1b25P+bfQ8TsxpGHKZcmHbXfNRKJawNna2jJ9+nSuXL5Ey+LmhC4bRGLwYQBKKe7RXHlCX1bSpICZ+HFsDJGRkQwaNAgvLy/MzMxwc3OjRYsWHD582KDcmTNn6NSpE66urpibm+Pn50f//v25du0aIM/1qVAoMr26deuW7blXrVrFwYMHOXLkCGFhYdjZFc6HFYJgLGXcbPH3cuDGw3h2XXnIL0F3MDNRgmdN+QFgvaFsiPYlDTlhbPoKP2wTU9Ppsfw4p+5GgzadPatn0Cp8CYtM59LL/uwLa2gBeT7W6Z6w4l3YPUWuZcyBFuXdmPheOf3y5M2X+edcaNaFQ8/Abx3hyj/ynKunf81URKeTmLXtqj5RrebtwNqP6+R9ogpQdzB0WQvWruBVB2p/kvfnfA2p6VpG/3meuJR0vvzrIl2XHePOo6xHec43N/dkJKoAaQlgYmG8ePLJw/gUZm67Sr0Ze/h2e7BBohpY1pW/P60nEtU3RIFLVhcuXIiPjw/m5ubUqlWL48ePZ1t2w4YNVK9eHXt7e6ysrKhSpQq//mp4I5YkiQkTJlC0aFEsLCwIDAzk+vXrBmWio6Pp2rUrtra22Nvb07dv3xzP/VNQpKenEy3JtXKSpCOwquirWlj4+vryxx9/sH/b3/g+2MXDdZOIjktibWodtE8m6ev92x127tpl5EjfTh06dODMmTOsWrWKa9eusWnTJgICAoiKitKX2bx5M7Vr1yY1NZXffvuNK1eusHr1auzs7Bg/frzB8Xbt2kVYWJj+tXDhwmzPffPmTcqWLUuFChVwc3PLsm9aWlpaFnsKgvBUWrqOe4/l8Xp9naz0/45SNFpO3Y1m5ZE7AJgoFTQolfM+f19vucKBa5F0WhLEyD8v0uD2XAaa/EMr1XE+9YvB6mXNREOOQnoy3D0EB+dASkyOz92rni+DG8vf85IE9x8nZ13Qoxo4l81YPvsbaNMNiiiVChZ85I+dhSlNyrjwa9+a2Fnk47gJpVvCJ0ehwzKjN/99mXSthL9XRo1l0K0oWsw9wMK9N0hL1xknqLKt4cP/gdoGrFyg82qj9/vNa1M3X6b+zL0s3neT+BT571mpgNaV3fl3aAOW9axOZU974wYp5JoClayuXbuWESNGMHHiRE6fPk3lypVp0aIFDx9mPTmvo6MjX375JUFBQZw/f57evXvTu3dvtm/fri8za9Ys5s+fz5IlSzh27BhWVla0aNGClJQUfZmuXbty6dIldu7cyebNmzlw4AADBgzI8+vNTRcvXcakiBcA6dGhNKhT08gRCa+qXr16HD16lGVTh/Nw6yJ6rbxOhcWJjN2Vwqq912jevDkNOg3gwPGz8g6SJPe7Si1cD1YKk5iYGA4ePMjMmTNp3Lgx3t7e1KxZk3HjxtGmTRtAbqrbu3dvWrVqxaZNmwgMDMTX15datWoxe/ZsfvzxR4NjFilSBDc3N/0ru9rSgIAA5syZw4EDB1AoFAQEBADg4+PD1KlT6dGjB7a2tvp71fr16ylfvjxmZmb4+PgwZ84cg+P5+Pjw9ddf06NHD6ytrfH29mbTpk1ERkbStm1brK2tqVSpEidPnszRZ7Ny5Urs7e3Zvn07ZcuWxdrampYtWxIWFpap7OTJk3F2dsbW1paBAwcaJNipqakMGTIEFxcXzM3NqV+/PidOnDDYf+vWrZQqVQoLCwsaN27MnTt39NsSExOxtbXlzz//NNhn48aNWFlZER8fn6PrEd5cIdGJ+gd/z/Y3vRIWR4fFQfrlGj6O2Jo/l6SFX4SjS+DMb3B5E6SnAnKiey1C/tvSSbD+zANCJBf9bs6abGo6n3XvaMZ7tTW4lH+l6xrZvBRda3kx4/2KDArIpi+eQiEPyqM0hXLtoN0i0iX0sT/l6WjJhk/qsqxHdSzVRujvaOkIdsXy/7yvyMrMhJkdK/FLn5p42Mu1l6npOr7dHsy78w9y4k60cQIr0wr674Yu/wNb95eXL+S0Okn/cMBUpaBzdU92jwzghy5VKVtUtEJ740gFSM2aNaVPP/1Uv6zVaiV3d3dp+vTpOT5G1apVpa+++kqSJEnS6XSSm5ub9O233+q3x8TESGZmZtL//vc/SZIk6fLlyxIgnThxQl/m33//lRQKhfTgwYMcnTM2NlYCpNjY2BzHmdtm/fir5D1ms+Q9ZrPk1Ga0dPHiRaPFIry+pKQkadq0aZKNjY2EPMGfpLJykDyHrZU8h66RWnz6tRS5f6kkTbSVpFklJenEz5KUrjF22NlKTk6WLl++LCUnJ2fe+DhEku4ckV93g7I+QGJURpk7RyQpNSFzGU2qYZn4iNeOW6PRSNbW1tKwYcOklJSULMts2LBBAqQjR4688Fi3b9+WAOnMmTM5OndUVJTUv39/qU6dOlJYWJgUFRUlSZIkeXt7S7a2ttLs2bOlGzduSDdu3JBOnjwpKZVKacqUKVJwcLC0YsUKycLCQlqxYoX+eN7e3pKjo6O0ZMkS6dq1a9KgQYMkW1tbqWXLltIff/whBQcHS+3atZPKli0r6XS6l8a3YsUKydTUVAoMDJROnDghnTp1Sipbtqz00Ucf6cv07NlTsra2ljp37ixdvHhR2rx5s+Ts7Cx98cUX+jJDhgyR3N3dpa1bt0qXLl2SevbsKTk4OOivNyQkRDIzM5NGjBghXb16VVq9erXk6uoqAdLjx48lSZKk/v37S61atTKIr02bNlKPHj1y9Fk/60V/qwXhXv82yM3POS1dK43846xUesx6qeSYjdJ3O4L12+JTNPrvTe8xm6WlB25mPsDRJfJ99ukrOSMmTbpW+mH3NanEuC2S95jN0vavGkupk5wk3Q81JGnLqJcHd22nJG0eIUkLa0vSqravfa1PabU66d8LoVJE3JO/4ZQ4SYp/KEUnpEqbzj6QmszeK1WevF2KTU7LtXO+jRJSNNLUfy5JvmM3G/wdDVtzRgqPzeK7zpjuBklSXLixo3hlaela6Z9zD6TohFSD9SFRiVKlSdulaVsuF7zPWsixnN7rC0yympqaKqlUKumvv/4yWN+jRw+pTZs2L91fp9NJu3btkiwtLaUdO3ZIkiRJN2/ezPLHYcOGDaUhQ4ZIkiRJP//8s2Rvb2+wXaPRSCqVStqwYUOOYi8IP2DaD5sm9R43RQocu0RyadhZ0mgKbuIi5Fx4eLg0cOBASalUSo4tP9N/GfqN+Uu6/YV3xg+oKc5y0ldAvTBZ3TPtmetwyvoAV/81/MEYfilzmbgwwzKnV+dK7H/++afk4OAgmZubS3Xr1pXGjRsnnTt3Tr995syZEiBFR0e/8DhPk1ULCwvJyspK/zp9+nS2+wwdOlRq1KiRwTpvb2+pXbt2Bus++ugjqVmzZgbrRo0aJZUrV85gv27duumXw8LCJEAaP368fl1QUJAESGFhYS+8FkmSk1VAunHjhn7dwoULJVdXV/1yz549JUdHRykxMVG/bvHixZK1tbWk1WqlhIQEydTUVPrtt9/029PS0iR3d3dp1qxZkiRJ0rhx4wyuQ5IkacyYMQbJ6rFjxySVSiWFhoZKkiRJERERkomJibRv376XXsfzRLJqfLn5OadrdZL3mM3SrC/6SdoJdlLytOKS9FMTSdJqJUmSDJKMmw/jMx9g/7eG95Un+z3r3L3HUrdlR6WPl+2VHsYm/cdAcy9xXHrgpv6aGs7aI3VbdlSqPW2XwbV6j9kszd5+NdfOmWMPr0rS3hm5er3GduF+jNT6h4MGn22fFceNHVaGqJuSNN1Tkr4tJUm3Dxk7mhyJTkiVFu69rv+7XbT3RqYyyWnpRohMyE05vdcXmGbAjx49QqvV6ofMf8rV1ZXw8PBs94uNjcXa2hq1Ws27777LDz/8QLNmzQD0+73omOHh4bi4uBhsNzExwdHRMdvzpqamEhcXZ/AytpuRCSw2nctOs9GENNqOyYmfjB2SkAtcXV1ZvHgxFy5coKZZGAkXdgLgqXiI6TPDsZ9Q10Fj5WasMN9oHTp0IDQ0lE2bNtGyZUv27duHv78/K1euBOR+8a9i7dq1nD17Vv8qV67cy3d6TvXq1Q2Wr1y5Qr169QzW1atXj+vXr6PVavXrKlWqpH//9L5YsWLFTOuy63rxPEtLS0qUyGh+WLRo0Uz7Vq5cGUvLjFGu69SpQ0JCAvfu3ePmzZtoNBqD2E1NTalZsyZXrlzRX1utWrUMjlmnTh2D5Zo1a1K+fHlWrVoFwOrVq/H29qZhw4Y5ug7hzfV0vlN3RRRKhYR56iOIvQdKJcRHcM5mOGfMBnDNvCfFH/yT+QCpzzSXVdvI+z2nUjF7fu1biyV9A3C2/Y8D27ziiMDZCYlKYtb2YP3y3agkDl5/RFhsikG5Gj4ONCrlnCvnzDFtOvw1EPZNg2VNIeJy/p4/j1TwsOOvT+oxtV0F7C1NUSkVjGqZw+mE8lpaEqztDimxkBAOq1rD7YPGjipb5+7F8Pm6c9SevptZ24L1f7e/BN1BozXsE2xuWrD7Nwu5p9BPxGRjY8PZs2dJSEhg9+7djBgxguLFi+v7d+WF6dOnM3ny5Dw7/qvSarVYqTSYKeRO5mZKXaGd4kTIWrly5fh34zr27NnD0G9+4IpPM5o4z6GXajudVXvpef890t7pyYyBHejQ4f2MgXjS08BEbdzg3wDm5uY0a9aMZs2aMX78ePr168fEiRPp1asXpUqVAuDq1auZkqiseHp6UrLk6w2AZmVl9Z/2MzXN+EH89G8kq3U6Xc4GCnl236f7v2rynlv69evHwoULGTt2LCtWrKB3795ZDkglvJ2KKjIGRMPWQ/6vyhQ7TQQ8/TPRZDGqa9OJ0HCUnLRqkvI8ztfl6WjBsh7VCboVxck70Zy7H0taug4bcxPKFrWlXFFbGpdxoaGfU/7/+zg8F0JPy+/DzsGeqXIfyzeASqmge21v3qtYlCM3oyjjZthv8tD1R6TrdDQq5Zy/n3tyNDx7T/asBV618+/8OZCYms4/50L5/XiIftqnpxQKaFrGhT71fDEx9hRBgtEUmGTVyckJlUpFRESEwfqIiAjc3LKvMVIqlfofflWqVOHKlStMnz6dgIAA/X4REREULVrU4JhVqlQBwM3NLVNNQHp6OtHR0dmed9y4cYwYMUK/HBcXh6enZ84vNpcFBwdTyum5J0xOpYwTjJCnmjRpwrmAAFb//j/Gr97C4nLvsFT9LjorJVTvyuANF5j5QwvmTP2Khv5l4ccGUL0P1BkM6jyc2P11VO0mzyML8jdTVjxrQu9tGcsO3pnLWDgalimSd5N/lytXTj93aPPmzXFycmLWrFn89ddfmcrGxMTk+dyoZcuWzTSVzuHDhylVqhQqlXGfPp87d47k5GQsLOQap6NHj2JtbY2npydOTk6o1WoOHz6Mt7f8/1Sj0XDixAmGDRsGyNe2adMmg2MePXqU53Xr1o3Ro0czf/58Ll++TM+ePfP2woRCY3mv6uz8qxUWbrWp45SSMZCP+rmHPmlZJKNKJZhZy69CQKFQ0LCUMw2f1JqmpmuJTdLgbGOWkSSlJcHxn+Tp0Kp0yb/gHIvLc38mP5YfqL875+X7FDIOVmrerVTUYJ1Gq2P83xe5/SiRKp72DG3qR0DpfEpa7YpBv12w9XO4vgM6Ls+1WvzccOJONL2WHycxTWuw3tbchI7VPOlRxxsfp//2cFbIQ5KU/e+1PFBgklW1Wk21atXYvXs37dq1A+Sn+7t372bw4ME5Po5OpyM1VR6tz9fXFzc3N3bv3q1PTuPi4jh27BiDBg0C5OZkMTExnDp1imrVqgGwZ88edDpdpqZnT5mZmWFmZvYfrzT3nTp9hr83baORb238rBP5plMVXJ1FsvqmUiqV9OjWlQ86dmDG/B9ZeioGU1+5WaiJowen1h+iUaNGbB5UmnddwmDvN3BqJfT8J08TuP/M3lN+vYilI3i/pNbSRP3yMq8oKiqKTp060adPHypVqoSNjQ0nT55k1qxZtG3bFpBrOZctW0anTp1o06YNQ4YMoWTJkjx69Ig//viDkJAQ1qxZk6txPW/kyJHUqFGDqVOn0rlzZ4KCgliwYAGLFi3K0/PmRFpaGn379uWrr77izp07TJw4kcGDB6NUKrGysmLQoEGMGjUKR0dHvLy8mDVrFklJSfTt2xeAgQMHMmfOHEaNGkW/fv04deqUvgn2sxwcHHj//fcZNWoUzZs3p1ixgj+yqJA/mpRxpcm4MZk3qNTywzxTS/lVrEb+BJSeBrr0fHmAaGaiwsX2mQdWx36EfTPkGjfbYlCxY/4lLxXeB++68M9QKN/+rRi1FmDrhTBuP5mL9ey9GHqvPEHlYnYMaFiCFuVdMVHlcY88tSW0WwTx4WCTRSWMJMmvLJq45zatTtI3zQco99zIveXdbelRx5s2lT2wUItmvgWKJMHtA3B0MbhXhYAs7ql5pMAkqwAjRoygZ8+eVK9enZo1azJ37lwSExPp3bs3AD169MDDw4Pp06cDcnPc6tWrU6JECVJTU9m6dSu//vorixcvBuQnjMOGDePrr7/Gz88PX19fxo8fj7u7uz4hLlu2LC1btqR///4sWbIEjUbD4MGD+fDDD3F3Lxw30rNnThNz4ywHbsBRtZrFa/eCacF5cibkDXNzcyaNHsqQ6GiGTP+RffEuPD7wK1JaMn6OSlo6hfK0fVua0hy1fRa1kcILWVtbU6tWLb7//nt9/0pPT0/69+/PF198oS/Xtm1bjhw5wvTp0/noo4/0rS2aNGnC119/nedx+vv788cffzBhwgSmTp1K0aJFmTJlCr169crzc79M06ZN8fPzo2HDhqSmptKlSxcmTZqk3z5jxgx0Oh3du3cnPj6e6tWrs337dhwc5LkMvby8WL9+PcOHD+eHH36gZs2aTJs2jT59+mQ6V9++ffn999+z3CYImSgU8N73uXvMe8ch8io8viPXalXP4m/x9n74Xxfw8JeTtzqDwSrn87u+lrREOVEFiLsPF/7M39pVGzfokrcP7wqa1pXcMVEqmb/7OsFPpgw6dz+WT38/jYe9Bb3r+fBBDc/M0ybltqwSVYDzf8CZX6Hd4pc/OP4PohJS2XoxnH/OheJhb8H3navot1mZmfBRLS8SUrV0qelJRQ870X2joPqjB1x50srpwUmoPwxM8qfiTiEZq4NRNhYsWMC3335LeHg4VapUYf78+foazoCAAHx8fPRP1b/66ivWrl3L/fv3sbCwoEyZMgwdOpTOnTvrjydJEhMnTuSnn34iJiaG+vXrs2jRIn0/M4Do6GgGDx7MP//8g1KppEOHDsyfPx9r65w1+4mLi8POzo7Y2FhsbfN/fqeAgAD2798PyAOvPD9HofB2uH7rDl9PmcSvv/wCkkT3yqZMC7TAwxpab7GnRL32fPHFF5kGFMsPKSkp3L59G19fX8zN3+zJygXj+fXXXxk+fDihoaGo1f+tr/aL/laNfa9/WxTqz3n5OxByRH7v0wB6bc5cZtckOPQkSVYoYcyd/BtnIjkGvq8AafFg5QyBk+SuGEKe0+kkdlwOZ97uG1wJMxyY08JURZeaXkxo/eoD7r2Wx3dhSX1IjQMzO3jvO7m2/TWFx6aw83I42y9FEHQrSj/PsbmpkhNfBmKT14m5kPuOL5Wbkz/VbjFU+ei1DpnTe32BS1YLI2N+sep0OhwcHPQjEn/88ccsWbIkX2MQCpYLFy4wbtw4tmzZglf7kbxfxoQN6XWJP72F9DMbGT54ICNHjpT/Vs/+D8q1ydx3K5eJZFXIS0lJSYSFhdGmTRvatWvHN99885+PJZJV4ytQn3PIUVCagJmNnNxZOr64/F+D4Nzv8ns7Txh+MXOZn5vDvWPy+6KV4eMDuRvzywQtBBNz+Yem6X8cvTgnkh+D2rpA9ZEsCCRJ4vCNKJYdusW+4Ej9+l51fZjUpnz+BrO6I9zYmbHc5Ct5QLFXpNNJnH8Qy77gh+y9+pBzzw2U9FRxZyt+6FKV8u5iENACSZIg9Izc6uN5qQnwXTlIS4BybeWa1aKVX+t0Ob3XF6hmwMKru3XrFukeVVBbPCDtUQj+/ln8gQlvlYoVK7J582b+3b2fwZvu8ZfOAYUSbKu3QVu2Id9t/IWFi0qw5POOdEz+HXZPlp+uV/wgX/qsCIXDO++8w8GDWU9x8MUXXxg0gza2WbNm8c0339CwYUPGjRtn7HCEN8na7pD4ZBDGWgPhnZkvLu/gI/9XaSongjotKJ/re1dvmNz36+5hufY1v9X5NO/PodPCul7yKMrvLy2Y4yUYiUKhoL6fE/X9nLjxMJ5VR+6y8ewDPqhu2AQ3PDaFHsuP0aycKw39nPH3dsA0t/u3tpoFGwbA/RPgWRvqj3j5PlkIjU2m3cLDWW7zdLTg3YrutK5clHJFbUUz34IoLVFuDn5iGURchH67oZjhFHmYWUOHpeBaPmOQunwialZzgTGfAv/y+1q+P6/DURFP8P3HbBzaNNMcjMLbKyUtnZFLt7LljlYeTOSJ9PBgdth9QzkHebojSaFE8ekJcHq9KVWyjUPUrBY6Dx48IDk5Octtjo6OODq+pIapkBI1q8aX65/zwe/kQebsism1ne2X5Hwky6/dIP3Jv4OGo+SapxdJeAjpqfLgQc8nqVnJ51E1882O8XBkvvxebQ0dlkHpd4wbUwGWotFmmjd0+aHbTNmcMRettZkJdUoUoZq3A/5eDlQqZpc7c41q0+Hw91CxU8bDlmdIksSjhDQuh8Vx7l4MZ+/FUMLZii/fNWyyHPjdfm48TACgjJsNLcq70aK8G2WL2ogEtaCLvgXz/YEnKWHFD+TENI+JmtW3xL5zN2hhEs0M02VofBWojvwBZXeAVRFjhyYUAOZqExZ+2oaxUQkMXLKdS/Hyj2+/orbYq20BeaCN366qYdtRunTxNfpUJ0LB4OHhYewQBCF3RN+CmLvyy8bdMDncN0OuVUpLApcyhgMuaTUZiSrISdfLWL/imABv4o/45Bi4uCFjWZLAUdSsvkhWSefTEYSfSkhNZ+flCHZelqd4NFEqKOFsTdOyLoxuWcagrCRJOU8QVSb6pr/hsSmcvRfDvegkQqKTuBERT5fwmexKLccmXV2eDtp4/7E1X75reJhBjUqg0epoWMoZd/s8bF4u5D7H4lAyMKNJ+JV/ICUOzAvGQ1mRrBZyF+495uPiDwAwVUoQ90Cex0wQnuFZxJotX3bgYHA4I1Yf4bamKE1S5/CxajMfKnYy7O8HRK3pzvTp05kyZQrt27dHqVTm+lN/0ZBDKOjE3+gbKO5Bxnu75x7ChJ6FG7vk99o0w20KJfTfIzdlTY0HZ8OE4I1y+wDcPQIBY1//WBb2MGCv3IT63lF4/0cQ0+m9sqntKvBZ05IcvPaIA9cjOXj9EdGJGX+j6TqJ4Ih4yha1ybRvnel7SE3XYmthio25CZamJiiVoFQoUCggRaMjOU3LrI6VqOCR0X9099UIvvwro5/1u8qjtFHvpY16Lx20Bxmn6UcoTkQlpJGarsXMJCPJ7lBNTBdWoD2+C6d/kf991v0s8/aaA+DBKfDvATX6FphEFUSyWqhJksSDJAUlFKEZK51Kin6HQrYalHbj6OT2rDx4nVnbrjBP24HJf18mNvk+AJcvX6Zjx45UrVqV6ZPG0TxsAYo6n0KFjq/1d2X6ZCqlpKQkLCzEE1eh4EpLk38MihYGb5BSLcHaFWLvg2sFw23PDjCkea7Zu1IFHtXyPj5jSnwEO76Cc/+Tl30bytPpvC5rF3lu75t7oHTL1z/eW8rFxpwO1YrRoVoxdDqJG5EJnL77mNMhjzl3L5ZbjxLwczVMVlPTtYTHpQDwOEnzwuPHJhtu93LMmPvXlgQmma7SL9czucrklqUoVaYSXo6WomlvYbJtnDw/KhJYucj9758f+KxkIIy4AqYFr6uWSFYLsbt37yLZeTAjvQsbtXX5yO4qtSo3N3ZYQgGnUiro26gUHWv48tuR6zxQBTJv3kUSE+UmRyaOHlyOTOPsD91pUc8MNvRHOvYjig9W/edO9SqVCnt7ex4+lAcqsbQUX3RCwaPT6YiMjMTS0hITE/H1+Mao9XH225zLgFcdMLXMsr9ertBq5B+Gd4/IyWHZ1gWn+e+jaxmJKsCWz2HQ4dyJz0QtEtVcpFQqKOVqQylXGz6s6QWARqtDo9UZlItPSaeChy1xyenEpWiIT0nXTx3zLLWJkrTn9i3tZsPIZqXwdLTEy06F1Y2P4dhc0KZh0mAozerVybPrE/KQY3H0/VETH8LVLVC+nWEZpRKUBS9RBTHAUq4w1qAb69Zv4PMgBQoTNZqoe6zvW4XatWvn2/mFN8fDhw+ZOXMmCxcuxLb1WMqU9GKn6UjMlPIX2YMkNdearyagafP/nGRKkkR4eDgxMTG5GLkg5C6lUomvr2+W87SKAZbyxxvxOacmQPBWuLAOHt+BQUfk+Swjr8q1ly1nyKNqFgR/fwpnVsvNnt9f+urzbEbfBk1SwbkewYAkSWi0EjpJQpJAJ0mYmSgxyenIwpHXYP9MaPMDqC0zb094+Op9tYXclxIH17bL/36f/52WHANzysh98J3LQtPxUObdLA+Tn8QAS2+BU1duoTApC0DaoxAqVuxu5IiEwsrFxYU5c+bQpPMAPt1wg0gphSW6dnys+AdzhYah29NY/21LGjZsyOTJkwkICHjlcygUCooWLYqLiwsazYubJgmCsajVarm/tiC8juM/ydOCPfX3YDlRBbl/6IllhoM5GVOzqXB9J7SY9uqJauQ1+KWt3N+397+ib2oBpFAoUJu8Rk25cyno+HPW2+LD5VFkSzWHJuPFFEXGEH0L9k6XB0VKTwZ7T/B6ruLKwh7emSG3JPGsVXBaduSQSFYLsav3HsGTsZQs0hOwsrIybkBCodeyeilmKiyYsfUK3yd3ZG16AO+rDnK8STNsLddz8MgmGjduTKNGjZg0aRIB3irwrvdK/VlVKpXoDygIQsGnSZab8KqtX73PfoX3DZPV82vkuVd1GjC3g8Zf5m6sr8PSET499uqDM8Y+gB8bZoyYvKo19Pn3SZND4a2wbzpoEuHSX3B5EwzYB0UrGTuqt4vKTG7B8bSZ75nVmZNVgGq98jOqXCUeHxdiIdFJ+vdOBbOZuVDIqJQKOtfw4tDYpgxt6ke0iTMLtO1Rmlnj0Kgn7gN+wrpSc/YfOMiXPQJh1XvEf1dd7oslCILwJjm/FmZ4whQHmFYMkqJzvq+DDxSrCWobqPwR9NoqJ4Sl3oGAcWDllGdh/yfZJapnfpOn94l9kHmbnYdhU0JrZzArpM22hVcXFwqnf81Ydqsov4S8EXkNYkIyr7fzkLsWPHV7P+i0+RdXPhA1q4VY5KNHOLvdIs7KC68iolZVyD1WZiYMb1aKrrW8+H7XNdaeuIdOAhObIhR5ZwgW3pX43nUxADYJN9Etf4ejNRZR592PxMBJgiAUHHGhsHuKPLKvQgU1++f8B3VqfMb7tHhQv+L37Ps/gY2b4YjDH62RpwQrDCQJDn0PUdflGrQhZ8HR17BMi2/kfnLuVeCDX+RaWuHtYOsOfXfCzvFw9zA0/iLr5qXJMXIzVOHVSRIcnCPXXEdchNqfQstpmctV7S7fnyp/KI9+rnyzWq+JZLWQSkpK4v6+/7Gp1CYq2CuJdSsC+x2h0Shjhya8QVxszZn+fiX61PNl1vZg/WTkXvf/pXyFjIYZv55Lo9eUbtStu4gJEybQvPl/H4hJEAQh1yQ/NhzttvQ7hsnqwytwcYM8QJAmSe539zThejZZVanBxOzVzv18YvdUYbk33j0sJ6pPxdzNfE02bvJctE5+hee6hNxTrBr02gL3joNnzczbdTpY3kJu+l6jP5Rr8+r/jt5mCoX8MCjiydy3lzdC868zd0uo1El+vaFEM+BC6tatWyiA0k5KTFUKnIiGlBhjhyW8ofxcbVjaozrrBtahX31ffvvfer4Ia8GqcxoS0iQmnXdFXbQUR44coWXLltSqVYtNmzYhBhsXBMGodOmGy8rnntE/ug4HZkHQAji5XJ5a5qlSLeCdWXIC22Bk3sda0GiSoYhfxnLUzazLOZcSierbTKEAr2wG7bm+Qx5Y7N4x2NAPji3J//gKOk0yXNsBF9dnvb18+4z3cQ8g7Ez+xFWAiJrVQurmzZt42SmwNH3m5uAkRuET8lYNH0dq+Mi1DvNWrOPatWuMnTGRlLpVKVqsPEnXjxFzcDUnTpzgww5t2TfABU3V3tTu9TUqMW+lIAj5TWkqJ1y6dLkfl+lzU288v6zJGAsCj2ry623l1wxKBso1rDd2Z19TLAjZOTI/471KLfffFjLs+Ub+jNJTwM4Tyr+fOekv3w5OrYBy7eTE1aWsMSI1KvHrsZC6ceMGj1Mkum5IoqyTitF92qEuWtnYYQlvmVKlSvHhuB/Y/PMxACz9amHpV4vEqwf5JGUFNZ1T4P5iTg1dxq2qX9Cu52eYmpoaOWpBEN4aruXgs5PZb1dbyqNpmlrIfb4kXf7FVhgoFOBTX34Jwqt673s4vhTOrZGb4Fs7Zy5za5/cN7psGyjzHti45nuYeUqSICkq60HVLB3lRBUg9h5EXAK3CoZlbN1h8Im8j7MAU0iind5rM8YE5t0Gj2FXtAPpseGoQi8QcWZ3vpxXEJ6n0er44+Q9fth9g/A4+abrTAz7zIZjpUgF4EGcDr8fEnDx8GbUqFH06dMHCwuLFx1WEAocY9zr30bicxaEN0xqPKQmgG3RzNv+GQqnVsrvTSxg7N03o1/rnUNy14KQo5CWAKPvZO5r+ug6LKguv1eaQJsFUKVLvodqLDm914s+q4XUrcgEzL0qYl2xGc5+okZVMB5TlZKutbzZNyqA8e+Vw8laTQpqVmsDSZXkxhszoxujsS3G3bt3GTx4MD4+PsyYMYPY2FgjRy8IgiAIQp4ys8k6UdWmw5XNGcvedbNOVB+cguu7DPuUFwSaZLk2NCuP78r9UOMeQEosRF7JXKZISagzGDqthFE336pE9VWIZLWQCovPGDTCw/YNeAIlFHrmpir61vflwOjGfNbKnx/NetM0bTZL0luz2a0/jk3768s+fPiQcePGMbiJFxO/GEVERIQRIxcEQRAEId+lJUDZ98DySRNZv2ZZlwtaBL91gG9LwPKW+Rdfdi78CXMrwTdF4ceGoEnJXKZYdcPlrOajVyjk6Z/KtxfT+7yA6LNaCGk0GuIlM6yfLJcsms1k3oJgBJZqEwY0LEHXWt78EnSXHw94oEvX8EF5W9bsdeLRI/nJqH9RJb+2hrD4JUxtuxD8ezDi89EUL17cyFcgCIIALG0iN180s4EKHaHOJ8aOSBDeLBb20HoetJojjxhcpETmMpIEIUEZy9bZ9Gnd8jnc2AW2HlC0ctbzkd4/CY+uye/NbKBs68xlLv8NJ36GhIfyv/8RWdScqkzlqZxAHrwt8qo81/CziviBgy+4lgevOlCiSdZxCy8lktVC6O7du9g72GNGMolYULF4Fk0rBMHIrMxMGBRQgh51vNl1JYK2Vd5l5qgBLFu2jNmzZzPznXQgkaI2Sha0VFJj6VL8flxKp06dGDNmDFWrVjX2JQiCUNhF35anz1Cq5D5hZdtkzKP6MlE35OZ7IDdPFAQhb6hMwKde1tviw+SmtE9lN5ho9E14fFt+kc1wPOf/gOM/yu/tvbJOVhMewu39GctPH1g9y6m04XL4hczJqlIJQ89mHYfwSkSyWgjdvHmTbm53mGA2n9s6F2xTy4CmE5iaGzs0QcjEysyEtlU8ALC0tGTIkCF83K09sfMaAIkAbIkvxUW1Fp3uDGvXrmXt2rUEBgYyevRoAgMDUYg5/ARB+C8eXoZ/R2cse9bOnKxe2wFp8XL/M5ey8nQ1kiT/SH3KTAz0JAhGYesOY+5A2HkIO5t9DWXsMwltTh5IZdV0F8Dc3nA5PjxzsupYXG5t4VxafnnWfvn5hP9MJKuFUPD1G1SyfIRSIVFCFYE2TicSVaFQiVI60dVsES0S/6a/yRa+U/fHtbMHqeE3iDv2J0nBR9i1axcnD+3Cp0wVRo0aRadOncS0N4IgvBpduuGyUpW5zJ+95b5zAPWGycmqLh2q9X4yimm8mMdcEIzJwgGKN5Jf2anYCaKuyzWxbjkYeDQ9m2TV3hO864G1C9gUBZMsfl+bqKHjzzmLXXhtIlkthC7dekBL6zv6ZaWHaC4pFC7u9hZsH92Sv89W5KO9HbgZpQHAzK0kzm3HookOJeXUek43PML58GC+GtGdsWPHMmzYMPr374+Njc1LziAIgkDOklVTy4xkVZMs/1dlCu99l7exCYKQexqNenmZJl9C/eHy++xabHnVht5bcy8u4bWJ0YALoWthj5me/hHfazqwJ94bRfEAY4ckCK9MbaKkU3VPto5sxqKu/lT0sNNvM3V0Z3DLUnjbKWhd2pRzA62pYR3GyJEj8fT0ZPTo0dy/f9+I0QuCUCiUbQvjHsCYuzD6Nth7Zy6jtsx4r0nMv9gEQchf5nbyFDq2RcHGzdjRCDmkkCQpm17IQk7l9wTmpVr1Ia1SBwC8Ig5zYEUWI54JQiEjSRJHbkaxeN9Njt0I57DZEFwUMQBEJuooPj+BhLSM8iYmJnTu3JmRI0eKwZiEfJHf9/q3Vb5/zo+ug0IJaiu5b5raKu/PKQiC8JbL6b1e1KwWMjqdjtALR3h84BcSzu+gtIuFsUMShFyhUCioV9KJ1f1q8ddnASz3mU2MZyAAF+yaYVOkKChVFHlnCGaeFUhPT+e3337D39+fgIAANm3ahE6nM/JVCIJQ6Dj5yVNm2LiJRFUQBKGAEX1WC5nQ0FAS7wfD/WAAarT70cgRCULuq+BhR4XenYBOcO8ETVzLc2e0CeOWbGB9qA3WlZqTGn6D6dJ80h6HM+3AAdq23U/JkiUZOnQovXr1wtra+qXnEQRBEARBEAouUbNayNy4ccNguWTJkkaKRBDyiWcNUFuiVqt5bJsxYXjZopZ094ligL8J14fYMqyBHTdu3OCzzz6jWLFifP7559y9e9eIgQuCUGhd3QL/6wJ/DYJt47Kf5kIQBEHIUyJZLWRu3biGnVnGcokSJbIvLAhvmB+7V2Peh1WoXMyOz0z+QqWQu9ybKiUe1BlLkfdGonYvTWxsLHPmzKF48eJ06NCBAwcOILrnC8JbKC4M7h2HB6cg9CzktKvAwysQvBXO/Q5HF8mjAwuCIAj5rsAlqwsXLsTHxwdzc3Nq1arF8ePHsy27dOlSGjRogIODAw4ODgQGBmYqr1Aosnx9++23+jI+Pj6Zts+YMSPPrvF1JN48RsxYW65/ZsO6D6woZp5s7JAEId+YqpS0reLBxk/rUeGd/twxKwNAkLYcxxUVsS7fmKLd52BTox0g9/HesGEDjRo1wt/fnxUrVpCSImpIBCE6OpquXbtia2uLvb09ffv2JSEh4YX7pKSk8Omnn1KkSBGsra3p0KEDERERBmWGDBlCtWrVMDMzo0qVKnl4BTl06S/4uRksbQI/NQJtWuYyKbHw+A5EXIaw80/WxWRsN7PLesobQRAEIc8VqGR17dq1jBgxgokTJ3L69GkqV65MixYtePjwYZbl9+3bR5cuXdi7dy9BQUF4enrSvHlzHjx4oC8TFhZm8Fq+fDkKhYIOHToYHGvKlCkG5T777LM8vdb/ShF7B4CSjgo6llWhMjV78Q6C8AZSKBT41W2Pz9ijRLX7nWuVR2FvKdd8KJDwMYkFoFslU9Z2tKCyq5KzZ8/Sp08fihUrxrhx47h3754xL0EQjKpr165cunSJnTt3snnzZg4cOMCAAQNeuM/w4cP5559/WLduHfv37yc0NJT3338/U7k+ffrQuXPnvAr91eg0hsvKLIbq2PM1zKsMi+vA6ie/DazdwL0qOPiCQxbT3QiCIAj5okBNXVOrVi1q1KjBggULALlWxNPTk88++4yxY8e+dH+tVouDgwMLFiygR48eWZZp164d8fHx7N69W7/Ox8eHYcOGMWzYsP8Ud34Os//nJ5Xo6CL3w4vTmmE7JSL7iY0F4S2SotGy6VwoNx8mMPadMhw8sI8S2z7CwywJgHUxZem5RSL55kmQdKhUKtq1a8fgwYNp1KgRCvHvSHiJN2XqmitXrlCuXDlOnDhB9erVAdi2bRutWrXi/v37uLu7Z9onNjYWZ2dnfv/9dzp27AjA1atXKVu2LEFBQdSuXdug/KRJk9i4cSNnz5595fhy9XM+OAd2T8lYnhiT+Ttz50Q4PFd+r7aBL8QczoIgCHmt0E1dk5aWxqlTpwgMDNSvUyqVBAYGEhQUlKNjJCUlodFocHR0zHJ7REQEW7ZsoW/fvpm2zZgxgyJFilC1alW+/fZb0tPTsz1PamoqcXFxBq/88muYF99qPuBfbQ3OaEuIRFUQnjA3VfFBdU/GtSqLQqGgYZHH+kQVINy6NC4dJuAx8Gfs6n4IFvasX7+exo0bU6lSJZYsWfLSZpCC8CYICgrC3t5en6gCBAYGolQqOXbsWJb7nDp1Co1GY/AdXaZMGby8vHL8HW0UFT+Anpuh+0bouj7r78xnp6vRJELBeYYvCILw1iswU9c8evQIrVaLq6urwXpXV1euXr2ao2OMGTMGd3d3gy/TZ61atQobG5tMzZaGDBmCv78/jo6OHDlyhHHjxhEWFsZ3332X5XGmT5/O5MmTcxRTbtJoNBxK9OSc9j3QQnur6zTK9ygEoZBw9IWSzeDGTlJQsyK9JQAmts7YN+iGXb0uJN88QcLZf7l46QyDBg1izJgx9OzZk08++YQyZcoY+QIEIW+Eh4fj4uJisM7ExARHR0fCw8Oz3UetVmNvb2+w3tXVNdt9cio1NZXU1FT9cq4+ALb3lF8vUuZdcCwOppagtsy9cwuCIAivrcDUrL6uGTNmsGbNGv766y/Mzc2zLLN8+XK6du2aafuIESMICAigUqVKDBw4kDlz5vDDDz8YfHk+a9y4ccTGxupf+dX3LSIiApVVRq2xj6tDvpxXEAol96rQ7U8YsB91m++Z06spgWVdUD6pWFEoVfj5leBi13i+HN6Tog0/ID4lnR9++IGyZcvStGlT1q9fj0ajefF5BKGAGDt2bLaDCj595fThb36aPn06dnZ2+pen50uSy9zmWh4qdoQyraB4gGixJAiCUIAUmJpVJycnVCpVppEFIyIicHNze+G+s2fPZsaMGezatYtKlSplWebgwYMEBwezdu3al8ZSq1Yt0tPTuXPnDqVLl8603czMDDOz/B/YKDw8HJWNnKxKko4SHs75HoMgFDruVVC6V6Ex0LiMC6Exyaw5cY8/TtyjX9JWiivD+dpmPSMbWVHlYjoh0fJue/bsYc+ePbi7u9O/f3/69++Ph4eHUS9FEF5k5MiR9OrV64VlihcvjpubW6aBC9PT04mOjs72+9bNzY20tDRiYmIMaldz8h39MuPGjWPEiBH65bi4uPxPWAVBEIQCqcDUrKrVaqpVq2Yw8JFOp2P37t3UqVMn2/1mzZrF1KlT2bZtm0H/m+f9/PPPVKtWjcqVK780lrNnz6JUKjM1kzK28PBwfc2qLikOD/eiRo5IEAofd3sLRjQrxaHPKtPD7IB+fbSJM+6lqhqUtaoYSKTGjMmTJ+Pt7U379u3ZsWMHupzO1SgI+cjZ2ZkyZcq88KVWq6lTpw4xMTGcOnVKv++ePXvQ6XTUqlUry2NXq1YNU1NTg+/o4OBgQkJCXvgdnRNmZmbY2toavIxKmw47J8DB7+DkcogMNm48giAIb7ECU7MKcnPcnj17Ur16dWrWrMncuXNJTEykd+/eAPTo0QMPDw+mT58OwMyZM5kwYQK///47Pj4++n4z1tbWWFtb648bFxfHunXrmDNnTqZzBgUFcezYMRo3boyNjQ1BQUEMHz6cbt264eBQsJrZhoWFo7J2AkCbkP0TcEEQXs7EVA2NRsKxHyExkiItxxE04UNOnTrF4sWL+d+GTRRp/ikuJok8iHhEwoXdbNq+h40bN1K8eHH69+9P7969M/WzF4SCrmzZsrRs2ZL+/fuzZMkSNBoNgwcP5sMPP9SPBPzgwQOaNm3KL7/8Qs2aNbGzs6Nv376MGDECR0dHbG1t+eyzz6hTp47BSMA3btwgISGB8PBwkpOT9aMBlytXDrVanf8Xq9XIAyYpTUCZw+fzKbFweF7G8nvfg3PmVlaCIAhC3itQyWrnzp2JjIxkwoQJhIeHU6VKFbZt26b/MRgSEoLymS+bxYsXk5aWph9G/6mJEycyadIk/fKaNWuQJIkuXbpkOqeZmRlr1qxh0qRJpKam4uvry/Dhww2aJBUURUJ3sc3iIpGSPQ/sdDg79DF2SIJQeJnbQsNRUGcwXPoL+4ryfaRatWosW7aMqp0v8+3uW6xWT0PyVLDcvSUbG3fj8Y2zhF3czbgvv2LChAm0b9+eAQMG0LhxY4P7kyAUZL/99huDBw+madOmKJVKOnTowPz58/XbNRoNwcHBJCVljKj9/fff68umpqbSokULFi1aZHDcfv36sX//fv1y1apya4Xbt2/j4+OTtxeVle1fwPGf5PfWbvD5S2pJdTpIijJcZ26fJ6EJgiAIL1eg5lktrPJr7r1NYwJoY3EGgBSdCvPJUWIgCEHII7FJGk7sXkfgqUH6dd9rOjBP2wEAbWIMiVf2k3hxD2kRNylZsiT9+vWjV69eorb1DfWmzLNa0OXq57x5BJz8WX5v6wEjLmcuE3EJVrWGtCRIT4amT5oApz2Zyqr7X1CiyevFIQiCIBgodPOsCi9nnZIx+FRUqkokqoKQh+wsTQmM3aBf1ipU/Ktupl9WWdljW70tji0GA3Lzx7Fjx1KsWDE6duzI9u3bRd9WQTA23TNzpitVWZdRmsq1qenJ8nIRP/jiAYx/BKNuglfdvI9TEARByFKBagYsvNipcInoMA1FrRXorBwR45IKQh5rPQ9OLINTK1CVbMbWdp05eP0Rf566x/aL4aRL4HLnX96tasrvFzQkp8ujqv57+REb2nbAy82JPn360Lt3bzG6qSAYQ7m2UKSknLSa2WRd5vm5VTVPmj6rTMHKKW/jEwRBEF5INAPOBfnVNKxEiRLcunULgJ49e7Jy5co8O5cgCM9IS4LUeLDJaN4bm6xh64Uwmt3+FqcrvxCTquDn0ylMuFgM5+7zkNLTSLp5gqTL+0m+dZIWgU3o27cvrVu3NsrUV8LrE82A80e+f86pCbD3GzC1lBPXUi3luVcFQRCEPJPTe72oWS0kJEnSj3YMiJGABSE/qS0z1b7YWZjSpUoR2PM3APZmEv2aleMP3y5EAAoTNVal62FVuh661EROBB9h36hvsP7kU7p1/Yi+fftSoUIFI1yMIAgGzKyh5XRjRyEIgiBkQSSrhURCQgIK39rYWNqhTYjGyVXMsSoIRvfwKpDRd9yu6Uh+7vIeqw9dZ9PZByRJ8i3W3EyNslIzrCs1Q5v4mFUXD7GoeQcqF7OjT58+fPjhh9jb2xvnGgRBEARBEAookawWEuHh4VhXaYl5sXIAuLnGGzkiQRAoVg1GXoULf8KFP6DC+1QwtWBG5+p83dGfwzcesXTHGSZEfk6I5Mr/tE3YZ1UFVbXWKNWWnNj6PSdOnGD48OG0b9+e3r1706RJE1SqbAaCEQQh790NkgdcsrAHKxdwLmXsiARBEN5aIlktJMLDw1FZOwKgTY7D08PdyBEJggCAqQX4d5dfzzBRKWlU2oVGagtYFUopQglUneGb1A9ZKrUh8eoBfdmUlBTWrN/Ivw9MsRk5ke6tm9CrV0/8/Pzy+2oEQQhaAFc3y++LVoaPD7y4vCAIgpBnRLJaSKTdOMjSIrt5qHAkTAHujqONHZIgCDlxckXGe4WSISO+xPZoGLfTG7P6lxAiIyMBsPSrjV2dDwBYGRnKor5T8bNIoF+Hd/jgg06imbAg/Bebh0PIMXnamqKVoe2Cl++THJPx3tw+ryITBEEQckAkq4VE+sOrtDI9KS/YQ1wRMRiEIBQKNQeA0gQu/w0lmmDj7MVnrb2gdS1mTp/Gli1b2PW/hVR1SWOD4g6XJB9MHd2xq9uZh8Dkkw/4cu1IanuoGfRha5o3b46Jibh1C0KOPL4DDy/J77ObugZgy0h4eAXSEiHsbMZ6C/s8DE4QBEF4GfGLp5BIj3+o/7+VLimwcfM1bkCCIOSMdx359c5MSIkx2GRqakq7du1oZ3ECghbQl7NcSnOjU/oUkpTWchlHD0wd3+cC0P/vUJjZnQ+ru9OjRw8qV66c/9cjCIWJTpvxXvmCvuChZ+HBkwfCHtWg7UJIfvziBFcQBEHIc0pjByDkTFiigis6T6IkGyI1Fihe9KUrCELBY+kIjsUzr9dq4Pxa/WI532IsbF+CimmXSQ+9gvTMj21Th6IkpGn57rvvqFKlCpUqVWLmzFncDbmXH1cgCIWPbwOo0AHKtQXvetmXM7XIeK+2Apey4F0X3CrmfYyCIAhCtkTNaiGxPKI0X5sNBsDhxr+cMXI8giDkkoQIKFISEuW+q4oqXWhcozqN61QnLS2NtX//y09bD+GpjCTRuRxbgw/pd71w4QLj5yxhwX13HJLu07qqJyO6vksRB3sjXYwgFDANR+WsnIc/qEzB1BJcxfzHgiAIBYVIVguJxyk6/Xt7S7URIxEEIVfZFYM+2+DRDTj7m1wL9IRaraZ7p7Z079gG7bwqqGLWEdJXzdQ9piw7rQHAsnRdVFYOxFk58Nt9+HXKDpw1EbTx92ZIp0AcbCyNdWWCUHg0m2LsCARBEIQsiGS1kEhIV/K04a+rncULywqCUAg5lYTAiVlvu38SVcwdALys0pj25QjczpiyevVqYkzN0GlSUJqaA6A0syLKrDgrrsHyydtxkaJp4+/DwNZ1cbYV9w5BEARBEAoP0We1ENBqtcRH3CM19CrpsQ8pVkQM+CAIb5V7Rw0WnRsPYurUqdy8eZN/pvSmWcJuknbMo+H95VimROrLKUzURJq68fOFFKr1n87o0aM5c+YMkiTl9xUIQuGQGg+R1yDhIaSnGTsaQRCEt55CEr9aXltcXBx2dnbExsZia2ub68ePiIjAzc1Nv/zjjz8yYMCAXD+PIAgF2OO7cOEPiL4D7RZm2px2/xzqZQ1J1SnZet+Kb6MaElKsJSY2RQCI3DidpODDAJQpU4YOnT8ivVRTPqhflirF7FEqFfl5NYVSXt/rAe7du8fEiRNZvnx5nhy/MMiPzzlb13fCbx0zlgfsB/cq+RuDIAjCWyCn93rRDLgQiLp1jm+amBGWoCMsXsLTycrYIQmCkN8cvF84WIw6eBMAZkod7b3ikWpVYOG6Xzh85T4WJWuRfPu0vuzVq1f5fs12nNv5s+b8ESwU6TQt40y7GiWoV9IJC7UYbdxYoqOjWbVq1VudrOaqXZMgIVKetsarNlT56MXlk2MMl83t8ioyQRAEIQdEsloIJN89wxcNzPTLl6x1LygtCMJb6cbOjPeuFXj/4y94/+MvCA0N5Y8//uD35CuEXj1JZTcVO2+mY1Gylr54smTC5iuP2XzlJCYKHbV9HHi3qhdNy7jgYmtuhIt5c23atOmF22/dupVPkbwlLm+C6Jvye1169slqyDG4+g8c+cFwvYV9noYnCIIgvJhIVguBlEd3DJYdvMoYJxBBEAquPjvkhPXCn+BZU7/a3d2dYcOGMWzYMB79NQ6nc4uIS1Pw9/VljNh+FoVvHcx9q+oHaEqXlBy6Hcuh2xcAaFWuCIt61DbKJb2J2rVrh0KheGG/YYVCNMnONbr0jPcvmp884oJhovp0dGAzUbMqCIJgTGKApUIg6vFjUqSM5wpFRLIqCMLzTM2hbGv4YBXU+TTLIk4RBwGwVUt0quVJ3xbVsTrzG/fnf8TDP6cQf3Yb6fFRBvv8b+kCAgMD+emnn3j06BGSJLEv+CFJaelZnUJ4iaJFi7JhwwZ0Ol2Wr9OnT7/8IELOOXiDY3Gw9wLLItmXM32ue02FjlBvKCjFzyRBEARjEjWrhcDax2UZou6GLYnYB//DAUsxGrAgCK8oPhwig/WL5lU/YEbTCUyfPoNjx46xZs0a1q1bR/U7P2Lv4spek3qkedUh6fpRdkfcZPfu3XzyySfUfacDIeV7oFYpqF3CiaZlXGhSxgVPRzGfa05Uq1aNU6dO0bZt2yy3v6zWVXhFPf/JWTkza7l/qqml/JK0eRuXIAiCkCMiWS0EImKTwVlBHNakpFsbOxxBEAojGzf4/DoE/wuX/4by7QE5Oapduza1a9fmu+++I2FuLWzjrqHR/svys38zMCJFfwitVsu5h1ocykOaVuLAtUgOXItk4qZLlHSxpkkZFwJKO1PDxxFTlaiRysqoUaNITEzMdnvJkiXZu3dvPkYkAHKrhLKtjR2FIAiC8ByRrBYCUUkZze3szcUPQEEQ/iMLe6jSRX5lQRkfhm3cNQBMVdCy7Qd87GHB+vXrefToEQCpDy4Rf+ZfLEpUx8TWWb/vjYcJ3HiYwE8HbmFjZsI7Fd2Y1bFynl9SYdOgQYMXbreysqJRo0b5FI0gCIIgFGwi8ykE4jQZg2242Ji9oKQgCMJreHgF1BndDLybf8KSJUsICwtj586d9O/fH+uUSOZbLWfojYH4/juQuAMrSLl/GUmX0WwyPjWd0+cvc/v2bYPDX4+IJ10rRjMXCjCd+PsUBEEoSETNaiGQLKlRP3nv7iDmWBUEIY/4BcLom3BrP9zcDcVqAGBiYkJgYCCBgYEsmjkB1bwKKJAYRRzfHNzMV7+tR2lug7mvP5YlamDuW5WjW1dQfOpHVK1alQ4dOvBum3Z0XhuCuamK+n5OBJRyplFpZ1xsxNQ4QgEyrxKkxIGFHVTtAY2yn9tYEARByHsiWS3gkmMf8YHTLaKVVjyUHPBzFcmqIAh5yMQMSjWXX1ltvrkTyBgA6J3Bswkre5UNGzYQdmU/SVf2g0KJh62KRODMmTOcOXOGr5f/hWunyaSm69hyPowt58MAKO9uS0BpZxqVcqGql73o6yrkruNL5f8qTcC9KrhXeXH5pGjQJEJqLKQl5Hl4giAIwouJZLWAi759jrlFtwJbAThg29e4AQmC8HazsAePavDgFFg44t9mIP7tTZg/fz5BQUH8+eefHPr3T058GMeVSDVbrqfz4ykNISkJJF45gLmvPyrzjIHiLoXGcSk0joV7b2JjbkK9Ek7M61IFM5MXzIn5hrl27RrFixfHxER8Jee6f8dkjOzb+Mvsk1WtBi79JSeqT1nY53V0giAIwkuIb8YCLuZ+MB7PLFu4FDdaLIIgCJRvL7/iw+HRdVDJXyNKpZJ69epRr149pO5VYdNnlHVWUdZZxcar6dy4F8yjTbNAocTMvQwWxathXrwaZm4l9YeOT0nnekRcpkT1VmQC7vYWmJu+mQls2bJluXLlCqVKlTJ2KG8WSTKcgkbxglp7XTps6G+4rqgYIEwQBMHYClx7q4ULF+Lj44O5uTm1atXi+PHj2ZZdunQpDRo0wMHBAQcHBwIDAzOV79WrFwqFwuDVsmVLgzLR0dF07doVW1tb7O3t6du3LwkJBaP5T3zEHYNlW3c/4wQiCILwLBs38M16ZFvF9R3695K5PT9uOcXUqVOpUqUKSDpSH1zG/MxqBt8bg/eGrjzeMofEy/vRJsdxfscaWrduzc8//0xERAQAA349ReXJO+ix/DjLDt7iekT8GzUX6Zt0LQWK7rm5UpUveD5vYg5kDGZI46+gRJM8CUsQBEHIuQJVs7p27VpGjBjBkiVLqFWrFnPnzqVFixYEBwfj4uKSqfy+ffvo0qULdevWxdzcnJkzZ9K8eXMuXbqEh0dGfWTLli1ZsWKFftnMzHBE3a5du+pHu9RoNPTu3ZsBAwbw+++/593F5tAFjReDdvljb2mKVfpjfh5QztghCYIgvFijMeBWCa5tR+HoS/mKlSlfsTJfffUVt2/fZuPGjaQeXcbYsvf5EomYlJPUXLqf65tBYWrG5rRkNm/ejEKhoEZACyJqDgbQz+v69ZYrFLUzp4GfEw38nKlf0gkHK/VLghLeOkoVjHsg167qtE8S0mwoFGBqmdEMWJOUPzEKgiAIL6SQCtAj3Vq1alGjRg0WLFgAgE6nw9PTk88++4yxY8e+dH+tVouDgwMLFiygR48egFyzGhMTw8aNG7Pc58qVK5QrV44TJ05QvXp1ALZt20arVq24f/8+7u7uLz1vXFwcdnZ2xMbGYmtrm8OrzZnZs2czalTGaIQpKSmZkm1BEIQCS6eVk4bn/dEDLv8NQHy6Ca5zEklOSTUoYmECKlsX1DU7Y+HrbzCv67MUCqjkYcf8LlXxLpJ3g9Dl1b1eqVRy9epV0Qz4ibz8Tn2h6NtyQqu2BFMrfRN3QRAEIffl9F5fYJoBp6WlcerUKQIDA/XrlEolgYGBBAUF5egYSUlJaDQaHB0dDdbv27cPFxcXSpcuzaBBg4iKitJvCwoKwt7eXp+oAgQGBqJUKjl27FiW50lNTSUuLs7glVdiYmL0783NzUWiKghC4ZJVogryqKtP2FRuw8PIR6xfv54ePXrg4OAAQNdKpjwcmMzvRX6m89mPiVoxkOjdS0m+dQopPU2/vyTB1fB4XG0Na86uRcRzMzJBNLMVcsbRF2yLgrmdSFQFQRAKiAJzN3706BFarRZXV1eD9a6urly9ejVHxxgzZgzu/2/vzuOiKvc/gH9mhplhZ9hkUVY1cddQicr0Bol5NUtyy3IjzQX7KepNytSsxNTUa5q2aqWlWXbLTG6KomW4hOIeqamoLK7szAww5/cH14MTyDpwZuDzfr3Oq7M855zvM8fm4TvnnOfx9jZKePv3748hQ4YgICAAFy5cwKuvvoonn3wSSUlJUCgUyMzMrPCIsZWVFVxcXJCZmVnpeeLi4vDGG2/UsoZ1k5OTI847OTk1yjmJiBrc2B/LOmk6nwBofGFvb48hQ4ZgyJAhKCkpwa+//grnXf8HG+UlRLSxQrC3HCsPXoXh+lXk/f49oFDC2qdj2diuAQ/CRgWsW/MeBg0ahNatWwMAVu7+Ez+dzIS3kzUebeuGSX1aI9DdvprAiIiIyFyYTbJaX4sXL8bmzZuRmJgIa+vyX9dHjBghznfu3BldunRB69atkZiYiLCwsDqdKzY2FjExMeJybm4ufHx86h58FW7lFsJK4wWDvhBOzi7V70BEZCkcPIHuoyqstrKyQt/ejwIH7wDasnXX7TuiV4gMBw8eLFtRWgztpRQMtD2Fh1WbsPuSgNc/1WPGjBlo164d/jlwIBKt/wEASM/R4uvfr2LiY+xNnapw5GMg5auyIWtsXYFnPih7xpyIiCRjNsmqm5sbFAqF2PvjXVlZWfD09Kxy32XLlmHx4sXYvXs3unTpUmXZwMBAuLm54fz58wgLC4OnpyeuX79uVKakpAS3b9++73nVanWjPY6rUyjR86U45MEWstSERjknEZH0BGDQKuBCAnB+Dzr0nYqkeS8gMzMTO3bswPbt27Fr1y6M7CRgSHslZjwEXMlRwXdlPlJTU/HnhUtwePAi7Nv0hKplBzioAAehEICD1BWjxlKiA9JTyh5FlysAjR9gW8WPvrf+Aq79XjZvrWGiSkRkBswmWVWpVAgODkZCQgKefvppAGUdLCUkJCA6Ovq++y1ZsgRvv/02/vvf/xq9d3o/V69exa1bt+Dl5QUACA0NRXZ2NpKTkxEcHAwA2LNnDwwGA0JCQupfsXp63S0B3ay/AgD81rr6zp6IiJoEhRLo+HTZJAiAYAAAeHp6IioqClFRUSgqyIPV8geA0rKeW/dfLh+qRCjRIffwNuQe3obgVmrI7VzhvSgDPXr2RHx8vPherDl45ZVX4OrqKnUYTU/+deDTfuXLQz4Cugy7f/mbf5bPa7MbLCwiIqo5s+lgCQBiYmLw0Ucf4bPPPsPZs2cxefJkFBQUYNy4cQCA0aNHIzY2Viz/zjvv4PXXX8enn34Kf39/ZGZmIjMzUxwjNT8/H7Nnz8bBgwdx6dIlJCQkYPDgwWjTpg0iIiIAlA3G3r9/f0yYMAGHDx/GgQMHEB0djREjRtSoJ+CGZisv70RED3auRETNkExWaUdNNqX5UHp1AmRl2x4dPRdvvvkmQkJCILvnrtj8R+U4PCIfwzoqcOPGDWg0msaKvEbi4uKYrDYEQ4nx8v06+6psu4OX6eMhIqJaM5s7qwAwfPhw3LhxA/PmzUNmZia6deuG+Ph4sdOltLQ0yOXl+fXatWuh1+vx7LPPGh1n/vz5WLBgARQKBU6cOIHPPvsM2dnZ8Pb2Rr9+/fDmm28aPca7adMmREdHIywsDHK5HJGRkVi1alXjVLoadvJicb5YXsUYcUREzY2jF/DiLkCbC1w+AL+WPTD3aXfMnTsX169fx86dO7Fzx3b08d8FAEi8VIpnx/7TKJGlJsxQarwsqyZZfeJN4M5lQF8APLOu4eIiIqIaM6txVi1VQ44JN+qFEWjh4w8HWSE0JXmIeWe9SY9PRNSkXTsKfPQPFNj6YMGNJzF48GA8+uijdTqUZON/NjMm+5z1hUD60bI7rIYSwKMz4OBR/X5ERNTgavpdb1Z3VsmYwWDArvzWsDU8DAAYaXdK4oiIiCyMd3fg5WOwy7+Opb4PSR0NNSaVLeBftx8miIjIPJjVO6tkLD8/HzK1rbjsruH4gEREtSKTAS6BgAUkqjt37sR7770HAMjMzMTZs2cljoiIiEhadU5Wi4uLceXKFaSmpuL27dumjIn+Jzs7G/L/JauCoRRuGj52RkTUFM2aNQubN2/GmjVrAAAKhQJjx45tsPPdvn0bo0aNgqOjIzQaDaKiosTOCe9Hq9Vi6tSpcHV1hb29PSIjI42Gmzt+/DhGjhwJHx8f2NjYoH379vj3v//dYHUgIqKmr1bJal5eHtauXYs+ffrA0dER/v7+aN++Pdzd3eHn54cJEybgyJEjDRVrs5OTkwO52g4AYNAXQaNxkjgiIiJqCAkJCfjss89gY2MDAHB3d4dWq22w840aNQqnT5/Grl278OOPP2L//v2YOHFilfvMmDED27dvx9atW7Fv3z6kp6djyJAh4vbk5GS0aNECGzduxOnTp/Haa68hNjYWq1evbrB6EBFR01bjd1aXL1+Ot99+G61bt8agQYPw6quvwtvbGzY2Nrh9+zZOnTqFX375Bf369UNISAjee+89tG3btiFjb/KM7qzqCqDRsCt9IqKmSKlUwmAwiD0V375926j3e1M6e/Ys4uPjceTIEXF88vfeew8DBgzAsmXLKh22LScnB5988gm+/PJLPP744wCA9evXo3379jh48CAeeughjB8/3mifwMBAJCUlYdu2bVWOl95gDIayjpXkVkADfZZERNSwapysHjlyBPv370fHjh0r3d6rVy+MHz8e69atw/r16/HLL78wWa0nVdo+/OG4FDk6GXKVMgjyL6QOiYiIGsDLL7+M4cOH4+bNm3jzzTexZcsWvPbaaw1yrqSkJGg0GjFRBYDw8HDI5XIcOnQIzzzzTIV9kpOTUVxcjPDwcHFdUFAQfH19kZSUhIceqvyd4JycHLi4uJi+EjVx+QDw2cD/LciAqJ8Bn17SxEJERHVS42T1q6++AgCUlpZi+/btCAsLg4ODQ4VyarUakyZNMl2EzVhx3k3YKQE7pQBvCLimcZY6JCIiagDPP/88evTogYSEBBgMBnz99dfo0KFDg5wrMzMTLVq0MFpnZWUFFxcXZGZm3ncflUoFjUZjtN7Dw+O++/z222/YsmULduzYUWU8Op0OOp1OXM7Nza1BLWpAuHecVaH6cVaJiMjs1HroGoVCgZEjR+L06dOVJqtkOiX5xh1X2btWfDSLiIiahqCgIAQFBdV5/zlz5uCdd96pskxj9TB86tQpDB48GPPnz0e/fv2qLBsXF4c33njD9EEYSoyX5UxWiYgsTZ3GWe3ZsycuXryIwMBAU8dD97ikdcCiX3RwspbBSQ2MdOU7q0RETdHnn39e6frRo0fX+BgzZ86stgfhwMBAeHp64vr160brS0pKcPv2bXh6ela6n6enJ/R6PbKzs43urmZlZVXY58yZMwgLC8PEiRMxd+7cauOOjY1FTEyMuJybmwsfH59q96uWaxug31uAobQscXVgG0pEZGnqlKxOmzYNr776Kr755hvTNChUqd9znfFF/gAYbhVCmZeB51XWUodEREQN4OTJk+K8TqfDrl270KVLl1olq+7u7nB3d6+2XGhoKLKzs5GcnIzg4GAAwJ49e2AwGBASElLpPsHBwVAqlUhISEBkZCQAIDU1FWlpaQgNDRXLnT59Go8//jjGjBmDt99+u0Zxq9VqqNXqGpWtFWd/4OFppj8uERE1mjolq8OHDwcAdOzYEU899RT69u2L7t27o3PnzlCpVCYNsDnLLBDg/I8oAIBwOl7iaIiIqKEsXbrUaDk/Px9PP/10g5yrffv26N+/PyZMmIB169ahuLgY0dHRGDFihNgT8LVr1xAWFobPP/8cvXr1gpOTE6KiohATEwMXFxc4Ojpi2rRpCA0NFTtXOnXqFB5//HFEREQgJiZGfJdVoVDUKIkmIiL6uzolqxcvXsTx48eRkpKC48ePIy4uDpcuXYKVlRXatWuHEydOmDrOZimnUA/877Vga4UgbTBERNRoZDIZLl++3GDH37RpE6KjoxEWFga5XI7IyEisWrVK3F5cXIzU1FQUFhaK61asWCGW1el0iIiIwPvvvy9u/+abb3Djxg1s3LgRGzduFNf7+fnh0qVLDVYXIiJqumSCIJgkC8rLy0NKSgpOnDiBqVOnmuKQFiM3NxdOTk7IycmBo6OjyY770HMzkOlbNkyA84V4HNv6nsmOTUREtdNQ3/VAWV8Qd8dYLS0tRUZGBv71r39h+vTpJj2PJWjIz5mIiMxDTb/r63RntTIODg7o3bs3evfubapDNnsFeoM4b6diL4ZERE3VF198ARsbGwBlw8i0aNECSqVS4qiIiIikVeNkNS0tDb6+vjU+8LVr19CyZcs6BUVl3m65D27Kw8iDLc67NUDnE0REJDlBEDBkyBCcOXNG6lCaljM/AImLAbkckFsBz28DbF2kjoqIiGpBXtOCPXv2xEsvvYQjR47ct0xOTg4++ugjdOrUCd9++61JAmzOutvewMOKM4hQ/I72NnekDoeIiBqATCZD165dcfr0aalDaVoKbwHXTwOZJ4H0Y4Bp3noiIqJGVOM7q2fOnMHbb7+NJ554AtbW1ggODoa3tzesra1x584dnDlzBqdPn8aDDz6IJUuWYMCAAQ0Zd7PgoNCL84LSVsJIiIioIZ0+fRrdu3fHAw88AFtbWwiCAJlMhsOHD0sdmuUSSo2X5XydhojI0tQ4WXV1dcXy5cvx9ttvY8eOHfj1119x+fJlFBUVwc3NDaNGjUJERAQ6derUkPE2G8XFxfgl3weuDmo4yApRpGa3/0RETdXQoUONxlQVBAFffPGFhBE1Ac4BQKdIwFACGEoBK75OQ0RkaUzSG/DVq1fh6ekJKyuT9ddkURqi58KbN2+iY/QHsPHvBgCY6Z+OaZMmmOTYRERUew3ZS+2DDz6Io0ePGq3r2rUrjh8/btLzWAL2BkxE1PTV9Lu+xu+sVmXAgAEoKCgQl+/cucNHl+opOzsbpXk3UHzrCkrybsFdwwabiKip+eijj9CzZ0+kpqaiV69e4tS+fXt07NhR6vCIiIgkZZJboVZWVnBychKXnZycMHnyZCQnJ5vi8M1STk4Obv30b3FZM2inhNEQEVFDGDZsGJ544gnMnTsXb7/9trjewcEBLi7suZaIiJo3kySrrVq1wi+//CKOsSqXy6HX66vZi6qSnZ1ttKzRaCSJg4iIGo6TkxOcnJywceNGqUMhIiIyOyZJVlevXo0BAwYgNDQUvXr1wsmTJ2s1JitVlJOTY7R8751rIiIiIiKipq5Oyerly5fh5+cnLvv6+uLYsWP47rvvcPLkSTzwwANYtGiRyYJsjpRZx7F6gDVytAJydAKcbdjlPhFRc5GRkQEXFxeo1ezBts7OfA/8+d+yIWuUtsCT70gdERER1VKdktWgoCBMnjwZc+fOFd+pUSqVGDZsGIYNG2bSAJsrRfZfmNpTJS4X2llLGA0RETWmF154ARcuXEBkZCSWLVsmdTiWKf0YkLKpbF7lwGSViMgC1ak34P379+P48eMIDAzEokWLUFRUZOq4mr2SojyjZRtNC4kiISKixrZ7925cvHgRL774otShWC5DSfm8nE8nERFZojolqz179kRCQgK2bNmCb7/9Fm3atMGHH34Ig8Fg6viarTxdKbIEDQoFNbQGBWRK3lklImqqrl69itLS0grrg4KCJIimibBxBlwCAY0f4OQjdTRERFQH9RpnNSIiAsnJyVi2bBmWLl2KDh06YNu2baaKrVnbeqc9QnTvo4NuPTqfeF7qcIiIqAENGDAA+fn54jLHKzeB3jOBl48B008Ak3+VOhoiIqqDeiWrdw0ePBiff/45XFxcMHTo0Hoda82aNfD394e1tTVCQkKqbKw/+ugj9O7dG87OznB2dkZ4eLhR+eLiYrzyyivo3Lkz7Ozs4O3tjdGjRyM9Pd3oOP7+/pDJZEbT4sWL61WP+sopKh/6R6kwyWUiIiIzdb/xyomIiJqzOmVBn376KWbNmoUBAwbA398fjo6O6N27NzIzMzFw4MA6B7NlyxbExMRg/vz5OHr0KLp27YqIiAhcv3690vKJiYkYOXIk9u7di6SkJPj4+KBfv364du0aAKCwsBBHjx7F66+/jqNHj2Lbtm1ITU3FU089VeFYCxcuREZGhjhNmzatzvUwhXxd+eNgtkqZhJEQEVFDuzte+V0cr5yIiAiQCYIg1HYnDw8PdO7cGZ06dRL/26lTJ9jZ2dUrmJCQEPTs2ROrV68GABgMBvj4+GDatGmYM2dOtfuXlpbC2dkZq1evxujRoystc+TIEfTq1QuXL18Wx4L19/fH9OnTMX369DrFnZubCycnJ+Tk5MDR0bFOx/i7Dk9PQWHQPwEAAZmJ2LthqUmOS0REddMQ3/V3paWlVRiv/MKFC9ixY4dJz2MJGvJzJiIi81DT7/o6DV2TlZVV58DuR6/XIzk5GbGxseI6uVyO8PBwJCUl1egYhYWFKC4uFofTqUxOTg5kMhk0Go3R+sWLF+PNN9+Er68vnnvuOcyYMQNWVnX6eEyiqKT8bqqDtVKyOIiIyPQ4XjkREVH1pMvG/ubmzZsoLS2Fh4eH0XoPDw/88ccfNTrGK6+8Am9vb4SHh1e6XavV4pVXXsHIkSONMviXX34ZDz74IFxcXPDbb78hNjYWGRkZWL58eaXH0el00Ol04nJubm6N4quNQS5/wUq+H3mwhbN9fvU7EBGRxeB45Y3g3G7gzsWyYWts3YAOFV8BIiIi82Y2yWp9LV68GJs3b0ZiYiKsrSsO81JcXIxhw4ZBEASsXbvWaFtMTIw436VLF6hUKrz00kuIi4uDWq2ucKy4uDi88cYbpq/E/wiCgHk+yXBT/gYASFT2bLBzERFR49u/fz/mzJmDwMBA/Otf/8KMGTNgY2MjdVhNS8pG4PR3ZfMenZmsEhFZILPpZtbNzQ0KhaLCI8ZZWVnw9PSsct9ly5Zh8eLF+Pnnn9GlS5cK2+8mqpcvX8auXbuqfQcmJCQEJSUluHTpUqXbY2NjkZOTI05XrlypunK1VFhQAEd5eccaCrW9SY9PRETS4njljcBQUj4vN5s/d4iIqBbM5ttbpVIhODgYCQkJ4jqDwYCEhASEhobed78lS5bgzTffRHx8PHr06FFh+91E9dy5c9i9ezdcXV2rjSUlJQVyuRwtWrSodLtarYajo6PRZErZt7KgUpT3e6W2c6qiNBERWSqOV96ADOW96kPeZB4kIyJqVszq2zsmJgZjxoxBjx490KtXL6xcuRIFBQUYN24cAGD06NFo2bIl4uLiAADvvPMO5s2bhy+//BL+/v7IzMwEANjb28Pe3h7FxcV49tlncfToUfz4448oLS0Vy7i4uEClUiEpKQmHDh3CP/7xDzg4OCApKQkzZszA888/D2dnZ0k+h5x8LToszoWTWgYnaxneee8fksRBRESNY/DgwfD398fMmTMxdOhQlJaWVr8TVe3Z9UCpvuwOq4xDwBERWSKzSlaHDx+OGzduYN68ecjMzES3bt0QHx8vdrqUlpYG+T2P8qxduxZ6vR7PPvus0XHmz5+PBQsW4Nq1a/jhhx8AAN26dTMqs3fvXvTt2xdqtRqbN2/GggULoNPpEBAQgBkzZhi9x9rYsnNykKsDcnUCruQKsHbzlSwWIiIyvU8//RRnzpwRp6tXrwIo6xW4PuOV0z2U1mUTERFZrDqNs0rGTD0m3M6dOzHwmaEw6IsAwYDk5GQ8+OCDJoiUiIjqypTf9Q01XnlTwHFWiYiavgYdZ5UaVk5ODlpO/RxypRq69D/h5MR3VomImpKGGK+ciIioqTGbDpao3K072ZAry4bMEUqLodFopA2IiIhMYt68eUhOTpY6DCIiIovAO6tmSHsnA11keuTBFtdLrsPRgUPXEBE1BVevXsWTTz4JlUqFQYMG4amnnkJYWBhUKpXUoTU9maeAEi0gVwA2zoCzv9QRERFRLTFZNUP+BccwU72vbKE9ACyUMhwiIjKRTz/9FAaDAQcOHMD27dsxffp0ZGRk4IknnsDgwYMxcOBAuLi4SB1m0/BDNJB+rGw+aCAwYpO08RARUa3xMWBzVFxQPivIAKWNhMEQEZEpyeVy9O7dG0uWLEFqaioOHTqEkJAQfPDBB/D29sZjjz2GZcuW4dq1a1KHatkMJeXzHGeViMgi8dvbDClKisT5vFIVXDg+HBFRk9W+fXs4ODggJiYGd+7cwQ8//CAOuzZr1iyJo7NghnvGqpUrpIuDiIjqjMmqGfrqZlt8az0IDiiE3Y1TWCp1QERE1KAGDBiAX375Be7u7oiKisKQIUNw7tw5qcOybINXA7q8sqTVzl3qaIiIqA6YrJqhP/NtccfQBQDgUaSVOBoiImpoVlZWRsOUOTk5YfLkyew5uD5aBksdARER1RPfWTVDBfryR5cc1Pw9gYioqWvVqhV++eUXcVkul0Ov10sYERERkfSYCZmhYpS/W2Ov5ns2RERN3erVqzFgwACEhoaiV69eOHnyJHx9faUOi4iISFK8s2qGtGf3IXPjv5C1+TW0UBRKHQ4REZnY5cuXjZZ9fX1x7NgxPPHEE0hLS8MDDzyALVu2SBQdERGReeCdVTOku50OXXYOAEBj00/iaIiIyNSCgoIwefJkzJ07VxxXValUYtiwYRg2bJjE0TURJfqyXoBlcoC96hMRWSTeWTVDZ180QD/XAblzHDDQhp1rEBE1Nfv378fx48cRGBiIRYsWoaioqPqdqHbefQBY6AK8oQF+nit1NEREVAdMVs2MIAhQKwClQgYHtQxKBS8REVFT07NnTyQkJGDLli349ttv0aZNG3z44YcwGAxSh9Z03PtZytj/AxGRJWImZGa0Wi2srcofVxKsbCSMhoiIGlJERASSk5OxbNkyLF26FB06dMC2bdukDqtpMJSUz8v51hMRkSVismpmtFotlt54BCuKI/F+yVO4Zt1W6pCIiKiBDR48GJ9//jlcXFwwdOjQBj/f7du3MWrUKDg6OkKj0SAqKgr5+flV7qPVajF16lS4urrC3t4ekZGRyMrKErffunUL/fv3h7e3N9RqNXx8fBAdHY3c3NyGrk7lwl4Hwt8AHn8dCOwrTQxERFQv/KnRzBQVFWF1zsOwce4OAJjjdFPiiIiIyNQ+/fRTnDlzRpyuXr0KoKxX4IEDBzb4+UeNGoWMjAzs2rULxcXFGDduHCZOnIgvv/zyvvvMmDEDO3bswNatW+Hk5ITo6GgMGTIEBw4cAFA2NuzgwYPx1ltvwd3dHefPn8fUqVNx+/btKo/bYB6a3PjnJCIik5IJgiBIHYSly83NhZOTE3JycuDo6FivY/311194eN43sG7VEQDwdtc8jBo5whRhEhFRPZjyu97DwwOdO3dGp06dxP926tQJdnZ2Jor2/s6ePYsOHTrgyJEj6NGjBwAgPj4eAwYMwNWrV+Ht7V1hn5ycHLi7u+PLL7/Es88+CwD4448/0L59eyQlJeGhhx6q9FyrVq3C0qVLceXKlRrHZ8rPmYiIzFNNv+t5Z9XMFBUVQaZQAQAEQynsbfnOKhFRU3Pv47ONLSkpCRqNRkxUASA8PBxyuRyHDh3CM888U2Gf5ORkFBcXIzw8XFwXFBQEX1/f+yar6enp2LZtG/r06dMwFSEioiaP76yaGa1WC5nyf8lqiR7W1tYSR0RERE1JZmYmWrRoYbTOysoKLi4uyMzMvO8+KpUKGo3GaL2Hh0eFfUaOHAlbW1u0bNkSjo6O+Pjjj6uMR6fTITc312giIiICmKyanaKiIsis1ADKklUbG95ZJSKi6s2ZMwcymazK6Y8//mjwOFasWIGjR4/i+++/x4ULFxATE1Nl+bi4ODg5OYmTj49Pg8dIRESWgY8Bmxn57QvY6boCxQpraOWARjsNwGNSh0VERGZu5syZGDt2bJVlAgMD4enpievXrxutLykpwe3bt+Hp6Vnpfp6entDr9cjOzja6u5qVlVVhH09PT3h6eiIoKAguLi7o3bs3Xn/9dXh5eVV67NjYWKOENjc3t/4Jqy4P+PiJsiFr5Arg0RlAx6frd0wiImp0TFbNTGnhHXRR/q8jChXwl7xU2oCIiMgiuLu7w93dvdpyoaGhyM7ORnJyMoKDgwEAe/bsgcFgQEhISKX7BAcHQ6lUIiEhAZGRkQCA1NRUpKWlITQ09L7nMhgMAMoe9b0ftVoNtVpdbdy1UloM3Dhbvlx027THJyKiRsFk1cyUaAuMlpU2DhJFQkRETVH79u3Rv39/TJgwAevWrUNxcTGio6MxYsQIsSfga9euISwsDJ9//jl69eoFJycnREVFISYmBi4uLnB0dMS0adMQGhoqdq70008/ISsrCz179oS9vT1Onz6N2bNn45FHHoG/v3/jVtLwtx965fxzh4jIEvHb28zklSiwQ98darkBSn0u2jm2qH4nIiKiWti0aROio6MRFhYGuVyOyMhIrFq1StxeXFyM1NRUFBYWiutWrFghltXpdIiIiMD7778vbrexscFHH32EGTNmQKfTwcfHB0OGDMGcOXMatW4AAIUV0OlZwFACCKWAxrfxYyAionrjOKsmYMox4T788EO89NJL4vKNGzfg5uZW3xCJiKieOP5n4+DnTETU9NX0u569AZsZrVZrtMzegImIiIiIqDlismpmioqKjJY5zioRERERETVHZpesrlmzBv7+/rC2tkZISAgOHz5837IfffQRevfuDWdnZzg7OyM8PLxCeUEQMG/ePHh5ecHGxgbh4eE4d+6cUZnbt29j1KhRcHR0hEajQVRUFPLz8xukftW5986qUqmEQqGQJA4iIiIiIiIpmVWyumXLFsTExGD+/Pk4evQounbtioiIiArjwd2VmJiIkSNHYu/evUhKSoKPjw/69euHa9euiWWWLFmCVatWYd26dTh06BDs7OwQERFhlBSOGjUKp0+fxq5du/Djjz9i//79mDhxYoPXtzI3i0rhOmA6XPpNgWOnf0gSAxERERERkdTMqoOlkJAQ9OzZE6tXrwZQNj6bj48Ppk2bVqPeBEtLS+Hs7IzVq1dj9OjREAQB3t7emDlzJmbNmgUAyMnJgYeHBzZs2IARI0bg7Nmz6NChA44cOYIePXoAAOLj4zFgwABcvXpV7Ma/KqbsDOLd2aPhpc6DDkpob6Vj8pp9ZQOaExGRpNjxT+Mwyed85zKw752y9lOmAEImAS2CTBsoERHVmcV1sKTX65GcnIzw8HBxnVwuR3h4OJKSkmp0jMLCQhQXF8PFxQUAcPHiRWRmZhod08nJCSEhIeIxk5KSoNFoxEQVAMLDwyGXy3Ho0CFTVK1WvIUMPGe1B+Os/ouXWpwEZGZziYiIiCxD4U0gZRNw9HMgeT2Qly51REREVAdmM87qzZs3UVpaCg8PD6P1Hh4e+OOPP2p0jFdeeQXe3t5icpqZmSke4+/HvLstMzMTLVoYj2VqZWUFFxcXsczf6XQ66HQ6cTk3N7dG8dWEzFAizusFBaxlMpMdm4iIqFkwlBovy83mzx0iIqqFJnPbbvHixdi8eTO+++67Bu9BNy4uDk5OTuLk4+NjsmPnl8hxVXDDDcERt0rYEzAREVGtKVSAaxtA4wc4tgKUtlJHREREdWA2PzW6ublBoVAgKyvLaH1WVhY8PT2r3HfZsmVYvHgxdu/ejS5duojr7+6XlZUFLy8vo2N269ZNLPP3DpxKSkpw+/bt+543NjYWMTEx4nJubq7JEtbPb3fGW7Zlx3Y4/zNOmuSoREREzYh3N2BastRREBFRPZnNnVWVSoXg4GAkJCSI6wwGAxISEhAaGnrf/ZYsWYI333wT8fHxRu+dAkBAQAA8PT2Njpmbm4tDhw6JxwwNDUV2djaSk8sbtT179sBgMCAkJKTSc6rVajg6OhpNpqIrNojzKgUfASYiIiIioubJbO6sAkBMTAzGjBmDHj16oFevXli5ciUKCgowbtw4AMDo0aPRsmVLxMXFAQDeeecdzJs3D19++SX8/f3Fd0zt7e1hb28PmUyG6dOn46233kLbtm0REBCA119/Hd7e3nj66acBAO3bt0f//v0xYcIErFu3DsXFxYiOjsaIESNq1BOwqelLyztnVinM5rcEIiIiIiKiRmVWyerw4cNx48YNzJs3D5mZmejWrRvi4+PFDpLS0tIgl5cncGvXroVer8ezzz5rdJz58+djwYIFAIB//etfKCgowMSJE5GdnY1HH30U8fHxRu+1btq0CdHR0QgLC4NcLkdkZCRWrVrV8BWuxL3JqlrJZJWIiIiIiJonsxpn1VKZcuy9BwZHQ9/+SQBA0I19iP9kiSlCJCKieuI4q42DnzMRUdNX0+96s7qzSkAfeQrsr6dBJ1PD3VYpdThERESW59YF4HwCIFeUDVvT8WnA2knqqIiIqJaYrJqZ8S1OI9SrrJOlM3qvakoTERFRBRnHgZ2zy5cDejNZJSKyQHwp0syoZOW9ARvkKgkjISIislCGUuNlmUKaOIiIqF6YrJoZpaz8FWJBzseAiYiIas1QYrws54NkRESWiN/eZkQQBDzyaT6srQBrK2Dm7Ah0ljooIiIiS9P5WSDon2VJq2AAbJyljoiIiOqAyaoZ0ev1UIe/DLX/gzCU6JGnzpc6JCIiIsujUJZNRERk0ZismhGtVgu5rQZWDq4AAFvrKxJHREREREREJA2+s2pGioqKILcq71TJzoYdLBERERERUfPEZNWMaLVa4J5k1cHWRsJoiIiIiIiIpMPHgM1IUWEhethmwSCzgbZUBieVo9QhERERWZ7cdCDnGiBXlE2eXQCZTOqoiIiolpismhFdUT5+9PpQXP4j93kAz0sXEBERkSU6vhlIeKN8ed4dJqtERBaIjwGbEV1BjtGyXG0rUSREREQWzFBaPi+TA3L+uUNEZIn47W1G9IV5RssKtZ1EkRAREVkwQ0n5vEwhXRxERFQvfAzYjOQXyzEiPwbWKgWs8jIx0ztE6pCIiIgsT7fnAP9HypJWwSB1NEREVEdMVs1Iob4USbKukBmU0OdfwGzXQKlDIiIisjzOfmUTERFZNCarZqSoqAi3fvoEMisVDLoC2Ng8LXVIREREREREkmCyaka0Wi0KziSKy9bW1tIFQ0REREREJCF2sGRGioqKjJZtbGwkioSIiIiIiEhaTFbNiLaoCPJ7hoHjnVUiIqI6KC0pmwRB6kiIiKge+BiwGfEuOovSeY4oLgW0pYDyzgWgRZDUYREREVmWHTHA0c/K5p0DgP9LkTQcIiKqGyarZqRQXwIoAaWibIKcl4eIiKjWDKXl8zLZ/csREZFZ42PAZsRQojdeYaWWJhAiIiJLZigpn+cPv0REFovf4GbkT60z4qxGQo1iqG6lItpGI3VIRERElqdTJODRoSxptXGWOhoiIqojJqtm5JxWg29tegMA5Bn/RbTaQeKIiIiILNAD/comIiKyaHwM2Ixoi8vfsVHK2YMhERERERE1X0xWzYjOKFllhxBERERERNR8MVk1I7oSgziv4pUhIiIiIqJmjCmRGdGXlj/6q7bipSEiIiIiouaLGZEZGe1yAj+qXsU21TwsbrlX6nCIiKiJun37NkaNGgVHR0doNBpERUUhPz+/yn20Wi2mTp0KV1dX2NvbIzIyEllZWZWWvXXrFlq1agWZTIbs7OwGqEE1fpgGrH0U+KAPsGNm45+fiIhMwuyS1TVr1sDf3x/W1tYICQnB4cOH71v29OnTiIyMhL+/P2QyGVauXFmhzN1tf5+mTp0qlunbt2+F7ZMmTWqI6lXJU5mPTvJLeFB+Hu2sbzb6+YmIqHkYNWoUTp8+jV27duHHH3/E/v37MXHixCr3mTFjBrZv346tW7di3759SE9Px5AhQyotGxUVhS5dujRE6DVz6y8g6ySQkQLcuiBdHEREVC9mlaxu2bIFMTExmD9/Po4ePYquXbsiIiIC169fr7R8YWEhAgMDsXjxYnh6elZa5siRI8jIyBCnXbt2AQCGDh1qVG7ChAlG5ZYsWWLaytWAKveKOG8Q2MESERGZ3tmzZxEfH4+PP/4YISEhePTRR/Hee+9h8+bNSE9Pr3SfnJwcfPLJJ1i+fDkef/xxBAcHY/369fjtt99w8OBBo7Jr165FdnY2Zs2a1RjVqZxQ3mEh5Bylj4jIUplVsrp8+XJMmDAB48aNQ4cOHbBu3TrY2tri008/rbR8z549sXTpUowYMQJqtbrSMu7u7vD09BSnH3/8Ea1bt0afPn2Mytna2hqVc3R0NHn9qnM0Q8A3Z4qxPbUYF4o9Gv38RETU9CUlJUGj0aBHjx7iuvDwcMjlchw6dKjSfZKTk1FcXIzw8HBxXVBQEHx9fZGUlCSuO3PmDBYuXIjPP/8ccrmEf2IEPAZ0fAZoPwjwCZEuDiIiqhez+blRr9cjOTkZsbGx4jq5XI7w8HCjhrC+59i4cSNiYmIgkxnfudy0aRM2btwIT09PDBo0CK+//jpsbW0rPY5Op4NOpxOXc3NzTRLfuqOluHWrCAAwY0Yf9DbJUYmIiMplZmaiRYsWRuusrKzg4uKCzMzM++6jUqmg0WiM1nt4eIj76HQ6jBw5EkuXLoWvry/++uuvGsXTIG3qP16t/zGIiEhyZnNn9ebNmygtLYWHh/EdxXsbwvr6z3/+g+zsbIwdO9Zo/XPPPYeNGzdi7969iI2NxRdffIHnn3/+vseJi4uDk5OTOPn4+JgkPq1WK85bW1ub5JhERNQ8zJkzp9I+Gu6d/vjjjwY7f2xsLNq3b19l+1mZhmpTiYjI8pnNndXG8Mknn+DJJ5+Et7e30fp7O5Xo3LkzvLy8EBYWhgsXLqB169YVjhMbG4uYmBhxOTc31ySNq8ynOxydPCGU6KGwtqv38YiIqPmYOXNmhR9j/y4wMBCenp4V+oIoKSnB7du379v/g6enJ/R6PbKzs43urmZlZYn77NmzBydPnsQ333wDABCEsuHY3Nzc8Nprr+GNN96o9NgN1aYSEZHlM5tk1c3NDQqFokI3+Pc2hPVx+fJl7N69G9u2bau2bEhI2fst58+frzRZVavV931Htq6Ki4thE/QYbNs9DABQqP806fGJiKhpc3d3h7u7e7XlQkNDkZ2djeTkZAQHBwMoSzQNBoPY/v1dcHAwlEolEhISEBkZCQBITU1FWloaQkNDAQDffvstioqKxH2OHDmC8ePH45dffqm0Lb2rIdpUIiJqGszmMWCVSoXg4GAkJCSI6wwGAxISEsSGsD7Wr1+PFi1a4J///Ge1ZVNSUgAAXl5e9T5vTWm1WsiUKnHZ3oYNNxERmV779u3Rv39/TJgwAYcPH8aBAwcQHR2NESNGiE8eXbt2DUFBQeLwcU5OToiKikJMTAz27t2L5ORkjBs3DqGhoXjooYcAAK1bt0anTp3EKSAgQDzf39+RJSIiqgmzubMKADExMRgzZgx69OiBXr16YeXKlSgoKMC4ceMAAKNHj0bLli0RFxcHoKzDpDNnzojz165dQ0pKCuzt7dGmTRvxuAaDAevXr8eYMWNgZWVc5QsXLuDLL7/EgAED4OrqihMnTmDGjBl47LHHGnWMuKKiIrzmmQQ3qxTooERLofpfx4mIiOpi06ZNiI6ORlhYGORyOSIjI7Fq1Spxe3FxMVJTU1FYWCiuW7FihVhWp9MhIiIC77//vhThV+/nuUDRnbJha/weAboMkzoiIiKqA5lw96USM7F69WosXboUmZmZ6NatG1atWiU+ltS3b1/4+/tjw4YNAIBLly6Jv9zeq0+fPkhMTBSXf/75Z0RERCA1NRUPPPCAUdkrV67g+eefx6lTp1BQUAAfHx8888wzmDt3bo2Hr8nNzYWTkxNycnLqPORNWloahA96w0+ZDQA45/gI2sb8VKdjERGR6Zniu56qZ5LPeXlHIPdq2XzwOGDQSpPFR0RE9VfT73qzurMKANHR0YiOjq50270JKAD4+/ujJrl2v3797lvOx8cH+/btq3WcplZUVAQnWfkg5jIlewMmIiKqE0NJ+bzc7P7UISKiGuI3uJnQarUoMGhQIqihEvQQ1E5Sh0RERGSZNL6A0howlAK2LlJHQ0REdcRk1UwUFRXh2eyZsHJsgZK8W/i8byu0lTooIiIiS/TiLqkjICIiEzCb3oCbO61WC5mirDdgoUQPGxsbiSMiIiIiIiKSDpNVM1FUVASZ1f+S1VI9rK35zioRERERETVffAzYTGi1WuhvXIJcZYPiO+m8s0pERERERM0ak1UzUVRUhKxN/xKXrVdMlDAaIiIiIiIiaTFZNROlhdmI7qWEtgTQlgB2JbcB+EsdFhERkWURBODwR4BcUTZsTctgwLOT1FEREVEdMFk1E7LCm3jvyfJHfwvunAXwoHQBERERWSLBAOycXb78xEImq0QmZjAYoNfrpQ6DzJhSqYRCoaj3cZismokSbYHRssrGQaJIiIiILJihxHhZVv8/loionF6vx8WLF2EwGKQOhcycRqOBp6cnZDJZnY/BZNVM5BYZ/zplZW0nUSREREQW7O/Jqpx/6hCZiiAIyMjIgEKhgI+PD+RyDixCFQmCgMLCQly/fh0A4OXlVedj8RvcTKTq3dCx9BOoUQwhNQHHXntY6pCIiIgsj9IWiL0KGErLJiV71ycylZKSEhQWFsLb2xu2trZSh0Nm7O7IJtevX0eLFi3q/Egwk1UzUagrRYGVDQpgA73elo0rERFRXchkgJqv0hA1hNLSUgCASqWSOBKyBHd/0CguLq5zssp792aiUF8szitkfAeAiIiIiMxTfd5BpObDFP9OmKyaCW1xqTiv5P//RERERETUzDFZNRNafXmyaiUXJIyEiIiIiKhpEQQBEydOhIuLC2QyGVJSUqQO6b4SExMhk8mQnZ3daOeUyWT4z3/+02jnqym+s2om7IR8dJedgw5KyG1yyzqFkLO7fSIiolop1gKZJwG5vKwnYI0fYKOROioiklh8fDw2bNiAxMREBAYGws3NTeqQzEpGRgacnZ0BAJcuXUJAQACOHTuGbt26SRoXk1UzEWp9AbPVG8sWggDo8ti4EhER1VbuNeCT8PLloZ8BHZ+WLBwiMg8XLlyAl5cXHn648hE39Hp9s+44ytPTU+oQKsXHgM2EQig1XmFlLU0gRERElozjrBLR34wdOxbTpk1DWloaZDIZ/P390bdvX0RHR2P69Olwc3NDREQEAGDfvn3o1asX1Go1vLy8MGfOHJSUlH+v9O3bF9OmTcP06dPh7OwMDw8PfPTRRygoKMC4cePg4OCANm3aYOfOnTWO76effsIDDzwAGxsb/OMf/8ClS5cqlPn111/Ru3dv2NjYwMfHBy+//DIKCgrE7f7+/li0aBHGjx8PBwcH+Pr64sMPPxS36/V6REdHw8vLC9bW1vDz80NcXJy4/d7HgAMCAgAA3bt3h0wmQ9++fbF//34olUpkZmYaxTV9+nT07t27xnWtLSarZkKOvyeramkCISIismQVklW+UkPU3P373//GwoUL0apVK2RkZODIkSMAgM8++wwqlQoHDhzAunXrcO3aNQwYMAA9e/bE8ePHsXbtWnzyySd46623jI732Wefwc3NDYcPH8a0adMwefJkDB06FA8//DCOHj2Kfv364YUXXkBhYWG1sV25cgVDhgzBoEGDkJKSghdffBFz5swxKnPhwgX0798fkZGROHHiBLZs2YJff/0V0dHRRuXeffdd9OjRA8eOHcOUKVMwefJkpKamAgBWrVqFH374AV9//TVSU1OxadMm+Pv7VxrT4cOHAQC7d+9GRkYGtm3bhsceewyBgYH44osvxHLFxcXYtGkTxo8fX20964o/N5qJH/9SIuHaw7BWytDNTYbX2CU4ERFR7Wn8gDHby5JWQyng1U3qiIiavI9/+Qsf/3Kx2nKdWjri4zE9jda9+NkRnLqWW+2+L/YOwIu9A+sUn5OTExwcHKBQKIwed23bti2WLFkiLr/22mvw8fHB6tWrIZPJEBQUhPT0dLzyyiuYN28e5PKy+3xdu3bF3LlzAQCxsbFYvHgx3NzcMGHCBADAvHnzsHbtWpw4cQIPPfRQlbGtXbsWrVu3xrvvvgsAaNeuHU6ePIl33nlHLBMXF4dRo0Zh+vTpYtyrVq1Cnz59sHbtWlhblz2ROWDAAEyZMgUA8Morr2DFihXYu3cv2rVrh7S0NLRt2xaPPvooZDIZ/Pz87huTu7s7AMDV1dXo84qKisL69esxe/ZsAMD27duh1WoxbNiwKutYH0xWzcSVS5fw559/AgBsR4+WOBoiIiILpbYHAh6TOgqiZiVPW4LMXG215bw0FV9zu1Wgr9G+edqSasvUVnBwsNHy2bNnERoaajQ+6COPPIL8/HxcvXoVvr6+AIAuXbqI2xUKBVxdXdG5c2dxnYeHBwDg+vXr1cZw9uxZhISEGK0LDQ01Wj5+/DhOnDiBTZs2iesEQYDBYMDFixfRvn37CnHJZDJ4enqKMYwdOxZPPPEE2rVrh/79+2PgwIHo169ftfHda+zYsZg7dy4OHjyIhx56CBs2bMCwYcNgZ2dXq+PUBpNVM6HVlv9PamNjI2EkREREREQ152BtBU/H6vtbcbWr2IGRq52qRvs6WJs+balrkqVUKo2WZTKZ0bq7ya7BYKh7cPfIz8/HSy+9hJdffrnCtrsJ9P3iuhvDgw8+iIsXL2Lnzp3YvXs3hg0bhvDwcHzzzTc1jqNFixYYNGgQ1q9fj4CAAOzcuROJiYl1q1QNMVk1E0VFReL83Vv5RERERETm7sXegXV+RPfvjwVLqX379vj2228hCIKYcB44cAAODg5o1apVg53zhx9+MFp38OBBo+UHH3wQZ86cQZs2bep1LkdHRwwfPhzDhw/Hs88+i/79++P27dtwcXExKne3V+TS0tIKx3jxxRcxcuRItGrVCq1bt8YjjzxSr5iqww6WzIS2RIBMqQZkct5ZJSIiIiJqZFOmTMGVK1cwbdo0/PHHH/j+++8xf/58xMTEiO+rmtqkSZNw7tw5zJ49G6mpqfjyyy+xYcMGozKvvPIKfvvtN0RHRyMlJQXnzp3D999/X6GDpaosX74cX331Ff744w/8+eef2Lp1Kzw9PaHRaCqUbdGiBWxsbBAfH4+srCzk5OSI2yIiIuDo6Ii33noL48aNq2u1a4zJqplw7DMWATFfw+9fP6BY5Sh1OERERJbJYABKiwFBkDoSIrIwLVu2xE8//YTDhw+ja9eumDRpEqKiosTOlBqCr68vvv32W/znP/9B165dsW7dOixatMioTJcuXbBv3z78+eef6N27N7p374558+bB29u7xudxcHDAkiVL0KNHD/Ts2ROXLl3CTz/9VGkSbmVlhVWrVuGDDz6At7c3Bg8eLG6Ty+UYO3YsSktLMboR+tmRCQK/zesrNzcXTk5OyMnJgaNj7RPNkpIS7JrdE086/YUSQY6r8lbwn3+yASIlIqK6qu93PdVMvT/nc7uBTZFl8zI5MDER8Opq0hiJmiutVouLFy8iICCAr601Y1FRUbhx40aFx5f/rqp/LzX9ruc7q2ZAq9VCpSh7+dlKZoCigR4zICIiavKEe96xEgyAjOOsEhGZQk5ODk6ePIkvv/yy2kTVVJgVmQGtVgtr+T29hSmU9y9MRERE92f42/AWcv4uT0TSmTRpEuzt7SudJk2aJHV4tTJ48GD069cPkyZNwhNPPNEo5zS7ZHXNmjXw9/eHtbU1QkJCcPjw4fuWPX36NCIjI+Hv7w+ZTIaVK1dWKLNgwQLIZDKjKSgoyKiMVqvF1KlT4erqCnt7e0RGRiIrK8vUVbsvrVaLz/J6Ia54JN7VD8Flp6oHDyYiIqL7cA8CnlgIhM0H/jEXsHOXOiIiasYWLlyIlJSUSqeFCxdKHV6tJCYmorCwECtWrGi0c5rVz41btmxBTEwM1q1bh5CQEKxcuRIRERFITU1FixYtKpQvLCxEYGAghg4dihkzZtz3uB07dsTu3bvFZSsr42rPmDEDO3bswNatW+Hk5ITo6GgMGTIEBw4cMF3lqlBUVIQf9Q9CVeoPg16Ld1uYZkwmIiKiZse1NfDI/0kdBRERgLKedSvLY6hmzOrO6vLlyzFhwgSMGzcOHTp0wLp162Bra4tPP/200vI9e/bE0qVLMWLECKjV6vse18rKCp6enuLk5uYmbsvJycEnn3yC5cuX4/HHH0dwcDDWr1+P3377rcIYRw1Fq9VCZlU2npFQouPQNURERERE1OyZTbKq1+uRnJyM8PBwcZ1cLkd4eDiSkpLqdexz587B29sbgYGBGDVqFNLS0sRtycnJKC4uNjpvUFAQfH19633emioqKipPVkuL2bsaERERERE1e2aTrN68eROlpaXw8PAwWu/h4YHMzMw6HzckJAQbNmxAfHw81q5di4sXL6J3797Iy8sDAGRmZkKlUlUYELeq8+p0OuTm5hpN9WF0Z7VYzzurRERERETU7JnVO6sN4cknnxTnu3TpgpCQEPj5+eHrr79GVFRUnY4ZFxeHN954w1Qh/u3Oqp53VomIiIiIqNkzm2TVzc0NCoWiQi+8WVlZ8PT0NNl5NBoNHnjgAZw/fx4A4OnpCb1ej+zsbKO7q1WdNzY2FjExMeJybm4ufHx86hyTVqvFf7QTIdfLoFUBXhmzAATX+XhERETN1qlvgV+WAzJ52bA1Y34A1A5SR0VERHVgNo8Bq1QqBAcHIyEhQVxnMBiQkJCA0NBQk50nPz8fFy5cgJeXFwAgODgYSqXS6LypqalIS0u773nVajUcHR2NpvooKipCV9didHMtxkMexbAuya7X8YiIiJqtgptA1ikg8wSQflTqaIjITAiCgIkTJ8LFxQUymQwpKSlSh1RjCxYsQLdu3Ux+3EuXLpn9Z2E2d1YBICYmBmPGjEGPHj3Qq1cvrFy5EgUFBRg3bhwAYPTo0WjZsiXi4uIAlHXKdObMGXH+2rVrSElJgb29Pdq0aQMAmDVrFgYNGgQ/Pz+kp6dj/vz5UCgUGDlyJADAyckJUVFRiImJgYuLCxwdHTFt2jSEhobioYcaZ7xTe1trKOQycdnK2r5RzktERNTkGEqNl+Vm9acOEUkkPj4eGzZsQGJiIgIDA41GByHzZVbf4MOHD8eNGzcwb948ZGZmolu3boiPjxc7XUpLS4NcXn4zOD09Hd27dxeXly1bhmXLlqFPnz5ITEwEAFy9ehUjR47ErVu34O7ujkcffRQHDx6Eu3v5IOErVqyAXC5HZGQkdDodIiIi8P777zdOpQEMHPAkUDIcKNECJXo4+nVrtHMTERE1Ka6tgY5DAENJWeLKZJWIAPHJyocffrjS7Xq9HiqVqpGjouqYzWPAd0VHR+Py5cvQ6XQ4dOgQQkJCxG2JiYnYsGGDuOzv7w9BECpMdxNVANi8eTPS09Oh0+lw9epVbN68Ga1btzY6p7W1NdasWYPbt2+joKAA27ZtM+l7stWyUgNDPgSGfQ48txloP7Dxzk1ERNSUPBABDF0PDP8CGPkloFBKHRERSWzs2LGYNm0a0tLSIJPJ4O/vj759+yI6OhrTp0+Hm5sbIiIiAAD79u1Dr169oFar4eXlhTlz5qCkpEQ8Vt++fTFt2jRMnz4dzs7O8PDwwEcffSQ+Derg4IA2bdpg586dNYotMTERMpkMCQkJ6NGjB2xtbfHwww8jNTW1QtkPPvgAPj4+sLW1xbBhw5CTkyNuMxgMWLhwIVq1agW1Wi3e9LvX4cOH0b17d1hbW6NHjx44duyYuE0QBLRp0wbLli0z2iclJQUymUzs76exmV2ySkREREREFiT7CnA5qWxKO1h5mcLb5WUuJwH6goplSvTGZfKvV36svKzK19/Hv//9bzGRy8jIwJEjRwAAn332GVQqFQ4cOIB169bh2rVrGDBgAHr27Injx49j7dq1+OSTT/DWW28ZHe+zzz6Dm5sbDh8+jGnTpmHy5MkYOnQoHn74YRw9ehT9+vXDCy+8gMLCwhrH+Nprr+Hdd9/F77//DisrK4wfP95o+/nz5/H1119j+/btiI+Px7FjxzBlyhSjOr777rtYtmwZTpw4gYiICDz11FM4d+4cgLJ+ewYOHIgOHTogOTkZCxYswKxZs8T9ZTIZxo8fj/Xr1xudd/369XjsscfEVywbnUD1lpOTIwAQcnJypA6FiIgaSFP6rr9165bw3HPPCQ4ODoKTk5Mwfvx4IS8vr8p9ioqKhClTpgguLi6CnZ2dMGTIECEzM9OoDIAK01dffVWr2JrS50zU1BQVFQlnzpwRioqKjDfsWSQI8x3LpoVule/8x87yMvMdBSHzdMUyuRnGZY5urPxYv6+vdewrVqwQ/Pz8xOU+ffoI3bt3Nyrz6quvCu3atRMMBoO4bs2aNYK9vb1QWloq7vfoo4+K20tKSgQ7OzvhhRdeENdlZGQIAISkpKRq49q7d68AQNi9e7e4bseOHQIA8XOeP3++oFAohKtXr4pldu7cKcjlciEjI0MQBEHw9vYW3n77baNj9+zZU5gyZYogCILwwQcfCK6urkbXbu3atQIA4dixY4IgCMK1a9cEhUIhHDp0SBAEQdDr9YKbm5uwYcOGautRmfv+exFq/l3PO6tERETNzKhRo3D69Gns2rULP/74I/bv34+JEydWuc+MGTOwfft2bN26Ffv27UN6ejqGDBlSodz69euRkZEhTk8//XQD1YKIqH6Cg42Hijx79ixCQ0Mhk5V3fPrII48gPz8fV69eFdd16dJFnFcoFHB1dUXnzp3FdXf727l+/T53hitx7zHvjlpy7/6+vr5o2bKluBwaGgqDwYDU1FTk5uYiPT0djzzyiNExH3nkEZw9e1asW5cuXWBtbW10jHt5e3vjn//8Jz799FMAwPbt26HT6TB06NAa18PUmKwSERE1I2fPnkV8fDw+/vhjhISE4NFHH8V7770n9vFQmZycHHzyySdYvnw5Hn/8cQQHB2P9+vX47bffcPCg8SN/Go0Gnp6e4nTvH0ZERObEzs6uTvsplcbvwstkMqN1d5Ndg8FQp2PWZX9TefHFF7F582YUFRVh/fr1GD58OGxtbRs9jrvYRZ45uPEn8Mu7ZR0tWVkDD00GXAKkjoqIiJqgpKQkaDQa9OjRQ1wXHh4OuVyOQ4cO4ZlnnqmwT3JyMoqLixEeHi6uCwoKgq+vL5KSkoyGeps6dSpefPFFBAYGYtKkSRg3bpzRXYoGd+pb4MKesl6A1Q5Av7eq34eI6qf780Bg37L5+/3/7tMLGHdPhz/OfhXL2LgYl3FtXbEMADzwZJ3CrE779u3x7bffQhAE8XvrwIEDcHBwQKtWrRrknDWVlpaG9PR0eHt7AwAOHjwIuVyOdu3awdHREd7e3jhw4AD69Okj7nPgwAH06tULQFndvvjiC2i1WvFHxL//2AgAAwYMgJ2dHdauXYv4+Hjs37+/EWp3f0xWzUFeOnBic/lyl2FMVomIqEFkZmaiRYsWRuusrKzg4uKCzMzM++6jUqmg0WiM1nt4eBjts3DhQjz++OOwtbXFzz//jClTpiA/Px8vv/zyfePR6XTQ6XTicm5ubh1qdY+rvwPHNpbN27oyWSVqDBqfsqkqti6AX2jVZaxU1ZcBAAePmsdWC1OmTMHKlSsxbdo0REdHIzU1FfPnz0dMTIzR8JlSsLa2xpgxY7Bs2TLk5ubi5ZdfxrBhw8QRTGbPno358+ejdevW6NatG9avX4+UlBRs2rQJAPDcc8/htddew4QJExAbG4tLly5V6PkXKHuseezYsYiNjUXbtm0rPCrc2JismoMSvfGygmM8ERFR7cyZMwfvvPNOlWXuvrvUUF5//XVxvnv37igoKMDSpUurTFbj4uLwxhtvmC4IQ/kQExxjlYhqo2XLlvjpp58we/ZsdO3aFS4uLoiKisLcuXOlDg1t2rTBkCFDMGDAANy+fRsDBw7E+++/L25/+eWXkZOTg5kzZ+L69evo0KEDfvjhB7Rt2xYAYG9vj+3bt2PSpEno3r07OnTogHfeeQeRkZEVzhUVFYVFixZh3LhxjVa/+5EJgiBIHYSly83NhZOTE3JycuDo6Fj7A/yVCOyYBZTqgBIdMPYnwE2i7qGJiKhS9f6ub2A3btzArVu3qiwTGBiIjRs3YubMmbhz5464vqSkBNbW1ti6dWuljwHv2bMHYWFhuHPnjtHdVT8/P0yfPh0zZsyo9Hw7duzAwIEDodVqoVarKy1T2Z1VHx+fun/OiYuB45sBQylg5wpMTKz9MYioUlqtFhcvXkRAQADfR2/CfvnlF4SFheHKlStiZ1F1UdW/l5q2qfzJ0RwE9gWm/S51FEREZMHc3d3h7u5ebbnQ0FBkZ2cjOTlZ7Alzz549MBgMCAkJqXSf4OBgKJVKJCQkiL/Cp6amIi0trcpHxFJSUuDs7HzfRBUA1Gp1ldtrre+csomIiGpFp9Phxo0bWLBgAYYOHVqvRNVU2BswERFRM9K+fXv0798fEyZMwOHDh3HgwAFER0djxIgRYscd165dQ1BQEA4fPgwAcHJyQlRUFGJiYrB3714kJydj3LhxCA0NFTtX2r59Oz7++GOcOnUK58+fx9q1a7Fo0SJMmzZNsroSEUlt0qRJsLe3r3SaNGmS1OEZ+eqrr+Dn54fs7GwsWbJE6nAA8M4qERFRs7Np0yZER0cjLCwMcrkckZGRWLVqlbi9uLgYqampKCwsFNetWLFCLKvT6RAREWH0vpRSqcSaNWswY8YMCIKANm3aYPny5ZgwYUKj1o2IyJwsXLgQs2bNqnSbub1SMnbsWIwdO1bqMIzwnVUTMPf3mIiIqP74Xd84+DkTmS++s0q1YYp3VvkYMBEREREREZkdJqtERERERFRjfDCTasIU/06YrBIRERERUbUUCgUAQK/XSxwJWYK7/R4olco6H4MdLBERERERUbWsrKxga2uLGzduQKlUQi7nfS+qSBAEFBYW4vr169BoNOKPHHXBZJWIiIiIiKolk8ng5eWFixcv4vLly1KHQ2ZOo9HA09OzXsdgskpERERERDWiUqnQtm1bPgpMVVIqlfW6o3oXk1UiIiIiIqoxuVzOoWuoUfBBcyIiIiIiIjI7TFaJiIiIiIjI7DBZJSIiIiIiIrPDd1ZN4O6At7m5uRJHQkREDeXud7wpBjmn+2ObSkTU9NW0TWWyagJ5eXkAAB8fH4kjISKihpaXlwcnJyepw2iy2KYSETUf1bWpMoE/EdebwWBAeno6HBwcIJPJarVvbm4ufHx8cOXKFTg6OjZQhNJjPZuW5lDP5lBHgPWsDUEQkJeXB29vb8jlfIumobBNrV5zqGdzqCPAejY1rGfN1bRN5Z1VE5DL5WjVqlW9juHo6Nik/1HfxXo2Lc2hns2hjgDrWVO8o9rw2KbWXHOoZ3OoI8B6NjWsZ83UpE3lT8NERERERERkdpisEhERERERkdlhsioxtVqN+fPnQ61WSx1Kg2I9m5bmUM/mUEeA9aSmpblc5+ZQz+ZQR4D1bGpYT9NjB0tERERERERkdnhnlYiIiIiIiMwOk1UiIiIiIiIyO0xWiYiIiIiIyOwwWZXYmjVr4O/vD2tra4SEhODw4cNSh2RSCxYsgEwmM5qCgoKkDqte9u/fj0GDBsHb2xsymQz/+c9/jLYLgoB58+bBy8sLNjY2CA8Px7lz56QJth6qq+fYsWMrXNv+/ftLE2w9xMXFoWfPnnBwcECLFi3w9NNPIzU11aiMVqvF1KlT4erqCnt7e0RGRiIrK0uiiGuvJnXs27dvhes5adIkiSKum7Vr16JLly7iuG+hoaHYuXOnuN3SryNVje2pZWKbWqYptKnNoT0F2Kbe1VjXksmqhLZs2YKYmBjMnz8fR48eRdeuXREREYHr169LHZpJdezYERkZGeL066+/Sh1SvRQUFKBr165Ys2ZNpduXLFmCVatWYd26dTh06BDs7OwQEREBrVbbyJHWT3X1BID+/fsbXduvvvqqESM0jX379mHq1Kk4ePAgdu3aheLiYvTr1w8FBQVimRkzZmD79u3YunUr9u3bh/T0dAwZMkTCqGunJnUEgAkTJhhdzyVLlkgUcd20atUKixcvRnJyMn7//Xc8/vjjGDx4ME6fPg3A8q8j3R/bU8vFNrWcpbepzaE9BdimNnqbKpBkevXqJUydOlVcLi0tFby9vYW4uDgJozKt+fPnC127dpU6jAYDQPjuu+/EZYPBIHh6egpLly4V12VnZwtqtVr46quvJIjQNP5eT0EQhDFjxgiDBw+WJJ6GdP36dQGAsG/fPkEQyq6fUqkUtm7dKpY5e/asAEBISkqSKsx6+XsdBUEQ+vTpI/zf//2fdEE1EGdnZ+Hjjz9ukteRyrE9bRrYpg6WJJ6G0hzaU0Fgm3pXQ11L3lmViF6vR3JyMsLDw8V1crkc4eHhSEpKkjAy0zt37hy8vb0RGBiIUaNGIS0tTeqQGszFixeRmZlpdF2dnJwQEhLS5K4rACQmJqJFixZo164dJk+ejFu3bkkdUr3l5OQAAFxcXAAAycnJKC4uNrqmQUFB8PX1tdhr+vc63rVp0ya4ubmhU6dOiI2NRWFhoRThmURpaSk2b96MgoIChIaGNsnrSGXYnjZdbFMtu01tDu0pwDb1roa6llYmPRrV2M2bN1FaWgoPDw+j9R4eHvjjjz8kisr0QkJCsGHDBrRr1w4ZGRl444030Lt3b5w6dQoODg5Sh2dymZmZAFDpdb27rano378/hgwZgoCAAFy4cAGvvvoqnnzySSQlJUGhUEgdXp0YDAZMnz4djzzyCDp16gSg7JqqVCpoNBqjspZ6TSurIwA899xz8PPzg7e3N06cOIFXXnkFqamp2LZtm4TR1t7JkycRGhoKrVYLe3t7fPfdd+jQoQNSUlKa1HWkcmxPm2Z7CrBNteQ2tTm0pwDb1Ma4lkxWqUE9+eST4nyXLl0QEhICPz8/fP3114iKipIwMqqvESNGiPOdO3dGly5d0Lp1ayQmJiIsLEzCyOpu6tSpOHXqVJN4D+x+7lfHiRMnivOdO3eGl5cXwsLCcOHCBbRu3bqxw6yzdu3aISUlBTk5Ofjmm28wZswY7Nu3T+qwiOqN7WnT1tTa1ObQngJsUxsDHwOWiJubGxQKRYVes7KysuDp6SlRVA1Po9HggQcewPnz56UOpUHcvXbN7boCQGBgINzc3Cz22kZHR+PHH3/E3r170apVK3G9p6cn9Ho9srOzjcpb4jW9Xx0rExISAgAWdz1VKhXatGmD4OBgxMXFoWvXrvj3v//dpK4jGWN7aln/j9YG21TLbFObQ3sKsE1trGvJZFUiKpUKwcHBSEhIENcZDAYkJCQgNDRUwsgaVn5+Pi5cuAAvLy+pQ2kQAQEB8PT0NLquubm5OHToUJO+rgBw9epV3Lp1y+KurSAIiI6OxnfffYc9e/YgICDAaHtwcDCUSqXRNU1NTUVaWprFXNPq6liZlJQUALC46/l3BoMBOp2uSVxHqhzbU8v+f7QqbFMtq01tDu0pwDa10dtUk3bXRLWyefNmQa1WCxs2bBDOnDkjTJw4UdBoNEJmZqbUoZnMzJkzhcTEROHixYvCgQMHhPDwcMHNzU24fv261KHVWV5ennDs2DHh2LFjAgBh+fLlwrFjx4TLly8LgiAIixcvFjQajfD9998LJ06cEAYPHiwEBAQIRUVFEkdeO1XVMy8vT5g1a5aQlJQkXLx4Udi9e7fw4IMPCm3bthW0Wq3UodfK5MmTBScnJyExMVHIyMgQp8LCQrHMpEmTBF9fX2HPnj3C77//LoSGhgqhoaESRl071dXx/PnzwsKFC4Xff/9duHjxovD9998LgYGBwmOPPSZx5LUzZ84cYd++fcLFixeFEydOCHPmzBFkMpnw888/C4Jg+deR7o/tqeVim9p02tTm0J4KAtvUxm5TmaxK7L333hN8fX0FlUol9OrVSzh48KDUIZnU8OHDBS8vL0GlUgktW7YUhg8fLpw/f17qsOpl7969AoAK05gxYwRBKOtq//XXXxc8PDwEtVothIWFCampqdIGXQdV1bOwsFDo16+f4O7uLiiVSsHPz0+YMGGCRf5hWFkdAQjr168XyxQVFQlTpkwRnJ2dBVtbW+GZZ54RMjIypAu6lqqrY1pamvDYY48JLi4uglqtFtq0aSPMnj1byMnJkTbwWho/frzg5+cnqFQqwd3dXQgLCxMbVUGw/OtIVWN7apnYpjadNrU5tKeCwDb1rsa6ljJBEATT3qslIiIiIiIiqh++s0pERERERERmh8kqERERERERmR0mq0RERERERGR2mKwSERERERGR2WGySkRERERERGaHySoRERERERGZHSarREREREREZHaYrBIREREREZHZYbJKREREREREZofJKhEREREREZkdJqtEZBIlJSVSh0BERGTx2J4SlWOySkS1dunSJchkMnz99dfo3bs31Go1fvjhB6nDIiIisihsT4mqZiV1AERkeY4fPw4AWLp0KRYtWoSAgAC4u7tLHBUREZFlYXtKVDUmq0RUaykpKbCzs8PWrVvh7+8vdThEREQWie0pUdX4GDAR1drx48fx1FNPsWElIiKqB7anRFVjskpEtZaSkoK+fftKHQYREZFFY3tKVDUmq0RUK7m5ubh06RK6d+8udShEREQWi+0pUfWYrBJRrRw/fhwKhQKdO3eWOhQiIiKLxfaUqHpMVomoVo4fP4527drB2tpa6lCIiIgsFttTourJBEEQpA6CiIiIiIiI6F68s0pERERERERmh8kqERERERERmR0mq0RERERERGR2mKwSERERERGR2WGySkRERERERGaHySoRERERERGZHSarREREREREZHaYrBIREREREZHZYbJKREREREREZofJKhEREREREZkdJqtERERERERkdpisEhERERERkdn5fz7a4QRls2EIAAAAAElFTkSuQmCC",
       "text/plain": [
-       "<Figure size 600x400 with 1 Axes>"
+       "<Figure size 950x400 with 2 Axes>"
       ]
      },
      "metadata": {},
@@ -426,40 +429,47 @@
     "\n",
     "nfw = potential.NFWPotential(amp=1.0, a=2.0)\n",
     "nfw.turn_physical_off()\n",
-    "nfw_df = isotropicNFWdf(nfw, rmax=100.0)\n",
+    "rmax = 100.0\n",
+    "nfw_df = isotropicNFWdf(nfw, rmax=rmax)\n",
     "numpy.random.seed(42)\n",
     "n = 300_000\n",
     "samples = nfw_df.sample(n=n)\n",
     "pos = numpy.array([samples.x(), samples.y(), samples.z()])\n",
     "# per-particle mass, so the sampled particles reproduce the halo's mass profile\n",
-    "mass = nfw.mass(100.0, use_physical=False) / n\n",
+    "mass = nfw.mass(rmax, use_physical=False) / n\n",
+    "\n",
+    "\n",
+    "# the sample is truncated at rmax, so for a fair, like-for-like comparison we build\n",
+    "# from_density from the *same* density truncated at rmax\n",
+    "def nfw_dens_truncated(R, z=0.0, phi=0.0):\n",
+    "    r = numpy.sqrt(R**2 + z**2)\n",
+    "    return nfw.dens(R, z, use_physical=False) * (r < rmax)\n",
+    "\n",
     "\n",
     "scf_nbody = SCFPotential.from_nbody(pos, N=15, symmetry=\"spherical\", a=2.0, mass=mass)\n",
-    "scf_dens = SCFPotential.from_density(nfw.dens, N=15, symmetry=\"spherical\", a=2.0)\n",
+    "scf_dens = SCFPotential.from_density(\n",
+    "    nfw_dens_truncated, N=15, symmetry=\"spherical\", a=2.0\n",
+    ")\n",
     "\n",
     "rs = numpy.linspace(0.2, 30.0, 100)\n",
-    "plt.figure(figsize=(6, 4))\n",
-    "plt.plot(\n",
-    "    rs, [nfw.vcirc(r, use_physical=False) for r in rs], \"k-\", lw=2.5, label=\"true NFW\"\n",
-    ")\n",
-    "plt.plot(\n",
-    "    rs,\n",
-    "    [scf_dens.vcirc(r, use_physical=False) for r in rs],\n",
-    "    \"C0--\",\n",
-    "    lw=2.0,\n",
-    "    label=\"SCF from_density\",\n",
-    ")\n",
-    "plt.plot(\n",
-    "    rs,\n",
-    "    [scf_nbody.vcirc(r, use_physical=False) for r in rs],\n",
-    "    \"C1:\",\n",
-    "    lw=2.5,\n",
-    "    label=\"SCF from_nbody\",\n",
-    ")\n",
-    "plt.xlabel(r\"$r$\")\n",
-    "plt.ylabel(r\"$v_c(r)$\")\n",
-    "plt.legend()\n",
-    "plt.tight_layout();"
+    "vc_true = numpy.array([nfw.vcirc(r, use_physical=False) for r in rs])\n",
+    "vc_dens = numpy.array([scf_dens.vcirc(r, use_physical=False) for r in rs])\n",
+    "vc_nbody = numpy.array([scf_nbody.vcirc(r, use_physical=False) for r in rs])\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(9.5, 4.0))\n",
+    "axes[0].plot(rs, vc_true, \"k-\", lw=2.5, label=\"true NFW\")\n",
+    "axes[0].plot(rs, vc_dens, \"C0--\", lw=2.0, label=\"SCF from_density\")\n",
+    "axes[0].plot(rs, vc_nbody, \"C1:\", lw=2.5, label=\"SCF from_nbody\")\n",
+    "axes[0].set_xlabel(r\"$r$\")\n",
+    "axes[0].set_ylabel(r\"$v_c(r)$\")\n",
+    "axes[0].legend()\n",
+    "axes[1].axhline(0.0, color=\"k\", lw=1)\n",
+    "axes[1].plot(rs, vc_dens / vc_true - 1.0, \"C0--\", lw=2.0, label=\"from_density\")\n",
+    "axes[1].plot(rs, vc_nbody / vc_true - 1.0, \"C1:\", lw=2.5, label=\"from_nbody\")\n",
+    "axes[1].set_xlabel(r\"$r$\")\n",
+    "axes[1].set_ylabel(r\"$v_c / v_{c,\\mathrm{true}} - 1$\")\n",
+    "axes[1].legend()\n",
+    "fig.tight_layout();"
    ]
   },
   {
@@ -467,17 +477,18 @@
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {
     "papermill": {
-     "duration": 0.012167,
-     "end_time": "2026-07-04T00:27:40.315280+00:00",
+     "duration": 0.012182,
+     "end_time": "2026-07-04T01:08:10.914210+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.303113+00:00",
+     "start_time": "2026-07-04T01:08:10.902028+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "The SCF built from the particles closely tracks the one built from the smooth\n",
-    "density; the small residual is the Poisson noise of the finite sample. As with\n",
+    "density; the small residual (right panel) is the Poisson noise of the finite sample,\n",
+    "while the `from_density` build is smooth. As with\n",
     "`from_density`, passing multiple snapshots — `pos` of shape `[3,n,nt]` together with\n",
     "a `tgrid` of length `nt` — builds a *time-dependent* `SCFPotential`, with the\n",
     "coefficients computed at each snapshot and interpolated in time. This makes it easy\n",
@@ -490,10 +501,10 @@
    "id": "e87e7bd1",
    "metadata": {
     "papermill": {
-     "duration": 0.011634,
-     "end_time": "2026-07-04T00:27:40.341833+00:00",
+     "duration": 0.011567,
+     "end_time": "2026-07-04T01:08:10.937181+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.330199+00:00",
+     "start_time": "2026-07-04T01:08:10.925614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -501,7 +512,7 @@
    "source": [
     "## Computing SCF coefficients manually\n",
     "\n",
-    "Instead of using `from_density`, you can compute the SCF expansion coefficients yourself and pass them directly to `SCFPotential`. This is useful when you want to inspect the coefficients or store them for later use.\n",
+    "Instead of using `from_density`, you can compute the SCF expansion coefficients yourself and pass them directly to `SCFPotential`. This is useful when you want to inspect the coefficients or store them for later use. The `scf_compute_coeffs_spherical`, `scf_compute_coeffs_axi`, and `scf_compute_coeffs` functions compute the coefficients from a density, while their `scf_compute_coeffs_spherical_nbody`, `scf_compute_coeffs_axi_nbody`, and `scf_compute_coeffs_nbody` counterparts do the same directly from an N-body particle set (as used by `from_nbody` above).\n",
     "\n",
     "The Hernquist profile is the lowest-order SCF basis function, so only the zeroth-order coefficient should be non-zero in the following example:"
    ]
@@ -512,16 +523,16 @@
    "id": "b3c4d5e6f7a8b9c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:40.366262Z",
-     "iopub.status.busy": "2026-07-04T00:27:40.366075Z",
-     "iopub.status.idle": "2026-07-04T00:27:40.375581Z",
-     "shell.execute_reply": "2026-07-04T00:27:40.374043Z"
+     "iopub.execute_input": "2026-07-04T01:08:10.962086Z",
+     "iopub.status.busy": "2026-07-04T01:08:10.961896Z",
+     "iopub.status.idle": "2026-07-04T01:08:10.972110Z",
+     "shell.execute_reply": "2026-07-04T01:08:10.970654Z"
     },
     "papermill": {
-     "duration": 0.023929,
-     "end_time": "2026-07-04T00:27:40.376744+00:00",
+     "duration": 0.024532,
+     "end_time": "2026-07-04T01:08:10.973218+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.352815+00:00",
+     "start_time": "2026-07-04T01:08:10.948686+00:00",
      "status": "completed"
     },
     "tags": []
@@ -571,10 +582,10 @@
    "id": "c4d5e6f7a8b9c0d1",
    "metadata": {
     "papermill": {
-     "duration": 0.015702,
-     "end_time": "2026-07-04T00:27:40.406719+00:00",
+     "duration": 0.014142,
+     "end_time": "2026-07-04T01:08:10.999508+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.391017+00:00",
+     "start_time": "2026-07-04T01:08:10.985366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -589,16 +600,16 @@
    "id": "3a2dc462",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:40.440404Z",
-     "iopub.status.busy": "2026-07-04T00:27:40.440101Z",
-     "iopub.status.idle": "2026-07-04T00:27:40.446321Z",
-     "shell.execute_reply": "2026-07-04T00:27:40.444849Z"
+     "iopub.execute_input": "2026-07-04T01:08:11.031802Z",
+     "iopub.status.busy": "2026-07-04T01:08:11.031491Z",
+     "iopub.status.idle": "2026-07-04T01:08:11.038838Z",
+     "shell.execute_reply": "2026-07-04T01:08:11.037084Z"
     },
     "papermill": {
-     "duration": 0.024953,
-     "end_time": "2026-07-04T00:27:40.447433+00:00",
+     "duration": 0.02663,
+     "end_time": "2026-07-04T01:08:11.040381+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.422480+00:00",
+     "start_time": "2026-07-04T01:08:11.013751+00:00",
      "status": "completed"
     },
     "tags": []
@@ -658,10 +669,10 @@
    "id": "b13a0695",
    "metadata": {
     "papermill": {
-     "duration": 0.016131,
-     "end_time": "2026-07-04T00:27:40.478133+00:00",
+     "duration": 0.018048,
+     "end_time": "2026-07-04T01:08:11.075890+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.462002+00:00",
+     "start_time": "2026-07-04T01:08:11.057842+00:00",
      "status": "completed"
     },
     "tags": []
@@ -675,10 +686,10 @@
    "id": "17d13f11",
    "metadata": {
     "papermill": {
-     "duration": 0.015998,
-     "end_time": "2026-07-04T00:27:40.508276+00:00",
+     "duration": 0.01436,
+     "end_time": "2026-07-04T01:08:11.108380+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.492278+00:00",
+     "start_time": "2026-07-04T01:08:11.094020+00:00",
      "status": "completed"
     },
     "tags": []
@@ -704,16 +715,16 @@
    "id": "d5e6f7a8b9c0d1e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:40.540340Z",
-     "iopub.status.busy": "2026-07-04T00:27:40.540125Z",
-     "iopub.status.idle": "2026-07-04T00:27:40.875187Z",
-     "shell.execute_reply": "2026-07-04T00:27:40.873806Z"
+     "iopub.execute_input": "2026-07-04T01:08:11.133712Z",
+     "iopub.status.busy": "2026-07-04T01:08:11.133515Z",
+     "iopub.status.idle": "2026-07-04T01:08:11.572132Z",
+     "shell.execute_reply": "2026-07-04T01:08:11.570300Z"
     },
     "papermill": {
-     "duration": 0.352269,
-     "end_time": "2026-07-04T00:27:40.877001+00:00",
+     "duration": 0.453315,
+     "end_time": "2026-07-04T01:08:11.573438+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.524732+00:00",
+     "start_time": "2026-07-04T01:08:11.120123+00:00",
      "status": "completed"
     },
     "tags": []
@@ -737,10 +748,10 @@
    "id": "e6f7a8b9c0d1e2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.014455,
-     "end_time": "2026-07-04T00:27:40.909440+00:00",
+     "duration": 0.014772,
+     "end_time": "2026-07-04T01:08:11.603937+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.894985+00:00",
+     "start_time": "2026-07-04T01:08:11.589165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -755,16 +766,16 @@
    "id": "f7a8b9c0d1e2f3a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:40.940016Z",
-     "iopub.status.busy": "2026-07-04T00:27:40.939804Z",
-     "iopub.status.idle": "2026-07-04T00:27:41.845134Z",
-     "shell.execute_reply": "2026-07-04T00:27:41.843967Z"
+     "iopub.execute_input": "2026-07-04T01:08:11.631387Z",
+     "iopub.status.busy": "2026-07-04T01:08:11.631125Z",
+     "iopub.status.idle": "2026-07-04T01:08:12.829882Z",
+     "shell.execute_reply": "2026-07-04T01:08:12.828361Z"
     },
     "papermill": {
-     "duration": 0.92293,
-     "end_time": "2026-07-04T00:27:41.847175+00:00",
+     "duration": 1.213017,
+     "end_time": "2026-07-04T01:08:12.831053+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:40.924245+00:00",
+     "start_time": "2026-07-04T01:08:11.618036+00:00",
      "status": "completed"
     },
     "tags": []
@@ -796,10 +807,10 @@
    "id": "a8b9c0d1e2f3a4b5",
    "metadata": {
     "papermill": {
-     "duration": 0.01527,
-     "end_time": "2026-07-04T00:27:41.884281+00:00",
+     "duration": 0.014027,
+     "end_time": "2026-07-04T01:08:12.859742+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:41.869011+00:00",
+     "start_time": "2026-07-04T01:08:12.845715+00:00",
      "status": "completed"
     },
     "tags": []
@@ -814,16 +825,16 @@
    "id": "b9c0d1e2f3a4b5c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:41.921275Z",
-     "iopub.status.busy": "2026-07-04T00:27:41.921075Z",
-     "iopub.status.idle": "2026-07-04T00:27:51.575771Z",
-     "shell.execute_reply": "2026-07-04T00:27:51.574465Z"
+     "iopub.execute_input": "2026-07-04T01:08:12.888663Z",
+     "iopub.status.busy": "2026-07-04T01:08:12.888480Z",
+     "iopub.status.idle": "2026-07-04T01:08:22.504188Z",
+     "shell.execute_reply": "2026-07-04T01:08:22.502662Z"
     },
     "papermill": {
-     "duration": 9.682033,
-     "end_time": "2026-07-04T00:27:51.581984+00:00",
+     "duration": 9.631316,
+     "end_time": "2026-07-04T01:08:22.505434+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:41.899951+00:00",
+     "start_time": "2026-07-04T01:08:12.874118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -858,10 +869,10 @@
    "id": "c0d1e2f3a4b5c6d7",
    "metadata": {
     "papermill": {
-     "duration": 0.021571,
-     "end_time": "2026-07-04T00:27:51.634018+00:00",
+     "duration": 0.018187,
+     "end_time": "2026-07-04T01:08:22.542626+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:51.612447+00:00",
+     "start_time": "2026-07-04T01:08:22.524439+00:00",
      "status": "completed"
     },
     "tags": []
@@ -876,16 +887,16 @@
    "id": "226e8f68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:27:51.685213Z",
-     "iopub.status.busy": "2026-07-04T00:27:51.684928Z",
-     "iopub.status.idle": "2026-07-04T00:28:11.914998Z",
-     "shell.execute_reply": "2026-07-04T00:28:11.913587Z"
+     "iopub.execute_input": "2026-07-04T01:08:22.581223Z",
+     "iopub.status.busy": "2026-07-04T01:08:22.581032Z",
+     "iopub.status.idle": "2026-07-04T01:08:42.765506Z",
+     "shell.execute_reply": "2026-07-04T01:08:42.763241Z"
     },
     "papermill": {
-     "duration": 20.254437,
-     "end_time": "2026-07-04T00:28:11.916700+00:00",
+     "duration": 20.205727,
+     "end_time": "2026-07-04T01:08:42.766904+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:27:51.662263+00:00",
+     "start_time": "2026-07-04T01:08:22.561177+00:00",
      "status": "completed"
     },
     "tags": []
@@ -895,7 +906,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.53 s ± 14.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.52 s ± 8.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -910,10 +921,10 @@
    "id": "acf72105",
    "metadata": {
     "papermill": {
-     "duration": 0.02674,
-     "end_time": "2026-07-04T00:28:11.974838+00:00",
+     "duration": 0.018332,
+     "end_time": "2026-07-04T01:08:42.807124+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:11.948098+00:00",
+     "start_time": "2026-07-04T01:08:42.788792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -928,16 +939,16 @@
    "id": "745deca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:12.024471Z",
-     "iopub.status.busy": "2026-07-04T00:28:12.024237Z",
-     "iopub.status.idle": "2026-07-04T00:28:18.413635Z",
-     "shell.execute_reply": "2026-07-04T00:28:18.412296Z"
+     "iopub.execute_input": "2026-07-04T01:08:42.862449Z",
+     "iopub.status.busy": "2026-07-04T01:08:42.862057Z",
+     "iopub.status.idle": "2026-07-04T01:08:49.198165Z",
+     "shell.execute_reply": "2026-07-04T01:08:49.196534Z"
     },
     "papermill": {
-     "duration": 6.420954,
-     "end_time": "2026-07-04T00:28:18.415675+00:00",
+     "duration": 6.3669,
+     "end_time": "2026-07-04T01:08:49.199207+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:11.994721+00:00",
+     "start_time": "2026-07-04T01:08:42.832307+00:00",
      "status": "completed"
     },
     "tags": []
@@ -947,7 +958,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "78.6 ms ± 1.12 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "78.1 ms ± 556 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -962,10 +973,10 @@
    "id": "3fa99bf4",
    "metadata": {
     "papermill": {
-     "duration": 0.021627,
-     "end_time": "2026-07-04T00:28:18.468324+00:00",
+     "duration": 0.023779,
+     "end_time": "2026-07-04T01:08:49.243134+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:18.446697+00:00",
+     "start_time": "2026-07-04T01:08:49.219355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -989,16 +1000,16 @@
    "id": "d1e2f3a4b5c6d7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:18.518069Z",
-     "iopub.status.busy": "2026-07-04T00:28:18.517822Z",
-     "iopub.status.idle": "2026-07-04T00:28:19.508647Z",
-     "shell.execute_reply": "2026-07-04T00:28:19.507191Z"
+     "iopub.execute_input": "2026-07-04T01:08:49.296188Z",
+     "iopub.status.busy": "2026-07-04T01:08:49.295991Z",
+     "iopub.status.idle": "2026-07-04T01:08:50.249147Z",
+     "shell.execute_reply": "2026-07-04T01:08:50.247535Z"
     },
     "papermill": {
-     "duration": 1.014879,
-     "end_time": "2026-07-04T00:28:19.510613+00:00",
+     "duration": 0.977932,
+     "end_time": "2026-07-04T01:08:50.250308+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:18.495734+00:00",
+     "start_time": "2026-07-04T01:08:49.272376+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1029,10 +1040,10 @@
    "id": "e2f3a4b5c6d7e8f9",
    "metadata": {
     "papermill": {
-     "duration": 0.020649,
-     "end_time": "2026-07-04T00:28:19.561153+00:00",
+     "duration": 0.021707,
+     "end_time": "2026-07-04T01:08:50.294431+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:19.540504+00:00",
+     "start_time": "2026-07-04T01:08:50.272724+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1047,16 +1058,16 @@
    "id": "f3a4b5c6d7e8f9a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:19.605935Z",
-     "iopub.status.busy": "2026-07-04T00:28:19.605703Z",
-     "iopub.status.idle": "2026-07-04T00:28:19.926918Z",
-     "shell.execute_reply": "2026-07-04T00:28:19.925675Z"
+     "iopub.execute_input": "2026-07-04T01:08:50.332856Z",
+     "iopub.status.busy": "2026-07-04T01:08:50.332666Z",
+     "iopub.status.idle": "2026-07-04T01:08:50.628873Z",
+     "shell.execute_reply": "2026-07-04T01:08:50.627395Z"
     },
     "papermill": {
-     "duration": 0.346288,
-     "end_time": "2026-07-04T00:28:19.928904+00:00",
+     "duration": 0.317502,
+     "end_time": "2026-07-04T01:08:50.630582+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:19.582616+00:00",
+     "start_time": "2026-07-04T01:08:50.313080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1089,10 +1100,10 @@
    "id": "a4b5c6d7e8f9a0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.023707,
-     "end_time": "2026-07-04T00:28:19.984020+00:00",
+     "duration": 0.020061,
+     "end_time": "2026-07-04T01:08:50.684795+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:19.960313+00:00",
+     "start_time": "2026-07-04T01:08:50.664734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1107,16 +1118,16 @@
    "id": "2d0d29d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:20.029945Z",
-     "iopub.status.busy": "2026-07-04T00:28:20.029650Z",
-     "iopub.status.idle": "2026-07-04T00:28:28.258202Z",
-     "shell.execute_reply": "2026-07-04T00:28:28.256868Z"
+     "iopub.execute_input": "2026-07-04T01:08:50.733015Z",
+     "iopub.status.busy": "2026-07-04T01:08:50.732670Z",
+     "iopub.status.idle": "2026-07-04T01:08:59.180265Z",
+     "shell.execute_reply": "2026-07-04T01:08:59.178554Z"
     },
     "papermill": {
-     "duration": 8.25447,
-     "end_time": "2026-07-04T00:28:28.260570+00:00",
+     "duration": 8.472923,
+     "end_time": "2026-07-04T01:08:59.181455+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:20.006100+00:00",
+     "start_time": "2026-07-04T01:08:50.708532+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1143,10 +1154,10 @@
    "id": "9ce6e0c9",
    "metadata": {
     "papermill": {
-     "duration": 0.021962,
-     "end_time": "2026-07-04T00:28:28.315696+00:00",
+     "duration": 0.03025,
+     "end_time": "2026-07-04T01:08:59.231829+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:28.293734+00:00",
+     "start_time": "2026-07-04T01:08:59.201579+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1161,16 +1172,16 @@
    "id": "04a6500d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:28.362201Z",
-     "iopub.status.busy": "2026-07-04T00:28:28.361966Z",
-     "iopub.status.idle": "2026-07-04T00:28:30.438265Z",
-     "shell.execute_reply": "2026-07-04T00:28:30.436999Z"
+     "iopub.execute_input": "2026-07-04T01:08:59.277306Z",
+     "iopub.status.busy": "2026-07-04T01:08:59.277096Z",
+     "iopub.status.idle": "2026-07-04T01:09:01.285700Z",
+     "shell.execute_reply": "2026-07-04T01:09:01.284087Z"
     },
     "papermill": {
-     "duration": 2.104171,
-     "end_time": "2026-07-04T00:28:30.442216+00:00",
+     "duration": 2.03325,
+     "end_time": "2026-07-04T01:09:01.286869+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:28.338045+00:00",
+     "start_time": "2026-07-04T01:08:59.253619+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1233,10 +1244,10 @@
    "id": "a5956d7b",
    "metadata": {
     "papermill": {
-     "duration": 0.025695,
-     "end_time": "2026-07-04T00:28:30.505993+00:00",
+     "duration": 0.036727,
+     "end_time": "2026-07-04T01:09:01.362542+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:30.480298+00:00",
+     "start_time": "2026-07-04T01:09:01.325815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1295,16 +1306,16 @@
    "id": "4d7c563b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:30.567524Z",
-     "iopub.status.busy": "2026-07-04T00:28:30.567267Z",
-     "iopub.status.idle": "2026-07-04T00:28:35.264757Z",
-     "shell.execute_reply": "2026-07-04T00:28:35.263476Z"
+     "iopub.execute_input": "2026-07-04T01:09:01.427726Z",
+     "iopub.status.busy": "2026-07-04T01:09:01.427516Z",
+     "iopub.status.idle": "2026-07-04T01:09:05.958420Z",
+     "shell.execute_reply": "2026-07-04T01:09:05.956613Z"
     },
     "papermill": {
-     "duration": 4.734956,
-     "end_time": "2026-07-04T00:28:35.267732+00:00",
+     "duration": 4.559777,
+     "end_time": "2026-07-04T01:09:05.959520+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:30.532776+00:00",
+     "start_time": "2026-07-04T01:09:01.399743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1413,10 +1424,10 @@
    "id": "aeabed99",
    "metadata": {
     "papermill": {
-     "duration": 0.038349,
-     "end_time": "2026-07-04T00:28:35.347943+00:00",
+     "duration": 0.026382,
+     "end_time": "2026-07-04T01:09:06.010637+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:35.309594+00:00",
+     "start_time": "2026-07-04T01:09:05.984255+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1446,16 +1457,16 @@
    "id": "2ad4d3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T00:28:35.414616Z",
-     "iopub.status.busy": "2026-07-04T00:28:35.414354Z",
-     "iopub.status.idle": "2026-07-04T00:28:35.805263Z",
-     "shell.execute_reply": "2026-07-04T00:28:35.804003Z"
+     "iopub.execute_input": "2026-07-04T01:09:06.069915Z",
+     "iopub.status.busy": "2026-07-04T01:09:06.069666Z",
+     "iopub.status.idle": "2026-07-04T01:09:06.451690Z",
+     "shell.execute_reply": "2026-07-04T01:09:06.450058Z"
     },
     "papermill": {
-     "duration": 0.432685,
-     "end_time": "2026-07-04T00:28:35.807990+00:00",
+     "duration": 0.407068,
+     "end_time": "2026-07-04T01:09:06.452776+00:00",
      "exception": false,
-     "start_time": "2026-07-04T00:28:35.375305+00:00",
+     "start_time": "2026-07-04T01:09:06.045708+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1531,14 +1542,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 173.644855,
-   "end_time": "2026-07-04T00:28:36.768488+00:00",
+   "duration": 170.639167,
+   "end_time": "2026-07-04T01:09:07.401741+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "output_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "parameters": {},
-   "start_time": "2026-07-04T00:25:43.123633+00:00",
+   "start_time": "2026-07-04T01:06:16.762574+00:00",
    "version": "2.7.0"
   }
  },

--- a/doc/source/tutorials/potentials/scf_and_multipole.ipynb
+++ b/doc/source/tutorials/potentials/scf_and_multipole.ipynb
@@ -5,10 +5,10 @@
    "id": "a1b2c3d4e5f6a7b8",
    "metadata": {
     "papermill": {
-     "duration": 0.013229,
-     "end_time": "2026-07-03T16:21:45.874011+00:00",
+     "duration": 0.01353,
+     "end_time": "2026-07-04T00:25:45.397190+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:21:45.860782+00:00",
+     "start_time": "2026-07-04T00:25:45.383660+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
    "id": "b1c2d3e4f5a6b7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:21:45.899172Z",
-     "iopub.status.busy": "2026-07-03T16:21:45.898939Z",
-     "iopub.status.idle": "2026-07-03T16:21:50.564419Z",
-     "shell.execute_reply": "2026-07-03T16:21:50.563526Z"
+     "iopub.execute_input": "2026-07-04T00:25:45.423548Z",
+     "iopub.status.busy": "2026-07-04T00:25:45.423087Z",
+     "iopub.status.idle": "2026-07-04T00:25:50.229081Z",
+     "shell.execute_reply": "2026-07-04T00:25:50.227878Z"
     },
     "papermill": {
-     "duration": 4.695263,
-     "end_time": "2026-07-03T16:21:50.581098+00:00",
+     "duration": 4.821855,
+     "end_time": "2026-07-04T00:25:50.231131+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:21:45.885835+00:00",
+     "start_time": "2026-07-04T00:25:45.409276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,10 +74,10 @@
    "id": "c2d3e4f5a6b7c8d9",
    "metadata": {
     "papermill": {
-     "duration": 0.006541,
-     "end_time": "2026-07-03T16:21:50.614733+00:00",
+     "duration": 0.008401,
+     "end_time": "2026-07-04T00:25:50.248797+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:21:50.608192+00:00",
+     "start_time": "2026-07-04T00:25:50.240396+00:00",
      "status": "completed"
     },
     "tags": []
@@ -94,16 +94,16 @@
    "id": "d3e4f5a6b7c8d9e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:21:50.627794Z",
-     "iopub.status.busy": "2026-07-03T16:21:50.627147Z",
-     "iopub.status.idle": "2026-07-03T16:23:16.677451Z",
-     "shell.execute_reply": "2026-07-03T16:23:16.674535Z"
+     "iopub.execute_input": "2026-07-04T00:25:50.267561Z",
+     "iopub.status.busy": "2026-07-04T00:25:50.267057Z",
+     "iopub.status.idle": "2026-07-04T00:27:03.545802Z",
+     "shell.execute_reply": "2026-07-04T00:27:03.544408Z"
     },
     "papermill": {
-     "duration": 86.059397,
-     "end_time": "2026-07-03T16:23:16.679723+00:00",
+     "duration": 73.289928,
+     "end_time": "2026-07-04T00:27:03.547299+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:21:50.620326+00:00",
+     "start_time": "2026-07-04T00:25:50.257371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -122,10 +122,10 @@
    "id": "e4f5a6b7c8d9e0f1",
    "metadata": {
     "papermill": {
-     "duration": 0.011547,
-     "end_time": "2026-07-03T16:23:16.705444+00:00",
+     "duration": 0.0054,
+     "end_time": "2026-07-04T00:27:03.560188+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:16.693897+00:00",
+     "start_time": "2026-07-04T00:27:03.554788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -142,16 +142,16 @@
    "id": "f5a6b7c8d9e0f1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:16.732254Z",
-     "iopub.status.busy": "2026-07-03T16:23:16.731904Z",
-     "iopub.status.idle": "2026-07-03T16:23:31.976296Z",
-     "shell.execute_reply": "2026-07-03T16:23:31.974476Z"
+     "iopub.execute_input": "2026-07-04T00:27:03.573373Z",
+     "iopub.status.busy": "2026-07-04T00:27:03.573162Z",
+     "iopub.status.idle": "2026-07-04T00:27:16.771011Z",
+     "shell.execute_reply": "2026-07-04T00:27:16.769573Z"
     },
     "papermill": {
-     "duration": 15.261318,
-     "end_time": "2026-07-03T16:23:31.978724+00:00",
+     "duration": 13.206447,
+     "end_time": "2026-07-04T00:27:16.772117+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:16.717406+00:00",
+     "start_time": "2026-07-04T00:27:03.565670+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "a6b7c8d9e0f1a2b3",
    "metadata": {
     "papermill": {
-     "duration": 0.012838,
-     "end_time": "2026-07-03T16:23:32.005654+00:00",
+     "duration": 0.006129,
+     "end_time": "2026-07-04T00:27:16.785063+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:31.992816+00:00",
+     "start_time": "2026-07-04T00:27:16.778934+00:00",
      "status": "completed"
     },
     "tags": []
@@ -213,16 +213,16 @@
    "id": "b7c8d9e0f1a2b3c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:32.034304Z",
-     "iopub.status.busy": "2026-07-03T16:23:32.033956Z",
-     "iopub.status.idle": "2026-07-03T16:23:37.972673Z",
-     "shell.execute_reply": "2026-07-03T16:23:37.970240Z"
+     "iopub.execute_input": "2026-07-04T00:27:16.805641Z",
+     "iopub.status.busy": "2026-07-04T00:27:16.805421Z",
+     "iopub.status.idle": "2026-07-04T00:27:21.493449Z",
+     "shell.execute_reply": "2026-07-04T00:27:21.492091Z"
     },
     "papermill": {
-     "duration": 5.955462,
-     "end_time": "2026-07-03T16:23:37.974399+00:00",
+     "duration": 4.700656,
+     "end_time": "2026-07-04T00:27:21.494734+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:32.018937+00:00",
+     "start_time": "2026-07-04T00:27:16.794078+00:00",
      "status": "completed"
     },
     "tags": []
@@ -239,10 +239,10 @@
    "id": "c8d9e0f1a2b3c4d5",
    "metadata": {
     "papermill": {
-     "duration": 0.012703,
-     "end_time": "2026-07-03T16:23:38.008273+00:00",
+     "duration": 0.006073,
+     "end_time": "2026-07-04T00:27:21.507643+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:37.995570+00:00",
+     "start_time": "2026-07-04T00:27:21.501570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "d9e0f1a2b3c4d5e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:38.037144Z",
-     "iopub.status.busy": "2026-07-03T16:23:38.036893Z",
-     "iopub.status.idle": "2026-07-03T16:23:53.851295Z",
-     "shell.execute_reply": "2026-07-03T16:23:53.850118Z"
+     "iopub.execute_input": "2026-07-04T00:27:21.522136Z",
+     "iopub.status.busy": "2026-07-04T00:27:21.521892Z",
+     "iopub.status.idle": "2026-07-04T00:27:35.020576Z",
+     "shell.execute_reply": "2026-07-04T00:27:35.019209Z"
     },
     "papermill": {
-     "duration": 15.832596,
-     "end_time": "2026-07-03T16:23:53.854058+00:00",
+     "duration": 13.507981,
+     "end_time": "2026-07-04T00:27:35.021790+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:38.021462+00:00",
+     "start_time": "2026-07-04T00:27:21.513809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,10 +299,10 @@
    "id": "a2b3c4d5e6f7a8b9",
    "metadata": {
     "papermill": {
-     "duration": 0.014097,
-     "end_time": "2026-07-03T16:23:53.883692+00:00",
+     "duration": 0.006424,
+     "end_time": "2026-07-04T00:27:35.035257+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:53.869595+00:00",
+     "start_time": "2026-07-04T00:27:35.028833+00:00",
      "status": "completed"
     },
     "tags": []
@@ -319,16 +319,16 @@
    "id": "6c7c334f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:53.905163Z",
-     "iopub.status.busy": "2026-07-03T16:23:53.904761Z",
-     "iopub.status.idle": "2026-07-03T16:23:58.555336Z",
-     "shell.execute_reply": "2026-07-03T16:23:58.553921Z"
+     "iopub.execute_input": "2026-07-04T00:27:35.050102Z",
+     "iopub.status.busy": "2026-07-04T00:27:35.049891Z",
+     "iopub.status.idle": "2026-07-04T00:27:38.445967Z",
+     "shell.execute_reply": "2026-07-04T00:27:38.444245Z"
     },
     "papermill": {
-     "duration": 4.667596,
-     "end_time": "2026-07-03T16:23:58.560847+00:00",
+     "duration": 3.405101,
+     "end_time": "2026-07-04T00:27:38.447292+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:53.893251+00:00",
+     "start_time": "2026-07-04T00:27:35.042191+00:00",
      "status": "completed"
     },
     "tags": []
@@ -359,13 +359,141 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010196,
+     "end_time": "2026-07-04T00:27:38.469148+00:00",
+     "exception": false,
+     "start_time": "2026-07-04T00:27:38.458952+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## SCFPotential from an N-body representation\n",
+    "\n",
+    "An `SCFPotential` can also be built directly from a set of particles — for example\n",
+    "a snapshot from an N-body simulation — with `SCFPotential.from_nbody`, the N-body\n",
+    "analogue of `from_density`. It takes the particle positions (`pos`, of shape\n",
+    "`[3,n]` in rectangular coordinates) and their masses and evaluates the expansion\n",
+    "coefficients as a direct sum over the particles. The sum is accumulated in batches,\n",
+    "so building from a very large number of particles stays memory-bounded.\n",
+    "\n",
+    "To illustrate this, we draw an isotropic sample from a spherical NFW halo with\n",
+    "`isotropicNFWdf`, build an `SCFPotential` from the samples, and compare its rotation\n",
+    "curve to the `from_density` build of the same halo (the \"direct\" calculation) and to\n",
+    "the exact result. We compare the circular velocity rather than the density because,\n",
+    "like any basis-function expansion truncated at a modest order, the SCF reproduces\n",
+    "the potential and forces of a cuspy NFW profile much more accurately than its\n",
+    "density."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T00:27:38.491314Z",
+     "iopub.status.busy": "2026-07-04T00:27:38.491087Z",
+     "iopub.status.idle": "2026-07-04T00:27:40.288627Z",
+     "shell.execute_reply": "2026-07-04T00:27:40.286985Z"
+    },
+    "papermill": {
+     "duration": 1.810062,
+     "end_time": "2026-07-04T00:27:40.289622+00:00",
+     "exception": false,
+     "start_time": "2026-07-04T00:27:38.479560+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk0AAAGGCAYAAABmPbWyAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjDBJREFUeJzs3Xd0FFUbwOHfbnovBBISUui9Q0JAeqhKURSQjoKKogIW4FOqJQiIqKAoShMVLBQBDUoJNXSQ3hMCpJDe6+58f6wsrEkgYJLdkPc5Z8/Zmblz550Qdt/ce+delaIoCkIIIYQQ4p7Uxg5ACCGEEKI8kKRJCCGEEKIYJGkSQgghhCgGSZqEEEIIIYpBkiYhhBBCiGKQpEkIIYQQohgkaRJCCCGEKAZJmoQQQgghisHc2AE8CrRaLVFRUTg4OKBSqYwdjhBCCCEegKIopKWl4enpiVpddHuSJE0lICoqCm9vb2OHIYQQQoj/4Pr161SrVq3I45I0lQAHBwdA98N2dHQ0cjRCCCGEeBCpqal4e3vrv8+LIklTCbjdJefo6ChJkxBCCFFO3W+IjQwEF0IIIYQoBkmahBBCCCGKQZImIYQQQohikDFNQgghSoRGoyEvL8/YYQhRgIWFBWZmZv+5HkmahBBC/CeKohATE0NycrKxQxGiSM7Oznh4ePyn+RQlaRJCCPGf3E6YqlSpgq2trUzyK0yKoihkZmZy69YtAKpWrfrQdUnSJIQQ4qFpNBp9wlSpUiVjhyNEoWxsbAC4desWVapUeeiuOhkILoQQ4qHdHsNka2tr5EiEuLfbv6P/ZdydJE1CCCH+M+mSE6auJH5HJWkSQgghhCgGSZpEicvO07D7Yhx/nIo2dihCCCFEiZGkSZSofI2WUcsPMWLZIV5fe6LA8Vup2ZyPSS37wIQQ4i6dOnViwoQJRo9BpVKxZs0ag/0LFy7Ez89Pv71ixQpUKlWB1zfffMP58+dRqVQcOHDAoI42bdpgbW1Ndna2fl92djbW1tZ8++23pXpfjzJJmkSJ+vivixy4mghAbr6WnHyN/phWq/DmLyfp+/k+vtlzFa1WMVaYQghxX4qikJ+fX6rXsLa25t13373v4GRHR0eio6MNXkOHDqVevXp4eHgQGhqqL5uWlsaxY8eoXLmyQTIVFhZGTk4OXbp0Ka3beeRJ0iRKzM7zt/gy9Ip+e0iAj8HxdcdvsvtiHLkaLe9vOcfI5YeITc3+dzV35OfA9cOQn1v48Zy0kghbCFHBjBo1il27dvHpp5/qW20iIiIIDQ1FpVLxxx9/0LJlS6ysrNi7dy+jRo2if//+BnVMmDCBTp066be1Wi3BwcFUr14dGxsbmjZtyi+//HLfWJ599lmSk5NZunTpPcupVCo8PDwMXrcfo+/cubNB0rR3717q1KlDnz59DPaHhobi6+tL9erV7xuXKJzM0yRKRFRyFpN+OqHffqd3fcZ2qGFQpk/TqpyPTuWbveEA7LkUT5/P97J6TAB13B3uFDyzHo4sh+sHIT8b3rgIDu6GF9TkwdwaYFsJqtSH+n2g1XOldXtCiGJKSUnh1KlTRrt+48aNcXJyumeZTz/9lIsXL9KoUSNmz54NQOXKlYmIiABgypQpzJ8/nxo1auDi4lKs6wYHB7N69WqWLFlC7dq12b17N8OGDaNy5cp07NixyPMcHR155513mD17NiNHjsTOzq54N3qXzp07M3HiRPLz8zE3N2fnzp106tSJ9u3b88UXXzBz5kwAdu7cSefOnR+4fnGHJE3iP8vTaHn1x+MkZeqal4PquzOmfcG/ZKzMzXj3iQZ0qluFN34+QWxqDrfSchiweA8jfFLJjr5EbGwsHSxOMdDphP68SRPGozhWw9XVlUqVKuHm5kbDKuY01ORCWrTu5fdYWd2uEOIeTp06Rfv27Y12/T179vDYY/f+PHBycsLS0hJbW1s8PDwKHJ89ezbdunUr9jVzcnL48MMP2bZtG4GBgQDUqFGDvXv38tVXX90zaQJ4+eWX+fTTT1mwYAHTpk0rtExKSgr29vb6bXt7e2JiYgBd0pSRkcHhw4cJDAwkNDSUt956i8cee4yRI0eSnZ2NoigcOnSIMWPGFPu+REGSNIn/bP7WCxy9lgSAl7MNHz/TtMj5MG7cuMH5XSG4H9tOsnNLctzqk5ar8PkZM279spacG2fY56Fm4It3Phy2bFzHxQStQT1PNzDn52fuTKY3fc1RfC58Q+vWrWnYsCHm5v/8al/6C3zagJUDQghRHK1atXqg8pcvXyYzM7NAopWbm0vz5s3ve76VlRWzZ8/m1VdfZdy4cYWWcXBw4NixY/pttfrO6JpatWpRrVo1QkNDadiwIcePH6djx45UqVIFHx8fwsLCUBSFnJwcaWn6jyRpEv/JwasJfLX7KgAWZioWD22Bk62FQZno6Gi++OILNm7cyKlTp3Cxhlmdrfmu1hba3pxAhlcAaitbqgycRdz6D/k7/BgHb2g4HqNhZ0Q+kSnaAtf9O0bLW39l06iyGlsLFe/98iPwI6CbLr958+Y80b45k62/R2Vph6rFcGjzMjh7l/rPRAhRvv27i0ytVqMohg+u3D1wOz09HYAtW7bg5eVlUM7KyqpY1xw2bBjz58/n/fffN3hy7u4YatWqVeT5nTp1YufOnTRp0oTatWtTpUoVADp27MjOnTtRFIVatWrh7S2fgf+FySVNixcvZt68ecTExNC0aVM+//xz/P39Cy27bt06PvzwQy5fvkxeXh61a9fmjTfeYPjw4YDul/rdd9/l999/5+rVqzg5OREUFMScOXPw9PTU1+Pn58e1a9cM6g4ODmbKlCmld6OPiPXHb+rfT+5Zj2bezvrtq1evMnfuXJYvX05urm4wdytPNb8PsaWyne6vpMFRH7Mo521sarRCbWGNW0B/zJVEhu+2wNLSEgsLC7yrZ5CQkEBSUpL+g+tSopb5+wsfIJ6VlcX+/ft5wuYo6sesIDcNDnzBygOx1O/9Eq1atTL4K00IUXIaN27Mnj17jHr94rC0tESj0dy/ILrxTqdPnzbYd+LECSwsdH8gNmjQACsrKyIjI+/bFVcUtVpNcHAwTz31VJGtTffSuXNnXnvtNRo0aGAwQL1Dhw4sXboURVGklakEmFTStHbtWiZNmsSSJUsICAhg4cKF9OjRgwsXLuiz5ru5urryzjvvUK9ePSwtLdm8eTOjR4+mSpUq9OjRg8zMTI4dO8a0adNo2rQpSUlJvP766/Tt25cjR44Y1DV79mzGjh2r33ZwkO6c4ni/fyN6NvLgj1MxjGzrB8D58+d57733WLNmDVqtYSvR2TgtWXc9wftWBweaN23Emmg7crDgu/f+h7VF4X36Go2GlJQUoqOjuXTpEpcuXeLixYtcuHCBEydOkJZm+DRdnzp3fr1PxWoYtWQ5zFqOu7s7vXv35oknnqB79+4G4wQKo9UqZOZpyMzNJzNHg5lahberrLMlRGGcnJzuO6bIFPj5+XHw4EEiIiKwt7fH1dW1yLJdunRh3rx5rFq1isDAQFavXs3p06f1XW8ODg68+eabTJw4Ea1Wy2OPPUZKSgr79u3D0dGRkSNHFiumxx9/nICAAL766ivc3d3vf8Jdbo9rWrZsmcGTeB07dtSPY3r55ZcfqE5RCMWE+Pv7K6+88op+W6PRKJ6enkpwcHCx62jevLny7rvvFnn80KFDCqBcu3ZNv8/X11f55JNPHipmRVGUlJQUBVBSUlIeuo5HgVarVT777DPFyspKAQq86tevr0ybNk05v+4jRZnhqCiftVCUCyGKotUqefkaJSMnr9A6i0Oj0Shnz55VVq5cqYwfP15p0aKFYmWuUoY1sVAOj7VTnm9uUWhM/j42ymuDg5TVq1crkTHxyr5LccqyvVeVKb/+rTy5eK/SeEaI4jt5s8FrzMrDBa7/zZ6ryndhEcqFmFRFoylezEI8CrKyspSzZ88qWVlZxg7lgVy4cEFp06aNYmNjowBKeHi4snPnTgVQkpKSCpSfPn264u7urjg5OSkTJ05Uxo8fr3Ts2FF/XKvVKgsXLlTq1q2rWFhYKJUrV1Z69Oih7Nq1q8gYOnbsqLz++usG+/bv368Aiq+vr37f8uXLFScnp/vek6+vrwIo0dHRBvv9/PwUQImKirpvHY+ye/2uFvd7XKUoiknMMJibm4utrS2//PKLwXwYI0eOJDk5mY0bN97zfEVR2LFjB3379mXDhg1FPvmwbds2unfvTnJyMo6OjoDuL47s7Gzy8vLw8fFhyJAhTJw48c5g4vtITU3FycmJlJQUfZ0VTUxMDKNHjyYkJAQAtQra+5ix65qGNm3aMHXqVJ544gldt5iiwKlfoEE/MLcsss4rcelMXHuCj59pSm33B2/5S0pKYteuXezcuYMd27dz+szZAmX2jLalrbcZP57K5wvXN7npFnDfeocG+PDBk3e6ABRFoeX720jM0HUXOtta0MrXhe4NPOjV2AMHa4uiqhKi3MvOziY8PJzq1atjbW1t7HCEKNK9fleL+z1uMt1z8fHxaDSaAk2S7u7unD9/vsjzUlJS8PLyIicnBzMzM7744osiE6bs7GwmT57Ms88+a/BDee2112jRogWurq7s37+fqVOnEh0dzYIFCwqtJycnh5ycHP12amrFWxZEURT9E3KbN2/mueeeIy4uDoB23mZ82tOa5lXNON5yPi36jDF8mk6lgibP3LP+1Ow8xq46wtW4DB7/bC+D/b15uVMtPJyK/6Hs4uJC//799Un4tWvX+HFjCBsOXeZqYg4tL33JYz66/wJDm1igitnA/zBMmlytwKeKE/ZWFthYmmFnaUb72pUNylyJS9cnTADJmXlsO3eLbeduMW3jabo39OCpFl60r+WGuZmMpRJCiPLKZJKmh+Xg4MCJEydIT09n+/btTJo0iRo1ahgMhAPdoPCBAweiKApffvmlwbFJkybp3zdp0gRLS0tefPFFgoODC33yITg4mFmzZpXK/ZQXn2y7xPHIJCxuHGPF+xNQ/pm129NBRegoW8zVuiSpZcwPoDyvS5QeQEZOPlbmZgDkarSsCrvGmsPXGRrgw7hONaniULzkKSUrj6PXEjl4NZFdF+M4H1MNqlXDthp81CMGkrYCkKdReG9XFqnVNpN36yq58dfIi4/kWm4WNypXZujQoYwaNYqmTZsWuIZvJTvWv9yWwxGJHI5I4khEon7Oqpx8LZv+jmLT31FUcbBi2ajWNPK698R7QgghTNMj0z1325gxY7h+/Tpbt27V77udMF29epUdO3ZQqVKle9Zx5swZGjVqxPnz56lbt26B44W1NHl7e1eY7jmtVqH93J3cTM5C0Wq4+cUoNBm6eZqaNm1K6IT6OEf8rits6QDP/wnuDR74Opm5+SzacZkV+yPIzL3zlIuluZpGno7U9XCkQVUHhrXxNWjJ+i4sgitxGRwKT+RcTCpF/YZ/8GQjhnpEod02m8hsG2YccmD9+vUGA8rtLMDeUkVshq6SZs2aMWrUKIYOHYqbm1uh9SqKwt83Ulh/7Aa//R2lT6Dc7C3ZO7kL1hZmD/yzEMJUSfecKC9KonvOZPoKLC0tadmyJdu3b9fv02q1bN++XT/DanFotVqDhOZ2wnTp0iW2bdt234QJdI+SqtXqQp/YA928G46OjgaviuRAeAI3kzPxVcWQHX5cnzBNmjSJgwcP4tznfVBbQJNB8OqRh0qYAGwtzXm7Zz32vN2ZFzvUwNpC9+uam6/lWGQyPx6K5Ju94QUm0ly6J5wV+yM4G22YMKlU0MzbmUnd6rD51ccY4u8DvoGon/sdvxd/ZOXKlcTGxvLTTz/Rr18/LCwseL2NJVdft2dBDyuq2qs4ceIEEyZMwMvLi8GDB7Nt27YCTwiqVCqaeTszq18jDv4viK+Ht6RbA3fGtq9RIGHacymOtOx7L9QphBDCNJhU99ykSZMYOXIkrVq1wt/fn4ULF5KRkcHo0aMBGDFiBF5eXgQHBwO6brJWrVpRs2ZNcnJy+P333/nuu+/03W95eXk8/fTTHDt2jM2bN6PRaPTTzru6umJpaUlYWBgHDx6kc+fOODg4EBYWxsSJExk2bFix1xyqUDT57F0dzB+Wf+KliqfOed36cgsWLGDixIm6MlY1YeKZguvFPaRK9lZM7V2fMe1r8PXuK/x+KoabyVkA1C1kgHgle0siEzNRqaC+hyP+1V0JqO5K6+quuNkXMtGcSgXmuv02NjY888wzPPPMMyTHRGDzVRuslCwmtrGiR01zGn6RAehaRteuXcvatWvx8/Pj+eef5/nnn6dq1aoGVVuaq+ne0IPuDT0KTI53MzmLMSuP4GBtzhvd6zKwlTdm6gfrxhRCCFF2TCppGjRoEHFxcUyfPp2YmBiaNWtGSEiIfnB4ZGSkwaSEGRkZvPzyy9y4cQMbGxvq1avH6tWrGTRoEAA3b97kt99+A3TdKne7vaChlZUVa9asYebMmeTk5FC9enUmTpxoMM5J3HF5XlfeVk7o2yhHOB/HNTj4TsJ0WwklTHer7GDFO4834J3HG5CWncfF2DQsChlYPbVXffK1Whp6OuFk8/BPrjlHhICSpd8+79IVL6+j3Lx506BcREQE06ZNY9asWfTt25eXXnqJrl27FphA898tYh//eYGcfC056blMXXeKlfsjmP5EA9rWKrzbTwghhHGZzJim8qyiTDmwY8cOxk+dzo6eN/BQ6brkknHAefo1UD+C43S0Wji3EXbNg5xUePUYGpUZW7du5ZtvvmHTpk3k5+fTsLKaM3GGXXQ1a9bkxRdfZPTo0UWOfbqemMmcP86z5VS0wf4+TT2Z0adB4a1iQpgYGdMkyouSGNMkSVMJqAhJU1JSEk2aNCG33TiaVXdhheVczmhr0vXNFaicqhk7vNKl1ULqDXD2MdgdExPD9uUfMDRnFaER+Sw8kMumi/lo7/ofZWVlxaBBg3j55Zfx9/cvdCHjQ+GJvLf5LKdupuj3Odta8E7v+jzdslqRix8LYQokaRLlxSM1EFyYtvHjxxOVlI61b2MuKD50z3yfLrP+fPQTJgC1ukDCBODh4cFQv3gAOvmZ8+sgO3ycDbsDc3JyWLVqFW3atKF169YsX76crKwsgzL+1V3Z+Eo75j7dBOd/FjtOzszjrV9OMuzbg8SmZpfSjQkhhHgQkjSJop3fAqnRrFmzhh9++AHbWgGoVLpfmWc7NpFFb1NuwsUQ/aZZw76EnY3kgw8+wMenYJJ19OhRnnvuOby9vZkyZYrBItFqtYqBrbzZNqkj/ZrdWUz6alwGdlYmNfRQCPEfZWZmMmDAABwdHVGpVCQnJxs7pHtasWIFzs7OZXa9iIgIVCrd08qmpoJ/64ki5aTBhnHkLu/L5NdfAsCisp/+8BPNvI0UmAlx8oKXD0Dz4WBuDQEv4eHhwf/+9z+uXr3Kb7/9Ro8ePXjV35LnmlvwTyMSCQkJfPTRR9SoUYMnn3ySnTt36p+sc7O34tPBzVk+ujVezja8378R9pI0CVHi4uLiGDduHD4+PlhZWeHh4UGPHj3Yt2+fQbnjx4/zzDPP4O7ujrW1NbVr12bs2LFcvHgRuPMF/+/XsGHDirz2ypUr2bNnD/v37yc6OhonJ5nw9m7e3t5ER0fTqFEjAEJDQ00muZSkSRTu2HeQnYJl0kVW9crD0QqStn3F01Ynea9/IxrLrNY6letCv0Uw6Rz43JlPzMzMjD59+hCyaT2f9KvMt31tiH7DkdcC7qy1p9Vq2bBhA126dKFJkyZ8/fXXZGZmAtC5bhW2v9GRrvUNn0KMTc3mt7+jCkxfIIR4MAMGDOD48eOsXLmSixcv8ttvv9GpUycSEhL0ZTZv3kybNm3Iycnh+++/59y5c6xevRonJyemTZtmUN+2bduIjo7WvxYvXlzkta9cuUL9+vVp1KgRHh4ehY5bzM3NLeTMisHMzAwPD49ir/9apkpq9eCKrLirI5cb+bmKsqChosxwVJQZjkrUJHvF0gzF399fyc3NNXZ05cvx7/U/R2WGo7J94UtK48aNFaDQl4uLi/LWW28pERERBarSarXKyGUHFd/Jm5XxPxxTkjPl30IY371WjjdVSUlJCqCEhoYWWSYjI0Nxc3NT+vfvX2QdiqIo4eHhCqAcP368WNfu2LGjwf/5jh07KoqiKL6+vsrs2bOV4cOHKw4ODsrIkSMVRVGUX375RWnQoIFiaWmp+Pr6KvPnzzeoz9fXV3nvvfeU4cOHK3Z2doqPj4+yceNG5datW0rfvn0VOzs7pXHjxsrhw4eLFZ+iKMry5csVb29vxcbGRunfv78yf/58xcnJyaDMhg0blObNmytWVlZK9erVlZkzZyp5eXn644CydOlSpX///oqNjY1Sq1YtZePGjfrjiYmJypAhQxQ3NzfF2tpaqVWrlrJs2bICP9Pb7+9+jRw5Ulm5cqXi6uqqZGdnG8TVr18/ZdiwYYXe171+V4v7PS5JUwl45JImrVZJObZe2THKQVFmOCqT21kqtra2yoULF4wdWflz8GtFmeOrS5o+8FKUnAxFq9UqoaGhytNPP62YmZkp5mqUUc0sFCerOx8KarVaeeqpp5Rdu3YpWq1WURRF2XMxTvGdvFn/ahu8XTkSkWDc+xMVXnlMmvLy8hR7e3tlwoQJBb50b1u3bp0CKPv3779nXQ+aNCUkJChjx45VAgMDlejoaCUhQfd/2NfXV3F0dFTmz5+vXL58Wbl8+bJy5MgRRa1WK7Nnz1YuXLigLF++XLGxsVGWL1+ur8/X11dxdXVVlixZoly8eFEZN26c4ujoqPTs2VP56aeflAsXLij9+/dX6tevr/8suZcDBw4oarVa+eijj5QLFy4on376qeLs7GyQNO3evVtxdHRUVqxYoVy5ckX5888/FT8/P2XmzJn6MoBSrVo15YcfflAuXbqkvPbaa4q9vb3+fl955RWlWbNmyuHDh5Xw8HDlr7/+Un777bcCP9P8/Hzl119/VQDlwoULSnR0tJKcnKxkZmYqTk5Oyk8//aS/ZmxsrGJubq7s2LGj0HsriaRJphwoAY/ilAPvvvsuH3zwAc091FxN0vL+/M8ZP368scMqn/Ky4dwmyIyHNuMMDl2/fp3tS6YwymIz2fkKWy7m88af2VxLufPfslmzZrz++usMHjyYvy4k8s76U6Rm5wOgVsHrXevwSueamBcy0acQpa2ox7i/2XOVb/aE3/f8Rl6OfDOytcG+MSsPc/pm6n3PHdO+OmPa13jwoIFff/2VsWPHkpWVRYsWLejYsSODBw+mSZMmAMydO5fJkyeTmJh4z9UhIiIiqF69OjY2NgYPx+zZs4fmzZsXes6ECRM4ceIEoaGh+n1+fn40b96c9evX6/cNHTqUuLg4/vzzT/2+t99+my1btnDmzBn9ee3bt+e7774DdFOhVK1alWnTpjF79mwADhw4QGBgINHR0Xh4eNzz5zJkyBBSUlLYsmWLft/gwYMJCQnRjykKCgqia9euTJ06VV9m9erVvP3220RFRQG6yXzfffdd3nvvPUA3GbW9vT1//PEHPXv2pG/fvri5ubFs2bIif6bHjx+nWbNmhIaG0rlzZ5KSkgwGpL/88stERETw+++6tU4XLFjA4sWLuXz5cqFdnjLlgCgVCQkJfPrppwAcj9Hi2qI367IbMeeP81y+lW7k6MohC2to8kyBhAl0Ax5HtbABwNpcRZ+6FiRnG/4dc+LECUaPHo2vry9H1n3FqiH1ae2n+xDXKvDJtos8u/SAfmkZIUxBWnY+ManZ930lZBQcu5OQkVusc9P++ePhYQwYMICoqCh+++03evbsSWhoKC1atGDFihUADzxucO3atZw4cUL/atDgwdfcbNWqlcH2uXPnaNeuncG+du3acenSJTSaO4uY3070AP0KGo0bNy6w79atW/eN4dy5cwQEBBjs+/f6r3///TezZ8/G3t5e/xo7dizR0dH6cZn/jsvOzg5HR0d9DOPGjWPNmjU0a9aMt99+m/379983tn8bO3Ysf/75p36VhhUrVjBq1KhSndtOkiZRwMcff0x6+p3kqGW/0VyNz2DJritcjE0zYmSPIK0GIg/oNy0a9GLj1lCeeuopg79aG1VR09IxkeD3Z+PfqBY2YV8zuKG9fq26wxFJ9P50DyGnY8r8FoQojIO1OR6O1vd9VbKzLHBuJTvLYp3rYP3fBgpbW1vTrVs3pk2bxv79+xk1ahQzZswAoE6dOgCcP3++WHV5e3tTq1Yt/cvK6sFn9Lezs3vgcwAsLO7MD3c7YShs378XF39Y6enpzJo1yyBJPHXqFJcuXTJowbk7httx3I6hV69eXLt2jYkTJxIVFUXXrl158803HyiO5s2b07RpU1atWsXRo0c5c+YMo0aN+s/3dy8mODRdGFN8fDyff/65frtW7TpEapyBHCzN1HSoU9losT2S1Gbw6jG4sh1O/oSqYX86NuhIx44diYiIYPHixSxdupRX/XN4oaUlSVkKv5zL44VVK2HVSvx7Dya35VCSclWkZOXx0uqjrH+5Lc19ZLFpYVxj2td46K6zf3fXlZUGDRqwYcMGALp3746bmxtz58416DK7LTk5udTnLqpfv36BKRD27dtHnTp1MDMrnaWr6tevz8GDBw32HThwwGC7RYsWXLhwgVq1av2na1WuXJmRI0cycuRI2rdvz1tvvcX8+fMLlLO01CXWd7eu3TZmzBgWLlzIzZs3CQoKwtu7dKfDkZYmcceuufy54CWyMu60Mj335gxiU3MAaFerkswZVBrMLaFuL3hmOTTop9/t5+fHvHnzuHEtnOGtnAFwsVHh43jnv+2h39fw99zBcP04AE80qiwJkxD3kZCQQJcuXVi9ejUnT54kPDycn3/+mblz59Kvn+7/oJ2dHd988w1btmyhb9++bNu2jYiICI4cOcLbb7/NSy+9VOpxvvHGG2zfvp333nuPixcvsnLlShYtWvTALTIP4rXXXiMkJIT58+dz6dIlFi1aREhIiEGZ6dOns2rVKmbNmsWZM2c4d+4ca9as4d133y32daZPn87GjRu5fPkyZ86cYfPmzdSvX7/Qsr6+vqhUKjZv3kxcXJxBT8iQIUO4ceMGS5cu5bnnnnu4m34AkjQJneTrKKFzGGL5F5deteeJOubUqVMHtfedgYzdG957AKEoHfaZkdio8vTb51S1DY4rORlc+2EaXU++Q9wnvZj02itcunSprMMUotywt7cnICCATz75hA4dOtCoUSOmTZvG2LFjWbRokb5cv3792L9/PxYWFgwZMoR69erx7LPPkpKSwvvvv1/qcbZo0YKffvqJNWvW0KhRI6ZPn87s2bNLtQuqTZs2LF26lE8//ZSmTZvy559/FkiGevTowebNm/nzzz9p3bo1bdq04ZNPPsHX17fY17G0tGTq1Kk0adKEDh06YGZmxpo1awot6+XlxaxZs5gyZQru7u4GDyU5OTkxYMAA7O3t6d+//0Pd84OQp+dKwCPx9NzuebDjzodA0KoMRr+3khWx1bh0Kx2VCg7+rytVHGRBTqPISoILf8CZDdD/S85ExPDZZ5+xatUqsrOzUQE3Jtnj6aAmNUfho325nHTqRvshr3FT5cYHTzaWVkJRKmTBXmFsXbt2pWHDhnz22Wf3LCdPz4kSkxV1Z7DjpQQNN61qERDUh0v/PC3XwsdFEiZjsnGBZkNg6E9gV4mGDRvy1VdfcePGDT788EP6tXDH00H339nRSkVqjpY/dh9i0cFENp6IosP7Wzhy9f5PzgghRHmRlJTE+vXrCQ0N5ZVXXimTa0rSJACYd9GXyvPSGPBTJu/uzGH69BlsPXvnS7Z7A/d7nC2MpVKlSkydOpWfv3gfjUrXkqRVFH49m4+Fqyf889RMYp45A77cz8ZpjxN/cC1o8u5VrRDiEdWrVy+DqQLufn344YfGDu+BNG/enFGjRvHRRx9Rt27dMrmmdM+VgPLePacoCrVr1+bKlSsA1K5dm0PHT9L5490kZeq+XEPf7ISf28M9DivKSHYqXAzhxvFtvPlHKr/88gsqezfc+k7GyrMOjVVX2WSlG5uQqrEkJnAmdXqXzV9n4tEl3XPly82bN8nKKnxON1dXV1xdXcs4orJTEt1zMshBcODAAX3CBDBq1CiiUnJxsLYgKTOPfs08JWEqD6wdoclAqjUZyJqRutnGFy9ezNfffEh24z480S5bX9TRLJeAyUtw/eAHJkyYwJNPPmmai2MKIUqUl5eXsUMo16R7TrBq1SqD7aFDh9LA05Ftkzoyu19D3uhWNs2eomR5e3szZ84crl+LIHiQP86xx8hTdP/lT2hrkvX4HM5a1WPgs0OoUaMGH330EcnhJyB0DiReNW7wQghhgqR7rgSU5+65nJwcqlatSlJSEgCdOnVi586dRo5KlAatVstvG9dxbM9mYq192ar1R5ORTNSy8WgzkwF4r6sd7z72z6R51VrD0J91g9CFKIJ0z4nyQp6eE//Z3l+/4s3mmXSrYYadBQwfPtzYIYlSolar6f/k08ycvxzflr1QKxrSd3ylT5gABt01t9y1i6fY9NeeQmfhFUKIikiSpgouetcK/tfeij+H25E02QGNR10uyfpyjzS1WsX/BrQh7J3uXN27kXnz5uHr60sVOxX5d30kfBWWTN9+/ahTpw6ffPKJfoVzIvZB1HGQRmohRAUj3XMloDx2z+VrtPz1dwQWX7YlyEv3JEVUngNtNV+hVsELHWoypVc9I0cpykp+fj4bN/7GtJBwfB019I5eyvzfrxCZcufjwc7OjpEjRzK/7jFsEs9ClYbQZhy0kNbJiky650R5Id1z4qF9+Pt5xv10FseqPmgV3Vw++9QtAdAq4OUsH34Vibm5Oarq/mRWqsc5i4Z87LOQnK7voLZ10pfJyMhgx09LdAkTwK0zKLFnjRSxEOVXZmYmAwYMwNHREZVKdacVt5wYNWpUqSxZEhoaavI/D0maKqDY1GxWH7gGqBiYO4NmOV8xJvcNVuUHAeBXyZbB/j7GDVKUuc51q9C3qad+27p2G2q/tgKvgMfvlPEzXFm997s/sGDBgoIfchnxpRmqEP9ZXFwc48aNw8fHBysrKzw8POjRowf79u0zKHf8+HGeeeYZ3N3dsba2pnbt2owdO5aLFy8CEBERgUqlKvAaNmxYkddeuXIle/bsYf/+/URHR+Pk5FRkWWFaJGmqgL4/cI1cjRaA7MhTxFw8xeH8OlyzqoOLrQUfPtUYCzP51ahoXOws+ezZ5nwxtAWudpYAZCsWmHcaxxPBGwjo2I0vj+RR+/N0PtiTw4bzeYQci+SNN97Ay8uLl156idOnT0NaLHxcD1b1gzPrIT/XyHcmREEDBgzg+PHjrFy5kosXL/Lbb7/RqVMnEhIS9GU2b95MmzZtyMnJ4fvvv+fcuXOsXr0aJycnpk2bZlDftm3biI6O1r8WL15c5LWvXLlC/fr1adSoER4eHqj+mbn/brm58v/GJCniP0tJSVEAJSUlxdihFEtmTr4y8J1FiueYLxUzOxcFUI4ePaooiqJotVojRydMwa3UbGXsysOK7+TN+leTmVuVeb/sUUaMHKlYWloqQKGvJcPrKcoMxzuvS38Z+3ZEKcrKylLOnj2rZGVlGTuUYktKSlIAJTQ0tMgyGRkZipubm9K/f/8i61AURQkPD1cA5fjx48W6dseOHQ3+v3Ts2FFRFEXx9fVVZs+erQwfPlxxcHBQRo4cqSiKovzyyy9KgwYNFEtLS8XX11eZP3++QX2+vr7Ke++9pwwfPlyxs7NTfHx8lI0bNyq3bt1S+vbtq9jZ2SmNGzdWDh8+XKz4li9frjg5OSkhISFKvXr1FDs7O6VHjx5KVFSUvszIkSOVfv36KTNnzlTc3NwUBwcH5cUXX1RycnL0ZbKzs5VXX31VqVy5smJlZaW0a9dOOXTokMG1tmzZotSuXVuxtrZWOnXqpCxfvlwBlKSkJCU9PV1xcHBQfv75Z4Nz1q9fr9ja2iqpqanFup+73et3tbjf49KcUAFZW6g58uMCor4ZhyYjiQYNGtC8eXOAQv/iERVPZQcrvhrekk8HN9O3OqVk5bHocArjpn/M9evXef/99wudXbiT43X9+2QcueXQqMziFiYk+TpcC9O9Ig8UXiYz8U6Za2GQm1GwTH6uYZn0IhaeTostdmi311rbsGEDOTk5hZbZunUr8fHxvP3224Ued3Z2Lvb17rZu3TrGjh1LYGAg0dHRrFu3Tn9s/vz5NG3alOPHjzNt2jSOHj3KwIEDGTx4MKdOnWLmzJlMmzaNFStWGNT5ySef0K5dO44fP87jjz/O8OHDGTFiBMOGDePYsWPUrFmTESNGoBTzua/MzEzmz5/Pd999x+7du4mMjOTNN980KLN9+3bOnTtHaGgoP/74I+vWrWPWrFn642+//Ta//vorK1eu5NixY9SqVYsePXqQmJgI6FYseOqpp+jTpw8nTpxgzJgxTJkyRX++nZ0dgwcPZvny5QbXXb58OU8//TQODg7FupcS98CpWilbtGiR4uvrq1hZWSn+/v7KwYMHiyz766+/Ki1btlScnJwUW1tbpWnTpsqqVasMymi1WmXatGmKh4eHYm1trXTt2lW5ePGiQZmEhARlyJAhioODg+Lk5KQ899xzSlpaWrFjLm8tTWfOnDH4Syc4ONjYIQkTFp+Wrbz24zHFd/Jm5aXvjhgcy83NVX766SelQ4cO+t+nAC8zZWkfayV9qoPyv/aWiqWlpTJ06FBl//79d1oyz/+uKNtmK0rSNSPckShJRf71vuPDO62Ns90KP/n8H4atkjFnCpZJjTYsc2x14XUdWf5Acf/yyy+Ki4uLYm1trbRt21aZOnWq8vfff+uPf/TRRwqgJCYm3rOe2y1NNjY2ip2dnf517NixIs95/fXX9S1Mt/n6+hZo1RoyZIjSrVs3g31vvfWW0qBBA4Pzhg0bpt+Ojo5WAGXatGn6fWFhYQqgREdH3/NeFEXRt/ZcvnxZv2/x4sWKu7u7fnvkyJGKq6urkpGRod/35ZdfKvb29opGo1HS09MVCwsL5fvvv9cfz83NVTw9PZW5c+cqiqIoU6dONbgPRVGUyZMn61uaFEVRDh48qJiZmelbuWJjYxVzc/N7thDeyyPX0rR27VomTZrEjBkzOHbsGE2bNqVHjx7culX4Xxaurq688847hIWFcfLkSUaPHs3o0aPZunWrvszcuXP57LPPWLJkCQcPHsTOzo4ePXqQnX1nHa6hQ4dy5swZ/vrrLzZv3szu3bt54YUXSv1+y5pGq/srY/v27QxuZM6cICt61TKnf6+uRo5MmLJK9lZ8Org5y0a1Yla/hgbHzM3Nqd+2O7t27eLEiROMHTuWk4mWjN2UTdWP01h0KJfc3Fy+//572rZtS8uWLfn222/R7P0U9syHT5vCL8/LnE+izA0YMICoqCh+++03evbsSWhoKC1atNC34igP+Du5du1aTpw4oX81aNDggWNq1aqVwfa5c+do166dwb527dpx6dIlg0lnmzRpon/v7u4OQOPGjQvsK+q79N9sbW2pWbOmfrtq1aoFzm3atCm2trb67cDAQNLT07l+/TpXrlwhLy/PIHYLCwv8/f05d+6c/t4CAgIM6gwMDDTY9vf3p2HDhqxcuRKA1atX4+vrS4cOHYp1H6XBpJKmBQsWMHbsWEaPHk2DBg1YsmQJtra2LFu2rNDynTp14sknn6R+/frUrFmT119/nSZNmrB3715A90u/cOFC3n33Xfr160eTJk1YtWoVUVFRbNiwAdD9w4WEhPDNN98QEBDAY489xueff86aNWuIiooqq1svdYqi0G/xXib/cpIte44wtLEFk9tZ8ftQW+qGjjF2eKIc6FLPnSoOhlNRbDoZzROf72Xi2hNUrV6Xr7/+mhs3bvDxxx9TuVoNUv/V83H8+HHmT3kBs+thuh2KFqzsQbqFhRFYW1vTrVs3pk2bxv79+xk1ahQzZswAoE6dOgCcP3++WHV5e3tTq1Yt/cvKyuqB47Gze7iF0S0sLPTvbw+xKGyfVqt94Ppun/+gSWRJGTNmjD6RXb58OaNHjzbqMBKTSZpyc3M5evQoQUFB+n1qtZqgoCDCwsLue76iKGzfvp0LFy7os9Dw8HBiYmIM6nRyciIgIEBfZ1hYGM7OzgYZflBQEGq1moMHD5bU7Rld6IU4Tt9MZe2R65y1aUR7nzsr2qt8Au9xphCFS8vO473Nunma1h+/Sef5oXwRehlbBycmTZrEpUuX2LJlC7179zb4kHOzVXHm1p2/kl/69gjr168nPz/f8AIpN8rkPkQpaT4MRofoXiM3FV7G2/9OmdEh4OJbsIyNq2GZ2t0Kr6tOr/8ccoMGDcjI0I2r6t69O25ubsydO7fQsmUxl1D9+vULTIGwb98+6tSpg5mZWRFnlY2///6brKws/faBAwewt7fH29ubmjVrYmlpaRB7Xl4ehw8f1rfA1a9fn0OHDhnUeeBAwbFvw4YN49q1a3z22WecPXuWkSNHltIdFY/5/YuUjfj4eDQajb4Z8TZ3d/d7ZvopKSl4eXmRk5ODmZkZX3zxBd266f5TxcTE6Ov4d523j8XExFClShWD4+bm5ri6uurL/FtOTo7B4MHU1NRi3qXxLNl1Rf/e4vgabthpcbBSo1apwLetESMT5ZWdpTkTgmozN+QCKVl5ZORqmBtygTWHrvPO4/Xp3sCd3r1707t3b65cucKSJUtYtmwZeyMTafRlBu19zAiqYc5Xofv5auNTeHl58cILLzBmzBg8na3h85bg3gj8X4CG/cH8wf9yF0bk7K173YutK/je5482c8v7lwFwcL9/mX8kJCTwzDPP8Nxzz9GkSRMcHBw4cuQIc+fOpV+/foCu1eebb77hmWeeoW/fvrz22mvUqlWL+Ph4fvrpJyIjI1mzZk2xr/kw3njjDVq3bs17773HoEGDCAsLY9GiRXzxxRelet3iyM3N5fnnn+fdd98lIiKCGTNmMH78eNRqNXZ2dowbN4633noLV1dXfHx8mDt3LpmZmTz//PMAvPTSS3z88ce89dZbjBkzhqNHjxYY4A7g4uLCU089xVtvvUX37t2pVq1aGd+pIZNpaXpYDg4OnDhxgsOHD/PBBx8wadIkQkNDS/WawcHBODk56V/e3vf5YDCyc9GpHAzXPbHgrM7m6qnjNPoyA6c5acT0/Bbq9DRyhKI8UqtVDA3wZeebnRjexhf1P41JkYmZvPjdUQZ/fYAT15MBqFmzJvPmzePGjRssX76cVq1asSdSw4zQO3983Lx5kxkzZuDj48PKid0hPxtuHoH1L8DFrYVEIMTDsbe3JyAggE8++YQOHTrQqFEjpk2bxtixY1m0aJG+XL9+/di/fz8WFhYMGTKEevXq8eyzz5KSksL7779f6nG2aNGCn376iTVr1tCoUSOmT5/O7NmzGTVqVKlf+366du1K7dq16dChA4MGDaJv377MnDlTf3zOnDkMGDCA4cOH06JFCy5fvszWrVtxcXEBwMfHh19//ZUNGzbQtGlTlixZwocffljotZ5//nlyc3N57rnnyuLW7slk1p7Lzc3F1taWX375xWB69pEjR5KcnMzGjRuLVc+YMWO4fv06W7du5erVq9SsWZPjx4/TrFkzfZmOHTvSrFkzPv30U5YtW8Ybb7xBUlKS/nh+fj7W1tb8/PPPPPnkkwWuUVhLk7e3t8muPbfh+E0mrD0BQKUbezj2/UeA7ovs8uXLRoxMPErOx6Qye9NZ9l9JMNjfp6knnw5qhlptOA7h8OHDfPnll/z4448GD2YAXBxvR+1Kuu6HNJUjuS8foVLl4rckiLIja8+J0vbdd98xceJEoqKisLS0fOh6Hqm15ywtLWnZsiXbt2/X79NqtWzfvr3AiPp70Wq1+oSmevXqeHh4GNSZmprKwYMH9XUGBgaSnJzM0aNH9WV27NiBVqstMLL/NisrKxwdHQ1epiw29c4X0pWTd/qQu3aVp+ZEyann4cj3YwJYMqwl1d3uDGi1NlcXSJgAWrduzbJly7h58yYLFiygdu3a+mNP/JjFpwdzSM1RmLP9Fl7evgwbNoy9e/feGZAasQ+OrYK8rAJ1CyHKv8zMTK5cucKcOXN48cUX/1PCVGIearKDUrJmzRrFyspKWbFihXL27FnlhRdeUJydnZWYmBhFURRl+PDhypQpU/TlP/zwQ+XPP/9Urly5opw9e1aZP3++Ym5urixdulRfZs6cOYqzs7OyceNG5eTJk0q/fv2U6tWrG8zT0LNnT6V58+bKwYMHlb179yq1a9dWnn322WLHberzNM367Yx+Vmcrrwb6+XTWrl1r7NDEIyo3X6Os2h+utA3ertxMyjQ4lpWbr8SmFpwnRaPRKH/99ZcyYMAAxczMTAEUe0sUB0vDGccbNGigfPrpp0rut4/r5u2Z46so298vozsT/1YeZwSvyHr27Gkwn9Tdrw8++MDY4RmYMWOGYm5urnTp0uWB5k4sSknM02QyA8EBBg0aRFxcHNOnTycmJoZmzZoREhKiH8gdGRmJWn2ncSwjI4OXX36ZGzduYGNjQ7169Vi9ejWDBg3Sl3n77bfJyMjghRdeIDk5mccee4yQkBCDprnvv/+e8ePH07VrV9RqNQMGDOCzzz4ruxsvZbfS7rQ0adLvdJ107tzZGOGICsDCTM3wQD+GBPhi9q9Wph8PRfJRyHlGBPrxQocauNnrBnjfflo2KCiIqKgovv32W/0UBnc7e/YsX8yeyGvj7XU7spJQUiKRSQuEuL9vvvnG4Km3u7m6upZxNPc2c+ZMg3FSpsBkxjSVZ8XtCzWWgUvCOBShGwjebNPTBFRVuGXhzSdrd4Gj533OFqLkZOdpaD93J3Fpui50aws1g1p5M7ZDDaq52BYon5+fzx9//MGSJUv4448/9F1zfeuas7yfDa42ulRp4DZ3Hhs4nmHDhhl+8Gu1oDaZUQiPJBnTJMqLR2pMkyg9sf+0NGmz0xlQB6Y+ZsUnAbdgSXuZiVmUqVyNlr5NPbEy1330ZOdpWRl2jY7zQpm09gQXY9MMypubm9OnTx+2bNlCeHg477zzDh4eHvx2IZ9qC9IY81sW3x7P5ed9l3j99dfx9PRk+PDh7N69GyU7FT5vDttmyZxPZUD+/hamriR+R6WlqQSYekvTvsvxbNkZxudffMnhdrup5/bPpGi1u8PQn40bnKiQYlOz+Xr3VX44GElWnsbgWKe6lXmuXXXa13YrdObfvLw8Nm/ezNdff83WrVuL/CCc/bgX01r9k4SpzHQTLPq1K7SseHgajYaLFy9SpUoVKlWqZOxwhChSQkICt27dKnRy0OJ+j5vUmCZROtrVcuOnz7eRc/IPsvztyNcqmKtV4NXS2KGJCsrd0ZppTzRgfOdarNgfwcqwCJIz8wDd7PWHwxM58L+uOFhbFDjXwsKCJ598kieffJKIiAi++eYbli1bRnR0tL6MChhUPRnQfTAm5Zpx8Ewi3bw1Rp9J+VFjZmaGs7Ozfm0yW1tboy5zIcS/KYpCZmYmt27dwtnZ+T99BkhLUwkw9ZYmgEaNGnHmzBkAurYPZNt3H4ODB7hWN3JkQkBGTj4/Hopk+b4IbiZnMbqdHzP6GC4OnJCeQyX7wmcFz8/PZ8uWLSxdupQ//vgDNVpGN7PgtQBLGlUxY/rObN7bnUu1atX0C3tXr14d4i/r1r5z8CiL23xkKYpCTExMmSwtIsTDcnZ2xsPDo9Ckvrjf45I0lQBTT5piYmKoWrWqfnvatGnMnj3biBEJUbh8jZa/zsbSyMsJb9c7A8OTMnJpE7ydlr4uDGvjS1B9dyzNCx+Sef36dZYvX863335LZGQkXaqbcSpWS1ym4Udd165dWdkjG8+sc6gaPgkB46CatL7+FxqNhry8PGOHIUQBFhYW92xhkqSpDJly0nQ9MZMVv2xi9tQ30KTGoeTnEhoaSseOHY0dmhDF9s2eq7y/5Zx+29XOkv7NvHimVTXqVy38/5xGo2Hbtm188803bNy4scCXeU0XFRdftdetvwgkenXBZcw66VoSogKSp+cEAFtORfPtVXu8xn6FTc3W2NjY0KZNG2OHJcQDcbG1xLfSnZanxIxclu0Lp9ene3ji8z2s2BdOfHqOwTlmZmb06NGDn3/+mZs3b/Lxxx9Tv359/fEhjS30CRNA71mbaN68OZ9++inx8fGlf1NCiHJHWppKgCm3NM3adIbl+yIAiFn9JoG1Pdi5c6dxgxLiIWi1CvuuxLP28HX+PBNLrkZrcNxMrWJM++pM7VW/iBp0Y28OHDjAt99+y9o1a2jrkc1r/pa42app822GvpyFhQV9+vRhzIhn6aHsRN1qNFRrVWr3JoQwLnl6TgAQk6Kb+bWl6gJtm92iUv26kHQNnH1AuiFEOaJWq2hfuzLta1cmOTOX3/6O4ucjNzh1MwUAjVahmrONwTlarUJ2vgZbS91HnUqlIjAwkMDAQBYuXMjPP//MnGXLOBy21+C8vLw81q1bR+Vrm+j1hA2cWE2mS31sh/8oD08IUYFJS1MJMOWWpscXbOPMrRzeMP+JV8036Haq1DDluu6pISHKufMxqWw4HsXvp6JZ/3JbgyfsDl5NYOTyQ3SuW4XejavSqW7lQqcxuHjxIsuXL2fVqlVERUXp958eZ0fDKrrBo3EZWp7cU5dnh49m8ODBMieREI8QGQhehkw5aWoxfROJuWpWmr1PR4uzup1VGsDLYcYNTIgSpihKgUHcMzaeZmXYNf22hZmKwJpudGvgTrf67ng4GS6lkJ+fz19//cXy5cvZtXUjy58wo3dtXZL1/u4cpu3UjZu63X03cuRIenV5DAs7F2m5FaIck+45gaIopOTqcmKVJpc8tYKFmQq8Whg5MiFKXmFPvTlYW+BqZ0liRi4AeRqF3Rfj2H0xjmkbTtPIy5EudavQo5EHDT2dMDc3p1evXvTq1YuEhAR+/PFHnvp5KR1sLrDkSK6+3tvdd+vWrWPzcCea+TiT32I0Po+/gUpacIV4ZElLUwkw1ZamlMw8ms7+E4Cs8GN4X/iJI5uXg4UNuDe8z9lCPBryNVoOhSfy59lY/joby83kgiu8FzaZ5t1Onz7NypUr+e6774iNjdXv93FScfU1e8zUuoRtQ4QtF+pPYOjQoVSrVq3kb0YIUSpkygHBrX8W6gXQpCdSv3Ez3RNAkjCJCsTcTE3bWm7M7NuQvZM7s+W1x3i9a20aet75YOxSr4rBOTeTs3j8sz3M+eM8+y/HU6tufebNm8eNGzfYsmULAwcOxMrKinGtLPUJE8DHO+OYMmUKPj4+dO3alRUrVpCWZrgIsRCi/JKWphJgqi1Nm49cZvwvFwBICfuJd/o05s033zRyVEKYjtjUbHaev8WTLbywMr8zW/CaQ5FMWXdKv21lrqaVnwtta7rRtmYlGns5kZaawu8/LEE5tJSe7nFEpSk0XZJR4BqVHG34bFgjqnSfSMfeT2NhUXAguhDCuGRMk+D0hSsomjxUZhZo0hNp2rSpsUMSwqS4O1oz2N+nwP6r8YbJT06+ln2XE9h3OQEAeytzWvu50LnFs4x4ZSpXLpwh9IevqF59M+Hh4Qbn9q+Zz5DKF8g98iK/rX2Zo24D6Dd0LP7+/jL7uBDljLQ0lQBTbWn6+OOPefPNN1HbOKJo8oi5HkGVKlXuf6IQgvj0HPZeimff5Xj2X0kodCxU57qVWT7aX7+tKAo//r6LHb+t5def1pCcnMyxF+xoXlXXihWfqaXagnRyNFCrVi2GDBnC0KFDqVOnTpndlxCiIJlyoAyZatI0fPhw4g+s4ekG5hxNtOeL30+Dg7uxwxKi3FEUhWsJmey/ksD+K/EcuJpIfHoOU3vV48WONfXl8jVamsz6k3ytQmNPB7yzr/J2wlQ8LdIBmLc/h7f/yilQfzv/FgwYPIxBgwbh6elZZvclhNCRpKkMmWrS1KRJE17xvcSLLS11O8xtYEokmFsaNzAhyjlFUbgSl4GjjTlVHO7M9fT39WT6Ld5nUFaFlo7qv3nO4i+Cb7Zmz6G/ybl5jvzEm/oy6wbaUM1RzVdH84iuFMhTg4fz1FNP4eLiUmb3JERFJklTGTLFpCknJwd7e3vOjbOmlus/D0lW7wgjfzNuYEI8wi7EpLF0z1UORyRyLSHznmWt/3yfC8cP4Omg4toEe8z/eQpv5YlcRm3MxtLSkl69evHss8/Sp08fbG1t71mfEOLhyUDwCu7cuXNU7jKKCHZTNf8WduZaqNHR2GEJ8Uir6+HA/Gd0D1zcSsvmaEQShyOSOHItkbNRqeRrdX+jejpZs+/ofk6ePEns2kmYq4/o61hn+QR2jVPIjb7Axo2/sXHjRuzs7OjXrx+DBw+mR48eWFpKa7EQxiAtTSXAFFuaVqxYyYzTjqjMLVFuXWLXyCr4NW0Pzt7GDk2ICikrV8PJG8kcjUzCXK3ihQ7/jIVKuIJy+FvSDqwgQWtP59wFgK7VSZuTQU70JcxjzjDdcx/LDqZwKUnFk08+xeDBg+ncuTPm5vK3rxD/lXTPlSFTTJrGT3qbzZa6lqWciONcXz1FPlyFMFFarcLAL0JJjbrMRW3BgeDPmIUyz+JrAE6m2vPUimiuJClUrlyZp59+mkGDBvHYY49hZmZW4FwhxP1J91wFd+JiBDTSJU2OlkjCJIQJU6tV/DK+M5m57Tl1I4Xj15M5HpnEsWtJxKXnMthsp75sNatMbqTq/taNi4tj6dpNrM+si/nCLbT0c2Vw90AGdHsMC3NJoIQoafJN+ghSFIVL12OxaaTbrupkY9yAhBDFYmtpTkCNSgTUqATo/i/HxCdi8VMliLsEwK5kT/JJAzQAWHnWwcqjFjWr2nBLsWLKrnQm/7WeymZZBNatyuNtGtLcxwV3R+uiLiuEKCZJmh5BUVFRZGjNuZ0q1fB0M2o8QoiHo1KpqFq5EryyFRKuwPHveLLxQGLeq8K6detYs2YNx3LdURQtb1uspZv6KHu1jfhB3ZUQrT+bLuew6fIxAHwdzdg5pTtqtSw5KsTDkjFNJcDUxjRt2bKF2HVv4+RZnX2ahtRt2JIXhw40dlhCiFIQExPDhrWrGJPwIeZq3cf5xuwWvI7hOpNZV49gsX8pAwYM4Omnn6Zdu3a8s+E0igLNvJ1p5uNM7SoOBgsQC1FRyEDwMmRqSVPwB+/zStZCHM3zAIj1eRz3534wclRCiFJzdAVsel2/OfGoL5+HRmFZtQ5WVetg5VmHrKtHUU6sIy1XV6aqpyc2w75Ao7rT4WBnaUbjak4093Ghmbczzb2dqSLdeqICKO73uMm10y5evBg/Pz+sra0JCAjg0KFDRZZdunQp7du3x8XFBRcXF4KCggqUV6lUhb7mzZunL+Pn51fg+Jw5c0rtHktb2sU9+oQJwLJukBGjEUKUuhYj4bk/oflwqFyPTzYeJ+LcCYJfGURDzWVi17xD/vF1XJ/owJ/DbBnWxILMfIV8xbBVKSNXw4GriXwZeoUXvzuK/4fbaTdnB0ciEo10Y0KYFpNqaVq7di0jRoxgyZIlBAQEsHDhQn7++WcuXLhQ6EKzQ4cOpV27drRt2xZra2s++ugj1q9fz5kzZ/Dy8gJ0Tdd3++OPP3j++ee5fPkyNWrUAHRJ0/PPP8/YsWP15RwcHLCzsytW3KbW0vRM2xq80M6VQNvr2KuyyR3/N5ZufsYOSwhRFrRa+Ne4pZs3b3L6h+n0yPhFv+/ZXzNZe8EMS/daWHnWwbJqXaw862DuWPCzds/bnfF2vTMj+f4r8fx5JpbmPs608HGhmosNKpV064nyq1x2zwUEBNC6dWsWLVoEgFarxdvbm1dffZUpU6bc93yNRoOLiwuLFi1ixIgRhZbp378/aWlpbN++Xb/Pz8+PCRMmMGHChIeK25SSpszMTBwcHHAIHIRNZW9613fk2w/fMWpMQggTsKo/XNVNXZCjsqLPrnps37UPrVZrUMzM3lWfQNl6N8C+ijczWsITTzyu/3z78PdzfL37qv6cyg5WNPd2poWvCy18XGhSzQlrC5nyQJQf5W6eptzcXI4ePcrUqVP1+9RqNUFBQYSFhRWrjszMTPLy8nB1dS30eGxsLFu2bGHlypUFjs2ZM4f33nsPHx8fhgwZwsSJE8vl3EZnz55Fq9WSsu9HUoDew3657zlCiAqg0xRw9oEz67Fq0I8/ZywiNjaWDRs28Ouvv7Jjxw5611TxQZccfjh9lB9OHCByl+5v6qGApaUlXbt25amnnuJgVm2DquPScvjzbCx/no0FwFytoqGnI08292JUu+plfadClBqTyQri4+PRaDS4u7sb7Hd3d+f8+fPFqmPy5Ml4enoSFFT4GJ6VK1fi4ODAU089ZbD/tddeo0WLFri6urJ//36mTp1KdHQ0CxYsKLSenJwccnJy9NupqanFiq8shIeHG2zXq1fPSJEIIUyKTxvdq9dHkJMO6D5fX3zxRV588UUSEhJI/XYA1TOPE+xuxvQOVrjNSyPzn+GRubm5/PHHH/zxxx+Y2zrSrGt/qrfqgtbVlwvxOaRl5+svla9V+PtGin6+qdsUReH7g5E0qeZE/aqOWJiZ3LBaIe7JZJKm/2rOnDmsWbOG0NBQrK0Lf9pj2bJlDB06tMDxSZMm6d83adIES0tLXnzxRYKDg7GysipQT3BwMLNmzSrZGyghERERBtu+vr7GCUQIYZosbHSvf6lkb0ml3HP67XjXljzevzK///47GRkZBmXzM1M5smkVRzatAqBxk6b07TuYak0fIx4HjkUmc/lWOi18nA3Ou5GUxbsbTgNgY2FGk2pOtPZzpaWfrlvPycaihG9WiJJlMkmTm5sbZmZmxMbGGuyPjY3Fw8PjnufOnz+fOXPmsG3bNpo0aVJomT179nDhwgXWrl1731gCAgLIz88nIiKCunXrFjg+depUg0QrNTUVb2/TWAg3IiICVGpQtLi5uWFvb2/skIQQ5YE2H9q+Bqd+gqQIvHtP4qc3+pCdnc22bdtYt24dv/32GzP8M/CwU7HmTB6/X8onOx9OnfybUyf/BsDHx4d+/frxau++tK3uYnCJo9eS9O+z8jQcDE/kYLjuyTyVCupUcaCVnwut/Vzp1dgDK1kKRpgYkxsI7u/vz+effw7oBoL7+Pgwfvz4IgeCz507lw8++ICtW7fSpk2bIuseNWoUp0+f5siRI/eN4/vvv2fEiBHEx8fj4uJy3/KmNBB8yejmqPLTueXVmct5lXh29Gv0bFTVqDEJIcoRRYEbR6BqEzA3bGnPz86AebUx1+hantafy+Opn7KKrMrJyYnevXvTr18/evbsSarGgp0XbnH0WhJHIpK4mVz4ubaWZpyc0R3zu7rvkjJycbSxkMk3RakodwPBQddNNnLkSFq1aoW/vz8LFy4kIyOD0aNHAzBixAi8vLwIDg4G4KOPPmL69On88MMP+Pn56acXsLe3N2hhSU1N5eeff+bjjz8ucM2wsDAOHjxI586dcXBwICwsjIkTJzJs2LBiJUymprnNTQKq5ABrOWhZj2TV6/c9Rwgh9FQq8G5d6CHziFDQ3Omqaz5kGu/WyWTjxo2cOnWqQPmUlBR+/PFHfvzxRywsLOjUqRN9+/ZlUp8++A5uTkxKNkeuJXIkIomj15I4G52KRqvQwsfFIGECmPTTCY5cS6Klr64lqrWfqzylJ8qcSbU0ASxatIh58+YRExNDs2bN+OyzzwgICACgU6dO+Pn5sWLFCkA3VcC1a9cK1DFjxgxmzpyp3/7666+ZMGEC0dHRODk5GZQ9duwYL7/8MufPnycnJ4fq1aszfPhwJk2aVOh4psKYSkuToihETnLC10n3l9ivmvbUGPsdzX3KX/InhDBBN45A2CK4EAKKBt66DNa6z9QrV66wceNGNm1cz1dNThB2PZ+fz+bz19V8cjUFq2ratCl9+vShT58+tGrVCrVaTUZOPieuJ6NWqQiseWcQuVar0HT2nwaDzQEszdU0reaEf3VX/KtXoqWvC/ZWJtUWIMqJcjlPU3llKklT3K1bXPlfdep42OFqnsPC/KcY+OYXeDoXHPQphBAPLScdov8Gv3YFj10NhVX99Jsvh2j48mBGwXJ38fDw4IknnqBPnz507dq1wMTCKZl5TFl3ksMRicSn5xZZj1oFi4e0oFdjGZIgHowkTWXIVJKmw4cP4+/vj8fw+bh5+qBCy9EPnpHHeoUQZWfT67q18ABUZmSNP8n2sBNs2rSJ3377jZiYGNQqsLNAvw7e3aytrenSpQtPPPEEjz/+OD4+PvpjiqIQkZDJ4X8GkB+OSCQyMdPg/B1vdKRG5TvDM45eS2TD8Sj8q7sSUMOVKg6ylp4oqFyOaRL/ze3pBswcKpOGLc7WakmYhBBlq0ZnSIuBKzvAJxCbStV44olqPPHEE3z55ZccPXqUv3/7khH8yp9X8lh/Pp+fzuRxuwEpOzub33//nd9//x3QTQPz+OOP8/jjj9OmTRuqu9lR3c2Oga11TyzHpmZzKDyRQ+GJXLqVRnU3w1aq7edu8d2Ba3x3QDeUo4abHQE1XAmoXomAGq5UdZKWeFF8kjQ9QiIiIlBZ2mDuoBsL4Ocm0w0IIcpYw/66V3YKZMQbHFKr1bRu3ZrW8b/AQXiijgWP17Ekw6sF6//cR25uwaankydPcvLkSYKDg6lUqRI9e/bk8ccfp0ePHri6uuLuaE2fpp70aepZaDiH/7XY8NX4DK7GZ/DjoesA+FaypU31SvRs5EHnegXX3RPibpI0PULCw8OxcLnzwVHb3fiLBwshKihrJ/0gcQOKAuc26TdV3gGsmbmVtLQ0tm3bxqZNm9iyZQt2uXE4W6s4HnNnbbyEhAS+//57vv/+e9RqNYGBgfTu3ZvHH3+cJk2aFLpo8PLR/hyJ0HXnHbyawMkbKeRr74xKuZaQybWETKwt1AWSplup2VRxlO48cYckTY+QiIgIzF2r6bdrVpGWJiGEiVG00Hs+nPsNLvwB9Z8AwMHBgSeffJInn3wSrVZL7HdjqBr+KzFZZvx8KovX/8jm7gG4Wq2Wffv2sW/fPt555x08PT3p1asXvXv3JigoSD8uxd7KnE51q9Cpri4hyszN59i1ZA5cTeBgeAInrieTp1Fo868lX26lZuP/4XZ9S1RgTd3LXZKoCk0GgpcAUxkIPqe/D0k21Yiv3pMLijfTh/Wie8N7z6YuhBBGo8nTvSxtDfcrCnzWDJIiAMh1b8Yqi+Fs3ryZbdu2FVjW5d/Mzc1p164dvXr1olevXjRu3LjQViiArFwNxyOTaOjlZLCMy8YTN3l9zYkC5au72dGmxj9JVI1KVHYo3tQ0wrTJ03NlyBSSJkVRiHvbiSp2ug+GrXmtaD55izQtCyHKn/hLsKjVne2uM6C9bumqnJwcdu/ezZYtW3C59AvZqXFsvpjP6VvaIioDLy8vevbsSc+ePQkKCsLZ2fm+IWw7G8vXu69y4noyuZqi627o6cim8Y+hlpnKyzVJmsqQKSRNcTfDqby0mX57v11P2r51/3X2hBDCJCVe1XXfXfgDHv8YKhdcB5TPWkDiFQD2JrgStDSanJyce1ZrZmZGYGAgPXv2pEePHrRo0QK1uuinjG+3RIVdTeDA1TvdebcFVHdl7YuBBuf8cvQGLrYWtK7uiqO1LEJcHkjSVIZMIWn6e+d6qv85Ekcr3V87x2q9Toths40SixBClLr4y7Co5Z3trtPJbDmOnTt38vvvv/PHH38QHh6OszUkZxddjZubG926daNHjx50796dqlXvPTFmZm4+RyJ0SVTYlQSC6ldhfJfa+uNarUKrD7aRmJGLWgWNqznTtmYl2tasRCtfV2wsZdkXUyRJUxkyhaTpp59+YtCgQbjaqKjhomL15r3UbR54/xOFEKI8Ct8Dm17TtUgBvLQPPBrpDyuKwqVLl6iypgcZGZlsPJPByhPZHLpZyJoud2nSpIk+gXrsscewtn6wIQ7nY1LpuXBPoccszFQ093GhXU032taqRNNqzliay1x6pkCSpjJkCknT3LlzeWfu51j7NCE/4QaXj+7Cy83ZKLEIIUSZib+kW7ql9RjdYsN3S7gCn7fQb17wHsKXp6wICQnhwoUL963axsaGjh070r17d7p3706DBg2KHFB+W0ZOPnsvxxN2RdcSdSE2rciyv7/WngaeMjWMKZAZwSuYiIgIbHyb4drtJQD2hqcySJImIcSjzq227lWYS38abNZ9/GUWPt8Y0H1mbt26la1bQ+iUu5094Vlsu5pv0JWXlZVFSEgIISEhAHh6etKtWze6detGUFAQ7u7uBS5pZ2VOj4Ye9PjnyeW4tBx9V97+K/FcS9At++JqZ0k9DweDc5ftDedQeCJta1WibU03ala2u2+SJsqWtDSVAFNoaerduzcH8nxxbKmb8+TnlwJp7edqlFiEEMIkxF+Gcxvh0l+QcgMmnCrYGnXXk3paRcXMv915/7dLFOersUmTJvokqn379tja2t73nBtJmYRdSSAzV8PItn4GxwZ/HcaBq3dmMHd3tKJtTTfa1XKjXa1KsuRLKZLuuTJkCklTgwYNSGgyFBu/ZgAcfTeISvYyf4gQQgCQnwvmlgX3H1gCIZPvbI/bT7yZO9u3b2fr1q389ddf3Lhxg/puas7FFz31gKWlJe3atdO3QrVo0QIzs+IP+s7XaGk7Zwe30op++q+Gmx1ta1ViYCtvmlRzLnbd4v4kaSpDxk6aFK2W1x9zJNH/FaJsahGrdeb0nKelWVcIIe5n54ew71PIzwZ7d3jjgkFrlKIoXD34OzVDhpCQa8nWS9nM3pnJhYSiEygAZ2dnunTpQteuXQkKCqJ27dr3/UzWaBXORaey73I8+64kcDg8kay8ggPXFw5qRv/mXvrtnHwNWi3yZN5/IElTGTJ20nQr/CxVVt55Um6+dhhvzl5c5nEIIUS5lJcF1/ZDVhI0frrg8QNfQsgU/eZh/8Vs3H+ev/76iyNHjqDV3juBAvD29tYnUV27dsXTs/AFhu+Wm6/lxPVk9l2OZ/+VeI5HJpOvVTj0v64GExdvPRPDqz8cp4WvM+1qutGuthtNvJwwN5Mn84pLkqYyZOyk6fTWFTQKe12//ZHtW0x++90yj0MIIR5JPwyCi7rB4Nh7wBvn9a1RiYmJhIaGcj70J/rzFyEXMtgRrmFHeD5Z+UVXWa9ePX0S1alTJ1xd7z8GNSMnn79vJNO2ppvB/ukbT7Mq7JrBPgcrcwJquP4zHsqN2lXspffhHuTpuQokNfK0wbZ91SKeJBFCCPHgur0HNTrD1Z3g6GXQfefq6spTTz0FHlHw5x80CLRiUiC8frUTP4aEERcXV2iV58+f5/z583zxxReoVCqaNWtG165d6dy5M+3bt8fBwaHAOXZW5gUSJgA3eyt8XG2JTMzU70vLyWfbuVtsO3cLgMoOVgwN8GFCUJ3/+tOo0KSlqQQYu6Xpozlz+PbPQzQKaI+36hbdnhzNE63lP4YQQpSZ7wfCpa26947VYOJptIrC6dOn2bZtG9u3byf+zC6erJXPrmsa9kbmk55beFVmZma0bt2azp0706VLF9q2bVusJ/OuJ2bqx0PtvxxPQobhBcZ1qsnknvX024qisOP8LVr5uuJkW7GXe5HuuTJk7KRp3Lhx/HLTAbsGHQH4a2IHarsX/CtFCCFEKdk9X9eFd/MYNH4GnvqqQBHNro8x26lb3ipfC36fZ3MzuYjM6S4WFhYEBATQuXNnOnfuTGBg4H1nKtdqFS7EpumSqMvxHAxPZOmIVrSrdaelKiI+g07zQ1GpoLGXk64rr6YbrfxcsLaoWIPKJWkqQ8ZOmnr16sWB7KrY1GyNpUtVLgT3wcq8Yv3CCyGESchOhdx0cCxkoPfqp+HyX7r3zr5kvnCA/fv3s2PHDrZv386RI0eo6QxNPdTsuaYhNqPwr2crKyvatGlDp06d6NSpE23atLlvEpWbr0WtwmBw+OoD13h3w+kCZS3N1bTyddGPh2rs5YSZ+tEeDyVJUxkydtJUv359zp8/D8DAQYNZu+bHMo9BCCHEfax4Aq7tA0ULzYZC/y8MDqekpBCzdhJ1o34B4GKCluZfpZOZd+9qbydRHTt21CdRNjb3nwjz1I0UNp64yd7L8ZyPKXq5Fy9nG/ZO7vxIDySXgeAVhKIoRERE6Ler+/kaLxghhBBFG7UZslMg8gDYFRzQ7eTkhJN1gn67Zs2arF47g507d7Jz505On9a1Cvk6qXCzVXEiRotGgZycHHbt2sWuXbuYPXs2lpaW+Pv707FjRzp27EhgYCD29vYFrte4mhONqzkBEJ+ew/4rCey7FM/ey/HcTM7Sl6vn4VAgYfpmz1Vc7SxpV8sNd8cHW9S4PJOWphJgzJamW5GXebZTPcKTtFxPVfh88Ze89NJLZRqDEEKIEqDVwryakPXPUiotRkDfz/WHb926xe7du7E7tJBetqdIz1UIu66h1/eZaO7xTW5ubk7Lli3p2LEjHTp0oF27djg7OxdZXlEUIhMz2Xs5nv2XE+hQx41BrX30x3PztTSb/SeZubqJN2tVsaddzUq0q+VGm5qVcLQuf4PKpXuuDBkzaTr3+1fUP/Q2APlahSON36PNM6/f5ywhhBAmKS8boo7puvG8WkHNzgXLrHgCIvYAkGLlxTs3u7Br1y59SxRANUcVlmZwNangV7xKpaJp06Z06NCBDh060L59e6pUqVLsEA9HJPLMkrBCj6lV0LiaM4/VqkS7mm609HMpF2NsJWkqQ8ZMmg599Sr+0av02we6/EKbDt3KNAYhhBBlRJMHc3wg7585mVo9B098AkBcXBy7d+9m165dNItfz3N1UolN17L7moZBv2Rxry/7unXr6hOo9u3b4+vrW+QYppx8DceuJbP/iq4r7+SNFDTawmvf/VZnfCrdf7oEY5OkqQwZM2na/34v2ubvByBPMSPm5ct4u99/ZlkhhBDlkKJAUgRcPwiRYVD3cajTvWC5Zb0gUvfdcF1TiSf/cOX48eMGS754O6owU0NEcsE0oFq1avoEqn379jRo0AC1uvBlWVKz8zh4NVG/3MvF2HRd/a427Hm7i0HZz7df4tTNlH+ezKtEzcqmMVO5JE1lyJhJ05vjRhFuUQ0/+zycNIlMm/O1SfwCCiGEMJL8XJjjrVuEGMD/Beg9j9TUVPbv369vjXrG8QQTAsyJTdey65/WqKK4uLjQrl07HnvsMR577DFatWqFlZVVoWVvpWaz/0oCeRotz7TyNjj2xOd7OH0zVb/t7mhF25putP1nTJSn8/2f+isN5TZpWrx4MfPmzSMmJoamTZvy+eef4+/vX2jZpUuXsmrVKn0/bsuWLfnwww8Nyo8aNYqVK1canNejRw9CQkL024mJibz66qts2rQJtVrNgAED+PTTTwt92qAwxkyauvd6gotNxwFgkXqDS1+8WKbXF0IIYWK0Woj5G64f0rVINR4IdXsWLPZ1F9RRRwE4m2qH/9epZGRkGJSp5arGxhzOxmkNBptbWVnRunVrfSLVtm3b+66fl52nod2cHQVmKr9bdTc7AmtWYoi/D428nB7gpv+bcpk0rV27lhEjRrBkyRICAgJYuHAhP//8MxcuXCh0kNrQoUNp164dbdu2xdramo8++oj169dz5swZvLy8AF3SFBsby/Lly/XnWVlZ4eLiot/u1asX0dHRfPXVV+Tl5TF69Ghat27NDz/8UKy4jZk0NWzXnYz2uoHfldIuc3SxDAIXQghxH/k5EFwNNP8kMG1eJq/rbI4fP86ePXvYs2cPe/fuZVZABq+0tiQ9V2H3tXwe/6Ho1qgGDRrQrl07/atmzZoFej60WoWz0ansvxLPvssJHApPJCtPU6Cub0a0IqiBu347K1eDVlGwsyqdmZLKZdIUEBBA69atWbRoEQBarRZvb29effVVpkyZct/zNRoNLi4uLFq0iBEjRgC6pCk5OZkNGzYUes65c+do0KABhw8fplWrVgCEhITQu3dvbty4gadnIbO6/osxkyavNn2w6KSbYqBuzgW2fjKpTK8vhBCiHNJqIPpvuHFY92o8sMDYKK1WS87ngdgk6SZPPhRrTsCSxAJVNfdQ426v5vBNDQlZd1KKKlWq0LZtW30S1aJFiwJdern5Wo5HJrHvSgJhV+I5HpmMApyY3g2Hu6Yu+OXoDab8epKXOtbkzR51S/AHoVPuJrfMzc3l6NGjTJ06Vb9PrVYTFBREWFjhjzb+W2ZmJnl5eQWaCENDQ6lSpQouLi506dKF999/n0qVKgEQFhaGs7OzPmECCAoKQq1Wc/DgQZ588skC18nJySEnJ0e/nZqaWqBMWVAUhUy1DbcbMD3sCh+kJ4QQQhhQm4FXC90roPBhHWpNLjYpl/Xb/k+O48a749i3bx979+5l7969/P3337zUypIXWloCcDxaQ4uvdV18t27dYsOGDfpGC0tLS1q1akXbtm31L3d3dwJqVCKgRiXoVoeMnHzORacaJEwA+6/Ek69V8HAy7kSaJpM0xcfHo9FocHd3N9jv7u6uXyLkfiZPnoynpydBQUH6fT179uSpp56ievXqXLlyhf/973/06tWLsLAwzMzMiImJKdD1Z25ujqurKzExMYVeJzg4mFmzZj3gHZa8lKQEHO1sAAVQUdXFztghCSGEeFSYWcK4MLh5BG4ehVpBeHl5MXDgQAYOHAjoGg1UX7WHjAgAUnIL/+M9qIYZDSrDkesH+eLT/cyfr9tfvXp12rZtS2BgIG3btqVx48a08is4NsrbxZYale1oW7NSqdxqcZlM0vRfzZkzhzVr1hAaGmqwcOHgwYP17xs3bkyTJk2oWbMmoaGhdO3a9aGuNXXqVCZNutMNlpqaire39z3OKB0pV49xrd0G8pRNJOHAfttRZR6DEEKIR5RaDZXr6F7NhhRaxNHGErJu6Lc7PDuBo6/2Z//+/ezbt499+/Zx/fp1hja2YFQzXWtUTLqWqh/rpiUIDw8nPDyc77//HgA7Oztat25NYGAggYGBtGnThsqVKzOxWx0mdqtTyjd8fyaTNLm5uWFmZkZsbKzB/tjYWDw8PO557vz585kzZw7btm2jSZMm9yxbo0YN3NzcuHz5Ml27dsXDw4Nbt24ZlMnPzycxMbHI61pZWRX5qGVZSouNAMBCpaEKybhVkvmZhBBClCELa3jrMkSdgKhjqP060MK7BS1atGD8+PEAXL9+HcfV3SEnCoATMdpCqxra2IJuNTQci9nP7tV7CA7WDRCvWbOmPoEKDAykcePGWFgYZ6kWkxkEY2lpScuWLdm+fbt+n1arZfv27QQGBhZ53ty5c3nvvfcICQkxGJdUlBs3bpCQkEDVqlUBCAwMJDk5maNHj+rL7NixA61WS0BAwH+4o9KXlXDDYNvNw6eIkkIIIUQpsXHRLffS/g3wbl3gsLenB04WdxKlLsPfJDQ0lODgYPr06YObm27x4p61zBjZzJJPe1rz0zN35mu6cuUKq1evZvz48bRs2RInJyc2b95c+vdVCJNpaQKYNGkSI0eOpFWrVvj7+7Nw4UIyMjIYPXo0ACNGjMDLy4vg4GAAPvroI6ZPn84PP/yAn5+ffgySvb099vb2pKenM2vWLAYMGICHhwdXrlzh7bffplatWvTo0QOA+vXr07NnT8aOHcuSJUvIy8tj/PjxDB48uFhPzhlTRJY9K3/Pws1WjZutigEj6xk7JCGEEMKQmQW8cR5SoyDqOJaVatGxSj06duwI6B5qunz5MpV/ehzydL1Nx6ILb41ytobkrCxq1qxZZuHfzaSSpkGDBhEXF8f06dOJiYmhWbNmhISE6AeHR0ZGGkzj/uWXX5Kbm8vTTz9tUM+MGTOYOXMmZmZmnDx5kpUrV5KcnIynpyfdu3fnvffeM+he+/777xk/fjxdu3bVT2752Weflc1N/wfhKbD4cJ5+e6xnDSNGI4QQQhRBpQInL92rwCEVtWvWAL9mugHnmfF0G/Em28d05MCBA4SFhXHgwAHi4+MBcHZ2pm7dkp92oDhMap6m8spY8zS99dZbzP/nEQRHR0dSUlLK7NpCCCFEiVMUXYuU2hwc3O/arXDlyhWO7dvBrbRc/XipklLq8zTl5eURExNDZmYmlStXvu/06aLkxSQkYelRG01mCpWquNz/BCGEEMKU3W6RKrBbRa2aNanl5w3mxnsQ64GSprS0NFavXs2aNWs4dOgQubm5KIqCSqWiWrVqdO/enRdeeIHWrQsOBBMl70Y6VB35CQDW1w8YORohhBCiFKlURk2Y4AGenluwYAF+fn4sX76coKAgNmzYwIkTJ7h48SJhYWHMmDGD/Px8unfvTs+ePbl06VJpxi2ApMx8/XsH4zx9KYQQQlQYxW5pOnz4MLt376Zhw4aFHvf39+e5555jyZIlLF++nD179lC7du0SC1QUtKxOKPaWh0jCgaOuVY0djhBCCPFIK3bS9OOPPwK6RXE3bdpE165dcXBwKFDOysqKl156qeQiFEWqaZuOkzoJgHibsl0oWAghhKhoHnhySzMzM5599lni4uJKIx5RTDmZ6TiZ35luAGunogsLIYQQ4j97qKfnWrduTXh4ODVqyLxAxpIYH8uWuEZUcXXAhTQ0LmW/9p0QQghRkTxU0vTqq6/yv//9j19++cUoC9UKuJWUzruJT2DtoFtrb75v4bOnCiGEEKJkPFTSNGjQIAAaNmxI37596dSpE82bN6dx48ZYWlqWaICicPHx8ajtdF1y2twsvNwLzmshhBBCiJLzUElTeHg4f//9NydOnODvv/8mODiYiIgIzM3NqVu3LidPnizpOMW/xMXFYWbrDIAmM4XKlZsZNR4hhBDiUfdQSZOvry++vr707dtXvy8tLY0TJ05IwlRGbsXFo7b2AUCbmaxfJVoIIYQQpaPEFux1cHCgffv2tG/fvqSqFPeQEB9H5IKJmNk6YW5pg9PKScYOSQghhHikFTtpioyMxMfHp9gV37x5Ey8vGWdTWhqk7+PXARbEZ2aQqNGtyyOEEEKI0lPseZpat27Niy++yOHDh4ssk5KSwtKlS2nUqBG//vpriQQoCuehuclT9S14oaUlg+srxg5HCCGEeOQVu6Xp7NmzfPDBB3Tr1g1ra2tatmyJp6cn1tbWJCUlcfbsWc6cOUOLFi2YO3cuvXv3Ls24Kzxrbbr+fYZi3AUMhRBCiIpApSjKAzVTZGVlsWXLFvbu3cu1a9fIysrCzc2N5s2b06NHDxo1alRasZqs1NRUnJycSElJwdGxbJYzWT2mIY2d0nA1zyYy3412H58tk+sKIYQQj5rifo8/8EBwGxsbnn76aZ5++mn9vhs3buDh4YG5eYmNKxf3MSWqA+ZuTwDgn3eIdkaORwghhHjUPfDac4Xp3bs3GRkZ+u2kpCQOHTpUElWLQiiKQg53JhH1cLY1YjRCCCFExVAiSZO5uTlOTncWjHVycmLcuHElUbUoREpKCiprB/22Z6Wy6RIUQgghKrISSZqqVavGnj177lSqVpObm1sSVYtC6JZQcdZv+7i7Gi8YIYQQooIokUFIixYtonfv3gQGBuLv78+pU6ceaE4n8WB0S6joWvY0Wam4V65i5IiEEEKIR99DtTRdu3bNYNvHx4fjx4/TrVs3IiMjqVOnDmvXri2RAEVBWTdO8j+X7Yw128zTbMfDSaYcEEIIIUrbQ7U01atXj3HjxvHuu+/i6qrrGrKwsGDgwIEMHDiwRAMUBeVHn+UV6z90Gy5wy3aUUeMRQgghKoKHamnavXs3f//9NzVq1ODDDz8kKyurpOMS95CVGm+w7exZ00iRCCGEEBXHQyVNrVu3Zvv27axdu5Zff/2VWrVq8fXXX6PVaks6PlGIjIwMMv+ZBVyrgKWjjGkSQgghStt/enquR48eHD16lPnz5zNv3jwaNGjAunXrSio2UYT18X5UP/sKNSLe4bHjvUFtZuyQhBBCiEdeiTw9169fP/z8/HjjjTd45pln0Gg0JVGtKEJW9GVubdkCQJWAACNHI4QQQlQMD5U0LVu2jLNnz+pfN27cAHRP0T3xxBMlGqAoKD7+zpimypUrGzESIYQQouJ4qO65qVOncuLECerUqcO0adPYt28fKSkpXL16lY0bN/6ngBYvXoyfnx/W1tYEBATcczmWpUuX0r59e1xcXHBxcSEoKMigfF5eHpMnT6Zx48bY2dnh6enJiBEjiIqKMqjHz88PlUpl8JozZ85/uo/SFBcXp3/v5uZmxEiEEEKIiuOhWppiY2NLOg4A1q5dy6RJk1iyZAkBAQEsXLiQHj16cOHCBapUKTjYOTQ0lGeffZa2bdtibW3NRx99RPfu3Tlz5gxeXl5kZmZy7Ngxpk2bRtOmTUlKSuL111+nb9++HDlyxKCu2bNnM3bsWP22g4PDvy9nMqSlSQghhCh7KkVRFGMHcVtAQACtW7dm0aJFAGi1Wry9vXn11VeZMmXKfc/XaDS4uLiwaNEiRowYUWiZw4cP4+/vz7Vr1/Szlvv5+TFhwgQmTJjwUHGnpqbi5ORESkoKjo6luw5cTk4OE18cSIadD/GZWoLqVmbilJmlek0hhBDiUVbc7/ESWXuuJOTm5nL06FGCgoL0+9RqNUFBQYSFhRWrjszMTPLy8vQTbhYmJSUFlUqFs7Ozwf45c+ZQqVIlmjdvzrx588jPzy+yjpycHFJTUw1eZSXhVjRf+IWysvIqtviu5jHry2V2bSGEEKIiK5Gn50pCfHw8Go0Gd3d3g/3u7u6cP3++WHVMnjwZT09Pg8TrbtnZ2UyePJlnn33WIJN87bXXaNGiBa6uruzfv5+pU6cSHR3NggULCq0nODiYWbNmFfPOSlZS1BU879q2cPIwShxCCCFERWMySdN/NWfOHNasWUNoaCjW1tYFjufl5TFw4EAUReHLL780ODZp0iT9+yZNmmBpacmLL75IcHAwVlYF13WbOnWqwTmpqal4e3uX4N0ULTUmwmDbxtWz8IJCCCGEKFEmkzS5ublhZmZWYJB5bGwsHh73bk2ZP38+c+bMYdu2bTRp0qTA8dsJ07Vr19ixY8d9xx0FBASQn59PREQEdevWLXDcysqq0GSqLFxMs2Zi9ue4qNKxiz3O3KfbGyUOIYQQoqIxmTFNlpaWtGzZku3bt+v3abVatm/fTmBgYJHnzZ07l/fee4+QkBBatWpV4PjthOnSpUts27aNSpUq3TeWEydOoFarC31iz9gi49KIoRLnFF92xTlTybuOsUMSQgghKgSTaWkCXTfZyJEjadWqFf7+/ixcuJCMjAxGjx4NwIgRI/Dy8iI4OBiAjz76iOnTp/PDDz/g5+dHTEwMAPb29tjb25OXl8fTTz/NsWPH2Lx5MxqNRl/G1dUVS0tLwsLCOHjwIJ07d8bBwYGwsDAmTpzIsGHDcHFxMc4P4h6iEtP075Xs1FJ/Wk8IIYQQOiaVNA0aNIi4uDimT59OTEwMzZo1IyQkRD84PDIyErX6TuPYl19+SW5uLk8//bRBPTNmzGDmzJncvHmT3377DYBmzZoZlNm5cyedOnXCysqKNWvWMHPmTHJycqhevToTJ040GLNkSm6lZoGN7r21Kh+VSmXcgIQQQogKwqTmaSqvynKepk7Pv0tEZV13pfXJXzn/+7JSvZ4QQgjxqCvu97hJtTSJ+3PSJlJdFU2i4oCtjckMSRNCCCEeeZI0lTNv2m2mvdX3AJypdf9B7UIIIYQoGdJUUc44aO8MBM9X2xgxEiGEEKJikaSpHFEUBSfLO8u7aKycjReMEEIIUcFI91w5kpKSwsj1WXjYq3CzVdFjiD8tjB2UEEIIUUFI0lSOxMXFcTCvJtqoVDSZKXR8s42xQxJCCCEqDEmaypFbcXF4DJ+PSqUmJ/oilStXNnZIQgghRIUhY5rKkcjoeFQq3T+ZNisNNzc3I0ckhBBCVBySNJUjMYkp+vfa7DRcXV2NGI0QQghRsUjSVI4kpmfr32uz03FwcDBiNEIIIUTFImOaypF66fs5b7WJTKzIbKHBTjUTcDJ2WEIIIUSFIElTOaLNzcbaLA9r8nC1BqxsjR2SEEIIUWFI91x5osk23LaQpEkIIYQoK9LSVI4cz6lGkro/NuRiGXWckWozY4ckhBBCVBiSNJUjh7J9WWdRHwDLi6mMNHI8QgghREUi3XPlSJb2zj+XraS7QgghRJmSr95yxOXqX/y9733U1vb4NKpl7HCEEEKICkVamsqRrPRUNBlJ5CVcx8HOxtjhCCGEEBWKJE3lSEZGhv69nZ2dESMRQgghKh7pnitHJjeMxrOZLZl5kFM50tjhCCGEEBWKJE3lSP2qtjSz183VdDInzcjRCCGEEBWLdM+VExqtgo3tnckstebWRoxGCCGEqHikpamcSMnM5bC2LrGKC5bZiWTbuxs7JCGEEKJCkaSpnIhLyeDd/OcByDgfytTOVelk3JCEEEKICkW658qJ6MRU/XtNdro8PSeEEEKUMUmayom45HT9e21OOvb29kaMRgghhKh4JGkqJ+JTM/XvtVlp0tIkhBBClDFJmsqJhLQs/XutdM8JIYQQZc7kkqbFixfj5+eHtbU1AQEBHDp0qMiyS5cupX379ri4uODi4kJQUFCB8oqiMH36dKpWrYqNjQ1BQUFcunTJoExiYiJDhw7F0dERZ2dnnn/+edLT0zEl2anxvGe+jP+Zf887dcKprI0zdkhCCCFEhWJSSdPatWuZNGkSM2bM4NixYzRt2pQePXpw69atQsuHhoby7LPPsnPnTsLCwvD29qZ79+7cvHlTX2bu3Ll89tlnLFmyhIMHD2JnZ0ePHj3Izs7Wlxk6dChnzpzhr7/+YvPmzezevZsXXnih1O/3QWgyExluvo0XzLcwtXE8LpI0CSGEEGVLMSH+/v7KK6+8ot/WaDSKp6enEhwcXKzz8/PzFQcHB2XlypWKoiiKVqtVPDw8lHnz5unLJCcnK1ZWVsqPP/6oKIqinD17VgGUw4cP68v88ccfikqlUm7evFms66akpCiAkpKSUqzyDyN4wQJFmeGof0XtWlFq1xJCCCEqkuJ+j5tMS1Nubi5Hjx4lKChIv0+tVhMUFERYWFix6sjMzCQvLw9XV1cAwsPDiYmJMajTycmJgIAAfZ1hYWE4OzvTqlUrfZmgoCDUajUHDx4s9Do5OTmkpqYavEpbfZtUbqRqScxSyM5XsLJzLvVrCiGEEOIOk0ma4uPj0Wg0uLsbznTt7u5OTExMseqYPHkynp6e+iTp9nn3qjMmJoYqVaoYHDc3N8fV1bXI6wYHB+Pk5KR/eXt7Fyu+/+Jargven6RTaW4aNh+kYVGnS6lfUwghhBB3mEzS9F/NmTOHNWvWsH79eqytS3ddtqlTp5KSkqJ/Xb9+vVSvB5CRkWGwbXvXOnRCCCGEKH0ms4yKm5sbZmZmxMbGGuyPjY3Fw8PjnufOnz+fOXPmsG3bNpo0aaLff/u82NhYqlatalBns2bN9GX+PdA8Pz+fxMTEIq9rZWWFlZVVse+tJNydNNnY2GBmZlam1xdCCCEqOpNpabK0tKRly5Zs375dv0+r1bJ9+3YCAwOLPG/u3Lm89957hISEGIxLAqhevToeHh4GdaampnLw4EF9nYGBgSQnJ3P06FF9mR07dqDVagkICCip2/vPtuQ2wH3IR7gEvSRzNAkhhBBGYDItTQCTJk1i5MiRtGrVCn9/fxYuXEhGRgajR48GYMSIEXh5eREcHAzARx99xPTp0/nhhx/w8/PTj0Gyt7fH3t4elUrFhAkTeP/996lduzbVq1dn2rRpeHp60r9/fwDq169Pz549GTt2LEuWLCEvL4/x48czePBgPD09jfJz+Lc8jZYktRPW3k6gVmMtSZMQQghR5kwqaRo0aBBxcXFMnz6dmJgYmjVrRkhIiH4gd2RkJGr1ncaxL7/8ktzcXJ5++mmDembMmMHMmTMBePvtt8nIyOCFF14gOTmZxx57jJCQEINxT99//z3jx4+na9euqNVqBgwYwGeffVb6N1xMqVl5NFSF00B9jSTLG1jVlq45IYQQoqypFEVRjB1EeZeamoqTkxMpKSk4OjqWeP1X4tLZ/Ol4XjdfD0CORoXVe8klfh0hhBCiIiru97jJjGkSRUvJysOWHP12tlb+2YQQQoiyJt++5UBKVh42dyVNuYp0zwkhhBBlTZKmciA1K48P8ofSOnsxzXb6M+dmG2OHJIQQQlQ4kjSVAylZeWRhTRwuXE7UkmLhfv+ThBBCCFGiJGkqB1Iy8/TvtdnpMk+TEEIIYQSSNJUDKVl3J00ZkjQJIYQQRiBJUznQuW5lknatJOXgr+SnxGBvb2/skIQQQogKx6QmtxSFa+Zpi/eVX1GATDMFFxvJdYUQQoiyJklTOZCRkcGmZ22p7qJLls7n7wCmGDcoIYQQooKRJotyID09HVuLO9sqC1vjBSOEEEJUUJI0lQNXY1OwtVDpt9XWMqZJCCGEKGvSPVcOvLI5ilaq/2EZf4PsXV8x8YNOxg5JCCGEqHAkaTJxuflacjSwj8ZkJ6uJPZ3PBPfGxg5LCCGEqHCke87E/XuOJkDmaRJCCCGMQJImE2eYNKUDyDxNQgghhBFI0mTiCkuapKVJCCGEKHsypsnEpWbloUILgDY7DZCkSQghhDAGSZpMXEpWHi1Ul/jVahaZndVktrXHJuE02PobOzQhhBCiQpGkycSlZOVhq8oBwNZMi62tGtTyzyaEEEKUNRnTZOKSM/OwIcdwp8wILoQQQpQ5abIwcSlZeVxRPJmbNxDt6d+pbJXP83aVjR2WEEIIUeFIS5OJe71rbWyvH2H6yn38LySJT8+7g10lY4clhBBCVDjS0mTinGwtUJKjyLl5DpA5moQQQghjkZamciAjI0P/XqYbEEIIIYxDkqZyID09Xf9ekiYhhBDCOCRpMnHfHbhGSqUGWFdvAUjSJIQQQhiLjGkycR9sOctLLc3p0iKL5ChbrKqcNnZIQgghRIVkci1Nixcvxs/PD2trawICAjh06FCRZc+cOcOAAQPw8/NDpVKxcOHCAmVuH/v365VXXtGX6dSpU4HjL730Umnc3gPJydeQnafFVx1DM8ubdPIzp4ZVkrHDEkIIISokk0qa1q5dy6RJk5gxYwbHjh2jadOm9OjRg1u3bhVaPjMzkxo1ajBnzhw8PDwKLXP48GGio6P1r7/++guAZ555xqDc2LFjDcrNnTu3ZG/uIdxerNeGXP0+jdrSWOEIIYQQFZpJdc8tWLCAsWPHMnr0aACWLFnCli1bWLZsGVOmTClQvnXr1rRu3Rqg0OMAlSsbTgQ5Z84catasSceOHQ3229raFpl4GUvqP0nT39qaKKkxWCRexa1ONTyNHJcQQghREZlMS1Nubi5Hjx4lKChIv0+tVhMUFERYWFiJXWP16tU899xzqFQqg2Pff/89bm5uNGrUiKlTp5KZmVki1/wvbrc0faXpw/DTbeixOpP9Lk8bOSohhBCiYjKZlqb4+Hg0Gg3u7u4G+93d3Tl//nyJXGPDhg0kJyczatQog/1DhgzB19cXT09PTp48yeTJk7lw4QLr1q0rtJ6cnBxycu6sB5eamloi8f1bcmae/r02WzftgDw9J4QQQhiHySRNZeHbb7+lV69eeHoadnC98MIL+veNGzematWqdO3alStXrlCzZs0C9QQHBzNr1qxSj/d2SxNI0iSEEEIYm8l0z7m5uWFmZkZsbKzB/tjY2BIZa3Tt2jW2bdvGmDFj7ls2ICAAgMuXLxd6fOrUqaSkpOhf169f/8/xFUaSJiGEEMJ0mEzSZGlpScuWLdm+fbt+n1arZfv27QQGBv7n+pcvX06VKlV4/PHH71v2xIkTAFStWrXQ41ZWVjg6Ohq8SsPdSZPmn6RJ1p4TQgghjMOkuucmTZrEyJEjadWqFf7+/ixcuJCMjAz903QjRozAy8uL4OBgQDew++zZs/r3N2/e5MSJE9jb21OrVi19vVqtluXLlzNy5EjMzQ1v+cqVK/zwww/07t2bSpUqcfLkSSZOnEiHDh1o0qRJGd154eytzKliA69lfUF6ixuk1bTCI/M80PG+5wohhBCiZJlU0jRo0CDi4uKYPn06MTExNGvWjJCQEP3g8MjISNTqO41jUVFRNG/eXL89f/585s+fT8eOHQkNDdXv37ZtG5GRkTz33HMFrmlpacm2bdv0CZq3tzcDBgzg3XffLb0bLaYx7Wvgeus4/U/uQd1QBVhxK/OKscMSQgghKiSVoiiKsYMo71JTU3FyciIlJaXEu+p+WPktQ8In6beT/N/CpbfxEzohhBDiUVHc73GTamkSBWVnpHIpQYOthQo7SxWW9q7GDkkIIYSokCRpMnFJWVrqLMrQb2fPet6I0QghhBAVl8k8PScKl56ern9vZmaGpaWsPSeEEEIYgyRNJi4j404rk52dXYHlX4QQQghRNiRpMnF3J00yR5MQQghhPJI0mbh/tzQJIYQQwjhkILiJs8+NZVwrCzLzoLKXAjnpYCUtTkIIIURZk6TJxHmr45j8uM0/W7cgK1GSJiGEEMIIpHvOxKnyswx3WNgaJxAhhBCigpOkycSp87MNd1jYFF5QCCGEEKVKkiYTt/y0Gc5zUvH8OI03I7tKS5MQQghhJDKmycSlpGeSkgMpOQoZVu4g8zQJIYQQRiEtTSZO5mkSQgghTIMkTSZO5mkSQgghTIMkTSYsNzeXvLw8/bYkTUIIIYTxyJgmE5aRkUF9NzW2Fugmt7TWGDskIYQQosKSpMmEZWRk8HF3a3rV1v0zxWb8BEwxblBCCCFEBSXdcyYsIyMDO8s724q5zNEkhBBCGIskTSYsPT0dW4u7phiQiS2FEEIIo5HuOROWkZHBhE1ZVLJVYWehYua8gXgYOyghhBCigpKkyYRlZGRwPEar355RrbURoxFCCCEqNumeM2F3z9EEMuWAEEIIYUySNJmw9PR0g21JmoQQQgjjkaTJhElLkxBCCGE6JGkyYRnp6VjfNepMkiYhhBDCeGQguAnTZiaQ9Y4jABm5ChZnfoZmQ4wclRBCCFExSUuTCcvLSNG/t7NUgcrMiNEIIYQQFZskTSYsPyvNcIdMbimEEEIYjcklTYsXL8bPzw9ra2sCAgI4dOhQkWXPnDnDgAED8PPzQ6VSsXDhwgJlZs6ciUqlMnjVq1fPoEx2djavvPIKlSpVwt7engEDBhAbG1vSt/bAbqXnM3FrNu/syOars/ZQua6xQxJCCCEqLJNKmtauXcukSZOYMWMGx44do2nTpvTo0YNbt24VWj4zM5MaNWowZ84cPDyKniu7YcOGREdH61979+41OD5x4kQ2bdrEzz//zK5du4iKiuKpp54q0Xt7GLFp+Sw8kMuHe3JZerWqJE1CCCGEEZlU0rRgwQLGjh3L6NGjadCgAUuWLMHW1pZly5YVWr5169bMmzePwYMHY2VlVWS95ubmeHh46F9ubm76YykpKXz77bcsWLCALl260LJlS5YvX87+/fs5cOBAid/jg7h7niZ5ck4IIYQwLpNJmnJzczl69ChBQUH6fWq1mqCgIMLCwv5T3ZcuXcLT05MaNWowdOhQIiMj9ceOHj1KXl6ewXXr1auHj4/Pf77uf3X3PE2SNAkhhBDGZTJJU3x8PBqNBnd3d4P97u7uxMTEPHS9AQEBrFixgpCQEL788kvCw8Np3749aWm6QdYxMTFYWlri7Oxc7Ovm5OSQmppq8CoNdydN9vb2pXINIYQQQhTPIz9PU69evfTvmzRpQkBAAL6+vvz00088//zzD1VncHAws2bNKqkQiyQtTUIIIYTpMJmWJjc3N8zMzAo8tRYbG3vPQd4PytnZmTp16nD58mUAPDw8yM3NJTk5udjXnTp1KikpKfrX9evXSyy+uz3ulcypcXYcHGPH1Kr7ID+3VK4jhBBCiPszmaTJ0tKSli1bsn37dv0+rVbL9u3bCQwMLLHrpKenc+XKFapWrQpAy5YtsbCwMLjuhQsXiIyMLPK6VlZWODo6GrxKg4t5Do2qmOHvZUYdy1gwsyiV6wghhBDi/kyqe27SpEmMHDmSVq1a4e/vz8KFC8nIyGD06NEAjBgxAi8vL4KDgwHd4PGzZ8/q39+8eZMTJ05gb29PrVq1AHjzzTfp06cPvr6+REVFMWPGDMzMzHj22WcBcHJy4vnnn2fSpEm4urri6OjIq6++SmBgIG3atDHCT0FHURTsrcwALQC5mGOpUhktHiGEEKKiM6mkadCgQcTFxTF9+nRiYmJo1qwZISEh+sHhkZGRqNV3GseioqJo3ry5fnv+/PnMnz+fjh07EhoaCsCNGzd49tlnSUhIoHLlyjz22GMcOHCAypUr68/75JNPUKvVDBgwgJycHHr06MEXX3xRNjddBJVKxRsffYNy/ne0OemYqU3qn0oIIYSocFSKoijGDqK8S01NxcnJiZSUlFLrqhNCCCFE6Sju97jJjGkSQgghhDBlkjQJIYQQQhSDJE1CCCGEEMUgSZMQQgghRDHII1mmbNtMSI8DCxuo1gqaDjZ2REIIIUSFJUmTKTu/BeIv6t7npErSJIQQQhiRdM+ZsrysO+8tbIwXhxBCCCGkpcmkOfuC2lyXPNlWMnY0QgghRIUmSZMpG73F2BEIIYQQ4h/SPSeEEEIIUQySNAkhhBBCFIMkTUIIIYQQxSBJkxBCCCFEMUjSJIQQQghRDJI0CSGEEEIUgyRNQgghhBDFIEmTEEIIIUQxSNIkhBBCCFEMkjQJIYQQQhSDJE1CCCGEEMUgSZMQQgghRDFI0iSEEEIIUQzmxg7gUaAoCgCpqalGjkQIIYQQD+r29/ft7/OiSNJUAtLS0gDw9vY2ciRCCCGEeFhpaWk4OTkVeVyl3C+tEvel1WqJiorCwcEBlUr1n+tLTU3F29ub69ev4+joWAIRPtrk5/Vg5Of1YOTn9WDk51V88rN6MKX581IUhbS0NDw9PVGrix65JC1NJUCtVlOtWrUSr9fR0VH+Iz0A+Xn9v717C2ky7uMA/jVfNytNXZpzxebUmpQHwnKN0CIlNbCTF3a4sANGNSOTDhSUBZGhNx2QugjqJq2M7ARRYWkEamRMM0pqKBJpkqDWyjT9vxfRYB3s8YX6P759PzDYnue5+PLjd/F1ezZHh/MaHc5rdDgv5Tir0flT8xrpHaZveCM4ERERkQIsTUREREQKsDSpkFarRWFhIbRarewoYwLnNTqc1+hwXqPDeSnHWY2OGubFG8GJiIiIFOA7TUREREQKsDQRERERKcDSRERERKQAS5PKlJaWIjw8HL6+vrBarXj06JHsSKp08OBBeHl5eTyio6Nlx1KNBw8eIDMzEwaDAV5eXrh69arHeSEEDhw4gLCwMIwfPx6pqal4+fKlnLAq8Lt5rVu37od9S09PlxNWBYqKijB37lz4+/tjypQpWL58OVpaWjyu6e/vh91ux+TJk+Hn54esrCy8fftWUmK5lMxr4cKFP+zY5s2bJSWW69SpU4iLi3P/HpPNZsOtW7fc52XuFkuTily8eBEFBQUoLCzEkydPEB8fj7S0NHR1dcmOpkqzZs1CR0eH+/Hw4UPZkVTD5XIhPj4epaWlPz1fXFyMEydO4PTp06ivr8fEiRORlpaG/v7+v5xUHX43LwBIT0/32Lfy8vK/mFBdampqYLfbUVdXh7t372JwcBCLFy+Gy+VyX7Njxw7cuHEDFRUVqKmpwZs3b7By5UqJqeVRMi8AyM3N9dix4uJiSYnlmjZtGo4ePYqGhgY8fvwYixYtwrJly/Ds2TMAkndLkGokJiYKu93ufj00NCQMBoMoKiqSmEqdCgsLRXx8vOwYYwIAUVlZ6X49PDws9Hq9KCkpcR/r6ekRWq1WlJeXS0ioLt/PSwghcnJyxLJly6TkGQu6uroEAFFTUyOE+LpPPj4+oqKiwn3N8+fPBQBRW1srK6ZqfD8vIYRYsGCB2L59u7xQKhcUFCTOnDkjfbf4TpNKDAwMoKGhAampqe5j48aNQ2pqKmprayUmU6+XL1/CYDAgIiICa9euRXt7u+xIY0Jrays6Ozs9di0gIABWq5W7NoLq6mpMmTIFFosFW7ZsQXd3t+xIqtHb2wsA0Ol0AICGhgYMDg567Fh0dDSMRiN3DD/O65vz588jODgYMTEx2Lt3Lz5+/CgjnqoMDQ3hwoULcLlcsNls0neL/3tOJd69e4ehoSGEhoZ6HA8NDcWLFy8kpVIvq9WKc+fOwWKxoKOjA4cOHUJSUhKam5vh7+8vO56qdXZ2AsBPd+3bOfKUnp6OlStXwmw2w+l0Yt++fcjIyEBtbS28vb1lx5NqeHgY+fn5mD9/PmJiYgB83TGNRoPAwECPa7ljP58XAKxZswYmkwkGgwFNTU3Ys2cPWlpacOXKFYlp5Xn69ClsNhv6+/vh5+eHyspKzJw5Ew6HQ+pusTTRmJSRkeF+HhcXB6vVCpPJhEuXLmHjxo0Sk9H/o1WrVrmfx8bGIi4uDpGRkaiurkZKSorEZPLZ7XY0NzfznkKFfjWvTZs2uZ/HxsYiLCwMKSkpcDqdiIyM/NsxpbNYLHA4HOjt7cXly5eRk5ODmpoa2bF4I7haBAcHw9vb+4dvALx9+xZ6vV5SqrEjMDAQM2bMwKtXr2RHUb1v+8Rd+99FREQgODj4n9+3vLw83Lx5E/fv38e0adPcx/V6PQYGBtDT0+Nx/b++Y7+a189YrVYA+Gd3TKPRICoqCgkJCSgqKkJ8fDyOHz8ufbdYmlRCo9EgISEBVVVV7mPDw8OoqqqCzWaTmGxs+PDhA5xOJ8LCwmRHUT2z2Qy9Xu+xa319faivr+euKfT69Wt0d3f/s/smhEBeXh4qKytx7949mM1mj/MJCQnw8fHx2LGWlha0t7f/kzv2u3n9jMPhAIB/dse+Nzw8jM+fP0vfLX48pyIFBQXIycnBnDlzkJiYiGPHjsHlcmH9+vWyo6nOzp07kZmZCZPJhDdv3qCwsBDe3t5YvXq17Giq8OHDB4+/UFtbW+FwOKDT6WA0GpGfn4/Dhw9j+vTpMJvN2L9/PwwGA5YvXy4vtEQjzUun0+HQoUPIysqCXq+H0+nE7t27ERUVhbS0NImp5bHb7SgrK8O1a9fg7+/vvpckICAA48ePR0BAADZu3IiCggLodDpMmjQJ27Ztg81mw7x58ySn//t+Ny+n04mysjIsWbIEkydPRlNTE3bs2IHk5GTExcVJTv/37d27FxkZGTAajXj//j3KyspQXV2N27dvy9+tP/79PBqVkydPCqPRKDQajUhMTBR1dXWyI6lSdna2CAsLExqNRkydOlVkZ2eLV69eyY6lGvfv3xcAfnjk5OQIIb7+7MD+/ftFaGio0Gq1IiUlRbS0tMgNLdFI8/r48aNYvHixCAkJET4+PsJkMonc3FzR2dkpO7Y0P5sVAHH27Fn3NZ8+fRJbt24VQUFBYsKECWLFihWio6NDXmiJfjev9vZ2kZycLHQ6ndBqtSIqKkrs2rVL9Pb2yg0uyYYNG4TJZBIajUaEhISIlJQUcefOHfd5mbvlJYQQf76aEREREY1tvKeJiIiISAGWJiIiIiIFWJqIiIiIFGBpIiIiIlKApYmIiIhIAZYmIiIiIgVYmoiIiIgUYGkiIiIiUoCliYiIiEgBliYiIiIiBViaiIhG6cuXL7IjEJEELE1ERCNoa2uDl5cXLl26hKSkJGi1Wly/fl12LCKS4D+yAxARqVljYyMAoKSkBEeOHIHZbEZISIjkVEQkA0sTEdEIHA4HJk6ciIqKCoSHh8uOQ0QS8eM5IqIRNDY2YunSpSxMRMTSREQ0EofDgYULF8qOQUQqwNJERPQLfX19aGtrw+zZs2VHISIVYGkiIvqFxsZGeHt7IzY2VnYUIlIBliYiol9obGyExWKBr6+v7ChEpAJeQgghOwQRERGR2vGdJiIiIiIFWJqIiIiIFGBpIiIiIlKApYmIiIhIAZYmIiIiIgVYmoiIiIgUYGkiIiIiUoCliYiIiEgBliYiIiIiBViaiIiIiBRgaSIiIiJSgKWJiIiISIH/AnRc6e8TD0eWAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from galpy.df import isotropicNFWdf\n",
+    "\n",
+    "nfw = potential.NFWPotential(amp=1.0, a=2.0)\n",
+    "nfw.turn_physical_off()\n",
+    "nfw_df = isotropicNFWdf(nfw, rmax=100.0)\n",
+    "numpy.random.seed(42)\n",
+    "n = 300_000\n",
+    "samples = nfw_df.sample(n=n)\n",
+    "pos = numpy.array([samples.x(), samples.y(), samples.z()])\n",
+    "# per-particle mass, so the sampled particles reproduce the halo's mass profile\n",
+    "mass = nfw.mass(100.0, use_physical=False) / n\n",
+    "\n",
+    "scf_nbody = SCFPotential.from_nbody(pos, N=15, symmetry=\"spherical\", a=2.0, mass=mass)\n",
+    "scf_dens = SCFPotential.from_density(nfw.dens, N=15, symmetry=\"spherical\", a=2.0)\n",
+    "\n",
+    "rs = numpy.linspace(0.2, 30.0, 100)\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.plot(\n",
+    "    rs, [nfw.vcirc(r, use_physical=False) for r in rs], \"k-\", lw=2.5, label=\"true NFW\"\n",
+    ")\n",
+    "plt.plot(\n",
+    "    rs,\n",
+    "    [scf_dens.vcirc(r, use_physical=False) for r in rs],\n",
+    "    \"C0--\",\n",
+    "    lw=2.0,\n",
+    "    label=\"SCF from_density\",\n",
+    ")\n",
+    "plt.plot(\n",
+    "    rs,\n",
+    "    [scf_nbody.vcirc(r, use_physical=False) for r in rs],\n",
+    "    \"C1:\",\n",
+    "    lw=2.5,\n",
+    "    label=\"SCF from_nbody\",\n",
+    ")\n",
+    "plt.xlabel(r\"$r$\")\n",
+    "plt.ylabel(r\"$v_c(r)$\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012167,
+     "end_time": "2026-07-04T00:27:40.315280+00:00",
+     "exception": false,
+     "start_time": "2026-07-04T00:27:40.303113+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "The SCF built from the particles closely tracks the one built from the smooth\n",
+    "density; the small residual is the Poisson noise of the finite sample. As with\n",
+    "`from_density`, passing multiple snapshots — `pos` of shape `[3,n,nt]` together with\n",
+    "a `tgrid` of length `nt` — builds a *time-dependent* `SCFPotential`, with the\n",
+    "coefficients computed at each snapshot and interpolated in time. This makes it easy\n",
+    "to turn the output of an N-body simulation directly into a smooth, time-dependent\n",
+    "potential."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e87e7bd1",
    "metadata": {
     "papermill": {
-     "duration": 0.013673,
-     "end_time": "2026-07-03T16:23:58.596826+00:00",
+     "duration": 0.011634,
+     "end_time": "2026-07-04T00:27:40.341833+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.583153+00:00",
+     "start_time": "2026-07-04T00:27:40.330199+00:00",
      "status": "completed"
     },
     "tags": []
@@ -380,20 +508,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "b3c4d5e6f7a8b9c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:58.626769Z",
-     "iopub.status.busy": "2026-07-03T16:23:58.626563Z",
-     "iopub.status.idle": "2026-07-03T16:23:58.636165Z",
-     "shell.execute_reply": "2026-07-03T16:23:58.634528Z"
+     "iopub.execute_input": "2026-07-04T00:27:40.366262Z",
+     "iopub.status.busy": "2026-07-04T00:27:40.366075Z",
+     "iopub.status.idle": "2026-07-04T00:27:40.375581Z",
+     "shell.execute_reply": "2026-07-04T00:27:40.374043Z"
     },
     "papermill": {
-     "duration": 0.02729,
-     "end_time": "2026-07-03T16:23:58.638432+00:00",
+     "duration": 0.023929,
+     "end_time": "2026-07-04T00:27:40.376744+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.611142+00:00",
+     "start_time": "2026-07-04T00:27:40.352815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -443,10 +571,10 @@
    "id": "c4d5e6f7a8b9c0d1",
    "metadata": {
     "papermill": {
-     "duration": 0.01339,
-     "end_time": "2026-07-03T16:23:58.671968+00:00",
+     "duration": 0.015702,
+     "end_time": "2026-07-04T00:27:40.406719+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.658578+00:00",
+     "start_time": "2026-07-04T00:27:40.391017+00:00",
      "status": "completed"
     },
     "tags": []
@@ -457,20 +585,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "3a2dc462",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:58.702354Z",
-     "iopub.status.busy": "2026-07-03T16:23:58.701882Z",
-     "iopub.status.idle": "2026-07-03T16:23:58.710397Z",
-     "shell.execute_reply": "2026-07-03T16:23:58.708278Z"
+     "iopub.execute_input": "2026-07-04T00:27:40.440404Z",
+     "iopub.status.busy": "2026-07-04T00:27:40.440101Z",
+     "iopub.status.idle": "2026-07-04T00:27:40.446321Z",
+     "shell.execute_reply": "2026-07-04T00:27:40.444849Z"
     },
     "papermill": {
-     "duration": 0.025661,
-     "end_time": "2026-07-03T16:23:58.711979+00:00",
+     "duration": 0.024953,
+     "end_time": "2026-07-04T00:27:40.447433+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.686318+00:00",
+     "start_time": "2026-07-04T00:27:40.422480+00:00",
      "status": "completed"
     },
     "tags": []
@@ -530,10 +658,10 @@
    "id": "b13a0695",
    "metadata": {
     "papermill": {
-     "duration": 0.013315,
-     "end_time": "2026-07-03T16:23:58.742467+00:00",
+     "duration": 0.016131,
+     "end_time": "2026-07-04T00:27:40.478133+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.729152+00:00",
+     "start_time": "2026-07-04T00:27:40.462002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -547,10 +675,10 @@
    "id": "17d13f11",
    "metadata": {
     "papermill": {
-     "duration": 0.01306,
-     "end_time": "2026-07-03T16:23:58.769309+00:00",
+     "duration": 0.015998,
+     "end_time": "2026-07-04T00:27:40.508276+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.756249+00:00",
+     "start_time": "2026-07-04T00:27:40.492278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,20 +700,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d5e6f7a8b9c0d1e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:58.798918Z",
-     "iopub.status.busy": "2026-07-03T16:23:58.798404Z",
-     "iopub.status.idle": "2026-07-03T16:23:59.193617Z",
-     "shell.execute_reply": "2026-07-03T16:23:59.191962Z"
+     "iopub.execute_input": "2026-07-04T00:27:40.540340Z",
+     "iopub.status.busy": "2026-07-04T00:27:40.540125Z",
+     "iopub.status.idle": "2026-07-04T00:27:40.875187Z",
+     "shell.execute_reply": "2026-07-04T00:27:40.873806Z"
     },
     "papermill": {
-     "duration": 0.41348,
-     "end_time": "2026-07-03T16:23:59.196070+00:00",
+     "duration": 0.352269,
+     "end_time": "2026-07-04T00:27:40.877001+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:58.782590+00:00",
+     "start_time": "2026-07-04T00:27:40.524732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -609,10 +737,10 @@
    "id": "e6f7a8b9c0d1e2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.013477,
-     "end_time": "2026-07-03T16:23:59.231393+00:00",
+     "duration": 0.014455,
+     "end_time": "2026-07-04T00:27:40.909440+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:59.217916+00:00",
+     "start_time": "2026-07-04T00:27:40.894985+00:00",
      "status": "completed"
     },
     "tags": []
@@ -623,20 +751,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f7a8b9c0d1e2f3a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:23:59.261264Z",
-     "iopub.status.busy": "2026-07-03T16:23:59.260994Z",
-     "iopub.status.idle": "2026-07-03T16:24:00.193407Z",
-     "shell.execute_reply": "2026-07-03T16:24:00.191847Z"
+     "iopub.execute_input": "2026-07-04T00:27:40.940016Z",
+     "iopub.status.busy": "2026-07-04T00:27:40.939804Z",
+     "iopub.status.idle": "2026-07-04T00:27:41.845134Z",
+     "shell.execute_reply": "2026-07-04T00:27:41.843967Z"
     },
     "papermill": {
-     "duration": 0.950241,
-     "end_time": "2026-07-03T16:24:00.195606+00:00",
+     "duration": 0.92293,
+     "end_time": "2026-07-04T00:27:41.847175+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:23:59.245365+00:00",
+     "start_time": "2026-07-04T00:27:40.924245+00:00",
      "status": "completed"
     },
     "tags": []
@@ -668,10 +796,10 @@
    "id": "a8b9c0d1e2f3a4b5",
    "metadata": {
     "papermill": {
-     "duration": 0.019783,
-     "end_time": "2026-07-03T16:24:00.238977+00:00",
+     "duration": 0.01527,
+     "end_time": "2026-07-04T00:27:41.884281+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:00.219194+00:00",
+     "start_time": "2026-07-04T00:27:41.869011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -682,20 +810,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "b9c0d1e2f3a4b5c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:00.270826Z",
-     "iopub.status.busy": "2026-07-03T16:24:00.270626Z",
-     "iopub.status.idle": "2026-07-03T16:24:09.974203Z",
-     "shell.execute_reply": "2026-07-03T16:24:09.972403Z"
+     "iopub.execute_input": "2026-07-04T00:27:41.921275Z",
+     "iopub.status.busy": "2026-07-04T00:27:41.921075Z",
+     "iopub.status.idle": "2026-07-04T00:27:51.575771Z",
+     "shell.execute_reply": "2026-07-04T00:27:51.574465Z"
     },
     "papermill": {
-     "duration": 9.725821,
-     "end_time": "2026-07-03T16:24:09.980741+00:00",
+     "duration": 9.682033,
+     "end_time": "2026-07-04T00:27:51.581984+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:00.254920+00:00",
+     "start_time": "2026-07-04T00:27:41.899951+00:00",
      "status": "completed"
     },
     "tags": []
@@ -730,10 +858,10 @@
    "id": "c0d1e2f3a4b5c6d7",
    "metadata": {
     "papermill": {
-     "duration": 0.031882,
-     "end_time": "2026-07-03T16:24:10.046247+00:00",
+     "duration": 0.021571,
+     "end_time": "2026-07-04T00:27:51.634018+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:10.014365+00:00",
+     "start_time": "2026-07-04T00:27:51.612447+00:00",
      "status": "completed"
     },
     "tags": []
@@ -744,20 +872,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "226e8f68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:10.092632Z",
-     "iopub.status.busy": "2026-07-03T16:24:10.092389Z",
-     "iopub.status.idle": "2026-07-03T16:24:30.345468Z",
-     "shell.execute_reply": "2026-07-03T16:24:30.344004Z"
+     "iopub.execute_input": "2026-07-04T00:27:51.685213Z",
+     "iopub.status.busy": "2026-07-04T00:27:51.684928Z",
+     "iopub.status.idle": "2026-07-04T00:28:11.914998Z",
+     "shell.execute_reply": "2026-07-04T00:28:11.913587Z"
     },
     "papermill": {
-     "duration": 20.278847,
-     "end_time": "2026-07-03T16:24:30.347426+00:00",
+     "duration": 20.254437,
+     "end_time": "2026-07-04T00:28:11.916700+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:10.068579+00:00",
+     "start_time": "2026-07-04T00:27:51.662263+00:00",
      "status": "completed"
     },
     "tags": []
@@ -767,7 +895,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.53 s ± 16.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.53 s ± 14.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -782,10 +910,10 @@
    "id": "acf72105",
    "metadata": {
     "papermill": {
-     "duration": 0.021889,
-     "end_time": "2026-07-03T16:24:30.404740+00:00",
+     "duration": 0.02674,
+     "end_time": "2026-07-04T00:28:11.974838+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:30.382851+00:00",
+     "start_time": "2026-07-04T00:28:11.948098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -796,20 +924,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "745deca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:30.464142Z",
-     "iopub.status.busy": "2026-07-03T16:24:30.463926Z",
-     "iopub.status.idle": "2026-07-03T16:24:36.774059Z",
-     "shell.execute_reply": "2026-07-03T16:24:36.772541Z"
+     "iopub.execute_input": "2026-07-04T00:28:12.024471Z",
+     "iopub.status.busy": "2026-07-04T00:28:12.024237Z",
+     "iopub.status.idle": "2026-07-04T00:28:18.413635Z",
+     "shell.execute_reply": "2026-07-04T00:28:18.412296Z"
     },
     "papermill": {
-     "duration": 6.337627,
-     "end_time": "2026-07-03T16:24:36.776020+00:00",
+     "duration": 6.420954,
+     "end_time": "2026-07-04T00:28:18.415675+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:30.438393+00:00",
+     "start_time": "2026-07-04T00:28:11.994721+00:00",
      "status": "completed"
     },
     "tags": []
@@ -819,7 +947,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "77.8 ms ± 161 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "78.6 ms ± 1.12 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -834,10 +962,10 @@
    "id": "3fa99bf4",
    "metadata": {
     "papermill": {
-     "duration": 0.022645,
-     "end_time": "2026-07-03T16:24:36.834241+00:00",
+     "duration": 0.021627,
+     "end_time": "2026-07-04T00:28:18.468324+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:36.811596+00:00",
+     "start_time": "2026-07-04T00:28:18.446697+00:00",
      "status": "completed"
     },
     "tags": []
@@ -857,20 +985,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "d1e2f3a4b5c6d7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:36.889539Z",
-     "iopub.status.busy": "2026-07-03T16:24:36.889327Z",
-     "iopub.status.idle": "2026-07-03T16:24:37.859352Z",
-     "shell.execute_reply": "2026-07-03T16:24:37.857749Z"
+     "iopub.execute_input": "2026-07-04T00:28:18.518069Z",
+     "iopub.status.busy": "2026-07-04T00:28:18.517822Z",
+     "iopub.status.idle": "2026-07-04T00:28:19.508647Z",
+     "shell.execute_reply": "2026-07-04T00:28:19.507191Z"
     },
     "papermill": {
-     "duration": 0.995942,
-     "end_time": "2026-07-03T16:24:37.861371+00:00",
+     "duration": 1.014879,
+     "end_time": "2026-07-04T00:28:19.510613+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:36.865429+00:00",
+     "start_time": "2026-07-04T00:28:18.495734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -901,10 +1029,10 @@
    "id": "e2f3a4b5c6d7e8f9",
    "metadata": {
     "papermill": {
-     "duration": 0.032139,
-     "end_time": "2026-07-03T16:24:37.926536+00:00",
+     "duration": 0.020649,
+     "end_time": "2026-07-04T00:28:19.561153+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:37.894397+00:00",
+     "start_time": "2026-07-04T00:28:19.540504+00:00",
      "status": "completed"
     },
     "tags": []
@@ -915,20 +1043,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "f3a4b5c6d7e8f9a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:37.972352Z",
-     "iopub.status.busy": "2026-07-03T16:24:37.972148Z",
-     "iopub.status.idle": "2026-07-03T16:24:38.299488Z",
-     "shell.execute_reply": "2026-07-03T16:24:38.298113Z"
+     "iopub.execute_input": "2026-07-04T00:28:19.605935Z",
+     "iopub.status.busy": "2026-07-04T00:28:19.605703Z",
+     "iopub.status.idle": "2026-07-04T00:28:19.926918Z",
+     "shell.execute_reply": "2026-07-04T00:28:19.925675Z"
     },
     "papermill": {
-     "duration": 0.35338,
-     "end_time": "2026-07-03T16:24:38.301628+00:00",
+     "duration": 0.346288,
+     "end_time": "2026-07-04T00:28:19.928904+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:37.948248+00:00",
+     "start_time": "2026-07-04T00:28:19.582616+00:00",
      "status": "completed"
     },
     "tags": []
@@ -961,10 +1089,10 @@
    "id": "a4b5c6d7e8f9a0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.023703,
-     "end_time": "2026-07-03T16:24:38.358768+00:00",
+     "duration": 0.023707,
+     "end_time": "2026-07-04T00:28:19.984020+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:38.335065+00:00",
+     "start_time": "2026-07-04T00:28:19.960313+00:00",
      "status": "completed"
     },
     "tags": []
@@ -975,20 +1103,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "2d0d29d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:38.411056Z",
-     "iopub.status.busy": "2026-07-03T16:24:38.410843Z",
-     "iopub.status.idle": "2026-07-03T16:24:46.575382Z",
-     "shell.execute_reply": "2026-07-03T16:24:46.572909Z"
+     "iopub.execute_input": "2026-07-04T00:28:20.029945Z",
+     "iopub.status.busy": "2026-07-04T00:28:20.029650Z",
+     "iopub.status.idle": "2026-07-04T00:28:28.258202Z",
+     "shell.execute_reply": "2026-07-04T00:28:28.256868Z"
     },
     "papermill": {
-     "duration": 8.195927,
-     "end_time": "2026-07-03T16:24:46.577151+00:00",
+     "duration": 8.25447,
+     "end_time": "2026-07-04T00:28:28.260570+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:38.381224+00:00",
+     "start_time": "2026-07-04T00:28:20.006100+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1015,10 +1143,10 @@
    "id": "9ce6e0c9",
    "metadata": {
     "papermill": {
-     "duration": 0.022999,
-     "end_time": "2026-07-03T16:24:46.635315+00:00",
+     "duration": 0.021962,
+     "end_time": "2026-07-04T00:28:28.315696+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:46.612316+00:00",
+     "start_time": "2026-07-04T00:28:28.293734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1029,20 +1157,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "04a6500d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:46.682967Z",
-     "iopub.status.busy": "2026-07-03T16:24:46.682678Z",
-     "iopub.status.idle": "2026-07-03T16:24:48.770720Z",
-     "shell.execute_reply": "2026-07-03T16:24:48.769209Z"
+     "iopub.execute_input": "2026-07-04T00:28:28.362201Z",
+     "iopub.status.busy": "2026-07-04T00:28:28.361966Z",
+     "iopub.status.idle": "2026-07-04T00:28:30.438265Z",
+     "shell.execute_reply": "2026-07-04T00:28:30.436999Z"
     },
     "papermill": {
-     "duration": 2.117193,
-     "end_time": "2026-07-03T16:24:48.775132+00:00",
+     "duration": 2.104171,
+     "end_time": "2026-07-04T00:28:30.442216+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:46.657939+00:00",
+     "start_time": "2026-07-04T00:28:28.338045+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1105,10 +1233,10 @@
    "id": "a5956d7b",
    "metadata": {
     "papermill": {
-     "duration": 0.037155,
-     "end_time": "2026-07-03T16:24:48.853187+00:00",
+     "duration": 0.025695,
+     "end_time": "2026-07-04T00:28:30.505993+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:48.816032+00:00",
+     "start_time": "2026-07-04T00:28:30.480298+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1163,20 +1291,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "4d7c563b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:48.909499Z",
-     "iopub.status.busy": "2026-07-03T16:24:48.909257Z",
-     "iopub.status.idle": "2026-07-03T16:24:53.696581Z",
-     "shell.execute_reply": "2026-07-03T16:24:53.695130Z"
+     "iopub.execute_input": "2026-07-04T00:28:30.567524Z",
+     "iopub.status.busy": "2026-07-04T00:28:30.567267Z",
+     "iopub.status.idle": "2026-07-04T00:28:35.264757Z",
+     "shell.execute_reply": "2026-07-04T00:28:35.263476Z"
     },
     "papermill": {
-     "duration": 4.820074,
-     "end_time": "2026-07-03T16:24:53.700193+00:00",
+     "duration": 4.734956,
+     "end_time": "2026-07-04T00:28:35.267732+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:48.880119+00:00",
+     "start_time": "2026-07-04T00:28:30.532776+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1285,10 +1413,10 @@
    "id": "aeabed99",
    "metadata": {
     "papermill": {
-     "duration": 0.030541,
-     "end_time": "2026-07-03T16:24:53.775672+00:00",
+     "duration": 0.038349,
+     "end_time": "2026-07-04T00:28:35.347943+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:53.745131+00:00",
+     "start_time": "2026-07-04T00:28:35.309594+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1314,20 +1442,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "2ad4d3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:24:53.846579Z",
-     "iopub.status.busy": "2026-07-03T16:24:53.846301Z",
-     "iopub.status.idle": "2026-07-03T16:24:54.258388Z",
-     "shell.execute_reply": "2026-07-03T16:24:54.256715Z"
+     "iopub.execute_input": "2026-07-04T00:28:35.414616Z",
+     "iopub.status.busy": "2026-07-04T00:28:35.414354Z",
+     "iopub.status.idle": "2026-07-04T00:28:35.805263Z",
+     "shell.execute_reply": "2026-07-04T00:28:35.804003Z"
     },
     "papermill": {
-     "duration": 0.446438,
-     "end_time": "2026-07-03T16:24:54.260820+00:00",
+     "duration": 0.432685,
+     "end_time": "2026-07-04T00:28:35.807990+00:00",
      "exception": false,
-     "start_time": "2026-07-03T16:24:53.814382+00:00",
+     "start_time": "2026-07-04T00:28:35.375305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1403,14 +1531,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 191.547401,
-   "end_time": "2026-07-03T16:24:55.326663+00:00",
+   "duration": 173.644855,
+   "end_time": "2026-07-04T00:28:36.768488+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "output_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "parameters": {},
-   "start_time": "2026-07-03T16:21:43.779262+00:00",
+   "start_time": "2026-07-04T00:25:43.123633+00:00",
    "version": "2.7.0"
   }
  },

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -352,8 +352,8 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             Expansion scale length.
         symmetry : {'spherical','axisymmetry',None}, optional
             Symmetry of the profile to assume. None is the general, non-axisymmetric case.
-        tgrid : numpy.ndarray or None, optional
-            Time grid for time-dependent potentials. If provided, the expansion coefficients are computed at each time in ``tgrid`` (passing ``t`` to the density function when it accepts one) and interpolated in time, producing a time-dependent SCFPotential. Default: ``None`` (static potential; any ``t`` argument of the density is ignored).
+        tgrid : numpy.ndarray, Quantity, or None, optional
+            Time grid for time-dependent potentials (a Quantity in physical time units, e.g. Gyr, is accepted). If provided, the expansion coefficients are computed at each time in ``tgrid`` (passing ``t`` to the density function when it accepts one) and interpolated in time, producing a time-dependent SCFPotential. Default: ``None`` (static potential; any ``t`` argument of the density is ignored).
         radial_order : int, optional
             Number of sample points for the radial integral. If None, radial_order=max(20, N + 3/2L + 1).
         costheta_order : int, optional
@@ -381,6 +381,7 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         internal_vo = dumm._vo
         a = conversion.parse_length(a, ro=internal_ro)
         if tgrid is not None:
+            tgrid = conversion.parse_time(tgrid, ro=internal_ro, vo=internal_vo)
             return cls._from_density_timedep(
                 dens,
                 N,
@@ -468,10 +469,11 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             Expansion scale length.
         symmetry : {'spherical','axisymmetry',None}, optional
             Symmetry to assume. None is the general, non-axisymmetric case.
-        tgrid : numpy.ndarray or None, optional
-            Time grid for a time-dependent potential. If provided, ``pos`` must
-            have shape ``[3,n,len(tgrid)]`` and the coefficients are computed at
-            each snapshot and interpolated in time. Default: ``None`` (static).
+        tgrid : numpy.ndarray, Quantity, or None, optional
+            Time grid for a time-dependent potential (a Quantity in physical time
+            units, e.g. Gyr, is accepted). If provided, ``pos`` must have shape
+            ``[3,n,len(tgrid)]`` and the coefficients are computed at each snapshot
+            and interpolated in time. Default: ``None`` (static).
         ro : float or Quantity, optional
             Distance scale for translation into internal units (default from configuration file).
         vo : float or Quantity, optional
@@ -510,7 +512,9 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
             mass = _nbody_parse_mass(mass, pos.shape[1])
             Acos, Asin = _batched_nbody(pos, N, L, mass, a, symmetry)
             return cls(Acos=Acos, Asin=Asin, a=a, ro=out_ro, vo=out_vo)
-        tgrid = numpy.asarray(tgrid)
+        tgrid = numpy.asarray(
+            conversion.parse_time(tgrid, ro=internal_ro, vo=internal_vo)
+        )
         Nt = len(tgrid)
         if pos.ndim != 3 or pos.shape[2] != Nt:
             raise ValueError(

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -423,6 +423,117 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
                 vo = internal_vo
         return cls(Acos=Acos, Asin=Asin, a=a, ro=ro, vo=vo)
 
+    @classmethod
+    def from_nbody(
+        cls,
+        pos,
+        N,
+        L=None,
+        mass=1.0,
+        a=1.0,
+        symmetry=None,
+        tgrid=None,
+        ro=None,
+        vo=None,
+    ):
+        """
+        Initialize an SCFPotential from an N-body / particle representation.
+
+        Computes the expansion coefficients directly from a set of particle
+        positions and masses (using ``scf_compute_coeffs_spherical_nbody`` and
+        its axisymmetric and general counterparts). A time-dependent potential is
+        built by passing multiple snapshots: give ``pos`` with shape ``[3,n,nt]``
+        together with a ``tgrid`` of length ``nt``, and the coefficients are
+        computed at each snapshot and interpolated in time (analogous to the
+        time-dependent ``from_density``). The particle sum is accumulated in
+        batches so that building from a very large number of particles stays
+        memory-bounded.
+
+        Parameters
+        ----------
+        pos : numpy.ndarray or Quantity
+            Positions of the particles in rectangular coordinates, with shape
+            ``[3,n]`` (static) or ``[3,n,nt]`` (time-dependent, one snapshot per
+            time in ``tgrid``).
+        N : int
+            Number of radial basis functions.
+        L : int, optional
+            Number of costheta basis functions; for non-axisymmetric profiles also
+            sets the number of azimuthal (phi) basis functions to M = 2L+1.
+            Required unless ``symmetry='spherical'``.
+        mass : float, numpy.ndarray, or Quantity, optional
+            Particle masses: a scalar (all equal), an array of shape ``[n]``, or,
+            for the time-dependent case, an array of shape ``[n,nt]``. Default 1.0.
+        a : float or Quantity, optional
+            Expansion scale length.
+        symmetry : {'spherical','axisymmetry',None}, optional
+            Symmetry to assume. None is the general, non-axisymmetric case.
+        tgrid : numpy.ndarray or None, optional
+            Time grid for a time-dependent potential. If provided, ``pos`` must
+            have shape ``[3,n,len(tgrid)]`` and the coefficients are computed at
+            each snapshot and interpolated in time. Default: ``None`` (static).
+        ro : float or Quantity, optional
+            Distance scale for translation into internal units (default from configuration file).
+        vo : float or Quantity, optional
+            Velocity scale for translation into internal units (default from configuration file).
+
+        Returns
+        -------
+        SCFPotential object
+
+        Notes
+        -----
+        - 2026-07-04 - Written - Bovy (UofT)
+
+        """
+        # Dummy object for ro/vo handling, to ensure consistency
+        dumm = cls(ro=ro, vo=vo)
+        internal_ro = dumm._ro
+        internal_vo = dumm._vo
+        # Physical outputs if any physical (Quantity) input was given
+        physical = _APY_LOADED and (
+            isinstance(mass, units.Quantity) or isinstance(pos, units.Quantity)
+        )
+        a = conversion.parse_length(a, ro=internal_ro)
+        pos = numpy.asarray(conversion.parse_length(pos, ro=internal_ro), dtype=float)
+        mass = numpy.asarray(
+            conversion.parse_mass(mass, ro=internal_ro, vo=internal_vo), dtype=float
+        )
+        if pos.ndim not in (2, 3) or pos.shape[0] != 3:
+            raise ValueError(
+                "pos must have shape [3,n] (static) or [3,n,nt] (time-dependent)"
+            )
+        out_ro, out_vo = (internal_ro, internal_vo) if physical else (ro, vo)
+        if tgrid is None:
+            if pos.ndim != 2:
+                raise ValueError("pos must have shape [3,n] when tgrid is not given")
+            mass = _nbody_parse_mass(mass, pos.shape[1])
+            Acos, Asin = _batched_nbody(pos, N, L, mass, a, symmetry)
+            return cls(Acos=Acos, Asin=Asin, a=a, ro=out_ro, vo=out_vo)
+        tgrid = numpy.asarray(tgrid)
+        Nt = len(tgrid)
+        if pos.ndim != 3 or pos.shape[2] != Nt:
+            raise ValueError(
+                "pos must have shape [3,n,nt] with nt=len(tgrid) when tgrid is given"
+            )
+        n = pos.shape[1]
+        mass2d = mass.ndim == 2
+        if mass2d and mass.shape != (n, Nt):
+            raise ValueError("a 2D mass must have shape [n,nt]")
+        Acos_list = []
+        Asin_list = []
+        any_sin = False
+        for it in range(Nt):
+            mass_it = _nbody_parse_mass(mass[:, it] if mass2d else mass, n)
+            Ac, As = _batched_nbody(pos[:, :, it], N, L, mass_it, a, symmetry)
+            Acos_list.append(Ac)
+            if As is not None:
+                any_sin = True
+            Asin_list.append(As)
+        Acos_all = numpy.array(Acos_list)
+        Asin_all = numpy.array(Asin_list) if any_sin else None
+        return cls(Acos=Acos_all, Asin=Asin_all, a=a, tgrid=tgrid, ro=out_ro, vo=out_vo)
+
     @staticmethod
     def _symmetry_coeffs(
         dens, N, L, a, symmetry, radial_order, costheta_order, phi_order
@@ -1411,6 +1522,82 @@ def scf_compute_coeffs_nbody(pos, N, L, mass=1.0, a=1.0):
                 Plmm1 = tmp
         # Recurse Assoc. Legendre
         Pll *= -(2 * mm + 1.0) * sintheta
+    return Acos, Asin
+
+
+# Peak-memory budget (bytes) for one working copy of the per-particle basis
+# arrays [shape (N, batch)] when computing N-body coefficients; the particle sum
+# is accumulated in batches no larger than this so building from a very large
+# number of particles stays memory-bounded. Module-level (not a public
+# parameter); tests set it small to exercise the batched path.
+_NBODY_BATCH_BYTES = 32 * 1024**2  # 32 MB
+
+
+def _nbody_parse_mass(mass, n):
+    """Normalize a particle-mass input (scalar or length-n array) to shape (n,).
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    mass = numpy.asarray(mass, dtype=float)
+    if mass.ndim == 0 or mass.size == 1:
+        return numpy.broadcast_to(mass.reshape(()), (n,))
+    if mass.shape != (n,):
+        raise ValueError("mass must be a scalar or match the number of particles")
+    return mass
+
+
+def _nbody_symmetry_coeffs(pos, N, L, mass, a, symmetry):
+    """Compute (Acos, Asin) from particle positions/masses for the assumed symmetry.
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    if symmetry is not None and symmetry.startswith("spher"):
+        return scf_compute_coeffs_spherical_nbody(pos, N, mass=mass, a=a)
+    elif symmetry is not None and symmetry.startswith("axi"):
+        return scf_compute_coeffs_axi_nbody(pos, N, L, mass=mass, a=a)
+    else:
+        return scf_compute_coeffs_nbody(pos, N, L, mass=mass, a=a)
+
+
+def _nbody_batch_size(n, N):
+    """Number of particles to process per batch so a working copy of the
+    (N, batch) per-particle basis arrays stays within ``_NBODY_BATCH_BYTES``.
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    per_batch = _NBODY_BATCH_BYTES // (max(N, 1) * 8 * 4)  # ~4 working copies
+    return int(min(n, max(1, per_batch)))
+
+
+def _batched_nbody(pos, N, L, mass, a, symmetry):
+    """Compute (Acos, Asin) from particle positions ``pos`` [shape (3,n)] and
+    masses ``mass`` [shape (n,)], accumulating the particle sum in batches to
+    bound memory. This is exact: each coefficient is a particle-independent
+    constant times a sum over particles, so summing per-batch coefficients
+    reproduces the all-at-once result (up to floating-point summation order).
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    if (symmetry is None or not symmetry.startswith("spher")) and L is None:
+        raise ValueError("L must be specified unless symmetry='spherical'")
+    n = pos.shape[1]
+    batch = _nbody_batch_size(n, N)
+    Acos = None
+    Asin = None
+    for start in range(0, n, batch):
+        sl = slice(start, start + batch)
+        Ac, As = _nbody_symmetry_coeffs(pos[:, sl], N, L, mass[sl], a, symmetry)
+        Acos = Ac if Acos is None else Acos + Ac
+        if As is not None:
+            Asin = As if Asin is None else Asin + As
     return Acos, Asin
 
 

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -10520,6 +10520,79 @@ def test_potential_paramunits():
     return None
 
 
+def test_scfpotential_from_nbody_units():
+    # SCFPotential.from_nbody accepts physical-unit (Quantity) particle positions,
+    # masses, and scale length, and (for the time-dependent case) a Gyr time grid,
+    # matching an equivalent build in galpy's internal units.
+    from galpy import potential
+    from galpy.util import conversion
+
+    ro, vo = 8.0, 220.0
+    numpy.random.seed(9)
+    n, N, L = 8000, 6, 3
+    pos_int = numpy.random.randn(3, n) * 1.5  # internal-unit positions
+    mass_int = (1e-3 / n) * numpy.ones(n)
+    # internal-unit build (no ro/vo -> physical outputs off)
+    sp_plain = potential.SCFPotential.from_nbody(
+        pos_int, N, L=L, symmetry=None, a=1.0, mass=mass_int
+    )
+    assert not sp_plain._roSet, "from_nbody w/ plain inputs unexpectedly set ro"
+    # equivalent build with Quantity inputs -> physical outputs on, same coeffs
+    ro0, vo0 = sp_plain._ro, sp_plain._vo
+    massfac = conversion.mass_in_msol(vo0, ro0)
+    sp_phys = potential.SCFPotential.from_nbody(
+        pos_int * ro0 * units.kpc,
+        N,
+        L=L,
+        symmetry=None,
+        a=1.0 * ro0 * units.kpc,
+        mass=mass_int * massfac * units.Msun,
+    )
+    assert sp_phys._roSet and sp_phys._voSet, (
+        "from_nbody w/ Quantity inputs did not turn on physical outputs"
+    )
+    assert numpy.max(numpy.fabs(sp_phys._Acos - sp_plain._Acos)) < 1e-10, (
+        "from_nbody w/ Quantity positions/masses/a does not match internal-unit build"
+    )
+    assert numpy.max(numpy.fabs(sp_phys._Asin - sp_plain._Asin)) < 1e-10, (
+        "from_nbody w/ Quantity positions/masses/a does not match internal-unit build"
+    )
+    # time-dependent: a Gyr time grid matches the equivalent internal-unit grid
+    nt = 4
+    pos_t = numpy.random.randn(3, n, nt) * 1.5
+    tg_int = numpy.linspace(0.0, 2.0, nt)
+    tg_gyr = tg_int * conversion.time_in_Gyr(vo, ro) * units.Gyr
+    sp_tint = potential.SCFPotential.from_nbody(
+        pos_t, N, L=L, symmetry=None, a=1.0, mass=mass_int, tgrid=tg_int, ro=ro, vo=vo
+    )
+    sp_tgyr = potential.SCFPotential.from_nbody(
+        pos_t, N, L=L, symmetry=None, a=1.0, mass=mass_int, tgrid=tg_gyr, ro=ro, vo=vo
+    )
+    assert numpy.all(numpy.fabs(sp_tint._tgrid - sp_tgyr._tgrid) < 1e-8), (
+        "from_nbody w/ Gyr tgrid does not match the internal-unit tgrid"
+    )
+    assert numpy.max(numpy.fabs(sp_tint._Acos_all - sp_tgyr._Acos_all)) < 1e-10, (
+        "from_nbody w/ Gyr tgrid does not match the internal-unit build"
+    )
+    # from_density likewise accepts a Gyr time grid
+    hp = potential.HernquistPotential(amp=0.5, a=1.0)
+    hp.turn_physical_off()
+    dens = lambda R, z, phi, t=0.0: (
+        hp.dens(R, z, use_physical=False)
+        * (1.0 + 0.1 * numpy.cos(2 * phi) * (1.0 + 0.05 * t))
+    )
+    sd_int = potential.SCFPotential.from_density(
+        dens, N, L=L, symmetry=None, a=1.0, tgrid=tg_int, ro=ro, vo=vo
+    )
+    sd_gyr = potential.SCFPotential.from_density(
+        dens, N, L=L, symmetry=None, a=1.0, tgrid=tg_gyr, ro=ro, vo=vo
+    )
+    assert numpy.max(numpy.fabs(sd_int._Acos_all - sd_gyr._Acos_all)) < 1e-10, (
+        "from_density w/ Gyr tgrid does not match the internal-unit build"
+    )
+    return None
+
+
 def test_potential_paramunits_2d():
     # Test that input units for potential parameters other than the amplitude
     # behave as expected

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -583,38 +583,6 @@ def test_from_nbody_matches_from_density():
     assert numpy.all(numpy.fabs(p_nb / p_true - 1.0) < 0.02)
 
 
-def test_from_nbody_physical():
-    # Physical (Quantity) positions/masses turn on physical outputs, and the
-    # internal-unit values match an equivalent plain-units build.
-    from astropy import units
-
-    from galpy.util import conversion
-
-    n, N, L = 10000, 6, 3
-    pos_int = _nbody_sample_positions(n, seed=9)  # internal-unit positions
-    mass_int = (1e-3 / n) * numpy.ones(n)
-    # plain floats, no ro/vo -> physical outputs off
-    sp_plain = SCFPotential.from_nbody(
-        pos_int, N, L=L, symmetry=None, a=1.0, mass=mass_int
-    )
-    assert not sp_plain._roSet
-    # equivalent build with Quantity inputs (no ro/vo passed) -> physical on
-    ro, vo = sp_plain._ro, sp_plain._vo
-    massfac = conversion.mass_in_msol(vo, ro)
-    sp_phys = SCFPotential.from_nbody(
-        pos_int * ro * units.kpc,
-        N,
-        L=L,
-        symmetry=None,
-        a=1.0 * ro * units.kpc,
-        mass=mass_int * massfac * units.Msun,
-    )
-    assert sp_phys._roSet and sp_phys._voSet  # Quantity inputs -> physical on
-    # unit parsing round-trips to identical internal coefficients
-    assert numpy.max(numpy.fabs(sp_phys._Acos - sp_plain._Acos)) < 1e-10
-    assert numpy.max(numpy.fabs(sp_phys._Asin - sp_plain._Asin)) < 1e-10
-
-
 def test_from_nbody_errors():
     n, N, L = 1000, 6, 3
     pos = _nbody_sample_positions(n, seed=2)

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -412,6 +412,238 @@ def test_scf_compute_nbody_twopowertriaxial():
     return None
 
 
+# ---------------------- from_nbody ----------------------
+
+_NBODY_A = 1.3
+
+
+def _nbody_sample_positions(n, seed=7):
+    numpy.random.seed(seed)
+    return numpy.random.randn(3, n) * 1.5
+
+
+def test_from_nbody_static_matches_direct():
+    # Static from_nbody reproduces a direct scf_compute_coeffs_*_nbody build
+    # (single batch -> exactly), for spherical, axisymmetric, and general symmetry.
+    n, N, L = 20000, 8, 4
+    pos = _nbody_sample_positions(n)
+    mass = (1.0 / n) * numpy.ones(n)
+    for symmetry, Lk, coeffs in [
+        (
+            "spherical",
+            None,
+            potential.scf_compute_coeffs_spherical_nbody(pos, N, mass=mass, a=_NBODY_A),
+        ),
+        (
+            "axi",
+            L,
+            potential.scf_compute_coeffs_axi_nbody(pos, N, L, mass=mass, a=_NBODY_A),
+        ),
+        (None, L, potential.scf_compute_coeffs_nbody(pos, N, L, mass=mass, a=_NBODY_A)),
+    ]:
+        sp = SCFPotential.from_nbody(
+            pos, N, L=Lk, symmetry=symmetry, a=_NBODY_A, mass=mass
+        )
+        ref = SCFPotential(Acos=coeffs[0], Asin=coeffs[1], a=_NBODY_A)
+        assert not sp._tdep
+        assert numpy.max(numpy.fabs(sp._Acos - ref._Acos)) < 1e-12
+        if sp._Asin is not None:
+            assert numpy.max(numpy.fabs(sp._Asin - ref._Asin)) < 1e-12
+    # general symmetry is non-axisymmetric; spherical/axi are not
+    assert SCFPotential.from_nbody(
+        pos, N, L=L, symmetry=None, a=_NBODY_A, mass=mass
+    ).isNonAxi
+    assert not SCFPotential.from_nbody(
+        pos, N, L=L, symmetry="axi", a=_NBODY_A, mass=mass
+    ).isNonAxi
+
+
+def test_from_nbody_scalar_vs_array_mass():
+    # A scalar mass is equivalent to a constant per-particle mass array.
+    n, N, L = 15000, 8, 3
+    pos = _nbody_sample_positions(n, seed=3)
+    sp_scalar = SCFPotential.from_nbody(
+        pos, N, L=L, symmetry=None, a=_NBODY_A, mass=1.0 / n
+    )
+    sp_array = SCFPotential.from_nbody(
+        pos, N, L=L, symmetry=None, a=_NBODY_A, mass=(1.0 / n) * numpy.ones(n)
+    )
+    assert numpy.max(numpy.fabs(sp_scalar._Acos - sp_array._Acos)) < 1e-12
+    assert numpy.max(numpy.fabs(sp_scalar._Asin - sp_array._Asin)) < 1e-12
+
+
+def test_from_nbody_particle_batching():
+    # Forcing a tiny memory budget processes the particle sum in many batches; the
+    # result must match the single-batch build (up to floating-point summation
+    # order). Covers the batched path and both symmetry branches.
+    import sys
+
+    scfmod = sys.modules[SCFPotential.__module__]
+    n, N, L = 40000, 8, 3
+    pos = _nbody_sample_positions(n, seed=5)
+    mass = (1.0 / n) * numpy.ones(n)
+    ref_g = SCFPotential.from_nbody(pos, N, L=L, symmetry=None, a=_NBODY_A, mass=mass)
+    ref_s = SCFPotential.from_nbody(pos, N, symmetry="spherical", a=_NBODY_A, mass=mass)
+    old = scfmod._NBODY_BATCH_BYTES
+    scfmod._NBODY_BATCH_BYTES = 4 * 1024  # tiny -> thousands of batches
+    try:
+        assert scfmod._nbody_batch_size(n, N) < n
+        bat_g = SCFPotential.from_nbody(
+            pos, N, L=L, symmetry=None, a=_NBODY_A, mass=mass
+        )
+        bat_s = SCFPotential.from_nbody(
+            pos, N, symmetry="spherical", a=_NBODY_A, mass=mass
+        )
+    finally:
+        scfmod._NBODY_BATCH_BYTES = old
+    assert numpy.max(numpy.fabs(bat_g._Acos - ref_g._Acos)) < 1e-10
+    assert numpy.max(numpy.fabs(bat_g._Asin - ref_g._Asin)) < 1e-10
+    assert numpy.max(numpy.fabs(bat_s._Acos - ref_s._Acos)) < 1e-10
+
+
+def test_from_nbody_timedep():
+    # Multiple snapshots (pos [3,n,nt] + tgrid) build a time-dependent potential;
+    # each snapshot's coefficients match a static build of that snapshot, the
+    # potential is genuinely time-dependent, and it evaluates at arbitrary t.
+    n, N, L, nt = 12000, 8, 3, 5
+    numpy.random.seed(11)
+    base = numpy.random.randn(3, n) * 1.5
+    tgrid = numpy.linspace(0.0, 4.0, nt)
+    # rotate the particles by a t-dependent angle -> genuine time dependence
+    pos_t = numpy.empty((3, n, nt))
+    for it, t in enumerate(tgrid):
+        ang = 0.3 * t
+        pos_t[0, :, it] = numpy.cos(ang) * base[0] - numpy.sin(ang) * base[1]
+        pos_t[1, :, it] = numpy.sin(ang) * base[0] + numpy.cos(ang) * base[1]
+        pos_t[2, :, it] = base[2]
+    mass = (1.0 / n) * numpy.ones(n)
+    sp = SCFPotential.from_nbody(
+        pos_t, N, L=L, symmetry=None, a=_NBODY_A, mass=mass, tgrid=tgrid
+    )
+    assert sp._tdep
+    assert sp._Acos_all.shape == (nt, N, L, L)
+    # each snapshot's coefficients equal a static build at that snapshot (exact at
+    # the grid nodes, where the cubic-spline interpolation is exact)
+    for it in range(nt):
+        static = SCFPotential.from_nbody(
+            pos_t[:, :, it], N, L=L, symmetry=None, a=_NBODY_A, mass=mass
+        )
+        assert numpy.max(numpy.fabs(sp._Acos_all[it] - static._Acos)) < 1e-12
+    # genuinely time-dependent: the potential at fixed position changes with t
+    p0 = sp(1.0, 0.2, phi=0.5, t=tgrid[0], use_physical=False)
+    p1 = sp(1.0, 0.2, phi=0.5, t=tgrid[-1], use_physical=False)
+    assert numpy.fabs(p0 - p1) > 1e-6
+    # evaluation at a grid node matches the static build there (Rforce, dens)
+    it = 2
+    static = SCFPotential.from_nbody(
+        pos_t[:, :, it], N, L=L, symmetry=None, a=_NBODY_A, mass=mass
+    )
+    for meth in ["__call__", "Rforce", "zforce", "dens"]:
+        a1 = getattr(sp, meth)(1.1, 0.3, phi=0.7, t=tgrid[it], use_physical=False)
+        a2 = getattr(static, meth)(1.1, 0.3, phi=0.7, use_physical=False)
+        assert numpy.fabs(a1 - a2) < 1e-9
+
+
+def test_from_nbody_timedep_2d_mass():
+    # A per-snapshot mass array [n,nt] is accepted and, when constant across
+    # snapshots, matches the [n] mass build.
+    n, N, L, nt = 8000, 6, 3, 4
+    numpy.random.seed(13)
+    pos_t = numpy.random.randn(3, n, nt) * 1.5
+    tgrid = numpy.linspace(0.0, 3.0, nt)
+    mass1d = (1.0 / n) * numpy.ones(n)
+    mass2d = (1.0 / n) * numpy.ones((n, nt))
+    sp1 = SCFPotential.from_nbody(
+        pos_t, N, L=L, symmetry=None, a=_NBODY_A, mass=mass1d, tgrid=tgrid
+    )
+    sp2 = SCFPotential.from_nbody(
+        pos_t, N, L=L, symmetry=None, a=_NBODY_A, mass=mass2d, tgrid=tgrid
+    )
+    assert numpy.max(numpy.fabs(sp1._Acos_all - sp2._Acos_all)) < 1e-12
+    assert numpy.max(numpy.fabs(sp1._Asin_all - sp2._Asin_all)) < 1e-12
+
+
+def test_from_nbody_matches_from_density():
+    # Sampling a Hernquist halo and building an SCF from the samples reproduces the
+    # from_density build (and the analytic potential) to within the sampling noise.
+    n, Mh, ah, N = int(2e5), 11.0, 50.0 / 8.0, 10
+    hern = potential.HernquistPotential(amp=2 * Mh, a=ah)
+    hern.turn_physical_off()
+    hdf = df.isotropicHernquistdf(hern)
+    numpy.random.seed(1)
+    s = hdf.sample(n=n)
+    pos = numpy.array([s.x(), s.y(), s.z()])
+    snb = SCFPotential.from_nbody(pos, N, symmetry="spherical", a=ah, mass=Mh / n)
+    sde = SCFPotential.from_density(hern.dens, N, symmetry="spherical", a=ah)
+    rs = numpy.array([1.0, 3.0, 8.0, 20.0])
+    p_nb = numpy.array([snb(r, 0.0, use_physical=False) for r in rs])
+    p_de = numpy.array([sde(r, 0.0, use_physical=False) for r in rs])
+    p_true = numpy.array([hern(r, 0.0, use_physical=False) for r in rs])
+    assert numpy.all(numpy.fabs(p_nb / p_de - 1.0) < 0.02)
+    assert numpy.all(numpy.fabs(p_nb / p_true - 1.0) < 0.02)
+
+
+def test_from_nbody_physical():
+    # Physical (Quantity) positions/masses turn on physical outputs, and the
+    # internal-unit values match an equivalent plain-units build.
+    from astropy import units
+
+    from galpy.util import conversion
+
+    n, N, L = 10000, 6, 3
+    pos_int = _nbody_sample_positions(n, seed=9)  # internal-unit positions
+    mass_int = (1e-3 / n) * numpy.ones(n)
+    # plain floats, no ro/vo -> physical outputs off
+    sp_plain = SCFPotential.from_nbody(
+        pos_int, N, L=L, symmetry=None, a=1.0, mass=mass_int
+    )
+    assert not sp_plain._roSet
+    # equivalent build with Quantity inputs (no ro/vo passed) -> physical on
+    ro, vo = sp_plain._ro, sp_plain._vo
+    massfac = conversion.mass_in_msol(vo, ro)
+    sp_phys = SCFPotential.from_nbody(
+        pos_int * ro * units.kpc,
+        N,
+        L=L,
+        symmetry=None,
+        a=1.0 * ro * units.kpc,
+        mass=mass_int * massfac * units.Msun,
+    )
+    assert sp_phys._roSet and sp_phys._voSet  # Quantity inputs -> physical on
+    # unit parsing round-trips to identical internal coefficients
+    assert numpy.max(numpy.fabs(sp_phys._Acos - sp_plain._Acos)) < 1e-10
+    assert numpy.max(numpy.fabs(sp_phys._Asin - sp_plain._Asin)) < 1e-10
+
+
+def test_from_nbody_errors():
+    n, N, L = 1000, 6, 3
+    pos = _nbody_sample_positions(n, seed=2)
+    tgrid = numpy.linspace(0.0, 1.0, 4)
+    # bad leading dimension
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(numpy.random.randn(2, n), N, L=L)
+    # 3D pos without tgrid
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(numpy.random.randn(3, n, 4), N, L=L)
+    # tgrid given but pos is 2D
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(pos, N, L=L, tgrid=tgrid)
+    # tgrid given but nt mismatched
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(numpy.random.randn(3, n, 3), N, L=L, tgrid=tgrid)
+    # missing L for non-spherical
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(pos, N, symmetry=None)
+    # mass array of the wrong length
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(pos, N, symmetry="spherical", mass=numpy.ones(n + 1))
+    # 2D mass of the wrong shape (time-dependent)
+    with pytest.raises(ValueError):
+        SCFPotential.from_nbody(
+            numpy.random.randn(3, n, 4), N, L=L, tgrid=tgrid, mass=numpy.ones((n, 3))
+        )
+
+
 def test_scf_compute_nfw():
     Acos, Asin = potential.scf_compute_coeffs_spherical(rho_NFW, 10)
     spherical_coeffsTest(Acos, Asin)


### PR DESCRIPTION
Adds `SCFPotential.from_nbody`, the N-body / particle-representation analogue of `from_density`: build an `SCFPotential` directly from particle positions and masses using the existing `scf_compute_coeffs_{spherical,axi,}_nbody` machinery. First of the planned SCF follow-ups after #1058.

## What's new
- **`SCFPotential.from_nbody(pos, N, L=None, mass=1.0, a=1.0, symmetry=None, tgrid=None, ro=None, vo=None)`**
  - `pos` is `[3,n]` (rectangular coords); `mass` a scalar or `[n]` array.
  - **Time dependence from multiple snapshots**: pass `pos` of shape `[3,n,nt]` with a `tgrid` of length `nt` (mass `[n]` or `[n,nt]`); coefficients are computed per snapshot and interpolated in time via the time-dependent machinery from #1058.
  - **Memory-bounded**: each coefficient is a particle-independent constant times a sum over particles, so the particle sum is accumulated in batches (`_batched_nbody`/`_NBODY_BATCH_BYTES`) — exact up to floating-point summation order — keeping builds from very large particle sets memory-bounded.
  - **Units**: `Quantity` positions/masses/scale-length are supported and turn on physical outputs.

## Validation
- Static spherical/axi/general reproduce a direct `scf_compute_coeffs_*_nbody` build; particle batching is exact (forced tiny budget → thousands of batches, matches to ~1e-13).
- Sampling a Hernquist halo and building via `from_nbody` matches `from_density` and the analytic potential to within the sampling noise.
- Time-dependent multi-snapshot builds evaluate correctly (Python + C) at arbitrary `t`.

## Docs
- `from_nbody` added to the SCFPotential API reference + HISTORY entry.
- New notebook section: sample a spherical NFW with `isotropicNFWdf`, build an SCF from the samples, and compare its rotation curve to the `from_density` build and the exact result.

All new lines are covered; full `test_scf.py` passes locally (91 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCoE6U3bdzXnxiNy2QtBps