### PR TITLE
Translate between SCFPotential and MultipoleExpansionPotential

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -18,6 +18,13 @@ v1.12.1 (expected around 2026-11-01)
   the particle sum is accumulated in batches so building from a very large number
   of particles stays memory-bounded.
 
+- Added translation between the ``SCFPotential`` and ``MultipoleExpansionPotential``
+  representations: ``SCFPotential.from_multipole`` builds an SCF expansion from a
+  multipole expansion, and ``MultipoleExpansionPotential.from_scf`` does the
+  reverse. Because both expand the density in the same real spherical harmonics,
+  the translation is purely radial (no angular quadrature), and it supports
+  time-dependent potentials.
+
 v1.12.0 (2026-07-01)
 ====================
 

--- a/doc/source/reference/potentialmultipole.rst
+++ b/doc/source/reference/potentialmultipole.rst
@@ -4,4 +4,4 @@ Multipole Expansion Potential
 =============================
 
 .. autoclass:: galpy.potential.MultipoleExpansionPotential
-   :members: __init__, from_density
+   :members: __init__, from_density, from_scf

--- a/doc/source/reference/potentialscf.rst
+++ b/doc/source/reference/potentialscf.rst
@@ -4,4 +4,4 @@ Hernquist & Ostriker Self-Consistent-Field-type potential
 ===========================================================
 
 .. autoclass:: galpy.potential.SCFPotential
-   :members: __init__, from_density, from_nbody
+   :members: __init__, from_density, from_nbody, from_multipole

--- a/doc/source/tutorials/potentials/scf_and_multipole.ipynb
+++ b/doc/source/tutorials/potentials/scf_and_multipole.ipynb
@@ -5,10 +5,10 @@
    "id": "a1b2c3d4e5f6a7b8",
    "metadata": {
     "papermill": {
-     "duration": 0.013939,
-     "end_time": "2026-07-04T01:06:19.032100+00:00",
+     "duration": 0.014076,
+     "end_time": "2026-07-04T04:41:02.121522+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:06:19.018161+00:00",
+     "start_time": "2026-07-04T04:41:02.107446+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
    "id": "b1c2d3e4f5a6b7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:06:19.058179Z",
-     "iopub.status.busy": "2026-07-04T01:06:19.057905Z",
-     "iopub.status.idle": "2026-07-04T01:06:23.210603Z",
-     "shell.execute_reply": "2026-07-04T01:06:23.209373Z"
+     "iopub.execute_input": "2026-07-04T04:41:02.148649Z",
+     "iopub.status.busy": "2026-07-04T04:41:02.148331Z",
+     "iopub.status.idle": "2026-07-04T04:41:08.232805Z",
+     "shell.execute_reply": "2026-07-04T04:41:08.231792Z"
     },
     "papermill": {
-     "duration": 4.170426,
-     "end_time": "2026-07-04T01:06:23.214915+00:00",
+     "duration": 6.105008,
+     "end_time": "2026-07-04T04:41:08.239229+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:06:19.044489+00:00",
+     "start_time": "2026-07-04T04:41:02.134221+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,10 +74,10 @@
    "id": "c2d3e4f5a6b7c8d9",
    "metadata": {
     "papermill": {
-     "duration": 0.015299,
-     "end_time": "2026-07-04T01:06:23.248978+00:00",
+     "duration": 0.00696,
+     "end_time": "2026-07-04T04:41:08.264985+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:06:23.233679+00:00",
+     "start_time": "2026-07-04T04:41:08.258025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -94,16 +94,16 @@
    "id": "d3e4f5a6b7c8d9e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:06:23.281904Z",
-     "iopub.status.busy": "2026-07-04T01:06:23.281307Z",
-     "iopub.status.idle": "2026-07-04T01:07:34.518076Z",
-     "shell.execute_reply": "2026-07-04T01:07:34.515598Z"
+     "iopub.execute_input": "2026-07-04T04:41:08.281109Z",
+     "iopub.status.busy": "2026-07-04T04:41:08.280585Z",
+     "iopub.status.idle": "2026-07-04T04:42:34.603562Z",
+     "shell.execute_reply": "2026-07-04T04:42:34.600551Z"
     },
     "papermill": {
-     "duration": 71.256246,
-     "end_time": "2026-07-04T01:07:34.519784+00:00",
+     "duration": 86.333607,
+     "end_time": "2026-07-04T04:42:34.605718+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:06:23.263538+00:00",
+     "start_time": "2026-07-04T04:41:08.272111+00:00",
      "status": "completed"
     },
     "tags": []
@@ -122,10 +122,10 @@
    "id": "e4f5a6b7c8d9e0f1",
    "metadata": {
     "papermill": {
-     "duration": 0.005361,
-     "end_time": "2026-07-04T01:07:34.532343+00:00",
+     "duration": 0.012157,
+     "end_time": "2026-07-04T04:42:34.631397+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:34.526982+00:00",
+     "start_time": "2026-07-04T04:42:34.619240+00:00",
      "status": "completed"
     },
     "tags": []
@@ -142,16 +142,16 @@
    "id": "f5a6b7c8d9e0f1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:07:34.569946Z",
-     "iopub.status.busy": "2026-07-04T01:07:34.569699Z",
-     "iopub.status.idle": "2026-07-04T01:07:47.506237Z",
-     "shell.execute_reply": "2026-07-04T01:07:47.504327Z"
+     "iopub.execute_input": "2026-07-04T04:42:34.659418Z",
+     "iopub.status.busy": "2026-07-04T04:42:34.658939Z",
+     "iopub.status.idle": "2026-07-04T04:42:49.813939Z",
+     "shell.execute_reply": "2026-07-04T04:42:49.812195Z"
     },
     "papermill": {
-     "duration": 12.946121,
-     "end_time": "2026-07-04T01:07:47.507390+00:00",
+     "duration": 15.172462,
+     "end_time": "2026-07-04T04:42:49.816464+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:34.561269+00:00",
+     "start_time": "2026-07-04T04:42:34.644002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "a6b7c8d9e0f1a2b3",
    "metadata": {
     "papermill": {
-     "duration": 0.006197,
-     "end_time": "2026-07-04T01:07:47.520232+00:00",
+     "duration": 0.01321,
+     "end_time": "2026-07-04T04:42:49.844096+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:47.514035+00:00",
+     "start_time": "2026-07-04T04:42:49.830886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -213,16 +213,16 @@
    "id": "b7c8d9e0f1a2b3c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:07:47.534799Z",
-     "iopub.status.busy": "2026-07-04T01:07:47.534603Z",
-     "iopub.status.idle": "2026-07-04T01:07:52.355240Z",
-     "shell.execute_reply": "2026-07-04T01:07:52.352802Z"
+     "iopub.execute_input": "2026-07-04T04:42:49.879717Z",
+     "iopub.status.busy": "2026-07-04T04:42:49.879497Z",
+     "iopub.status.idle": "2026-07-04T04:42:55.747214Z",
+     "shell.execute_reply": "2026-07-04T04:42:55.745459Z"
     },
     "papermill": {
-     "duration": 4.830557,
-     "end_time": "2026-07-04T01:07:52.356957+00:00",
+     "duration": 5.884748,
+     "end_time": "2026-07-04T04:42:55.748924+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:47.526400+00:00",
+     "start_time": "2026-07-04T04:42:49.864176+00:00",
      "status": "completed"
     },
     "tags": []
@@ -239,10 +239,10 @@
    "id": "c8d9e0f1a2b3c4d5",
    "metadata": {
     "papermill": {
-     "duration": 0.006397,
-     "end_time": "2026-07-04T01:07:52.373589+00:00",
+     "duration": 0.013481,
+     "end_time": "2026-07-04T04:42:55.776989+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:52.367192+00:00",
+     "start_time": "2026-07-04T04:42:55.763508+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "d9e0f1a2b3c4d5e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:07:52.397241Z",
-     "iopub.status.busy": "2026-07-04T01:07:52.396916Z",
-     "iopub.status.idle": "2026-07-04T01:08:05.525328Z",
-     "shell.execute_reply": "2026-07-04T01:08:05.523691Z"
+     "iopub.execute_input": "2026-07-04T04:42:55.806265Z",
+     "iopub.status.busy": "2026-07-04T04:42:55.805989Z",
+     "iopub.status.idle": "2026-07-04T04:43:11.364130Z",
+     "shell.execute_reply": "2026-07-04T04:43:11.362383Z"
     },
     "papermill": {
-     "duration": 13.144598,
-     "end_time": "2026-07-04T01:08:05.526799+00:00",
+     "duration": 15.575554,
+     "end_time": "2026-07-04T04:43:11.366103+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:07:52.382201+00:00",
+     "start_time": "2026-07-04T04:42:55.790549+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,10 +299,10 @@
    "id": "a2b3c4d5e6f7a8b9",
    "metadata": {
     "papermill": {
-     "duration": 0.00671,
-     "end_time": "2026-07-04T01:08:05.541160+00:00",
+     "duration": 0.014427,
+     "end_time": "2026-07-04T04:43:11.396099+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:05.534450+00:00",
+     "start_time": "2026-07-04T04:43:11.381672+00:00",
      "status": "completed"
     },
     "tags": []
@@ -319,16 +319,16 @@
    "id": "6c7c334f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:05.559413Z",
-     "iopub.status.busy": "2026-07-04T01:08:05.559225Z",
-     "iopub.status.idle": "2026-07-04T01:08:08.942182Z",
-     "shell.execute_reply": "2026-07-04T01:08:08.940544Z"
+     "iopub.execute_input": "2026-07-04T04:43:11.427797Z",
+     "iopub.status.busy": "2026-07-04T04:43:11.427571Z",
+     "iopub.status.idle": "2026-07-04T04:43:14.913137Z",
+     "shell.execute_reply": "2026-07-04T04:43:14.911414Z"
     },
     "papermill": {
-     "duration": 3.39574,
-     "end_time": "2026-07-04T01:08:08.943486+00:00",
+     "duration": 3.504353,
+     "end_time": "2026-07-04T04:43:14.915203+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:05.547746+00:00",
+     "start_time": "2026-07-04T04:43:11.410850+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "papermill": {
-     "duration": 0.016465,
-     "end_time": "2026-07-04T01:08:08.971567+00:00",
+     "duration": 0.013886,
+     "end_time": "2026-07-04T04:43:14.944972+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:08.955102+00:00",
+     "start_time": "2026-07-04T04:43:14.931086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,16 +398,16 @@
    "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:08.996285Z",
-     "iopub.status.busy": "2026-07-04T01:08:08.996092Z",
-     "iopub.status.idle": "2026-07-04T01:08:10.888278Z",
-     "shell.execute_reply": "2026-07-04T01:08:10.886370Z"
+     "iopub.execute_input": "2026-07-04T04:43:14.971046Z",
+     "iopub.status.busy": "2026-07-04T04:43:14.970791Z",
+     "iopub.status.idle": "2026-07-04T04:43:16.904245Z",
+     "shell.execute_reply": "2026-07-04T04:43:16.902586Z"
     },
     "papermill": {
-     "duration": 1.90508,
-     "end_time": "2026-07-04T01:08:10.889399+00:00",
+     "duration": 1.949526,
+     "end_time": "2026-07-04T04:43:16.906542+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:08.984319+00:00",
+     "start_time": "2026-07-04T04:43:14.957016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -477,10 +477,10 @@
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {
     "papermill": {
-     "duration": 0.012182,
-     "end_time": "2026-07-04T01:08:10.914210+00:00",
+     "duration": 0.015461,
+     "end_time": "2026-07-04T04:43:16.945270+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:10.902028+00:00",
+     "start_time": "2026-07-04T04:43:16.929809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -498,13 +498,102 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1d1d6037",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02053,
+     "end_time": "2026-07-04T04:43:16.981019+00:00",
+     "exception": false,
+     "start_time": "2026-07-04T04:43:16.960489+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Translating between the SCF and multipole expansions\n",
+    "\n",
+    "Because the `SCFPotential` and `MultipoleExpansionPotential` both expand the density\n",
+    "in the same real spherical harmonics, you can translate directly between them\n",
+    "without going back to the density: `MultipoleExpansionPotential.from_scf` builds a\n",
+    "multipole expansion from an SCF, and `SCFPotential.from_multipole` builds an SCF from\n",
+    "a multipole expansion. Only the *radial* part is re-expanded — the angular\n",
+    "decomposition is shared, so no angular quadrature is needed — and time-dependent\n",
+    "expansions are translated as well.\n",
+    "\n",
+    "Reusing the SCF and multipole expansions of the triaxial NFW halo from the first\n",
+    "section, we translate each into the other representation and confirm that the\n",
+    "translations reproduce the independently-built expansions (and the true vertical\n",
+    "force):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c8a271cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-04T04:43:17.023551Z",
+     "iopub.status.busy": "2026-07-04T04:43:17.023315Z",
+     "iopub.status.idle": "2026-07-04T04:43:36.577574Z",
+     "shell.execute_reply": "2026-07-04T04:43:36.575951Z"
+    },
+    "papermill": {
+     "duration": 19.578184,
+     "end_time": "2026-07-04T04:43:36.579721+00:00",
+     "exception": false,
+     "start_time": "2026-07-04T04:43:17.001537+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6sAAAGGCAYAAACdTxdEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAls5JREFUeJzs3Xl81fWV//HXXXKzLySsWUgICdn3sIsg4lrXVmtrp6L2p+2MdmqZ+U1rp9XWzkw7nU7rb0ZaOh2X1tal7rZaF1BUEBCysYSEJWHLvt2b5CZ3v78/AhEEhUCSm+X9fDzykNx7870nXrjnns9yPga/3+9HREREREREZAwxBjoAERERERERkU9SsSoiIiIiIiJjjopVERERERERGXNUrIqIiIiIiMiYo2JVRERERERExhwVqyIiIiIiIjLmqFgVERERERGRMUfFqoiIiIiIiIw55kAHIAN8Ph+NjY1ERkZiMBgCHY6IiJyB3++np6eHyMhIoqKi9H49BimfioiMfSfyaXx8PEbjp8+fqlgdIxobG0lKSgp0GCIico5sNhtRUVGBDkM+QflURGT8OHr0KImJiZ96v4rVMSIyMhIYeMH04UdEZGzq7u4mKSmJo0ePDr5vy9iifCoiMvadyKdny6UqVseIE0uVoqKilFxFRMY4LQEeu5RPRUTGj7PlUjVYEhERERERkTFHxaqIiIiIiIiMOSpWRUREREREZMxRsSoiIiIiIiJjjopVERERERERGXNUrIqIiIiIiMiYo2JVRERERERExhwVqwG2du1asrOzmT9/fqBDERERGbeUT0VEJh6D3+/3BzoIge7ubqKjo7HZbDrEXERkjNJ79din10hEZOw71/dq8yjGJDJheTweXC4XXq8Xr9eLz+cb/LPZbCYoKGjwy2w2YzAYAh2yiIjImOPxePB4PKfkUa/XC3BaLhWRiU//0kXOkdPppK2tjc7OTnp7e0/56u934PV5MfqcGHxe/H4vBp8Xg9+D32AGkwWPOQyT0YTRABaLhfDwcCIiIgb/GxERQVRUFFOmTCE4ODjQv66IiMiI6OnpobW1le7u7sE8arfb6e3txeF04fYb8PgNeP0GPH7w+AcGeC0GPxajn2CjD7PRQFBQEKGhoafk0RNfMTExREREBPg3FZELpWJV5FN0dHTQ0tJCa2srra2tdHV2YOhvI8zRTJini2hfF8/7r2evJ55ubyxfMb7FQ0G/+9Trfd11H2/6FmA2+Fhu2sU/mP5Ep2EKVuMUmkwx9JujcVli8YfEEhEVw5QpU4iNjSU2NpapU6cyZcoUzciKiMi44vF4TsmlLS0t2PsdtDiDaHcHYXWbsHrMWD0mbO5Yerymc7quCT8Wo48Ik48os5Mocx9R5kaizV6ig7zEBXmICTUP5tIpU6YQFxfHtGnTNCsrMo7oX6vISdra2qirq6Ouro6mLjs+eyvzHBXM8x4iw3+IUIPrlMf/0bWULt9sAFwEAeDxG3EShJsg3Jiw4CYcB32EDN4/y99KtqEeqAcfA19uoB+8VgP3N/4dVZZipgXZSA6qZLalF0t4LNNnzGDGjBlMnz6dGTNmaAZWRETGHI/Hw5EjR6irq+PIkSPYXV4aHRaOOiwcdYTT6JyC23/2Hp8m/JgMfsyGgfYqLr9xcJbVi4F+n4l+n4k2d9AZfz7c5GVqkIeplkamWQ4z3eJhZrCbmdPiBvPo9OnTiY6OHr5fXkSGlYpVmfQ6Ozs5cOAAdXV1WNsaqemPoKxvKkcdkVxrrOcfLW8NPNAA3f4w9hlSaDdOo8cYQ2p4KPGWNqLNXsKN8/iN4d8xGAcSsMlkwmg0Duy38XhZ7IcSmnD5DJjdyTzuuotgj40Ir5Uon5VYXyezaSLGYKfGM5Nadyi1hJJk2s7Xgx6lpX0K+46kcjAohYqQJHxh05k2Yxbx8fEkJiYyc+ZMjRaLiEhA+Hw+Dh8+zMGDBzly5Ag2p49aewh7e6M54gjGz6krg0KNPmYEu4gxe4kxe4gOOv5fs3dgma8BzrSYyOcHp8+Ay2/E6TPQ6zHR7TFh85joOf5fq8eMzWPG7jVh95o47Ph4YNeIn+kNbuJDGogPPsSsYBdJ0RaSEhNISBj4Cg8PH+n/XSJyjvTJViatpqYmKisrOVy3j8juarKclRT6a/mp50sc9V4LQL05lTeNF9NqmU1fSCKm8KlMOz4KOzUigryT9pyGhoZiMpkGi9STeb1e3G734JfD4Rjcn3Nir05tTw/buqz4nN3ke8KZ7rbS5g5irqsdj9/IDEMXMygDdxm4wdEdxO6WdJ7fdwuh4dHMCvEya+YMEhMTSU5OJjY2NhD/W0VEZBLxeDzs3buXnTt30t7dR609lL32aA71n1qgxpg9JIa4SApxkhjiIiHSzPRpU0/baxoeHk5QUNAp+fRETvV4PKfkUpfLRV9f3yk9JOx2OzZbJ3anh3aXmXZ3EG0uM+2uIJpcQfR5TTS7LDS7LJQfjy200UvyoQ5mhzSSHLqJtGkRJCYmkJSUREJCAibTuS1NFpHhp2JVJp0jR45QWVlJ4+H9JFi38DeeD4gwOAbuNECe+RiXRtvIiugnYUoYlplrKJ4+nenTpxMXF3daIXouTiTdkJCQz3ycz+fDZrPR1dVFZ2cnnZ2dtLdfyf9aF2DuaybaeZQE9yHm+euYauimyL+XO62z6LZGEGL08TdNm7Dt7mZbRDpRcTNJTk4mOTmZWbNmKdmKiMiwcTqd7Nmzh927d9PU42arNYKdvbPw+j8uUGdaXGRF9JMV4WBefCzTpycw/Xg+PZ9jhcxmM2azmdDQ0LM+tre3dzCXdnV10dHRQUdHCza3kUZnEI1OC41OC83OIPp9JmrsodTYB64b3uQlZX8jaWF1ZER6SEtOYPbs2cyePZuwsLAhxy0i50/Fqkwahw8fZseOHexv6qKg88/c4d1EsMEDBjjgT6TMsoCuyGxipifxjblzSU1NJS4ublRjNBqNTJkyhSlTppCamjp4e19f32CDipaWFqpbWvHa2zD0tzLTZMLZ78PhM3KF5x3m+/aBE6rb57C3Lpc94RmYoxJITkkmNTWVpKQkLRcWEZHz4nK5qKiooLq6mmO9sMUawV577OAs6nSLm6zwPrIjHeQmz2Du3CxSUlLOOlg73E7M1CYlJQ3e5vF4aGtrOyWf9vb10+S0cLjfwmFHMMccwdi9Jvb0hrGnNwxjq5/ZjT2kV5WRHraZeQlxpKamkpqaqm7DIqPA4Pf7/YEOQnSI+Ujq6+tj8+bNVO4/wrsdUey1h/Jw0FquN33ITtLZEb4S07QcMrMymTt3LlOnTg10yGfl9XppbW2loaGBhoYGmltaaXSYyeneSK676njzpo81+uPYal5AVfQVzA73k6LCVeS86L167NNrNHIOHTrEpk2b2N/p5oOuKOr6Py5A54Y6WBzTw/yUWObNS2fOnDmjXqCeD5vNNphLGxsbsTucNDgs1PWHsN8eQvsnmjfNtLjIjegjO6Kf1PipKlxFztO5vlerWB0jlFyHn9/vp6amhq1btmBp3sKvepbR4B+YKV0eUs+yyBbCZmVRUFBARkbGuC7aXC4Xzc3NHD16lMOHD9PT0Ux4735SndUU+asJNbh4wzufb7i/TZTJQ2aEgxXB+wmJnkXq3LmkpaWRkJCgo3FEzkLv1WOfXqPh19fXx6ZNm6itO8x7nVHs6A4HDBjwkxXeP1CkpsdTVFTEjBkzAh3uefP7/bS3t9PQ0MCRI0doaWmhw2XkgD2EfX2hHHVYBmeQDfhJCXWSG9FHRriDpFnTSU9PJzU1dVwU6SKBpmJ1nFFyHV5Wq5X333+fpoM7ucj6AjmGOv7qnc+/Gv+Oy6fayJwRTmFhIWlpaee1B3Ws6+zs5PDhwxw+fJjmpgaCe+rY45zKq325uPxGkg3NvBe8hgb/VLab59MSWUD41CTS0tJIT08f9eXPIuOF3qvHPr1Gw+fEoO+2bduothp4oy2Gbu/AwG5uRB8Xx/ZQmplCYWHhhGzq53A4OHLkCEeOHOHo0aPYHF729oayuzeUBufHHYaDDD7mhTvIi+gjNdxN8uwk0tPTSU5OVr8IkU+hYnWcUXIdPtXV1Wz64D1mtG7kas/bBBm89PhDeTXketyzlrBkyWLS09MnzSxiX18fhw4dGjjvrqGJg33BxPTU8G3vox83lgL2+lOoCi7FGpnD1FmzycjIID09XSPEIifRe/XYp9doeDgcDtavX8/+o8283R5NtX2gsVCM2cNVU60smzeNpUuXTpozSn0+Hw0NDdTV1XHo0CGaez3sPr6vtdP98cqsCJOXnIg+8iL7SIwwkpaWRkZGBtOmTQtg9CJjj4rVcUbJ9cL5fD4+/PBDdpdv4rKO3zHX0AjAB5SwJ+5zZOQWs3jx4kldfPX391NfX09dXR0Nx44QbNtPRn8Zpf7dBBm8AHj9Br5j/Af8UcnMi3Axd04KGRkZJCYmTpoCX+TT6L167NNrdOE6Ozt54403qGp182prLP0+Iwb8LIju5bJZLlZctIS0tLRAhxkwPp+PxsZG6urqqKurp77bx+7eMKp7w+j3fbxaa7rFTXZEH9nh/aTOiNYgsMhJVKyOM0quF+bECPDh2nK+0r2OGIOdVn8Mr4XfTEhSCcuWLSMxMTHQYY4pfX19HDx4kP3799PadIQoWzX5zh0k0cQC569wYiHM6OWW8ApmhpuJmDZQtGZmZqqRhExaeq8e+/QaXZhDhw6xYcM7bOkIZkNnNH4MTLe4+Nw0K8vz5rBo0SIVWyfx+XwcO3aMffv2UXfoMLU9QezuCWN/Xwi+k86ZTQh2kR3RR06kk9y02WRnZxMfHx/AyEUCS8XqOKPkev6sVit//esbvHvMy7YOMy9aHqTfEMrmqV8lv3Qx8+fPH9fNk0ZDV1cXBw4cGChc29vZZp/Ozt4w7F4j6y3/lzRjI7v9qVSELqE/JofkOXPJysoiKSlJs60yqei9euzTa3T+Kioq2PrRdt5oj6GqJxyAgkg7n5/t5tJLlmvQ9yxcLhf19fXs37+fg0ebqLWHsqc3lMOOYDipMVNamIPSKDsFM0PIzs5i3rx5GgCQSUfF6jij5Hp+jh49yltvv8VfGiOo6B2Y7bsk/ChLZ8CKlasm9TKl8+H3+2lsbKS2tpaDdfUc7vZwVffTLPDvHFwm3O0PY5NpEUejSomcPoesrCwyMzPP6ZB2kfFO79Vjn16jofN4PLz//vtU1dbxYkssRx3BGPBzaZyNa9IjuOKKy/UeP0S9vb3s27eP2tpamrrs7LWHUt0bRoPTMviYuCA3pVF2CmOcZMxNIScnZ1x3UxYZChWr44yS69DV1dXx9ht/ZmHrH3nRvYjfey9nZWw3l8zyceWVV6iZwQVyOp0cPHiQmpoaWhsPE2erZLFrM4mGtsHHPM51VEZdTnakk3lpc8nJyWH69OkBjFpkZOm9euzTazQ0Ho+HN954g8pDrTzXHIfNYybY4OOGGZ1cVZjMsmXL1NH2Avj9fpqamqipqaG+vp6WfgNl3eHs6gnD5R/Y3xps8JEf2UdxlJ2M+BhycnKYO3euVoXJhHau79X6VyDj0pEjR1j/5ussb3mUTMNhks0NEJdF0ZyZXH755YSHhwc6xHEvODiY7OxssrOz6ejoYO/e+bxVezH+zv1k2LexyF/JW+48trTGsr7Dy/L2fdTuLmdGYupgotUHHBGRscvn8/H2229TXt/GH5um4fQZmWL2cPPMDq65uJT8/PxAhzjuGQwG4uPjiY+Px+l0sn//ftL37mVFRzM7e8Io6w6n0x3E9u4ItndHMKfDQenhbWRP2Up2VibZ2dlERkYG+tcQCRjNrI4RGgk+d42Njbz251dY2Pi/5BsO0OGP5IUpf8vcvEUsX75cI5EjyO12c+DAAfbu3UtrQz2b7bOo6Img12vin81/4HbTm3xoLGJf+BKCp6WTk5tDVlYWYWFhgQ5dZFjovXrs02t0bnw+H++88w7bao7wh8ap9PtMJAY7+XJSN9devpLZs2cHOsQJrbm5merqag4erOOgPYgd3eEc6AvhxN7WaLOH4ig7hVF9ZM9NJi8vj5kzZwY2aJFhpGXA44yS67lpbW3lz6+8RGHD45SwF5s/jGdj/o6cBStZunRpoMObVNra2tizZw/7DhykutvCF7r/l2VUDt5f40/mo9DlOGJzmDcvk9zcXKZOnRq4gEWGgd6rxz69Rmfn9/t577332LrnIE82TsPuNTEr2MXq2d3cdP3n9F49ihwOB7W1tVRXV3O0s4/y7nCqesIHj8AxG/zkRPRRGmUnJyGavLw8UlNTtXJJxj0Vq+OMkuvZdXR08MorL5N15HcspopefwhPRX+DecWXsHz5cnWlDRCHw0FNTQ3V1dX0ttSR0r2VZb5thBpcALT7o3kz6DJaYheTnjSDvLw8kpOT9XrJuKT36rFPr9HZbd68mQ8ra3iycSrdXjPTLW5WJ3Vx8/WfU9+BAPH7/Rw5coQ9e/ZQf+QY1fYwdtjCaXF93JApKcRJaVQvhdOM5OUMbNNRF2EZr7RnVSYUq9XKn//yGq1H93InVTj8QTwdeRep+cu4+OKLVfgEUEhICIWFheTn53PkyBF27y7kd4cvI85azsWu95hh6KLP0cfaIzPJ6exjweF3SJ8WTl5eHvPmzdOybRGRUfTRRx+xrWovTzVNo9trJjbIzd8kdHHj565QoRpABoOB5ORkkpOTsVqtVFdXU1JTy6FeA9tt4dTaQznqCOaoI5j1HR7mN9Uwv6yKvKx08vLyiI6ODvSvIDIi9ClRxjyn08lrr73OS8dCqOpfgdlkIzYmlqTci1i5ciVGozHQIQpgNBpJSUkhJSWFzs5Odu8u4tXapQR17uGvfbl4PQZ29oYTbD/KZe2P8uGR5Wz/KIOc3BxycnJ0LIKIyAirrq7mw7KdPNU0lS6PmRizh79J6OSGq1YRHx8f6PDkuJiYGJYsWUJpaSm1tbVk7d5NY1cz5d3hVPSE0+M1805nNJu7fBS1H2P+zhry0maTn5+vfa0y4WgZ8BihZUtn5vf7efPNN3lhVwdvd8RgwM+NMzpZmR7LlVdeqVm5Mc7hcFBdXU11dTX7Oj1ss0XwD65fcbmpDIB9/tlsC12OMy6PzKwc8vPz9fdfxjS9V499eo3OrL29nRdfepk/NMRyxBFMpMnLbQntfOHKFaSmpgY6PPkMfr+fw4cPs3v3bo40NLKnN4yt1gg63EEAGPGTG9HHwphecpPiKCgo0HYbGfO0Z3WcUXI9s6qqKrZteJGEri3c7/4aC+I8XJMezuc+9zmCgoICHZ6cI5/Px8GDB6mqqqK9sY7Z1i0s924m3OAEoNkfy3uWS+iaUkTavCwKCgp0Tq6MSXqvHvv0Gp3O5XLxwgsv8OphA1uskVgMPm5PaOMLly0lIyMj0OHJELS3t7Nr1y4OHDjIvl4LW20RHHUED96fHtbPophecmeEUVCQT3p6upoxyZikYnWcUXI9XXNzMy+/+Ceua3mYeEMHrxhWYk25kZtvvklHoYxjDQ0N7Ny5k8N1+4izlrPC9S7TDDYAdvnm8JOw71Ia1cu82TMpKCggKSkpwBGLfEzv1WOfXqPTvfXWW7y9p5nnWuIAuHF6B7csmceiRYsCHJmcL7vdzu7du9m7dy/13X62WCPZd9LRNwnBLhbF9FAw1Uh+Xi7Z2dlYLJbPvqjIKFKDJRnX+vv7eeuttyhofZ54QwdH/DNomn4J1666VIXqOJeQkEBCQgKdnQvZtauQl2oXE9axk6WOd3jGewkfWiPZZo2gqLObyw7+kamJ6RQWFpKamqolTSIiQ7Rr1y4q9x/lz20DzZNKo3pZMTeaBQsWBDgyuRDh4eEsXLiQ4uJiampqyNi1i8Od3WyzRbCrN4wGp4UXWuJ4t9PNwpbdFJdXUpCbTV5ennpEyLiiYnWE3HjjjWzcuJFLL72U559/PtDhjCt+v593332XkKPvsJgqnP4g3oj5KvMXLiUhISHQ4ckwiY2NZfny5ZSWlrJ7927e3VOK22ogweakwRnMnP4K7nL/lk3WEjYcWcH2WekUFBQwb948LWkSmSSUSy9Ma2srm7du46XWOBw+I/HBLq5OcHLppZ9Tc8IJIigoiLy8PHJycqirqyO9spIjrc3s6I6gvDucTncQf22fwntdXua3HWB+5W4Ks+dRUFBAZGRkoMMXOSstAx4hGzdupKenh9/97nfnlGC1bOlj5eXllL3zEnf0PILZ4OMPwbcyJf8arr76as2sTWAul4u9e/eya9cuajs9lHS+yg1sGLz/I3LZGbGC4OmZFBQWkJWVpX3LMur0Xj26hppLQa/RCQ6HgxdffJEXDpko644gxOjjawmtfOm6y7W9YoI7duwYlZWV1B9roqo7jI9sEXR7B+anggw+CiP7WBhjpzgzhaKiIqZMmRLgiGUy0jLgAFuxYgUbN24MdBjjTmNjIx9teY8be57EbPDxjmER/oQlrFy5UoXqBGexWCgoKCA3N5f9+/dTVRXK/zQWk979Phf7PmKBYTcLenezq2cu25tXUV6eQ15eLrm5uQQHB5/9CURk3FEuPX8bN27ko2YvZd0D529eN72TFQvyVahOAomJiSQmJtLW1kZmZSUldfXs7Q1lqy2SVlcQ27sjKOsOJ7+rnSV7X6QwPYmioiI1NpQxacyuAfnpT3+KwWDgvvvuG9brvv/++1x77bXEx8djMBh4+eWXz/i4tWvXkpKSQkhICAsXLuSjjz4a1jjkdF6vl/fff5+97U48GDnoj2f/9OtYddkq7a+YREwmE5mZmXzxi19k1fW30pX3DX4b9z3eMC7H6Q8iz3CQ9J7N/Kouiiffq+YPf3yKbdu20dfXF+jQRcYc5dLJ6cCBA+w82MDrbTEALInpYdncWEpKSgIbmIyqadOmcdlll/HlW77IF0pnc1dSO1+a2U5yiAMfBip7wll3dAZrt1t57E+v8vrrr9PU1BTosEVOMSZnVrdv385vfvMb8vPzP/NxmzdvZsGCBactBayuriYuLo4ZM2ac9jN2u52CggLuvPNOPv/5z5/xus8++yxr1qxh3bp1LFy4kIcffpgrrriC2tpapk8faFBQWFiIx+M57WffeustHax9nqqqqtjR5OKV/jzW8zO+PuswFy9eyqxZswIdmgSAwWAgNTWV1NRUGhoaqKjI5vH6FcRbt/CMawGtPgsvt8ayu6uD1S2/Z+fOAnJycsnPzyciIiLQ4YsEnHLp5ORyudiyZQtvd0Tj8htJDHFyebybSy+9VPtUJ6mYmJjBHhG7du1iXnU19b09bOqKpL4/hKqecHb2hJHX1cuS+tfJTppGcXExiYmJgQ5dZOwVq729vXzlK1/ht7/9Lf/yL//yqY/z+Xzcc889pKen88wzzww2XKmtrWXlypWsWbOGf/qnfzrt56666iquuuqqz4zhF7/4BXfddRd33HEHAOvWreO1117jscce47vf/S4AlZWV5/kbypl0d3ezrayStzsG2uoXxHhITkmjoKAgwJHJWHCig3BraysVFTksrDuCqbub7bYIvuB/i686/0zjsb/ybvtl7NlVSEZWDoWFhZN6v5pMbsqlk9eOHTuoavezvy8UI36unmplxcUr1UlfCA8PZ9GiRRQWFrJ7927m7t5NXfdA0VrXH8LO3nB29YaR2dnPksNvkZs4heLiYpKTkwMdukxiY26I7Z577uFzn/scq1at+szHGY1GXn/9dSoqKrjtttvw+XwcPHiQlStXcsMNN5wxuZ4Ll8tFWVnZKc9vNBpZtWoVW7ZsOa9rfpa1a9eSnZ3N/Pnzh/3a48nmzZuJbvmAK/0fEGN2cdGUXi666CLtU5VTTJ8+nSuuuIKv3vIF7pg/g3uTWwgPDafdH028oYOvOJ/h+saf0vTBEzz9xyd59913sVqtgQ5bZNRNtlwKyqcA7e3tVOyq5u2OgX2qC2N6KU6LJyUlJbCByZgSEhJCaWkpt956K19YXsQdqX3cHt9KWlg/fgzstYfxaMMM1u7y8egr7/L8889TV1eHerJKIIypmdVnnnmG8vJytm/ffk6Pj4+P55133mHZsmXceuutbNmyhVWrVvHrX//6vGNob2/H6/WetuxpxowZ1NTUnPN1Vq1aRVVVFXa7ncTERJ577jkWL1582uPuuece7rnnnsGOWJNRfX09R2orucP9CrcGeZkTHkxB/jXExcUFOjQZo2JjY1m5ciWlpaVUVs7jxb2FRHRUcInzbWYZOrnF/QKdzW/xRucV7K49QHZ6KkVFRcTGxgY6dJERNxlzKSif+v1+Nm3axOauCGweM1FmDxfH9bF06ecCHZqMUScaG+bk5FBbW8u8qioOdnSzxRrJXnsoB/pCONAXQlKnk4uOfUDhrB2UlBSTmpqqJeUyasZMsXr06FG+9a1v8fbbbxMSEnLOPzd79myefPJJli9fTmpqKo8++uiYmI1bv359oEMYF9xuN5s3babU+goWg5ctFBA+I1NNIOScREVFcfHFF1NcXExVVT6vVZcQ0l7Jcsd6kgytePptrD0ykwW2Vvbse4GstBSKi4s1ECITlnLp5FVbW0v1sU62Wgf2A18eZ2NhSaHO0pSzMpvN5OTkkJWVxb59+0ivrORQRwtbrZHs7AnjqCOYp5uDea/LxdLGDymZVUZxcRFpaWkqWmXEjZlitaysjNbWVoqLiwdvO9Ed9pFHHsHpdA7upTlZS0sLd999N9deey3bt2/n29/+Nv/93/993nFMnToVk8lES0vLac8zc+bM876unFl5eTnexu2UsBeHP4idcdewaukSLBZLoEOTcSQiIoKlS5dSVFTEzp0FvLW7mKD2nTxjL8ThM/J+VxS9tjaS2h/juX3VzEkbGBCZOnVqoEMXGVbKpZOTw+Fg69ZtvNkegw8DaWH9lM4KVt8HGRKj0UhmZibz5s2jrq6O1PJyLmpvZps1koqeMBqdFp5riTtetG6ldGYZJcVFzJs3T0WrjJgxU6xeeuml7Nq165Tb7rjjDjIzM/nOd75zxuTa3t7OpZdeSlZWFs899xz79u1jxYoVBAcH8/Of//y84rBYLJSUlLBhwwZuuOEGYKABxYYNG7j33nvP65pyZl1dXVSVb+fGvpfAAH8JuorEuTnMnTs30KHJOBUWFjbYPGLXrl18Yddu0q2dbO6K5G95mcu8ZfS2vsOGzhU8f2AvKXMzKS4uHuxMKjLeKZdOTtu2baOi08hhRzBmg4/L42xcdNEVZ3y9Rc7GaDSSlpbG3Llzqa+vJ6W8nCVtLXxki6DMFk6ry8JLrXG83+XmoubtzC8rp6S4iIyMDBWtMuzGTLEaGRlJbm7uKbeFh4cTFxd32u0wkPSuuuoqkpOTefbZZzGbzWRnZ/P222+zcuVKEhIS+Pa3v33az/X29nLgwIHB7+vr66msrCQ2NpbZs2cDsGbNGlavXk1paSkLFizg4Ycfxm63D3Y0lOGxadMmEto2MM1g45B/Jp3Tl/LFpUsDHZZMACEhIcyfP5/8/Hx2795Nwc5dHGstZF9fK/MMR7ne+wb21nfZ0LmcFw/uJTl1oGg90xEdIuOJcunk09zcTFX1PtZ3DLx/LY3poSQzRceOyAU7cYTcnDlzOHz4MMnl5SxqaWZHdwTbbRF0uIN4pTWWTV1uljbvYEF5BcVFhWRkZGigRIbNmClWh8poNPJv//ZvLFu27JQlowUFBaxfv55p06ad8ed27NjBJZdcMvj9mjVrAFi9ejVPPPEEALfccgttbW088MADNDc3U1hYyBtvvKEPssPo0KFDHK6r4W+974IB1kd8gaKiEmJiYgIdmkwgwcHBlJSUkJeXx549BWypKmBT626W2N8k03CY67xv0d+6kRc7P8cf6xvITImnuLhYyxRl0lAuHf+2bt3K+11R2L0mYoPcXDTVyaJFiwIdlkwgBoOBlJQUUlJSOHLkCMnl5SxobmaHLZyPbJF0uIN4tS2WTVY3FzWXUVpeQUlRIZmZmSpa5YIZ/OpDPSac6F5os9kmxdmQL774Iv+zx0dIXwPXhlQRNu8ybr75ZszmcTt+IuOA2+2murqayopKvG17WNT7FtmGeh50r+aPvsspirSzOKaHjORZlJSUqGiV00y29+rxaDK9RseOHeOZV9/kV0dm4MPAl2e2c+ulxeTl5QU6NJngjh07Rnl5OYcbWyizhbPNFkm/b2AJcGyQm4tieiiZbqC0uEhFq5zRub5XqzKQUXfkyBGqG63U2GcAaZTGRfKl+fNVqMqICwoKGmzTX11dzY6KXLa0VvN+bxEep4Ht3RHMtO8mo/11XqmrJWHOPEpLS1W0isiYVFZWxhZrBD4MzA5xUjAzmJycnECHJZNAYmIiiYmJNDY2klJWRklDM2Xd4WyzRtB58kxrazmlx5cHZ2Zm6rOeDJn+xsioKy8vp6Jz4K9eRng/6dPC1VRJRpXZbCY/P5/s7Gz27t2LpbKKPR3tbO4K51v+50nzNeJsf5/1Xct4ub6WxDkZKlpFZExpbGzkQEMblT0D70sXTemmsHCRGtzIqIqPjyc+Pp6mpibmlJVRcqzpeNEa+YmitYLSikqKiwrJysrSTKucMxWrMqqOHTtGy6G9POn9Jc+aV3As+gqKipaNifP8ZPIxm83k5eWRlZVFTU0NOeUVvNdyA329b5Nv2M/nfO/gbP9ARauIjDllZWVstUbi9RtIDHaSM9XCvHnzAh2WTFKzZs3immuuObVoPb48WEWrXAgVqzKqysrKSLdtJMzgJMPcQuj0cNLS0gIdlkxyZrOZ3NxcMjMzqampoaI8m49a9zK/9y0KTipan7R+gT8eaSZj9kwVrSISME1NTew/2kJFz0Czqoum9FBcvECzqhJwJ4rW5uZmUsvKKDnaONiI6ZNFa0lFJSUqWuUsVKzKqGloaKD50F6u8W0DA+yOvpTlRUVKrjJmnChaT8y0lpdlsf2konVj/xy2HJ1JkdVO7ZG/kKlGTCISAOXl5Xxki8DjNxIf7CJ3qlmzqjKmzJw5k8997nODRWvp0cZPnWlV0SqfRcWqjJry8nLmWt/HZPCzlXwiZqSRnp4e6LBETmMymcjJyRmcaS0vy2Jz20EO9aTjdRjY0R3Bwr710N7Oy3U1JKVmqmgVkVHR3NzM/iNNlHV/fK5qUVGJPuTLmPTJorXkM4rW0opKStQ9WD5BxaqMiqamJhrr9/I13xYwwM6olSzTrKqMcZ8sWiPLK6ju7KWsy8zX/X8mytf/8Z7Wuhpmz82ipKRE50iKyIg5Mavq9huZYXGRP9VIZmZmoMMS+UyfXrSe3j14/vGiNSMjQ0WrqFiV0VFWVsacrvcxG3xsJ4eImRlasiTjxieL1uyycv7UeicLet4abMTkaP+ADV0X8/LBGpLmZqpoFZFh19rayv7DDeywnegA3ENhYZE+0Mu4ccai9UxH3rSUseB4IyYVrZObilUZcc3NzRw4dJiv+XaAASojV7G0sFBvPDLunFy07t27l4ryLD5q2cuC3jfJNxzgc74NONrf59fW1dQcaiQzJZ7S0lKmT58e6NBFZAIoLy9nuy0Cl9/INIub/DgDWVlZgQ5LZMhOLlrn7Nhx0pE3pxaty1rKTplp1Yq8yUfFqoy4iooK3u+eyh+d/8mtIR8ybcY8MjIyAh2WyHkzmUyf6B6cxfaWaub3vkU2dbzUl0Nj33SKbT3UHHqVrDkJlJSUqGgVkfPW3t7OvkNH2d49MKu6NKaHosICzGZ9lJPxa+bMmZ955M0rrbF80OVmWcsO5pdXUFpSzLx581S0TiJ6h5MR1d3dzf5Dx9jZMxMPRtqnzOcyzarKBHGmI2/WtzXg7Z6Cx2ngI1sEN/f9EU+HhRfrakg5vqd12rRpgQ5dRMaZ6upqqrrDcfqMxAW5KYzza1ZVJoyTz2lN2bGDkoZmdnyiaN3U5eailu0sKK+gpLhIReskoWJVRlRNTQ21PWY8fiPTgtykRxvUCEImnJOL1r179zK1opI9nT7qu/r4Au9j9Prpa32f9Z3LeeFgDXPSBorWqVOnBjp0ERkH3G43+/cfoKInFoAF0b3k5eYQFBQU4MhEhtesWbO49tpraWxsJKWsjNKTitaOk4rWZc3bWXB8eXB6erqK1glMxaqMGJ/PR83eGr5l/wW3BkXy14ibmDdvkZYsyYRlNpvJy8sjKyuL6upqKisqeaL16yzqfZNsQz3Xed+ir/U91ncu5/kDe0lNz6akpIS4uLhAhy4iY9iBAwc42Guk0x2ExeAjJ9KhgV+Z0OLj44mPj6exsZHkHTsoaWxmhy2Cj2wRdLiDePnETGvTRyyYNbA8OC0tTUXrBKSqQUbM4cOHcXQcZJ7hCLONQeyKMGnJkkwKZrOZ/Px8srOzqa6uZnt5Nlvb9rCo963BotXe+h7/abuX6oNHyJ47m9LSUmJjYwMduoiMQXv37qWiOxyAnIh+0lOSCA8PD3BUIiMvPj6e6667joaGBpJ37KC0qZntx4vW9pOK1mVNW1kQP1C0zp07V0XrBKJiVUbM3r17mdOzA4APjaXEJ81hypQpAY5KZPScXLTu2bOH7RU5bG3dwxL7G0yjk2e6c/D0WCi1dbL3wPNkp8+hpKRERauIDGpvb+dwSye19oHGSkVRdrKyFgU4KpHRlZCQQEJCAseOHWP2jh3Mb2pme/fHRetLrXEDM62NW1gQX8780hLmzp2LwWAIdOhygVSsyojo6enhyKGD3ObbDgaoi5jPxVqyJJOU2WymoKBgsGjdWpFNY2cnkTYjLS4jH1ojuK/vlzR0pPKnfdWkZeRQXFysolVEqKmpYWdPGD4MzAp2MTfWQlJSUqDDEgmIxMREEhMTOXr0KLPLypjf1MxHtgi22yJoO1G0Wt0sa/yQBQnlgzOtKlrHLxWrMiJqamqItO0mzOCk3j8L05RUUlNTAx2WSEAFBQVRWFhITk4Ou3fvJr5qJ7u6DLi7DrHAWAPeGnpa3+Xtzkv4U+0e0jJyKCkp0YoEkUnK7Xazb99+KrsHBq6KIu1kZmbpg7dMeklJSSQlJXHkyBGSysqY33xS0eoK4sXjRetFjR8OzrSmpqbq3844pGJVhp3P56O2tpZSxxYwwEeWJczLmKfGSiLHBQUFUVRUNFi0VlZ6eLz9/3CR/Q3SDcf4vPd1uls3sr7zEp6trSY9c6BojYmJCXToIjKKDh48yP5uI10eM8HHGyvpnHKRj82ePZvZs2dz+PBhksrKWNDycdHa6grixZY4NnW5WNa4mQUJA0XrnDlzVLSOI6oeZNgdOXKEvrY6Mg2HcfrNdMXkc5kaK4mcxmKxUFxcTG5uLrt37+aDyhw2t+3ior63SDMc4/Pe1+hufZeHur/Dnv115M6bS3FxsYpWkUmipqaGip7jjZUi+5ibnEhERESAoxIZe5KTk0lOTubw4cMk7tjBgtZmttki2GGLoNVl4YXjRetFDZtYlFhOSUmxitZxQsWqDLuamho22OdQ4/oGhcHNzExI0d47kc9wctG6a9cu3q/KY1PbLpb1vUmfP4jnbWmE9PhZYGuhet+fyJ6XRklJCdHR0YEOXURGSEdHB3WN7ew73lipOFKNlUTO5kTReujQIRLLyljQ2sJHtnB22CJoOaloXXZsEwsTyyktLSElJUVF6ximYlWGVW9vLwcOHaXCPpNt/osJjWnjNs2qipwTi8VCSUnJYNH6XlUuh7r6iLN56HAHUdYVxEN9/8n29gU8U1vNvMyBRkwqWkUmnpMbKyUEu0iZosZKIucqJSXl1KK1rYWPbBHssIXT4rLw/GDR+gELkz4uWmXsUbEqw6qmpobq3lBcfiOxQR7SomDu3LmBDktkXAkODqa0tJS8vDx27dpF8s5d7LSamWX9iBRDMymeV7E2v8PbHSt5pmYPGVm5FBUVqWgVmSA8Hg+1+/ZT2TPQXK0oyk5mZqbOjhQZAoPBwJw5c0hJSaG+vp6EsjIWtLewzRrBju5wml0WnmuJY5PVxcXH3mN+YpmK1jFIxaoMmxONla7veZJZprk0RZSQnp6hxkoi5+lE0Zqbm0v+rl3s2uni9+0GlvW9xRxDEzcPFq2X8szeBWRk5VJcXExUVFSgQxeRC1BXV8c+mwGrx0yw0UdWeD+ZOv5N5LwYDAZSU1OZM2fOaUVrWXc4TU4LzzZPZVOXk4uPvUfp8ZnW5OTkQIcuqFiVYXTs2DHsrXV8xbCVS8zbeSwinSwtARa5YCEhIcyfP5+8vDx27szjnZ35BLXv5OL+N0kxNHOz5xU6mt/h+90/Yk/tAXIy0lS0ioxje/fupbx7oLFSXkQfqWqsJHLBTi5a6+rqSCgrY2FHC1utEZR1R9DgDObp5mA2WZ1cfOxdSpKiKClR0RpoKlZl2Bw4cIBZvVUAbDUWMTNhDnFxcQGOSmTiCAkJYcGCBeTn57Nz50427MwjqH0ny/vfpMqXyl+7ZrLR5mWRrZG9NbVkZWaoaBUZZ3p7eznU2MqBvlkAFEbZycpaGOCoRCYOg8HA3LlzSU1N5eDBgySUl7OwvZkPrZFU9IRz1BHMH5umsanLwfJj71KYqKI1kFSsyrDw+XwcPnSYyzyVYICDoYUsSE8PdFgiE9Ini9b1O/OptfqYYvXQ5TFT19XPz+z/yrsdK3lm7x7mZeWoaBUZJ+rr69nfF4oPA9MtbpIiTcyePTvQYYlMOAaDgbS0NObOncvBgwdJLC9n0fGitbI7nMOOEH7fGMKmLgcXH3uH/MRoFa0BoGJVhkVDQwNu2zESDW30+y24IgeWWYjIyDm5aK2qqmLe7j1UWYOYb3ubaQYbX3S/RGfzetZ3rlLRKjJO1NfXU2sPASAjvJ+UlBQ1VhIZQZ8sWpPKyljc3sJmayRVPWHU9YdQ1x9CurWfZQ3vkJsQTWlpqQaRRomKVRkW9fX1TO2tBqDMkMvM+ETCwsICHJXI5BASEsLChQvJz88nb+dOdu9y8GR7HMv732K2oVVFq8g40d/fz+HGFur6B5YAZ4T3a+BXZJR8smidfbxo3dQVye7eMPb3hbK/L5R5Xf0sa1hPTkKMitZRoGJVLpjf7+fQoUMs9VSBAepCcilUchUZdaGhoYNF686d+by9qxBLexXL+98cLFoPNW/hoe4fDDZi0pE3ImPHoUOHONgXgtdvIDbIQ3yYgYSEhECHJTKpnChaT+xpTSkvp66tlQ+6Iqm2h7Kvb+Aro6ufPceLVi0PHjkqVuWCNTc302Lro9aXwDRjF32R6TqjSiSATi5aq6ryeHt3wWDR+pJnKe90TWGLzcsiawO1e/cwLzOb4uJiFa0iAXbKEuCwfpKTZ2MymQIclcjkZDQaSU9PH5xpTS0v50BbK5uPF621fQNfGV39XNSwQUXrCFGxKhesvr6ePf1RrHXfR3pIL9+YadbyQpExIDQ0lEWLFlFQUHB8prWAI1bTYCMmr+0wN/f9ig2dl/JsTTXpmdkUFRURExMT6NBFJh2Xy8WRY40c7JsBaAmwyFjxyaI17VOK1vSufpYce4eCxGiKi4s1cTNMVKzKBTt06BC19lAA0iLczJmjLsAiY8mJmdaCggKqqqrI2b2HSquFa2zvEWvo4Wb3y3Qd39P6bM0e0jMGZlpVtIqMnsOHD3PQbsHlNxJp8pAY5iMpKSnQYYnIcSeK1rS0tIGitayMA22tbOqKZK89dHBPa0qXg6VHN1KUEElJyUDRajAYAh3+uKVidYTceOONbNy4kUsvvZTnn38+0OGMmLa2Njo72wlxhQEzSQ9zaCRJZIw60YipoKCA/J072bXzJn7fPo/l/W+SbGjhZvfLWJvX83bHSp45qWidMmVKoEOXSWqy5FL4ZBdgB0lJiQQFBQU4KhH5pE82YkorK6OurZUt1gh294ZxqD+EQ/0hvNfpZOmx9ylNKKOkpJg5c+aoaD0PKlZHyLe+9S3uvPNOfve73wU6lBFVX19PXPdO3g1+jr+yhO6424mNjQ10WCLyGT55TuuGXQWY26q4uP8tUgzN3Ox5le3Ntfx3z7fZs/95stPmUFxcrH/bMuomSy71eDwcPnqM/X3TgBNLgIsCHJWIfJZPFq1zy8s53NbCFlsEVT3hHHMG82xzMO91ulh6bBMLE8spVdE6ZCpWR8iKFSvYuHFjoMMYcfX19WS4dgHQbZml/TUi48jJReuuXQW8s7MQc1sVy/rf4neey3m/K4qPbBEssTZwoLaaufOyKC4uJi4uLtChyyQxWXLp0aNHqesx0e8zEmb0MjvUreMwRMaJTxatyeXlXNTezDZbBOXd4TS7LLzQEsf7nW6WHN3MksQySoqLmDt3rorWczCmTpn+9a9/TX5+PlFRUURFRbF48WL++te/DutzvP/++1x77bXEx8djMBh4+eWXz/i4tWvXkpKSMrhs7qOPPhrWOCaCrq4uutqbKPDXAmCNyNISYJFxKCQkhPnz53PrV75C1qVf5d3Z/xdzXDpxQW4cPiMpPdu5tfUn9Gx9nOee+QNvvfUW7e3tgQ5bPoVy6fhTX19Pbd/AEuB54Q4SE+IJCQkJcFQiMhQnitabb76Z66+4hJvSTNwzu4UlMd0EG3y0uYN4pTWWf98VxH+/uoVn//Qc+/fvx+fzBTr0MW1MzawmJiby05/+lPT0dPx+P7/73e+4/vrrqaioICcn57THb968mQULFpy2p6O6upq4uDhmzJhx2s/Y7XYKCgq48847+fznP3/GOJ599lnWrFnDunXrWLhwIQ8//DBXXHEFtbW1TJ8+HYDCwkI8Hs9pP/vWW28RHx9/Pr/+uFNfX09E9z5MBj81/mQi4uKZNm1aoMMSkfN0omjNz88nf9cu8nftZmeXictt5UQZ+vi89zV6WzfwduclPL9/LylzMygpKdG/+zFGuXR88fl8HDp8hFr7wDL7gSXAuQGOSkTOl8FgYO7cuaSmplJfX09ieTmL2prZ0R3BdlsEnceL1g+tbpY3bqF0VjnFxUWkpaVhNI6pecQxweD3+/2BDuKzxMbG8h//8R987WtfO+V2n89HcXEx6enpPPPMM4PnkNXW1rJ8+XLWrFnDP/3TP33mtQ0GAy+99BI33HDDKbcvXLiQ+fPn88gjjww+V1JSEt/85jf57ne/e86xb9y4kUceeeScmkJ0d3cTHR2NzWYbN8e+vPDCCyTsephF7OR583XEr/xblixZEuiwRGSYuFwudu3aRVVVFca2XSzte4t0wzEAev0hbDAvpyl2CcmpGRQXF5+xqJloxuN7NUyeXArj7zU6evQo//PSBp5snEaw0cd9yU2s/urfEBYWFujQRGQY+P1+Dh06RFlZGU3tXWy3RbDNFoHTN1CYzgp2sXxKNwUzgikqKmTevHmTomg91/fqMft/wuv18swzz2C321m8ePFp9xuNRl5//XUqKiq47bbb8Pl8HDx4kJUrV3LDDTecNbl+GpfLRVlZGatWrTrluVatWsWWLVvO+/f5NGvXriU7O5v58+cP+7VHUnd3N+0tDRT5qwHoiMjWEmCRCcZisVBSUsLf/M3fkH/ZV9mU8o88HvZ/qPXPJsLg4HrvmyQ2/5UnKm388YU/89prr9HU1BTosOUkkyWXwvjNpyd3AU4PcxA/c4YKVZEJxGAwMGfOHL7whS9w7ZWXcUN6MH+X1MySmB6CDD6anBaeaZ7K2loLv3tjG08//QzV1dV4vd5Ahz4mjKllwAC7du1i8eLFOBwOIiIieOmll8jOzj7jY+Pj43nnnXdYtmwZt956K1u2bGHVqlX8+te/Pu/nb29vx+v1njZDMGPGDGpqas75OqtWraKqqgq73U5iYiLPPffcGT8o3HPPPdxzzz2DowvjxaFDhwjpOUiwwUO9fxahsQnMnDkz0GGJyAiwWCwUFxeTm5tLdXU1Wyvz2dy6m0X2t/m151r22CIp645gRVcDx+pqiE+ZR3FxMQkJCYEOfdKabLkUxmc+9fv91NcfotY+EO/AEuCMAEclIiPBYDCQkpJCSkoKhw8fZnZ5OfObW/iwK5LynnCOOYJ5ujmYhC4XS9u2k19eQWFhAZmZmZjNY65kGzVj7jfPyMigsrISm83G888/z+rVq3nvvfc+NcnOnj2bJ598kuXLl5Oamsqjjz46JjprrV+/PtAhjKj6+npecC7gA1ccOeG9lKSkTIolCyKTmcViobCwkJycHPbu3cuOijxyuvxYu1w0OC2s6H+Dm13v8W7XUv586GJmzU6nuLiYpKSkQIc+6SiXjg/Nzc0c7vZi85gJMvhIDXVqlZLIJJCcnExycjJHjx5lTlkZixqb2WqNpKInnAanhT81T+X9ThcXtZWTX1FJYUE+2dnZk7JoHXO/scViIS0tDYCSkhK2b9/O//t//4/f/OY3Z3x8S0sLd999N9deey3bt2/n29/+Nv/93/993s8/depUTCYTLS0tpz2PZg4H9Pf309DUwt7+Wez0l5AU1arkKjKJBAUFkZ8/kDj37t1LXmUVe9utZNiaCMbDlb73cLVvYmPnEl4/vIzpSfMoKirS+8QoUi4dHw4dOjS4BDg1zMnMabHjYp+tiAyPpKQkkpKSOHbsGOnl5Sw+duqRN8+3xPFup5tFLTspKa+kuHAg91oslkCHPmrGXLH6ST6fD6fTecb72tvbufTSS8nKyuK5555j3759rFixguDgYH7+85+f1/Od2KO1YcOGwWYRPp+PDRs2cO+9957vrzGhNDU10eC04PYbiTB5SQzza7mfyCRkNpvJy8sjOzubmpoaKistVDbtpbh3PSWGvVzu/wBPx2be71rIm4eXE5c4MNOqA9FHn3Lp2NTQ0MCh/o/3q6akZAU4IhEJhMTERBITE2lsbGReeTmLjjbzkS2Ccls4He4gXmufwntdXkpbq1lUvpP5BTnk5uYSHBwc6NBH3JgqVu+//36uuuoqZs+eTU9PD0899RQbN27kzTffPO2xPp+Pq666iuTkZJ599lnMZjPZ2dm8/fbbrFy5koSEBL797W+f9nO9vb0cOHBg8Pv6+noqKyuJjY0dPIB7zZo1rF69mtLSUhYsWMDDDz+M3W7njjvuGLlffhxpaGgguWcH/2DuYW9wIfHxmYMdJEVk8jGZTOTk5JCZmcm+ffuoqMimvKmW/J71LDTsZqV/CzXtU3msJ42a5o3Mm76DoqKBA9G1fWD4KZeODw6Hg6b2LhqdswBIDnVq4FdkkouPjyc+Pp7m5mYyystZfKSByu5wttsi6PGa2NgZzYddPopa9nNxxW4WFGSTl5c3oc9lHlPFamtrK7fddhtNTU1ER0eTn5/Pm2++yWWXXXbaY41GI//2b//GsmXLTpkKLygoYP369Z967t+OHTu45JJLBr9fs2YNAKtXr+aJJ54A4JZbbqGtrY0HHniA5uZmCgsLeeONNybFsQznorGxkUWereSb9/MHcxjx8SsDHZKIjAEmk4msrCwyMjLYv38/FRVZVDXWktn9Hv/r+RydnjCq7WFc1VGDtaGGslnzKCycPG36R4ty6fjQ2NjIUYcFPwammD3EhRgGz58Vkclt5syZXH311bS2tjKvvJz5h49Q3RvKVmskbe4gttkiqegOZ377AZZW7qY4L4v8/PwJ2Ul8zJ+zOlmMl3Ph7HY7T/7uce5seQCLwcu62H/mplvvZOrUqYEOTUTGGJ/PR11dHeXl5dS29LLZGkmNPZSngv6VJaZqtpHHzshLCZs5ULRmZGSM+eYR4+W9ejIbL6/Rpk2b+K8PjvGRLZLCSDt3F0Vw9dVXBzosERmD2tvbKS8vp77+EAf7g3m/M4pm18AAY4jRx6KYHhZOcZCfnUFBQQEREREBjvjszvW9emx/KpAxp7GxkSD7MSwGL43+OIIjphEXFxfosERkDDIajaSlpTF37lzq6+vJrqjgQGMjjs5oPD4jCw27WNizi/KeTLY0XUrZjkwKCgvIzs4mKCgo0OGLjKjGxkYO9w/sN0sJdRIfPy/AEYnIWDV16lQuv/xyOjs7qaioYO6Bg9TaQ3i/K4p2dxAbO6P5yBbBoq7DlOypITcjjcLCwnFzjNdnUbEqQ9LY2MhURx0Ae43zSEhMUKMUEflMBoOB1NRUUlNTOXz4MBUV03n0yCXM6fqAFb4PKTbUUNxbw56eVD5o/RwVFenk5+eRk5MzKZpHyOTT19dHY0c3La6B/aqzQ5zEx8cHOCoRGetiY2O59NJLKSkpobKykox9+9nTM1C0Wj1m3umM5kNrJCWdjSzYe4C8eXMoLCwkNjY20KGfNxWrMiSNjY3ke/aDARqD0yhSchWRIThxttyxY8eoqMjm8UMrSOrazErvB+QY6nisy80HPVEs7dxNbmUVebk55OXlERoaGujQRYZNY2MjR/oHlvBNC3ITG2bWdhoROWcxMTGsWLGC4uJiqqqqyKmpZWd3CFusEXS6g9hsjWKbLYLCzjYW1bxEfloSRUVFn9qHYCxTsSrnrKenh+6uNjKpB6AvPEUjwSJyXk606W9qKqWiIpsnDi4j1lrBX/2L6HNZeKk1Dot1E5bWMqqq8snJySU/P39c7MMROZvGxkYOOQZWDSSHOpk5c6aajInIkEVFRbFs2TKKiorI27mTwuq9VHcHscUaSbPLwo7ugTNbczqtLNr3Z4pSZ1JUVMSsWbMCHfo5U7Eq56yxsRFnn41uwunxhxEaPZ0pU6YEOiwRGcdmzZrFrFmzaGubT0VFLl8/eJjttggqu0P4puFPJDraaTg2lffaLmXPriIysnIoLCwc041zRM5mYL/qwFETKTqyRkQuUEREBEuWLKGoqIhdu3aRt3sP+7qNfGiN5IgjmF294ezqDSe9s49FB95kfkosRUVFJCUlBTr0s1KxKuessbGRTe50fulcxyURjdwaH6/9qiIyLKZNm8bll19OaWcnuRUV1O6r5cPOZax0bSDB0M6trmdpa3yDd9ovZe+eEtLmZVFUVDSu9+HI5NTb20tDZy8d7kgM+LVfVUSGTWhoKAsWLKCgoIDdu3eTuWsX9d1+tlojqe0LYX9fKPv7Qnm3w8nSundYkBRJUVEhc+bMGbOf6VWsyjlraGjgcH84foxEhoUpuYrIsDvRPKK0tJTKyhxerFlIZEc5K5zrmWXo5Bb3i1ib3+TJzi+za189mXMSKSoq0tmdMm6c3AV4ZrCb6DCLBl1EZFgFBwdTUlJCfn4+1dXVpO3cyTFbN9tsEezqCeOYM5hnm4PZ1OXk4qMfUDhrB0VFhaSlpY25LQkqVuWc2Gw2OrrttLgGWmAnayRYREZQdHQ0y5cvp6SkhKqqfF6rLiW4YyfL+teTYmjmnd4kdvfOoNhqZU/dn8mYPZPCwkISExMDHbrIZ2psbOTwif2qx3PpWJ3REJHxLSgoiIKCAnJycqitrSW5qopl1ma22SIo746gwRnM083BbLI6Wd78IdnTdlBQUDCmzj0fG1HImNfQ0EBU7z4+DP4pr/uXEhJ1JTExMYEOS0QmuIiICJYuXTq4D+ed3cU4Oupo9CXjdhnZZovkUvurBLX38FrdRUxLTKeoqIiUlBQVADImNTY2cqg/HDhxvqoGfkVkZJnNZnJycsjKymL//v0kVlayqKOZD62RVHSHc9QRzB+appFidbCwdQfZZeUU5OeRnZ2NxWIJbOwBfXYZNxobG5nhqCPe0EmCqYdgJVcRGUVhYWEsXLiQwsJC9uzZQ9jOXey1ws4uA1/lbUJ9LrwdH/BB13zePrycmIR5FBaOzSVNMnl1d3dzrKsfmycaI34SQ1wqVkVk1BiNRjIyMpg3bx719fUkV1SwqKWZzV2RVPWEc6g/hEP9IcR2eChp2UNJWRXFeVkBPUJOxaqck8bGRpZ6a8EALcGpLFJyFZEACA4Opri4mLy8PGpqaqiqquIPzd8gv/ddFhp2scL/EStsH7HVls97R1eyY1YG+fn5ZGZmjpklTTJ5DcyqDiwBjg9xER0eoq76IjLqDAYDqamppKamcuTIEdIrKqg91sJ2WwQ7e8LodJt5uyOG9zp95LfUs7CsmiX56eTn5xMZGTmqsSpzy1l1dnbS19PBXEMDAI6IZLXZF5GACgoKIi9vYInS/v37qazMoappPxndG1nmK2ORYSeLenbyi56/oarVTXZZOXl5ueTk5BAcHBzo8GWSOnm/aop6P4jIGDB79mxmz55NU1MTuRUV1B1pYFdPGDu6w+lwB7GjO4Ky7nA2dzawbGcNxZmpFBYWjtpAm4pVOavGxkZCeo8AsN+fRNSU6aM+qiIiciYmk4nMzMzBJU0VFVn8tuEAc6ybWOzbztPOxbQ1T2F6p4vL2rZSWVFOdk4u+fn5hIWFBTp8mWSOHWvgUP/xRoXaryoiY8iJc8/b29vJrKyk+GAdh/qD+cgWwcH+ECp7wtnVE0ZxVyuL975AztwkioqKmD59+ojGpWJVzqqxsZFZzgMA7DPN06yqiIw5RqORuXPnMnfuXI4cOUJlZTaPH7mS1B4z1m4frS4LV9ieIqWnhSfb76By524WL5xPQUFBoEOXScJqtXKs243da8Js8JMQ4lI+FZExZ+rUqaxatYrSUitVVVXM3b+fI31mNnZGccQRzPbuCCp7wpjf3UVN3SukJs5k1apVI7anVcWqfCa/309TUxPLvfsG9quGzGWeRoJFZAw7saSpubmZeZWVLKk/Sq0NcvsPEYSHZ7vSuCW8l+jo6ECHKpPIyftVE0OcREeEExUVFeCoRETOLCYmZvAIuZ07d5K8t4YDPSY2dkXR5LTwoTWSVlcQd8X2ERISMmJxqFiVz9TR0UFHr4N3vIUsMlbjCk/SsiURGRdmzpzJlVdeyfyODqqqqniu9n66bB2kBftJnx5BcnJyoEOUSaShoYHD/R/vV9WsqoiMBxERESxZsoTi4mJ2795Nxu497Ooy8H5nFIuieygoWDSiR8WpWJXP1NjYyCFHGK96bmNWsIv7proIDw8PdFgiIucsLi6OlStXUlpaSlVVFVNrayksvFjnsMqo8fv9NDQ2cdgx0JBE+1VFZLwJCQmhtLSUgoIC9u7dS0HVTkzGIObNmzeiz6tiVT5TU1PTYOfC5BAn8fEaCRaR8SkqKoply5ZRUlIyokuWRD6pq6uLY90eHD4jFoOPWcFuFasiMi4FBQWRn59PTk4ONpttxM8y10np8pna2tqIcDYRgpPEEBezZs0KdEgiIhckLCxsxJOryMna2tpocloAmBXsJioygoiIiABHJSJy/kwmE7GxsSP+PMrW8qn6+vro7enmd4Yfsjv4a8wN6mDq1KmBDktERGRcaW9vp8kVBMDMYBfTpk0LcEQiIuODilX5VO3t7Rj7WzEbfFiJJDg0Wt0zRUREhqitrY3mk2ZWVayKiJwbFavyqdra2oh0NABwwJDMtOnT1JBERERkCHw+H63tHbScNLOqVUoiIufmvBssud1umpub6evrY9q0aaOyZllGV1tbG9PcxwBoMiUySyPBIiLDTvl0YrNarbT0G/H6DQQbfUwxe1WsioicoyHNrPb09PDrX/+a5cuXExUVRUpKCllZWUybNo3k5GTuuusutm/fPlKxyihrb28n2XcEAGtwgpKriMgwUT6dPAaaKx2fVbW4iIqKVDdqEZFzdM7F6i9+8QtSUlJ4/PHHWbVqFS+//DKVlZXs27ePLVu28OCDD+LxeLj88su58sor2b9//0jGLSPsRHOlOTQC4AqdpWJVRGQYKJ9OLicXq7OC3cqlIiJDcM7LgLdv3877779PTk7OGe9fsGABd955J+vWrePxxx/ngw8+ID09fdgCldHV1tY22Fyp3R9NUNgUNVcSERkGyqeTS3t7O82ugeZKM9VcSURkSM65WH366acH//xf//Vf3HTTTWc80Do4OJhvfOMbwxOdBExbWxsH3FP5sftvmG5xEa/mSiIiw0L5dPI40Vyp1TkDgFlqriQiMiTn1Q34vvvuY9myZRw9evSU210uF2VlZcMSmARWe3s7Ne7pPOq9mg+CV2okWERkBCifTmxdXV009xvxYiDE6CNGzZVERIbkvI+uWbVqFcuXLz8lwXZ1dbFgwYJhCUwCq729nSbnx8uWlFxFREaG8unENZBLPz6yRs2VRESG5ryOrjEYDPz4xz9m+vTpLF++nPfee4+kpCQA/H7/sAYoo89ut9Pb080y7y6qDHOZZTFoZlVEZAQon05sbW1tNB8f+J1l0X5VEZGhOu9zVgF+/OMfYzAYBhOsxWLRvsYJoL29HVNfC7+wrKPdH82rIT8kKioq0GGJiExYyqcT0ydnVrVKSURkaM6rWD15tPehhx4aTLDPPPPMsAUmgdPW1kaEc+DImgOGZKbPmK4PTSIiI0D5dOLy+Xy0tHXQ6jrRXElbakREhuq8itV//dd/JTw8fPD7H/3oRwBce+21wxOVBFR7ezvT3QN7pxpNScQruYqIjAjl04mrq6uLZocR3/HmStFmr5YBi4gM0XkVq/fff/9pt/3oRz8iKCiIn//85xcclARWW1sbi31HwQDW4ATyVayKiIwI5dOJa2C/6sAS4FnHmysFBwcHOCoRkfHlvLsBn8n3v/99rFbrcF5SRpndbqevt5s5NADgDp2pkWARkVGmfDr+fbKrvnKpiMjQDWuxKuNfW1sbxr5WTAY/7f5ogiNi1VxJRERkiNrb2z+eWbWouZKIyPlQsSqnaG9vP6W50tRp09RcSUREZAg+bq50ohOwZlZFRM7HBR1dIxNPe3s7f/EuYr0ridRwH5dqJFhERGRITm6uFGr0Em32amZVROQ8qFiVU7S1tbHPFUebbyaxYR0aCRYRERmitra2k85Xdau5kojIedIyYBlkt9vptjtodw+MYegAcxERkaEb2K860FxplpYAi4ict2EvVo1GIytXrqSsrGy4Ly0jrK2tDV9/B98yv8BK807iwsxqriQiEiDKp+PXqTOrGvgVETlfw16sPvbYY1x88cXcc889w31pGWHt7e1M7T/AfeYXudv8OlOnTlVzJRGRAFE+HZ98Ph+t7Z20uU6csaqZVRGR8zXse1Zvv/12AH74wx8O96VlhLW1tTHdfQyARlMS8RoJFhEJGOXT8amzs5Om/o+bK0WZ1FxJROR8ac+qDGpvbyfZdxQAa3CCRoJFRESGqL29nSbXx/tVo6Oj1FxJROQ8DWuxevToUe68887hvKSMkt7eXvp6bMyhAQBX6EwVqyIiAaJ8On4NNFfSflURkeEwrMVqZ2cnv/vd74bzkjJKOjo6MPa3YTL4afNHExIZp+ZKIiIBonw6frW3t9Ny0rE1KlZFRM7fkPasvvrqq595f11d3QUFI4FjtVoJdbUBcMiQSGxsbIAjEhGZuJRPJ66uLiud7jgApgZ5iIuLC3BEIiLj15CK1RtuuAGDwYDf7//Ux6h77Phks9mI8gwUq23G6cTExAQ2IBGRCUz5dGLq6+ujs9+Dy2/EgJ8pQR7lUxGRCzCkZcCzZs3ixRdfxOfznfGrvLx8pOKUEWa1Wlnn+wKXOv+DD4IvITo6OtAhiYhMWMqnE5PNZqPDPTAPEGP2YjGbiIiICHBUIiLj15CK1ZKSks88nPxso8QydlmtVlo8IRz0J0BwjEaCRURGkPLpxGS1WulwD+xXjbO4iY6O1gy5iMgFGNIy4P/7f/8vdrv9U+9PS0vj3XffveCgZHQ5nU76+h10uQf2qcZaPJpZFREZQcqnE5PNZqPTNfDRKi7IQ0yMmiuJiFyIIc2sLlu2jCuvvPJT7w8PD2f58uUXHNREcOONNzJlyhRuuummQIdyVjabDZ+zm58F/Ya7zK8RE+RXJ2ARkRGkfHpuxlMuhRMzqwPFamyQBn5FRC7UsB5dIx/71re+xe9///tAh3FOrFYrIY5WbjK9z82m94mKisRo1F8NEREJrPGUS2Egn3a6T55ZjQlsQCIi45wqkhGyYsUKIiMjAx3GObFarUS4BzoBNxlnKLmKiMiYMJ5yqc/no8vWg9VjAjSzKiIyHMZUsfqTn/yE+fPnExkZyfTp07nhhhuora0d1ud4//33ufbaa4mPj8dgMPDyyy+f8XFr164lJSWFkJAQFi5cyEcffTSscYwlNpuNmOPH1nQYpyu5ioiMY8qlgdHd3U2H2wQYCDb6CDf5NPgrInKBxlSx+t5773HPPfewdetW3n77bdxuN5dffvmnNqHYvHkzbrf7tNurq6tpaWk548/Y7XYKCgpYu3btp8bx7LPPsmbNGh588EHKy8spKCjgiiuuoLW1dfAxhYWF5ObmnvbV2Ng4xN868KxWK9P9A/+/eoOmKbmKiIxjyqWBYbVa6TipuVJYWCgWiyXAUYmIjG9D6gZ8smPHjhEfH4/RaDzlzxfijTfeOOX7J554gunTp1NWVsbFF198yn0+n4977rmH9PR0nnnmGUymgWU3tbW1rFy5kjVr1vBP//RPpz3HVVddxVVXXfWZcfziF7/grrvu4o477gBg3bp1vPbaazz22GN897vfBaCysvJ8f80xxe/3093dTaK/GQzgCI5TsSoiMoqGO58qlwaG9quKiAy/886G2dnZHDp06LQ/DyebzQZAbGzsafcZjUZef/11KioquO222/D5fBw8eJCVK1dyww03nDG5nguXy0VZWRmrVq065blWrVrFli1bzu8X+Qxr164lOzub+fPnD/u1z0VPTw9up52phm4AfMGxWgYsIjKKRjqfToZcCoHPpzabbfCM1dggt3KpiMgwOO9i9eTDykfi4HKfz8d9993H0qVLyc3NPeNj4uPjeeedd9i0aRO33norK1euZNWqVfz6178+7+dtb2/H6/UyY8aMU26fMWMGzc3N53ydVatWcfPNN/P666+TmJj4qcn5nnvuobq6mu3bt593zBfCZrOBw4bPb6DVH0NoeBShoaEBiUVEZDIayXw6WXIpBD6famZVRGT4nfcy4JF2zz33sHv3bjZt2vSZj5s9ezZPPvkky5cvJzU1lUcffRSDwTBKUX669evXBzqEc2K1WtnjTyHL+TiFIa18WSPBIiIThnLp6LFabXS4pwAQa1GxKiIyHMZUg6UT7r33Xv7yl7/w7rvvkpiY+JmPbWlp4e677+baa6+lr6+Pb3/72xf03FOnTsVkMp3WVKKlpYWZM2de0LXHooEDzINwYsEVNEXJVURkglAuHT0Oh4MOuwunzwj4iTXr2BoRkeEwpopVv9/Pvffey0svvcQ777zDnDlzPvPx7e3tXHrppWRlZfHiiy+yYcMGnn32Wf7xH//xvGOwWCyUlJSwYcOGwdt8Ph8bNmxg8eLF533dsWpgj82JZUtuFasiIuOccunos9lsg0uAY8xeLGbjuDkfVkRkLBtTy4DvuecennrqKV555RUiIyMH97VER0efto/S5/Nx1VVXkZyczLPPPovZbCY7O5u3336blStXkpCQcMaR4d7eXg4cODD4fX19PZWVlcTGxjJ79mwA1qxZw+rVqyktLWXBggU8/PDD2O32wY6GE4nVauWb7qfpNZupNy0nOnpJoEMSEZELoFw6+gZWKQ18pIoN8hAVFXXBJySIiMgYK1ZPNHNYsWLFKbc//vjj3H777afcZjQa+bd/+zeWLVt2yjlmBQUFrF+/nmnTpp3xOXbs2MEll1wy+P2aNWsAWL16NU888QQAt9xyC21tbTzwwAM0NzdTWFjIG2+8cVqjiPHO5XJh7+3lZsM2gs1u1gUt1cyqiMg4p1w6+k5dpeQhJmZKgCMSEZkYxlSxOtQuiJdddtkZby8qKvrUn1mxYsU5Pc+9997LvffeO6R4xhubzQauboINbpx+M8bgaKKiogIdloiIXADl0tE30Al44NiaOIuOrRERGS7nvUble9/73uCZbSf/WcYPm82G2dkBwDGmExUdPXggvIiIjA7l0/HParXS4fp4GbBWKYmIDI/znlm9//77z/hnGT+sVith7nYAmgwzNRIsIhIAyqfjm8/no8vWjdUz0OU4LkidgEVEhot2/09iVquVKZ42ADpM0zUSLCIiMkS9vb10OI34MWAx+Igw+ZRPRUSGiYrVScxmszHN1wpAd9BUjQSLiIgM0Sc7AYeEBBMSEhLgqEREJgYVq5OU3+/HZrMR5HMC4AiaqpFgERGRITq5WI2zaL+qiMhwGnKxevjwYd56663Bc9s+qbGx8YKDkpFnt9vpc3m5zvUvZDkewxE6SwlWRGQUKZ9ODDabjU7XycfWxAQ2IBGRCWRIxerTTz9NWloaV155JampqTz55JMAHDlyhJ/+9KcsXLhw8DBwGdsG2uwf769lDCIiNJiwsLDABiUiMkkon04cn1wGrC01IiLDZ0jF6o9//GO++c1vsmvXLi677DL+9m//lh/84AfMnTuXJ554gtLSUp577rmRilWG0ScPMFdyFREZPcqnE4fNZvv4jNUgt2ZWRUSG0ZCOrjl48CDf+ta3SE5OZu3atcyePZvNmzezc+dOsrKyRipGGQFWq5XSvve4JWgPW82LiYm5JtAhiYhMGsqnE4PL5aK9x0G/bwoAsUFeFasiIsNoSDOrbreb0NBQABITEwkJCeHnP/+5Eus4ZLPZSPIeZompmgRjp5KriMgoUj6dGE5epRRl9mAxQVRUVICjEhGZOIbcYOmpp56ipqYGAJPJxJQpU4Y9KBl5VquVmb4WAOxB01SsioiMMuXT8c9qtdJxUnOlyMhIjEYdtCAiMlyG9I66bNkyHnzwQXJycpg6dSoOh4P/9//+H3/605+orq7G4/GMVJwyjDweDz3dPSQx0IHSZYnTnlURkVGkfDoxDOxX/bi5kgZ+RUSG15D2rL733nsA7N+/n7KyMsrLyykvL+f3v/89VqsVi8XCvHnz2Llz54gEK8PDZrPhd/cQbnDi9pswhESrWBURGUXKpxPDKWesqlgVERl2QypWT0hPTyc9PZ0vfelLg7fV19ezY8cOKioqhi04GRk2mw2zsxOABqYRGRWN2XxefxVEROQCKJ+Ob58sVjXwKyIyvM65Qjly5Mhnnvk2Z84c5syZw8033wxAQ0MDCQkJFx6hDDur1UqYqx2ARsMMjQSLiIwi5dOJwe/302XrxuqeDkCcRTOrIiLD7Zz3rM6fP5+vf/3rbN++/VMfY7PZ+O1vf0tubi4vvPDCsAQow89qtdLvNdDqj6HdNF0jwSIio0j5dGKw2+2094MPA0EGH5Emr/KpiMgwO+eZ1erqav71X/+Vyy67jJCQEEpKSoiPjyckJISuri6qq6vZs2cPxcXF/OxnP+Pqq68eybjlAthsNv7ou5wfO6/j6ogO7tFIsIjIqFE+nRisVuspzZWCgy2EhYUFOCoRkYnlnGdW4+Li+MUvfkFTUxOPPPII6enptLe3s3//fgC+8pWvUFZWxpYtW5RYx7ju7m66jifYKRafRoJFREaR8unE0N3djdVjAiDGrFlVEZGRMOSuOqGhodx0003cdNNNIxGPjDCPx4PD4aT7eIKNNnuJiIgIcFQiIpOP8un41tvbS8/xXBpl9hIZGRPYgEREJqBhObm6vLx8OC4jo8But+P39LHBsoangv6FSJOb8PDwQIclIiIon44ndrudHu9AsRpp9iqXioiMgGEpVhcsWMCaNWtOue31118fjkvLMLPb7RhdPaQYW0g3NhAaEkJQUFCgwxIREZRPxxO73T64SilKxaqIyIgYlmI1Ly+PqKgo7rjjjsHbvv/97w/HpWWY9fb2YnZ3A9BGrJYAi4iMIcqn44fdbh9cBhypLTUiIiNiWIpVg8HAD3/4QwoKCrjppptwu934/f7huLQMM7vdTrB3oFjtMsRoJFhEZAxRPh0/ens/LlajTJpZFREZCUNusHQmUVFRANx3331MmTKF6667jv7+/uG4tAwzu91OuMcGgM0YQ4SSq4jImKF8Oj44nU66XT68GAA/EVoGLCIyIoY0s9rX13fG2zdu3Dj459WrV3P33XfT2tp6QYHJyLDb7UT5rAN/NkVr2ZKISAAon45vJy8BDjf5MBnQGasiIiNgSMVqdHQ07e3tZ33cjTfeSGdn53kHJSPHbrcT4+8CoN8UrZFgEZEAUD4d33p7e09prhQWFobROCw7q0RE5CRDemf1er34fL7B75ctW0ZLS8uwByUjp7e3lw5/JM3+KTjNUSpWRUQCQPl0fDuluZL2q4qIjJgL2rNaWVmJ3W4frlhkhHm9Xvr7Hfyt61t4/Eb+dnqzEqyIyBigfDq+nHzG6sCxNVEBjkhEZGLSmpVJxG634/AZ8PgHXnaNBouIiAzdycuAdWyNiMjIGXKx+tRTT1FeXo7b7R6JeGQEnbxsKdToJTQ4CIvFEuCoREQmJ+XT8ctut5+yZ1UDvyIiI2NIy4CXLVvGgw8+SE9PD0FBQXg8Hh588EGWLVtGUVER+fn5BAcHj1SscoHsdjszHPt4z/ITKgyZuMK/GuiQREQmJeXT8W1g8Hfg9dEqJRGRkTOkYvW9994DYP/+/ZSVlVFeXk55eTnf/e53sVqtmM1msrKyqKqqGpFg5cL09vYS5rGSbGylkVl0admSiEhAKJ+Obz09vfR4B46qidTMqojIiDmvBkvp6emkp6fzpS99afC2+vp6duzYQUVFxbAFJ8PLbrcT6rEBYDPGKLmKiASY8un443K56HH58PgNgIpVEZGRdEHdgAH27dtHamoqc+bMYc6cOdx8883DEZeMALvdTpRvoFjtMUYzVclVRGTMUD4dHwaWAA+0/AgzeTEbULEqIjJCLrgbcFZWFnV1dcMRi4wwu91OtN8KgMMcreQqIjKGKJ+OD6ccW2PyEhoaislkCnBUIiIT0wUXq36/fzjikFFgt9uJ83cB4DRHqVgVERlDlE/Hh08eW6NcKiIycnTO6iTh8/mw2/uYTicA3qAonQsnIiIyRCcfW6NiVURkZKlYnSTsdjsen4cD/gRa/DH4gyKUYEVERIbo5DPLo3RsjYjIiLrgBksyPtjtdqzeEG5w/ZgQo49/CmnTGX4iIiJD1NvbO7hnNdLs1SolEZERpJnVSeLkkWAtWxIRETk/Jy8DjlI+FREZUSpWJ4lTkquWLYmIiJyX3l4N/oqIjBYVq5NEb28vyx1v857lPr5qeF3LlkRERIbI7XbT43Dj9g98fIrU4K+IyIi64GL1O9/5DnFxccMRi4wgu93OFG8HycZWIo1OJVcRkTFG+XTss9vtdB/frxpq9BJkRPlURGQEXXCDpZ/85CfDEYeMMLvdzqzjZ6z264xVEZExR/l07Ptk/4fg4GDMZvWqFBEZKVoGPEnY7Xbi/FYAXCYVqyIiIkN1anMln3KpiMgIU7E6Cfh8Pvr6+phGJwCeIBWrIiIiQ9Xb2/vxzKrJo/4PIiIjTMXqJNDX14fP7STa0AeAzxKpBCsiIjJEdrt98IxVHVsjIjLyVKxOAna7HVw9APT6QwgKDiMkJCTAUYmIiIwvJy8DjtQyYBGREaeuAJOA3W7H4fVT4UvDYwhSchURETkPvb29dHsGPjpFmr1apSQiMsJUrE4Cdrud/czml66HmBPqYE24JdAhiYiIjDsD3YBjAYjSGasiIiNOy4AngVO7Fyq5ioiIDJXH46G734XLP/DRKVL5VERkxKlYnQRO7V6oZUsiIiJDdfLAb4jRh8XoV7EqIjLCtAx4ErDb7axxr2O25SivcyPh4fmBDklERGRcGVgCfKK5kheLxUJQUFCAoxIRmdg0szoJ2O12ZvhbSTa2EmwyaCRYRERkiE4uVrVfVURkdKhYneD8fj99fX1MowsAd1CkEqyIiMgQ2e12ur0fz6wql4qIjDwVqxNcf38/HreTKYbegRtUrIqIiAzZKf0fdGyNiMioULE6wfX29mJw9QBg9wdjDAojNDQ0wFGJiIiML6d01tcyYBGRUaFidYKz2+2Y3APFaiuxhEeEYzAYAhyViIjI+PLJBksqVkVERp6K1QnObrcT7OkGoNMQo2VLIiIi56G3t5cer84sFxEZTSpWJzi73Y7VF0KFL40jhkQlVxERkSHyer109zlx+AY+NmlmVURkdOic1QnObrfzLqX8p2sFS2K6+XslVxERkSE5eQlwsMFHsNGvlUoiIqNAM6sT3MndC6PUvVBERGTITm6uFGn2YjabsVgsAY5KRGTiU7E6wQ2MBh9ftmTyadmSiIjIENnt9sH9qjq2RkRk9GgZ8ATm9/ux2+28ZPhn3BYjrxruVrEqIiIyRKccW6P9qiIio0bF6gTmcDjweFzMMnSAAcxBwUqwIiIiQ3TKsTU6Y1VEZNRoGfAEZrfbMbh6AXD4gzCaQwkLCwtwVCIiIuPLJ4+t0TJgEZHRoWJ1Auvt7cXo6gGglVjCI8IxGAwBjkpERGR8GVgGrGNrRERGm4rVCcxut2PxdgPQbpii5CoiInIeTlkGrGJVRGTUqFidwPr7+wnxDMys2gzRSq4iIiJD5Pf76bX30e8bKFbD1VlfRGTUqFidwBwOByE+OwD9hnBCQkICHJGIiMj44nK5cPg+/rgUYvQpn4qIjBIVqxOY0+mkxT+FMl86babpBAcHBzokERGRccXpdOLwDfR7sBh8mAwon4qIjBIVqxOY0+nkRcOlfMH1IzZbLtZIsIiIyBA5HA76vQMfl0JNPkwmE2azTv4TERkNKlYnsIHR4I8TrEaCRUREhubkXBpiVC4VERlNKlYnMKfTOTgarAQrIiIydCfn0lCT9quKiIwmrWOZwBwOB08ZHiI0uJ+Xff9HxaqIiMgQORwO+k+sUjL6CA5WsSoiMlpUrE5QPp8Pl8vFDDqIMDgwmk0qVkVERIZIy4BFRAJHy4AnKJfLhd/nJcLgGLjBFKqlSyIiIkN06jJgv4pVEZFRpGJ1gnI6nfg8A4Wqz2/AYArGYrEEOCoREZHx5ZRmhZpZFREZVSpWJyin04nxeLHaTRhBFota7YuIiAzRKc0K1WBJRGRUqVidoBwOB0ZvPwDdhGskWERE5Dw4HA7NrIqIBIiK1QnK6XRiOl6s9qpYFREROS9Op5N+nwFQgyURkdGmdaETlNPppNcfTJkvnWbjLCVXERGR8zCwDDgUGDhnVflURGT0qFidoJxOJzsNWfzCtZjs8D7uU3IVEREZEr/fj8OhBksiIoGiZcAT1MCypROt9tUQQkREZKjcbjcOL/j5eBmw8qmIyOhRsTpBORyOwWJVe2xERESG7uSB3yCDD7MR5VMRkVGkZcATlNPp5Bvu35EbvJfXfdcSHJwV6JBERETGlZPPWA0x+jAajQQFBQU4KhGRyUMzqxOU0+lkit9KvKGTYM2sioiIDJnD4Rg8YzXU5FcuFREZZSpWJyin00m4vw8AtzFMCVZERGSITl4GrC01IiKjT8XqBOV0OonEDoDXFKqGECIiIkPkdDpxeNUJWEQkUFSsTkB+vx+n00kUvQD4TKFKsCIiIkP0yc76yqUiIqNLxeoE5Ha78Xm9RBsGlgH7g0KUYEVERIbokw2WtEpJRGR0qVidgBwOB36vc/B7gylYCVZERGSIBhosDZyxqplVEZHRp6NrJiCn04nH62WHbx4huDGZgzCb9VKLiIgMxckzq9qzKiIy+lTBTEBOp5M2pnCT64dEmz3835CeQIckIiIy7jidzsGja0JMWgYsIjLatAx4AtJIsIiIyIU7pcGS8qmIyKhTsToBfXIkWMlVRERk6DT4KyISWCpWJyCHw8EC5yY+DL6Xe3lWyVVEROQ89Pc7NPgrIhJAKlaH2Y033siUKVO46aabAhaD0+kkzNdDvKGTCINDyVVERMaVsZBLPR4PTq8fH8e7ARv9yqciIqNMxeow+9a3vsXvf//7gMbgdDoJ9vUD4DCEqSGEiIiMK2MhlzocjsH9qiaDH7PBr3wqIjLKVKwOsxUrVhAZGRnQGBwOB6H+PgCcxjCNBIuIyLgyFnKp0+nE4f14v6rRaCAoKCigMYmITDaTqlh9//33ufbaa4mPj8dgMPDyyy+f9pi1a9eSkpJCSEgICxcu5KOPPhr9QC+Q0+kk7Hix6jKFqlgVEZFhM5lyab9vYAlwyPHmSgaDIcBRiYhMLpOqWLXb7RQUFLB27doz3v/ss8+yZs0aHnzwQcrLyykoKOCKK66gtbV18DGFhYXk5uae9tXY2Dhav8ZZOZ1OIvx2ADxGFasiIjJ8JlMuPdFcKVTNlUREAsIc6ABG01VXXcVVV131qff/4he/4K677uKOO+4AYN26dbz22ms89thjfPe73wWgsrJyWGJxOp04nc7B77u7u4fluieuHYGKVRERGX5jKZfCyOVTnbEqIhJ4k2pm9bO4XC7KyspYtWrV4G1Go5FVq1axZcuWYX++n/zkJ0RHRw9+JSUlDdu1nU4nh/0zOOCLx2tWgyURERkdo51LYeTyqcPhGNyzGqJiVUQkIFSsHtfe3o7X62XGjBmn3D5jxgyam5vP+TqrVq3i5ptv5vXXXycxMfFTk/P999+PzWYb/Dp69OgFxX+C2+3G6/Vxu+ufWOX6OX2WaUqwIiIyKkY7l8LI5dNTZla1DFhEJCAm1TLg0bB+/fpzelxwcPCIJD6n04nTZ8DPqU0hRERExotzzaUwsvnU4ft4ZlWrlERERp+K1eOmTp2KyWSipaXllNtbWlqYOXNmgKIaupPPhQsy+AgyGbBYLAGOSmRkeL1e3G53oMOQCSooKAiTyRToMMaViZJL4Xg+VYMlGaOU/2S8uNBcqmL1OIvFQklJCRs2bOCGG24AwOfzsWHDBu69997ABjcETqeTaFcjW4L/hXp/PAeCvx7okERGRG9vL8eOHcPv9wc6FJmgDAYDiYmJREREBDqUcWOi5FI4dRlwiNGvYlXGDOU/GU8uNJdOqmK1t7eXAwcODH5fX19PZWUlsbGxzJ49mzVr1rB69WpKS0tZsGABDz/8MHa7fbCj4XjgdDoxe/qYZeikl3COKrnKBOT1ejl27BhhYWFMmzZNZx/KsPP7/bS1tXHs2DHS09M1w3qSyZBL4fgyYO/AxyR1A5axQvlPxpPhyKWTqljdsWMHl1xyyeD3a9asAWD16tU88cQT3HLLLbS1tfHAAw/Q3NxMYWEhb7zxxmmNIsYyp9OJ2dcHQI8hXMlVJiS3243f72fatGmEhoYGOhyZoKZNm8ahQ4dwu90qVk8yGXIpnJhZHdhGo2XAMlYo/8l4c6G5dFIVqytWrDjrkol777133C1VOpnT6cTi7QegDx1bIxObRpRlJOnv15lNhlwKJxosRQMDM6vKpzKW6P1JxosL/buqo2smGIfDgcV3vFjVzKqIiMiQeTwe+l0ePP7jnfU1syoiEhAqVicYp9NJiH9gGbDDGKrkKjKKfvjDH+JwOAIdhohcIJfLNXhsjRE/FoMaLIl8GuU+GUmTahnwZOB0Ogn12Qf+bNQyYJnY/H7/qCXI4ODgsy5l+dGPfsR999132r87j8eD2ay3W5Hx4uRj4EJMPgwGdAycjCljKf8p98lI0t+gCcbpdNLnj+aAL54eY7RGgmVCczqd/OlPfxqV57rttts+c/DnG9/4BgDLli3DZDIRHx/PzJkzOXDgAK2trdTU1GAwGOjq6iImJgYYOJNyx44dpKSksH//fu677z5aW1txOp3cfffd437Pn8h45XQ6Pz5j1ejDYrFgNGoxmowdYyX/KffJSNM77wTjdDr5b/8trHL9nN0hpSpWRUbJunXrAPjggw+orKxk+vTplJWV8dprr1FTU/OZP+v1evnyl7/Mf/7nf7J9+3a2bt3K//zP/7B9+/bRCF1EPmGgudLHxapyqciZKffJSNPM6gQzsHRp4NBdJViRwLr55puJjIw86+Nqa2vZs2cPX/rSlwZv6+npobq6mvnz549kiCJyBifPrKq5ksjQKPfJcFKxOsEMjAZHASpWRQItIiLilO9NJhNer3fw+xP7jfx+P7GxsVRWVo5meCLyKU6dWfWr/4PIECj3yXBSsTqBeDwePG4Pb5jW0GsK4V3D15RgZUILDg7mtttuG7XnOpvIyEhsNtvgvpxPSktLY9u2bVx99dW8+OKL2O0DzdAyMjKIiori8ccf54477gDgwIEDxMbGEhsbO2y/g4icG4fD8fHMqgZ+ZQwaS/lPuU9GkorVCcTpdILPTZKxDYD3jUFKsDKhGQyGMTUg8w//8A9cdtllhIWFER8ff9r9v/zlL/n7v/97vv/97/O5z32OuLg4AMxmM3/5y1+47777+OUvf4nX62Xq1Kk89dRTo/0riAjHlwGfmFnVMmAZg8ZS/lPuk5GkYjXA1q5dy9q1a09ZHnG+nE4nfu/A0gqnPwiMQWq1LzKKHnzwQR588MFPvf+qq65i//79g9//+Mc/Hvzz3Llz+fOf/zyi8YlMZMOdTwePrjH6xkxRIDIWKffJSFI34AC75557qK6uHpbOZ06nE6OnHwAb4YSEhpz1XEgREZGJYLjzqcOrmVURkUBTsTqBOBwOjN6BYrWHcCVXERGR8zAwszow2KtmhSIigaNidQJxOp2YTxSrBhWrIiIi58PhcAzOrKrBkohI4KhYnUCcTidBvj4A+ghTchURETkParAkIjI2qFidQJxOJ3ZfMPt9CbQZpqohhIiIyBD5fD76XW7cfjVYEhEJNBWrE4jD4WCDcQmXuf6Dpyw3ayRYRERkiE5urgR+Qox+5VMRkQBRsTqBOJ1OHD7tsREJhBdffJGSkhIKCwvJzMxk5cqV+Hy+wfvXrl1Lbm4uWVlZFBcX8+Uvf5kjR44AA+fl5eXlUVhYSGFhIQ888MAZn6Ovr4/S0lJ6enoA2Lp1K3l5eRQVFfHmm2+O/C95Bn/5y19YsWLFiFx73bp1/Md//AcAlZWVPPPMM+f0czt37uSqq64akZhk4jtlCbDRj8GA8qnIZ0hJSWH69Om43e7B2959910MBgP33XffWX9+48aNFBYWAmC1WvnpT396yv3/5//8H959990LjrGysnLIP9fU1MSiRYsG8/krr7xCVlYWhYWF7Nq164JiOl+PPPIIt99++4hc+4EHHuCPf/wjMPC6vPHGG+f0c3/5y1+4++67RyQmnbM6gTidTvrVal9k1DU1NXH33XdTVlZGcnIyAOXl5YNHRz344IO89dZbvPHGGyQmJgKwYcMGmpubmT17NgAffPABMTExn/k8jzzyCNdffz2RkZEA/O53v+PWW2/l/vvvP+2xHo8Hs3l8v8V/4xvfGPxzZWUlL7/8Ml/60pfO+nP5+fkEBwfzzjvvsHLlypEMUSagkwd+Q00+goKCMBo1ti/yWWbPns2rr77KF77wBQAeffRRSktLh3ydE8Xqd7/73cHb/vd//3fY4hyqH//4x9xzzz2D7wHr1q3jgQce4Mtf/vJpj50Iefehhx4a/PPGjRuxWq1ceeWVZ/25a665hgcffJD9+/eTnp4+rDHp3XcCcTqd3O/7NX+1fIdcX62KVZkU/H4/fS7PiH75/f7PjKGlpQWTyURsbOzgbcXFxRgMBux2Oz/72c949NFHBwtVgEsvvZQFCxYM6Xf9zW9+w6233grAT3/6U5599lkeeeQRCgsLsVqtpKSk8J3vfIcFCxawevVqent7ufPOO8nNzSU3N5cf/ehHg9dasWIF//AP/8DFF1/M7Nmz+cEPfsDrr7/ORRddREpKCr/4xS/OGIPb7ebv/u7vSE9PZ8GCBaeNdj/55JMsXLiQ4uJiLr74YqqqqgB44oknWLVqFV/+8pfJy8ujtLSUuro6APbv38/SpUspKCggLy+P73//+wD88Ic/5L777qO1tZUHHniAd999l8LCQr7xjW/w85///JRRXKvVytSpU+ns7ATgy1/+Mr/5zW+G9P9XBE4d+NUqJRnLxkL+O+GOO+7gscceA8Bms7F169ZTipwnnniCG264YfD7T1uV841vfIOenh4KCwsHi90VK1bw8ssvA3D77bdz5513smTJEubNm8fq1avp7x84CaO1tZXPf/7z5OXlkZub+6k5oLm5mS9+8YssWLDglJzzSQ6Hg2effXawAP/7v/97PvjgA773ve+xZMkSYGBl1IMPPsj8+fO5//77PzOGlJQUvv/977NkyRKSkpJYt24djz/+OIsXLyYlJeVTVw/19PRwyy23kJGRwUUXXXTajO7Pf/5zFixYQHFxMVdeeSWHDx8GBnLoLbfcwrXXXkt2djYrV64czJFbt24dXA2Wm5vLr3/968H/vw8//DCVlZWsW7eOP/7xjxQWFvLQQw9x77338m//9m+Dz1tbW0tSUhIejweAL37xiyMysDC+y385hdPpJMnfTJrxGJsNXjWEkEmh3+0l+4GRXQJb/dAVhFk+/e0yPz+fiy66iOTkZJYvX86SJUu49dZbSUhIYM+ePVgsFrKzsz/zOZYtW4bJZAIGitKFCxeecv/Ro0ex2WzMnTsXgO9+97vU1NRQWFh4yjKrjo4Otm3bhsFg4Dvf+Q5Op5OdO3fS39/PRRddRGZmJrfccgsAhw8f5t1336W7u5uUlBS6urr44IMPaGxsJCMjgzvvvPO02d7/+Z//oba2lj179gBwxRVXDN63efNmnn76ad5//32Cg4P54IMPuPXWWwcfu337diorK5kzZw7f/e53+fd//3d+85vf8Mgjj3DNNdcMzhCfSKYnTJ8+nYceeoiXX3558AOL1Wpl3rx5/OxnPyMmJobHH3+c66+/fnDAYPHixdxzzz2f+f9c5EwcDsfHM6sqVmUMGwv574SlS5fyq1/9isbGRl599VVuvvnmwZw2FOvWraOwsPAzl+xu27aNrVu3EhYWxg033MAvf/lLvve97/HNb36TjIwMXnzxRVpbWykpKaGgoIBFixad8vOrV6/me9/7HsuXL8fj8XDNNdfw3HPPcfPNN5/yuO3btzNnzhzCwsIA+K//+i927tzJfffdd0rhbTKZ2L59O8BgUflpMdjtdj788EMOHDhAXl4e//zP/8yWLVvYvn07V1999RlXDz300EMEBwdTU1NDd3c3ixYtGvyM8NRTT1FbW8uWLVswmUw8+eST/N3f/R2vvfba4P+rsrIy4uLi+NKXvsRvfvMb7r//fn7yk5/wj//4j4MzxF1dXac854mBYavVysMPPwwMFKdXXHEF3/nOdzCZTPzqV7/i7rvvHpxNXrx4MWvWrPnU1+18aWZ1AnE4HERiB8BnDlGCFRklRqORF154gQ8//JArr7ySzZs3k5OTw4EDB875Gh988AGVlZVUVlaeVqgCHDt2jBkzZpz1Orfffvvg8uP169dz1113YTQaCQ8P57bbbuPtt98efOxNN92EyWRiypQppKamcs0112AwGEhISGDatGkcOnTotOtv2LCB2267DYvFgsVi4c477xy875VXXqGqqoqFCxdSWFjIN7/5TTo7OwdHvRcvXsycOXMG/3zw4EEALr74Yn7729/yz//8z7z11ltnXQ4NEBMTw0033cRjjz2G3+/n17/+Nffee+/g/TNnzqSjowOHw3HWa4mc7JSZVW2pETlnX/3qV3niiSd47LHHTskNw+2LX/wikZGRmEwmvva1r7F+/XpgIOd9/etfBwYGOT//+c8P3neC3W5nw4YNfOtb3xqcvT1w4AC1tbWnPc+55t2Tf9ezxXBisDgtLY2QkBBuuukmAEpLS+ns7MRqtZ52/Q0bNvC1r30Ng8FAdHT04AorgJdffpn169cPzpL+7Gc/G+yHAXDllVcSFxcHnJp3L7nkEn784x/z0EMPsWnTJqZMmXLW3zMjI4Ps7GxeeeUV7HY7Tz/99CkrnGbOnMmxY8fOep2h0szqBOH1evF4PETTC4DPFKoEK5NCaJCJ6oeuOPsDL/A5zkVmZiaZmZl8/etf58orr+TVV1/l7rvvxuVyUV1dfdbZ1c8SFhZ2ToVXRETEp953oog94eTVFyaT6bTvTyzt+SwnX9Pv97N69epTlgl91vOduP4XvvAFlixZwttvv80jjzzCww8/zOuvv37W5/77v/97rrvuOrKyspg2bRpFRUWD9zkcDkwmExaL5azXETnZQIOlgb/XoTq2RsawsZT/AG677TaKi4uZN2/eafsWzWYzXq938PvhHEj8ZG77rNtPLGveunXrWf9tj2beNRgMGAyG88q7999//6c2N/q0vHvfffdx/fXXs379er73ve+Rm5vLr371q7M+97e+9S3+/d//nba2Ni677LJTinmHw0FoaOhZrzFUmlmdIJxOJz6vmxDD8U5s5hAlWJkUDAYDYRbziH59WiI8oaGhgc2bNw9+39XVRX19PXPnziUiIoJ//Md/5K677qKhoWHwMe+++y4fffTROf+eGRkZtLa2Ds5SnotVq1bx6KOP4vf7sdvtPPnkk1x++eXn/POfds0//OEPuN1uXC4Xjz/++OB91113HX/4wx8GR3V9Ph87duw46zX379/PjBkzuO222/jZz37G1q1bT3tMVFQUNpvtlNsyMzNJTU3l7rvvPmVWFWDv3r3k5uaqMY4MmTrry3gxFvLfyeLj4/nJT37Cv//7v592X1pa2uCWFI/Hw1NPPXXGa0RFRdHf34/L5frU53n++efp7e3F6/Xy+OOPs2rVKmAgP/32t78FoK2tjRdffJHLLrvslJ+NiIjgkksuOaXjcGNj4xlnBPPz88844/pZziWGoVq1ahWPP/44fr+f7u5unn766cH7brjhBtatWze4fcbtdlNRUXHWa9bW1jJnzhzuuusuvve9751z3r388stpbm7mX/7lX86YdwsKCs7nV/xMyuIThNPpxOAZGP1x+00YjBbNKIiMEo/Hw0MPPcS8efMoLCxk2bJlrF69muuvvx4Y2G/yxS9+kSuuuIKsrCyys7P57W9/y6xZs875OUJCQrj88st55513zvlnfvCDHxAUFEReXh4LFy7kuuuu44tf/OKQf7+T3XXXXaSnp5Odnc1FF100eNwADOy7/dnPfsaNN95IQUEBOTk553TczPPPPz94BM8tt9zCunXrTnvMpZdeitPpJD8//5QuwXfddRcej2dwKdUJb7zxxmm3iZwLh8Ohzvoi5+mOO+5g8eLFp92+aNEirr76anJzc1mxYsWndoyNjY3ltttuIz8//1O7Cc+fP38wn8bExAz2bfiv//ov9u7dS15eHpdccgn//M//fMZtNX/84x85cOAAubm55OXl8fnPf56Ojo7THjdnzhxmzJgx2HfhXJxrDEPxgx/8gP7+fjIzM7n66qu56KKLBu/7yle+wu23384ll1xCQUEBhYWF5/Q54ZFHHiEnJ4eioiK+//3v85//+Z+nPebGG2+ksrJysMESDAyQfO1rX2P69Omnvc4jlXcN/nNt8yUjqru7m+joaGw2G1FRUUP++ebmZl555n/5uvU/aPdH8Zc5Px6xM5hEAs3hcFBfX8+cOXMm1QqCjz76iIceeoi//OUvgQ5lzLj33nuZMWMGP/jBDwZvc7lclJaW8s477zB16tTzvvaZ/p5d6Hu1jLwLfY1ef/11fra9n0P9IVw3rZOvrcofkdkCkfMxWfPfCbfffvtpjQVH0nPPPcfGjRtZu3btqDzfeHDNNddwyy238NWvfnXwtvb2dlauXMmOHTtOmyz7tL+z5/perZnVCcLpdOL2wn5fAkeZqZFgkQlowYIFfP7zn6enpyfQoQRcY2MjmZmZlJeXn/ahpb6+np/+9KcXVKjK5OV0OnGowZKIADfffDNZWVn4fL5AhxJwO3bsIC0tDaPReEqTJ4CDBw+ybt26EVnVqQZLE4TT6aTeOJvLXP9BQrCTf1BuFZmQRrLD4ngSHx9PTU3NGe/LyMggIyNjlCOSiWKgwdJAkxA1WBIZW5544olRf85P7s2crE50Tj6TC13q/Fk0sxpga9euJTs7m/nz51/QdU7dY+PXSLCIiMh5cDgcH8+sGpVPRUQCScVqgN1zzz1UV1cPHiZ8vtS9UEREJrPhGPz1+/30O104/WqwJCIyFqhYnSCcTieXud7iDct3uNG/XsuWRERkUhmOwd+TB35Bg78iIoGmYnWCcDqdxPo6yDQeJdpgV3IVEREZopObKwUbfRgNKJ+KiASQitUJwul0EuazA+Ayhim5ioiIDNFAc6XjS4CNPkwmE2azelGKiASKitUJwuFwEEYfAO7/3969B0V13m8Afw4riMiCkAhVAZcExcsuLlcFwUvES40djYJWTUFMjKaYaLW/Ro1CgplI60xrHYnS1mBicWS0Gq1twUtE0XhBLCMxk8zQQNUgl7bA4iogsL8/KKcSLi5y4JwDz2eGP/Z29ruvuA/fc97zHs0gNqtEvUyn08HNzQ2PHz8W7zt//jwEQbDqenDZ2dkwGo0AgKqqKiQnJ7d6/PXXX8f58+e7XWN+fn6XX3f//n1MmjRJXLr/xIkTGDt2LIxGIwoKCrpVk7Wqqqrw6quvQq/Xw8/PD3q9HocOHRIf/8c//oGoqCh4e3sjMDAQISEh+MMf/gAAeO+99zB06FAYjUbxp6SkBGVlZQgJCUFDQ0OvfAZSvuZpwAIATgEmstaxY8cQGBgIo9GIMWPG4KWXXmp1qZeUlBTo9XqMHTsWAQEBWLp0Ke7cuQMAEAQBBoNB/G5OSEho9z0ePnyIoKAg8dJtV69ehcFggL+/P7Kysnr+Q6I5pwVBwLp161rdHxsbC0EQrMrXFStWYNeuXeL2MjMzxcdKSkoQERHR7Rpb/pbojJryj7sL+4i6ujo4WsyAADTYsFklkoOXlxdOnjyJRYsWAQD279+PoKCgLm+npVndtGmTeF9L4yWH7du3Iz4+HjY2zfs39+3bh4SEBCxdurTNcxsaGnrkSNTWrVsxdOhQFBQUQBAE1NTUoLS0FABQWlqK8PBwJCUl4ejRowCAyspKZGRkiK9fvny5+AfCk8LCwvDpp5/ykkAE4L9HVhv/t7gS138g6tz9+/fxxhtvIC8vDyNHjgQA3Lx5E4LQvNMnMTERp0+fRmZmJjw8PAAA586dQ2lpKby8vAAAOTk5GDJkSKfvs2fPHsyfPx9arRYA8Mknn2DZsmXYvHlzm+f2VA4BwKhRo/DnP/8ZO3fuhJ2dHUwmEy5fvowRI0Z0eVvZ2dmoqqrCnDlzADRfki0nJ0fqktvl7u6umvzjkdU+oq6uDlo0TwNu1AxiwFL/U2/u+OdxbRee++iZS4iLi8PHH38MAKiursbVq1fFEAKarw+3YMEC8fapU6cwbdq0NttZs2YNampqYDQaxWZ32rRp+OyzzwA075lduXIlwsLCMHr0aMTGxuLRo+a6y8vLsXDhQhgMBuj1eqSmprZba2lpKRYvXoyQkBAYDAZs3bq13efV1tYiIyNDbMDffvtt5OTkYMuWLQgLCwPQvGc8MTERwcHB2Lx5c6c16HQ6bN26FWFhYfD09MS+ffuQlpaG0NBQ6HQ6HD58uN067t27h2HDhol/AGm1WowaNQpA8177iIgIrFq1Sny+i4sL1qxZ0+62nrR06dIOx4j6n9raWnEaMI+skmrImH9lZWXQaDRwdXUV7wsICIAgCDCbzfjVr36F/fv3i40qAMyYMQMhISFdep/U1FQsW7YMAJCcnIyMjAzs2bMHRqMRVVVV0Ol0eOeddxASEoLY2Fg8ePAAK1euhF6vh16vx/vvvy9ua9q0adi4cSOmTJkCLy8vbNu2DX/9618RHh4OnU6HX//61x3W4eDggBkzZuDEiRMAgMOHD2PRokWtmuMn8xoAoqKi2lwfNj8/H/v27UN6ejqMRiOSkpJQXFzcqmkXBAFbt26Fv78/Ro8ejfT0dPGxrKwsBAQEwM/PD1OnTsVXX33Vbr1ZWVkIDw8XZxw9OUNLLfnHI6t9QFNTE+rr6+H032bVMsCeAUv9z4fDO35s1Cxg+ZH/3d7pAzx+2P5zR4YDcX95phImT56Mjz76CCUlJTh58iSio6Oh0Wi6vJ19+/bBaDR2OqXo2rVruHr1KhwcHLBgwQL85je/wZYtW/DWW2/B19cXx44dQ3l5OQIDAzFhwgRMmjSp1etjY2OxZcsWTJ06FQ0NDZg3bx6OHDmC6OjoVs/Lzc2Ft7c3HBwcAAC7d+/GrVu3sH79+laNt0ajEVdhXbJkSac1mM1mfPHFFygsLITBYMC7776LK1euIDc3F3PnzsWPf/zjNp933bp1iIqKQkZGBkJDQzFnzhzMmzcPAJCXl4eZM2d2Oqbp6enIzs4GAPj7+yMtLQ0AEBgYiFu3bsFkMsHJyanTbVDf9+QCS7xsDamGjPnn5+eH8PBwjBw5ElOnTkVYWBiWLVuGESNG4Pbt27Czs8O4ceM63UZERISYlampqZg4cWKrx+/evYvq6mq8+OKLAIBNmzbh66+/htFobHWazb///W9cu3YNgiDgnXfeQV1dHW7duoVHjx4hPDwcY8aMwZIlSwAA//znP3H+/HmYTCbodDpUVlYiJycHJSUl8PX1xcqVKzs82hsXF4ft27cjOjoaaWlpOHDgQKuZPNYwGo1Ys2YNqqqqxFk/xcXFbZ4nCAL+/ve/49tvv0VQUBAmT54MBwcHLFu2DNnZ2TAYDEhPT0dUVBRu377d6rXffvst3nvvPWRlZcHJyQmFhYWIiIhAcXExBg4cqJr845HVPqC+vh5NTU24b3kOFRZnWDRsVonk8pOf/AQHDhzAxx9/3KNTaxYvXgytVguNRoPXXnsNZ8+eBQCcPXsWq1evBgC4ublh4cKF4mMtzGYzzp07h3Xr1olHbwsLC/HNN9+0eZ979+7B3d39qfU8+VmfVkPLHws+Pj6wt7dHVFQUACAoKAj/+c9/UFVV1Wb706dPx507d7B9+3YMGTIEq1evRnx8/FPrarF8+XLk5+cjPz9fbFQBYMCAAXBxcUFJSYnV26K+6/sLLHGWElHnbGxs8Kc//QlffPEF5syZg8uXL2P8+PEoLCy0ehs5OTni9/P3G1XA+hxasWKFOPvm7NmzWLVqFWxsbDB48GDExMTgzJkz4nOjoqKg0Wjg4uKCF154AfPmzYMgCBgxYgSGDh3abuPYIiwsDHfu3EFWVhY0Gg18fX2t/qxd9frrrwMAXnjhBUyZMgUXL17EtWvXYDAYYDAYADTnW0lJCb777rtWr83MzERhYSGmTJkCo9GIqKgo2NjYiOcLqyX/eGS1D6itrUWtZQAWNe1AXaMNNgy4z2aV+p8tnXzZCt87uvl/nYSo0L19eDExMQgICMDo0aPFaaotBgwYgMbGRvF2bW3t91/+zFoC2pr7LRYLgOYFKp72x7iDg4NVdTo6Olpd25PvqdFoxNuCIEAQhA4XfBg8eDDmzp2LuXPnYt68eZg1axZSUlIQGBiIK1eu4Gc/+9lT62xPbW0tBg0a9Eyvpb6lrq4OU11NCHZ+ADvBwiwldVBA/o0ZMwZjxozB6tWrMWfOHJw8eRJvvPEG6uvr8dVXXz316GpnejOHWm4/beGhmJgYvPrqq20WQwTkyfr2WCwWzJw5s9VihN+nhvzjkdU+QKPRwDDaG8lhtkgOaYCrq8szTT0kUjW7wR3/2Np34bnd+9IePnw4duzYgV/+8pdtHvPx8RGnJDU0NHQYIE5OTnj06BHq6+s7fJ+jR4/iwYMHaGxsRFpaGiIjIwEAkZGR+P3vfw8AqKiowLFjx9pMkXV0dMT06dNbhWxJSQnu3bvX5n38/PzaPeLaGWtq6KrTp0+jsrJSvJ2XlydOCfvpT3+KCxcutDpiWlVVZdW5OGVlZRAEAZ6ent2qj/oGW1tbPKd1gNsgAY4DOA2YVELG/Pvuu+9w+fJl8XZlZSWKiorw4osvwtHRET//+c+xatWqVkf9zp8/j+vXr1v9Hr6+vigvLxfXZrBGZGQk9u/fD4vFArPZjIMHD2LWrFlWv/5p4uLisHHjRnGm0JN8fHxw7do1AEBRUREuXbrU7jacnJxQXV3d6fu05FpxcTFycnIQERGBSZMmoaCgAF9++SWA5vNmR4wY0WaRp9mzZ+Ps2bO4deuWeN+T466W/OOR1T5Aq9VixowZcpdBRP8VFxfX7v2TJk3C3LlzodfrMWzYMEyePFkMtCe5uroiJiYGfn5+cHR0xI0bN9o8Jzg4GLNnz0ZFRQVCQ0PF83Z2796NN998EwaDARaLBe+++26706rS09OxYcMG6PV6CIKAwYMHIzU1tdUiGADg7e0Nd3d33L59G+PHj7fq81tbQ1cUFBRg48aNsFgssLGxwbBhw/DHP/4RADBs2DBcunQJmzZtQlJSErRaLWxtba2aJpyZmYlXXnlFXOmY+rfw8HCEh4cDgCou6UAkt4aGBiQlJaGoqAgODg5oaGhAbGws5s+fDwBISkrC888/j9mzZ6OxsRGCIMBoNLa7Q7cj9vb2mDVrFj7//HO8/PLLVr1m27ZtePvtt8WpstHR0Vi8eHHXP2AH3NzcWq3Y/6Rf/OIXWLJkCQwGA8aPH99h/r3yyis4ePAgjEYjFi5ciJiYmDbPaWxshL+/P8xmM3bv3g2dTgegOcNjYmLQ0NAAFxcXHDlypM1RVx8fHxw6dAirV6/Gw4cPUV9fD39/f3FHuVryT7C0zAcjWZlMJjg7O6O6ulrRJzkTKUFtbS2Kiorg7e3dL88pW7FiRZuFJXrSkSNHkJ2djZSUlF55v94UERGB3/3udxg7dmybx9r7PeN3tfLx34j6sv6af9evX0dSUhJOnToldym9RhAEVFZWPvWyPs+qs/yTUke/s9Z+V/PIKhERdSo6OhplZWVoampS/B7YrigrK8Obb77Z40FNRETdExISgoULF6Kmpka81io9OzXlH5tVIiKV+f712nrD2rVre/09e5q7u7t43T4iIlK2nlxhX4l6cvKrmvKv7+wiJyIiIiIioj6DzSoRqRZPuaeexN8vIlIqfj+RWnT3d5XTgIlIdWxtbSEIAioqKjB06NAuXXeMyBoWiwUVFRUQBAG2trZyl0NEBID5R+oiRZayWSUi1dFoNPDw8MC9e/dQXFwsdznURwmCAA8PD163mogUg/lHatPdLGWzSkSq5OjoiFGjRuHx48dyl0J9lK2tLRtVIlIc5h+pSXezlM0qEamWRqNhM0FERP0O84/6Cy6wJLOUlBSMGzcOwcHBcpdCRESkWsxTIqK+R7BwOTFFMJlMcHZ2RnV1NZycnOQuh4iI2sHvauXjvxERkfJZ+13NacAK0bLPwGQyyVwJERF1pOU72mQyQavVciVOBWKeEhEpX8t39NOOm7JZVYiamhoAgKenp8yVEBHR03h6evLInUIxT4mI1KOmpgbOzs4dPs5pwArR1NSEkpKSTvfUm0wmeHp64u7du/wDSQIcT+lxTKXF8ZRed8fUYrGgpqYGWq0WTk5OPLKqQE/LU/6/kh7HVFocT+lxTKUlxXi25Onw4cNhY9PxMko8sqoQNjY28PDwsOq5Tk5O/I8mIY6n9Dim0uJ4Sq87Y9rZHmCSn7V5yv9X0uOYSovjKT2OqbS6O57W5ClXAyYiIiIiIiLFYbNKREREREREisNmVUUGDhyIxMREDBw4UO5S+gSOp/Q4ptLieEqPY0r8HZAex1RaHE/pcUyl1ZvjyQWWiIiIiIiISHF4ZJWIiIiIiIgUh80qERERERERKQ6bVSIiIiIiIlIcNqsqkZKSAp1OB3t7e0ycOBHXr1+XuyTVunjxIn70ox9h+PDhEAQBn332mdwlqdqOHTsQHBwMrVYLNzc3LFiwAN98843cZana3r174efnJ16/LDQ0FH/729/kLqvPSE5OhiAIWL9+vdylkAyYp9JhnkqLeSo95mnP6o08ZbOqAhkZGdiwYQMSExNx8+ZNTJgwAbNnz0Z5ebncpamS2WzGhAkTkJKSIncpfcKFCxcQHx+Pq1ev4syZM3j8+DFmzZoFs9ksd2mq5eHhgeTkZOTl5eHGjRt46aWXMH/+fNy+fVvu0lQvNzcXqamp8PPzk7sUkgHzVFrMU2kxT6XHPO05vZWnXA1YBSZOnIjg4GDs2bMHANDU1ARPT0+89dZb2LRpk8zVqZsgCDh+/DgWLFggdyl9RkVFBdzc3HDhwgVMmTJF7nL6DFdXV+zcuROvvfaa3KWo1oMHDxAQEICPPvoIH3zwAYxGI3bt2iV3WdSLmKc9h3kqPeZpz2Cedl9v5imPrCpcfX098vLyEBkZKd5nY2ODyMhIXLlyRcbKiNpXXV0NoDkMqPsaGxtx+PBhmM1mhIaGyl2OqsXHx+Pll19u9X1K/QfzlNSGeSot5ql0ejNPB/T4O1C3/Otf/0JjYyPc3d1b3e/u7o6vv/5apqqI2tfU1IT169dj8uTJ0Ov1cpejagUFBQgNDUVtbS0cHR1x/PhxjBs3Tu6yVOvw4cO4efMmcnNz5S6FZMI8JTVhnkqHeSqt3s5TNqtEJJn4+Hh8+eWXuHTpktylqJ6vry/y8/NRXV2No0ePIjY2FhcuXGDAPoO7d+9i3bp1OHPmDOzt7eUuh4joqZin0mGeSkeOPGWzqnDPP/88NBoNysrKWt1fVlaGH/zgBzJVRdTW2rVrcerUKVy8eBEeHh5yl6N6dnZ28PHxAQAEBgYiNzcXv/3tb5GamipzZeqTl5eH8vJyBAQEiPc1Njbi4sWL2LNnD+rq6qDRaGSskHoD85TUgnkqLeapdOTIU56zqnB2dnYIDAzEuXPnxPuamppw7tw5zrcnRbBYLFi7di2OHz+Ozz//HN7e3nKX1Cc1NTWhrq5O7jJUacaMGSgoKEB+fr74ExQUhOXLlyM/P5+Naj/BPCWlY572Dubps5MjT3lkVQU2bNiA2NhYBAUFISQkBLt27YLZbEZcXJzcpanSgwcPUFhYKN4uKipCfn4+XF1d4eXlJWNl6hQfH49Dhw7hxIkT0Gq1KC0tBQA4Oztj0KBBMlenTps3b8YPf/hDeHl5oaamBocOHUJ2djaysrLkLk2VtFptm3O+Bg8ejOeee47ngvUzzFNpMU+lxTyVHvNUWnLkKZtVFViyZAkqKiqQkJCA0tJSGI1GZGZmtlkkgqxz48YNTJ8+Xby9YcMGAEBsbCwOHDggU1XqtXfvXgDAtGnTWt2flpaGFStW9H5BfUB5eTliYmJw//59ODs7w8/PD1lZWZg5c6bcpRGpGvNUWsxTaTFPpcc8VT9eZ5WIiIiIiIgUh+esEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYiIiIiIiBSHzSoREREREREpDptVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYgk9+GHH0IQhDY/u3btkrs0IiIi1WCeUn8nWCwWi9xFEFHfUlNTA7PZLN5OSEjA6dOncenSJXh4eMhYGRERkXowT6m/GyB3AUTU92i1Wmi1WgDAtm3bcPr0aWRnZzNYiYiIuoB5Sv0dpwETUY9JSEjAwYMHkZ2dDZ1OJ3c5REREqsQ8pf6KzSoR9YjExER8+umnDFYiIqJuYJ5Sf8ZmlYgkl5iYiE8++YTBSkRE1A3MU+rveM4qEUnqgw8+wN69e3Hy5EnY29ujtLQUAODi4oKBAwfKXB0REZE6ME+JuBowEUnIYrFgyJAhMJlMbR67fv06goODZaiKiIhIXZinRM3YrBIREREREZHi8JxVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYiIiIiIiBSHzSoREREREREpDptVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeL8P5e40Z30LJl2AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 950x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# translate each expansion into the other representation\n",
+    "scf_as_mep = MultipoleExpansionPotential.from_scf(\n",
+    "    scf_tri, rgrid=numpy.geomspace(1e-3, 200.0, 401)\n",
+    ")\n",
+    "mep_as_scf = SCFPotential.from_multipole(mep_tri, N=80, a=50.0)\n",
+    "\n",
+    "zs = numpy.linspace(0.1, 4.0, 60)\n",
+    "Fz = lambda p: [-p.zforce(1.0, z, use_physical=False) for z in zs]\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(9.5, 4.0))\n",
+    "axes[0].plot(zs, Fz(tri_nfw), \"k-\", lw=3, alpha=0.4, label=\"true\")\n",
+    "axes[0].plot(zs, Fz(scf_tri), \"C0-\", lw=1.5, label=\"SCF (from density)\")\n",
+    "axes[0].plot(zs, Fz(scf_as_mep), \"C1--\", lw=1.5, label=\"Multipole (from SCF)\")\n",
+    "axes[0].set_yscale(\"log\")\n",
+    "axes[0].set_xlabel(r\"$z$\")\n",
+    "axes[0].set_ylabel(r\"$-F_z(R=1,\\,z)$\")\n",
+    "axes[0].legend(fontsize=8)\n",
+    "axes[1].plot(zs, Fz(tri_nfw), \"k-\", lw=3, alpha=0.4, label=\"true\")\n",
+    "axes[1].plot(zs, Fz(mep_tri), \"C0-\", lw=1.5, label=\"Multipole (from density)\")\n",
+    "axes[1].plot(zs, Fz(mep_as_scf), \"C1--\", lw=1.5, label=\"SCF (from Multipole)\")\n",
+    "axes[1].set_yscale(\"log\")\n",
+    "axes[1].set_xlabel(r\"$z$\")\n",
+    "axes[1].set_ylabel(r\"$-F_z(R=1,\\,z)$\")\n",
+    "axes[1].legend(fontsize=8)\n",
+    "fig.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e87e7bd1",
    "metadata": {
     "papermill": {
-     "duration": 0.011567,
-     "end_time": "2026-07-04T01:08:10.937181+00:00",
+     "duration": 0.017017,
+     "end_time": "2026-07-04T04:43:36.622372+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:10.925614+00:00",
+     "start_time": "2026-07-04T04:43:36.605355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,20 +608,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b3c4d5e6f7a8b9c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:10.962086Z",
-     "iopub.status.busy": "2026-07-04T01:08:10.961896Z",
-     "iopub.status.idle": "2026-07-04T01:08:10.972110Z",
-     "shell.execute_reply": "2026-07-04T01:08:10.970654Z"
+     "iopub.execute_input": "2026-07-04T04:43:36.658613Z",
+     "iopub.status.busy": "2026-07-04T04:43:36.658150Z",
+     "iopub.status.idle": "2026-07-04T04:43:36.668955Z",
+     "shell.execute_reply": "2026-07-04T04:43:36.667346Z"
     },
     "papermill": {
-     "duration": 0.024532,
-     "end_time": "2026-07-04T01:08:10.973218+00:00",
+     "duration": 0.030511,
+     "end_time": "2026-07-04T04:43:36.670324+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:10.948686+00:00",
+     "start_time": "2026-07-04T04:43:36.639813+00:00",
      "status": "completed"
     },
     "tags": []
@@ -582,10 +671,10 @@
    "id": "c4d5e6f7a8b9c0d1",
    "metadata": {
     "papermill": {
-     "duration": 0.014142,
-     "end_time": "2026-07-04T01:08:10.999508+00:00",
+     "duration": 0.016382,
+     "end_time": "2026-07-04T04:43:36.703987+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:10.985366+00:00",
+     "start_time": "2026-07-04T04:43:36.687605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -596,20 +685,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "3a2dc462",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:11.031802Z",
-     "iopub.status.busy": "2026-07-04T01:08:11.031491Z",
-     "iopub.status.idle": "2026-07-04T01:08:11.038838Z",
-     "shell.execute_reply": "2026-07-04T01:08:11.037084Z"
+     "iopub.execute_input": "2026-07-04T04:43:36.744968Z",
+     "iopub.status.busy": "2026-07-04T04:43:36.744543Z",
+     "iopub.status.idle": "2026-07-04T04:43:36.752878Z",
+     "shell.execute_reply": "2026-07-04T04:43:36.750782Z"
     },
     "papermill": {
-     "duration": 0.02663,
-     "end_time": "2026-07-04T01:08:11.040381+00:00",
+     "duration": 0.034654,
+     "end_time": "2026-07-04T04:43:36.754506+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.013751+00:00",
+     "start_time": "2026-07-04T04:43:36.719852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -669,10 +758,10 @@
    "id": "b13a0695",
    "metadata": {
     "papermill": {
-     "duration": 0.018048,
-     "end_time": "2026-07-04T01:08:11.075890+00:00",
+     "duration": 0.015963,
+     "end_time": "2026-07-04T04:43:36.790961+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.057842+00:00",
+     "start_time": "2026-07-04T04:43:36.774998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -686,10 +775,10 @@
    "id": "17d13f11",
    "metadata": {
     "papermill": {
-     "duration": 0.01436,
-     "end_time": "2026-07-04T01:08:11.108380+00:00",
+     "duration": 0.015923,
+     "end_time": "2026-07-04T04:43:36.823349+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.094020+00:00",
+     "start_time": "2026-07-04T04:43:36.807426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -711,20 +800,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "d5e6f7a8b9c0d1e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:11.133712Z",
-     "iopub.status.busy": "2026-07-04T01:08:11.133515Z",
-     "iopub.status.idle": "2026-07-04T01:08:11.572132Z",
-     "shell.execute_reply": "2026-07-04T01:08:11.570300Z"
+     "iopub.execute_input": "2026-07-04T04:43:36.857922Z",
+     "iopub.status.busy": "2026-07-04T04:43:36.857470Z",
+     "iopub.status.idle": "2026-07-04T04:43:37.244376Z",
+     "shell.execute_reply": "2026-07-04T04:43:37.242820Z"
     },
     "papermill": {
-     "duration": 0.453315,
-     "end_time": "2026-07-04T01:08:11.573438+00:00",
+     "duration": 0.406624,
+     "end_time": "2026-07-04T04:43:37.246133+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.120123+00:00",
+     "start_time": "2026-07-04T04:43:36.839509+00:00",
      "status": "completed"
     },
     "tags": []
@@ -748,10 +837,10 @@
    "id": "e6f7a8b9c0d1e2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.014772,
-     "end_time": "2026-07-04T01:08:11.603937+00:00",
+     "duration": 0.016316,
+     "end_time": "2026-07-04T04:43:37.280617+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.589165+00:00",
+     "start_time": "2026-07-04T04:43:37.264301+00:00",
      "status": "completed"
     },
     "tags": []
@@ -762,20 +851,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "f7a8b9c0d1e2f3a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:11.631387Z",
-     "iopub.status.busy": "2026-07-04T01:08:11.631125Z",
-     "iopub.status.idle": "2026-07-04T01:08:12.829882Z",
-     "shell.execute_reply": "2026-07-04T01:08:12.828361Z"
+     "iopub.execute_input": "2026-07-04T04:43:37.313466Z",
+     "iopub.status.busy": "2026-07-04T04:43:37.313227Z",
+     "iopub.status.idle": "2026-07-04T04:43:38.313077Z",
+     "shell.execute_reply": "2026-07-04T04:43:38.311423Z"
     },
     "papermill": {
-     "duration": 1.213017,
-     "end_time": "2026-07-04T01:08:12.831053+00:00",
+     "duration": 1.018403,
+     "end_time": "2026-07-04T04:43:38.314626+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:11.618036+00:00",
+     "start_time": "2026-07-04T04:43:37.296223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -807,10 +896,10 @@
    "id": "a8b9c0d1e2f3a4b5",
    "metadata": {
     "papermill": {
-     "duration": 0.014027,
-     "end_time": "2026-07-04T01:08:12.859742+00:00",
+     "duration": 0.024433,
+     "end_time": "2026-07-04T04:43:38.363215+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:12.845715+00:00",
+     "start_time": "2026-07-04T04:43:38.338782+00:00",
      "status": "completed"
     },
     "tags": []
@@ -821,20 +910,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "b9c0d1e2f3a4b5c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:12.888663Z",
-     "iopub.status.busy": "2026-07-04T01:08:12.888480Z",
-     "iopub.status.idle": "2026-07-04T01:08:22.504188Z",
-     "shell.execute_reply": "2026-07-04T01:08:22.502662Z"
+     "iopub.execute_input": "2026-07-04T04:43:38.400651Z",
+     "iopub.status.busy": "2026-07-04T04:43:38.400408Z",
+     "iopub.status.idle": "2026-07-04T04:43:48.245846Z",
+     "shell.execute_reply": "2026-07-04T04:43:48.244009Z"
     },
     "papermill": {
-     "duration": 9.631316,
-     "end_time": "2026-07-04T01:08:22.505434+00:00",
+     "duration": 9.870564,
+     "end_time": "2026-07-04T04:43:48.251930+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:12.874118+00:00",
+     "start_time": "2026-07-04T04:43:38.381366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -869,10 +958,10 @@
    "id": "c0d1e2f3a4b5c6d7",
    "metadata": {
     "papermill": {
-     "duration": 0.018187,
-     "end_time": "2026-07-04T01:08:22.542626+00:00",
+     "duration": 0.02304,
+     "end_time": "2026-07-04T04:43:48.310497+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:22.524439+00:00",
+     "start_time": "2026-07-04T04:43:48.287457+00:00",
      "status": "completed"
     },
     "tags": []
@@ -883,20 +972,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "226e8f68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:22.581223Z",
-     "iopub.status.busy": "2026-07-04T01:08:22.581032Z",
-     "iopub.status.idle": "2026-07-04T01:08:42.765506Z",
-     "shell.execute_reply": "2026-07-04T01:08:42.763241Z"
+     "iopub.execute_input": "2026-07-04T04:43:48.360052Z",
+     "iopub.status.busy": "2026-07-04T04:43:48.359487Z",
+     "iopub.status.idle": "2026-07-04T04:44:09.562382Z",
+     "shell.execute_reply": "2026-07-04T04:44:09.560814Z"
     },
     "papermill": {
-     "duration": 20.205727,
-     "end_time": "2026-07-04T01:08:42.766904+00:00",
+     "duration": 21.23103,
+     "end_time": "2026-07-04T04:44:09.564855+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:22.561177+00:00",
+     "start_time": "2026-07-04T04:43:48.333825+00:00",
      "status": "completed"
     },
     "tags": []
@@ -906,7 +995,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.52 s ± 8.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.66 s ± 179 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -921,10 +1010,10 @@
    "id": "acf72105",
    "metadata": {
     "papermill": {
-     "duration": 0.018332,
-     "end_time": "2026-07-04T01:08:42.807124+00:00",
+     "duration": 0.025518,
+     "end_time": "2026-07-04T04:44:09.626207+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:42.788792+00:00",
+     "start_time": "2026-07-04T04:44:09.600689+00:00",
      "status": "completed"
     },
     "tags": []
@@ -935,20 +1024,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "745deca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:42.862449Z",
-     "iopub.status.busy": "2026-07-04T01:08:42.862057Z",
-     "iopub.status.idle": "2026-07-04T01:08:49.198165Z",
-     "shell.execute_reply": "2026-07-04T01:08:49.196534Z"
+     "iopub.execute_input": "2026-07-04T04:44:09.675781Z",
+     "iopub.status.busy": "2026-07-04T04:44:09.675550Z",
+     "iopub.status.idle": "2026-07-04T04:44:16.147591Z",
+     "shell.execute_reply": "2026-07-04T04:44:16.145829Z"
     },
     "papermill": {
-     "duration": 6.3669,
-     "end_time": "2026-07-04T01:08:49.199207+00:00",
+     "duration": 6.498849,
+     "end_time": "2026-07-04T04:44:16.149112+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:42.832307+00:00",
+     "start_time": "2026-07-04T04:44:09.650263+00:00",
      "status": "completed"
     },
     "tags": []
@@ -958,7 +1047,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "78.1 ms ± 556 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "79.9 ms ± 1.56 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -973,10 +1062,10 @@
    "id": "3fa99bf4",
    "metadata": {
     "papermill": {
-     "duration": 0.023779,
-     "end_time": "2026-07-04T01:08:49.243134+00:00",
+     "duration": 0.024633,
+     "end_time": "2026-07-04T04:44:16.209345+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:49.219355+00:00",
+     "start_time": "2026-07-04T04:44:16.184712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -996,20 +1085,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "d1e2f3a4b5c6d7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:49.296188Z",
-     "iopub.status.busy": "2026-07-04T01:08:49.295991Z",
-     "iopub.status.idle": "2026-07-04T01:08:50.249147Z",
-     "shell.execute_reply": "2026-07-04T01:08:50.247535Z"
+     "iopub.execute_input": "2026-07-04T04:44:16.266098Z",
+     "iopub.status.busy": "2026-07-04T04:44:16.265833Z",
+     "iopub.status.idle": "2026-07-04T04:44:17.460849Z",
+     "shell.execute_reply": "2026-07-04T04:44:17.459161Z"
     },
     "papermill": {
-     "duration": 0.977932,
-     "end_time": "2026-07-04T01:08:50.250308+00:00",
+     "duration": 1.223579,
+     "end_time": "2026-07-04T04:44:17.463012+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:49.272376+00:00",
+     "start_time": "2026-07-04T04:44:16.239433+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1129,10 @@
    "id": "e2f3a4b5c6d7e8f9",
    "metadata": {
     "papermill": {
-     "duration": 0.021707,
-     "end_time": "2026-07-04T01:08:50.294431+00:00",
+     "duration": 0.025159,
+     "end_time": "2026-07-04T04:44:17.523912+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:50.272724+00:00",
+     "start_time": "2026-07-04T04:44:17.498753+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1054,20 +1143,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "f3a4b5c6d7e8f9a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:50.332856Z",
-     "iopub.status.busy": "2026-07-04T01:08:50.332666Z",
-     "iopub.status.idle": "2026-07-04T01:08:50.628873Z",
-     "shell.execute_reply": "2026-07-04T01:08:50.627395Z"
+     "iopub.execute_input": "2026-07-04T04:44:17.579025Z",
+     "iopub.status.busy": "2026-07-04T04:44:17.578747Z",
+     "iopub.status.idle": "2026-07-04T04:44:17.933604Z",
+     "shell.execute_reply": "2026-07-04T04:44:17.931986Z"
     },
     "papermill": {
-     "duration": 0.317502,
-     "end_time": "2026-07-04T01:08:50.630582+00:00",
+     "duration": 0.388,
+     "end_time": "2026-07-04T04:44:17.935437+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:50.313080+00:00",
+     "start_time": "2026-07-04T04:44:17.547437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1100,10 +1189,10 @@
    "id": "a4b5c6d7e8f9a0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.020061,
-     "end_time": "2026-07-04T01:08:50.684795+00:00",
+     "duration": 0.034774,
+     "end_time": "2026-07-04T04:44:18.004660+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:50.664734+00:00",
+     "start_time": "2026-07-04T04:44:17.969886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1114,20 +1203,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "2d0d29d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:50.733015Z",
-     "iopub.status.busy": "2026-07-04T01:08:50.732670Z",
-     "iopub.status.idle": "2026-07-04T01:08:59.180265Z",
-     "shell.execute_reply": "2026-07-04T01:08:59.178554Z"
+     "iopub.execute_input": "2026-07-04T04:44:18.062555Z",
+     "iopub.status.busy": "2026-07-04T04:44:18.062317Z",
+     "iopub.status.idle": "2026-07-04T04:44:28.009635Z",
+     "shell.execute_reply": "2026-07-04T04:44:28.007909Z"
     },
     "papermill": {
-     "duration": 8.472923,
-     "end_time": "2026-07-04T01:08:59.181455+00:00",
+     "duration": 9.981627,
+     "end_time": "2026-07-04T04:44:28.011385+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:50.708532+00:00",
+     "start_time": "2026-07-04T04:44:18.029758+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1243,10 @@
    "id": "9ce6e0c9",
    "metadata": {
     "papermill": {
-     "duration": 0.03025,
-     "end_time": "2026-07-04T01:08:59.231829+00:00",
+     "duration": 0.034458,
+     "end_time": "2026-07-04T04:44:28.083198+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:59.201579+00:00",
+     "start_time": "2026-07-04T04:44:28.048740+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1168,20 +1257,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "04a6500d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:08:59.277306Z",
-     "iopub.status.busy": "2026-07-04T01:08:59.277096Z",
-     "iopub.status.idle": "2026-07-04T01:09:01.285700Z",
-     "shell.execute_reply": "2026-07-04T01:09:01.284087Z"
+     "iopub.execute_input": "2026-07-04T04:44:28.142734Z",
+     "iopub.status.busy": "2026-07-04T04:44:28.142424Z",
+     "iopub.status.idle": "2026-07-04T04:44:30.362317Z",
+     "shell.execute_reply": "2026-07-04T04:44:30.360652Z"
     },
     "papermill": {
-     "duration": 2.03325,
-     "end_time": "2026-07-04T01:09:01.286869+00:00",
+     "duration": 2.257881,
+     "end_time": "2026-07-04T04:44:30.365999+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:08:59.253619+00:00",
+     "start_time": "2026-07-04T04:44:28.108118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1244,10 +1333,10 @@
    "id": "a5956d7b",
    "metadata": {
     "papermill": {
-     "duration": 0.036727,
-     "end_time": "2026-07-04T01:09:01.362542+00:00",
+     "duration": 0.038774,
+     "end_time": "2026-07-04T04:44:30.463443+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:09:01.325815+00:00",
+     "start_time": "2026-07-04T04:44:30.424669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1302,20 +1391,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "4d7c563b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:09:01.427726Z",
-     "iopub.status.busy": "2026-07-04T01:09:01.427516Z",
-     "iopub.status.idle": "2026-07-04T01:09:05.958420Z",
-     "shell.execute_reply": "2026-07-04T01:09:05.956613Z"
+     "iopub.execute_input": "2026-07-04T04:44:30.530009Z",
+     "iopub.status.busy": "2026-07-04T04:44:30.529668Z",
+     "iopub.status.idle": "2026-07-04T04:44:36.168781Z",
+     "shell.execute_reply": "2026-07-04T04:44:36.166830Z"
     },
     "papermill": {
-     "duration": 4.559777,
-     "end_time": "2026-07-04T01:09:05.959520+00:00",
+     "duration": 5.680059,
+     "end_time": "2026-07-04T04:44:36.171728+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:09:01.399743+00:00",
+     "start_time": "2026-07-04T04:44:30.491669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1424,10 +1513,10 @@
    "id": "aeabed99",
    "metadata": {
     "papermill": {
-     "duration": 0.026382,
-     "end_time": "2026-07-04T01:09:06.010637+00:00",
+     "duration": 0.031219,
+     "end_time": "2026-07-04T04:44:36.249380+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:09:05.984255+00:00",
+     "start_time": "2026-07-04T04:44:36.218161+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1453,20 +1542,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "2ad4d3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T01:09:06.069915Z",
-     "iopub.status.busy": "2026-07-04T01:09:06.069666Z",
-     "iopub.status.idle": "2026-07-04T01:09:06.451690Z",
-     "shell.execute_reply": "2026-07-04T01:09:06.450058Z"
+     "iopub.execute_input": "2026-07-04T04:44:36.311448Z",
+     "iopub.status.busy": "2026-07-04T04:44:36.311115Z",
+     "iopub.status.idle": "2026-07-04T04:44:37.108967Z",
+     "shell.execute_reply": "2026-07-04T04:44:37.107268Z"
     },
     "papermill": {
-     "duration": 0.407068,
-     "end_time": "2026-07-04T01:09:06.452776+00:00",
+     "duration": 0.832242,
+     "end_time": "2026-07-04T04:44:37.111077+00:00",
      "exception": false,
-     "start_time": "2026-07-04T01:09:06.045708+00:00",
+     "start_time": "2026-07-04T04:44:36.278835+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1542,14 +1631,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 170.639167,
-   "end_time": "2026-07-04T01:09:07.401741+00:00",
+   "duration": 218.306926,
+   "end_time": "2026-07-04T04:44:38.176257+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "output_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "parameters": {},
-   "start_time": "2026-07-04T01:06:16.762574+00:00",
+   "start_time": "2026-07-04T04:40:59.869331+00:00",
    "version": "2.7.0"
   }
  },

--- a/doc/source/tutorials/potentials/scf_and_multipole.ipynb
+++ b/doc/source/tutorials/potentials/scf_and_multipole.ipynb
@@ -5,10 +5,10 @@
    "id": "a1b2c3d4e5f6a7b8",
    "metadata": {
     "papermill": {
-     "duration": 0.014076,
-     "end_time": "2026-07-04T04:41:02.121522+00:00",
+     "duration": 0.033239,
+     "end_time": "2026-07-04T12:05:15.110636+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:41:02.107446+00:00",
+     "start_time": "2026-07-04T12:05:15.077397+00:00",
      "status": "completed"
     },
     "tags": []
@@ -32,16 +32,16 @@
    "id": "b1c2d3e4f5a6b7c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:41:02.148649Z",
-     "iopub.status.busy": "2026-07-04T04:41:02.148331Z",
-     "iopub.status.idle": "2026-07-04T04:41:08.232805Z",
-     "shell.execute_reply": "2026-07-04T04:41:08.231792Z"
+     "iopub.execute_input": "2026-07-04T12:05:15.137912Z",
+     "iopub.status.busy": "2026-07-04T12:05:15.137608Z",
+     "iopub.status.idle": "2026-07-04T12:05:20.557551Z",
+     "shell.execute_reply": "2026-07-04T12:05:20.556662Z"
     },
     "papermill": {
-     "duration": 6.105008,
-     "end_time": "2026-07-04T04:41:08.239229+00:00",
+     "duration": 5.441493,
+     "end_time": "2026-07-04T12:05:20.565017+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:41:02.134221+00:00",
+     "start_time": "2026-07-04T12:05:15.123524+00:00",
      "status": "completed"
     },
     "tags": []
@@ -74,10 +74,10 @@
    "id": "c2d3e4f5a6b7c8d9",
    "metadata": {
     "papermill": {
-     "duration": 0.00696,
-     "end_time": "2026-07-04T04:41:08.264985+00:00",
+     "duration": 0.018132,
+     "end_time": "2026-07-04T12:05:20.600011+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:41:08.258025+00:00",
+     "start_time": "2026-07-04T12:05:20.581879+00:00",
      "status": "completed"
     },
     "tags": []
@@ -94,16 +94,16 @@
    "id": "d3e4f5a6b7c8d9e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:41:08.281109Z",
-     "iopub.status.busy": "2026-07-04T04:41:08.280585Z",
-     "iopub.status.idle": "2026-07-04T04:42:34.603562Z",
-     "shell.execute_reply": "2026-07-04T04:42:34.600551Z"
+     "iopub.execute_input": "2026-07-04T12:05:20.623164Z",
+     "iopub.status.busy": "2026-07-04T12:05:20.622386Z",
+     "iopub.status.idle": "2026-07-04T12:06:37.309248Z",
+     "shell.execute_reply": "2026-07-04T12:06:37.306141Z"
     },
     "papermill": {
-     "duration": 86.333607,
-     "end_time": "2026-07-04T04:42:34.605718+00:00",
+     "duration": 76.700294,
+     "end_time": "2026-07-04T12:06:37.311330+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:41:08.272111+00:00",
+     "start_time": "2026-07-04T12:05:20.611036+00:00",
      "status": "completed"
     },
     "tags": []
@@ -122,10 +122,10 @@
    "id": "e4f5a6b7c8d9e0f1",
    "metadata": {
     "papermill": {
-     "duration": 0.012157,
-     "end_time": "2026-07-04T04:42:34.631397+00:00",
+     "duration": 0.013121,
+     "end_time": "2026-07-04T12:06:37.340140+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:34.619240+00:00",
+     "start_time": "2026-07-04T12:06:37.327019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -142,16 +142,16 @@
    "id": "f5a6b7c8d9e0f1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:42:34.659418Z",
-     "iopub.status.busy": "2026-07-04T04:42:34.658939Z",
-     "iopub.status.idle": "2026-07-04T04:42:49.813939Z",
-     "shell.execute_reply": "2026-07-04T04:42:49.812195Z"
+     "iopub.execute_input": "2026-07-04T12:06:37.369996Z",
+     "iopub.status.busy": "2026-07-04T12:06:37.369604Z",
+     "iopub.status.idle": "2026-07-04T12:06:50.718183Z",
+     "shell.execute_reply": "2026-07-04T12:06:50.716519Z"
     },
     "papermill": {
-     "duration": 15.172462,
-     "end_time": "2026-07-04T04:42:49.816464+00:00",
+     "duration": 13.366818,
+     "end_time": "2026-07-04T12:06:50.720369+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:34.644002+00:00",
+     "start_time": "2026-07-04T12:06:37.353551+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,10 +183,10 @@
    "id": "a6b7c8d9e0f1a2b3",
    "metadata": {
     "papermill": {
-     "duration": 0.01321,
-     "end_time": "2026-07-04T04:42:49.844096+00:00",
+     "duration": 0.014122,
+     "end_time": "2026-07-04T12:06:50.749684+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:49.830886+00:00",
+     "start_time": "2026-07-04T12:06:50.735562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -213,16 +213,16 @@
    "id": "b7c8d9e0f1a2b3c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:42:49.879717Z",
-     "iopub.status.busy": "2026-07-04T04:42:49.879497Z",
-     "iopub.status.idle": "2026-07-04T04:42:55.747214Z",
-     "shell.execute_reply": "2026-07-04T04:42:55.745459Z"
+     "iopub.execute_input": "2026-07-04T12:06:50.787817Z",
+     "iopub.status.busy": "2026-07-04T12:06:50.787323Z",
+     "iopub.status.idle": "2026-07-04T12:06:55.498438Z",
+     "shell.execute_reply": "2026-07-04T12:06:55.496748Z"
     },
     "papermill": {
-     "duration": 5.884748,
-     "end_time": "2026-07-04T04:42:55.748924+00:00",
+     "duration": 4.729858,
+     "end_time": "2026-07-04T12:06:55.500326+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:49.864176+00:00",
+     "start_time": "2026-07-04T12:06:50.770468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -239,10 +239,10 @@
    "id": "c8d9e0f1a2b3c4d5",
    "metadata": {
     "papermill": {
-     "duration": 0.013481,
-     "end_time": "2026-07-04T04:42:55.776989+00:00",
+     "duration": 0.014146,
+     "end_time": "2026-07-04T12:06:55.529692+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:55.763508+00:00",
+     "start_time": "2026-07-04T12:06:55.515546+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "d9e0f1a2b3c4d5e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:42:55.806265Z",
-     "iopub.status.busy": "2026-07-04T04:42:55.805989Z",
-     "iopub.status.idle": "2026-07-04T04:43:11.364130Z",
-     "shell.execute_reply": "2026-07-04T04:43:11.362383Z"
+     "iopub.execute_input": "2026-07-04T12:06:55.560289Z",
+     "iopub.status.busy": "2026-07-04T12:06:55.560063Z",
+     "iopub.status.idle": "2026-07-04T12:07:09.126070Z",
+     "shell.execute_reply": "2026-07-04T12:07:09.124242Z"
     },
     "papermill": {
-     "duration": 15.575554,
-     "end_time": "2026-07-04T04:43:11.366103+00:00",
+     "duration": 13.583674,
+     "end_time": "2026-07-04T12:07:09.127800+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:42:55.790549+00:00",
+     "start_time": "2026-07-04T12:06:55.544126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,10 +299,10 @@
    "id": "a2b3c4d5e6f7a8b9",
    "metadata": {
     "papermill": {
-     "duration": 0.014427,
-     "end_time": "2026-07-04T04:43:11.396099+00:00",
+     "duration": 0.015343,
+     "end_time": "2026-07-04T12:07:09.159613+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:11.381672+00:00",
+     "start_time": "2026-07-04T12:07:09.144270+00:00",
      "status": "completed"
     },
     "tags": []
@@ -319,16 +319,16 @@
    "id": "6c7c334f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:11.427797Z",
-     "iopub.status.busy": "2026-07-04T04:43:11.427571Z",
-     "iopub.status.idle": "2026-07-04T04:43:14.913137Z",
-     "shell.execute_reply": "2026-07-04T04:43:14.911414Z"
+     "iopub.execute_input": "2026-07-04T12:07:09.192407Z",
+     "iopub.status.busy": "2026-07-04T12:07:09.192141Z",
+     "iopub.status.idle": "2026-07-04T12:07:12.675086Z",
+     "shell.execute_reply": "2026-07-04T12:07:12.673278Z"
     },
     "papermill": {
-     "duration": 3.504353,
-     "end_time": "2026-07-04T04:43:14.915203+00:00",
+     "duration": 3.504584,
+     "end_time": "2026-07-04T12:07:12.679695+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:11.410850+00:00",
+     "start_time": "2026-07-04T12:07:09.175111+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {
     "papermill": {
-     "duration": 0.013886,
-     "end_time": "2026-07-04T04:43:14.944972+00:00",
+     "duration": 0.015074,
+     "end_time": "2026-07-04T12:07:12.717894+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:14.931086+00:00",
+     "start_time": "2026-07-04T12:07:12.702820+00:00",
      "status": "completed"
     },
     "tags": []
@@ -398,16 +398,16 @@
    "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:14.971046Z",
-     "iopub.status.busy": "2026-07-04T04:43:14.970791Z",
-     "iopub.status.idle": "2026-07-04T04:43:16.904245Z",
-     "shell.execute_reply": "2026-07-04T04:43:16.902586Z"
+     "iopub.execute_input": "2026-07-04T12:07:12.751189Z",
+     "iopub.status.busy": "2026-07-04T12:07:12.750696Z",
+     "iopub.status.idle": "2026-07-04T12:07:14.672275Z",
+     "shell.execute_reply": "2026-07-04T12:07:14.670815Z"
     },
     "papermill": {
-     "duration": 1.949526,
-     "end_time": "2026-07-04T04:43:16.906542+00:00",
+     "duration": 1.940517,
+     "end_time": "2026-07-04T12:07:14.674349+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:14.957016+00:00",
+     "start_time": "2026-07-04T12:07:12.733832+00:00",
      "status": "completed"
     },
     "tags": []
@@ -477,10 +477,10 @@
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {
     "papermill": {
-     "duration": 0.015461,
-     "end_time": "2026-07-04T04:43:16.945270+00:00",
+     "duration": 0.015528,
+     "end_time": "2026-07-04T12:07:14.713080+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:16.929809+00:00",
+     "start_time": "2026-07-04T12:07:14.697552+00:00",
      "status": "completed"
     },
     "tags": []
@@ -501,10 +501,10 @@
    "id": "1d1d6037",
    "metadata": {
     "papermill": {
-     "duration": 0.02053,
-     "end_time": "2026-07-04T04:43:16.981019+00:00",
+     "duration": 0.015945,
+     "end_time": "2026-07-04T12:07:14.745380+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:16.960489+00:00",
+     "start_time": "2026-07-04T12:07:14.729435+00:00",
      "status": "completed"
     },
     "tags": []
@@ -520,10 +520,10 @@
     "decomposition is shared, so no angular quadrature is needed — and time-dependent\n",
     "expansions are translated as well.\n",
     "\n",
-    "Reusing the SCF and multipole expansions of the triaxial NFW halo from the first\n",
-    "section, we translate each into the other representation and confirm that the\n",
-    "translations reproduce the independently-built expansions (and the true vertical\n",
-    "force):"
+    "We build SCF and multipole expansions of the same triaxial NFW halo from the first\n",
+    "section over a common radial range, translate each into the other representation, and\n",
+    "confirm that the translations (markers) reproduce the independently-built expansions\n",
+    "(lines) and the true vertical force:"
    ]
   },
   {
@@ -532,16 +532,16 @@
    "id": "c8a271cd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:17.023551Z",
-     "iopub.status.busy": "2026-07-04T04:43:17.023315Z",
-     "iopub.status.idle": "2026-07-04T04:43:36.577574Z",
-     "shell.execute_reply": "2026-07-04T04:43:36.575951Z"
+     "iopub.execute_input": "2026-07-04T12:07:14.780179Z",
+     "iopub.status.busy": "2026-07-04T12:07:14.779976Z",
+     "iopub.status.idle": "2026-07-04T12:07:26.745405Z",
+     "shell.execute_reply": "2026-07-04T12:07:26.743909Z"
     },
     "papermill": {
-     "duration": 19.578184,
-     "end_time": "2026-07-04T04:43:36.579721+00:00",
+     "duration": 11.985754,
+     "end_time": "2026-07-04T12:07:26.747463+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:17.001537+00:00",
+     "start_time": "2026-07-04T12:07:14.761709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -549,7 +549,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6sAAAGGCAYAAACdTxdEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAls5JREFUeJzs3Xl81fWV//HXXXKzLySsWUgICdn3sIsg4lrXVmtrp6L2p+2MdmqZ+U1rp9XWzkw7nU7rb0ZaOh2X1tal7rZaF1BUEBCysYSEJWHLvt2b5CZ3v78/AhEEhUCSm+X9fDzykNx7870nXrjnns9yPga/3+9HREREREREZAwxBjoAERERERERkU9SsSoiIiIiIiJjjopVERERERERGXNUrIqIiIiIiMiYo2JVRERERERExhwVqyIiIiIiIjLmqFgVERERERGRMUfFqoiIiIiIiIw55kAHIAN8Ph+NjY1ERkZiMBgCHY6IiJyB3++np6eHyMhIoqKi9H49BimfioiMfSfyaXx8PEbjp8+fqlgdIxobG0lKSgp0GCIico5sNhtRUVGBDkM+QflURGT8OHr0KImJiZ96v4rVMSIyMhIYeMH04UdEZGzq7u4mKSmJo0ePDr5vy9iifCoiMvadyKdny6UqVseIE0uVoqKilFxFRMY4LQEeu5RPRUTGj7PlUjVYEhERERERkTFHxaqIiIiIiIiMOSpWRUREREREZMxRsSoiIiIiIiJjjopVERERERERGXNUrIqIiIiIiMiYo2JVRERERERExhwVqwG2du1asrOzmT9/fqBDERERGbeUT0VEJh6D3+/3BzoIge7ubqKjo7HZbDrEXERkjNJ79din10hEZOw71/dq8yjGJDJheTweXC4XXq8Xr9eLz+cb/LPZbCYoKGjwy2w2YzAYAh2yiIjImOPxePB4PKfkUa/XC3BaLhWRiU//0kXOkdPppK2tjc7OTnp7e0/56u934PV5MfqcGHxe/H4vBp8Xg9+D32AGkwWPOQyT0YTRABaLhfDwcCIiIgb/GxERQVRUFFOmTCE4ODjQv66IiMiI6OnpobW1le7u7sE8arfb6e3txeF04fYb8PgNeP0GPH7w+AcGeC0GPxajn2CjD7PRQFBQEKGhoafk0RNfMTExREREBPg3FZELpWJV5FN0dHTQ0tJCa2srra2tdHV2YOhvI8zRTJini2hfF8/7r2evJ55ubyxfMb7FQ0G/+9Trfd11H2/6FmA2+Fhu2sU/mP5Ep2EKVuMUmkwx9JujcVli8YfEEhEVw5QpU4iNjSU2NpapU6cyZcoUzciKiMi44vF4TsmlLS0t2PsdtDiDaHcHYXWbsHrMWD0mbO5Yerymc7quCT8Wo48Ik48os5Mocx9R5kaizV6ig7zEBXmICTUP5tIpU6YQFxfHtGnTNCsrMo7oX6vISdra2qirq6Ouro6mLjs+eyvzHBXM8x4iw3+IUIPrlMf/0bWULt9sAFwEAeDxG3EShJsg3Jiw4CYcB32EDN4/y99KtqEeqAcfA19uoB+8VgP3N/4dVZZipgXZSA6qZLalF0t4LNNnzGDGjBlMnz6dGTNmaAZWRETGHI/Hw5EjR6irq+PIkSPYXV4aHRaOOiwcdYTT6JyC23/2Hp8m/JgMfsyGgfYqLr9xcJbVi4F+n4l+n4k2d9AZfz7c5GVqkIeplkamWQ4z3eJhZrCbmdPiBvPo9OnTiY6OHr5fXkSGlYpVmfQ6Ozs5cOAAdXV1WNsaqemPoKxvKkcdkVxrrOcfLW8NPNAA3f4w9hlSaDdOo8cYQ2p4KPGWNqLNXsKN8/iN4d8xGAcSsMlkwmg0Duy38XhZ7IcSmnD5DJjdyTzuuotgj40Ir5Uon5VYXyezaSLGYKfGM5Nadyi1hJJk2s7Xgx6lpX0K+46kcjAohYqQJHxh05k2Yxbx8fEkJiYyc+ZMjRaLiEhA+Hw+Dh8+zMGDBzly5Ag2p49aewh7e6M54gjGz6krg0KNPmYEu4gxe4kxe4gOOv5fs3dgma8BzrSYyOcHp8+Ay2/E6TPQ6zHR7TFh85joOf5fq8eMzWPG7jVh95o47Ph4YNeIn+kNbuJDGogPPsSsYBdJ0RaSEhNISBj4Cg8PH+n/XSJyjvTJViatpqYmKisrOVy3j8juarKclRT6a/mp50sc9V4LQL05lTeNF9NqmU1fSCKm8KlMOz4KOzUigryT9pyGhoZiMpkGi9STeb1e3G734JfD4Rjcn3Nir05tTw/buqz4nN3ke8KZ7rbS5g5irqsdj9/IDEMXMygDdxm4wdEdxO6WdJ7fdwuh4dHMCvEya+YMEhMTSU5OJjY2NhD/W0VEZBLxeDzs3buXnTt30t7dR609lL32aA71n1qgxpg9JIa4SApxkhjiIiHSzPRpU0/baxoeHk5QUNAp+fRETvV4PKfkUpfLRV9f3yk9JOx2OzZbJ3anh3aXmXZ3EG0uM+2uIJpcQfR5TTS7LDS7LJQfjy200UvyoQ5mhzSSHLqJtGkRJCYmkJSUREJCAibTuS1NFpHhp2JVJp0jR45QWVlJ4+H9JFi38DeeD4gwOAbuNECe+RiXRtvIiugnYUoYlplrKJ4+nenTpxMXF3daIXouTiTdkJCQz3ycz+fDZrPR1dVFZ2cnnZ2dtLdfyf9aF2DuaybaeZQE9yHm+euYauimyL+XO62z6LZGEGL08TdNm7Dt7mZbRDpRcTNJTk4mOTmZWbNmKdmKiMiwcTqd7Nmzh927d9PU42arNYKdvbPw+j8uUGdaXGRF9JMV4WBefCzTpycw/Xg+PZ9jhcxmM2azmdDQ0LM+tre3dzCXdnV10dHRQUdHCza3kUZnEI1OC41OC83OIPp9JmrsodTYB64b3uQlZX8jaWF1ZER6SEtOYPbs2cyePZuwsLAhxy0i50/Fqkwahw8fZseOHexv6qKg88/c4d1EsMEDBjjgT6TMsoCuyGxipifxjblzSU1NJS4ublRjNBqNTJkyhSlTppCamjp4e19f32CDipaWFqpbWvHa2zD0tzLTZMLZ78PhM3KF5x3m+/aBE6rb57C3Lpc94RmYoxJITkkmNTWVpKQkLRcWEZHz4nK5qKiooLq6mmO9sMUawV577OAs6nSLm6zwPrIjHeQmz2Du3CxSUlLOOlg73E7M1CYlJQ3e5vF4aGtrOyWf9vb10+S0cLjfwmFHMMccwdi9Jvb0hrGnNwxjq5/ZjT2kV5WRHraZeQlxpKamkpqaqm7DIqPA4Pf7/YEOQnSI+Ujq6+tj8+bNVO4/wrsdUey1h/Jw0FquN33ITtLZEb4S07QcMrMymTt3LlOnTg10yGfl9XppbW2loaGBhoYGmltaaXSYyeneSK676njzpo81+uPYal5AVfQVzA73k6LCVeS86L167NNrNHIOHTrEpk2b2N/p5oOuKOr6Py5A54Y6WBzTw/yUWObNS2fOnDmjXqCeD5vNNphLGxsbsTucNDgs1PWHsN8eQvsnmjfNtLjIjegjO6Kf1PipKlxFztO5vlerWB0jlFyHn9/vp6amhq1btmBp3sKvepbR4B+YKV0eUs+yyBbCZmVRUFBARkbGuC7aXC4Xzc3NHD16lMOHD9PT0Ux4735SndUU+asJNbh4wzufb7i/TZTJQ2aEgxXB+wmJnkXq3LmkpaWRkJCgo3FEzkLv1WOfXqPh19fXx6ZNm6itO8x7nVHs6A4HDBjwkxXeP1CkpsdTVFTEjBkzAh3uefP7/bS3t9PQ0MCRI0doaWmhw2XkgD2EfX2hHHVYBmeQDfhJCXWSG9FHRriDpFnTSU9PJzU1dVwU6SKBpmJ1nFFyHV5Wq5X333+fpoM7ucj6AjmGOv7qnc+/Gv+Oy6fayJwRTmFhIWlpaee1B3Ws6+zs5PDhwxw+fJjmpgaCe+rY45zKq325uPxGkg3NvBe8hgb/VLab59MSWUD41CTS0tJIT08f9eXPIuOF3qvHPr1Gw+fEoO+2bduothp4oy2Gbu/AwG5uRB8Xx/ZQmplCYWHhhGzq53A4OHLkCEeOHOHo0aPYHF729oayuzeUBufHHYaDDD7mhTvIi+gjNdxN8uwk0tPTSU5OVr8IkU+hYnWcUXIdPtXV1Wz64D1mtG7kas/bBBm89PhDeTXketyzlrBkyWLS09MnzSxiX18fhw4dGjjvrqGJg33BxPTU8G3vox83lgL2+lOoCi7FGpnD1FmzycjIID09XSPEIifRe/XYp9doeDgcDtavX8/+o8283R5NtX2gsVCM2cNVU60smzeNpUuXTpozSn0+Hw0NDdTV1XHo0CGaez3sPr6vtdP98cqsCJOXnIg+8iL7SIwwkpaWRkZGBtOmTQtg9CJjj4rVcUbJ9cL5fD4+/PBDdpdv4rKO3zHX0AjAB5SwJ+5zZOQWs3jx4kldfPX391NfX09dXR0Nx44QbNtPRn8Zpf7dBBm8AHj9Br5j/Af8UcnMi3Axd04KGRkZJCYmTpoCX+TT6L167NNrdOE6Ozt54403qGp182prLP0+Iwb8LIju5bJZLlZctIS0tLRAhxkwPp+PxsZG6urqqKurp77bx+7eMKp7w+j3fbxaa7rFTXZEH9nh/aTOiNYgsMhJVKyOM0quF+bECPDh2nK+0r2OGIOdVn8Mr4XfTEhSCcuWLSMxMTHQYY4pfX19HDx4kP3799PadIQoWzX5zh0k0cQC569wYiHM6OWW8ApmhpuJmDZQtGZmZqqRhExaeq8e+/QaXZhDhw6xYcM7bOkIZkNnNH4MTLe4+Nw0K8vz5rBo0SIVWyfx+XwcO3aMffv2UXfoMLU9QezuCWN/Xwi+k86ZTQh2kR3RR06kk9y02WRnZxMfHx/AyEUCS8XqOKPkev6sVit//esbvHvMy7YOMy9aHqTfEMrmqV8lv3Qx8+fPH9fNk0ZDV1cXBw4cGChc29vZZp/Ozt4w7F4j6y3/lzRjI7v9qVSELqE/JofkOXPJysoiKSlJs60yqei9euzTa3T+Kioq2PrRdt5oj6GqJxyAgkg7n5/t5tJLlmvQ9yxcLhf19fXs37+fg0ebqLWHsqc3lMOOYDipMVNamIPSKDsFM0PIzs5i3rx5GgCQSUfF6jij5Hp+jh49yltvv8VfGiOo6B2Y7bsk/ChLZ8CKlasm9TKl8+H3+2lsbKS2tpaDdfUc7vZwVffTLPDvHFwm3O0PY5NpEUejSomcPoesrCwyMzPP6ZB2kfFO79Vjn16jofN4PLz//vtU1dbxYkssRx3BGPBzaZyNa9IjuOKKy/UeP0S9vb3s27eP2tpamrrs7LWHUt0bRoPTMviYuCA3pVF2CmOcZMxNIScnZ1x3UxYZChWr44yS69DV1dXx9ht/ZmHrH3nRvYjfey9nZWw3l8zyceWVV6iZwQVyOp0cPHiQmpoaWhsPE2erZLFrM4mGtsHHPM51VEZdTnakk3lpc8nJyWH69OkBjFpkZOm9euzTazQ0Ho+HN954g8pDrTzXHIfNYybY4OOGGZ1cVZjMsmXL1NH2Avj9fpqamqipqaG+vp6WfgNl3eHs6gnD5R/Y3xps8JEf2UdxlJ2M+BhycnKYO3euVoXJhHau79X6VyDj0pEjR1j/5ussb3mUTMNhks0NEJdF0ZyZXH755YSHhwc6xHEvODiY7OxssrOz6ejoYO/e+bxVezH+zv1k2LexyF/JW+48trTGsr7Dy/L2fdTuLmdGYupgotUHHBGRscvn8/H2229TXt/GH5um4fQZmWL2cPPMDq65uJT8/PxAhzjuGQwG4uPjiY+Px+l0sn//ftL37mVFRzM7e8Io6w6n0x3E9u4ItndHMKfDQenhbWRP2Up2VibZ2dlERkYG+tcQCRjNrI4RGgk+d42Njbz251dY2Pi/5BsO0OGP5IUpf8vcvEUsX75cI5EjyO12c+DAAfbu3UtrQz2b7bOo6Img12vin81/4HbTm3xoLGJf+BKCp6WTk5tDVlYWYWFhgQ5dZFjovXrs02t0bnw+H++88w7bao7wh8ap9PtMJAY7+XJSN9devpLZs2cHOsQJrbm5merqag4erOOgPYgd3eEc6AvhxN7WaLOH4ig7hVF9ZM9NJi8vj5kzZwY2aJFhpGXA44yS67lpbW3lz6+8RGHD45SwF5s/jGdj/o6cBStZunRpoMObVNra2tizZw/7DhykutvCF7r/l2VUDt5f40/mo9DlOGJzmDcvk9zcXKZOnRq4gEWGgd6rxz69Rmfn9/t577332LrnIE82TsPuNTEr2MXq2d3cdP3n9F49ihwOB7W1tVRXV3O0s4/y7nCqesIHj8AxG/zkRPRRGmUnJyGavLw8UlNTtXJJxj0Vq+OMkuvZdXR08MorL5N15HcspopefwhPRX+DecWXsHz5cnWlDRCHw0FNTQ3V1dX0ttSR0r2VZb5thBpcALT7o3kz6DJaYheTnjSDvLw8kpOT9XrJuKT36rFPr9HZbd68mQ8ra3iycSrdXjPTLW5WJ3Vx8/WfU9+BAPH7/Rw5coQ9e/ZQf+QY1fYwdtjCaXF93JApKcRJaVQvhdOM5OUMbNNRF2EZr7RnVSYUq9XKn//yGq1H93InVTj8QTwdeRep+cu4+OKLVfgEUEhICIWFheTn53PkyBF27y7kd4cvI85azsWu95hh6KLP0cfaIzPJ6exjweF3SJ8WTl5eHvPmzdOybRGRUfTRRx+xrWovTzVNo9trJjbIzd8kdHHj565QoRpABoOB5ORkkpOTsVqtVFdXU1JTy6FeA9tt4dTaQznqCOaoI5j1HR7mN9Uwv6yKvKx08vLyiI6ODvSvIDIi9ClRxjyn08lrr73OS8dCqOpfgdlkIzYmlqTci1i5ciVGozHQIQpgNBpJSUkhJSWFzs5Odu8u4tXapQR17uGvfbl4PQZ29oYTbD/KZe2P8uGR5Wz/KIOc3BxycnJ0LIKIyAirrq7mw7KdPNU0lS6PmRizh79J6OSGq1YRHx8f6PDkuJiYGJYsWUJpaSm1tbVk7d5NY1cz5d3hVPSE0+M1805nNJu7fBS1H2P+zhry0maTn5+vfa0y4WgZ8BihZUtn5vf7efPNN3lhVwdvd8RgwM+NMzpZmR7LlVdeqVm5Mc7hcFBdXU11dTX7Oj1ss0XwD65fcbmpDIB9/tlsC12OMy6PzKwc8vPz9fdfxjS9V499eo3OrL29nRdfepk/NMRyxBFMpMnLbQntfOHKFaSmpgY6PPkMfr+fw4cPs3v3bo40NLKnN4yt1gg63EEAGPGTG9HHwphecpPiKCgo0HYbGfO0Z3WcUXI9s6qqKrZteJGEri3c7/4aC+I8XJMezuc+9zmCgoICHZ6cI5/Px8GDB6mqqqK9sY7Z1i0s924m3OAEoNkfy3uWS+iaUkTavCwKCgp0Tq6MSXqvHvv0Gp3O5XLxwgsv8OphA1uskVgMPm5PaOMLly0lIyMj0OHJELS3t7Nr1y4OHDjIvl4LW20RHHUED96fHtbPophecmeEUVCQT3p6upoxyZikYnWcUXI9XXNzMy+/+Ceua3mYeEMHrxhWYk25kZtvvklHoYxjDQ0N7Ny5k8N1+4izlrPC9S7TDDYAdvnm8JOw71Ia1cu82TMpKCggKSkpwBGLfEzv1WOfXqPTvfXWW7y9p5nnWuIAuHF6B7csmceiRYsCHJmcL7vdzu7du9m7dy/13X62WCPZd9LRNwnBLhbF9FAw1Uh+Xi7Z2dlYLJbPvqjIKFKDJRnX+vv7eeuttyhofZ54QwdH/DNomn4J1666VIXqOJeQkEBCQgKdnQvZtauQl2oXE9axk6WOd3jGewkfWiPZZo2gqLObyw7+kamJ6RQWFpKamqolTSIiQ7Rr1y4q9x/lz20DzZNKo3pZMTeaBQsWBDgyuRDh4eEsXLiQ4uJiampqyNi1i8Od3WyzRbCrN4wGp4UXWuJ4t9PNwpbdFJdXUpCbTV5ennpEyLiiYnWE3HjjjWzcuJFLL72U559/PtDhjCt+v593332XkKPvsJgqnP4g3oj5KvMXLiUhISHQ4ckwiY2NZfny5ZSWlrJ7927e3VOK22ogweakwRnMnP4K7nL/lk3WEjYcWcH2WekUFBQwb948LWkSmSSUSy9Ma2srm7du46XWOBw+I/HBLq5OcHLppZ9Tc8IJIigoiLy8PHJycqirqyO9spIjrc3s6I6gvDucTncQf22fwntdXua3HWB+5W4Ks+dRUFBAZGRkoMMXOSstAx4hGzdupKenh9/97nfnlGC1bOlj5eXllL3zEnf0PILZ4OMPwbcyJf8arr76as2sTWAul4u9e/eya9cuajs9lHS+yg1sGLz/I3LZGbGC4OmZFBQWkJWVpX3LMur0Xj26hppLQa/RCQ6HgxdffJEXDpko644gxOjjawmtfOm6y7W9YoI7duwYlZWV1B9roqo7jI9sEXR7B+anggw+CiP7WBhjpzgzhaKiIqZMmRLgiGUy0jLgAFuxYgUbN24MdBjjTmNjIx9teY8be57EbPDxjmER/oQlrFy5UoXqBGexWCgoKCA3N5f9+/dTVRXK/zQWk979Phf7PmKBYTcLenezq2cu25tXUV6eQ15eLrm5uQQHB5/9CURk3FEuPX8bN27ko2YvZd0D529eN72TFQvyVahOAomJiSQmJtLW1kZmZSUldfXs7Q1lqy2SVlcQ27sjKOsOJ7+rnSV7X6QwPYmioiI1NpQxacyuAfnpT3+KwWDgvvvuG9brvv/++1x77bXEx8djMBh4+eWXz/i4tWvXkpKSQkhICAsXLuSjjz4a1jjkdF6vl/fff5+97U48GDnoj2f/9OtYddkq7a+YREwmE5mZmXzxi19k1fW30pX3DX4b9z3eMC7H6Q8iz3CQ9J7N/Kouiiffq+YPf3yKbdu20dfXF+jQRcYc5dLJ6cCBA+w82MDrbTEALInpYdncWEpKSgIbmIyqadOmcdlll/HlW77IF0pnc1dSO1+a2U5yiAMfBip7wll3dAZrt1t57E+v8vrrr9PU1BTosEVOMSZnVrdv385vfvMb8vPzP/NxmzdvZsGCBactBayuriYuLo4ZM2ac9jN2u52CggLuvPNOPv/5z5/xus8++yxr1qxh3bp1LFy4kIcffpgrrriC2tpapk8faFBQWFiIx+M57WffeustHax9nqqqqtjR5OKV/jzW8zO+PuswFy9eyqxZswIdmgSAwWAgNTWV1NRUGhoaqKjI5vH6FcRbt/CMawGtPgsvt8ayu6uD1S2/Z+fOAnJycsnPzyciIiLQ4YsEnHLp5ORyudiyZQtvd0Tj8htJDHFyebybSy+9VPtUJ6mYmJjBHhG7du1iXnU19b09bOqKpL4/hKqecHb2hJHX1cuS+tfJTppGcXExiYmJgQ5dZOwVq729vXzlK1/ht7/9Lf/yL//yqY/z+Xzcc889pKen88wzzww2XKmtrWXlypWsWbOGf/qnfzrt56666iquuuqqz4zhF7/4BXfddRd33HEHAOvWreO1117jscce47vf/S4AlZWV5/kbypl0d3ezrayStzsG2uoXxHhITkmjoKAgwJHJWHCig3BraysVFTksrDuCqbub7bYIvuB/i686/0zjsb/ybvtl7NlVSEZWDoWFhZN6v5pMbsqlk9eOHTuoavezvy8UI36unmplxcUr1UlfCA8PZ9GiRRQWFrJ7927m7t5NXfdA0VrXH8LO3nB29YaR2dnPksNvkZs4heLiYpKTkwMdukxiY26I7Z577uFzn/scq1at+szHGY1GXn/9dSoqKrjtttvw+XwcPHiQlStXcsMNN5wxuZ4Ll8tFWVnZKc9vNBpZtWoVW7ZsOa9rfpa1a9eSnZ3N/Pnzh/3a48nmzZuJbvmAK/0fEGN2cdGUXi666CLtU5VTTJ8+nSuuuIKv3vIF7pg/g3uTWwgPDafdH028oYOvOJ/h+saf0vTBEzz9xyd59913sVqtgQ5bZNRNtlwKyqcA7e3tVOyq5u2OgX2qC2N6KU6LJyUlJbCByZgSEhJCaWkpt956K19YXsQdqX3cHt9KWlg/fgzstYfxaMMM1u7y8egr7/L8889TV1eHerJKIIypmdVnnnmG8vJytm/ffk6Pj4+P55133mHZsmXceuutbNmyhVWrVvHrX//6vGNob2/H6/WetuxpxowZ1NTUnPN1Vq1aRVVVFXa7ncTERJ577jkWL1582uPuuece7rnnnsGOWJNRfX09R2orucP9CrcGeZkTHkxB/jXExcUFOjQZo2JjY1m5ciWlpaVUVs7jxb2FRHRUcInzbWYZOrnF/QKdzW/xRucV7K49QHZ6KkVFRcTGxgY6dJERNxlzKSif+v1+Nm3axOauCGweM1FmDxfH9bF06ecCHZqMUScaG+bk5FBbW8u8qioOdnSzxRrJXnsoB/pCONAXQlKnk4uOfUDhrB2UlBSTmpqqJeUyasZMsXr06FG+9a1v8fbbbxMSEnLOPzd79myefPJJli9fTmpqKo8++uiYmI1bv359oEMYF9xuN5s3babU+goWg5ctFBA+I1NNIOScREVFcfHFF1NcXExVVT6vVZcQ0l7Jcsd6kgytePptrD0ykwW2Vvbse4GstBSKi4s1ECITlnLp5FVbW0v1sU62Wgf2A18eZ2NhSaHO0pSzMpvN5OTkkJWVxb59+0ivrORQRwtbrZHs7AnjqCOYp5uDea/LxdLGDymZVUZxcRFpaWkqWmXEjZlitaysjNbWVoqLiwdvO9Ed9pFHHsHpdA7upTlZS0sLd999N9deey3bt2/n29/+Nv/93/993nFMnToVk8lES0vLac8zc+bM876unFl5eTnexu2UsBeHP4idcdewaukSLBZLoEOTcSQiIoKlS5dSVFTEzp0FvLW7mKD2nTxjL8ThM/J+VxS9tjaS2h/juX3VzEkbGBCZOnVqoEMXGVbKpZOTw+Fg69ZtvNkegw8DaWH9lM4KVt8HGRKj0UhmZibz5s2jrq6O1PJyLmpvZps1koqeMBqdFp5riTtetG6ldGYZJcVFzJs3T0WrjJgxU6xeeuml7Nq165Tb7rjjDjIzM/nOd75zxuTa3t7OpZdeSlZWFs899xz79u1jxYoVBAcH8/Of//y84rBYLJSUlLBhwwZuuOEGYKABxYYNG7j33nvP65pyZl1dXVSVb+fGvpfAAH8JuorEuTnMnTs30KHJOBUWFjbYPGLXrl18Yddu0q2dbO6K5G95mcu8ZfS2vsOGzhU8f2AvKXMzKS4uHuxMKjLeKZdOTtu2baOi08hhRzBmg4/L42xcdNEVZ3y9Rc7GaDSSlpbG3Llzqa+vJ6W8nCVtLXxki6DMFk6ry8JLrXG83+XmoubtzC8rp6S4iIyMDBWtMuzGTLEaGRlJbm7uKbeFh4cTFxd32u0wkPSuuuoqkpOTefbZZzGbzWRnZ/P222+zcuVKEhIS+Pa3v33az/X29nLgwIHB7+vr66msrCQ2NpbZs2cDsGbNGlavXk1paSkLFizg4Ycfxm63D3Y0lOGxadMmEto2MM1g45B/Jp3Tl/LFpUsDHZZMACEhIcyfP5/8/Hx2795Nwc5dHGstZF9fK/MMR7ne+wb21nfZ0LmcFw/uJTl1oGg90xEdIuOJcunk09zcTFX1PtZ3DLx/LY3poSQzRceOyAU7cYTcnDlzOHz4MMnl5SxqaWZHdwTbbRF0uIN4pTWWTV1uljbvYEF5BcVFhWRkZGigRIbNmClWh8poNPJv//ZvLFu27JQlowUFBaxfv55p06ad8ed27NjBJZdcMvj9mjVrAFi9ejVPPPEEALfccgttbW088MADNDc3U1hYyBtvvKEPssPo0KFDHK6r4W+974IB1kd8gaKiEmJiYgIdmkwgwcHBlJSUkJeXx549BWypKmBT626W2N8k03CY67xv0d+6kRc7P8cf6xvITImnuLhYyxRl0lAuHf+2bt3K+11R2L0mYoPcXDTVyaJFiwIdlkwgBoOBlJQUUlJSOHLkCMnl5SxobmaHLZyPbJF0uIN4tS2WTVY3FzWXUVpeQUlRIZmZmSpa5YIZ/OpDPSac6F5os9kmxdmQL774Iv+zx0dIXwPXhlQRNu8ybr75ZszmcTt+IuOA2+2murqayopKvG17WNT7FtmGeh50r+aPvsspirSzOKaHjORZlJSUqGiV00y29+rxaDK9RseOHeOZV9/kV0dm4MPAl2e2c+ulxeTl5QU6NJngjh07Rnl5OYcbWyizhbPNFkm/b2AJcGyQm4tieiiZbqC0uEhFq5zRub5XqzKQUXfkyBGqG63U2GcAaZTGRfKl+fNVqMqICwoKGmzTX11dzY6KXLa0VvN+bxEep4Ht3RHMtO8mo/11XqmrJWHOPEpLS1W0isiYVFZWxhZrBD4MzA5xUjAzmJycnECHJZNAYmIiiYmJNDY2klJWRklDM2Xd4WyzRtB58kxrazmlx5cHZ2Zm6rOeDJn+xsioKy8vp6Jz4K9eRng/6dPC1VRJRpXZbCY/P5/s7Gz27t2LpbKKPR3tbO4K51v+50nzNeJsf5/1Xct4ub6WxDkZKlpFZExpbGzkQEMblT0D70sXTemmsHCRGtzIqIqPjyc+Pp6mpibmlJVRcqzpeNEa+YmitYLSikqKiwrJysrSTKucMxWrMqqOHTtGy6G9POn9Jc+aV3As+gqKipaNifP8ZPIxm83k5eWRlZVFTU0NOeUVvNdyA329b5Nv2M/nfO/gbP9ARauIjDllZWVstUbi9RtIDHaSM9XCvHnzAh2WTFKzZs3immuuObVoPb48WEWrXAgVqzKqysrKSLdtJMzgJMPcQuj0cNLS0gIdlkxyZrOZ3NxcMjMzqampoaI8m49a9zK/9y0KTipan7R+gT8eaSZj9kwVrSISME1NTew/2kJFz0Czqoum9FBcvECzqhJwJ4rW5uZmUsvKKDnaONiI6ZNFa0lFJSUqWuUsVKzKqGloaKD50F6u8W0DA+yOvpTlRUVKrjJmnChaT8y0lpdlsf2konVj/xy2HJ1JkdVO7ZG/kKlGTCISAOXl5Xxki8DjNxIf7CJ3qlmzqjKmzJw5k8997nODRWvp0cZPnWlV0SqfRcWqjJry8nLmWt/HZPCzlXwiZqSRnp4e6LBETmMymcjJyRmcaS0vy2Jz20EO9aTjdRjY0R3Bwr710N7Oy3U1JKVmqmgVkVHR3NzM/iNNlHV/fK5qUVGJPuTLmPTJorXkM4rW0opKStQ9WD5BxaqMiqamJhrr9/I13xYwwM6olSzTrKqMcZ8sWiPLK6ju7KWsy8zX/X8mytf/8Z7Wuhpmz82ipKRE50iKyIg5Mavq9huZYXGRP9VIZmZmoMMS+UyfXrSe3j14/vGiNSMjQ0WrqFiV0VFWVsacrvcxG3xsJ4eImRlasiTjxieL1uyycv7UeicLet4abMTkaP+ADV0X8/LBGpLmZqpoFZFh19rayv7DDeywnegA3ENhYZE+0Mu4ccai9UxH3rSUseB4IyYVrZObilUZcc3NzRw4dJiv+XaAASojV7G0sFBvPDLunFy07t27l4ryLD5q2cuC3jfJNxzgc74NONrf59fW1dQcaiQzJZ7S0lKmT58e6NBFZAIoLy9nuy0Cl9/INIub/DgDWVlZgQ5LZMhOLlrn7Nhx0pE3pxaty1rKTplp1Yq8yUfFqoy4iooK3u+eyh+d/8mtIR8ybcY8MjIyAh2WyHkzmUyf6B6cxfaWaub3vkU2dbzUl0Nj33SKbT3UHHqVrDkJlJSUqGgVkfPW3t7OvkNH2d49MKu6NKaHosICzGZ9lJPxa+bMmZ955M0rrbF80OVmWcsO5pdXUFpSzLx581S0TiJ6h5MR1d3dzf5Dx9jZMxMPRtqnzOcyzarKBHGmI2/WtzXg7Z6Cx2ngI1sEN/f9EU+HhRfrakg5vqd12rRpgQ5dRMaZ6upqqrrDcfqMxAW5KYzza1ZVJoyTz2lN2bGDkoZmdnyiaN3U5eailu0sKK+gpLhIReskoWJVRlRNTQ21PWY8fiPTgtykRxvUCEImnJOL1r179zK1opI9nT7qu/r4Au9j9Prpa32f9Z3LeeFgDXPSBorWqVOnBjp0ERkH3G43+/cfoKInFoAF0b3k5eYQFBQU4MhEhtesWbO49tpraWxsJKWsjNKTitaOk4rWZc3bWXB8eXB6erqK1glMxaqMGJ/PR83eGr5l/wW3BkXy14ibmDdvkZYsyYRlNpvJy8sjKyuL6upqKisqeaL16yzqfZNsQz3Xed+ir/U91ncu5/kDe0lNz6akpIS4uLhAhy4iY9iBAwc42Guk0x2ExeAjJ9KhgV+Z0OLj44mPj6exsZHkHTsoaWxmhy2Cj2wRdLiDePnETGvTRyyYNbA8OC0tTUXrBKSqQUbM4cOHcXQcZJ7hCLONQeyKMGnJkkwKZrOZ/Px8srOzqa6uZnt5Nlvb9rCo963BotXe+h7/abuX6oNHyJ47m9LSUmJjYwMduoiMQXv37qWiOxyAnIh+0lOSCA8PD3BUIiMvPj6e6667joaGBpJ37KC0qZntx4vW9pOK1mVNW1kQP1C0zp07V0XrBKJiVUbM3r17mdOzA4APjaXEJ81hypQpAY5KZPScXLTu2bOH7RU5bG3dwxL7G0yjk2e6c/D0WCi1dbL3wPNkp8+hpKRERauIDGpvb+dwSye19oHGSkVRdrKyFgU4KpHRlZCQQEJCAseOHWP2jh3Mb2pme/fHRetLrXEDM62NW1gQX8780hLmzp2LwWAIdOhygVSsyojo6enhyKGD3ObbDgaoi5jPxVqyJJOU2WymoKBgsGjdWpFNY2cnkTYjLS4jH1ojuK/vlzR0pPKnfdWkZeRQXFysolVEqKmpYWdPGD4MzAp2MTfWQlJSUqDDEgmIxMREEhMTOXr0KLPLypjf1MxHtgi22yJoO1G0Wt0sa/yQBQnlgzOtKlrHLxWrMiJqamqItO0mzOCk3j8L05RUUlNTAx2WSEAFBQVRWFhITk4Ou3fvJr5qJ7u6DLi7DrHAWAPeGnpa3+Xtzkv4U+0e0jJyKCkp0YoEkUnK7Xazb99+KrsHBq6KIu1kZmbpg7dMeklJSSQlJXHkyBGSysqY33xS0eoK4sXjRetFjR8OzrSmpqbq3844pGJVhp3P56O2tpZSxxYwwEeWJczLmKfGSiLHBQUFUVRUNFi0VlZ6eLz9/3CR/Q3SDcf4vPd1uls3sr7zEp6trSY9c6BojYmJCXToIjKKDh48yP5uI10eM8HHGyvpnHKRj82ePZvZs2dz+PBhksrKWNDycdHa6grixZY4NnW5WNa4mQUJA0XrnDlzVLSOI6oeZNgdOXKEvrY6Mg2HcfrNdMXkc5kaK4mcxmKxUFxcTG5uLrt37+aDyhw2t+3ior63SDMc4/Pe1+hufZeHur/Dnv115M6bS3FxsYpWkUmipqaGip7jjZUi+5ibnEhERESAoxIZe5KTk0lOTubw4cMk7tjBgtZmttki2GGLoNVl4YXjRetFDZtYlFhOSUmxitZxQsWqDLuamho22OdQ4/oGhcHNzExI0d47kc9wctG6a9cu3q/KY1PbLpb1vUmfP4jnbWmE9PhZYGuhet+fyJ6XRklJCdHR0YEOXURGSEdHB3WN7ew73lipOFKNlUTO5kTReujQIRLLyljQ2sJHtnB22CJoOaloXXZsEwsTyyktLSElJUVF6ximYlWGVW9vLwcOHaXCPpNt/osJjWnjNs2qipwTi8VCSUnJYNH6XlUuh7r6iLN56HAHUdYVxEN9/8n29gU8U1vNvMyBRkwqWkUmnpMbKyUEu0iZosZKIucqJSXl1KK1rYWPbBHssIXT4rLw/GDR+gELkz4uWmXsUbEqw6qmpobq3lBcfiOxQR7SomDu3LmBDktkXAkODqa0tJS8vDx27dpF8s5d7LSamWX9iBRDMymeV7E2v8PbHSt5pmYPGVm5FBUVqWgVmSA8Hg+1+/ZT2TPQXK0oyk5mZqbOjhQZAoPBwJw5c0hJSaG+vp6EsjIWtLewzRrBju5wml0WnmuJY5PVxcXH3mN+YpmK1jFIxaoMmxONla7veZJZprk0RZSQnp6hxkoi5+lE0Zqbm0v+rl3s2uni9+0GlvW9xRxDEzcPFq2X8szeBWRk5VJcXExUVFSgQxeRC1BXV8c+mwGrx0yw0UdWeD+ZOv5N5LwYDAZSU1OZM2fOaUVrWXc4TU4LzzZPZVOXk4uPvUfp8ZnW5OTkQIcuqFiVYXTs2DHsrXV8xbCVS8zbeSwinSwtARa5YCEhIcyfP5+8vDx27szjnZ35BLXv5OL+N0kxNHOz5xU6mt/h+90/Yk/tAXIy0lS0ioxje/fupbx7oLFSXkQfqWqsJHLBTi5a6+rqSCgrY2FHC1utEZR1R9DgDObp5mA2WZ1cfOxdSpKiKClR0RpoKlZl2Bw4cIBZvVUAbDUWMTNhDnFxcQGOSmTiCAkJYcGCBeTn57Nz50427MwjqH0ny/vfpMqXyl+7ZrLR5mWRrZG9NbVkZWaoaBUZZ3p7eznU2MqBvlkAFEbZycpaGOCoRCYOg8HA3LlzSU1N5eDBgySUl7OwvZkPrZFU9IRz1BHMH5umsanLwfJj71KYqKI1kFSsyrDw+XwcPnSYyzyVYICDoYUsSE8PdFgiE9Ini9b1O/OptfqYYvXQ5TFT19XPz+z/yrsdK3lm7x7mZeWoaBUZJ+rr69nfF4oPA9MtbpIiTcyePTvQYYlMOAaDgbS0NObOncvBgwdJLC9n0fGitbI7nMOOEH7fGMKmLgcXH3uH/MRoFa0BoGJVhkVDQwNu2zESDW30+y24IgeWWYjIyDm5aK2qqmLe7j1UWYOYb3ubaQYbX3S/RGfzetZ3rlLRKjJO1NfXU2sPASAjvJ+UlBQ1VhIZQZ8sWpPKyljc3sJmayRVPWHU9YdQ1x9CurWfZQ3vkJsQTWlpqQaRRomKVRkW9fX1TO2tBqDMkMvM+ETCwsICHJXI5BASEsLChQvJz88nb+dOdu9y8GR7HMv732K2oVVFq8g40d/fz+HGFur6B5YAZ4T3a+BXZJR8smidfbxo3dQVye7eMPb3hbK/L5R5Xf0sa1hPTkKMitZRoGJVLpjf7+fQoUMs9VSBAepCcilUchUZdaGhoYNF686d+by9qxBLexXL+98cLFoPNW/hoe4fDDZi0pE3ImPHoUOHONgXgtdvIDbIQ3yYgYSEhECHJTKpnChaT+xpTSkvp66tlQ+6Iqm2h7Kvb+Aro6ufPceLVi0PHjkqVuWCNTc302Lro9aXwDRjF32R6TqjSiSATi5aq6ryeHt3wWDR+pJnKe90TWGLzcsiawO1e/cwLzOb4uJiFa0iAXbKEuCwfpKTZ2MymQIclcjkZDQaSU9PH5xpTS0v50BbK5uPF621fQNfGV39XNSwQUXrCFGxKhesvr6ePf1RrHXfR3pIL9+YadbyQpExIDQ0lEWLFlFQUHB8prWAI1bTYCMmr+0wN/f9ig2dl/JsTTXpmdkUFRURExMT6NBFJh2Xy8WRY40c7JsBaAmwyFjxyaI17VOK1vSufpYce4eCxGiKi4s1cTNMVKzKBTt06BC19lAA0iLczJmjLsAiY8mJmdaCggKqqqrI2b2HSquFa2zvEWvo4Wb3y3Qd39P6bM0e0jMGZlpVtIqMnsOHD3PQbsHlNxJp8pAY5iMpKSnQYYnIcSeK1rS0tIGitayMA22tbOqKZK89dHBPa0qXg6VHN1KUEElJyUDRajAYAh3+uKVidYTceOONbNy4kUsvvZTnn38+0OGMmLa2Njo72wlxhQEzSQ9zaCRJZIw60YipoKCA/J072bXzJn7fPo/l/W+SbGjhZvfLWJvX83bHSp45qWidMmVKoEOXSWqy5FL4ZBdgB0lJiQQFBQU4KhH5pE82YkorK6OurZUt1gh294ZxqD+EQ/0hvNfpZOmx9ylNKKOkpJg5c+aoaD0PKlZHyLe+9S3uvPNOfve73wU6lBFVX19PXPdO3g1+jr+yhO6424mNjQ10WCLyGT55TuuGXQWY26q4uP8tUgzN3Ox5le3Ntfx3z7fZs/95stPmUFxcrH/bMuomSy71eDwcPnqM/X3TgBNLgIsCHJWIfJZPFq1zy8s53NbCFlsEVT3hHHMG82xzMO91ulh6bBMLE8spVdE6ZCpWR8iKFSvYuHFjoMMYcfX19WS4dgHQbZml/TUi48jJReuuXQW8s7MQc1sVy/rf4neey3m/K4qPbBEssTZwoLaaufOyKC4uJi4uLtChyyQxWXLp0aNHqesx0e8zEmb0MjvUreMwRMaJTxatyeXlXNTezDZbBOXd4TS7LLzQEsf7nW6WHN3MksQySoqLmDt3rorWczCmTpn+9a9/TX5+PlFRUURFRbF48WL++te/DutzvP/++1x77bXEx8djMBh4+eWXz/i4tWvXkpKSMrhs7qOPPhrWOCaCrq4uutqbKPDXAmCNyNISYJFxKCQkhPnz53PrV75C1qVf5d3Z/xdzXDpxQW4cPiMpPdu5tfUn9Gx9nOee+QNvvfUW7e3tgQ5bPoVy6fhTX19Pbd/AEuB54Q4SE+IJCQkJcFQiMhQnitabb76Z66+4hJvSTNwzu4UlMd0EG3y0uYN4pTWWf98VxH+/uoVn//Qc+/fvx+fzBTr0MW1MzawmJiby05/+lPT0dPx+P7/73e+4/vrrqaioICcn57THb968mQULFpy2p6O6upq4uDhmzJhx2s/Y7XYKCgq48847+fznP3/GOJ599lnWrFnDunXrWLhwIQ8//DBXXHEFtbW1TJ8+HYDCwkI8Hs9pP/vWW28RHx9/Pr/+uFNfX09E9z5MBj81/mQi4uKZNm1aoMMSkfN0omjNz88nf9cu8nftZmeXictt5UQZ+vi89zV6WzfwduclPL9/LylzMygpKdG/+zFGuXR88fl8HDp8hFr7wDL7gSXAuQGOSkTOl8FgYO7cuaSmplJfX09ieTmL2prZ0R3BdlsEnceL1g+tbpY3bqF0VjnFxUWkpaVhNI6pecQxweD3+/2BDuKzxMbG8h//8R987WtfO+V2n89HcXEx6enpPPPMM4PnkNXW1rJ8+XLWrFnDP/3TP33mtQ0GAy+99BI33HDDKbcvXLiQ+fPn88gjjww+V1JSEt/85jf57ne/e86xb9y4kUceeeScmkJ0d3cTHR2NzWYbN8e+vPDCCyTsephF7OR583XEr/xblixZEuiwRGSYuFwudu3aRVVVFca2XSzte4t0wzEAev0hbDAvpyl2CcmpGRQXF5+xqJloxuN7NUyeXArj7zU6evQo//PSBp5snEaw0cd9yU2s/urfEBYWFujQRGQY+P1+Dh06RFlZGU3tXWy3RbDNFoHTN1CYzgp2sXxKNwUzgikqKmTevHmTomg91/fqMft/wuv18swzz2C321m8ePFp9xuNRl5//XUqKiq47bbb8Pl8HDx4kJUrV3LDDTecNbl+GpfLRVlZGatWrTrluVatWsWWLVvO+/f5NGvXriU7O5v58+cP+7VHUnd3N+0tDRT5qwHoiMjWEmCRCcZisVBSUsLf/M3fkH/ZV9mU8o88HvZ/qPXPJsLg4HrvmyQ2/5UnKm388YU/89prr9HU1BTosOUkkyWXwvjNpyd3AU4PcxA/c4YKVZEJxGAwMGfOHL7whS9w7ZWXcUN6MH+X1MySmB6CDD6anBaeaZ7K2loLv3tjG08//QzV1dV4vd5Ahz4mjKllwAC7du1i8eLFOBwOIiIieOmll8jOzj7jY+Pj43nnnXdYtmwZt956K1u2bGHVqlX8+te/Pu/nb29vx+v1njZDMGPGDGpqas75OqtWraKqqgq73U5iYiLPPffcGT8o3HPPPdxzzz2DowvjxaFDhwjpOUiwwUO9fxahsQnMnDkz0GGJyAiwWCwUFxeTm5tLdXU1Wyvz2dy6m0X2t/m151r22CIp645gRVcDx+pqiE+ZR3FxMQkJCYEOfdKabLkUxmc+9fv91NcfotY+EO/AEuCMAEclIiPBYDCQkpJCSkoKhw8fZnZ5OfObW/iwK5LynnCOOYJ5ujmYhC4XS9u2k19eQWFhAZmZmZjNY65kGzVj7jfPyMigsrISm83G888/z+rVq3nvvfc+NcnOnj2bJ598kuXLl5Oamsqjjz46JjprrV+/PtAhjKj6+npecC7gA1ccOeG9lKSkTIolCyKTmcViobCwkJycHPbu3cuOijxyuvxYu1w0OC2s6H+Dm13v8W7XUv586GJmzU6nuLiYpKSkQIc+6SiXjg/Nzc0c7vZi85gJMvhIDXVqlZLIJJCcnExycjJHjx5lTlkZixqb2WqNpKInnAanhT81T+X9ThcXtZWTX1FJYUE+2dnZk7JoHXO/scViIS0tDYCSkhK2b9/O//t//4/f/OY3Z3x8S0sLd999N9deey3bt2/n29/+Nv/93/993s8/depUTCYTLS0tpz2PZg4H9Pf309DUwt7+Wez0l5AU1arkKjKJBAUFkZ8/kDj37t1LXmUVe9utZNiaCMbDlb73cLVvYmPnEl4/vIzpSfMoKirS+8QoUi4dHw4dOjS4BDg1zMnMabHjYp+tiAyPpKQkkpKSOHbsGOnl5Sw+duqRN8+3xPFup5tFLTspKa+kuHAg91oslkCHPmrGXLH6ST6fD6fTecb72tvbufTSS8nKyuK5555j3759rFixguDgYH7+85+f1/Od2KO1YcOGwWYRPp+PDRs2cO+9957vrzGhNDU10eC04PYbiTB5SQzza7mfyCRkNpvJy8sjOzubmpoaKistVDbtpbh3PSWGvVzu/wBPx2be71rIm4eXE5c4MNOqA9FHn3Lp2NTQ0MCh/o/3q6akZAU4IhEJhMTERBITE2lsbGReeTmLjjbzkS2Ccls4He4gXmufwntdXkpbq1lUvpP5BTnk5uYSHBwc6NBH3JgqVu+//36uuuoqZs+eTU9PD0899RQbN27kzTffPO2xPp+Pq666iuTkZJ599lnMZjPZ2dm8/fbbrFy5koSEBL797W+f9nO9vb0cOHBg8Pv6+noqKyuJjY0dPIB7zZo1rF69mtLSUhYsWMDDDz+M3W7njjvuGLlffhxpaGgguWcH/2DuYW9wIfHxmYMdJEVk8jGZTOTk5JCZmcm+ffuoqMimvKmW/J71LDTsZqV/CzXtU3msJ42a5o3Mm76DoqKBA9G1fWD4KZeODw6Hg6b2LhqdswBIDnVq4FdkkouPjyc+Pp7m5mYyystZfKSByu5wttsi6PGa2NgZzYddPopa9nNxxW4WFGSTl5c3oc9lHlPFamtrK7fddhtNTU1ER0eTn5/Pm2++yWWXXXbaY41GI//2b//GsmXLTpkKLygoYP369Z967t+OHTu45JJLBr9fs2YNAKtXr+aJJ54A4JZbbqGtrY0HHniA5uZmCgsLeeONNybFsQznorGxkUWereSb9/MHcxjx8SsDHZKIjAEmk4msrCwyMjLYv38/FRVZVDXWktn9Hv/r+RydnjCq7WFc1VGDtaGGslnzKCycPG36R4ty6fjQ2NjIUYcFPwammD3EhRgGz58Vkclt5syZXH311bS2tjKvvJz5h49Q3RvKVmskbe4gttkiqegOZ377AZZW7qY4L4v8/PwJ2Ul8zJ+zOlmMl3Ph7HY7T/7uce5seQCLwcu62H/mplvvZOrUqYEOTUTGGJ/PR11dHeXl5dS29LLZGkmNPZSngv6VJaZqtpHHzshLCZs5ULRmZGSM+eYR4+W9ejIbL6/Rpk2b+K8PjvGRLZLCSDt3F0Vw9dVXBzosERmD2tvbKS8vp77+EAf7g3m/M4pm18AAY4jRx6KYHhZOcZCfnUFBQQEREREBjvjszvW9emx/KpAxp7GxkSD7MSwGL43+OIIjphEXFxfosERkDDIajaSlpTF37lzq6+vJrqjgQGMjjs5oPD4jCw27WNizi/KeTLY0XUrZjkwKCgvIzs4mKCgo0OGLjKjGxkYO9w/sN0sJdRIfPy/AEYnIWDV16lQuv/xyOjs7qaioYO6Bg9TaQ3i/K4p2dxAbO6P5yBbBoq7DlOypITcjjcLCwnFzjNdnUbEqQ9LY2MhURx0Ae43zSEhMUKMUEflMBoOB1NRUUlNTOXz4MBUV03n0yCXM6fqAFb4PKTbUUNxbw56eVD5o/RwVFenk5+eRk5MzKZpHyOTT19dHY0c3La6B/aqzQ5zEx8cHOCoRGetiY2O59NJLKSkpobKykox9+9nTM1C0Wj1m3umM5kNrJCWdjSzYe4C8eXMoLCwkNjY20KGfNxWrMiSNjY3ke/aDARqD0yhSchWRIThxttyxY8eoqMjm8UMrSOrazErvB+QY6nisy80HPVEs7dxNbmUVebk55OXlERoaGujQRYZNY2MjR/oHlvBNC3ITG2bWdhoROWcxMTGsWLGC4uJiqqqqyKmpZWd3CFusEXS6g9hsjWKbLYLCzjYW1bxEfloSRUVFn9qHYCxTsSrnrKenh+6uNjKpB6AvPEUjwSJyXk606W9qKqWiIpsnDi4j1lrBX/2L6HNZeKk1Dot1E5bWMqqq8snJySU/P39c7MMROZvGxkYOOQZWDSSHOpk5c6aajInIkEVFRbFs2TKKiorI27mTwuq9VHcHscUaSbPLwo7ugTNbczqtLNr3Z4pSZ1JUVMSsWbMCHfo5U7Eq56yxsRFnn41uwunxhxEaPZ0pU6YEOiwRGcdmzZrFrFmzaGubT0VFLl8/eJjttggqu0P4puFPJDraaTg2lffaLmXPriIysnIoLCwc041zRM5mYL/qwFETKTqyRkQuUEREBEuWLKGoqIhdu3aRt3sP+7qNfGiN5IgjmF294ezqDSe9s49FB95kfkosRUVFJCUlBTr0s1KxKuessbGRTe50fulcxyURjdwaH6/9qiIyLKZNm8bll19OaWcnuRUV1O6r5cPOZax0bSDB0M6trmdpa3yDd9ovZe+eEtLmZVFUVDSu9+HI5NTb20tDZy8d7kgM+LVfVUSGTWhoKAsWLKCgoIDdu3eTuWsX9d1+tlojqe0LYX9fKPv7Qnm3w8nSundYkBRJUVEhc+bMGbOf6VWsyjlraGjgcH84foxEhoUpuYrIsDvRPKK0tJTKyhxerFlIZEc5K5zrmWXo5Bb3i1ib3+TJzi+za189mXMSKSoq0tmdMm6c3AV4ZrCb6DCLBl1EZFgFBwdTUlJCfn4+1dXVpO3cyTFbN9tsEezqCeOYM5hnm4PZ1OXk4qMfUDhrB0VFhaSlpY25LQkqVuWc2Gw2OrrttLgGWmAnayRYREZQdHQ0y5cvp6SkhKqqfF6rLiW4YyfL+teTYmjmnd4kdvfOoNhqZU/dn8mYPZPCwkISExMDHbrIZ2psbOTwif2qx3PpWJ3REJHxLSgoiIKCAnJycqitrSW5qopl1ma22SIo746gwRnM083BbLI6Wd78IdnTdlBQUDCmzj0fG1HImNfQ0EBU7z4+DP4pr/uXEhJ1JTExMYEOS0QmuIiICJYuXTq4D+ed3cU4Oupo9CXjdhnZZovkUvurBLX38FrdRUxLTKeoqIiUlBQVADImNTY2cqg/HDhxvqoGfkVkZJnNZnJycsjKymL//v0kVlayqKOZD62RVHSHc9QRzB+appFidbCwdQfZZeUU5OeRnZ2NxWIJbOwBfXYZNxobG5nhqCPe0EmCqYdgJVcRGUVhYWEsXLiQwsJC9uzZQ9jOXey1ws4uA1/lbUJ9LrwdH/BB13zePrycmIR5FBaOzSVNMnl1d3dzrKsfmycaI34SQ1wqVkVk1BiNRjIyMpg3bx719fUkV1SwqKWZzV2RVPWEc6g/hEP9IcR2eChp2UNJWRXFeVkBPUJOxaqck8bGRpZ6a8EALcGpLFJyFZEACA4Opri4mLy8PGpqaqiqquIPzd8gv/ddFhp2scL/EStsH7HVls97R1eyY1YG+fn5ZGZmjpklTTJ5DcyqDiwBjg9xER0eoq76IjLqDAYDqamppKamcuTIEdIrKqg91sJ2WwQ7e8LodJt5uyOG9zp95LfUs7CsmiX56eTn5xMZGTmqsSpzy1l1dnbS19PBXEMDAI6IZLXZF5GACgoKIi9vYInS/v37qazMoappPxndG1nmK2ORYSeLenbyi56/oarVTXZZOXl5ueTk5BAcHBzo8GWSOnm/aop6P4jIGDB79mxmz55NU1MTuRUV1B1pYFdPGDu6w+lwB7GjO4Ky7nA2dzawbGcNxZmpFBYWjtpAm4pVOavGxkZCeo8AsN+fRNSU6aM+qiIiciYmk4nMzMzBJU0VFVn8tuEAc6ybWOzbztPOxbQ1T2F6p4vL2rZSWVFOdk4u+fn5hIWFBTp8mWSOHWvgUP/xRoXaryoiY8iJc8/b29vJrKyk+GAdh/qD+cgWwcH+ECp7wtnVE0ZxVyuL975AztwkioqKmD59+ojGpWJVzqqxsZFZzgMA7DPN06yqiIw5RqORuXPnMnfuXI4cOUJlZTaPH7mS1B4z1m4frS4LV9ieIqWnhSfb76By524WL5xPQUFBoEOXScJqtXKs243da8Js8JMQ4lI+FZExZ+rUqaxatYrSUitVVVXM3b+fI31mNnZGccQRzPbuCCp7wpjf3UVN3SukJs5k1apVI7anVcWqfCa/309TUxPLvfsG9quGzGWeRoJFZAw7saSpubmZeZWVLKk/Sq0NcvsPEYSHZ7vSuCW8l+jo6ECHKpPIyftVE0OcREeEExUVFeCoRETOLCYmZvAIuZ07d5K8t4YDPSY2dkXR5LTwoTWSVlcQd8X2ERISMmJxqFiVz9TR0UFHr4N3vIUsMlbjCk/SsiURGRdmzpzJlVdeyfyODqqqqniu9n66bB2kBftJnx5BcnJyoEOUSaShoYHD/R/vV9WsqoiMBxERESxZsoTi4mJ2795Nxu497Ooy8H5nFIuieygoWDSiR8WpWJXP1NjYyCFHGK96bmNWsIv7proIDw8PdFgiIucsLi6OlStXUlpaSlVVFVNrayksvFjnsMqo8fv9NDQ2cdgx0JBE+1VFZLwJCQmhtLSUgoIC9u7dS0HVTkzGIObNmzeiz6tiVT5TU1PTYOfC5BAn8fEaCRaR8SkqKoply5ZRUlIyokuWRD6pq6uLY90eHD4jFoOPWcFuFasiMi4FBQWRn59PTk4ONpttxM8y10np8pna2tqIcDYRgpPEEBezZs0KdEgiIhckLCxsxJOryMna2tpocloAmBXsJioygoiIiABHJSJy/kwmE7GxsSP+PMrW8qn6+vro7enmd4Yfsjv4a8wN6mDq1KmBDktERGRcaW9vp8kVBMDMYBfTpk0LcEQiIuODilX5VO3t7Rj7WzEbfFiJJDg0Wt0zRUREhqitrY3mk2ZWVayKiJwbFavyqdra2oh0NABwwJDMtOnT1JBERERkCHw+H63tHbScNLOqVUoiIufmvBssud1umpub6evrY9q0aaOyZllGV1tbG9PcxwBoMiUySyPBIiLDTvl0YrNarbT0G/H6DQQbfUwxe1WsioicoyHNrPb09PDrX/+a5cuXExUVRUpKCllZWUybNo3k5GTuuusutm/fPlKxyihrb28n2XcEAGtwgpKriMgwUT6dPAaaKx2fVbW4iIqKVDdqEZFzdM7F6i9+8QtSUlJ4/PHHWbVqFS+//DKVlZXs27ePLVu28OCDD+LxeLj88su58sor2b9//0jGLSPsRHOlOTQC4AqdpWJVRGQYKJ9OLicXq7OC3cqlIiJDcM7LgLdv3877779PTk7OGe9fsGABd955J+vWrePxxx/ngw8+ID09fdgCldHV1tY22Fyp3R9NUNgUNVcSERkGyqeTS3t7O82ugeZKM9VcSURkSM65WH366acH//xf//Vf3HTTTWc80Do4OJhvfOMbwxOdBExbWxsH3FP5sftvmG5xEa/mSiIiw0L5dPI40Vyp1TkDgFlqriQiMiTn1Q34vvvuY9myZRw9evSU210uF2VlZcMSmARWe3s7Ne7pPOq9mg+CV2okWERkBCifTmxdXV009xvxYiDE6CNGzZVERIbkvI+uWbVqFcuXLz8lwXZ1dbFgwYJhCUwCq729nSbnx8uWlFxFREaG8unENZBLPz6yRs2VRESG5ryOrjEYDPz4xz9m+vTpLF++nPfee4+kpCQA/H7/sAYoo89ut9Pb080y7y6qDHOZZTFoZlVEZAQon05sbW1tNB8f+J1l0X5VEZGhOu9zVgF+/OMfYzAYBhOsxWLRvsYJoL29HVNfC7+wrKPdH82rIT8kKioq0GGJiExYyqcT0ydnVrVKSURkaM6rWD15tPehhx4aTLDPPPPMsAUmgdPW1kaEc+DImgOGZKbPmK4PTSIiI0D5dOLy+Xy0tHXQ6jrRXElbakREhuq8itV//dd/JTw8fPD7H/3oRwBce+21wxOVBFR7ezvT3QN7pxpNScQruYqIjAjl04mrq6uLZocR3/HmStFmr5YBi4gM0XkVq/fff/9pt/3oRz8iKCiIn//85xcclARWW1sbi31HwQDW4ATyVayKiIwI5dOJa2C/6sAS4FnHmysFBwcHOCoRkfHlvLsBn8n3v/99rFbrcF5SRpndbqevt5s5NADgDp2pkWARkVGmfDr+fbKrvnKpiMjQDWuxKuNfW1sbxr5WTAY/7f5ogiNi1VxJRERkiNrb2z+eWbWouZKIyPlQsSqnaG9vP6W50tRp09RcSUREZAg+bq50ohOwZlZFRM7HBR1dIxNPe3s7f/EuYr0ridRwH5dqJFhERGRITm6uFGr0Em32amZVROQ8qFiVU7S1tbHPFUebbyaxYR0aCRYRERmitra2k85Xdau5kojIedIyYBlkt9vptjtodw+MYegAcxERkaEb2K860FxplpYAi4ict2EvVo1GIytXrqSsrGy4Ly0jrK2tDV9/B98yv8BK807iwsxqriQiEiDKp+PXqTOrGvgVETlfw16sPvbYY1x88cXcc889w31pGWHt7e1M7T/AfeYXudv8OlOnTlVzJRGRAFE+HZ98Ph+t7Z20uU6csaqZVRGR8zXse1Zvv/12AH74wx8O96VlhLW1tTHdfQyARlMS8RoJFhEJGOXT8amzs5Om/o+bK0WZ1FxJROR8ac+qDGpvbyfZdxQAa3CCRoJFRESGqL29nSbXx/tVo6Oj1FxJROQ8DWuxevToUe68887hvKSMkt7eXvp6bMyhAQBX6EwVqyIiAaJ8On4NNFfSflURkeEwrMVqZ2cnv/vd74bzkjJKOjo6MPa3YTL4afNHExIZp+ZKIiIBonw6frW3t9Ny0rE1KlZFRM7fkPasvvrqq595f11d3QUFI4FjtVoJdbUBcMiQSGxsbIAjEhGZuJRPJ66uLiud7jgApgZ5iIuLC3BEIiLj15CK1RtuuAGDwYDf7//Ux6h77Phks9mI8gwUq23G6cTExAQ2IBGRCUz5dGLq6+ujs9+Dy2/EgJ8pQR7lUxGRCzCkZcCzZs3ixRdfxOfznfGrvLx8pOKUEWa1Wlnn+wKXOv+DD4IvITo6OtAhiYhMWMqnE5PNZqPDPTAPEGP2YjGbiIiICHBUIiLj15CK1ZKSks88nPxso8QydlmtVlo8IRz0J0BwjEaCRURGkPLpxGS1WulwD+xXjbO4iY6O1gy5iMgFGNIy4P/7f/8vdrv9U+9PS0vj3XffveCgZHQ5nU76+h10uQf2qcZaPJpZFREZQcqnE5PNZqPTNfDRKi7IQ0yMmiuJiFyIIc2sLlu2jCuvvPJT7w8PD2f58uUXHNREcOONNzJlyhRuuummQIdyVjabDZ+zm58F/Ya7zK8RE+RXJ2ARkRGkfHpuxlMuhRMzqwPFamyQBn5FRC7UsB5dIx/71re+xe9///tAh3FOrFYrIY5WbjK9z82m94mKisRo1F8NEREJrPGUS2Egn3a6T55ZjQlsQCIi45wqkhGyYsUKIiMjAx3GObFarUS4BzoBNxlnKLmKiMiYMJ5yqc/no8vWg9VjAjSzKiIyHMZUsfqTn/yE+fPnExkZyfTp07nhhhuora0d1ud4//33ufbaa4mPj8dgMPDyyy+f8XFr164lJSWFkJAQFi5cyEcffTSscYwlNpuNmOPH1nQYpyu5ioiMY8qlgdHd3U2H2wQYCDb6CDf5NPgrInKBxlSx+t5773HPPfewdetW3n77bdxuN5dffvmnNqHYvHkzbrf7tNurq6tpaWk548/Y7XYKCgpYu3btp8bx7LPPsmbNGh588EHKy8spKCjgiiuuoLW1dfAxhYWF5ObmnvbV2Ng4xN868KxWK9P9A/+/eoOmKbmKiIxjyqWBYbVa6TipuVJYWCgWiyXAUYmIjG9D6gZ8smPHjhEfH4/RaDzlzxfijTfeOOX7J554gunTp1NWVsbFF198yn0+n4977rmH9PR0nnnmGUymgWU3tbW1rFy5kjVr1vBP//RPpz3HVVddxVVXXfWZcfziF7/grrvu4o477gBg3bp1vPbaazz22GN897vfBaCysvJ8f80xxe/3093dTaK/GQzgCI5TsSoiMoqGO58qlwaG9quKiAy/886G2dnZHDp06LQ/DyebzQZAbGzsafcZjUZef/11KioquO222/D5fBw8eJCVK1dyww03nDG5nguXy0VZWRmrVq065blWrVrFli1bzu8X+Qxr164lOzub+fPnD/u1z0VPTw9up52phm4AfMGxWgYsIjKKRjqfToZcCoHPpzabbfCM1dggt3KpiMgwOO9i9eTDykfi4HKfz8d9993H0qVLyc3NPeNj4uPjeeedd9i0aRO33norK1euZNWqVfz6178+7+dtb2/H6/UyY8aMU26fMWMGzc3N53ydVatWcfPNN/P666+TmJj4qcn5nnvuobq6mu3bt593zBfCZrOBw4bPb6DVH0NoeBShoaEBiUVEZDIayXw6WXIpBD6famZVRGT4nfcy4JF2zz33sHv3bjZt2vSZj5s9ezZPPvkky5cvJzU1lUcffRSDwTBKUX669evXBzqEc2K1WtnjTyHL+TiFIa18WSPBIiIThnLp6LFabXS4pwAQa1GxKiIyHMZUg6UT7r33Xv7yl7/w7rvvkpiY+JmPbWlp4e677+baa6+lr6+Pb3/72xf03FOnTsVkMp3WVKKlpYWZM2de0LXHooEDzINwYsEVNEXJVURkglAuHT0Oh4MOuwunzwj4iTXr2BoRkeEwpopVv9/Pvffey0svvcQ777zDnDlzPvPx7e3tXHrppWRlZfHiiy+yYcMGnn32Wf7xH//xvGOwWCyUlJSwYcOGwdt8Ph8bNmxg8eLF533dsWpgj82JZUtuFasiIuOccunos9lsg0uAY8xeLGbjuDkfVkRkLBtTy4DvuecennrqKV555RUiIyMH97VER0efto/S5/Nx1VVXkZyczLPPPovZbCY7O5u3336blStXkpCQcMaR4d7eXg4cODD4fX19PZWVlcTGxjJ79mwA1qxZw+rVqyktLWXBggU8/PDD2O32wY6GE4nVauWb7qfpNZupNy0nOnpJoEMSEZELoFw6+gZWKQ18pIoN8hAVFXXBJySIiMgYK1ZPNHNYsWLFKbc//vjj3H777afcZjQa+bd/+zeWLVt2yjlmBQUFrF+/nmnTpp3xOXbs2MEll1wy+P2aNWsAWL16NU888QQAt9xyC21tbTzwwAM0NzdTWFjIG2+8cVqjiPHO5XJh7+3lZsM2gs1u1gUt1cyqiMg4p1w6+k5dpeQhJmZKgCMSEZkYxlSxOtQuiJdddtkZby8qKvrUn1mxYsU5Pc+9997LvffeO6R4xhubzQauboINbpx+M8bgaKKiogIdloiIXADl0tE30Al44NiaOIuOrRERGS7nvUble9/73uCZbSf/WcYPm82G2dkBwDGmExUdPXggvIiIjA7l0/HParXS4fp4GbBWKYmIDI/znlm9//77z/hnGT+sVith7nYAmgwzNRIsIhIAyqfjm8/no8vWjdUz0OU4LkidgEVEhot2/09iVquVKZ42ADpM0zUSLCIiMkS9vb10OI34MWAx+Igw+ZRPRUSGiYrVScxmszHN1wpAd9BUjQSLiIgM0Sc7AYeEBBMSEhLgqEREJgYVq5OU3+/HZrMR5HMC4AiaqpFgERGRITq5WI2zaL+qiMhwGnKxevjwYd56663Bc9s+qbGx8YKDkpFnt9vpc3m5zvUvZDkewxE6SwlWRGQUKZ9ODDabjU7XycfWxAQ2IBGRCWRIxerTTz9NWloaV155JampqTz55JMAHDlyhJ/+9KcsXLhw8DBwGdsG2uwf769lDCIiNJiwsLDABiUiMkkon04cn1wGrC01IiLDZ0jF6o9//GO++c1vsmvXLi677DL+9m//lh/84AfMnTuXJ554gtLSUp577rmRilWG0ScPMFdyFREZPcqnE4fNZvv4jNUgt2ZWRUSG0ZCOrjl48CDf+ta3SE5OZu3atcyePZvNmzezc+dOsrKyRipGGQFWq5XSvve4JWgPW82LiYm5JtAhiYhMGsqnE4PL5aK9x0G/bwoAsUFeFasiIsNoSDOrbreb0NBQABITEwkJCeHnP/+5Eus4ZLPZSPIeZompmgRjp5KriMgoUj6dGE5epRRl9mAxQVRUVICjEhGZOIbcYOmpp56ipqYGAJPJxJQpU4Y9KBl5VquVmb4WAOxB01SsioiMMuXT8c9qtdJxUnOlyMhIjEYdtCAiMlyG9I66bNkyHnzwQXJycpg6dSoOh4P/9//+H3/605+orq7G4/GMVJwyjDweDz3dPSQx0IHSZYnTnlURkVGkfDoxDOxX/bi5kgZ+RUSG15D2rL733nsA7N+/n7KyMsrLyykvL+f3v/89VqsVi8XCvHnz2Llz54gEK8PDZrPhd/cQbnDi9pswhESrWBURGUXKpxPDKWesqlgVERl2QypWT0hPTyc9PZ0vfelLg7fV19ezY8cOKioqhi04GRk2mw2zsxOABqYRGRWN2XxefxVEROQCKJ+Ob58sVjXwKyIyvM65Qjly5Mhnnvk2Z84c5syZw8033wxAQ0MDCQkJFx6hDDur1UqYqx2ARsMMjQSLiIwi5dOJwe/302XrxuqeDkCcRTOrIiLD7Zz3rM6fP5+vf/3rbN++/VMfY7PZ+O1vf0tubi4vvPDCsAQow89qtdLvNdDqj6HdNF0jwSIio0j5dGKw2+2094MPA0EGH5Emr/KpiMgwO+eZ1erqav71X/+Vyy67jJCQEEpKSoiPjyckJISuri6qq6vZs2cPxcXF/OxnP+Pqq68eybjlAthsNv7ou5wfO6/j6ogO7tFIsIjIqFE+nRisVuspzZWCgy2EhYUFOCoRkYnlnGdW4+Li+MUvfkFTUxOPPPII6enptLe3s3//fgC+8pWvUFZWxpYtW5RYx7ju7m66jifYKRafRoJFREaR8unE0N3djdVjAiDGrFlVEZGRMOSuOqGhodx0003cdNNNIxGPjDCPx4PD4aT7eIKNNnuJiIgIcFQiIpOP8un41tvbS8/xXBpl9hIZGRPYgEREJqBhObm6vLx8OC4jo8But+P39LHBsoangv6FSJOb8PDwQIclIiIon44ndrudHu9AsRpp9iqXioiMgGEpVhcsWMCaNWtOue31118fjkvLMLPb7RhdPaQYW0g3NhAaEkJQUFCgwxIREZRPxxO73T64SilKxaqIyIgYlmI1Ly+PqKgo7rjjjsHbvv/97w/HpWWY9fb2YnZ3A9BGrJYAi4iMIcqn44fdbh9cBhypLTUiIiNiWIpVg8HAD3/4QwoKCrjppptwu934/f7huLQMM7vdTrB3oFjtMsRoJFhEZAxRPh0/ens/LlajTJpZFREZCUNusHQmUVFRANx3331MmTKF6667jv7+/uG4tAwzu91OuMcGgM0YQ4SSq4jImKF8Oj44nU66XT68GAA/EVoGLCIyIoY0s9rX13fG2zdu3Dj459WrV3P33XfT2tp6QYHJyLDb7UT5rAN/NkVr2ZKISAAon45vJy8BDjf5MBnQGasiIiNgSMVqdHQ07e3tZ33cjTfeSGdn53kHJSPHbrcT4+8CoN8UrZFgEZEAUD4d33p7e09prhQWFobROCw7q0RE5CRDemf1er34fL7B75ctW0ZLS8uwByUjp7e3lw5/JM3+KTjNUSpWRUQCQPl0fDuluZL2q4qIjJgL2rNaWVmJ3W4frlhkhHm9Xvr7Hfyt61t4/Eb+dnqzEqyIyBigfDq+nHzG6sCxNVEBjkhEZGLSmpVJxG634/AZ8PgHXnaNBouIiAzdycuAdWyNiMjIGXKx+tRTT1FeXo7b7R6JeGQEnbxsKdToJTQ4CIvFEuCoREQmJ+XT8ctut5+yZ1UDvyIiI2NIy4CXLVvGgw8+SE9PD0FBQXg8Hh588EGWLVtGUVER+fn5BAcHj1SscoHsdjszHPt4z/ITKgyZuMK/GuiQREQmJeXT8W1g8Hfg9dEqJRGRkTOkYvW9994DYP/+/ZSVlVFeXk55eTnf/e53sVqtmM1msrKyqKqqGpFg5cL09vYS5rGSbGylkVl0admSiEhAKJ+Obz09vfR4B46qidTMqojIiDmvBkvp6emkp6fzpS99afC2+vp6duzYQUVFxbAFJ8PLbrcT6rEBYDPGKLmKiASY8un443K56HH58PgNgIpVEZGRdEHdgAH27dtHamoqc+bMYc6cOdx8883DEZeMALvdTpRvoFjtMUYzVclVRGTMUD4dHwaWAA+0/AgzeTEbULEqIjJCLrgbcFZWFnV1dcMRi4wwu91OtN8KgMMcreQqIjKGKJ+OD6ccW2PyEhoaislkCnBUIiIT0wUXq36/fzjikFFgt9uJ83cB4DRHqVgVERlDlE/Hh08eW6NcKiIycnTO6iTh8/mw2/uYTicA3qAonQsnIiIyRCcfW6NiVURkZKlYnSTsdjsen4cD/gRa/DH4gyKUYEVERIbo5DPLo3RsjYjIiLrgBksyPtjtdqzeEG5w/ZgQo49/CmnTGX4iIiJD1NvbO7hnNdLs1SolEZERpJnVSeLkkWAtWxIRETk/Jy8DjlI+FREZUSpWJ4lTkquWLYmIiJyX3l4N/oqIjBYVq5NEb28vyx1v857lPr5qeF3LlkRERIbI7XbT43Dj9g98fIrU4K+IyIi64GL1O9/5DnFxccMRi4wgu93OFG8HycZWIo1OJVcRkTFG+XTss9vtdB/frxpq9BJkRPlURGQEXXCDpZ/85CfDEYeMMLvdzqzjZ6z264xVEZExR/l07Ptk/4fg4GDMZvWqFBEZKVoGPEnY7Xbi/FYAXCYVqyIiIkN1anMln3KpiMgIU7E6Cfh8Pvr6+phGJwCeIBWrIiIiQ9Xb2/vxzKrJo/4PIiIjTMXqJNDX14fP7STa0AeAzxKpBCsiIjJEdrt98IxVHVsjIjLyVKxOAna7HVw9APT6QwgKDiMkJCTAUYmIiIwvJy8DjtQyYBGREaeuAJOA3W7H4fVT4UvDYwhSchURETkPvb29dHsGPjpFmr1apSQiMsJUrE4Cdrud/czml66HmBPqYE24JdAhiYiIjDsD3YBjAYjSGasiIiNOy4AngVO7Fyq5ioiIDJXH46G734XLP/DRKVL5VERkxKlYnQRO7V6oZUsiIiJDdfLAb4jRh8XoV7EqIjLCtAx4ErDb7axxr2O25SivcyPh4fmBDklERGRcGVgCfKK5kheLxUJQUFCAoxIRmdg0szoJ2O12ZvhbSTa2EmwyaCRYRERkiE4uVrVfVURkdKhYneD8fj99fX1MowsAd1CkEqyIiMgQ2e12ur0fz6wql4qIjDwVqxNcf38/HreTKYbegRtUrIqIiAzZKf0fdGyNiMioULE6wfX29mJw9QBg9wdjDAojNDQ0wFGJiIiML6d01tcyYBGRUaFidYKz2+2Y3APFaiuxhEeEYzAYAhyViIjI+PLJBksqVkVERp6K1QnObrcT7OkGoNMQo2VLIiIi56G3t5cer84sFxEZTSpWJzi73Y7VF0KFL40jhkQlVxERkSHyer109zlx+AY+NmlmVURkdOic1QnObrfzLqX8p2sFS2K6+XslVxERkSE5eQlwsMFHsNGvlUoiIqNAM6sT3MndC6PUvVBERGTITm6uFGn2YjabsVgsAY5KRGTiU7E6wQ2MBh9ftmTyadmSiIjIENnt9sH9qjq2RkRk9GgZ8ATm9/ux2+28ZPhn3BYjrxruVrEqIiIyRKccW6P9qiIio0bF6gTmcDjweFzMMnSAAcxBwUqwIiIiQ3TKsTU6Y1VEZNRoGfAEZrfbMbh6AXD4gzCaQwkLCwtwVCIiIuPLJ4+t0TJgEZHRoWJ1Auvt7cXo6gGglVjCI8IxGAwBjkpERGR8GVgGrGNrRERGm4rVCcxut2PxdgPQbpii5CoiInIeTlkGrGJVRGTUqFidwPr7+wnxDMys2gzRSq4iIiJD5Pf76bX30e8bKFbD1VlfRGTUqFidwBwOByE+OwD9hnBCQkICHJGIiMj44nK5cPg+/rgUYvQpn4qIjBIVqxOY0+mkxT+FMl86babpBAcHBzokERGRccXpdOLwDfR7sBh8mAwon4qIjBIVqxOY0+nkRcOlfMH1IzZbLtZIsIiIyBA5HA76vQMfl0JNPkwmE2azTv4TERkNKlYnsIHR4I8TrEaCRUREhubkXBpiVC4VERlNKlYnMKfTOTgarAQrIiIydCfn0lCT9quKiIwmrWOZwBwOB08ZHiI0uJ+Xff9HxaqIiMgQORwO+k+sUjL6CA5WsSoiMlpUrE5QPp8Pl8vFDDqIMDgwmk0qVkVERIZIy4BFRAJHy4AnKJfLhd/nJcLgGLjBFKqlSyIiIkN06jJgv4pVEZFRpGJ1gnI6nfg8A4Wqz2/AYArGYrEEOCoREZHx5ZRmhZpZFREZVSpWJyin04nxeLHaTRhBFota7YuIiAzRKc0K1WBJRGRUqVidoBwOB0ZvPwDdhGskWERE5Dw4HA7NrIqIBIiK1QnK6XRiOl6s9qpYFREROS9Op5N+nwFQgyURkdGmdaETlNPppNcfTJkvnWbjLCVXERGR8zCwDDgUGDhnVflURGT0qFidoJxOJzsNWfzCtZjs8D7uU3IVEREZEr/fj8OhBksiIoGiZcAT1MCypROt9tUQQkREZKjcbjcOL/j5eBmw8qmIyOhRsTpBORyOwWJVe2xERESG7uSB3yCDD7MR5VMRkVGkZcATlNPp5Bvu35EbvJfXfdcSHJwV6JBERETGlZPPWA0x+jAajQQFBQU4KhGRyUMzqxOU0+lkit9KvKGTYM2sioiIDJnD4Rg8YzXU5FcuFREZZSpWJyin00m4vw8AtzFMCVZERGSITl4GrC01IiKjT8XqBOV0OonEDoDXFKqGECIiIkPkdDpxeNUJWEQkUFSsTkB+vx+n00kUvQD4TKFKsCIiIkP0yc76yqUiIqNLxeoE5Ha78Xm9RBsGlgH7g0KUYEVERIbokw2WtEpJRGR0qVidgBwOB36vc/B7gylYCVZERGSIBhosDZyxqplVEZHRp6NrJiCn04nH62WHbx4huDGZgzCb9VKLiIgMxckzq9qzKiIy+lTBTEBOp5M2pnCT64dEmz3835CeQIckIiIy7jidzsGja0JMWgYsIjLatAx4AtJIsIiIyIU7pcGS8qmIyKhTsToBfXIkWMlVRERk6DT4KyISWCpWJyCHw8EC5yY+DL6Xe3lWyVVEROQ89Pc7NPgrIhJAKlaH2Y033siUKVO46aabAhaD0+kkzNdDvKGTCINDyVVERMaVsZBLPR4PTq8fH8e7ARv9yqciIqNMxeow+9a3vsXvf//7gMbgdDoJ9vUD4DCEqSGEiIiMK2MhlzocjsH9qiaDH7PBr3wqIjLKVKwOsxUrVhAZGRnQGBwOB6H+PgCcxjCNBIuIyLgyFnKp0+nE4f14v6rRaCAoKCigMYmITDaTqlh9//33ufbaa4mPj8dgMPDyyy+f9pi1a9eSkpJCSEgICxcu5KOPPhr9QC+Q0+kk7Hix6jKFqlgVEZFhM5lyab9vYAlwyPHmSgaDIcBRiYhMLpOqWLXb7RQUFLB27doz3v/ss8+yZs0aHnzwQcrLyykoKOCKK66gtbV18DGFhYXk5uae9tXY2Dhav8ZZOZ1OIvx2ADxGFasiIjJ8JlMuPdFcKVTNlUREAsIc6ABG01VXXcVVV131qff/4he/4K677uKOO+4AYN26dbz22ms89thjfPe73wWgsrJyWGJxOp04nc7B77u7u4fluieuHYGKVRERGX5jKZfCyOVTnbEqIhJ4k2pm9bO4XC7KyspYtWrV4G1Go5FVq1axZcuWYX++n/zkJ0RHRw9+JSUlDdu1nU4nh/0zOOCLx2tWgyURERkdo51LYeTyqcPhGNyzGqJiVUQkIFSsHtfe3o7X62XGjBmn3D5jxgyam5vP+TqrVq3i5ptv5vXXXycxMfFTk/P999+PzWYb/Dp69OgFxX+C2+3G6/Vxu+ufWOX6OX2WaUqwIiIyKkY7l8LI5dNTZla1DFhEJCAm1TLg0bB+/fpzelxwcPCIJD6n04nTZ8DPqU0hRERExotzzaUwsvnU4ft4ZlWrlERERp+K1eOmTp2KyWSipaXllNtbWlqYOXNmgKIaupPPhQsy+AgyGbBYLAGOSmRkeL1e3G53oMOQCSooKAiTyRToMMaViZJL4Xg+VYMlGaOU/2S8uNBcqmL1OIvFQklJCRs2bOCGG24AwOfzsWHDBu69997ABjcETqeTaFcjW4L/hXp/PAeCvx7okERGRG9vL8eOHcPv9wc6FJmgDAYDiYmJREREBDqUcWOi5FI4dRlwiNGvYlXGDOU/GU8uNJdOqmK1t7eXAwcODH5fX19PZWUlsbGxzJ49mzVr1rB69WpKS0tZsGABDz/8MHa7fbCj4XjgdDoxe/qYZeikl3COKrnKBOT1ejl27BhhYWFMmzZNZx/KsPP7/bS1tXHs2DHS09M1w3qSyZBL4fgyYO/AxyR1A5axQvlPxpPhyKWTqljdsWMHl1xyyeD3a9asAWD16tU88cQT3HLLLbS1tfHAAw/Q3NxMYWEhb7zxxmmNIsYyp9OJ2dcHQI8hXMlVJiS3243f72fatGmEhoYGOhyZoKZNm8ahQ4dwu90qVk8yGXIpnJhZHdhGo2XAMlYo/8l4c6G5dFIVqytWrDjrkol777133C1VOpnT6cTi7QegDx1bIxObRpRlJOnv15lNhlwKJxosRQMDM6vKpzKW6P1JxosL/buqo2smGIfDgcV3vFjVzKqIiMiQeTwe+l0ePP7jnfU1syoiEhAqVicYp9NJiH9gGbDDGKrkKjKKfvjDH+JwOAIdhohcIJfLNXhsjRE/FoMaLIl8GuU+GUmTahnwZOB0Ogn12Qf+bNQyYJnY/H7/qCXI4ODgsy5l+dGPfsR999132r87j8eD2ay3W5Hx4uRj4EJMPgwGdAycjCljKf8p98lI0t+gCcbpdNLnj+aAL54eY7RGgmVCczqd/OlPfxqV57rttts+c/DnG9/4BgDLli3DZDIRHx/PzJkzOXDgAK2trdTU1GAwGOjq6iImJgYYOJNyx44dpKSksH//fu677z5aW1txOp3cfffd437Pn8h45XQ6Pz5j1ejDYrFgNGoxmowdYyX/KffJSNM77wTjdDr5b/8trHL9nN0hpSpWRUbJunXrAPjggw+orKxk+vTplJWV8dprr1FTU/OZP+v1evnyl7/Mf/7nf7J9+3a2bt3K//zP/7B9+/bRCF1EPmGgudLHxapyqciZKffJSNPM6gQzsHRp4NBdJViRwLr55puJjIw86+Nqa2vZs2cPX/rSlwZv6+npobq6mvnz549kiCJyBifPrKq5ksjQKPfJcFKxOsEMjAZHASpWRQItIiLilO9NJhNer3fw+xP7jfx+P7GxsVRWVo5meCLyKU6dWfWr/4PIECj3yXBSsTqBeDwePG4Pb5jW0GsK4V3D15RgZUILDg7mtttuG7XnOpvIyEhsNtvgvpxPSktLY9u2bVx99dW8+OKL2O0DzdAyMjKIiori8ccf54477gDgwIEDxMbGEhsbO2y/g4icG4fD8fHMqgZ+ZQwaS/lPuU9GkorVCcTpdILPTZKxDYD3jUFKsDKhGQyGMTUg8w//8A9cdtllhIWFER8ff9r9v/zlL/n7v/97vv/97/O5z32OuLg4AMxmM3/5y1+47777+OUvf4nX62Xq1Kk89dRTo/0riAjHlwGfmFnVMmAZg8ZS/lPuk5GkYjXA1q5dy9q1a09ZHnG+nE4nfu/A0gqnPwiMQWq1LzKKHnzwQR588MFPvf+qq65i//79g9//+Mc/Hvzz3Llz+fOf/zyi8YlMZMOdTwePrjH6xkxRIDIWKffJSFI34AC75557qK6uHpbOZ06nE6OnHwAb4YSEhpz1XEgREZGJYLjzqcOrmVURkUBTsTqBOBwOjN6BYrWHcCVXERGR8zAwszow2KtmhSIigaNidQJxOp2YTxSrBhWrIiIi58PhcAzOrKrBkohI4KhYnUCcTidBvj4A+ghTchURETkParAkIjI2qFidQJxOJ3ZfMPt9CbQZpqohhIiIyBD5fD76XW7cfjVYEhEJNBWrE4jD4WCDcQmXuf6Dpyw3ayRYRERkiE5urgR+Qox+5VMRkQBRsTqBOJ1OHD7tsREJhBdffJGSkhIKCwvJzMxk5cqV+Hy+wfvXrl1Lbm4uWVlZFBcX8+Uvf5kjR44AA+fl5eXlUVhYSGFhIQ888MAZn6Ovr4/S0lJ6enoA2Lp1K3l5eRQVFfHmm2+O/C95Bn/5y19YsWLFiFx73bp1/Md//AcAlZWVPPPMM+f0czt37uSqq64akZhk4jtlCbDRj8GA8qnIZ0hJSWH69Om43e7B2959910MBgP33XffWX9+48aNFBYWAmC1WvnpT396yv3/5//8H959990LjrGysnLIP9fU1MSiRYsG8/krr7xCVlYWhYWF7Nq164JiOl+PPPIIt99++4hc+4EHHuCPf/wjMPC6vPHGG+f0c3/5y1+4++67RyQmnbM6gTidTvrVal9k1DU1NXH33XdTVlZGcnIyAOXl5YNHRz344IO89dZbvPHGGyQmJgKwYcMGmpubmT17NgAffPABMTExn/k8jzzyCNdffz2RkZEA/O53v+PWW2/l/vvvP+2xHo8Hs3l8v8V/4xvfGPxzZWUlL7/8Ml/60pfO+nP5+fkEBwfzzjvvsHLlypEMUSagkwd+Q00+goKCMBo1ti/yWWbPns2rr77KF77wBQAeffRRSktLh3ydE8Xqd7/73cHb/vd//3fY4hyqH//4x9xzzz2D7wHr1q3jgQce4Mtf/vJpj50Iefehhx4a/PPGjRuxWq1ceeWVZ/25a665hgcffJD9+/eTnp4+rDHp3XcCcTqd3O/7NX+1fIdcX62KVZkU/H4/fS7PiH75/f7PjKGlpQWTyURsbOzgbcXFxRgMBux2Oz/72c949NFHBwtVgEsvvZQFCxYM6Xf9zW9+w6233grAT3/6U5599lkeeeQRCgsLsVqtpKSk8J3vfIcFCxawevVqent7ufPOO8nNzSU3N5cf/ehHg9dasWIF//AP/8DFF1/M7Nmz+cEPfsDrr7/ORRddREpKCr/4xS/OGIPb7ebv/u7vSE9PZ8GCBaeNdj/55JMsXLiQ4uJiLr74YqqqqgB44oknWLVqFV/+8pfJy8ujtLSUuro6APbv38/SpUspKCggLy+P73//+wD88Ic/5L777qO1tZUHHniAd999l8LCQr7xjW/w85///JRRXKvVytSpU+ns7ATgy1/+Mr/5zW+G9P9XBE4d+NUqJRnLxkL+O+GOO+7gscceA8Bms7F169ZTipwnnniCG264YfD7T1uV841vfIOenh4KCwsHi90VK1bw8ssvA3D77bdz5513smTJEubNm8fq1avp7x84CaO1tZXPf/7z5OXlkZub+6k5oLm5mS9+8YssWLDglJzzSQ6Hg2effXawAP/7v/97PvjgA773ve+xZMkSYGBl1IMPPsj8+fO5//77PzOGlJQUvv/977NkyRKSkpJYt24djz/+OIsXLyYlJeVTVw/19PRwyy23kJGRwUUXXXTajO7Pf/5zFixYQHFxMVdeeSWHDx8GBnLoLbfcwrXXXkt2djYrV64czJFbt24dXA2Wm5vLr3/968H/vw8//DCVlZWsW7eOP/7xjxQWFvLQQw9x77338m//9m+Dz1tbW0tSUhIejweAL37xiyMysDC+y385hdPpJMnfTJrxGJsNXjWEkEmh3+0l+4GRXQJb/dAVhFk+/e0yPz+fiy66iOTkZJYvX86SJUu49dZbSUhIYM+ePVgsFrKzsz/zOZYtW4bJZAIGitKFCxeecv/Ro0ex2WzMnTsXgO9+97vU1NRQWFh4yjKrjo4Otm3bhsFg4Dvf+Q5Op5OdO3fS39/PRRddRGZmJrfccgsAhw8f5t1336W7u5uUlBS6urr44IMPaGxsJCMjgzvvvPO02d7/+Z//oba2lj179gBwxRVXDN63efNmnn76ad5//32Cg4P54IMPuPXWWwcfu337diorK5kzZw7f/e53+fd//3d+85vf8Mgjj3DNNdcMzhCfSKYnTJ8+nYceeoiXX3558AOL1Wpl3rx5/OxnPyMmJobHH3+c66+/fnDAYPHixdxzzz2f+f9c5EwcDsfHM6sqVmUMGwv574SlS5fyq1/9isbGRl599VVuvvnmwZw2FOvWraOwsPAzl+xu27aNrVu3EhYWxg033MAvf/lLvve97/HNb36TjIwMXnzxRVpbWykpKaGgoIBFixad8vOrV6/me9/7HsuXL8fj8XDNNdfw3HPPcfPNN5/yuO3btzNnzhzCwsIA+K//+i927tzJfffdd0rhbTKZ2L59O8BgUflpMdjtdj788EMOHDhAXl4e//zP/8yWLVvYvn07V1999RlXDz300EMEBwdTU1NDd3c3ixYtGvyM8NRTT1FbW8uWLVswmUw8+eST/N3f/R2vvfba4P+rsrIy4uLi+NKXvsRvfvMb7r//fn7yk5/wj//4j4MzxF1dXac854mBYavVysMPPwwMFKdXXHEF3/nOdzCZTPzqV7/i7rvvHpxNXrx4MWvWrPnU1+18aWZ1AnE4HERiB8BnDlGCFRklRqORF154gQ8//JArr7ySzZs3k5OTw4EDB875Gh988AGVlZVUVlaeVqgCHDt2jBkzZpz1Orfffvvg8uP169dz1113YTQaCQ8P57bbbuPtt98efOxNN92EyWRiypQppKamcs0112AwGEhISGDatGkcOnTotOtv2LCB2267DYvFgsVi4c477xy875VXXqGqqoqFCxdSWFjIN7/5TTo7OwdHvRcvXsycOXMG/3zw4EEALr74Yn7729/yz//8z7z11ltnXQ4NEBMTw0033cRjjz2G3+/n17/+Nffee+/g/TNnzqSjowOHw3HWa4mc7JSZVW2pETlnX/3qV3niiSd47LHHTskNw+2LX/wikZGRmEwmvva1r7F+/XpgIOd9/etfBwYGOT//+c8P3neC3W5nw4YNfOtb3xqcvT1w4AC1tbWnPc+55t2Tf9ezxXBisDgtLY2QkBBuuukmAEpLS+ns7MRqtZ52/Q0bNvC1r30Ng8FAdHT04AorgJdffpn169cPzpL+7Gc/G+yHAXDllVcSFxcHnJp3L7nkEn784x/z0EMPsWnTJqZMmXLW3zMjI4Ps7GxeeeUV7HY7Tz/99CkrnGbOnMmxY8fOep2h0szqBOH1evF4PETTC4DPFKoEK5NCaJCJ6oeuOPsDL/A5zkVmZiaZmZl8/etf58orr+TVV1/l7rvvxuVyUV1dfdbZ1c8SFhZ2ToVXRETEp953oog94eTVFyaT6bTvTyzt+SwnX9Pv97N69epTlgl91vOduP4XvvAFlixZwttvv80jjzzCww8/zOuvv37W5/77v/97rrvuOrKyspg2bRpFRUWD9zkcDkwmExaL5azXETnZQIOlgb/XoTq2RsawsZT/AG677TaKi4uZN2/eafsWzWYzXq938PvhHEj8ZG77rNtPLGveunXrWf9tj2beNRgMGAyG88q7999//6c2N/q0vHvfffdx/fXXs379er73ve+Rm5vLr371q7M+97e+9S3+/d//nba2Ni677LJTinmHw0FoaOhZrzFUmlmdIJxOJz6vmxDD8U5s5hAlWJkUDAYDYRbziH59WiI8oaGhgc2bNw9+39XVRX19PXPnziUiIoJ//Md/5K677qKhoWHwMe+++y4fffTROf+eGRkZtLa2Ds5SnotVq1bx6KOP4vf7sdvtPPnkk1x++eXn/POfds0//OEPuN1uXC4Xjz/++OB91113HX/4wx8GR3V9Ph87duw46zX379/PjBkzuO222/jZz37G1q1bT3tMVFQUNpvtlNsyMzNJTU3l7rvvPmVWFWDv3r3k5uaqMY4MmTrry3gxFvLfyeLj4/nJT37Cv//7v592X1pa2uCWFI/Hw1NPPXXGa0RFRdHf34/L5frU53n++efp7e3F6/Xy+OOPs2rVKmAgP/32t78FoK2tjRdffJHLLrvslJ+NiIjgkksuOaXjcGNj4xlnBPPz88844/pZziWGoVq1ahWPP/44fr+f7u5unn766cH7brjhBtatWze4fcbtdlNRUXHWa9bW1jJnzhzuuusuvve9751z3r388stpbm7mX/7lX86YdwsKCs7nV/xMyuIThNPpxOAZGP1x+00YjBbNKIiMEo/Hw0MPPcS8efMoLCxk2bJlrF69muuvvx4Y2G/yxS9+kSuuuIKsrCyys7P57W9/y6xZs875OUJCQrj88st55513zvlnfvCDHxAUFEReXh4LFy7kuuuu44tf/OKQf7+T3XXXXaSnp5Odnc1FF100eNwADOy7/dnPfsaNN95IQUEBOTk553TczPPPPz94BM8tt9zCunXrTnvMpZdeitPpJD8//5QuwXfddRcej2dwKdUJb7zxxmm3iZwLh8Ohzvoi5+mOO+5g8eLFp92+aNEirr76anJzc1mxYsWndoyNjY3ltttuIz8//1O7Cc+fP38wn8bExAz2bfiv//ov9u7dS15eHpdccgn//M//fMZtNX/84x85cOAAubm55OXl8fnPf56Ojo7THjdnzhxmzJgx2HfhXJxrDEPxgx/8gP7+fjIzM7n66qu56KKLBu/7yle+wu23384ll1xCQUEBhYWF5/Q54ZFHHiEnJ4eioiK+//3v85//+Z+nPebGG2+ksrJysMESDAyQfO1rX2P69Omnvc4jlXcN/nNt8yUjqru7m+joaGw2G1FRUUP++ebmZl555n/5uvU/aPdH8Zc5Px6xM5hEAs3hcFBfX8+cOXMm1QqCjz76iIceeoi//OUvgQ5lzLj33nuZMWMGP/jBDwZvc7lclJaW8s477zB16tTzvvaZ/p5d6Hu1jLwLfY1ef/11fra9n0P9IVw3rZOvrcofkdkCkfMxWfPfCbfffvtpjQVH0nPPPcfGjRtZu3btqDzfeHDNNddwyy238NWvfnXwtvb2dlauXMmOHTtOmyz7tL+z5/perZnVCcLpdOL2wn5fAkeZqZFgkQlowYIFfP7zn6enpyfQoQRcY2MjmZmZlJeXn/ahpb6+np/+9KcXVKjK5OV0OnGowZKIADfffDNZWVn4fL5AhxJwO3bsIC0tDaPReEqTJ4CDBw+ybt26EVnVqQZLE4TT6aTeOJvLXP9BQrCTf1BuFZmQRrLD4ngSHx9PTU3NGe/LyMggIyNjlCOSiWKgwdJAkxA1WBIZW5544olRf85P7s2crE50Tj6TC13q/Fk0sxpga9euJTs7m/nz51/QdU7dY+PXSLCIiMh5cDgcH8+sGpVPRUQCScVqgN1zzz1UV1cPHiZ8vtS9UEREJrPhGPz1+/30O104/WqwJCIyFqhYnSCcTieXud7iDct3uNG/XsuWRERkUhmOwd+TB35Bg78iIoGmYnWCcDqdxPo6yDQeJdpgV3IVEREZopObKwUbfRgNKJ+KiASQitUJwul0EuazA+Ayhim5ioiIDNFAc6XjS4CNPkwmE2azelGKiASKitUJwuFwEEYfAO7/3969B0V13m8Afw4riMiCkAhVAZcExcsuLlcFwUvES40djYJWTUFMjKaYaLW/Ro1CgplI60xrHYnS1mBicWS0Gq1twUtE0XhBLCMxk8zQQNUgl7bA4iogsL8/KKcSLi5y4JwDz2eGP/Z29ruvuA/fc97zHs0gNqtEvUyn08HNzQ2PHz8W7zt//jwEQbDqenDZ2dkwGo0AgKqqKiQnJ7d6/PXXX8f58+e7XWN+fn6XX3f//n1MmjRJXLr/xIkTGDt2LIxGIwoKCrpVk7Wqqqrw6quvQq/Xw8/PD3q9HocOHRIf/8c//oGoqCh4e3sjMDAQISEh+MMf/gAAeO+99zB06FAYjUbxp6SkBGVlZQgJCUFDQ0OvfAZSvuZpwAIATgEmstaxY8cQGBgIo9GIMWPG4KWXXmp1qZeUlBTo9XqMHTsWAQEBWLp0Ke7cuQMAEAQBBoNB/G5OSEho9z0ePnyIoKAg8dJtV69ehcFggL+/P7Kysnr+Q6I5pwVBwLp161rdHxsbC0EQrMrXFStWYNeuXeL2MjMzxcdKSkoQERHR7Rpb/pbojJryj7sL+4i6ujo4WsyAADTYsFklkoOXlxdOnjyJRYsWAQD279+PoKCgLm+npVndtGmTeF9L4yWH7du3Iz4+HjY2zfs39+3bh4SEBCxdurTNcxsaGnrkSNTWrVsxdOhQFBQUQBAE1NTUoLS0FABQWlqK8PBwJCUl4ejRowCAyspKZGRkiK9fvny5+AfCk8LCwvDpp5/ykkAE4L9HVhv/t7gS138g6tz9+/fxxhtvIC8vDyNHjgQA3Lx5E4LQvNMnMTERp0+fRmZmJjw8PAAA586dQ2lpKby8vAAAOTk5GDJkSKfvs2fPHsyfPx9arRYA8Mknn2DZsmXYvHlzm+f2VA4BwKhRo/DnP/8ZO3fuhJ2dHUwmEy5fvowRI0Z0eVvZ2dmoqqrCnDlzADRfki0nJ0fqktvl7u6umvzjkdU+oq6uDlo0TwNu1AxiwFL/U2/u+OdxbRee++iZS4iLi8PHH38MAKiursbVq1fFEAKarw+3YMEC8fapU6cwbdq0NttZs2YNampqYDQaxWZ32rRp+OyzzwA075lduXIlwsLCMHr0aMTGxuLRo+a6y8vLsXDhQhgMBuj1eqSmprZba2lpKRYvXoyQkBAYDAZs3bq13efV1tYiIyNDbMDffvtt5OTkYMuWLQgLCwPQvGc8MTERwcHB2Lx5c6c16HQ6bN26FWFhYfD09MS+ffuQlpaG0NBQ6HQ6HD58uN067t27h2HDhol/AGm1WowaNQpA8177iIgIrFq1Sny+i4sL1qxZ0+62nrR06dIOx4j6n9raWnEaMI+skmrImH9lZWXQaDRwdXUV7wsICIAgCDCbzfjVr36F/fv3i40qAMyYMQMhISFdep/U1FQsW7YMAJCcnIyMjAzs2bMHRqMRVVVV0Ol0eOeddxASEoLY2Fg8ePAAK1euhF6vh16vx/vvvy9ua9q0adi4cSOmTJkCLy8vbNu2DX/9618RHh4OnU6HX//61x3W4eDggBkzZuDEiRMAgMOHD2PRokWtmuMn8xoAoqKi2lwfNj8/H/v27UN6ejqMRiOSkpJQXFzcqmkXBAFbt26Fv78/Ro8ejfT0dPGxrKwsBAQEwM/PD1OnTsVXX33Vbr1ZWVkIDw8XZxw9OUNLLfnHI6t9QFNTE+rr6+H032bVMsCeAUv9z4fDO35s1Cxg+ZH/3d7pAzx+2P5zR4YDcX95phImT56Mjz76CCUlJTh58iSio6Oh0Wi6vJ19+/bBaDR2OqXo2rVruHr1KhwcHLBgwQL85je/wZYtW/DWW2/B19cXx44dQ3l5OQIDAzFhwgRMmjSp1etjY2OxZcsWTJ06FQ0NDZg3bx6OHDmC6OjoVs/Lzc2Ft7c3HBwcAAC7d+/GrVu3sH79+laNt0ajEVdhXbJkSac1mM1mfPHFFygsLITBYMC7776LK1euIDc3F3PnzsWPf/zjNp933bp1iIqKQkZGBkJDQzFnzhzMmzcPAJCXl4eZM2d2Oqbp6enIzs4GAPj7+yMtLQ0AEBgYiFu3bsFkMsHJyanTbVDf9+QCS7xsDamGjPnn5+eH8PBwjBw5ElOnTkVYWBiWLVuGESNG4Pbt27Czs8O4ceM63UZERISYlampqZg4cWKrx+/evYvq6mq8+OKLAIBNmzbh66+/htFobHWazb///W9cu3YNgiDgnXfeQV1dHW7duoVHjx4hPDwcY8aMwZIlSwAA//znP3H+/HmYTCbodDpUVlYiJycHJSUl8PX1xcqVKzs82hsXF4ft27cjOjoaaWlpOHDgQKuZPNYwGo1Ys2YNqqqqxFk/xcXFbZ4nCAL+/ve/49tvv0VQUBAmT54MBwcHLFu2DNnZ2TAYDEhPT0dUVBRu377d6rXffvst3nvvPWRlZcHJyQmFhYWIiIhAcXExBg4cqJr845HVPqC+vh5NTU24b3kOFRZnWDRsVonk8pOf/AQHDhzAxx9/3KNTaxYvXgytVguNRoPXXnsNZ8+eBQCcPXsWq1evBgC4ublh4cKF4mMtzGYzzp07h3Xr1olHbwsLC/HNN9+0eZ979+7B3d39qfU8+VmfVkPLHws+Pj6wt7dHVFQUACAoKAj/+c9/UFVV1Wb706dPx507d7B9+3YMGTIEq1evRnx8/FPrarF8+XLk5+cjPz9fbFQBYMCAAXBxcUFJSYnV26K+6/sLLHGWElHnbGxs8Kc//QlffPEF5syZg8uXL2P8+PEoLCy0ehs5OTni9/P3G1XA+hxasWKFOPvm7NmzWLVqFWxsbDB48GDExMTgzJkz4nOjoqKg0Wjg4uKCF154AfPmzYMgCBgxYgSGDh3abuPYIiwsDHfu3EFWVhY0Gg18fX2t/qxd9frrrwMAXnjhBUyZMgUXL17EtWvXYDAYYDAYADTnW0lJCb777rtWr83MzERhYSGmTJkCo9GIqKgo2NjYiOcLqyX/eGS1D6itrUWtZQAWNe1AXaMNNgy4z2aV+p8tnXzZCt87uvl/nYSo0L19eDExMQgICMDo0aPFaaotBgwYgMbGRvF2bW3t91/+zFoC2pr7LRYLgOYFKp72x7iDg4NVdTo6Olpd25PvqdFoxNuCIEAQhA4XfBg8eDDmzp2LuXPnYt68eZg1axZSUlIQGBiIK1eu4Gc/+9lT62xPbW0tBg0a9Eyvpb6lrq4OU11NCHZ+ADvBwiwldVBA/o0ZMwZjxozB6tWrMWfOHJw8eRJvvPEG6uvr8dVXXz316GpnejOHWm4/beGhmJgYvPrqq20WQwTkyfr2WCwWzJw5s9VihN+nhvzjkdU+QKPRwDDaG8lhtkgOaYCrq8szTT0kUjW7wR3/2Np34bnd+9IePnw4duzYgV/+8pdtHvPx8RGnJDU0NHQYIE5OTnj06BHq6+s7fJ+jR4/iwYMHaGxsRFpaGiIjIwEAkZGR+P3vfw8AqKiowLFjx9pMkXV0dMT06dNbhWxJSQnu3bvX5n38/PzaPeLaGWtq6KrTp0+jsrJSvJ2XlydOCfvpT3+KCxcutDpiWlVVZdW5OGVlZRAEAZ6ent2qj/oGW1tbPKd1gNsgAY4DOA2YVELG/Pvuu+9w+fJl8XZlZSWKiorw4osvwtHRET//+c+xatWqVkf9zp8/j+vXr1v9Hr6+vigvLxfXZrBGZGQk9u/fD4vFArPZjIMHD2LWrFlWv/5p4uLisHHjRnGm0JN8fHxw7do1AEBRUREuXbrU7jacnJxQXV3d6fu05FpxcTFycnIQERGBSZMmoaCgAF9++SWA5vNmR4wY0WaRp9mzZ+Ps2bO4deuWeN+T466W/OOR1T5Aq9VixowZcpdBRP8VFxfX7v2TJk3C3LlzodfrMWzYMEyePFkMtCe5uroiJiYGfn5+cHR0xI0bN9o8Jzg4GLNnz0ZFRQVCQ0PF83Z2796NN998EwaDARaLBe+++26706rS09OxYcMG6PV6CIKAwYMHIzU1tdUiGADg7e0Nd3d33L59G+PHj7fq81tbQ1cUFBRg48aNsFgssLGxwbBhw/DHP/4RADBs2DBcunQJmzZtQlJSErRaLWxtba2aJpyZmYlXXnlFXOmY+rfw8HCEh4cDgCou6UAkt4aGBiQlJaGoqAgODg5oaGhAbGws5s+fDwBISkrC888/j9mzZ6OxsRGCIMBoNLa7Q7cj9vb2mDVrFj7//HO8/PLLVr1m27ZtePvtt8WpstHR0Vi8eHHXP2AH3NzcWq3Y/6Rf/OIXWLJkCQwGA8aPH99h/r3yyis4ePAgjEYjFi5ciJiYmDbPaWxshL+/P8xmM3bv3g2dTgegOcNjYmLQ0NAAFxcXHDlypM1RVx8fHxw6dAirV6/Gw4cPUV9fD39/f3FHuVryT7C0zAcjWZlMJjg7O6O6ulrRJzkTKUFtbS2Kiorg7e3dL88pW7FiRZuFJXrSkSNHkJ2djZSUlF55v94UERGB3/3udxg7dmybx9r7PeN3tfLx34j6sv6af9evX0dSUhJOnToldym9RhAEVFZWPvWyPs+qs/yTUke/s9Z+V/PIKhERdSo6OhplZWVoampS/B7YrigrK8Obb77Z40FNRETdExISgoULF6Kmpka81io9OzXlH5tVIiKV+f712nrD2rVre/09e5q7u7t43T4iIlK2nlxhX4l6cvKrmvKv7+wiJyIiIiIioj6DzSoRqRZPuaeexN8vIlIqfj+RWnT3d5XTgIlIdWxtbSEIAioqKjB06NAuXXeMyBoWiwUVFRUQBAG2trZyl0NEBID5R+oiRZayWSUi1dFoNPDw8MC9e/dQXFwsdznURwmCAA8PD163mogUg/lHatPdLGWzSkSq5OjoiFGjRuHx48dyl0J9lK2tLRtVIlIc5h+pSXezlM0qEamWRqNhM0FERP0O84/6Cy6wJLOUlBSMGzcOwcHBcpdCRESkWsxTIqK+R7BwOTFFMJlMcHZ2RnV1NZycnOQuh4iI2sHvauXjvxERkfJZ+13NacAK0bLPwGQyyVwJERF1pOU72mQyQavVciVOBWKeEhEpX8t39NOOm7JZVYiamhoAgKenp8yVEBHR03h6evLInUIxT4mI1KOmpgbOzs4dPs5pwArR1NSEkpKSTvfUm0wmeHp64u7du/wDSQIcT+lxTKXF8ZRed8fUYrGgpqYGWq0WTk5OPLKqQE/LU/6/kh7HVFocT+lxTKUlxXi25Onw4cNhY9PxMko8sqoQNjY28PDwsOq5Tk5O/I8mIY6n9Dim0uJ4Sq87Y9rZHmCSn7V5yv9X0uOYSovjKT2OqbS6O57W5ClXAyYiIiIiIiLFYbNKREREREREisNmVUUGDhyIxMREDBw4UO5S+gSOp/Q4ptLieEqPY0r8HZAex1RaHE/pcUyl1ZvjyQWWiIiIiIiISHF4ZJWIiIiIiIgUh80qERERERERKQ6bVSIiIiIiIlIcNqsqkZKSAp1OB3t7e0ycOBHXr1+XuyTVunjxIn70ox9h+PDhEAQBn332mdwlqdqOHTsQHBwMrVYLNzc3LFiwAN98843cZana3r174efnJ16/LDQ0FH/729/kLqvPSE5OhiAIWL9+vdylkAyYp9JhnkqLeSo95mnP6o08ZbOqAhkZGdiwYQMSExNx8+ZNTJgwAbNnz0Z5ebncpamS2WzGhAkTkJKSIncpfcKFCxcQHx+Pq1ev4syZM3j8+DFmzZoFs9ksd2mq5eHhgeTkZOTl5eHGjRt46aWXMH/+fNy+fVvu0lQvNzcXqamp8PPzk7sUkgHzVFrMU2kxT6XHPO05vZWnXA1YBSZOnIjg4GDs2bMHANDU1ARPT0+89dZb2LRpk8zVqZsgCDh+/DgWLFggdyl9RkVFBdzc3HDhwgVMmTJF7nL6DFdXV+zcuROvvfaa3KWo1oMHDxAQEICPPvoIH3zwAYxGI3bt2iV3WdSLmKc9h3kqPeZpz2Cedl9v5imPrCpcfX098vLyEBkZKd5nY2ODyMhIXLlyRcbKiNpXXV0NoDkMqPsaGxtx+PBhmM1mhIaGyl2OqsXHx+Pll19u9X1K/QfzlNSGeSot5ql0ejNPB/T4O1C3/Otf/0JjYyPc3d1b3e/u7o6vv/5apqqI2tfU1IT169dj8uTJ0Ov1cpejagUFBQgNDUVtbS0cHR1x/PhxjBs3Tu6yVOvw4cO4efMmcnNz5S6FZMI8JTVhnkqHeSqt3s5TNqtEJJn4+Hh8+eWXuHTpktylqJ6vry/y8/NRXV2No0ePIjY2FhcuXGDAPoO7d+9i3bp1OHPmDOzt7eUuh4joqZin0mGeSkeOPGWzqnDPP/88NBoNysrKWt1fVlaGH/zgBzJVRdTW2rVrcerUKVy8eBEeHh5yl6N6dnZ28PHxAQAEBgYiNzcXv/3tb5GamipzZeqTl5eH8vJyBAQEiPc1Njbi4sWL2LNnD+rq6qDRaGSskHoD85TUgnkqLeapdOTIU56zqnB2dnYIDAzEuXPnxPuamppw7tw5zrcnRbBYLFi7di2OHz+Ozz//HN7e3nKX1Cc1NTWhrq5O7jJUacaMGSgoKEB+fr74ExQUhOXLlyM/P5+Naj/BPCWlY572Dubps5MjT3lkVQU2bNiA2NhYBAUFISQkBLt27YLZbEZcXJzcpanSgwcPUFhYKN4uKipCfn4+XF1d4eXlJWNl6hQfH49Dhw7hxIkT0Gq1KC0tBQA4Oztj0KBBMlenTps3b8YPf/hDeHl5oaamBocOHUJ2djaysrLkLk2VtFptm3O+Bg8ejOeee47ngvUzzFNpMU+lxTyVHvNUWnLkKZtVFViyZAkqKiqQkJCA0tJSGI1GZGZmtlkkgqxz48YNTJ8+Xby9YcMGAEBsbCwOHDggU1XqtXfvXgDAtGnTWt2flpaGFStW9H5BfUB5eTliYmJw//59ODs7w8/PD1lZWZg5c6bcpRGpGvNUWsxTaTFPpcc8VT9eZ5WIiIiIiIgUh+esEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYiIiIiIiBSHzSoREREREREpDptVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYgk9+GHH0IQhDY/u3btkrs0IiIi1WCeUn8nWCwWi9xFEFHfUlNTA7PZLN5OSEjA6dOncenSJXh4eMhYGRERkXowT6m/GyB3AUTU92i1Wmi1WgDAtm3bcPr0aWRnZzNYiYiIuoB5Sv0dpwETUY9JSEjAwYMHkZ2dDZ1OJ3c5REREqsQ8pf6KzSoR9YjExER8+umnDFYiIqJuYJ5Sf8ZmlYgkl5iYiE8++YTBSkRE1A3MU+rveM4qEUnqgw8+wN69e3Hy5EnY29ujtLQUAODi4oKBAwfKXB0REZE6ME+JuBowEUnIYrFgyJAhMJlMbR67fv06goODZaiKiIhIXZinRM3YrBIREREREZHi8JxVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeKwWSUiIiIiIiLFYbNKREREREREisNmlYiIiIiIiBSHzSoREREREREpDptVIiIiIiIiUhw2q0RERERERKQ4bFaJiIiIiIhIcdisEhERERERkeL8P5e40Z30LJl2AAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6sAAAGGCAYAAACdTxdEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmu5JREFUeJzs3Xl8lfWZ///XfdbsOwRCCGvYCQk7CoqIW+vautX+qtWOTme0rWXmO7WdVls703Y6nY7tYKvTabW1VZGOVae1LuCOsiWEnbBDIAsJyUnOOcnZ798fJzkQQjRAkpPl/Xw8ouTk5Jzr5oRz5fos18cwTdNEREREREREpB+xxDsAERERERERkTOpWBUREREREZF+R8WqiIiIiIiI9DsqVkVERERERKTfUbEqIiIiIiIi/Y6KVREREREREel3VKyKiIiIiIhIv6NiVURERERERPodW7wDkKhIJEJVVRWpqakYhhHvcERE5CxM08TtdpOamkpaWprer/sh5VMRkf6vPZ/m5eVhsXQ9f6pitZ+oqqpi9OjR8Q5DRES6qampibS0tHiHIWdQPhURGTgqKyvJz8/v8usqVvuJ1NRUIPqC6ZcfEZH+qbm5mdGjR1NZWRl735b+RflURKT/a8+nn5RLVaz2E+1LldLS0pRcRUT6OS0B7r+UT0VEBo5PyqVqsCQiIiIiIiL9jopVERERERER6XdUrIqIiIiIiEi/o2JVRERERERE+h0VqyIiIiIiItLvqFgVERERERGRfkfFqoiIiIiIiPQ7Klbj7PHHH2fatGnMmzcv3qGIiIgMWMqnIiKDj2GaphnvIASam5tJT0+nqalJh5gPBScPwJZnwHUUMgqg5AuQPSHeUYnIJ9B7df+n12gIUS4VGbC6+15t68OYRAY80zRpbW2lubm5w0drayuhUIhIJEIoFCIcDsc+DMPA4XDgcDhwOp2MafyAaft+AYYBJtH/r/sZkWt/hnXOnfG+RBERkV4XDodxu900NTXFcqnb7SYYDHbIoad/2O32WC4d2/gBMw4+2SmXBq7+Dxzz78YwjHhfooj0ABWrIh/D5/Nx/Phxjh8/Tl1dHc3NzQSDwS7vb5oQNI3oRyT6fwCHJYDDiDA8coKpdb/AwIzeGcBsy7P/91Ve2lqPJWciaWlpZGZmMmzYMHJycnA4HH1wtSIiIj0vEolw8uRJjh07RnV1NS6XC4/H84nfFzYh0JZLQ6aBzQjiMLwMi5xget2TZ82l9r+uYPWWExjZE0hLSyM9PZ2cnBxycnJIT09XESsywKhYFWl38gCR0t/iq9mLizS224s54u74T8QXNmgI2mkI2jp8NIWsbcn047eB/5PtPSJWA4vRcfW9AUQwyDixjo2t6aTaarCelk/bk2178Tp8+HBsNv3zFRGRfqZtaW6w7gBNlgwqEuexv9HE7/fH7mKa4AlbOuTRxrb/+yKW2IBvhLMXlp+US3MaN/FRaDgZJxuxn5aW7XZ7p1yampqqAlakH9NvuzLkmaZJ0zuPk/7utwGDBExGYDCCF3g99Tb+z1zCoVYnR31OvGFrtx/XZpjYjQhg4G9LuvlGXXQk+OyB0Oz18gvXCCyYZDtCjHAEGOEMktvaSm7jQZwHDgBgsVgYPnw4eXl55OXlkZubi9Xa/dhERER6WnDT09j+8nVMwIpJFgaLeIZA+i28bb2YQ61ODrU4qQ3YCX7C4O7pLJjYDJOQ2b1c6mnx8qumXADSbSHynAHynEHyEgK0+Kuprq6O3T05OTmWS/Py8khNTb2QvwIR6WEqVmXICoVC7N+/nyNlb3HF3m9jYJ6W/ExME65sXsWPAvM5YmbGvi/FGibLHurwkWEL4bCY2C0mdiP6ceZAbdiEkU2JGC0GnC3JGgb1RhZWwyRsGtQF7NQF7GyPrZQyybKHGeEIUJDoZ4yvnurqGsrKyrBareTm5pKXl0dBQQHZ2dkaKRYRkT7R0NDA/o1vMHf9g225tJ2JCVziWs13Aws5Yp5qomJgkmGL5tPM0/JpkjWC3TBxWKL/t1vMDiuNupNLGy1ZOI0IftNCU8hGU8jGbm/0yxZMhjuihWtBQoCx4Va83n3s27cPgNTUVPLy8sjPzyc/Px+n09kLf2Mi0l0qVmXIcbvd7Ny5k4qKCvx+P/Oa3yC6eOiM5UQGmKbB3zjW8nridYxL8jPcEcRp6Xg/q9VKSkoKdrsdq9Xa6cM0TQKBAH6/nxNJl2EceDu6R/W0x4h+bpI0Ygb/ZK2iOWyl1m+nxm+nNhD9vzt8arnULm8SEC2cCxL8jEn0U9B6guPHq9i8eTPJyckUFBQwZswY8hJasW17Tt0SRUSkx0QiEQ4fPszOnTuprq5mXvOrnDWXAiYGn7e9zYuOGxiX6Gd0QoBMe6hDEQqQlJREQkIyNputUy61WCwEAgGCwSAnU5Zj7Os6lzpzZ7DCWk1rxEJtwE6Vz06V30GV34E3bKUm4KAm4KCsOfpdec4g4xJ9jE/yk2e6cbsrqKiowDAMRo4cSUFBAePSIqTuf0m5VKSPqViVIaO1tZUNGzawb98+TNMkYsK+lgQmeFowTZOzbY2xGCaLEo/TmukmOTmZ4cNHkZ6eTlpaWqxxQ1JS0rnNYm7JhlceaBt7bku1psn+aV8lPbUEo7kZS3Mz6TYfk5J9sW/zhi3U+u0c9zs40urkuN+BJ2xllzcpVrymWUNMTPZR2OKjyb2bcOnvyHetJoIRvTzDwFj3M7h+JZR8/kL+OkVEZAgyTZNDhw6xYcMG3G43AE1BK60tno/NpZclV0JWY2wbS2ZmZodcmpqait1u734gWzLOmkuPzPoHhqcvJKG5maamJpKsfsYl+ttih+awlSqfneP+6JLkuuCpQnadC5xGhDGJfsYl+Rmf6MOsqiJl/8vMiOVSEwwLrPsZhnKpSK9TsSqDnmma7N69m40bNxIIBGgNG5S7UyhtTqY5ZGOCLZdLrV0sJ8IgfcxMbr361p7rIljyeShYiHHG2XCTsicwqe0uoVCIkydPUl9fT11dHfX19RiNjSRb/YxP8rMk000oQqxwPepzctznoDlso6w5hbLmFCZaqviyYzUWzFPX1tYtkZcfIDBiNs6RUy/8ekREZEhobm5m3bp1VFZWYppw2OektCmZfS0JJNtGMv9jcmnSyElcfdnVjBw58tyK0q50kUvHZU9gXNtdTNPE6/VSV1cXy6X19fWk23xMTfFBNrhDFg61JnCwxcmhVietESt7WxLZ25IIwCzbMf7GdmYuDUc/e/l+GlImkTVxrrbeiPQSFasyqNXX1/P+++9TV1dHxIQt7mTebUjDF4k2dki0hNmXNBdL4P/OupzIYsCwK74OGRk9G1j2BFj+3S6/bLPZyM3NJTc3N3ZbKBSivr6empoajh8/Tk1NDWMsAcYkBgA3wQgc8TnZ501gf0sinzHeI2J21S0Rdj/7LWqm/y3jx49n7NixOh5HRETOKhwOs3XrVrZs2UI4HOZkwMYbJ9M51JoQu8862yK+TNe5dNS1D0F2Qc8G9gm51DAMUlJSSElJYdy4aAlrmiYej4fa2lqqqqqorq4mtamJotQWTBNqAnYOtjg52JrAcZ+Dq/jgY3KpwdGX/5U3Rt3G+PHjGT9+PDk5OSpcRXqQilUZlAKBAJs3b2bnzp2YpkmVz87rJzOo9kcLsmH2IPMzPExLbsFuSaTMcg9zjj2FabQt8Wlf6nP9yn6zJ8VmszFixAhGjBhBcXEx4XCYuro6qqqqqKqqora2lokWPxOT/JhmExefrMQSOHu3RBOTYGsTuw8d4+jRo1itVsaOHUthYSH5+flYLN3v0igiIoPX8ePH+eCDD2hqaiIYgQ9dqax3pRLGwGqYzEr1MifNyzCHjQ98t7Ok4XlMw9Jvc6lhGKSmppKamsrEiRMB8Hg8sVyaWlXFSKeHizM9+CMGi04ewwh2kUtNE3+rm0MnW3G7t7J161YyMjKYNGkSEydOJCUlpS8vTWRQUrEqg87Ro0d57733aGlpoTVs8E5DOlvcyYCB04hwaVYzs9O8WC0G48dPYPr06eTm3ovRcD+csZyovyTXs7FarbHidfbs2QSDQY4fP86RI0c4evQoQXcGBM6+JMs0DTb5RvHzIyMYm+hnZkoLvn0HOXDgAImJiRQWFjJp0iSysrL6/LpERCT+AoEA69ati3XJ3d/i5I36DFyh6K+O4xN9XJnjIsseJi0tjenTpzNp0l0Ynv83oHIpQEpKCpMmTWLSpEmYponL5YrlUsOTgRHsIpdiUObP47+P5ZJtDzItpZVZITcu10Y2btzIqFGjmDRpEmPHju2Zpc8iQ5BhmmYXB1VJX2pubiY9PZ2mpibS0tI++RukE9M02b59O+vXr8c0YbsnibUn02iNRM8fnZHSwrKsJlJsEcaPH8/ChQsH7ainaZo07NtE1rNXwRnHqkd33RjcGvkRmwOjY7c7jAhTU1opSm0h3xnAMCA7O5vJkydTWFio9v0i6L16INBrdOHcbjevv/46DQ0NNIWsvFmfHtvDmWoNc0W2i8nJPpKSElm4cCETJ04ctEtf/VW7cPz3xXSVS+/iB6zzFcS+amAyIclPSaqXCUk+LAbY7XbGjRvHlClTyM3NHbR/VyLnorvv1SpW+wkl1wsTDodZt24de/bswR8xePlEFvtbontpcuxBrspxMSYxQFpaGosXLyY/Pz/OEfeRLX841S3RNNvGhU3ey7iFvUnzaAha2elJYrs7KTZaDpBpCzEztYWZqS2k28JYrVbGjx/P1KlTlWhlSNN7df+n1+jC1NbW8sYbb9Da2spebwKvnMgkYEaX9c5P97A4043TYjJt2jTmzZs3NAYyT8+lbeewn55LfRGD/d4Eyt3JHPWd+vtItYaZleplVlo0lwJkZmYyZcoUCgsLSUhIOOvTiQwFKlYHGCXX8+fz+VizZg1VVVU0Bq2srsmmPmjHZpgsyWxmfroHu9VCcXExxcXF2GxDbPX7yQMdlmQ1T7yR/Q0RDhw4QGNjIxBt51/pc7Ddk8RuTyIBs33PqsmERD8laV4mto0QZ2RkMHXqVCVaGZL0Xt3/6TU6f/v37+fdd98lFAqzoSmFtxrSAIN8p5+rh7kY7giRk5PD4sWLGT58eLzD7Vtn5NJQ0R1Ueu0cOHCAo0ePEgqFoncL2Ch3J7HNnRRb2WVgMi7RT1FqC5OSWrFZolt5xo0bx9SpUxkxYoQGgWXIUbE6wCi5nh+Xy8Xrr79OU1MTR1odvFibTWvEQoo1zM25J8lLCDJq1CguvvhiMnq6o+8g0NDQwL59+9i3bx8tLS0ABCIGFd4EtrmTOdJhhDhEcVoLs1K9pNkisdnW6dOnM2zYMCVaGRL0Xt3/6TU6d6ZpUlpaSllZGWET/lqXwTZPMgAlqR6uzGkiwWFn3rx5TJs2TU34zhAMBjly5Ah79+7l+PHjmKZJyIS93kS2NHfMpQmWCNNSWpiV2sIIRxCjbRB42rRpTJo0SZ35ZchQsTrAKLmeu+PHj7NmzRr8fj9bmpN4vT6DCAYjnQFuzj1Jqi3CggULKCoqUiH1CSKRCFVVVezdu5dDhw4RDkeXKzUErZQ3J7P1jBHiiUk+Zqd5GZ/oxzAgJyeH6dOnMyETbNueG1CNNUTOhd6r+z+9RucmFArx7rvvcuDAAVrCFv63NotKnxMDk+XZTcxN85KVlcnVV19NampqvMPt97xeb2wQuH31UkPQynZ3dMtNc/jU6q5h9iBFbVtukqwR7HY7hYWFzMhLJOPg/ymXyqCmYnWAUXI9N/v37+ftt98mHDFZczKdzc3RRknTklv49LBGEh02li1bxtixY+Mb6AAUCAQ4ePAgFRUV1NbWAhAyoaJthPj0/ThZ9hBz0jzRZOvbyCWu1bGBAaNtbw/Xr4we3i4yCOi9uv/Ta9R9gUCAv/71r9TW1lIXsLG6JhtXyIbTiHBjbgMTkvwUFBSwbNkyzfidI9M0qa+vZ+/evezfvx+/30/EhCOtTra6k9jbkkjIjOZLq2EyLbmFOWlelkY+5BLXasAgmk5PO/5HuVQGERWrA4ySa/dVVlby2muv4QvDi7VZsUPJL81s4qIMDykpyVx99dVkZ2fHOdKBr7Gxkd27d7Nv3z78fj8A9QEbW5qT2eZOwt+2t7XQUsXrjv+H5YzW/iaAYcF4YLNGhWVQ0Ht1/6fXqHvC4TCvvfYax48f52CLkz/VZuE3LWTYQtwy4iTDHCFmzpzJggULtOz3AoVCIQ4dOsSePXuorq4GwBc22NU2CFwbiA4EjDWqWev4R6yGcqkMft19rx5inWZkoKurq+PNN98kGDZZXZPDUZ8TuxHh+uGNTE72MWzYMK666iqSkpLiHeqgkJmZyUUXXcT8+fM5fPgwu3fvhupqrshp4tKsZrZ7ktjclMxN5ntETAPLGQnWACImNKz5Gemf/enQa24lItIPmabJu+++y/Hjxzna6mB1bTZh02B0gp/P5jaQbDNZvHgJU6dOjXeog4LNZqOwsJDCwkJcLhd79uyhoqKC2dYWSlJbqPLbKW1O4dO+d2Idh0/XnkuPvfIDUm78CZmZmXG5DpF40G+OMmA0Nzfz2muvEQiGePlEFkd9ThxGhM/n1TPSGWT8+PEsXbpUBVEvsNlsTJw4kYkTJ+Jyudi9ezcVFRXMsXiZneplYf0xjGBXizRMGg9v5dXnnmPq1KlMmzZNgwkiInG0YcMG9u/fz4mALVaoTkpq5cbcBpKcDq644gpGjRoV7zAHpYyMDBYuXMi8efM4dOgQu3btwqipYVRCI5ecrMTi7zqX+k/s56+rV5Ofn8/MmTPJz89XTw4Z9PRbvQwIra2t/PWvf6WlpZXX6zOoaEnEisnNI04y0hmkqKiIBQsW6E27D2RkZLBo0SLmzp3LgQMH2LlzJxF3Okaw82gwQMQ02BXIpd7jp6ysjPLycgoLCykqKtLosIhIH9u+fTvbtm2jOWRlVXUO/oiFfKefG4Y3kJacxLXXXqvu+X3AarXGBoFPnjzJzp078W/OBn/XuXR9ax77HAmYlcc4duwYmZmZzJw5k8LCQqxWa99fhEgf0J7VfkJ7bLoWDAb585//TF1dHe81pPKBKw0w+czwBqak+Jg0aRKXXnqpCtU4MU2T+ooN5Dx/NbQtYDr1NYhgsCzwHxwjl5kpLcxP95DjiJ5HV1BQQFFRESNHjtTrJwOC3qv7P71GXTt48CBr1qyhNWzwTNUw6oN2su1B7syrIy3BxvXXX69+D3EUqN6N/cmLiGbOU0yixeqywH9wxBxBlj3I/HQPM1NasVtMEhMTmTFjBlOnTtX55zJgaM+qDAqRun1U/un7zGw8wr7QcI55rgLSuDrHxZQUH6NHj+aSSy5RoRNHhmEwbMpCuOFxzFcewCRawIIBhsmqhM8TJIuw36DcnUy5O5lJSa0szPDA0aMcPXqUnJwcioqKGD9+vBp5iIj0tJMHcL//S8yKTcy1ZPLv3iupD9pJsYa5fcRJku0GV111lQrVOHOMnAo3rGzLpQamGYG2PaxvpN3KyEAyNc0RGoJ2XqvP5N2GdErSvMxO89C6aRNbtmxh8uTJzJw5UwM1MmhoZrWf0EhwZ2bZM/DKV2LNBiJmtH37/9i/gDF8JsOGDePaa6/FbrfHO1Rpd/IAbHmGSMMRGs1UNoYmU+m1Y5pwzO9ggyuFvS0J0DZmnO/0szDDQ2GSD8OAlJQUioqKmDJlivYeS7+k9+r+T6/RGbb8HvOVrxD9bc+M5lTT5J9D95IyYirDnSGWLVvGxIkT4x2ptGvLpbiO0uocznZ7MduPewmHw/gjBlvdSWxuSsEViuZJCyZTkluZn+4hLyGIYRiMGzeO4uJicnJy4nwxImeno2sGGCXXM5w8gPlfczGIdLjZJLrQ9NXxj3L5LfeSmJgYn/ikW0zTpLq6mu3bt3PkyBEgevTNxqYUtruTCLcVrdn2IAvSPcxMbcFqgNPpZMaMGUyfPl1LmqRf0Xt1/6fX6DQnD2CunIthnpFLTTANgxeG/xPTFl9LUVFRnAKU7vL5fOzevZudO3fS0tJCxIR9LQlsakrpcP75KKefBRkeJrcNAo8aNYri4mLy8vK0Ck36FS0DlgGt9cNf4QTOfFuNzrEaLM+uJkGFar9nGAZ5eXnk5eXR1NTE9u3bqaio4FMOF5dkNrOpOYWy5mROBu28Wp/J+41pLEh3U5zWQmlpKVu3bmXKlCkUFRWRkpIS78sRERlYtjyDaZ4llxrRXLok+RCjVKgOCAkJCZSUlFBUVMTBgwfZtm0blpMnmZzso8ZvZ1NTMrs8SRz3O3mx1km2PchFGW7Cx45z/Phxhg0bxqxZsxg7dqy228iAopnVfkIjwaeEw2Gqfn41o5o2YTlLRzzTsGBMvwlu/k0copML1drayq5du9i5cyc+nw9/xGBLczIbm1LwhKPdDBMtEeame5ib5iHRamIYBoWFhcyaNUsdhCWu9F7d/+k1OsXz9K0kHX7jrLk0ggVjxk0YyqUDkmmaHD9+nG3btnHs2DEAPCELm5uTKW1OwR+JFqTpthAL0z0UpXqxWyA9PZ1Zs2apg7DEXXffqzW00ktuuukmMjMzufnmm+MdyoCzZcsW6sPJZ/SVPcXAgIyCPo5KekpiYiJz5szhjjvuYMmSJQzPTGNhhoe/L6jhmpxGMm0hWiMW3m9MY+XREaw5mUZz0GDv3r2sXr2aN954g7q6unhfhoj0AeXS89fS0sIhV3uDns4Mw8BQLh2wDMMgPz+fT33qU3z2s59l0qRJpDlgaZabBwpquCyriSRrmKaQjddPZvCLyhF85ErhRGMz7733Hs8//zzbt28nGAzG+1JEPpZmVnvJO++8g9vt5re//S1//OMfP/H+GgmOOnHiBC+//DI+byN/3/gDLJh02mJhWOCBzZA9IS4xSs8yTZMjR45QXl7OiRMniJiwx5vIh64UTgQcAFgxKUptYVGGmwx7GIBJOVbmWHaTEmqI/sJV8gX9TEiv03t13zrXXAp6jSD6vvrGG2/QeGAzt574dwyzYy41AUO5dNDxer1s376d3bt3EwwGCUZgqzuZDU0pNLU1Y3JaIsxJ8zI3zUOKLUKOpYmLEg4yzN6KNXuscqn0Ge1ZjbOlS5fyzjvvxDuMASUUCvHOO+8QCJs8fXISRyL38WP7f8e6ARuGBQMTrl+pN9JBxDAMxo4dy5gxY6ipqaG8vBxLZSVTk1s52OpknSuVYz4nW9zJlLuTmJ7SypcT1nBJ1SrAwMSMDmCs+xnG9Suh5PPxviQR6SHKpedn3759HDlyhJpwHt8I3suPbL8iui5JuXQwS05OZuHChZSUlLBr1y527NjBXIuXkjQvOz1JfORK4WTQzoeuVDY2pfBg0hvcGP4d7R1BTMNQLpV+p98uA/7Rj36EYRg8+OCDPfq47733Htddd12sK9pLL7101vs9/vjjjB07loSEBBYsWMDGjRt7NA7pbNOmTbhcLt5pSOdk0M5fWcxvsx9iW8pSAoWfxrj4q9FRYL2BDkqGYTBy5EiuueYabr75ZgoLJzIxOcCdefX8fyPrGJ/ow8TA423iGvcqLJhYiERn380wmBHMlx/APHkg3pci0m8olw49Ho+HdevWEYrAKycyWR1eyt9Y/4VtyZdSm3MRXKRcOtg5nU5KSkr43Oc+x+LFi8lMT6MotYX78k/w2dyT5DkD5FPD34V+d0YujbTl0vvxVm6P92WIAP10ZnXTpk08+eSTn9hKfd26dcyfP7/TOZu7du0iOzub3NzcTt/j9XqZNWsW99xzD5/5zGfO+rirVq1ixYoVPPHEEyxYsIDHHnuMq666ioqKCoYPHw5AcXExoVCo0/e+8cYb5OXldfdSpU378SaHWpxsao52fb12WCNBZxbhi75Nwpw5cY5Q+lJWVhbLli1j3rx5bNu2DeuePRQknqTab2fyybWYZnQU+HQGEAEqnvtnbFd9nwkTJqjjoQxpyqVDj2mavPvuuwSDQd5rTKM+aCfJGmbWsAS2J3+GKbfcgqFO+kOGzWZj2rRpTJkyhUOHDlFeXo5x8iSTknxMbnwd09dVLjXY98LDNM/7OsXFxUN2Ob30D/2uWPV4PHz+85/nV7/6Ff/yL//S5f0ikQj3338/hYWFPP/887GOZhUVFSxbtowVK1bwT//0T52+75prruGaa6752Bh++tOfcu+993L33XcD8MQTT/CXv/yF3/zmNzz00EMAlJeXn+cVypkCgQDvvPMOrWGDP9dFO73OTvMwIclPTk4OJSUlcY5Q4iU1NZWLL76YkpISduzYgX3nTua2VGFp7WqrvYndW81bb79NaWkpxcXF6ngoQ5Jy6dC0a9cujh8/zjGfg/VN0YHfT+W4SLJGuOSSS3Q2+RBlsViYMGEC48ePp7Kyki1btpDvqj9rl2gAExPD52L37j1UVFQwceJESkpKyMjI6NvAReiHy4Dvv/9+Pv3pT7N8+fKPvZ/FYuHVV19ly5Yt3HnnnUQiEQ4cOMCyZcu48cYbz5pcuyMQCFBaWtrh+S0WC8uXL+ejjz46r8f8OI8//jjTpk1j3rx5Pf7YA8X69etxu928cTIDd9hKlj3EsqxmrFYrl112mWbHhKSkJObPn88dd9xBSv40uupuGTEN1rfmcajFSVNTtOPhqlWr2LVrF+FwuG+DFomjoZZLQfm0qamJDRs2EIgY/N+JTMBgZoqXSck+CgsLGTt2bLxDlDgzDIOCggJuuOEGRkyeR1e51DQN1rXm80xVDvu9Dvbu3ccLL7zA2rVraWho6NugZcjrVzOrzz//PGVlZWzatKlb98/Ly+Ott95iyZIl3HHHHXz00UcsX76cX/7yl+cdQ319PeFwuNOyp9zcXPbs2dPtx1m+fDlbt27F6/WSn5/P6tWrWbRoUaf73X///dx///2xjlhDTVVVFXv27GGnJ5GdniQMTK4b1oDDYjJv3jydqSkdOJ1ORlz9j5j7n+900L1JtN3Sr/zLOVKTwyhngIszm5lgevjggw/YsmULs2bNYsqUKdhs/eqtT6RHDcVcCkM7n5qmyXvvvUcoFOLthnQaQzZSrSGuyG4iOTmZiy66KN4hSj+TsuTvYOuvz5pLLYbJH8OXcizkZFWNkxGOAEsy3Zj7D3DgwAHGjRtHSUkJOTk58QpfhpB+8xtbZWUlX/va13jzzTdJSEjo9vcVFBTwzDPPcOmllzJ+/Hh+/etfY3Q666TvrVmzJt4h9HumabJhwwb8EYM36qO/WFyc4WZUQpARI0YwY8aMOEco/VL2hGinwlceiHWKjh7AZfJG2q0M86dw3G1y3O/ghZocRjgCLM50U2h6+fDDD2NF69SpUzvt0RMZ6JRLh6ajR49SXV3N0VYHpW19Hz49zEWC1eTSSy/F6XTGOULpd7InwPUrMV55gPbO+u259L2MW/i0AzY0udnSnExNwMHq2uxTRevBQxw6dIgxY8Ywe/Zshg0bFueLkcGs3xSrpaWlnDhxgtmzZ8duC4fDvPfee6xcuRK/33/WfWe1tbXcd999XHfddWzatImvf/3r/Nd//dd5x5GTk4PVaqW2trbT84wYMeK8H1c6O3ToEHV1dax3pdIasZJlD3JxphubzcbSpUu1/Fe6VvJ5KFiIseUZcB2F9NEczroE94GTXOlycVGGmw1NKZS1Jdk/1maT21a0TjJbWb9+PeXl5RQVFTF9+nQVrTJoKJcOPaZpsmnTJkwT3mqIDvwWp3oZn+Rn2rRp5OfnxzlC6bfacilbnsFwHcXIKMBdeBOWI02k793L8uxmFmV42OhKYfMZReviTDfm4SMcOXKE0aNHM2fOnFjjNJGe1G+K1csvv5zt2zu2yb777ruZMmUK3/jGN86aXOvr67n88suZOnUqq1evZu/evSxduhSn08lPfvKT84rD4XAwZ84c1q5dy4033ghEG1CsXbuWBx544LweUzqLRCJs3rwZT8jCxrYmEEszm7EaMHfuXHWek0+WPQGWfxeILmEaB4wpiXD48GHKyspIsTWwMMPDxqYUSpuSqQ04+N/abIY5gizOaGaK6WPjxo1s27aNoqIipk2bhsPhiOcViVww5dKh58CBAzQ0NLC3JYEqvwO7EeGSzGaSkpJYsGBBvMOT/u60XAqQClwyBmbPns3WrVvZs2cPl2U3syDDw4amFDY3dR4ENo9WUllZSX5+PnPmzDlrB3GR89VvitXU1NROyz6Tk5PJzs4+63LQSCTCNddcw5gxY1i1alWsPfebb77JsmXLGDVqFF//+tc7fZ/H42H//v2xz9tbeWdlZVFQUADAihUruOuuu5g7dy7z58/nsccew+v1xjoayoXbt28fLpeLda50gqaFPGeAyck+UlJSmD59erzDkwHKYrEwfvx4xo0bx5EjRygrKyPZWs+CdA+bmpLZ3JRCXcDOn05kk9M2kz/VbGXjxo1s3bo1NtOqolUGKuXSoaV94DdiwrsN0UHeeeleUmwRZs+erVUjct5SUlJi3fi3bt3Krl27uCyrmQXp0UHgzWcMAl+c4SZSeYxjx44xatQo5syZo1UU0iP6TbF6riwWCz/4wQ9YsmRJh18sZ82axZo1a7pcP79582Yuu+yy2OcrVqwA4K677uLpp58G4LbbbqOuro6HH36YmpoaiouLee211zRS1EPC4TClpaU0Bq1saU4GYGlWE4YBc+bM0TEjcsEMw2Ds2LGMGTOGyspKysrKSLKeYH66h01NKWxuTqE+aOflE1l8YI8m2WlmK5s2bWLbtm3MnDmTGTNmqGiVQU+5dGDbs2cPzc3N7PQkUh+0k2CJsDDdTVpaGlOmTIl3eDIIJCUlsWjRIoqLi9m2bRs7d+5kaVYz808rWusCdl46kUV2Wz6NHDvO8ePHVbRKjzBM0+zqwELpQ+3dC5uamgb9EtgdO3bw4Ycf8lJtJru8SYxP9HH7yJNkZGRw8803a6+q9DjTNDl+/DhlZWXU1NTgixhsbkphY1MKvkj05y2rLclOT2nFYkQ7D6tolTMNpffqgWqovEahUIjnn3+eZm8LT1bm0hSycVlWE4syPCxbtoyJEyfGO0QZhHw+H9u3b2fHjh0Eg0Fawwabm1PYdFo+zbSFWJThZmZqC1Yj2nF8zpw5jBw5Ms7RS3/S3ffqATuzKgNTMBiMFgx+O7u8SQAszWoGontVVahKbzAMg/z8fEaNGkV1dTWlpaUkWKqZl+5hc1MyG5tSaQja+b+6LD5oDHFxppsZZgubN29m27ZtzBufxZTWTVjdxyGjAEq+EN3nIyISJzt37qSlpYUtzck0hWykWMPMTfOSlZXFhAl6f5LekZCQwLx58ygqKooVrUusbuaneyhtSmZDUwqNIRuv1mfyoSuVizPchM0qqqqqKMyyMM+2h5RQg3KpdJuKVelT27dvx+fz8U5DNgDTklsY4QySk5PDuHHj4hydDHaGYZCXl0deXh5VVVWUlZXhtFQxN91LWXMy613RJPvnukzWNaZyUaabz1reZepbq4m29gcMA2Pdz+D6ldFOiiIifSwQCFBeXk4gYrCuMRWAxZnN2NvOKO8Pxw7J4OZ0Opk7dy4zZ85kx44dbN++nYssHuame9nSnMxHTSm4Qjb+Up/JOlcq/5D8BpdW/QEwiGBiGBblUukWFavSZ3w+H1u3buVwq4ODrQlYMLmkbVZ1/vz5Sq7Sp9qL1urq6mjRevw4c9I6Fq0763383LEai2ESPSo9+j8T4JUHMAoWalRYRPrc1q1b8fv9bGxKpSViJdMWYlZqC7m5ubEGVyJ9wel0MmfOnA5F6wKLh9lt+fSjphQywnXc4fvDGbk0rFwq3aJiVfpMeXk5gUCQdxqiDTuK07xk2cOMHDmSUaNGxTk6GapGjhzJpz/9aWpqaigtLcVx/HgsyS5yv42JQSy5tjGAiAm1f/0JWbf+THtaRaTPtLS0sH37dlrCFja4oke/XZIVPfpNs6oSLw6Hg9mzZzNjxgx27tzJtm3bWGDxUJLmZVz9m5jBrnPpgdXfJeXGf1cjJjkrFavSJ7xeLzt37qTitHPgFme4Ac2qSv8wYsSIWNFaVlaG49gxLo0cw+Lrqgedief4Ll5/7jk1YhKRPlNeXk4oFOIjVxp+00KuI8C05Fby8/PJy8uLd3gyxDkcDkpKSpg+fXqsaJ1sr8US6jqXmq6jvPLKK+oeLGelYlX6RFlZGcFQOLZXdX66hxRbhDFjxugYA+lXRowYwac+9Slqamrwvvw+VG/jzNFggIhpsD80nBafn82bN7N9+3YVrSLSq9xuN7t27aI5ZKG0OTqrujSrGcOIDvyK9BenF60Nq9fDvq5z6fst+WyzJ+nIGzkrFavS69xuN3v27GGbO4mGoJ1ES5iFGR4gumRJpD8aMWIE3PxdzJV/xjSjy5XaRT83+aHnahpbc7gow82s1JZY0VpUVMT06dNVtIpIj9qyZQuRSIQPGjMImQajE/yMT/Qzfvx4cnJy4h2eSCcOh4MRV/8j5v7nO+dSorn0t8FlHGlrbHhx5qlzWvPz85kzZ44mNYY4nRMivW737t1EIiYbmqKjwBdleHBaTCZOnEhWVlacoxP5GNkTMK5fiWFYMA0rEQwiWDANg985/z9OWobRHLLxWn0mv6zMpaw5Ca/Pz6ZNm3juuecoLy8nGAzG+ypEZBDw+/3s27ePpqCVre5TR79ZLAZz586Nc3QiH+OMXGpiieZSDN5Ov5UJmYkkWsKxbvxPVuay3Z3I0cpjvPzyy7z66qucOHEi3lchcaKZVelV4XCYiooKjvocnAzasRsRitO8GIaSqwwQJZ+HgoUYW57BcB3FY89mU2gKwZNh/i6rhnJ3Mh+5UmNF64eNqSzK9DAr1cvGjRvZtm1bbKbVbrfH+2pEZIDat28f4XCYLe40TAzGJPgYnRCgsHASGRkZ8Q5P5OOdlktxHSWSOoo9SfM5frCBhf5o9+DS07rx/19dFutcIRZnNBOpPMaxY8cYPXo0c+bMYfjw4fG+GulDKlalVx0+fJjW1lZKmzMBmJHSitNiMm7ceNLS0uIcnUg3ZU+A5d8FIAW4DJja1j3Yfvw4Jaleyt3JfOhKpTls4/X6DD5sTOGiDA+zzFNF66xZs5g+fTo2m956RaT7TNNk165dhEwob47Oqs5N9wJQVFQUz9BEuu+0XGoFpgOFCwKxI28WWTzMSfOyuTmZDa4UGoI2XqnL4gNXkMUZbiJHK6msrKSgoIA5c+YwbNiweF6N9BH9xiS9ateuXXhCFvZ6EwGYnRbdqzpt2rR4hiVywdq7B1dXV1NaWoqtqoritqL1I1cq7rCN109m8KErlUUZboojXjZs2BArWqdNm6aiVUS6pbq6GpfLxR5PIi0RK6nWMIVJPkaOHKntNDKgnX7kzY4dO9i2bRsXtRWtpU3JbGhKpSFo55W6LNa5gizJdGMeOcrRo0cpKChg7ty52q89yOk3Jek1LpeL6upqyt2pRDDId/rJdYZIT09n5MiR8Q5PpEeMHDmSa6+9tlPRurVtptUdtvLGyQw+Oq1oXb9+PVu3bqW4uJipU6eqaBWRj7V7924AypqTAShJ82IxYOrUqfEMS6THnF60bt++ne3bt0eL1nQvm9uK1pNBOy+dyGKdPciSrOZY0TpmzBjmzJmjonWQ0m9I0mt27dpFxIQtbcl1TtuSpWnTpulcVRl02ovWqqqqaNFaXc2stLaitTEFd9jGG6fNtJZEvHz00UexonXKlCkqWkWkk5aWFg4dOkSt384xvxMLJsWpXhISEhg3bly8wxPpUQ6Hgzlz5sRmWrdv387FbUXrpqYUNrpSqAvaebE2m1xHgEsy3ZiHj3DkyBHGjh3LnDlzyM7OjvdlSA/Sb0bSK0KhEHv37mVfSwLusJUkS5jJya1YrVYKCwvjHZ5Ir8nLyyMvL69j0do20/pRYwrNYRtvnjHT+uGHH1JeXk5JSQlTpkzBarXG+zJEpJ/Yu3cvkUiE0uZon4fJya2k2CJMnjxZ7xUyaDmdzljR2j7TuiTTzdw0DxubUtjUlEJtwMHq2mxGOgMsyWzGPHSYw4cPM27cOObMmaMl8oOEilXpFQcOHCAQCFDaHB3dmpXWgs2ACRMmkJCQEOfoRHpfXl4eI0eOpKqqis2bN2MzapmV6mWbO4kPG1M7FK0L22Zat7/7EqwpJz/FJHX0dCxz7ow2pBCRISkSibB79258EYOdnmjvhzlp0VVKWgIsQ4HT6WTu3LmxonXHjh1canUzL93LhqYUNjclU+138EJNDnntRevBQ5zct5EFjn3kJYVwDp8IJV9QPh2gVKxKr9i1axcnAzYOtyYAJiWpp5YAiwwVhmEwatQo8vLyOH78eHSm1ailKLUlWrS2HXmz5mQGuU1b+Dvb/wAGNJpQuRbzw59jXv9zLLO/EO9LEZE4OHbsGG63m+3uZIKmhRx7kNEJAUaPHq2O+jKkJCQkMG/ePGbOnMm2bdvYuXMnl1mbmZ/uYb0rhdLmZKr8DlbV5HCvcw33Gk8BBmAS2WtgrPsZxvUro0foyICiYlV6XH19PXV1dZQ1pwMwMclHhj1Mdna22ozLkGQYBvn5+YwaNYpjx461Fa0nmNVWtB5zeXnU+j9YMAGz7btMTMB45SvsD+Uybs7lWvInMsTs3r0b0zzVWGlOmhdDjZVkCEtISGD+/PkUFRWxbds2duzYweXZzSxI97C+KZWTbjcP8VTnfGqC+fL9uDOnkza2OI5XIOdKxar0uF27dhGMGGz3RM+Ca1+ypMZKMtQZhsHo0aPJz8+nsrKS0tJSrEYd95p/BW90BLjD/YEIBu73fsELB05SUlLCpEmTsFgscYlfRPqOx+Ph6NGjHPE5OBm04zAizEhtITk5mYKCgniHJxJX7UXr6TOty21NFFv/Ci1d59ODf/weDbO/wuzZs8nIyIhH6HKOVKxKjwoEAuzfv59dnkR8EQsZthDjE/3Y7XYmTNBeARGIFq0FBQWMHj2ayspKjP/9I8YZibWdaZoEWt2cbPLw3nvvsWXLFhWtIkPAnj17ME2T0uYUAGaktuC0mEyZMkX/9kXaJCYmsmDBAoqKiti6dSvZ7z37sfnU8LvYt28/Bw4cYMKECcyZM4f09PQ+jlrOhd7tpEft27ePYDBE6WlnwRkGFBYW4nA44hydSP/SXrTmz7gIwzj727GJQak/j18czWW9KyVWtK5atYqKigoikUgfRy0ivS0SibBnzx7cIQt7vdGmhLPTvBiGwZQpU+IcnUj/k5iYyMKFCymYeXGXq/hMDNa15vNMVQ4HvQ727dvPCy+8wNtvv01TU1MfRyzdpWJVeoxpmuzatYtqv52agAOrYTIrtQXQ/hqRj2PM/gJG2x7V05mAxTD5K0toiVh5qyGdx4/m8lFb0fruu+/ywgsvxI62EJHB4fDhw7S0tLClORkTg9EJfoY7QowZM4bk5OR4hyfSb9nn30PnRcCn8un/hi/lmN/JczU5/K4qhwNeB3v37uOFF17gnXfeobm5OQ5Ry8dRsSo9pra2lsbGxtis6tTkVpKsEXJzc3VAs8jHyZ4A16+Mzq4aVkzDgmlYAYP3Mm7hU6Ph2mGNZNpCtEasvN1WtH7oSqHO5eadd95R0SoyiOzevZuwCeXuU42VQB31RT7R2fIpFsy2fPrp0TAvzYPNMDnud/J8TQ6/rRrGPq+Dioq9rFq1SkVrP6M9q9Jjdu3aRUvYwi5ve2MlD6BZVZFuKfk8FCyELc9guI5CRgFmyRcoaDKoKy2lyGhkRkoLOz2JfNCYRmPIxjsN6WxwpTI/3c3cSLRobd/TOnHiRO1rExmAmpqaOH78OHu9CXjCVpKtYSYnt5KWlsaoUaPiHZ5I/3eWfNo65WZsh12k7dnDFTlNLMpws74plbLmJKrazmkd6QywOMNNpGIv+/btY9KkSZSUlOiYqDhTsSo9IhAIcOjQIXZ5EgmbBrmOAHnOIE6nk/Hjx8c7PJGBIXsCLP9u7FMDGJ8N48aN49ChQ5SWljLTaGR6Sis7PYmsc6XSELTzbmM6G5pSmZ/uYW6kOVa0zp49mwkTJqhoFRlAKioqgFPH1RSnerG2HVejjvoi3XRGPk0CFudDcXEx5eXl7Nmzh+XZTSxMd7OhKXpOa7XfwerabEY4AizJdBPZU8HevXtVtMaZilXpEZWVlYTDYSraGkFMT2nFMGDy5MnYbPoxE7kQhmEwfvx4xo0bx8GDBykrK4sVrbs8iXzQVrS+15jGxqYU5qV7mBdu5u2336asrExFq8gAcvjwYbxhC0d8TgCKU1uwWq1Mnjw5zpGJDHwpKSksXry4Q9F6eXYzCzM8bHBFi9aawNmL1smTJ1NcXKyitY+pipAecfjwYVrCFo62JdfJya0ATJo0KZ5hiQwqhmEwYcKEDjOtMwwX01Ja2e1N5IPGVE4G7bzfXrSmeZivolVkwHC5XLhcLvZ5kwCDEY4A6fYwo0ePJSEhId7hiQwapxetW7ZsoaKigmXZzSzI8LDRlcLmsxWtu/dQUVGhorWPqViVCxYOhzl69Cj7WxIwMRjmCJJpD5OWlkZmZma8wxMZdCwWS6xobZ9pnW64mJocLVrXNaZSH7TzgSuNTU0pzE1X0SoyEBw+fBiAvS3RwnRSsg+IbgUQkZ6XkpLCkiVLOsy0XpbdzHwVrf2GilW5YFVVVQSDQfZ6UwGYnBSdVR07dqz214j0IovFwsSJExk/fnyHonXaaUVrXdDOug5Fq5u3336bvev/yiLnATKNZozMMVDyhegeHxGJm8OHDxOIGBxqjRark5NbY+cxi0jvSU1NjRWt7TOtXRWtI50BlmQ2x4rWWfkpzIpsx9laAxkFyqc9TMWqXLD25HrwtOQK0WJVRHrfmUVraWkp04wmpia3UuFN4ANXGicCdj50pbG5KYV/SH6Da0LPQPvproYF1v0M4/qV0S6KItLnvF4vJ06c4EBLAmHTINMWIsceIi9vFE6nM97hiQwJqampXHLJJZSUlHQqWtv3tFa3dQ/Ocwb4etIbzD3+HKfnU2Pdz0D5tMeoWJULYpomhw8f5mCLk5BpkGELMdwRIjExkeHDh8c7PJEh5fSi9cCBA5SVlTHFaGJyso+9LQl80JhKYvAkfxN8BothEjs23QxjAubLD2COXoAlZ2I8L0NkSDpy5AgAe1sSAZiUHG1UqIFfkb7XXrS2Lw8+fU/r+rai1RE4yWd47qz5lFcewChYqBnWHqBiVS7IiRMnaG1tpaIluje1PbmOGTNG++FE4sRisVBYWMiECRNiRetko4lJST4mNryB6TOIJdY2BhAB9jz7z1ivepTCwkL9GxbpQ4cPHyZswv4z9quqWBWJn7S0tE5F6+XZzSxI9zDu5JuYoS7yqQlHX/5XMj77n6Snp8cl9sFCxapckEOHDnVIrpOVXEX6jbMVrWNcdW2jwJ2ZmFi8Nbz77ruxRkwqWkV6n9/v5/jx4xxtdeKPWEi2hhnlDDBs2DCSk5PjHZ7IkHe2onWmowZL+Oz5FEyCJw7wwgsvMHHiRGbPnq2i9TzpN5BectNNN5GZmcnNN98c71B6TfsS4COnJdd8ZwC73c6oUaPiHZ6ItGkvWm+55RayxxcTHfftzDQN3vaO5o36dKoavbz77rusWrWKPXv2EA6H+zRmERgauRSiZ5WbpklF28BvYZIPi5YAi/Q77UXr7bffjmP4RLrKpxHTYL0vj0Mtdvbu3ccLL7zAW2+9hcvl6tN4BwMVq73ka1/7Gr/73e/iHUavcrlcNDc3U+GN7q8pTPJhGDB69GisVmucoxORM1ksFjKXfRXDOHPRUvRzA5Pnw5exuTmFXxwdwWv16RxvbOG9995j1apV7Nq1S0Wr9KmhkEshugTYNGGf99R+VVCxKtJfpaamUnD9tz42n/7Kv5xnq4fx++ocDrXY2bdvPy+88AJr166lsbExHmEPSCpWe8nSpUtJTU2Ndxi96tChQ5jmqfPg1AVYZADInoBx/UoMw4JpWDENCxEsmBi8l3ELF+XayE/wE8agrDmFXxzN5a91GRxrbOWDDz7g+eefV9EqfWYo5NJQKERlZSXVfjvusBWHEWFsgp/09HSdVS7Sn52ZTzmVT99Mu5Wc1BSsmFT6nLGi9XCrg/37D7B69WrWrFlDQ0NDvK+i3+tXxeovf/lLioqKSEtLIy0tjUWLFvHXv/61R5/jvffe47rrriMvLw/DMHjppZfOer/HH3+csWPHkpCQwIIFC9i4cWOPxjEYHDlyhON+B96wFacRYWyiH4vFovPgRPq7ks/DA5sxLv4qxvSbMC7+KpU3/In6/CsZl+TnCyPruWNkHQUJfiIYbHEn80RlLn+py+CYyxcrWnfs2EEoFIr31cgZlEsHlthZ5W1dgMcn+bBZNPArMiCcnk9n3ERo/t9TuuhJjqXP56qcJv6uoIY5aZ6zFq0HDhzkj3/8I2+++SYnT56M95X0W/2qwVJ+fj4/+tGPKCwsxDRNfvvb33LDDTewZcsWpk+f3un+69atY/78+djt9g6379q1i+zsbHJzczt9j9frZdasWdxzzz185jOfOWscq1atYsWKFTzxxBMsWLCAxx57jKuuuoqKiorYcSzFxcVn/SXtjTfeIC8v73wuf0DxeDzU1dVR4U0DYGKyD6sBo0aNwuFwxDk6EflE2RNg+XeB6I6bMUBBscnBgwcpKyvDaGxkbGI9R1sdfOBK5XBrAlvdyWxzJzEjpYWLM914P/yQ8vJyioqKmDZtGjZbv0opQ5Zy6cBy6NAhAPZ6OzYqHDduXNxiEpFzcFo+dQDzgKkeD+Xl5ezZs4ercppYlOHmI1cq5c3JsaJ1dIKfJZnNmAcPcejQIcaMGcPs2bMZNmxYPK+m3zFM0+yqjVW/kJWVxb//+7/zpS99qcPtkUgk1qny+eefj+2RrKio4NJLL2XFihX80z/908c+tmEY/OlPf+LGG2/scPuCBQuYN28eK1eujD3X6NGj+cpXvsJDDz3U7djfeecdVq5cyR//+MdPvG9zczPp6ek0NTWRlpbW7eeIlx07drBu3Yf8sjIXV8jGTcNPMjXFx+LFi5k2bVq8wxORC2CaJocOHaKsrCy2ROmYz8EHjakcbI3+Qm1gMi2llYsz3OS0na3cXrSeWfQMJgPtvbrdUMmlMLBeo0gkwu9//3uON4d48lguFkweHFtNVkoin//85zGMszdvEZGBwePxsHXr1lijwuaQJVa0htuaM+Un+FmS4WZsoh/DgIKCAmbPnh0b1Busuvte3a+WAZ8uHA7z/PPP4/V6WbRoUaevWywWXn31VbZs2cKdd95JJBLhwIEDLFu2jBtvvPETk2tXAoEApaWlLF++vMNzLV++nI8++ui8r6crjz/+ONOmTWPevHk9/ti96fDhw9QFbLhCNqyGyYQkP6BlSyKDgWEYjB8/ns9+9rNcccUVZGdnk58Q4PaRJ/li3gkmJrViYrDTk8R/HxvOn2ozOdIUZMOGDTz77LNs2bKFQCAQ78sQhk4uhYGZT2tra/H5fLHeD2MS/SRYTMaOHatCVWQQSElJ4eKLL+b2229nxowZZDoNrspp4u/blwcbJsd8Tp6ryeGZqhwOtjg5cuQoL730Eq+++io1NTXxvoS463drtrZv386iRYvw+XykpKTwpz/9qcuZury8PN566y2WLFnCHXfcwUcffcTy5cv55S9/ed7PX19fTzgc7rTsKTc3lz179nT7cZYvX87WrVvxer3k5+ezevXqs/6icP/993P//ffHRhcGAp/PR3V1NRUtKQCMT/ThsJjk5uaSlJQU5+hEpKcYhsG4ceMYO3YsR44coaysDOrruXVEAzV+Ox80prK3JZHd3iR2e5OYnNTK4kw3/k2b2Lp1KzNnzmTGjBk4nc54X8qQM9RyKQzMfHr48GHg1BLgSTqrXGRQSk5O5qKLLqK4uJitW7eya9curspp4qL25cHuZI75nTxf4yTPGYguD648xrFjx8jLy2P27NmMHDlySA5i9btidfLkyZSXl9PU1MQf//hH7rrrLt59990uk2xBQQHPPPMMl156KePHj+fXv/51v3gh16xZE+8Qes3Ro0ej58Gdsb9GyVVkcDIMg7FjxzJmzBgqKyspLS2FujpuHtHACb+ND1yp7PEmUtES/ShMii4PDpSWsm3bNmaPTWe6vwybpwoyCqDkC9E9PtJrlEv7v/azyj0hC8f90V4Pk5JacTgcjBw5Ms7RiUhvSEpKYtGiRR2K1ivbitb1TamUNSdR5XewqiaHkc4AizPcmMerqKqqIjc3l/kTshlRvQaj6eiQyaf9rlh1OBxMnDgRgDlz5rBp0yZ+9rOf8eSTT571/rW1tdx3331cd911bNq0ia9//ev813/913k/f05ODlarldra2k7PM2LEiPN+3MHkxO6PmNn4V75ttnLMlkOSYzoBslWsigxyhmFQUFDA6NGjOX78eLRora3lM7mN1AXcfOhKZZcnkX0t0Y/xiT6+kvQmM488T3SXqwmGBWPdz+D6ldEuitIrlEv7P9fBUqYcX8VEXzMJtlG8Y72IVJuVgoICnVUuMsglJiaycOFCiouL2bZtGzt37mS5rYmF6W42NKVQ2pxMtd/B6tpsch0BFme6mXTwz+RuWY2JEe2MiDEk8mm/K1bPFIlE8Pv9Z/1afX09l19+OVOnTmX16tXs3buXpUuX4nQ6+clPfnJez+dwOJgzZw5r166NNYuIRCKsXbuWBx544HwvY9AIb/4tF235WvQfisXENAwsJ//M5rwvDphlVyJyYQzDID8/n1GjRlFVVRVdHlxdzQ3DG1mcES1ad3gSifgauT7yPBbDJHZsuhmO/umVBzAKFg76EeH+Qrm0n9nyezJe/gqzABOTEusWvmz8H++13ELB2OWf+O0iMjgkJCQwf/58ioqK2LFjBzt27OByWzMLMzxsdKWwuTmZ2oCD0hMBfuxYfSqftqdUGPT5tF8Vq9/85je55pprKCgowO128+yzz/LOO+/w+uuvd7pvJBLhmmuuYcyYMaxatQqbzca0adN48803WbZsGaNGjeLrX/96p+/zeDzs378/9vmhQ4coLy8nKysrdj7oihUruOuuu5g7dy7z58/nsccew+v1cvfdd/fexQ8EJw9g+cuDGLT9QzEgmmZhXtVv4eRXBu0/FBHpzDAMRo0a1bForariuuGNLM5sZsLJNZhhg1hWbf8+IGJC5Ss/IOOz/9nvO7YONMql/dzJA/DKVzCIEFtobURz6SWu1YSS/iGOwYlIPCQkJDB37lxmzpwZK1ovszazIMPDxqZkLvW8E50o6iKfut76Oemf/U8sln7bO/e89ati9cSJE9x5551UV1eTnp5OUVERr7/+OldccUWn+1osFn7wgx+wZMmSDud6zpo1izVr1nR5RtHmzZu57LLLYp+vWLECgLvuuounn34agNtuu426ujoefvhhampqKC4u5rXXXjvrWXNDypZnMNtr1NMYgGkYsOWZ2DlTIjK05OXlkZeXR01NDVu2bIHKSoqd1VhauzodzSRQu59Vq1ZRWFhIcXExGRkZfRnyoKVc2s9teQYT4+y5FAPHjudhxHfjEJiIxJvT6WTOnDnMnDmTXbt2sW3bNpZa3VxqVmL4u86nJw+W8/oLL1BSUkJhYeGgKlr7/TmrQ8VAOBfO/OM9mDtexELnHxnTsGBMvwlu/k0cIhOR/ubEiRN4Xvp/jK16BQuRTl8PmRb+wDVszbiayUk+LJbocTklJSVkZWXFIeLuGQjv1UNdv3+N/ngP5o4/YZzl34VyqYicLhgMsnv3bixvPco019ou8+mbjuUcyr4CmyV6XE5xcTGTJk3CZutX85IddPe9uv9egfQ7gcQR2M+yBAGIjhFnFPR9UCLSLw0fPpzhn30Yc+UrnVZkmETbLf0mcDlHarMZZg9yUaab8P4DHDhwgDFjxlBSUjLoD0SXISqjoO3fwNkol4rIKXa7naKiIkIj/hXjF2s7vXdE86vJjzxXc7JlGAsz3JREvHzwwQeUlZVRVFTE1KlTsdvt8bqECzZ45oil11XlLgNMzpyLN9v/W/KFvg9KRPqv7AkY16/EMCyYhpUIFiJYMDFYm34ro9KTcBoR6oJ2Xj6RxX8fG842dxIHDx/hpZde4i9/+QvV1dXxvgqRnlXyhfbe2B20D+Iol4rImWzDJ2PcsBJi+dSI5lPD4HfO/48GSw6esJU1JzN4/GguHzam0OhpZf369Tz77LOUlZV12WSvv9My4H6i3y9bAt59910CpX9gWdMLmBhtHckMDAOMQd42W0QuwMkD0T3trqP4EnPZaili2zEPpmniCxtsbk5hU1MKrZHo+Gm6LcSiDDdFqS3YDBgxYgQlJSXk5+fH/ezPgfBePdT199fI4/Gw+X++ziWu1URMAwMTw2j7/w2PK5eKSNfa8qnZeIRGM5WP/IUcb3USMmG7O4mPXKm4QtGFs05LhLlpHuale0myRrDb7UyfPp2ZM2eSmJgY5wvp/nu1itV+or8nV4BVq1ZRVu1jfW2IO+1vcWnyMQKJuUz7/A/VBVhEzonb7Wbr1q1UVFQQDofxRwy2NCezvimFlnD0jMlUa5gFGW5KUluwW0xycnIoLi5m3LhxcStaB8J79VDX31+j/fv389Zbb1F2IkCRbwOzHNUkJaWQcdlXGDfn8niHJyIDSCQS4dChQ5SVldHY2EjEhF2eRNa5UjkZjC79tRsRZqd5WZDuIcUWwWq1MnXqVIqKikhJSYlb7NqzKj2qpaWFpqYmKn1pHDFzeMlxA+FMF4WFhUxToSoi5yg1NZXFixdTUlLCtm3b2L17NwszPMxJ81LuTmK9KxV325KmDxtTWZDhYXbkJPVr1pCRkUFxcTETJ04cVB0PZWioqakBYJM/n9dC47g5+ySTkn3cXjgvzpGJyEBjsViYMGEC48eP58iRI2zZsgWLUcf0lFYqvAmsc6VSG3CwoSmVzc0pzEr1sjDdw44dO9i1axeTJk1i1qxZpKenx/tSuqRiVbqlPbke9UWPNihICAAwcuTIuMUkIgNfcnIyixYtoqSkhO3bt7Njxw7mWbyUpHnZ7k7iQ1cqTSEbbzek85ErNbqkKdyE6513KC0tZdasWf2+46HI6aqrq/GGLbFZj9EJfpKTk0lNTY1zZCIyUBmGwdixYxkzZgzHjx+nrKwMo6aGyck+DrY6WdeYyjG/k7LmFLY0JzM9pZVFGW4ie/ZQUVHRr7vxK7tLt9TU1BCKQHVbsTo6MbpJe8SIEfEMS0QGiYSEBObNm0dRURE7d+5k+/btlBgtFKW2xJY0NQTtfOBKY2NTCnPSvMwLeXB/8AGlpaWxjoennxUq0t/4fD4aGxup9CUAMMweJNFqMmLEiLjvxxaRgc8wDPLz88nPz6e6upotW7ZgHDvG+EQ/lT4HH7pSOdiawA5PEjs8SUxKauWiDDfmgVPd+IuLi/vVedgqVqVbampqqPI7CGOQbA2TaQuTmJjYr5cNiMjA43Q6mT17NjNnzmT37t1s27aNmUZLhyVNJwIOPmpKZVNzCsWpXhZmeNiwYQPl5eXMHpPOVN9mbJ6q6BEgJV/QnnrpN2prawGobHUCGvgVkd4zcuRIRo4cyYkTJygvL8c4fJiCxJNU++186EqlwpvA3pZE9rYkMjbRFy1aDx/hyJEj5OXlMXdcJrlVb2I0HY1rPlWxKp8oEAhw8uRJKn3JQHTJkmFAbm6uRoJFpFe0ny03ffp0Kioq2Lp1K1MNN1OSfexviRatVX4Hm5tTKGtOZmZqC/clrGX6oVXQfjCIYcFY9zNQt3LpJ9qPYqpsX6WkLTUi0suGDx/OlVdeSUNDQ7RoPXCAz+Y2UB+w8ZErhR2eJA63JnC4NYGRzgCLMtxM2vcywzevxsRoO9jViFs+VbEqn6i2thbTNDnqi44Ea7+qiPQVq9XKtGnTmDJlCgcOHKC8vJxCo5GJST4O+5x82JjKEZ+TJk8zVwdWtR2p1dbk3gxH//TKAxgFCzXDKnFXU1ODP2JQG4juVy1I8ON0OsnMzIxzZCIy2GVlZbFs2TLmzp1LeXk5e/fu5brhLpZkutnQlMJWdzLVfgdlJwL8u2P1qXzanlIhLvlUxap8opqaGiImHI+NBGvZkoj0LYvFQmFhIRMnTox1PDTq6hiX6OeYz8HUhrWYpkEsq7YxgIgJh1/8Pqk3/YScnJy4xC8SCoWoq6vjmM+BiUGmLUSqLaJVSiLSp9LS0rjkkkuYM2dOrBv/VfYmFme62dSUzFLvO9EZ1S7yaf0bPyXj5sew2+19Eq+KVflENTU11AbsBEwLCZYIwxwh7HY72dnZ8Q5NRIaYMzselpeXQ1UV8xKrsLR2dWy4SfjkIV588UXy8/MpLi5m5MiRKhCkT504cQLTNKlsW6WkgV8RiafTu/Hv2LGDHTt2sNTqZimVWHxd59Omozv463PPMWPGDKZPn47T6ezVOFWsyscKh8OcOHGCytZo58L8hACWtv2qOt9QROLl9I6HtbW1eF/+AFq3ceZIMEDENPiwdRQV3gTMymMcO3aM4cOHU1xczJgxY1S0Sp9o3696tLW9q7621IhI/CUkJDB37lyKiorYvXs3gbffAF/nmVWI5tOt/hFUuYP4Nm+O9pOYOpWZM2eSnJzcK/Gp2pCPVVdXRzgcju1X1UiwiPQ3ubm5jP/sIxhG59RqEm239OvA5fxvbTa/OjacHe5EampP8MYbb1BaWhqPkGUIqqmpIRiBan/7eeV+rFarlqaLSL/gcDiYNWsWU+7417MsAgbTjObTn7deyZOVubxYm8lRD2zbto0XXniBQCDQK3GpWJWPVV1djWl27lyoYlVE+pXsCRjXr8QwLJiGFRMLESyYGKxJv5VR6ck4jQj1QTuv1GVRH7BhGAaTJk2Kd+QyBEQiEWpra2NHwKVYw2TYwgwfPhyr1Rrv8EREYmzDJ2PcsBLa8mkEI5pPDYOXkj+HLSEDE4M93iQ2NqUAMH78+F4751zLgOVj1dTUUB+00RqxYjMijHQGsFgsDB8+PN6hiYh0VPJ5KFiIseUZcB0llDySnc45VB1pYmmwmYXpbkqbk2kI2hjuDDFhwkTS0tLiHbUMAfX19YRCISp9qcCpI+C0BFhE+qWSz0e7/rbl02Yjg03hKZx0wW0ZJzkRsLHelcrCdDcAs2bN6rVQVKxKlyKRCDU1NbFZ1VHOIFYDhg0bhs2mHx0R6YeyJ8Dy7wJgB4qBqX4/O3fuZMeOHVxs9cTuWlxcHIcAZSiqqakBTq1SKtAqJRHp79ryqQGkA5ebJtOqq9m6dStUVnL98EYAxo0bR0ZGRq+FoYpDutTQ0EAwGKTSF53ib9+vqpFgERlInE4ns2fPpqioiD179rBt2zaysrLIysqKd2gyRFRXVxMx4Vj7lppEP4ZhkJubG+fIRES6xzAM8vLyyMvLo76+nvLycg4dOtTrA78qVqVLsZHgMzoXaiRYRAYim83GjBkzmDZtGj6fL97hyBBhmiY1NTXU+O0E24+As4fIyRnWZ+cUioj0pJycHJYvX47X6+21LsDt1GBJulRTU0NT0Epz2IYFk1HOaLGqkWARGcgsFgtJSUnxDkOGCJfLhd/v73C+qmFo4FdEBr7eLlRBxap0wTRNqqurOdq2ZGmEM4jDYpKdnd3rh/+KiIgMFrHzVc/oqq8tNSIin0zFqpxVc3Mzra2tsZHgAp2vKiIics5qamowTTimfCoics7Oe89qMBikpqaGlpYWhg0bpkYVg0z7ftUzR4KVXEVEepby6eBWU1NDXdBGa8SC3YiQ6wySkZFBQkJCvEMTEen3zmlm1e1288tf/pJLL72UtLQ0xo4dy9SpUxk2bBhjxozh3nvvZdOmTb0Vq/Sh6upqvGELDUE7YJKvTsAiIj1G+XRocLvdeDweKlujs6qjEgJYtV9VRKTbul2s/vSnP2Xs2LE89dRTLF++nJdeeony8nL27t3LRx99xCOPPEIoFOLKK6/k6quvZt++fb0Zt/SympqaWBfgYY4QiVaTtLQ0NSUREblAyqdDR1fnq2rgV0Ske7q9DHjTpk289957TJ8+/axfnz9/Pvfccw9PPPEETz31FO+//z6FhYU9Fqj0nZaWFpqbm6n0pQPaXyMi0pOUT4eO6upqTBOOntYJGJRPRUS6q9vF6nPPPRf7889//nNuvvlm8vLyOt3P6XTy5S9/uWeik7ho71xYqf2qIiI9Tvl06KipqcEVsuIJW7FgkucMkJycTGpqarxDExEZEM6rG/CDDz7IkiVLqKys7HB7IBCgtLS0RwKT+Dlx4gQRE+qC0cPKRzq1bElEpDconw5efr8fl8vF8baB35HOAHaLcqmIyLk476Nrli9fzqWXXtohwTY2NjJ//vweCUzip6GhgYagjbBp4DAiZNjCJCQkkJaWFu/QREQGHeXTwamxsRGAE4HowG+uMxj9f25u3GISERlozuvoGsMw+P73v8/w4cO59NJLeffddxk9ejQApmn2aIDS9xoaGmLJdZgjhGFAdnY2hmHEOTIRkcFF+XTwamhoAE4Vq8Md0WI1Ozs7bjGJiAw0533OKsD3v/99DMOIJViHw6GCZoBrbW2ltbWVE4Hofpphbck1MzMznmGJiAxqyqeDT3uxWnfa4C8on4qInIvzKlZPH+199NFHYwn2+eef77HAJD46J9dosapD6kVEep7y6eDV0NBAa9jAHbYC0XyanJyM0+mMc2QiIgPHeRWr//qv/0pycnLs8+9973sAXHfddT0TlcTNmcXqcBWrIiK9Rvl0cDJNk4aGhlguTbOFSLCYyqUiIufovIrVb37zm51u+973vofdbucnP/nJBQcl8dPQ0IA/YuAKRX802pctKcGKiPQ85dPByev1EggEqAtEByKGK5eKiJyX8+4GfDbf/va3cblcPfmQ0sdOHwlOsYZJskZIS0vDZrug7c0iInIOlE8HtlPNldoHfrVKSUTkfPRosSoDm2maNDY2UteWXLUEWERE5NxpS42ISM9QsSoxzc3NhEKh046tUXIVERE5Vw0NDZgm1AVP5VPDMMjIyIhvYCIiA4yKVYnRSLCIiMiFa2hooDlsxR+xYMEk2x4iIyMDq9Ua79BERAYUFasSExsJPuNMOBWrIiIi3ROJRHC5XLEtNdn2EFZDuVRE5HyoWJWYhoYGPGELrRELBiY59iBWq5W0tLR4hyYiIjIguFwuIpGIttSIiPSAHi9WLRYLy5Yto7S0tKcfWnpZQ0NDLLlm2UPYLJCZmYnFojENEZG+pnw6MGlLjYhIz+nxKuQ3v/kNl1xyCffff39PP7T0olAoRHNzs5KriEg/oXw6MJ06tkZbakRELlSPH575xS9+EYDvfve7Pf3Q0otcLhemaSq5ioj0E8qnA1NDQwNhE06edgyc3W4nJSUlzpGJiAw8Wt8pwOnLlnTGqoiIyPlqbGzkZNBGBAOnESHNFiYrKwvDMOIdmojIgNOjxWplZSX33HNPTz6k9JH2keB6NYQQEYk75dOBKRAI4Ha7T+uqH8Qwov0fRETk3PVosdrQ0MBvf/vbnnxI6SMNDQ00BG2EMXAYETJsYZxOJ4mJifEOTURkyFE+HZgaGxsBHQEnItJTzmnP6iuvvPKxXz948OAFBSPx09DQ0CG5Gm1nwmnZkohIz1M+HZxONVeK/nqlVUoiIhfmnIrVG2+8EcMwME2zy/uouBl4fD4fLS0tnAikAkquIiK9Tfl0cNKxNSIiPeuclgGPHDmSF198kUgkctaPsrKy3opTetGZyVXFqohI71I+HZwaGhrwRwyaQqdmVpOSkkhISIhzZCIiA9M5Fatz5sz52MPJP2mUWPonjQSLiPQt5dPBxzTNDltqUq1hEq2mcqmIyAU4p2XA/+///T+8Xm+XX584cSJvv/32BQclfat9JNgVGwmONoRQ90IRkd6hfDr4tLS04Pf7ORFIArRKSUSkJ5zTzOqSJUu4+uqru/x6cnIyl1566QUHNRjcdNNNZGZmcvPNN8c7lE90+khwijVMkjVCamoqDocjzpGJiAxOyqfdM9ByKWiVkohIT+rRo2vklK997Wv87ne/i3cYn8g0TRobG6lr61yo5CoiIv3FQMmlcHonYPV/EBHpKSpWe8nSpUtJTU2NdxifyO12EwwGlVxFRKTfGSi5FKLFqmmePrMawjAMMjIy4huYiMgA1q+K1R/+8IfMmzeP1NRUhg8fzo033khFRUWPPsd7773HddddR15eHoZh8NJLL531fo8//jhjx44lISGBBQsWsHHjxh6No7/QsiURkcFFuTQ+Ghoa8IQt+CIWDEyyHUHS09Ox2c6pPYiIiJymXxWr7777Lvfffz/r16/nzTffJBgMcuWVV3bZhGLdunUEg8FOt+/atYva2tqzfo/X62XWrFk8/vjjXcaxatUqVqxYwSOPPEJZWRmzZs3iqquu4sSJE7H7FBcXM2PGjE4fVVVV53jV8dU+EnxqZjXaXEnFqojIwKRc2vcikQgulyuWS7PsIWyGcqmIyIU67+G+Y8eOkZeXh8Vi6fDnC/Haa691+Pzpp59m+PDhlJaWcskll3T4WiQS4f7776ewsJDnn38eq9UKQEVFBcuWLWPFihX80z/9U6fnuOaaa7jmmms+No6f/vSn3Hvvvdx9990APPHEE/zlL3/hN7/5DQ899BAA5eXl53uZ/cqZI8E59iAWi4X09PR4hyYiMiT0dD5VLu17zc3NhMNh6gKJgFYpiYj0lPPOhtOmTePw4cOd/tyTmpqagLO/2VssFl599VW2bNnCnXfeSSQS4cCBAyxbtowbb7zxrMm1OwKBAKWlpSxfvrzDcy1fvpyPPvro/C7kYzz++ONMmzaNefPm9fhjd0djY2PHkWBL9MiaCx14EBGR7untfDoUcinEN592bq6kVUoiIj3hvCuS0w8r742DyyORCA8++CAXX3wxM2bMOOt98vLyeOutt/jggw+44447WLZsGcuXL+eXv/zleT9vfX094XCY3NzcDrfn5uZSU1PT7cdZvnw5t9xyC6+++ir5+fldJuf777+fXbt2sWnTpvOO+XyFw2FcLpf2q4qIxFFv5tOhkkshvvn0VP8HddYXEelJ/XbX//3338+OHTv44IMPPvZ+BQUFPPPMM1x66aWMHz+eX//61xiG0UdRdm3NmjXxDuETuVwuTNPUSLCIyCClXNo3GhoaiJhQHzzVWd9msw2YTsYiIv1Vv1zr+cADD/DnP/+Zt99+m/z8/I+9b21tLffddx/XXXcdLS0tfP3rX7+g587JycFqtXZqKlFbW8uIESMu6LH7m1PLljQSLCIy2CiX9p2GhgYagjbCpoHdiJBhC5OVldUvCn4RkYGsXxWrpmnywAMP8Kc//Ym33nqLcePGfez96+vrufzyy5k6dSovvvgia9euZdWqVfzjP/7jecfgcDiYM2cOa9eujd0WiURYu3YtixYtOu/H7Y8aGhoIm3BSZ6yKiAwayqV9KxgM0tzc3GGVkqFOwCIiPaJfLQO+//77efbZZ3n55ZdJTU2N7WtJT08nMTGxw30jkQjXXHMNY8aMYdWqVdhsNqZNm8abb77JsmXLGDVq1FlHhj0eD/v37499fujQIcrLy8nKyqKgoACAFStWcNdddzF37lzmz5/PY489htfrjXU0HCxiI8GcGgl2Op0kJSXFOzQRETlPyqV9q7GxEdB+VRGR3tCvitX2Zg5Lly7tcPtTTz3FF7/4xQ63WSwWfvCDH7BkyRIcDkfs9lmzZrFmzRqGDRt21ufYvHkzl112WezzFStWAHDXXXfx9NNPA3DbbbdRV1fHww8/TE1NDcXFxbz22mudGkUMdA0NDac1Vzo1EqxlSyIiA5dyad861VxJq5RERHpavypWz7UL4hVXXHHW20tKSrr8nqVLl3breR544AEeeOCBc4pnIPH7/Xi9Xk4Eos0f2pNrZmZmPMMSEZELpFzatzofW6NiVUSkp5z3ntVvfetbsTfi0/8sA0N7cnUFo+MV2XZ1AhYRiQfl04GtoaGBQMTAFYrm02GOEImJiSQkJMQ5MhGRge+8Z1a/+c1vnvXPMjA0NzcD0NSWXNNsKlZFROJB+XRga25upilkBSDBEiHZGlEuFRHpIf2qG7D0HY/HAxBLsBn2MIDOhBMREemmSCSC1+uN5dL2gV/lUhGRnqFidYhyu92ETPCE2xNsGIvFok7AIiIi3dTS0oJpmjS1balJt0UHflNSUuIZlojIoKFidYjyeDw0t40E24wISZYIKSkp6gQsIiLSTW63Gzi1Sqm9WNXMqohIzzjnYvXIkSO88cYbsXPbzlRVVXXBQUnvc7vdHUaCDUMjwSIifUn5dODrqlhVPhUR6RnnVKw+99xzTJw4kauvvprx48fzzDPPAHD06FF+9KMfsWDBgthh4NJ/mabZYY+NRoJFRPqW8ung0N7/oTnUPvirPasiIj3pnIrV73//+3zlK19h+/btXHHFFfzd3/0d3/nOd5gwYQJPP/00c+fOZfXq1b0Vq/SQlpYWIpGIRoJFROJE+XRwOLNZYbo9jGEY6v8gItJDzunomgMHDvC1r32NMWPG8Pjjj1NQUMC6devYtm0bU6dO7a0YpYedWrakkWARkXhQPh0cztasMCUlBYtFLUFERHrCOb2bBoNBEhMTAcjPzychIYGf/OQnSqwDzNlGgkEzqyIifUX5dHDoqlmhiIj0jHMe+nv22WfZs2cPAFarlczMzB4PSnpX+8xqs5YBi4jEjfLpwGaaJh6PR80KRUR60TkVq0uWLOGRRx5h+vTp5OTk4PP5+NnPfsYLL7zArl27CIVCvRWn9CCPx0PEPL1YDWEYhhKsiEgfUT4d+FpbWwmHw2pWKCLSi85pz+q7774LwL59+ygtLaWsrIyysjJ+97vf4XK5cDgcTJo0iW3btvVKsNIzPB4P7pAVEwMLJinWCElJydpjIyLSR5RPB75OW2q0SklEpMedU7HarrCwkMLCQm6//fbYbYcOHWLz5s1s2bKlx4KT3uF2uzskV8PQSLCISDwonw5cp7bUqFmhiEhv6XaxevTo0Y89823cuHGMGzeOW265BYDjx48zatSoC49QelRsj03IDkBaW3LVSLCISN9QPh0c1KxQRKT3dXvd57x58/jbv/1bNm3a1OV9mpqa+NWvfsWMGTP43//93x4JUHqWz+cjFAqddmyNkquISF9SPh0cTh0Dd+rYGlA+FRHpSd2eWd21axf/+q//yhVXXEFCQgJz5swhLy+PhIQEGhsb2bVrFzt37mT27Nn8+Mc/5lOf+lRvxi3nqauRYC1bEhHpG8qng8PZmhUmJSVhtVrjHJmIyODR7ZnV7OxsfvrTn1JdXc3KlSspLCykvr6effv2AfD5z3+e0tJSPvroIyXWfuzMkWB1LxQR6VvKp4OD2+3GHe7YrFC5VESkZ51zg6XExERuvvlmbr755t6IR3pZ+8zqmQ0htGxJRKRvKZ8OXKfOWD21BNiiM1ZFRHpcj5xVUlZW1hMPI33A4/FgmsQSrPasioj0H8qnA0MgECAYDJ62BFi5VESkN/RIsTp//nxWrFjR4bZXX321Jx5aepjb7cYbthDGwMAk1RYmMTERm+28TjESEZEepHw6MHTeUqNja0REekOPFKszZ84kLS2Nu+++O3bbt7/97Z54aOlh0WNrosk11RrGqmVLIiL9hvLpwHCqWWF0oFedgEVEekePFKuGYfDd736XWbNmcfPNNxMMBjFNsyceWnqY2+0+lVzVCVhEpF9RPh0YOs2sKp+KiPSKHln7mZaWBsCDDz5IZmYm119/Pa2trT3x0NKDAoEAgUCAplB05Fd7bERE+hfl04Gh0zFwalYoItIrzqlYbWlpISkpqdPt77zzTuzPd911F2lpaXzpS1+64OCkZym5ioj0D8qnA5vb7cY0T++sH8bpdGK32+McmYjI4HJOy4DT09Opr6//xPvddNNNNDQ0nHdQ0jtiy5aCp5IraNmSiEhfUz4d2DweD96whZBpACZptrByqYhILzinYjUcDhOJRGKfL1myhNra2h4PSnpH5+6FWgYsIhIPyqcDm9vtjh1bk2qNqFmhiEgvuaAGS+Xl5Xi93p6KRXpZ7IzVM4pVjQaLiMSX8unAEQwG8fv92lIjItIHeqQbsAwMHo+H1oiFoBl92dNtIRwOBw6HI86RiYiIDAxdHVujgV8RkZ53zsXqs88+S1lZGcFgsDfikV50+rKlZGsYm0XJVUQkXpRPByYdWyMi0nfOqRvwkiVLeOSRR3C73djtdkKhEI888ghLliyhpKSEoqIinE5nb8UqF8jj8eDSflURkbhTPh241FlfRKTvnFOx+u677wKwb98+SktLKSsro6ysjIceegiXy4XNZmPq1Kls3bq1V4KV8xcKhWhtbaU5mAwouYqIxJPy6cB1ama1Y2d95VMRkZ53TsVqu8LCQgoLC7n99ttjtx06dIjNmzezZcuWHgtOes6Ze2zUXElEJP6UTwee9nzaHDy1Uslut2smXESkF5xXsXq6vXv3Mn78eMaNG8e4ceO45ZZbeiIu6WFnLltK00iwiEi/onw6MHg8HnxhA39bs8I0W5iUlAwMw4hzZCIig88FdwOeOnUqBw8e7IlYpBd1dcaqZlZFRPoH5dOBwe12x3JpoiWMw2Iql4qI9JILLlZN0+yJOKSXdVoGbNeeVRGR/kT5tP8Lh8O0tLRov6qISB/ROatDhNvtxh8x8EXaz1gNY7VaSUhIiHNkIiIiA0PnTsAqVkVEepOK1SHC4/HEkmuCJYKzbdmS9tiIiIh0T6ditW2VkpYBi4j0DhWrQ4Tb7aYp2L5sSUuARUREzpWOrRER6VsqVoeASCTStsdGzZVERETOV+zYGuVTEZE+oWJ1CPB6vZim2Sm5aiRYRESk+2LLgE87Y9VqtZKYmBjPsEREBi0Vq0NA52NrtMdGRETkXLndboIRg5ZI+5nlIVJSUtT/QUSkl1xwsfqNb3yD7OzsnohFeknnY2s0syoi0t8on/Z/pzcrdBgREiymcqmISC+yXegD/PCHP+yJOKQXdZ5ZVbEqItLfKJ/2b5FIpK1YdQDRXGoYyqUiIr1Jy4CHAI/HQzAC3nD7sqUwhmGQlJQU58hEREQGhpaWFkzT1LE1IiJ9SMXqEODxeGhuWwJsNyIkWiKkpKRgsejlFxER6Y5TnYB1bI2ISF9RtTIEuN3uDkuADUMjwSIiIueiqy01yqciIr1HxeogZ5pmh4YQGgkWERE5d7FiNXhqSw0on4qI9CYVq4NcS0sLkUik0x4bJVcREZHuO9VZ/9QxcIZhkJycHM+wREQGNRWrg1ynY2u0bElEROSceTwewia4w6dWKiUnJ6v/g4hIL9I77CCnPTYiIiIXzu120xyyAgY2wyTZGlEuFRHpZSpWB7lY98LgqWVLoGXAIiIi3XVm/4c0W0hnrIqI9AEVq4Oc2+3utGwJ0B4bERGRbmptbSUcDuvYGhGRPqZidZDzeDy4Q1ZMDKxty5aSk5OxWq3xDk1ERGRA6NxcSVtqRET6gorVQe7MY2u0bElEROTcxIpVHVsjItKnVKwOYqZp4na78bQtAU6xKrmKiIicq1PNCtuXAav/g4hIX1CxOogFg0FCoRCt4ejLnGiNAFq2JCIici68Xi8AnrZ8mqqZVRGRPqFidRDz+XwAtEbailVLtFhNSEiIW0wiIiIDjd/vB4gN/iZZItjtdmw2WzzDEhEZ9FSsDmKxYrU9uVpVrIqIiJwrn8+HaZ42+GuNKJeKiPQBFauDWGwkWDOrIiIi583v9+OPGJgYQDSfKpeKiPQ+FauD2JkzqwltM6tOpzNuMYmIiAw0Pp8vNvBrNyLYLMqlIiJ9QcXqINbVzKoSrIiISPf5/f5TzQqVS0VE+oyK1UHszJnVRO1ZFREROSeRSCRarEaUS0VE+pqK1UGsq5lVh8MRt5hEREQGkkAgAHQe+NXMqohI71OxOoj5fD4iJvhPGw12Op1YLHrZRUREuuPMY+AS1KxQRKTPqGoZxE5ftgTqXigiInKuzjxjVZ31RUT6jorVQczn853qBGyJYDG0bElERORcnDmzqmXAIiJ9R8XqINahIYRGgkVERM7ZmTOrScqnIiJ9RsXqINZhZlUjwSIiIudMM6siIvGjYnWQikQiBINBnbEqIiJyATrtWdXRNSIifUbF6iClM1ZFREQuXOduwCaGYWC32+MZlojIkKBidZDq6oxVFasiIiLdd7ZuwAkJCRiGEc+wRESGBBWrg1RXM6taBiwiItJ9Pp+PsAkBs+OZ5SIi0vtUrA5SmlkVERG5cH6/PzbwCyYJOrNcRKTPqFgdpDSzKiIicuF8Pt9pA7+mziwXEelDKlYHqU6t9jWzKiIics5OPwZOA78iIn1Lxeog1VWrfSVYERGR7gmFQoTDYQ38iojEiYrVQcrv92OaHWdWrVYrNpstzpGJiIgMDGcO/CaoWBUR6VMqVgcpn89H0DQIm9HW+u3dC9VqX0REpHs6banRKiURkT6lYnWQ8vv9seRqwcRhmBoJFhEROQdnO2MVNLMqItJXVKwOUmc2hDDUvVBEROScaGZVRCS+VKwOUh1b7WskWERE5Fx1dQyc8qmISN9QsToImabZ4RBzjQSLiIicu9gy4DMGf5VPRUT6horVQSgUChGJRDSzKiIicgG6OgZO+VREpG+oWB2Eulq2pJFgERGR7uu0Z9USwWazYbVa4xmWiMiQoWJ1EFL3QhERkQvn8/miZ5afNvirXCoi0ndUrA5C6l4oIiJy4fx+PwHTIELbmeWWiHKpiEgfUrE6CHVaBqyZVRERkXN2+jFwVsPErjPLRUT6lIrVQah9GbAvooYQIiIi58vv93fYr6ozy0VE+paK1UHobA0hQAlWRESku9qPgfOpE7CISNyoWB2Eumq1r2JVRESkewKBAKZp0qKBXxGRuFGxOgj5fD4iJrRGTjWEcDgcWCx6uUVERLpDnfVFROJP1csg5Pf72/arthWrVnUvFBERORfqrC8iEn8qVgeh07sXOowIVkMjwSIiIueiU2d97VkVEelzKlYHoQ7dC5VcRUREzllsGXBEy4BFROJFxeogdPrMqhpCiIiInLuuZlaVT0VE+o6K1UEmEokQCATwRU7tVwUlVxERkXPR6cxyDf6KiPQ5Fas97KabbiIzM5Obb745Ls+v7oUiIjLQxTuXwtlnVg3DULEqItKHVKz2sK997Wv87ne/i9vztxerLepeKCIiA1S8cymcfc+qw+HAMIx4hiUiMqSoWO1hS5cuJTU1NW7P32kkWDOrIiIywMQ7l8KpM8t9pw3+KpeKiPStIVWsvvfee1x33XXk5eVhGAYvvfRSp/s8/vjjjB07loSEBBYsWMDGjRv7PtAL0GkkWN2ARUSkBw2FXAodO+tDdPBXuVREpG8NqWLV6/Uya9YsHn/88bN+fdWqVaxYsYJHHnmEsrIyZs2axVVXXcWJEydi9ykuLmbGjBmdPqqqqvrqMj5WVzOrWgYsIiI9YSjkUujYWd9piWAxlEtFRPqaLd4B9KVrrrmGa665psuv//SnP+Xee+/l7rvvBuCJJ57gL3/5C7/5zW946KGHACgvL++RWPx+f2wWFKC5ubnHHhc0syoiIr2jP+VS6N18emYnYOVSEZG+NaRmVj9OIBCgtLSU5cuXx26zWCwsX76cjz76qMef74c//CHp6emxj9GjR/fI42pmVURE4qWvcyn0Tj4Nh8MEg0GdsSoiEmcqVtvU19cTDofJzc3tcHtubi41NTXdfpzly5dzyy238Oqrr5Kfn99lcv7mN79JU1NT7KOysvKC4m/XXqye3hDCMAzsdnuPPL6IiEhX+jqXQu/k07N1AgYVqyIifW1ILQPuC2vWrOnW/ZxOZ68kPb/fTygCQbNj90K12hcRkYGiu7kUeiefnu2MVdAyYBGRvqZitU1OTg5Wq5Xa2toOt9fW1jJixIg4RXXuTu9eaGDiNEwlVxm02pfqifQGu92O1WqNdxgDymDKpdB5ZlX5VPoL5T8ZKC40l6pYbeNwOJgzZw5r167lxhtvBCASibB27VoeeOCB+AZ3Dk7vXphoiWCoe6EMUh6Ph2PHjmGaZrxDkUHKMAzy8/NJSUmJdygDxmDKpQAt2rMq/ZDynwwkF5pLh1Sx6vF42L9/f+zzQ4cOUV5eTlZWFgUFBaxYsYK77rqLuXPnMn/+fB577DG8Xm+so+FA4Pf7aVEnYBnkwuEwx44dIykpiWHDhmmZu/Q40zSpq6vj2LFjFBYWaob1NEMll4JmVqX/Uf6TgaQncumQKlY3b97MZZddFvt8xYoVANx11108/fTT3HbbbdTV1fHwww9TU1NDcXExr732WqdGEf1ZdGY12kxJDSFksAoGg5imybBhw0hMTIx3ODJIDRs2jMOHDxMMBlWsnmao5FIAn2ZWpZ9R/pOB5kJz6ZAqVpcuXfqJSyYeeOCBAbVU6XShUIhwOExrJJpMlVxlsNOIsvQm/Xyd3WDPpXBagyXNrEo/pfcnGSgu9GdVR9cMIp1GgpVcRUREzllsGfBpM6tWqxWbbUiN8YuIxJ2K1UGk0x4b7VkV6VPf/e53Y4NGIjJwnW3PqnKpyNkp90lv0hDhINLpXDjtWZVB7sMPP6S5ublPnisrK4tLLrnkY+/zve99jwcffLDTL7WhUEgzMiIDiM/nIxgxCJnR5WuJ1ohyqfQr/Sn/KfdJb9JP0CCimVUZalwuF/X19fEOA4Avf/nLACxZsgSr1UpeXh4jRoxg//79nDhxgj179mAYBo2NjWRkZADRMyk3b97M2LFj2bdvHw8++CAnTpzA7/dz3333Deg9fyID2elnllswcejMculn+kv+U+6T3qZlwIOIZlZF4ueJJ54A4P3336e8vJzhw4dTWlrKX/7yF/bs2fOx3xsOh/nc5z7Hf/zHf7Bp0ybWr1/Pf//3f7Np06a+CF1EztDhzHKrziwX6Ypyn/Q2zawOIrFDzDWzKtIv3HLLLaSmpn7i/SoqKti5cye333577Da3282uXbuYN29eb4YoImcwTTNarEY6HgOnXCrSPcp90pNUrA4iZ+teCBoNFomXlJSUDp9brVbC4XDs8/YBJtM0ycrKory8vC/DE5GzaD/HUrlU5Pwo90lPUrE6iPh8PkwTfKd1L7Tb7TrMXgatjIwMLJa+2c2QlZX1ifdJTU2lqakpti/nTBMnTmTDhg186lOf4sUXX8Tr9QIwefJk0tLSeOqpp7j77rsB2L9/P1lZWd16XhHpOTpjVQaC/pT/lPukN6lYHUT8fj/+iIHJ6d0Lk+IclUjvueiii/rVL5D/8A//wBVXXEFSUhJ5eXmdvv6f//mffPWrX+Xb3/42n/70p8nOzgbAZrPx5z//mQcffJD//M//JBwOk5OTw7PPPtvXlyAy5GmVkgwE/Sn/KfdJbzJM0zTjHcRQ9vjjj/P4448TDofZu3cvTU1NpKWlnddjvfzyy+w5Vs8vK0dgNyL8v3HV5OTk8JnPfKaHoxaJL5/Px6FDhxg3bly/SdYy+Jzt56y5uZn09PQLeq+W3tFT+fTYsWO8+uqrrDmZzsamFBamu1mW3cxVV13FmDFjeiFyke5T/pOBpquf2e7mU3UDjrP777+fXbt29Ujnsw7dC9UJWEREhpCeyqedOutrZlVEJG5UrA4i0e6F6gQsIiJyvrRnVUSk/1CxOkiYpkkgENBIsIiIyAU4tWf1VP8HUD4VEYkHFauDhN/vxzTNU2esaiRYRETknHU1s6piVUSk76lYHSTUvVBEROTCnZlPE6wRHA5Hnx0TIiIip+idd5CIJVfNrIqIiJy36EqlU2eWJ1kiyqUiInGiYnWQaF+25NPMqkhcvPjii8yZM4fi4mKmTJnCsmXLiEQisa8//vjjzJgxg6lTpzJ79mw+97nPcfToUQAMw2DmzJkUFxdTXFzMww8/fNbnaGlpYe7cubjdbgDWr1/PzJkzKSkp4fXXX+/9izyLP//5zyxdurRXHvuJJ57g3//93wEoLy/n+eef79b3bdu2jWuuuaZXYpLBz+fz4et0ZrlyqUhXxo4dy/DhwwkGg7Hb3n77bQzD4MEHH/zE73/nnXcoLi4GwOVy8aMf/ajD1//mb/6Gt99++4JjLC8vP+fvq66uZuHChbF8/vLLLzN16lSKi4vZvn37BcV0vlauXMkXv/jFXnnshx9+mD/84Q9A9HV57bXXuvV9f/7zn7nvvvt6JSZbrzyq9Dl1LxSJn+rqau677z5KS0tj5zCWlZVhGNFfdh955BHeeOMNXnvtNfLz8wFYu3YtNTU1FBQUAPD++++TkZHxsc+zcuVKbrjhBlJTUwH47W9/yx133ME3v/nNTvcNhULYbAP7Lf7LX/5y7M/l5eW89NJL3H777Z/4fUVFRTidTt566y2WLVvWmyHKIHR6Z32HEcFqKJeKfJKCggJeeeUVPvvZzwLw61//mrlz557z47QXqw899FDstv/5n//psTjP1fe//33uv//+2DaAJ554gocffpjPfe5zne47GPLuo48+GvvzO++8g8vl4uqrr/7E77v22mt55JFH2LdvH4WFhT0ak2ZWB4mu9qwqwcpgZ5omLYFQr36YpvmxMdTW1mK1WsnKyordNnv2bAzDwOv18uMf/5hf//rXsUIV4PLLL2f+/PnndK1PPvkkd9xxBwA/+tGPWLVqFStXrqS4uBiXy8XYsWP5xje+wfz587nrrrvweDzcc889zJgxgxkzZvC9730v9lhLly7lH/7hH7jkkksoKCjgO9/5Dq+++iqLFy9m7Nix/PSnPz1rDMFgkL//+7+nsLCQ+fPndxrtfuaZZ1iwYAGzZ8/mkksuYevWrQA8/fTTLF++nM997nPMnDmTuXPncvDgQQD27dvHxRdfzKxZs5g5cybf/va3Afjud7/Lgw8+yIkTJ3j44Yd5++23KS4u5stf/jI/+clPOoziulwucnJyaGhoAOBzn/scTz755Dn9/YpANJ+q/4MMBP0h/7W7++67+c1vfgNAU1MT69ev71DkPP3009x4442xz7talfPlL38Zt9tNcXFxrNhdunQpL730EgBf/OIXueeee7jooouYNGkSd911F62trQCcOHGCz3zmM8ycOZMZM2Z0mQNqamq49dZbmT9/foeccyafz8eqVatiBfhXv/pV3n//fb71rW9x0UUXAdGVUY888gjz5s3jm9/85sfGMHbsWL797W9z0UUXMXr0aJ544gmeeuopFi1axNixY7tcPeR2u7ntttuYPHkyixcv7jSj+5Of/IT58+cze/Zsrr76ao4cOQJEc+htt93Gddddx7Rp01i2bFksR65fvz62GmzGjBn88pe/jP39PvbYY5SXl/PEE0/whz/8geLiYh599FEeeOABfvCDH8Set6KigtGjRxMKhQC49dZbe2VgYWCX/xKj7oUyVLUGw0x7uHeXwO569CqSHF2/XRYVFbF48WLGjBnDpZdeykUXXcQdd9zBqFGj2LlzJw6Hg2nTpn3scyxZsgSr1QpEi9IFCxZ0+HplZSVNTU1MmDABgIceeog9e/ZQXFzcYZnVyZMn2bBhA4Zh8I1vfAO/38+2bdtobW1l8eLFTJkyhdtuuw2AI0eO8Pbbb9Pc3MzYsWNpbGzk/fffp6qqismTJ3PPPfd0mu397//+byoqKti5cycAV111Vexr69at47nnnuO9997D6XTy/vvvc8cdd8Tuu2nTJsrLyxk3bhwPPfQQ//Zv/8aTTz7JypUrufbaa2MzxO3JtN3w4cN59NFHeemll2K/sLhcLiZNmsSPf/xjMjIyeOqpp7jhhhtiAwaLFi3i/vvv/9i/c5EzRSKR6DFwkWju1Col6c/6Q/5rd/HFF/OLX/yCqqoqXnnlFW655ZZYTjsXTzzxBMXFxR+7ZHfDhg2sX7+epKQkbrzxRv7zP/+Tb33rW3zlK19h8uTJvPjii5w4cYI5c+Ywa9YsFi5c2OH777rrLr71rW9x6aWXEgqFuPbaa1m9ejW33HJLh/tt2rSJcePGkZSUBMDPf/5ztm3bxoMPPtih8LZarWzatAkgVlR2FYPX6+XDDz9k//79zJw5k3/+53/mo48+YtOmTXzqU5866+qhRx99FKfTyZ49e2hubmbhwoWx3xGeffZZKioq+Oijj7BarTzzzDP8/d//PX/5y19if1elpaVkZ2dz++238+STT/LNb36TH/7wh/zjP/5jbIa4sbGxw3O2Dwy7XC4ee+wxIFqcXnXVVXzjG9/AarXyi1/8gvvuuy82m7xo0SJWrFjR5et2vjSzOkicbWbVMAwcDkc8wxIZEiwWC//7v//Lhx9+yNVXX826deuYPn06+/fv7/ZjvP/++5SXl1NeXt6pUAU4duwYubm5n/g4X/ziF2PLj9esWcO9996LxWIhOTmZO++8kzfffDN235tvvhmr1UpmZibjx4/n2muvxTAMRo0axbBhwzh8+HCnx1+7di133nknDocDh8PBPffcE/vayy+/zNatW1mwYAHFxcV85StfoaGhITbqvWjRIsaNGxf784EDBwC45JJL+NWvfsU///M/88Ybb3zicmiAjIwMbr75Zn7zm99gmia//OUveeCBB2JfHzFiBCdPnowN5Il0x9k6AYMGfkW64wtf+AJPP/00v/nNbzrkhp526623kpqaitVq5Utf+hJr1qwBojnvb//2b4HoIOdnPvOZ2Nfaeb1e1q5dy9e+9rXY7O3+/fupqKjo9DzdzbunX+snxdA+WDxx4kQSEhK4+eabAZg7dy4NDQ24XK5Oj7927Vq+9KUvYRgG6enpsRVWAC+99BJr1qyJzZL++Mc/jvXDALj66qvJzs4GOubdyy67jO9///s8+uijfPDBB2RmZn7idU6ePJlp06bx8ssv4/V6ee655zqscBoxYgTHjh37xMc5V5pZHSR8Ph9hEwLmqZlVp9MZ+6VVZLBKtFvZ9ehVn3zHC3yO7pgyZQpTpkzhb//2b7n66qt55ZVXuO+++wgEAuzatesTZ1c/TlJSUrcKr5SUlC6/dub7wemzRVartdPn7Ut7Ps7pj2maJnfddVeHZUIf93ztj//Zz36Wiy66iDfffJOVK1fy2GOP8eqrr37ic3/1q1/l+uuvZ+rUqQwbNoySkpLY13w+H1arVQN2ck7U/0EGkv6U/wDuvPNOZs+ezaRJkzrtW7TZbITD4djnPTmQ2NXvume7vX1Z8/r16z/x33Vf5l3DMDAM47zy7je/+c0umxt1lXcffPBBbrjhBtasWcO3vvUtZsyYwS9+8YtPfO6vfe1r/Nu//Rt1dXVcccUVHYp5n89HYmLiJz7GudLM6iBx+h4bA5MEi6mRYBkSDMMgyWHr1Y9PGvQ5fvw469ati33e2NjIoUOHmDBhAikpKfzjP/4j9957L8ePH4/d5+2332bjxo3dvs7Jkydz4sSJ2Cxldyxfvpxf//rXmKaJ1+vlmWee4corr+z293f1mL///e8JBoMEAgGeeuqp2Neuv/56fv/738dGdSORCJs3b/7Ex9y3bx+5ubnceeed/PjHP2b9+vWd7pOWlkZTU1OH26ZMmcL48eO57777OsyqAuzevZsZM2bobEw5JzqzXAaS/pD/TpeXl8cPf/hD/u3f/q3T1yZOnBjbkhIKhXj22WfP+hhpaWm0trYSCAS6fJ4//vGPeDwewuEwTz31FMuXLwei+elXv/oVAHV1dbz44otcccUVHb43JSWFyy67rEPH4aqqqrPOCBYVFZ11xvXjdCeGc7V8+XKeeuopTNOkubmZ5557Lva1G2+8kSeeeCK2fSYYDLJly5ZPfMyKigrGjRvHvffey7e+9a1u590rr7ySmpoa/uVf/uWseXfWrFnnc4kfS1l8kDi9e2GCJYKh7oUifSYUCvHoo48yadIkiouLWbJkCXfddRc33HADEN1vcuutt3LVVVcxdepUpk2bxq9+9StGjhzZ7edISEjgyiuv5K233ur293znO9/Bbrczc+ZMFixYwPXXX8+tt956ztd3unvvvZfCwkKmTZvG4sWLY8cNQHTf7Y9//GNuuukmZs2axfTp07t13Mwf//jH2BE8t912G0888USn+1x++eX4/X6Kioo6dAm+9957CYVCsaVU7V577bVOt4l8Es2silyYu+++m0WLFnW6feHChXzqU59ixowZLF26tMuOsVlZWdx5550UFRV12U143rx5sXyakZER69vw85//nN27dzNz5kwuu+wy/vmf//ms22r+8Ic/sH//fmbMmMHMmTP5zGc+w8mTJzvdb9y4ceTm5sb6LnRHd2M4F9/5zndobW1lypQpfOpTn2Lx4sWxr33+85/ni1/8IpdddhmzZs2iuLi4W78nrFy5kunTp1NSUsK3v/1t/uM//qPTfW666SbKy8tjDZYgOkDypS99ieHDh3d6nXsr7xpmd9t8Sa9qbm4mPT2dpqYm0tLSzvn7n332WXbVBfh99TCy7EG+PPoEBQUF3Wo3LTLQ+Hw+Dh06xLhx44bUL5EbN27k0Ucf5c9//nO8Q+k3HnjgAXJzc/nOd74Tuy0QCDB37lzeeustcnJyzvuxz/ZzdqHv1dL7LuQ1qqio+P/bu/OgKO68DeBPz4gSZEA0wqpAIKJ4AA6nguCJxypZDQGJGkFNjGYx0dWtjRoVF1MbEqt2jSURdtdgYrC0dDUS3yx4xEEwoojySnTNWxiMGuTQ5XI8EJj3D0KXhEMMDd0Nz6fKoubq/tIO88y3f92/Rnp6Og4V2+A/RgsE9yuHn7URoaGh7XovEUmlu+Zfg4ULFzaZWLAj7d+/HwaDAfHx8Z2yPjUICQlBREQEFixYIN53584dTJo0CefPn29y+k1L79m2flZzZLWLeHJk9TlN/f6H7vghRtSV+fn5ITQ0FFVVVXKXIrvCwkIMGzYMFy5caPKlpaCgAHFxcWwu6Jn9cmTVgjPrE3Vr4eHhGD58OOrq6uQuRXbnz5+Hi4sLNBpNo0meAODatWtISEjokHkiOMFSF1BbW4uamho8qK1/g/AcG6KuqyNnWFSTgQMH4urVq80+5urqCldX106uiLoCnrNKpGy7du3q9HX+8tzM7qph5uTmtPdQ59ZwZLUL4Dk2RERE7ffLPDXX1EGj0cDMzEzOsoiIui02qzKLj4/HiBEj4Ovr+6uXwT3BRETU3UmRp2Kz+kSe8jJwRETyYbMqs+joaFy5cgXZ2dm/ehlNR1brr2PFkVUiIuoupMjTR48eocYEPH7imuXMUiIi+bBZ7QJaGlllwBIREbVdc9csZ5YSEcmHEyx1AQ8fPoRVTSki607CyqwMFtWWuFPjycOAiYiInoFZ5Q2MqcrEELP7KEI/WNWOQK9eTnKXRUTUbXFktQvo/X+HMKdkC141pWKmJgsTq09gTskWWOYflrs0ImW5ew04vgk4sLj+591rki3ayckJtra2ePz4sXjfyZMnIQhCm64HZzAYoNfrAQDl5eWIi4tr9Pgbb7yBkydPtrvG3NzcZ37d7du3MWbMGHHq/sOHD2P48OHQ6/XIy8trV01tVV5ejtdeew1ubm7w8PCAm5sb9uzZIz5+7do1hIWFwdnZGd7e3vDz88M///lPAMCmTZvQv39/6PV68V9hYSGKi4vh5+eHmpqaTvkdSNlMF3bjpRuxGPPgJGZqsrBY8zXmlGzBC2WZcpdG1H4dmH8HDx6Et7c39Ho9hg0bhkmTJjW61Et8fDzc3NwwfPhweHl5Ye7cubhx4wYAQBAEuLu7i5/NGzdubHYd9+/fh4+Pj3jptqysLLi7u8PT0xNpaWmS/S6tMRgMEAQBK1asaHR/VFQUBEFoU74uXLgQW7duFZeXmpoqPlZYWIigoKB219jwXaI1aso/jqyq3d1rcLj4EQSYoBFMP99pgglAz9TVgMt4oN9gOSskUoaLXwApbwMQAJjqf57+GPjddsBzviSrcHR0REpKCl555RUAwM6dO+Hj4/PMy2loVtesWSPe19B4yWHz5s2Ijo6GRlO/fzMhIQEbN27E3Llzmzy3pqYGPXpIHy3r169H//79kZeXB0EQUFVVhaKiIgBAUVERAgMDERsbiwMHDgAAysrKsG/fPvH18+fPF78gPCkgIACff/45LwnU3d29Bnz1DjQwATDVf0z8nKVD/7MNuBvFLCX16sD8u337Nt58803k5OTghRdeAABcuHBBnJQsJiYGR48eRWpqKuzt7QEAJ06cQFFRERwdHQEAGRkZ6NOnT6vr2b59O2bNmgWdTgcA+OyzzzBv3jysXbu2yXM7KocAYMiQIfjqq6+wZcsW9OzZE5WVlTh9+jQGDRr0zMsyGAwoLy/H9OnTAdRfki0jI0PqkptlZ2enmvzjyKraXdwNE5rOUigAECAAF3d3fk1ESnP3Wn1Qm+oAU23jnynLJdvDvGjRInz66acAgIqKCmRlZYkhBNRfH2727Nni7SNHjmDChAlNlrNs2TJUVVVBr9eLze6ECRPw5ZdfAqjfM7t48WIEBARg6NChiIqKwoMHDwAAJSUlCA0Nhbu7O9zc3JCYmNhsrUVFRZgzZw78/Pzg7u6O9evXN/u8hw8fYt++fWID/s477yAjIwPr1q1DQEAAgPo94zExMfD19cXatWtbrcHJyQnr169HQEAAHBwckJCQgKSkJPj7+8PJyQl79+5tto5bt25hwIAB4hcgnU6HIUOGAKjfax8UFIQlS5aIz7exscGyZcuaXdaT5s6d2+I2om7k4m6ghSyFwCwlFevg/CsuLoZWq0Xfvn3F+7y8vCAIAoxGIz766CPs3LlTbFQBYPLkyfDz83um9SQmJmLevHkAgLi4OOzbtw/bt2+HXq9HeXk5nJyc8O6778LPzw9RUVG4d+8eFi9eDDc3N7i5ueHPf/6zuKwJEyZg9erVGDduHBwdHbFhwwZ8/fXXCAwMhJOTE/7617+2WIeFhQUmT56Mw4frj17cu3cvXnnllUbN8ZN5DQBhYWFNrg+bm5uLhIQEJCcnQ6/XIzY2FtevX2/UtAuCgPXr18PT0xNDhw5FcnKy+FhaWhq8vLzg4eGB8ePH48qVK83Wm5aWhsDAQPGIoyeP0FJL/nFkVe3Kb6B+L1lzTD8/TtTNtfBFtN7PX0SDN7V7NWPHjsUnn3yCwsJCpKSkIDw8HFqt9pmXk5CQAL1e3+ohRWfPnkVWVhYsLCwwe/Zs/O1vf8O6devw9ttvw9XVFQcPHkRJSQm8vb0xatQojBkzptHro6KisG7dOowfPx41NTUICQnB/v37ER4e3uh52dnZcHZ2hoWFBQBg27ZtuHTpElauXNmo8dZqteIsrBEREa3WYDQa8e233yI/Px/u7u547733cObMGWRnZ2PGjBl49dVXm/y+K1asQFhYGPbt2wd/f39Mnz4dISEhAICcnBxMmTKl1W2anJwMg8EAAPD09ERSUhIAwNvbG5cuXUJlZSWsrKxaXQZ1Ya1mKZilpF4dnH8eHh4IDAzECy+8gPHjxyMgIADz5s3DoEGDcPnyZfTs2RMjRoxodRlBQUFiViYmJmL06NGNHr958yYqKioweHD90Q1r1qzB1atXodfrG51mc/fuXZw9exaCIODdd9/Fo0ePcOnSJTx48ACBgYEYNmwYIiIiAAA//vgjTp48icrKSjg5OaGsrAwZGRkoLCyEq6srFi9e3OJo76JFi7B582aEh4cjKSkJu3btanQkT1vo9XosW7YM5eXl4lE/169fb/I8QRBw8eJF/PDDD/Dx8cHYsWNhYWGBefPmwWAwwN3dHcnJyQgLC8Ply5cbvfaHH37Apk2bkJaWBisrK+Tn5yMoKAjXr19Hr169VJN/HFlVuz6OaPVDqI9jZ1ZDpEyduFNnwYIF2LVrFz799NMOPbRmzpw50Ol00Gq1eP3113H8+HEAwPHjx7F06VIAgK2tLUJDQ8XHGhiNRpw4cQIrVqwQR2/z8/Px/fffN1nPrVu3YGdn99R6nvxdn1ZDw5cFFxcXmJubIywsDADg4+OD//73vygvL2+y/IkTJ+LGjRvYvHkz+vTpg6VLlyI6OvqpdTWYP38+cnNzkZubKzaqANCjRw/Y2NigsLCwzcuiLohZSl1VB+efRqPBv/71L3z77beYPn06Tp8+jZEjRyI/P7/Ny8jIyBA/n3/ZqAJtz6GFCxeKR98cP34cS5YsgUajQe/evREZGYljx46Jzw0LC4NWq4WNjQ1efPFFhISEQBAEDBo0CP3792+2cWwQEBCAGzduIC0tDVqtFq6urm3+XZ/VG2+8AQB48cUXMW7cOJw6dQpnz56Fu7s73N3dAdTnW2FhIX766adGr01NTUV+fj7GjRsHvV6PsLAwaDQa8XxhteQfR1bVznMBhMytDWcgiOpvmwDPBTIVRqQgnfhFNDIyEl5eXhg6dKh4mGqDHj16oLa2VrzdcI1kKTQEdFvuN5nqv7hkZWU99bIcFhYWbarT0tKyzbU9uU6tViveFgQBgiC0OOFD7969MWPGDMyYMQMhISGYOnUq4uPj4e3tjTNnzuAPf/jDU+tszsOHD/Hcc8/9qtdSF+G5AMj8uNksBbOU1KyT8m/YsGEYNmwYli5diunTpyMlJQVvvvkmqqurceXKlaeOrramM3Oo4fbTJh6KjIzEa6+91mQyRECerG+OyWTClClTGk1G+EtqyD+OrKpdv8H4tv98mCCgDhrU/fwTEOpPnOeEEEQ/f9FsZc+yhF9EBw4ciA8++AAffvhhk8dcXFzEQ5JqampaDBArKys8ePAA1dXVLa7nwIEDuHfvHmpra5GUlITg4GAAQHBwMP7xj38AAEpLS3Hw4MEmh8haWlpi4sSJjUK2sLAQt27darIeDw+PZkdcW9OWGp7V0aNHUVZWJt7OyckRDwn7/e9/j/T09EYjpuXl5W06F6e4uBiCIMDBwaFd9ZHK9RuMQt91TbLUBAH3gz9klpJ6dXD+/fTTTzh9+rR4u6ysDAUFBRg8eDAsLS3xxz/+EUuWLGk06nfy5EmcO3euzetwdXVFSUmJODdDWwQHB2Pnzp0wmUwwGo3YvXs3pk6d2ubXP82iRYuwevVq8UihJ7m4uODs2bMAgIKCAmRmNj+juJWVFSoqKlpdT0OuXb9+HRkZGQgKCsKYMWOQl5eH7777DkD9ebODBg1qMsnTtGnTcPz4cVy6dEm878ntrpb848hqF2AZ+Cb+984k9P3xf9DTeBtVPfqiemQE3Dx/J3dpRMrQb3D9zpuU5Wg0GyJMHbJTZ9GiRc3eP2bMGMyYMQNubm4YMGAAxo4dKwbak/r27YvIyEh4eHjA0tIS58+fb/IcX19fTJs2DaWlpfD39xfP29m2bRveeustuLu7w2Qy4b333mv2sKrk5GSsWrUKbm5uEAQBvXv3RmJiYqNJMADA2dkZdnZ2uHz5MkaOHNmm37+tNTyLvLw8rF69GiaTCRqNBgMGDMAXX3wBABgwYAAyMzOxZs0axMbGQqfTwczMrE2HCaempuLll18WZzqm7svMNwqXLYeiT8FXMLtXiHs9+uGadQDGeXFUlVSsg/OvpqYGsbGxKCgogIWFBWpqahAVFYVZs2YBAGJjY/H8889j2rRpqK2thSAI0Ov1ze7QbYm5uTmmTp2Kb775BjNnzmzTazZs2IB33nlHPFQ2PDwcc+bMefZfsAW2traNZux/0p/+9CdERETA3d0dI0eObDH/Xn75ZezevRt6vR6hoaGIjIxs8pza2lp4enrCaDRi27ZtcHJyAlCf4ZGRkaipqYGNjQ3279/fZNTVxcUFe/bswdKlS3H//n1UV1fD09NT3FGulvwTTA3Hg5GsKisrYW1tjYqKCkWf5EykBA8fPkRBQQGcnZ2fehhrI3ev1U8mUX6j/tAnzwWqHDFZuHBhk4klOtL+/fthMBgQHx/fKevrTEFBQfj73/+O4cOHN3msufcZP6uVj/9H1JV11/w7d+4cYmNjceTIEblL6TSCIKCsrOypl/X5tVrLPym19J5t62c1R1aJqPvoN1iSWX+7m/DwcBQXF6Ourk7xe2CfRXFxMd56660OD2oiItmpPP/8/PwQGhqKqqoq8Vqr9OupKf/YrBIRqcwvr9fWGZYvX97p6+xodnZ24nX7iIhI2Tpyhn0l6siDX9WUf11nFzkRERERERF1GWxWiUi1eMo9dSS+v4hIqfj5RGrR3vcqDwMmItUxMzODIAgoLS1F//79n+m6Y0RtYTKZUFpaCkEQYGZmJnc5REQAmH+kLlJkKZtVIlIdrVYLe3t73Lp1C9evX5e7HOqiBEGAvb09tFqt3KUQEQFg/pH6tDdL2awSkSpZWlpiyJAhePz4sdylUBdlZmbGRpWIFIf5R2rS3ixls0pEqqXVatlMEBFRt8P8o+6CEyzJLD4+HiNGjICvr6/cpRAREakW85SIqOsRTJxOTBEqKythbW2NiooKWFlZyV0OERE1g5/Vysf/IyIi5WvrZzUPA1aIhn0GlZWVMldCREQtafiMrqyshE6n40ycCsQ8JSJSvobP6KeNm7JZVYiqqioAgIODg8yVEBHR0zg4OHDkTqGYp0RE6lFVVQVra+sWH+dhwApRV1eHwsLCVvfUV1ZWwsHBATdv3uQXJAlwe0qP21Ra3J7Sa+82NZlMqKqqgk6ng5WVFUdWFehpecq/K+lxm0qL21N63KbSkmJ7NuTpwIEDodG0PI0SR1YVQqPRwN7evk3PtbKy4h+ahLg9pcdtKi1uT+m1Z5u2tgeY5NfWPOXflfS4TaXF7Sk9blNptXd7tiVPORswERERERERKQ6bVSIiIiIiIlIcNqsq0qtXL8TExKBXr15yl9IlcHtKj9tUWtye0uM2Jb4HpMdtKi1uT+lxm0qrM7cnJ1giIiIiIiIixeHIKhERERERESkOm1UiIiIiIiJSHDarREREREREpDhsVlUiPj4eTk5OMDc3x+jRo3Hu3Dm5S1KtU6dO4aWXXsLAgQMhCAK+/PJLuUtStQ8++AC+vr7Q6XSwtbXF7Nmz8f3338tdlqrt2LEDHh4e4vXL/P398e9//1vusrqMuLg4CIKAlStXyl0KyYB5Kh3mqbSYp9JjnnaszshTNqsqsG/fPqxatQoxMTG4cOECRo0ahWnTpqGkpETu0lTJaDRi1KhRiI+Pl7uULiE9PR3R0dHIysrCsWPH8PjxY0ydOhVGo1Hu0lTL3t4ecXFxyMnJwfnz5zFp0iTMmjULly9flrs01cvOzkZiYiI8PDzkLoVkwDyVFvNUWsxT6TFPO05n5SlnA1aB0aNHw9fXF9u3bwcA1NXVwcHBAW+//TbWrFkjc3XqJggCDh06hNmzZ8tdSpdRWloKW1tbpKenY9y4cXKX02X07dsXW7Zsweuvvy53Kap17949eHl54ZNPPsH7778PvV6PrVu3yl0WdSLmacdhnkqPedoxmKft15l5ypFVhauurkZOTg6Cg4PF+zQaDYKDg3HmzBkZKyNqXkVFBYD6MKD2q62txd69e2E0GuHv7y93OaoWHR2NmTNnNvo8pe6DeUpqwzyVFvNUOp2Zpz06fA3ULnfu3EFtbS3s7Owa3W9nZ4erV6/KVBVR8+rq6rBy5UqMHTsWbm5ucpejanl5efD398fDhw9haWmJQ4cOYcSIEXKXpVp79+7FhQsXkJ2dLXcpJBPmKakJ81Q6zFNpdXaeslklIslER0fju+++Q2ZmptylqJ6rqytyc3NRUVGBAwcOICoqCunp6QzYX+HmzZtYsWIFjh07BnNzc7nLISJ6KuapdJin0pEjT9msKtzzzz8PrVaL4uLiRvcXFxfjN7/5jUxVETW1fPlyHDlyBKdOnYK9vb3c5ahez5494eLiAgDw9vZGdnY2Pv74YyQmJspcmfrk5OSgpKQEXl5e4n21tbU4deoUtm/fjkePHkGr1cpYIXUG5impBfNUWsxT6ciRpzxnVeF69uwJb29vnDhxQryvrq4OJ06c4PH2pAgmkwnLly/HoUOH8M0338DZ2Vnukrqkuro6PHr0SO4yVGny5MnIy8tDbm6u+M/Hxwfz589Hbm4uG9VugnlKSsc87RzM019PjjzlyKoKrFq1ClFRUfDx8YGfnx+2bt0Ko9GIRYsWyV2aKt27dw/5+fni7YKCAuTm5qJv375wdHSUsTJ1io6Oxp49e3D48GHodDoUFRUBAKytrfHcc8/JXJ06rV27Fr/97W/h6OiIqqoq7NmzBwaDAWlpaXKXpko6na7JOV+9e/dGv379eC5YN8M8lRbzVFrMU+kxT6UlR56yWVWBiIgIlJaWYuPGjSgqKoJer0dqamqTSSKobc6fP4+JEyeKt1etWgUAiIqKwq5du2SqSr127NgBAJgwYUKj+5OSkrBw4cLOL6gLKCkpQWRkJG7fvg1ra2t4eHggLS0NU6ZMkbs0IlVjnkqLeSot5qn0mKfqx+usEhERERERkeLwnFUiIiIiIiJSHDarREREREREpDhsVomIiIiIiEhx2KwSERERERGR4rBZJSIiIiIiIsVhs0pERERERESKw2aViIiIiIiIFIfNKhERERERESkOm1UiIiIiIiJSHDarREREREREpDhsVomIiIiIiEhx2KwSkeT+8pe/QBCEJv+2bt0qd2lERESqwTyl7k4wmUwmuYsgoq6lqqoKRqNRvL1x40YcPXoUmZmZsLe3l7EyIiIi9WCeUnfXQ+4CiKjr0el00Ol0AIANGzbg6NGjMBgMDFYiIqJnwDyl7o6HARNRh9m4cSN2794Ng8EAJycnucshIiJSJeYpdVdsVomoQ8TExODzzz9nsBIREbUD85S6MzarRCS5mJgYfPbZZwxWIiKidmCeUnfHc1aJSFLvv/8+duzYgZSUFJibm6OoqAgAYGNjg169eslcHRERkTowT4k4GzARSchkMqFPnz6orKxs8ti5c+fg6+srQ1VERETqwjwlqsdmlYiIiIiIiBSH56wSERERERGR4rBZJSIiIiIiIsVhs0pERERERESKw2aViIiIiIiIFIfNKhERERERESkOm1UiIiIiIiJSHDarREREREREpDhsVomIiIiIiEhx2KwSERERERGR4rBZJSIiIiIiIsVhs0pERERERESKw2aViIiIiIiIFOf/Ac62+/XtzcE0AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 950x400 with 2 Axes>"
       ]
@@ -559,29 +559,39 @@
     }
    ],
    "source": [
-    "# translate each expansion into the other representation\n",
-    "scf_as_mep = MultipoleExpansionPotential.from_scf(\n",
-    "    scf_tri, rgrid=numpy.geomspace(1e-3, 200.0, 401)\n",
+    "# build SCF and multipole expansions of the same halo over a common radial range\n",
+    "rgrid = numpy.geomspace(1e-3, 200.0, 601)\n",
+    "scf_halo = SCFPotential.from_density(\n",
+    "    tri_nfw.dens, 40, L=20, a=50.0, symmetry=\"axisymmetry\"\n",
     ")\n",
-    "mep_as_scf = SCFPotential.from_multipole(mep_tri, N=80, a=50.0)\n",
+    "mep_halo = MultipoleExpansionPotential.from_density(\n",
+    "    tri_nfw, L=20, rgrid=rgrid, symmetry=\"axisymmetry\"\n",
+    ")\n",
+    "# translate each expansion into the other representation\n",
+    "mep_from_scf = MultipoleExpansionPotential.from_scf(scf_halo, rgrid=rgrid)\n",
+    "scf_from_mep = SCFPotential.from_multipole(mep_halo, N=40, a=50.0)\n",
     "\n",
-    "zs = numpy.linspace(0.1, 4.0, 60)\n",
-    "Fz = lambda p: [-p.zforce(1.0, z, use_physical=False) for z in zs]\n",
+    "zs = numpy.linspace(0.1, 4.0, 50)\n",
+    "Fz = lambda p, zv=zs: numpy.array([-p.zforce(1.0, z, use_physical=False) for z in zv])\n",
+    "zm = zs[::4]  # sparse points for the translated-expansion markers\n",
     "fig, axes = plt.subplots(1, 2, figsize=(9.5, 4.0))\n",
-    "axes[0].plot(zs, Fz(tri_nfw), \"k-\", lw=3, alpha=0.4, label=\"true\")\n",
-    "axes[0].plot(zs, Fz(scf_tri), \"C0-\", lw=1.5, label=\"SCF (from density)\")\n",
-    "axes[0].plot(zs, Fz(scf_as_mep), \"C1--\", lw=1.5, label=\"Multipole (from SCF)\")\n",
-    "axes[0].set_yscale(\"log\")\n",
-    "axes[0].set_xlabel(r\"$z$\")\n",
-    "axes[0].set_ylabel(r\"$-F_z(R=1,\\,z)$\")\n",
-    "axes[0].legend(fontsize=8)\n",
-    "axes[1].plot(zs, Fz(tri_nfw), \"k-\", lw=3, alpha=0.4, label=\"true\")\n",
-    "axes[1].plot(zs, Fz(mep_tri), \"C0-\", lw=1.5, label=\"Multipole (from density)\")\n",
-    "axes[1].plot(zs, Fz(mep_as_scf), \"C1--\", lw=1.5, label=\"SCF (from Multipole)\")\n",
-    "axes[1].set_yscale(\"log\")\n",
-    "axes[1].set_xlabel(r\"$z$\")\n",
-    "axes[1].set_ylabel(r\"$-F_z(R=1,\\,z)$\")\n",
-    "axes[1].legend(fontsize=8)\n",
+    "axes[0].plot(zs, Fz(tri_nfw), color=\"0.6\", lw=4, label=\"true\", zorder=1)\n",
+    "axes[0].plot(zs, Fz(scf_halo), \"C0-\", lw=1.5, label=\"SCF (from density)\", zorder=2)\n",
+    "axes[0].plot(\n",
+    "    zm, Fz(mep_from_scf, zm), \"C1o\", ms=5, label=\"Multipole (from SCF)\", zorder=3\n",
+    ")\n",
+    "axes[1].plot(zs, Fz(tri_nfw), color=\"0.6\", lw=4, label=\"true\", zorder=1)\n",
+    "axes[1].plot(\n",
+    "    zs, Fz(mep_halo), \"C0-\", lw=1.5, label=\"Multipole (from density)\", zorder=2\n",
+    ")\n",
+    "axes[1].plot(\n",
+    "    zm, Fz(scf_from_mep, zm), \"C1o\", ms=5, label=\"SCF (from Multipole)\", zorder=3\n",
+    ")\n",
+    "for ax in axes:\n",
+    "    ax.set_yscale(\"log\")\n",
+    "    ax.set_xlabel(r\"$z$\")\n",
+    "    ax.set_ylabel(r\"$-F_z(R=1,\\,z)$\")\n",
+    "    ax.legend(fontsize=8)\n",
     "fig.tight_layout();"
    ]
   },
@@ -590,10 +600,10 @@
    "id": "e87e7bd1",
    "metadata": {
     "papermill": {
-     "duration": 0.017017,
-     "end_time": "2026-07-04T04:43:36.622372+00:00",
+     "duration": 0.017178,
+     "end_time": "2026-07-04T12:07:26.791121+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.605355+00:00",
+     "start_time": "2026-07-04T12:07:26.773943+00:00",
      "status": "completed"
     },
     "tags": []
@@ -612,16 +622,16 @@
    "id": "b3c4d5e6f7a8b9c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:36.658613Z",
-     "iopub.status.busy": "2026-07-04T04:43:36.658150Z",
-     "iopub.status.idle": "2026-07-04T04:43:36.668955Z",
-     "shell.execute_reply": "2026-07-04T04:43:36.667346Z"
+     "iopub.execute_input": "2026-07-04T12:07:26.828114Z",
+     "iopub.status.busy": "2026-07-04T12:07:26.827884Z",
+     "iopub.status.idle": "2026-07-04T12:07:26.837651Z",
+     "shell.execute_reply": "2026-07-04T12:07:26.836156Z"
     },
     "papermill": {
-     "duration": 0.030511,
-     "end_time": "2026-07-04T04:43:36.670324+00:00",
+     "duration": 0.03016,
+     "end_time": "2026-07-04T12:07:26.839094+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.639813+00:00",
+     "start_time": "2026-07-04T12:07:26.808934+00:00",
      "status": "completed"
     },
     "tags": []
@@ -671,10 +681,10 @@
    "id": "c4d5e6f7a8b9c0d1",
    "metadata": {
     "papermill": {
-     "duration": 0.016382,
-     "end_time": "2026-07-04T04:43:36.703987+00:00",
+     "duration": 0.016635,
+     "end_time": "2026-07-04T12:07:26.873918+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.687605+00:00",
+     "start_time": "2026-07-04T12:07:26.857283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -689,16 +699,16 @@
    "id": "3a2dc462",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:36.744968Z",
-     "iopub.status.busy": "2026-07-04T04:43:36.744543Z",
-     "iopub.status.idle": "2026-07-04T04:43:36.752878Z",
-     "shell.execute_reply": "2026-07-04T04:43:36.750782Z"
+     "iopub.execute_input": "2026-07-04T12:07:26.909949Z",
+     "iopub.status.busy": "2026-07-04T12:07:26.909711Z",
+     "iopub.status.idle": "2026-07-04T12:07:26.914727Z",
+     "shell.execute_reply": "2026-07-04T12:07:26.913473Z"
     },
     "papermill": {
-     "duration": 0.034654,
-     "end_time": "2026-07-04T04:43:36.754506+00:00",
+     "duration": 0.025104,
+     "end_time": "2026-07-04T12:07:26.915721+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.719852+00:00",
+     "start_time": "2026-07-04T12:07:26.890617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -758,10 +768,10 @@
    "id": "b13a0695",
    "metadata": {
     "papermill": {
-     "duration": 0.015963,
-     "end_time": "2026-07-04T04:43:36.790961+00:00",
+     "duration": 0.016913,
+     "end_time": "2026-07-04T12:07:26.950055+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.774998+00:00",
+     "start_time": "2026-07-04T12:07:26.933142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,10 +785,10 @@
    "id": "17d13f11",
    "metadata": {
     "papermill": {
-     "duration": 0.015923,
-     "end_time": "2026-07-04T04:43:36.823349+00:00",
+     "duration": 0.016243,
+     "end_time": "2026-07-04T12:07:26.983236+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.807426+00:00",
+     "start_time": "2026-07-04T12:07:26.966993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -804,16 +814,16 @@
    "id": "d5e6f7a8b9c0d1e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:36.857922Z",
-     "iopub.status.busy": "2026-07-04T04:43:36.857470Z",
-     "iopub.status.idle": "2026-07-04T04:43:37.244376Z",
-     "shell.execute_reply": "2026-07-04T04:43:37.242820Z"
+     "iopub.execute_input": "2026-07-04T12:07:27.017597Z",
+     "iopub.status.busy": "2026-07-04T12:07:27.017360Z",
+     "iopub.status.idle": "2026-07-04T12:07:27.356337Z",
+     "shell.execute_reply": "2026-07-04T12:07:27.354760Z"
     },
     "papermill": {
-     "duration": 0.406624,
-     "end_time": "2026-07-04T04:43:37.246133+00:00",
+     "duration": 0.35803,
+     "end_time": "2026-07-04T12:07:27.358148+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:36.839509+00:00",
+     "start_time": "2026-07-04T12:07:27.000118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -837,10 +847,10 @@
    "id": "e6f7a8b9c0d1e2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.016316,
-     "end_time": "2026-07-04T04:43:37.280617+00:00",
+     "duration": 0.017356,
+     "end_time": "2026-07-04T12:07:27.398715+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:37.264301+00:00",
+     "start_time": "2026-07-04T12:07:27.381359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -855,16 +865,16 @@
    "id": "f7a8b9c0d1e2f3a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:37.313466Z",
-     "iopub.status.busy": "2026-07-04T04:43:37.313227Z",
-     "iopub.status.idle": "2026-07-04T04:43:38.313077Z",
-     "shell.execute_reply": "2026-07-04T04:43:38.311423Z"
+     "iopub.execute_input": "2026-07-04T12:07:27.439997Z",
+     "iopub.status.busy": "2026-07-04T12:07:27.439761Z",
+     "iopub.status.idle": "2026-07-04T12:07:28.344947Z",
+     "shell.execute_reply": "2026-07-04T12:07:28.343437Z"
     },
     "papermill": {
-     "duration": 1.018403,
-     "end_time": "2026-07-04T04:43:38.314626+00:00",
+     "duration": 0.925266,
+     "end_time": "2026-07-04T12:07:28.346659+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:37.296223+00:00",
+     "start_time": "2026-07-04T12:07:27.421393+00:00",
      "status": "completed"
     },
     "tags": []
@@ -896,10 +906,10 @@
    "id": "a8b9c0d1e2f3a4b5",
    "metadata": {
     "papermill": {
-     "duration": 0.024433,
-     "end_time": "2026-07-04T04:43:38.363215+00:00",
+     "duration": 0.018202,
+     "end_time": "2026-07-04T12:07:28.391130+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:38.338782+00:00",
+     "start_time": "2026-07-04T12:07:28.372928+00:00",
      "status": "completed"
     },
     "tags": []
@@ -914,16 +924,16 @@
    "id": "b9c0d1e2f3a4b5c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:38.400651Z",
-     "iopub.status.busy": "2026-07-04T04:43:38.400408Z",
-     "iopub.status.idle": "2026-07-04T04:43:48.245846Z",
-     "shell.execute_reply": "2026-07-04T04:43:48.244009Z"
+     "iopub.execute_input": "2026-07-04T12:07:28.436999Z",
+     "iopub.status.busy": "2026-07-04T12:07:28.436771Z",
+     "iopub.status.idle": "2026-07-04T12:07:38.362546Z",
+     "shell.execute_reply": "2026-07-04T12:07:38.361278Z"
     },
     "papermill": {
-     "duration": 9.870564,
-     "end_time": "2026-07-04T04:43:48.251930+00:00",
+     "duration": 9.952872,
+     "end_time": "2026-07-04T12:07:38.369554+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:38.381366+00:00",
+     "start_time": "2026-07-04T12:07:28.416682+00:00",
      "status": "completed"
     },
     "tags": []
@@ -958,10 +968,10 @@
    "id": "c0d1e2f3a4b5c6d7",
    "metadata": {
     "papermill": {
-     "duration": 0.02304,
-     "end_time": "2026-07-04T04:43:48.310497+00:00",
+     "duration": 0.024804,
+     "end_time": "2026-07-04T12:07:38.432921+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:48.287457+00:00",
+     "start_time": "2026-07-04T12:07:38.408117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -976,16 +986,16 @@
    "id": "226e8f68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:43:48.360052Z",
-     "iopub.status.busy": "2026-07-04T04:43:48.359487Z",
-     "iopub.status.idle": "2026-07-04T04:44:09.562382Z",
-     "shell.execute_reply": "2026-07-04T04:44:09.560814Z"
+     "iopub.execute_input": "2026-07-04T12:07:38.485439Z",
+     "iopub.status.busy": "2026-07-04T12:07:38.484979Z",
+     "iopub.status.idle": "2026-07-04T12:07:59.623294Z",
+     "shell.execute_reply": "2026-07-04T12:07:59.621765Z"
     },
     "papermill": {
-     "duration": 21.23103,
-     "end_time": "2026-07-04T04:44:09.564855+00:00",
+     "duration": 21.167516,
+     "end_time": "2026-07-04T12:07:59.625605+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:43:48.333825+00:00",
+     "start_time": "2026-07-04T12:07:38.458089+00:00",
      "status": "completed"
     },
     "tags": []
@@ -995,7 +1005,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.66 s ± 179 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.65 s ± 157 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1010,10 +1020,10 @@
    "id": "acf72105",
    "metadata": {
     "papermill": {
-     "duration": 0.025518,
-     "end_time": "2026-07-04T04:44:09.626207+00:00",
+     "duration": 0.025593,
+     "end_time": "2026-07-04T12:07:59.687379+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:09.600689+00:00",
+     "start_time": "2026-07-04T12:07:59.661786+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1028,16 +1038,16 @@
    "id": "745deca2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:09.675781Z",
-     "iopub.status.busy": "2026-07-04T04:44:09.675550Z",
-     "iopub.status.idle": "2026-07-04T04:44:16.147591Z",
-     "shell.execute_reply": "2026-07-04T04:44:16.145829Z"
+     "iopub.execute_input": "2026-07-04T12:07:59.739760Z",
+     "iopub.status.busy": "2026-07-04T12:07:59.739506Z",
+     "iopub.status.idle": "2026-07-04T12:08:06.231559Z",
+     "shell.execute_reply": "2026-07-04T12:08:06.229969Z"
     },
     "papermill": {
-     "duration": 6.498849,
-     "end_time": "2026-07-04T04:44:16.149112+00:00",
+     "duration": 6.519705,
+     "end_time": "2026-07-04T12:08:06.233165+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:09.650263+00:00",
+     "start_time": "2026-07-04T12:07:59.713460+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1047,7 +1057,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "79.9 ms ± 1.56 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "79.9 ms ± 548 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1062,10 +1072,10 @@
    "id": "3fa99bf4",
    "metadata": {
     "papermill": {
-     "duration": 0.024633,
-     "end_time": "2026-07-04T04:44:16.209345+00:00",
+     "duration": 0.025297,
+     "end_time": "2026-07-04T12:08:06.293875+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:16.184712+00:00",
+     "start_time": "2026-07-04T12:08:06.268578+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1089,16 +1099,16 @@
    "id": "d1e2f3a4b5c6d7e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:16.266098Z",
-     "iopub.status.busy": "2026-07-04T04:44:16.265833Z",
-     "iopub.status.idle": "2026-07-04T04:44:17.460849Z",
-     "shell.execute_reply": "2026-07-04T04:44:17.459161Z"
+     "iopub.execute_input": "2026-07-04T12:08:06.345614Z",
+     "iopub.status.busy": "2026-07-04T12:08:06.345121Z",
+     "iopub.status.idle": "2026-07-04T12:08:07.301036Z",
+     "shell.execute_reply": "2026-07-04T12:08:07.299313Z"
     },
     "papermill": {
-     "duration": 1.223579,
-     "end_time": "2026-07-04T04:44:17.463012+00:00",
+     "duration": 0.983512,
+     "end_time": "2026-07-04T12:08:07.302728+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:16.239433+00:00",
+     "start_time": "2026-07-04T12:08:06.319216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1129,10 +1139,10 @@
    "id": "e2f3a4b5c6d7e8f9",
    "metadata": {
     "papermill": {
-     "duration": 0.025159,
-     "end_time": "2026-07-04T04:44:17.523912+00:00",
+     "duration": 0.026018,
+     "end_time": "2026-07-04T12:08:07.360784+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:17.498753+00:00",
+     "start_time": "2026-07-04T12:08:07.334766+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1147,16 +1157,16 @@
    "id": "f3a4b5c6d7e8f9a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:17.579025Z",
-     "iopub.status.busy": "2026-07-04T04:44:17.578747Z",
-     "iopub.status.idle": "2026-07-04T04:44:17.933604Z",
-     "shell.execute_reply": "2026-07-04T04:44:17.931986Z"
+     "iopub.execute_input": "2026-07-04T12:08:07.412859Z",
+     "iopub.status.busy": "2026-07-04T12:08:07.412352Z",
+     "iopub.status.idle": "2026-07-04T12:08:07.721069Z",
+     "shell.execute_reply": "2026-07-04T12:08:07.719421Z"
     },
     "papermill": {
-     "duration": 0.388,
-     "end_time": "2026-07-04T04:44:17.935437+00:00",
+     "duration": 0.336095,
+     "end_time": "2026-07-04T12:08:07.722851+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:17.547437+00:00",
+     "start_time": "2026-07-04T12:08:07.386756+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1189,10 +1199,10 @@
    "id": "a4b5c6d7e8f9a0b1",
    "metadata": {
     "papermill": {
-     "duration": 0.034774,
-     "end_time": "2026-07-04T04:44:18.004660+00:00",
+     "duration": 0.035129,
+     "end_time": "2026-07-04T12:08:07.794539+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:17.969886+00:00",
+     "start_time": "2026-07-04T12:08:07.759410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1207,16 +1217,16 @@
    "id": "2d0d29d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:18.062555Z",
-     "iopub.status.busy": "2026-07-04T04:44:18.062317Z",
-     "iopub.status.idle": "2026-07-04T04:44:28.009635Z",
-     "shell.execute_reply": "2026-07-04T04:44:28.007909Z"
+     "iopub.execute_input": "2026-07-04T12:08:07.848832Z",
+     "iopub.status.busy": "2026-07-04T12:08:07.848619Z",
+     "iopub.status.idle": "2026-07-04T12:08:15.961593Z",
+     "shell.execute_reply": "2026-07-04T12:08:15.959901Z"
     },
     "papermill": {
-     "duration": 9.981627,
-     "end_time": "2026-07-04T04:44:28.011385+00:00",
+     "duration": 8.142631,
+     "end_time": "2026-07-04T12:08:15.963637+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:18.029758+00:00",
+     "start_time": "2026-07-04T12:08:07.821006+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1243,10 +1253,10 @@
    "id": "9ce6e0c9",
    "metadata": {
     "papermill": {
-     "duration": 0.034458,
-     "end_time": "2026-07-04T04:44:28.083198+00:00",
+     "duration": 0.034818,
+     "end_time": "2026-07-04T12:08:16.036923+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:28.048740+00:00",
+     "start_time": "2026-07-04T12:08:16.002105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1261,16 +1271,16 @@
    "id": "04a6500d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:28.142734Z",
-     "iopub.status.busy": "2026-07-04T04:44:28.142424Z",
-     "iopub.status.idle": "2026-07-04T04:44:30.362317Z",
-     "shell.execute_reply": "2026-07-04T04:44:30.360652Z"
+     "iopub.execute_input": "2026-07-04T12:08:16.089986Z",
+     "iopub.status.busy": "2026-07-04T12:08:16.089690Z",
+     "iopub.status.idle": "2026-07-04T12:08:18.154784Z",
+     "shell.execute_reply": "2026-07-04T12:08:18.153344Z"
     },
     "papermill": {
-     "duration": 2.257881,
-     "end_time": "2026-07-04T04:44:30.365999+00:00",
+     "duration": 2.097019,
+     "end_time": "2026-07-04T12:08:18.158688+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:28.108118+00:00",
+     "start_time": "2026-07-04T12:08:16.061669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1333,10 +1343,10 @@
    "id": "a5956d7b",
    "metadata": {
     "papermill": {
-     "duration": 0.038774,
-     "end_time": "2026-07-04T04:44:30.463443+00:00",
+     "duration": 0.040873,
+     "end_time": "2026-07-04T12:08:18.239854+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:30.424669+00:00",
+     "start_time": "2026-07-04T12:08:18.198981+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1395,16 +1405,16 @@
    "id": "4d7c563b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:30.530009Z",
-     "iopub.status.busy": "2026-07-04T04:44:30.529668Z",
-     "iopub.status.idle": "2026-07-04T04:44:36.168781Z",
-     "shell.execute_reply": "2026-07-04T04:44:36.166830Z"
+     "iopub.execute_input": "2026-07-04T12:08:18.323916Z",
+     "iopub.status.busy": "2026-07-04T12:08:18.323665Z",
+     "iopub.status.idle": "2026-07-04T12:08:23.539081Z",
+     "shell.execute_reply": "2026-07-04T12:08:23.537381Z"
     },
     "papermill": {
-     "duration": 5.680059,
-     "end_time": "2026-07-04T04:44:36.171728+00:00",
+     "duration": 5.261739,
+     "end_time": "2026-07-04T12:08:23.542314+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:30.491669+00:00",
+     "start_time": "2026-07-04T12:08:18.280575+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1513,10 +1523,10 @@
    "id": "aeabed99",
    "metadata": {
     "papermill": {
-     "duration": 0.031219,
-     "end_time": "2026-07-04T04:44:36.249380+00:00",
+     "duration": 0.043285,
+     "end_time": "2026-07-04T12:08:23.630368+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:36.218161+00:00",
+     "start_time": "2026-07-04T12:08:23.587083+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1546,16 +1556,16 @@
    "id": "2ad4d3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T04:44:36.311448Z",
-     "iopub.status.busy": "2026-07-04T04:44:36.311115Z",
-     "iopub.status.idle": "2026-07-04T04:44:37.108967Z",
-     "shell.execute_reply": "2026-07-04T04:44:37.107268Z"
+     "iopub.execute_input": "2026-07-04T12:08:23.716334Z",
+     "iopub.status.busy": "2026-07-04T12:08:23.716091Z",
+     "iopub.status.idle": "2026-07-04T12:08:24.099588Z",
+     "shell.execute_reply": "2026-07-04T12:08:24.098149Z"
     },
     "papermill": {
-     "duration": 0.832242,
-     "end_time": "2026-07-04T04:44:37.111077+00:00",
+     "duration": 0.429406,
+     "end_time": "2026-07-04T12:08:24.102018+00:00",
      "exception": false,
-     "start_time": "2026-07-04T04:44:36.278835+00:00",
+     "start_time": "2026-07-04T12:08:23.672612+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1631,14 +1641,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 218.306926,
-   "end_time": "2026-07-04T04:44:38.176257+00:00",
+   "duration": 192.483765,
+   "end_time": "2026-07-04T12:08:25.067623+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "output_path": "doc/source/tutorials/potentials/scf_and_multipole.ipynb",
    "parameters": {},
-   "start_time": "2026-07-04T04:40:59.869331+00:00",
+   "start_time": "2026-07-04T12:05:12.583858+00:00",
    "version": "2.7.0"
   }
  },

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -490,6 +490,83 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
                 vo=vo,
             )
 
+    @classmethod
+    def from_scf(
+        cls,
+        scf,
+        rgrid=numpy.geomspace(1e-3, 30, 1_001),
+        amp=1.0,
+        normalize=False,
+        ro=None,
+        vo=None,
+    ):
+        """
+        Initialize a MultipoleExpansionPotential from an SCFPotential.
+
+        Because both potentials expand the density in the same real spherical
+        harmonics, the translation is purely radial: the SCF density multipoles
+        rho_lm(r) = sum_n A_nlm rho_tilde_nl(r) are evaluated on ``rgrid`` and
+        stored as the multipole's radial density coefficients (no angular
+        computation). The angular resolution (``L``, ``M``) is inherited from the
+        SCF expansion. A time-dependent SCFPotential (built on a ``tgrid``)
+        produces a time-dependent MultipoleExpansionPotential on the same
+        ``tgrid``.
+
+        Parameters
+        ----------
+        scf : SCFPotential
+            The SCF potential to translate.
+        rgrid : numpy.ndarray or Quantity, optional
+            Radial grid on which to sample the density multipoles. Should span the
+            radial range of interest; for a good match choose it to cover where the
+            SCF density is non-negligible.
+        amp : float, optional
+            Overall amplitude, multiplying the SCF's amplitude (default: 1.0, i.e.
+            reproduce the SCF).
+        normalize : bool or float, optional
+            If True, normalize such that vc(1,0)=1, or, if a number, such that the
+            force is this fraction of the force necessary to make vc(1,0)=1.
+        ro : float or Quantity, optional
+            Distance scale for translation into internal units (default from configuration file).
+        vo : float or Quantity, optional
+            Velocity scale for translation into internal units (default from configuration file).
+
+        Returns
+        -------
+        MultipoleExpansionPotential object
+
+        Notes
+        -----
+        - 2026-07-04 - Written - Bovy (UofT)
+
+        """
+        dumm = cls(ro=ro, vo=vo)
+        rgrid = numpy.asarray(conversion.parse_length(rgrid, ro=dumm._ro))
+        # multipole does not halve amp, so its amp is simply amp * scf's amp
+        out_amp = amp * scf._amp
+        if not scf._tdep:
+            rho_cos_splines, rho_sin_splines = _scf_rho_splines(scf, rgrid)
+            return cls(
+                amp=out_amp,
+                rho_cos_splines=rho_cos_splines,
+                rho_sin_splines=rho_sin_splines,
+                rgrid=rgrid,
+                normalize=normalize,
+                ro=ro,
+                vo=vo,
+            )
+        rho_cos_funcs, rho_sin_funcs = _scf_rho_funcs(scf)
+        return cls(
+            amp=out_amp,
+            rho_cos_splines=rho_cos_funcs,
+            rho_sin_splines=rho_sin_funcs,
+            rgrid=rgrid,
+            tgrid=scf._tgrid,
+            normalize=normalize,
+            ro=ro,
+            vo=vo,
+        )
+
     @staticmethod
     def _density_has_units(dens):
         """
@@ -2137,3 +2214,72 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
                     # Rho: sampled values for GSL cubic spline
                     args.extend(rho_sp(rgrid))
         return args
+
+
+def _scf_density_multipoles(scf, r_arr, Acos, Asin):
+    """Evaluate the SCF density multipoles D_lm(r) = sum_n A_nlm rho_tilde_nl(r)
+    on an array of radii, for coefficient arrays ``Acos``/``Asin`` of shape
+    (N, L, M). Returns ``(Dcos, Dsin)`` each of shape (len(r_arr), L, M), the
+    coefficients of P_l^m(cos theta) cos(m phi) [resp. sin] in the density (the
+    same beta-baked convention the multipole stores).
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    N, L, M = Acos.shape
+    rhoT = numpy.array([scf._rhoTilde(r, N, L) for r in r_arr])  # (Nr, N, L)
+    Dcos = numpy.einsum("nlm,rnl->rlm", Acos, rhoT)
+    Dsin = numpy.einsum("nlm,rnl->rlm", Asin, rhoT)
+    return Dcos, Dsin
+
+
+def _scf_rho_splines(scf, rgrid):
+    """Build the multipole density-coefficient splines [L][M] from a static SCF."""
+    N, L, M = scf._Acos.shape
+    Dcos, Dsin = _scf_density_multipoles(scf, rgrid, scf._Acos, scf._Asin)
+    rho_cos = [
+        [InterpolatedUnivariateSpline(rgrid, Dcos[:, l, m], k=3) for m in range(M)]
+        for l in range(L)
+    ]
+    if not scf.isNonAxi:
+        return rho_cos, None
+    rho_sin = [
+        [InterpolatedUnivariateSpline(rgrid, Dsin[:, l, m], k=3) for m in range(M)]
+        for l in range(L)
+    ]
+    return rho_cos, rho_sin
+
+
+def _scf_rho_funcs(scf):
+    """Build the multipole density-coefficient callables f(r,t) [L][M] from a
+    time-dependent SCF. The (time-independent) radial basis is cached over r."""
+    N, L, M = scf._Acos_all.shape[1:]
+    cache = {}
+
+    def _multipoles_at(r, t):
+        rr = numpy.atleast_1d(numpy.asarray(r, dtype=float))
+        key = rr.tobytes()
+        if key not in cache:
+            cache[key] = numpy.array([scf._rhoTilde(x, N, L) for x in rr])  # (Nr,N,L)
+        rhoT = cache[key]
+        scf._ensure_coeffs_for_time(t)
+        Dcos = numpy.einsum("nlm,rnl->rlm", scf._Acos, rhoT)
+        Dsin = numpy.einsum("nlm,rnl->rlm", scf._Asin, rhoT)
+        return Dcos, Dsin
+
+    def _make(l, m, sin):
+        def f(r, t):
+            Dcos, Dsin = _multipoles_at(r, t)
+            out = (Dsin if sin else Dcos)[:, l, m]
+            return out if numpy.ndim(r) else out[0]
+
+        return f
+
+    rho_cos = [[_make(l, m, False) for m in range(M)] for l in range(L)]
+    rho_sin = (
+        [[_make(l, m, True) for m in range(M)] for l in range(L)]
+        if scf.isNonAxi
+        else None
+    )
+    return rho_cos, rho_sin

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -6,7 +6,7 @@ import scipy
 from numpy.polynomial.legendre import leggauss
 from packaging.version import parse as parse_version
 from scipy import integrate
-from scipy.interpolate import CubicSpline
+from scipy.interpolate import CubicSpline, InterpolatedUnivariateSpline
 from scipy.special import gamma, gammaln
 
 _SCIPY_VERSION = parse_version(scipy.__version__)
@@ -538,6 +538,89 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         Asin_all = numpy.array(Asin_list) if any_sin else None
         return cls(Acos=Acos_all, Asin=Asin_all, a=a, tgrid=tgrid, ro=out_ro, vo=out_vo)
 
+    @classmethod
+    def from_multipole(cls, mult, N, a=1.0, radial_order=None, ro=None, vo=None):
+        """
+        Initialize an SCFPotential from a MultipoleExpansionPotential.
+
+        Because both potentials expand the density in the same real spherical
+        harmonics, the translation is purely radial: the density multipoles
+        rho_lm(r) of the multipole expansion are projected onto the SCF radial
+        basis (a set of 1D radial integrals), with no angular quadrature. The
+        angular resolution (``L``, ``M``) is taken from the multipole expansion;
+        ``N`` sets the number of SCF radial basis functions. A time-dependent
+        multipole expansion (built on a ``tgrid``) produces a time-dependent
+        SCFPotential on the same ``tgrid``.
+
+        Parameters
+        ----------
+        mult : MultipoleExpansionPotential
+            The multipole expansion to translate.
+        N : int
+            Number of radial basis functions of the SCF expansion.
+        a : float or Quantity, optional
+            SCF expansion scale length.
+        radial_order : int, optional
+            Number of sample points for the radial projection integral. If None,
+            ``max(2*N+L, 200)``.
+        ro : float or Quantity, optional
+            Distance scale for translation into internal units (default from configuration file).
+        vo : float or Quantity, optional
+            Velocity scale for translation into internal units (default from configuration file).
+
+        Returns
+        -------
+        SCFPotential object
+
+        Notes
+        -----
+        - 2026-07-04 - Written - Bovy (UofT)
+
+        """
+        dumm = cls(ro=ro, vo=vo)
+        a = conversion.parse_length(a, ro=dumm._ro)
+        L, M = mult._L, mult._M
+        nonaxi = mult.isNonAxi
+        beta = sph_harm_normalization(L, M)
+        beta_safe = numpy.where(beta > 0, beta, 1.0)
+
+        def _snapshot(t):
+            # beta-baked SCF coefficients (N,L,M) from the multipole's density
+            # multipoles at time t (t=None for a static multipole)
+            Acos_b, Asin_b = _scf_coeffs_from_multipole(
+                mult, N, L, M, a, radial_order, t=t
+            )
+            raw_cos = numpy.where(beta[None] > 0, Acos_b / beta_safe[None], 0.0)
+            raw_sin = numpy.where(beta[None] > 0, Asin_b / beta_safe[None], 0.0)
+            if nonaxi:  # SCF stores (N,L,L); pad m>=M with zeros
+                pcos = numpy.zeros((N, L, L))
+                psin = numpy.zeros((N, L, L))
+                pcos[:, :, :M] = raw_cos
+                psin[:, :, :M] = raw_sin
+                return pcos, psin
+            return raw_cos[:, :, :1], None  # axisymmetric: only m=0
+
+        # SCF __init__ halves amp, so pass 2*amp to preserve the multipole's amp
+        amp = 2.0 * mult._amp
+        if not mult._tdep:
+            Acos, Asin = _snapshot(None)
+            return cls(amp=amp, Acos=Acos, Asin=Asin, a=a, ro=ro, vo=vo)
+        tgrid = mult._tgrid
+        Acos_list = []
+        Asin_list = []
+        any_sin = False
+        for t in tgrid:
+            Ac, As = _snapshot(t)
+            Acos_list.append(Ac)
+            if As is not None:
+                any_sin = True
+            Asin_list.append(As)
+        Acos_all = numpy.array(Acos_list)
+        Asin_all = numpy.array(Asin_list) if any_sin else None
+        return cls(
+            amp=amp, Acos=Acos_all, Asin=Asin_all, a=a, tgrid=tgrid, ro=ro, vo=vo
+        )
+
     @staticmethod
     def _symmetry_coeffs(
         dens, N, L, a, symmetry, radial_order, costheta_order, phi_order
@@ -713,21 +796,7 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         -----
          - Written on 2016-05-17 by Aladdin Seaifan (UofT)
         """
-        xi = _RToxi(r, self._a)
-        CC = _C(xi, N, L)
-        a = self._a
-        rho = numpy.zeros((N, L), float)
-        n = numpy.arange(0, N, dtype=float)[:, numpy.newaxis]
-        l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
-        K = 0.5 * n * (n + 4 * l + 3) + (l + 1.0) * (2 * l + 1)
-        rho[:, :] = (
-            K
-            * ((a * r) ** l)
-            / ((r / a) * (a + r) ** (2 * l + 3.0))
-            * CC[:, :]
-            * (numpy.pi) ** -0.5
-        )
-        return rho
+        return _rhoTilde_basis(r, N, L, self._a)
 
     def _phiTilde(self, r, N, L):
         """
@@ -752,23 +821,7 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         - Written on 2016-05-17 by Aladdin Seaifan (UofT)
 
         """
-        xi = _RToxi(r, self._a)
-        CC = _C(xi, N, L)
-        a = self._a
-        phi = numpy.zeros((N, L), float)
-        n = numpy.arange(0, N)[:, numpy.newaxis]
-        l = numpy.arange(0, L)[numpy.newaxis, :]
-        if r == 0:
-            phi[:, :] = -1.0 / a * CC[:, :] * (4 * numpy.pi) ** 0.5
-        else:
-            phi[:, :] = (
-                -(a**l)
-                * r ** (-l - 1.0)
-                / ((1.0 + a / r) ** (2 * l + 1.0))
-                * CC[:, :]
-                * (4 * numpy.pi) ** 0.5
-            )
-        return phi
+        return _phiTilde_basis(r, N, L, self._a)
 
     def _compute_at_point(self, radial_func, R, z, phi, t=0.0):
         """
@@ -1092,6 +1145,53 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
 
     def OmegaP(self):
         return 0
+
+
+def _rhoTilde_basis(r, N, L, a):
+    """Evaluate the SCF density basis functions rho_tilde_nl(r), shape (N, L).
+
+    Module-level implementation of ``SCFPotential._rhoTilde`` (which depends only
+    on the scale length ``a``), so the basis can be evaluated without an instance
+    (e.g. when translating a MultipoleExpansionPotential into an SCFPotential).
+    """
+    xi = _RToxi(r, a)
+    CC = _C(xi, N, L)
+    rho = numpy.zeros((N, L), float)
+    n = numpy.arange(0, N, dtype=float)[:, numpy.newaxis]
+    l = numpy.arange(0, L, dtype=float)[numpy.newaxis, :]
+    K = 0.5 * n * (n + 4 * l + 3) + (l + 1.0) * (2 * l + 1)
+    rho[:, :] = (
+        K
+        * ((a * r) ** l)
+        / ((r / a) * (a + r) ** (2 * l + 3.0))
+        * CC[:, :]
+        * (numpy.pi) ** -0.5
+    )
+    return rho
+
+
+def _phiTilde_basis(r, N, L, a):
+    """Evaluate the SCF potential basis functions phi_tilde_nl(r), shape (N, L).
+
+    Module-level implementation of ``SCFPotential._phiTilde`` (see
+    ``_rhoTilde_basis``).
+    """
+    xi = _RToxi(r, a)
+    CC = _C(xi, N, L)
+    phi = numpy.zeros((N, L), float)
+    n = numpy.arange(0, N)[:, numpy.newaxis]
+    l = numpy.arange(0, L)[numpy.newaxis, :]
+    if r == 0:
+        phi[:, :] = -1.0 / a * CC[:, :] * (4 * numpy.pi) ** 0.5
+    else:
+        phi[:, :] = (
+            -(a**l)
+            * r ** (-l - 1.0)
+            / ((1.0 + a / r) ** (2 * l + 1.0))
+            * CC[:, :]
+            * (4 * numpy.pi) ** 0.5
+        )
+    return phi
 
 
 def _xiToR(xi, a=1):
@@ -1602,6 +1702,69 @@ def _batched_nbody(pos, N, L, mass, a, symmetry):
         Acos = Ac if Acos is None else Acos + Ac
         if As is not None:
             Asin = As if Asin is None else Asin + As
+    return Acos, Asin
+
+
+def _scf_coeffs_from_multipole(mult, N, L, M, a, radial_order, t=None):
+    """Project a ``MultipoleExpansionPotential``'s density multipoles onto the SCF
+    radial basis, returning beta-baked SCF coefficients (Acos, Asin), each of shape
+    (N, L, M).
+
+    Both expansions use the same real spherical harmonics, so the density
+    multipole ``D_lm(r)`` (the coefficient of ``P_l^m(cos theta) cos/sin(m phi)``,
+    which the multipole stores beta-baked) is projected onto the SCF radial basis
+    ``phi_tilde_nl`` using the biorthogonality of the density/potential bases:
+    ``A_nlm = (1/W_nl) int D_lm(r) phi_tilde_nl(r) r^2 dr`` with
+    ``W_nl = int rho_tilde_nl phi_tilde_nl r^2 dr`` (diagonal in n). ``t`` selects
+    the snapshot for a time-dependent multipole (None for a static one).
+
+    Notes
+    -----
+    - 2026-07-04 - Written - Bovy (UofT)
+    """
+    rmin, rmax = mult._rgrid[0], mult._rgrid[-1]
+    if t is None:  # static: use the stored density-multipole splines
+        cos_splines = mult._rho_cos_splines
+        sin_splines = mult._rho_sin_splines
+    else:  # time-dependent: interpolate rho_lm on the multipole's rgrid at time t
+        cos_splines = [[None] * M for _ in range(L)]
+        sin_splines = [[None] * M for _ in range(L)]
+        for l in range(L):
+            for mm in range(min(l + 1, M)):
+                cos_splines[l][mm] = InterpolatedUnivariateSpline(
+                    mult._rgrid, mult._rho_cos_interp[l][mm](t), k=3
+                )
+                if mm > 0:  # the m=0 sine coefficient is identically zero
+                    sin_splines[l][mm] = InterpolatedUnivariateSpline(
+                        mult._rgrid, mult._rho_sin_interp[l][mm](t), k=3
+                    )
+
+    def _eval(splines, rq):
+        # density multipoles D_lm(rq) matching the multipole's extrapolation
+        # (clamp below rmin, zero above rmax); shape (L, M, len(rq))
+        out = numpy.zeros((L, M, len(rq)))
+        rr = numpy.clip(rq, rmin, rmax)
+        beyond = rq > rmax
+        for l in range(L):
+            for mm in range(min(l + 1, M)):
+                if splines[l][mm] is None:
+                    continue
+                v = splines[l][mm](rr)
+                v[beyond] = 0.0
+                out[l, mm] = v
+        return out
+
+    K = radial_order if radial_order is not None else max(2 * N + L, 200)
+    xi, w = leggauss(K)
+    rq = _xiToR(xi, a)
+    weight = w * (2.0 * a / (1.0 - xi) ** 2.0) * rq**2.0  # w * dr/dxi * r^2
+    rhoTq = numpy.array([_rhoTilde_basis(r, N, L, a) for r in rq]).transpose(1, 2, 0)
+    phiTq = numpy.array([_phiTilde_basis(r, N, L, a) for r in rq]).transpose(1, 2, 0)
+    Wnl = numpy.einsum("nlk,nlk,k->nl", rhoTq, phiTq, weight)  # (N, L), diagonal in n
+    Dcos = _eval(cos_splines, rq)
+    Dsin = _eval(sin_splines, rq)
+    Acos = numpy.einsum("lmk,nlk,k->nlm", Dcos, phiTq, weight) / Wnl[:, :, None]
+    Asin = numpy.einsum("lmk,nlk,k->nlm", Dsin, phiTq, weight) / Wnl[:, :, None]
     return Acos, Asin
 
 

--- a/tests/test_MultipoleExpansionPotential.py
+++ b/tests/test_MultipoleExpansionPotential.py
@@ -9,6 +9,7 @@ from galpy.potential import (
     MiyamotoNagaiPotential,
     MultipoleExpansionPotential,
     SCFPotential,
+    TriaxialHernquistPotential,
 )
 
 # Shared grids for reuse
@@ -1952,3 +1953,114 @@ def test_large_L_c_orbit():
     o.integrate(ts, mp, method="dop853_c")
     assert numpy.all(numpy.isfinite(o.R(ts))), "Orbit R not finite"
     assert numpy.all(numpy.isfinite(o.z(ts))), "Orbit z not finite"
+
+
+# --- from_scf (SCFPotential -> MultipoleExpansionPotential) ---
+
+_TRANS_PTS = [(1.0, 0.3, 0.5), (2.0, -0.4, 1.1), (0.7, 0.2, 2.0)]
+
+
+def _rel(p, q, meth, R, z, phi, t=None):
+    kw = {} if t is None else {"t": t}
+    return numpy.fabs(
+        getattr(p, meth)(R, z, phi, use_physical=False, **kw)
+        / getattr(q, meth)(R, z, phi, use_physical=False, **kw)
+        - 1.0
+    )
+
+
+def test_from_scf_static():
+    # Translating an SCFPotential into a MultipoleExpansionPotential reproduces its
+    # density and forces (purely radial, shared angular basis).
+    th = TriaxialHernquistPotential(amp=1.0, a=1.5, b=0.9, c=0.8)
+    th.turn_physical_off()
+    dg = lambda R, z, phi: th.dens(R, z, phi, use_physical=False)
+    scf = SCFPotential.from_density(dg, 10, L=6, a=1.5, symmetry=None)
+    mult = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 100.0, 400)
+    )
+    assert mult.isNonAxi
+    assert not mult._tdep
+    for R, z, phi in _TRANS_PTS:
+        assert _rel(mult, scf, "dens", R, z, phi) < 1e-5
+        assert _rel(mult, scf, "Rforce", R, z, phi) < 1e-3
+        assert _rel(mult, scf, "zforce", R, z, phi) < 1e-3
+
+
+def test_from_scf_amp_preserved():
+    # The multipole reproduces a rescaled SCF, and the amp argument scales it.
+    hp = HernquistPotential(amp=3.0, a=1.5)
+    hp.turn_physical_off()
+    scf = SCFPotential.from_density(
+        lambda r: hp.dens(r, 0.0, use_physical=False), 8, a=1.5, symmetry="spherical"
+    )
+    mult = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 100.0, 400)
+    )
+    assert _rel(mult, scf, "dens", 1.0, 0.3, 0.0) < 1e-5
+    mult2 = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 100.0, 400), amp=2.0
+    )
+    assert (
+        numpy.fabs(
+            mult2.dens(1.0, 0.3, 0.0, use_physical=False)
+            / mult.dens(1.0, 0.3, 0.0, use_physical=False)
+            - 2.0
+        )
+        < 1e-10
+    )
+
+
+def test_from_scf_axi_and_spherical():
+    # Axisymmetric and spherical SCFs translate to axi/spherical multipoles.
+    th = TriaxialHernquistPotential(amp=1.0, a=1.5, b=1.0, c=0.7)
+    th.turn_physical_off()
+    scf_axi = SCFPotential.from_density(
+        lambda R, z: th.dens(R, z, 0.0, use_physical=False),
+        10,
+        L=6,
+        a=1.5,
+        symmetry="axi",
+    )
+    mult_axi = MultipoleExpansionPotential.from_scf(
+        scf_axi, rgrid=numpy.geomspace(1e-3, 100.0, 400)
+    )
+    assert not mult_axi.isNonAxi
+    hp = HernquistPotential(amp=1.0, a=1.5)
+    hp.turn_physical_off()
+    scf_sph = SCFPotential.from_density(
+        lambda r: hp.dens(r, 0.0, use_physical=False), 8, a=1.5, symmetry="spherical"
+    )
+    mult_sph = MultipoleExpansionPotential.from_scf(
+        scf_sph, rgrid=numpy.geomspace(1e-3, 100.0, 400)
+    )
+    assert not mult_sph.isNonAxi
+    for R, z in [(1.0, 0.3), (2.0, -0.4)]:
+        assert _rel(mult_axi, scf_axi, "dens", R, z, 0.0) < 1e-5
+        assert _rel(mult_sph, scf_sph, "Rforce", R, z, 0.0) < 1e-4
+
+
+def test_from_scf_timedep():
+    # A time-dependent SCF (rotating bar) translates to a time-dependent multipole.
+    hp = HernquistPotential(normalize=1.0, a=1.0)
+    hp.turn_physical_off()
+    OmegaP = 1.3
+    tgrid = numpy.linspace(0.0, 2.0, 6)
+    dens = lambda R, z, phi, t=0.0: (
+        hp.dens(R, z, use_physical=False)
+        * (1.0 + 0.2 * numpy.cos(2.0 * (phi - OmegaP * t)))
+    )
+    scf = SCFPotential.from_density(dens, 10, L=4, a=1.0, symmetry=None, tgrid=tgrid)
+    mult = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 30.0, 400)
+    )
+    assert mult._tdep
+    assert numpy.allclose(mult._tgrid, scf._tgrid)
+    # genuinely time-dependent and reproduces the SCF at arbitrary t
+    d0 = mult.dens(1.0, 0.2, 0.5, t=tgrid[0], use_physical=False)
+    d1 = mult.dens(1.0, 0.2, 0.5, t=tgrid[-1], use_physical=False)
+    assert numpy.fabs(d0 - d1) > 1e-3
+    for t in [0.3, 1.1]:
+        for R, z, phi in _TRANS_PTS:
+            assert _rel(mult, scf, "dens", R, z, phi, t=t) < 1e-4
+            assert _rel(mult, scf, "Rforce", R, z, phi, t=t) < 1e-3

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -10593,6 +10593,43 @@ def test_scfpotential_from_nbody_units():
     return None
 
 
+def test_scf_multipole_translation_units():
+    # SCFPotential.from_multipole and MultipoleExpansionPotential.from_scf accept
+    # physical-unit (Quantity) scale lengths / radial grids, matching the
+    # equivalent internal-unit translation.
+    from galpy import potential
+
+    ro = 8.0
+    hp = potential.HernquistPotential(amp=1.0, a=1.5)
+    hp.turn_physical_off()
+    scf = potential.SCFPotential.from_density(
+        lambda r: hp.dens(r, 0.0, use_physical=False), 8, a=1.5, symmetry="spherical"
+    )
+    rgrid = numpy.geomspace(1e-3, 100.0, 400)
+    # from_scf with the rgrid as a Quantity (kpc)
+    mult = potential.MultipoleExpansionPotential.from_scf(scf, rgrid=rgrid)
+    mult_q = potential.MultipoleExpansionPotential.from_scf(
+        scf, rgrid=rgrid * ro * units.kpc, ro=ro
+    )
+    assert (
+        numpy.fabs(
+            mult_q.dens(1.0, 0.3, 0.0, use_physical=False)
+            / mult.dens(1.0, 0.3, 0.0, use_physical=False)
+            - 1.0
+        )
+        < 1e-8
+    ), "from_scf w/ Quantity rgrid does not match the internal-unit build"
+    # from_multipole with the scale length a as a Quantity (kpc)
+    scf_plain = potential.SCFPotential.from_multipole(mult, N=8, a=1.5)
+    scf_q = potential.SCFPotential.from_multipole(
+        mult, N=8, a=1.5 * ro * units.kpc, ro=ro
+    )
+    assert numpy.max(numpy.fabs(scf_q._Acos - scf_plain._Acos)) < 1e-10, (
+        "from_multipole w/ Quantity a does not match the internal-unit build"
+    )
+    return None
+
+
 def test_potential_paramunits_2d():
     # Test that input units for potential parameters other than the amplitude
     # behave as expected

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -5,7 +5,7 @@ import pytest
 
 from galpy import df, potential
 from galpy.orbit import Orbit
-from galpy.potential import SCFPotential
+from galpy.potential import MultipoleExpansionPotential, SCFPotential
 from galpy.util import coords
 
 EPS = 1e-13  ## default epsilon
@@ -610,6 +610,106 @@ def test_from_nbody_errors():
         SCFPotential.from_nbody(
             numpy.random.randn(3, n, 4), N, L=L, tgrid=tgrid, mass=numpy.ones((n, 3))
         )
+
+
+# ---------------------- from_multipole (Multipole -> SCF) ----------------------
+
+_TRANS_PTS = [(1.0, 0.3, 0.5), (2.0, -0.4, 1.1), (0.7, 0.2, 2.0)]
+
+
+def _rel(p, q, meth, R, z, phi, t=None):
+    kw = {} if t is None else {"t": t}
+    return numpy.fabs(
+        getattr(p, meth)(R, z, phi, use_physical=False, **kw)
+        / getattr(q, meth)(R, z, phi, use_physical=False, **kw)
+        - 1.0
+    )
+
+
+def test_from_multipole_static():
+    # Translating a MultipoleExpansionPotential into an SCFPotential reproduces its
+    # density and forces (purely radial projection, shared angular basis).
+    th = potential.TriaxialHernquistPotential(amp=1.0, a=1.5, b=0.9, c=0.8)
+    th.turn_physical_off()
+    dg = lambda R, z, phi: th.dens(R, z, phi, use_physical=False)
+    rgrid = numpy.geomspace(1e-3, 100.0, 400)
+    mult = MultipoleExpansionPotential.from_density(dg, L=6, rgrid=rgrid, symmetry=None)
+    scf = SCFPotential.from_multipole(mult, N=10, a=1.5)
+    assert scf.isNonAxi
+    assert not scf._tdep
+    for R, z, phi in _TRANS_PTS:
+        assert _rel(scf, mult, "dens", R, z, phi) < 1e-2
+        assert _rel(scf, mult, "Rforce", R, z, phi) < 5e-3
+        assert _rel(scf, mult, "zforce", R, z, phi) < 5e-3
+
+
+def test_from_multipole_roundtrip():
+    # SCF -> Multipole -> SCF recovers the original coefficients and potential.
+    th = potential.TriaxialHernquistPotential(amp=1.0, a=1.5, b=0.9, c=0.8)
+    th.turn_physical_off()
+    dg = lambda R, z, phi: th.dens(R, z, phi, use_physical=False)
+    scf = SCFPotential.from_density(dg, 10, L=6, a=1.5, symmetry=None)
+    mult = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 100.0, 400)
+    )
+    scf2 = SCFPotential.from_multipole(mult, N=10, a=1.5)
+    # same amplitude and (to the radial-grid accuracy) same coefficients
+    assert numpy.fabs(scf2._amp - scf._amp) < 1e-12
+    assert numpy.max(numpy.fabs(scf2._Acos - scf._Acos)) < 1e-2
+    for R, z, phi in _TRANS_PTS:
+        assert _rel(scf2, scf, "dens", R, z, phi) < 1e-2
+        assert _rel(scf2, scf, "Rforce", R, z, phi) < 5e-3
+
+
+def test_from_multipole_axi_and_spherical():
+    # Axisymmetric and spherical multipoles translate to axi/spherical SCFs.
+    th = potential.TriaxialHernquistPotential(amp=1.0, a=1.5, b=1.0, c=0.7)
+    th.turn_physical_off()  # oblate -> axisymmetric
+    rgrid = numpy.geomspace(1e-3, 100.0, 400)
+    da = lambda R, z: th.dens(R, z, 0.0, use_physical=False)
+    mult_axi = MultipoleExpansionPotential.from_density(
+        da, L=6, rgrid=rgrid, symmetry="axi"
+    )
+    scf_axi = SCFPotential.from_multipole(mult_axi, N=10, a=1.5)
+    assert not scf_axi.isNonAxi
+    assert numpy.all(scf_axi._Asin == 0.0)
+    hp = potential.HernquistPotential(amp=1.0, a=1.5)
+    hp.turn_physical_off()
+    ds = lambda r: hp.dens(r, 0.0, use_physical=False)
+    mult_sph = MultipoleExpansionPotential.from_density(
+        ds, rgrid=rgrid, symmetry="spherical"
+    )
+    scf_sph = SCFPotential.from_multipole(mult_sph, N=10, a=1.5)
+    assert not scf_sph.isNonAxi
+    for R, z in [(1.0, 0.3), (2.0, -0.4)]:
+        assert _rel(scf_axi, mult_axi, "dens", R, z, 0.0) < 1e-2
+        assert _rel(scf_sph, mult_sph, "Rforce", R, z, 0.0) < 5e-3
+
+
+def test_from_multipole_timedep():
+    # A time-dependent multipole (rotating bar) translates to a time-dependent SCF.
+    hp = potential.HernquistPotential(normalize=1.0, a=1.0)
+    hp.turn_physical_off()
+    OmegaP = 1.3
+    tgrid = numpy.linspace(0.0, 2.0, 6)
+    dens = lambda R, z, phi, t=0.0: (
+        hp.dens(R, z, use_physical=False)
+        * (1.0 + 0.2 * numpy.cos(2.0 * (phi - OmegaP * t)))
+    )
+    scf = SCFPotential.from_density(dens, 10, L=4, a=1.0, symmetry=None, tgrid=tgrid)
+    mult = MultipoleExpansionPotential.from_scf(
+        scf, rgrid=numpy.geomspace(1e-3, 30.0, 400)
+    )
+    scf2 = SCFPotential.from_multipole(mult, N=10, a=1.0)
+    assert scf2._tdep
+    assert numpy.allclose(scf2._tgrid, scf._tgrid)
+    # genuinely time-dependent and reproduces the source at arbitrary t
+    p0 = scf2(1.0, 0.2, phi=0.5, t=tgrid[0], use_physical=False)
+    p1 = scf2(1.0, 0.2, phi=0.5, t=tgrid[-1], use_physical=False)
+    assert numpy.fabs(p0 - p1) > 1e-3
+    for t in [0.3, 1.1]:
+        for R, z, phi in _TRANS_PTS:
+            assert _rel(scf2, scf, "Rforce", R, z, phi, t=t) < 1e-2
 
 
 def test_scf_compute_nfw():


### PR DESCRIPTION
Adds direct translation between galpy's two general density/potential expansions, the second of the planned SCF follow-ups (after #1058 and #1061).

## What's new
- **`SCFPotential.from_multipole(mult, N, a=1.0, ...)`** — build an SCF expansion from a `MultipoleExpansionPotential`.
- **`MultipoleExpansionPotential.from_scf(scf, rgrid=..., ...)`** — build a multipole expansion from an `SCFPotential`.

Because both potentials expand the density in the **same real spherical harmonics** (shared `compute_legendre` / `sph_harm_normalization`), the translation is **purely radial** — no angular quadrature:
- `from_scf` evaluates the SCF density multipoles `D_lm(r) = Σ_n A_nlm ρ̃_nl(r)` on `rgrid` and stores them as the multipole's radial density-coefficient splines.
- `from_multipole` projects the multipole's density multipoles onto the SCF radial basis via the density/potential biorthogonality: `A_nlm = (1/W_nl) ∫ D_lm(r) φ̃_nl(r) r² dr`.

Time-dependent expansions translate as well (per-snapshot on the shared `tgrid`), and Quantity (physical-unit) scale lengths / radial grids are supported.

## Validation
- `from_scf` reproduces the SCF to **~1e-7** (density and forces), static and time-dependent.
- `from_multipole` reproduces the source to the SCF's radial-representation accuracy, and the **SCF↔multipole round trip closes** (coefficients recovered).
- Notebook: translating the triaxial-NFW SCF and multipole expansions both ways overlaps the true vertical force exactly (using the documented large-`a` SCF prescription for NFW).

## Tests / docs
- `from_multipole` tests in `test_scf.py`, `from_scf` tests in `test_MultipoleExpansionPotential.py` (static general/axi/spherical, round trip, time-dependent), Quantity units in `test_quantity.py`. All new lines covered; `test_scf.py` + `test_MultipoleExpansionPotential.py` = 201 passed.
- API reference for both methods, HISTORY entry, and a notebook section.

Refactor: extracted the SCF radial basis to module-level `_rhoTilde_basis`/`_phiTilde_basis` (byte-identical) so `from_multipole` can evaluate the basis without an instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCoE6U3bdzXnxiNy2QtBps