### PR TITLE
actionAngle: fix Staeckel EccZmaxRperiRap backend crash on default (c=True) objects (AA-milestone completeness)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -16,7 +16,7 @@ from scipy import interpolate
 from .. import potential
 from ..backend import get_namespace
 from ..backend import interpolate as backend_interpolate
-from ..backend import promote_scalars
+from ..backend import is_backend_array, promote_scalars
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -545,6 +545,10 @@ class actionAngleAdiabaticGrid(actionAngle):
         - 2012-07-30 - Written - Bovy (IAS@MPIA)
 
         """
+        if any(is_backend_array(a) for a in args):
+            # backend arrays: ride the migrated _evaluate path (numpy stays
+            # byte-identical below); the standalone grid lookup is numpy-only.
+            return self(*args, **kwargs)[2]
         self._parse_eval_args(*args)
         Phi = _evaluatePotentials(self._pot, self._eval_R, self._eval_z)
         Phio = _evaluatePotentials(self._pot, self._eval_R, 0.0)

--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -1039,7 +1039,8 @@ class actionAngleIsochroneApprox(actionAngle):
 
     def _actionsFreqsAngles_backend(self, R, vR, vT, z, vz, phi, ts, maxn, **kwargs):
         """Backend counterpart of _actionsFreqsAngles (actions via angle-averaging,
-        frequencies and angles via the linear angle-fit Y=AX). Axisymmetric only."""
+        frequencies and angles via the linear angle-fit Y=AX). Axisymmetric and
+        non-axisymmetric (the nonAxi Lz/angle-fit branches below)."""
         xp = get_namespace(R, vR, vT, z, vz, phi)
         # ts is the (2*ntintJ-1) symmetric time grid (numpy from self._tsJ); move
         # it onto the input backend for the angle-fit design matrix column A[..,1].

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -1441,9 +1441,15 @@ class actionAngleStaeckel(actionAngle):
             z = numpy.array([z])
             vz = numpy.array([vz])
         if (
-            (self._c and not ("c" in kwargs and not kwargs["c"]))
-            or (ext_loaded and ("c" in kwargs and kwargs["c"]))
-        ) and _check_c(self._pot):
+            (
+                (self._c and not ("c" in kwargs and not kwargs["c"]))
+                or (ext_loaded and ("c" in kwargs and kwargs["c"]))
+            )
+            and _check_c(self._pot)
+            # backend arrays route to the vectorised _staeckel_prep path below
+            # (no C-native uminUmaxVmin Jacobian); numpy stays on the C path here
+            and not any(is_backend_array(c) for c in (R, vR, vT, z, vz))
+        ):
             Lz = R * vT
             if self._useu0:
                 # First calculate u0

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1016,6 +1016,30 @@ def test_staeckel_turningpoint_parity(backend):
         )
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_default_c_ecczmax_backend(backend):
+    # DEFAULT object (c=True): EccZmaxRperiRap / _uminumaxvmin must route backend
+    # arrays to the vectorised _staeckel_prep path (the C ctypes wrapper cannot
+    # take jax/torch arrays). Pre-fix this raised; the sibling actions/freqs/angles
+    # methods already dispatched, _uminumaxvmin did not. numpy c=True is the ref.
+    aC = actionAngleStaeckel(pot=MWPotential2014, delta=0.45)  # default c=True
+    assert aC._c
+    bargs = [_arr(backend, v) for v in _STK]
+    ref = aC.EccZmaxRperiRap(*_STK)  # numpy c=True (C path)
+    got = aC.EccZmaxRperiRap(*bargs)  # backend -> _staeckel_prep
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-9
+        )
+    # _uminumaxvmin directly, too (backs EccZmax; also a public turning-point query)
+    for r, g in zip(aC._uminumaxvmin(*_STK), aC._uminumaxvmin(*bargs)):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-7, atol=1e-9
+        )
+
+
 # Exactly-planar orbits (z=vz=0, so J_z=0): the vertical turning point snaps to
 # v=pi/2, the J_z derivative panels collapse to zero width, and the frequency
 # determinant det(A)=0. The C path then returns Omegar,Omegaphi=NaN and
@@ -1919,6 +1943,19 @@ def test_adiabaticgrid_numpy_byte_identity():
         sact = _aAAG(*[v[ii] for v in _GRID])
         for comp, s in zip(act, sact):
             numpy.testing.assert_array_equal(comp[ii], s)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabaticgrid_Jz_backend(backend):
+    # The standalone AdiabaticGrid.Jz accessor (numpy scalar-only) now guards on
+    # backend arrays and rides the migrated _evaluate path -> jz. Matches numpy.
+    ic = (1.1, 0.15, 0.9, 0.12, 0.13)
+    ref = numpy.asarray(_aAAG.Jz(*ic)).reshape(-1)[0]
+    got = _aAAG.Jz(*[_arr(backend, numpy.array([x])) for x in ic])
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(
+        as_numpy(got).reshape(-1)[0], ref, rtol=1e-10, atol=1e-12
+    )
 
 
 # Single-point bound IC well inside both grids, away from turning points / edges.


### PR DESCRIPTION
Part of the action-angle milestone completeness sweep (the AA-completeness audit that precedes the ledger regen).

## The one real gap
`actionAngleStaeckel._uminumaxvmin` (backing `EccZmaxRperiRap` and the public turning-point query) lacked the `is_backend_array` dispatch its sibling compute methods (`_evaluate`/`_actionsFreqs`/`_actionsFreqsAngles`) all have. On a **default** object (`c=True` — the standard case whenever the C extension is loaded), `EccZmaxRperiRap` with jax/torch inputs entered the c=True branch and called the numpy/ctypes `actionAngleUminUmaxVminStaeckel_c` wrapper with backend arrays → `TypeError: Multiple namespaces...`. The existing tests missed it because they feed **numpy** arrays (byte-identical C path); only explicitly-`c=False` objects were exercised under a backend.

**Fix:** exclude backend arrays from the c=True guard so they fall through to the already-working vectorised `_staeckel_prep` path (no C-native uminUmaxVmin Jacobian exists, so no custom_vjp is needed). numpy stays on the C path — **byte-identical**. Verified jax/torch `EccZmax` + `_uminumaxvmin` now match numpy c=True to ~1e-14; the numpy Staeckel EccZmax + AdiabaticGrid tests are unchanged.

## Also in this sweep
- `actionAngleAdiabaticGrid.Jz`: the standalone (numpy scalar-only) accessor now guards on backend arrays and rides the migrated `_evaluate` path (numpy path untouched, byte-identical).
- `actionAngleIsochroneApprox._actionsFreqsAngles_backend`: corrected a stale `Axisymmetric only` docstring (the body implements the non-axi branches).

## Tests
`test_backend_actionAngle.py` adds `test_staeckel_default_c_ecczmax_backend` (EccZmax + `_uminumaxvmin` on a default c=True object, jax+torch vs numpy) and `test_adiabaticgrid_Jz_backend`.

Follow-ups (separate PRs): the coercion/device-anchoring mop-up (sphericaldf `Lz` numpy-bug + GPU-latent device anchoring) and the AA-milestone ledger regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm