### PR TITLE
Track F Pdf.4 (qdf): backend-migrate quasiisothermaldf __call__ + _rg

### DIFF
--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -7,6 +7,8 @@ from scipy import integrate, interpolate, optimize
 
 from .. import actionAngle, potential
 from ..actionAngle import actionAngleIsochrone
+from ..backend import get_namespace, is_backend_array
+from ..backend.interpolate import Spline1D
 from ..orbit import Orbit
 from ..potential import IsochronePotential
 from ..potential.Potential import _check_potential_list_and_deprecate
@@ -145,9 +147,12 @@ class quasiisothermaldf(df):
             self._rgInterp = interpolate.InterpolatedUnivariateSpline(
                 self._precomputergLzgrid, self._rls, k=3
             )
+            # backend-array eval of the same spline (numpy path stays byte-identical)
+            self._rgInterpBackend = Spline1D(self._precomputergLzgrid, self._rls, k=3)
         else:
             self._precomputergrmax = 0.0
             self._rgInterp = None
+            self._rgInterpBackend = None
             self._rls = None
             self._precomputergnr = None
             self._precomputergLzgrid = None
@@ -235,7 +240,13 @@ class quasiisothermaldf(df):
                     return 0.0
             # if isinstance(jr,(list,numpy.ndarray)) and len(jr) > 1: jr= jr[0]
             # if isinstance(jz,(list,numpy.ndarray)) and len(jz) > 1: jz= jz[0]
-        if not isinstance(lz, numpy.ndarray) and self._cutcounter and lz < 0.0:
+        xp = get_namespace(jr, lz, jz)
+        if (
+            not isinstance(lz, numpy.ndarray)
+            and not is_backend_array(lz)
+            and self._cutcounter
+            and lz < 0.0
+        ):
             if log:
                 return -numpy.finfo(numpy.dtype(numpy.float64)).max
             else:
@@ -245,7 +256,7 @@ class quasiisothermaldf(df):
             thisrg = self._rg(lz)
             # Then calculate the epicycle and vertical frequencies
             kappa, nu = self._calc_epifreq(thisrg), self._calc_verticalfreq(thisrg)
-            Omega = numpy.fabs(lz) / thisrg / thisrg
+            Omega = xp.abs(lz) / thisrg / thisrg
         # calculate surface-densities and sigmas
         lnsurfmass = (self._refr - thisrg) / self._hr
         lnsr = self._lnsr + (self._refr - thisrg) / self._hsr
@@ -253,7 +264,7 @@ class quasiisothermaldf(df):
         # Calculate func
         if not _func is None:
             if log:
-                funcTerm = numpy.log(_func(jr, lz, jz))
+                funcTerm = xp.log(_func(jr, lz, jz))
             else:
                 funcFactor = _func(jr, lz, jz)
         # Calculate fsr
@@ -264,42 +275,51 @@ class quasiisothermaldf(df):
                 funcFactor = 1.0
         if log:
             lnfsr = (
-                numpy.log(Omega)
+                xp.log(Omega)
                 + lnsurfmass
                 - 2.0 * lnsr
                 - numpy.log(numpy.pi)
-                - numpy.log(kappa)
-                + numpy.log(1.0 + numpy.tanh(lz / self._lo))
-                - kappa * jr * numpy.exp(-2.0 * lnsr)
+                - xp.log(kappa)
+                + xp.log(1.0 + xp.tanh(lz / self._lo))
+                - kappa * jr * xp.exp(-2.0 * lnsr)
             )
             lnfsz = (
-                numpy.log(nu)
+                xp.log(nu)
                 - numpy.log(2.0 * numpy.pi)
                 - 2.0 * lnsz
-                - nu * jz * numpy.exp(-2.0 * lnsz)
+                - nu * jz * xp.exp(-2.0 * lnsz)
             )
             out = lnfsr + lnfsz + funcTerm
-            if isinstance(lz, numpy.ndarray):
+            if is_backend_array(out):
+                sentinel = -xp.finfo(out.dtype).max
+                out = xp.where(xp.isnan(out), sentinel, out)
+                if self._cutcounter:
+                    out = xp.where(lz < 0.0, sentinel, out)
+            elif isinstance(lz, numpy.ndarray):
                 out[numpy.isnan(out)] = -numpy.finfo(numpy.dtype(numpy.float64)).max
                 if self._cutcounter:
                     out[(lz < 0.0)] = -numpy.finfo(numpy.dtype(numpy.float64)).max
             elif numpy.isnan(out):  # pragma: no cover
                 out = -numpy.finfo(numpy.dtype(numpy.float64)).max
         else:
-            srm2 = numpy.exp(-2.0 * lnsr)
+            srm2 = xp.exp(-2.0 * lnsr)
             fsr = (
                 Omega
-                * numpy.exp(lnsurfmass)
+                * xp.exp(lnsurfmass)
                 * srm2
                 / numpy.pi
                 / kappa
-                * (1.0 + numpy.tanh(lz / self._lo))
-                * numpy.exp(-kappa * jr * srm2)
+                * (1.0 + xp.tanh(lz / self._lo))
+                * xp.exp(-kappa * jr * srm2)
             )
-            szm2 = numpy.exp(-2.0 * lnsz)
-            fsz = nu / 2.0 / numpy.pi * szm2 * numpy.exp(-nu * jz * szm2)
+            szm2 = xp.exp(-2.0 * lnsz)
+            fsz = nu / 2.0 / numpy.pi * szm2 * xp.exp(-nu * jz * szm2)
             out = fsr * fsz * funcFactor
-            if isinstance(lz, numpy.ndarray):
+            if is_backend_array(out):
+                out = xp.where(xp.isnan(out), 0.0, out)
+                if self._cutcounter:
+                    out = xp.where(lz < 0.0, 0.0, out)
+            elif isinstance(lz, numpy.ndarray):
                 out[numpy.isnan(out)] = 0.0
                 if self._cutcounter:
                     out[(lz < 0.0)] = 0.0
@@ -3051,6 +3071,19 @@ class quasiisothermaldf(df):
         -----
         - 2012-07-25 - Written - Bovy (IAS@MPIA)
         """
+        if is_backend_array(lz):  # leaf data-guard: numpy callers stay numpy
+            if self._rgInterpBackend is None:  # _precomputerg=False: rl everywhere
+                return potential.rl(self._pot, lz)
+            xp = get_namespace(lz)
+            # mirror the numpy-array indx: spline everywhere, rl a dead branch
+            # guarded so the in-range regime never root-finds a bad lz (AD-safe)
+            indx = (lz > self._precomputergLzmax) * (lz < self._precomputergLzmin)
+            lzsafe = xp.where(indx, self._precomputergLzmin, lz)
+            return xp.where(
+                indx,
+                potential.rl(self._pot, lzsafe),
+                self._rgInterpBackend(lz),
+            )
         if isinstance(lz, numpy.ndarray):
             indx = (lz > self._precomputergLzmax) * (lz < self._precomputergLzmin)
             indxc = True ^ indx

--- a/tests/test_backend_qdf.py
+++ b/tests/test_backend_qdf.py
@@ -1,0 +1,163 @@
+###############################################################################
+# test_backend_qdf.py: Track F Pdf.4 PR-4a -- backend (jax/torch) coverage for
+# the quasiisothermaldf __call__ + _rg core. The numpy path is byte-identical
+# (test_qdf unchanged); this exercises the resolved-namespace dispatch:
+#   (a) value parity numpy<->jax<->torch of __call__ (log + non-log), including
+#       the lz<0 / NaN sentinel branches, and
+#   (b) grad-vs-FD of __call__ w.r.t. (R,vR,vT,z,vz), flowing the #131 Staeckel
+#       c=True action gradients through the pure-arithmetic DF core.
+# The Staeckel action gradient is first-order-accurate (#1050), so grad-vs-FD is
+# checked at rtol 8e-3 (>2x margin over the observed ~3.4e-3 floor).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.actionAngle import actionAngleStaeckel
+from galpy.backend import as_numpy, is_backend_array
+from galpy.df import quasiisothermaldf
+from galpy.potential import MWPotential
+
+# Staeckel-based qdf fixture, mirroring test_qdf.py's Staeckel qdf setup.
+_aAS = actionAngleStaeckel(pot=MWPotential, c=True, delta=0.5)
+_qdf = quasiisothermaldf(
+    1.0 / 4.0, 0.2, 0.1, 1.0, 1.0, pot=MWPotential, aA=_aAS, cutcounter=True
+)
+
+# Interior prograde orbits (bound, lz>0); includes vR=0/vz=0/z=0 edge orbits.
+_ORBITS = numpy.array(
+    [
+        [0.9, 0.1, 0.9, 0.05, 0.02],
+        [1.1, -0.05, 0.8, 0.1, -0.03],
+        [0.7, 0.2, 1.0, -0.08, 0.05],
+        [1.0, 0.0, 0.95, 0.0, 0.0],
+    ]
+)
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(numpy.asarray(x, float))
+
+
+def _cols(backend, orbits):
+    return [_arr(backend, orbits[:, i]) for i in range(5)]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("log", [False, True])
+def test_call_value_parity(backend, log):
+    # __call__ (R,vR,vT,z,vz) value byte-identity numpy<->backend, both modes.
+    cn = [_ORBITS[:, i] for i in range(5)]
+    ref = as_numpy(_qdf(*cn, log=log))
+    got = _qdf(*_cols(backend, _ORBITS), log=log)
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12, atol=1e-300)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("log", [False, True])
+def test_call_sentinel_lzneg(backend, log):
+    # cutcounter lz<0 sentinel branch: retrograde orbit -> -finfo.max (log) / 0.
+    retro = numpy.array([[0.9, 0.1, -1.5, 0.05, 0.02]])
+    cn = [retro[:, i] for i in range(5)]
+    ref = as_numpy(_qdf(*cn, log=log))
+    got = as_numpy(_qdf(*_cols(backend, retro), log=log))
+    # exact match of the sentinel/zero (dtype-generic finfo max == float64 max)
+    assert numpy.array_equal(got, ref)
+    if log:
+        assert ref[0] == -numpy.finfo(numpy.float64).max
+    else:
+        assert ref[0] == 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_sentinel_nan(backend):
+    # NaN sentinel branch (log mode): a func returning a negative value makes
+    # log(func) NaN -> masked to -finfo.max on both numpy and backend paths.
+    negfunc = lambda jr, lz, jz: jr - 100.0
+    cn = [_ORBITS[:, i] for i in range(5)]
+    ref = as_numpy(_qdf(*cn, log=True, func=negfunc))
+    got = as_numpy(_qdf(*_cols(backend, _ORBITS), log=True, func=negfunc))
+    assert numpy.all(ref == -numpy.finfo(numpy.float64).max)  # NaN tripped
+    assert numpy.array_equal(got, ref)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("log", [False, True])
+def test_call_func_parity(backend, log):
+    # func-path value parity (moment weight lz**2 * jr) through xp.log/funcFactor.
+    f = lambda jr, lz, jz: lz**2 * jr + 1e-3
+    cn = [_ORBITS[:, i] for i in range(5)]
+    ref = as_numpy(_qdf(*cn, log=log, func=f))
+    got = _qdf(*_cols(backend, _ORBITS), log=log, func=f)
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12, atol=1e-300)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_rg_backend_parity(backend):
+    # _rg backend Spline1D eval matches the numpy scipy spline to ~1e-12 in the
+    # physical (in-precompute-range) regime; output is a backend array.
+    lzn = numpy.array([0.3, 0.5, 0.81, 1.0, 1.4])
+    ref = as_numpy(_qdf._rg(lzn))
+    got = _qdf._rg(_arr(backend, lzn))
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("log", [False, True])
+def test_call_grad_vs_fd(backend, log):
+    # jax.grad / torch.autograd of __call__ w.r.t. (R,vR,vT,z,vz) vs central FD.
+    # Exercises the #131 Staeckel c=True action grads through jr/lz/jz; the
+    # action grad is first-order-accurate (#1050) -> rtol 8e-3.
+    def npval(p):
+        a = [numpy.atleast_1d(x) for x in p]
+        return float(as_numpy(_qdf(*a, log=log)).reshape(-1)[0])
+
+    def fd(p, h=1e-6):
+        g = numpy.zeros(5)
+        for i in range(5):
+            pp = p.copy()
+            pp[i] += h
+            pm = p.copy()
+            pm[i] -= h
+            g[i] = (npval(pp) - npval(pm)) / (2.0 * h)
+        return g
+
+    for ic in _ORBITS:
+        ic = numpy.asarray(ic, float)
+        gfd = fd(ic)
+        if backend == "jax":
+
+            def f(v):
+                a = [v[i].reshape(1) for i in range(5)]
+                return _qdf(*a, log=log).reshape(())
+
+            g = as_numpy(jax.grad(f)(jnp.asarray(ic)))
+        else:
+            vt = torch.tensor(ic, requires_grad=True)
+            a = [vt[i].reshape(1) for i in range(5)]
+            _qdf(*a, log=log).reshape(()).backward()
+            g = vt.grad.numpy()
+        numpy.testing.assert_allclose(g, gfd, rtol=8e-3, atol=1e-3)

--- a/tests/test_backend_qdf.py
+++ b/tests/test_backend_qdf.py
@@ -126,6 +126,32 @@ def test_rg_backend_parity(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_rg_no_precompute(backend):
+    # _precomputerg=False: the rg spline is never built (_rgInterpBackend is None),
+    # so the backend _rg falls through to potential.rl everywhere -- matching the
+    # numpy scalar path (which also always takes rl since Lzmin/max are +/-finfo).
+    from galpy.potential import rl
+
+    qdf0 = quasiisothermaldf(
+        1.0 / 4.0,
+        0.2,
+        0.1,
+        1.0,
+        1.0,
+        pot=MWPotential,
+        aA=_aAS,
+        cutcounter=True,
+        _precomputerg=False,
+    )
+    assert qdf0._rgInterpBackend is None
+    lzn = numpy.array([0.3, 0.81, 1.4])
+    ref = numpy.array([float(rl(MWPotential, l)) for l in lzn])
+    got = qdf0._rg(_arr(backend, lzn))
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("log", [False, True])
 def test_call_grad_vs_fd(backend, log):
     # jax.grad / torch.autograd of __call__ w.r.t. (R,vR,vT,z,vz) vs central FD.


### PR DESCRIPTION
First PR of the next DF wave (Track F). Makes `qdf(R,vR,vT,z,vz)` **jax/torch-differentiable** — qdf's `__call__` is the clean action-based autodiff surface (`__call__` → Staeckel/Adiabatic/Isochrone **actions** → pure arithmetic in `_func`), so this leverages the just-merged **#131 Staeckel action gradients**. **numpy path byte-identical** (resolved-namespace dispatch — numpy inputs stay on the numpy path). First-order only.

## Scope (deliberately the AD/DF core)
- **`__call__`**: `xp = get_namespace(...)`; ndim/backend-aware dispatch replacing the `isinstance(lz, numpy.ndarray)` scalar branch (backend arrays aren't `ndarray` → were crashing on the python-bool `lz<0` scalar path); NaN + `lz<0` cutcounter sentinel masking via `xp.where` under a shape guard (sentinel from `xp.finfo(dtype).max`, dtype-generic for torch f32); `numpy.fabs/log/exp/tanh → xp.*`. The numpy fancy-assign path is preserved verbatim as the fall-through.
- **`_rg`**: numpy `InterpolatedUnivariateSpline` kept byte-identical + a backend `Spline1D` from the same knots/coeffs; `is_backend_array(lz)` leaf data-guard; out-of-precompute-range fallback via the already-backend-migrated `potential.rl`, `xp.where` dead-branch-guarded so the in-range physical regime never evaluates the `rl` root-find live.

**Out of scope (PR-4b / numpy-guarded):** the GL-quadrature moment paths (pvR/pvT/pvz, surfacemass_z, density gl-path) + mc/sampling stay numpy.

## Validation
`tests/test_backend_qdf.py` (new, per the one-test-file-per-df-module rule):
- **value byte-identity** vs numpy (jax+torch, `log=True`+`log=False`, incl. the NaN/`lz<0` sentinel branches) to **1e-12**
- **grad-vs-FD** (jax `grad` + torch `autograd`) to ~3e-3 — the first-order Staeckel-action-grad floor (#1050); jax and torch analytic grads agree to machine precision
- numpy `test_qdf.py` `__call__` subset: **21 pass** (no regression)

Recommended wave order (qdf first, then diskdf which needs a novel `_scimath_log`; evolveddiskdf = reject-guard): `galpy-jax/plan/pdf3_pdf4_diskdf_qdf/scope_and_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm