### PR TITLE
estimateDeltaStaeckel: resolved-namespace dispatch — runs on jax/torch (drop numpy island) [AA redesign #113, cluster 1]

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -2497,29 +2497,42 @@ def estimateDeltaStaeckel(pot, R, z, no_median=False, delta0=1e-6):
         if isinstance(pot, CompositePotential)
         else isinstance(pot, SCFPotential) or isinstance(pot, DiskSCFPotential)
     )
-    if is_backend_array(R):
-        # Vectorised, differentiable jax/torch path: the migrated potential
-        # evaluators accept array R,z, so evaluate the whole array at once;
-        # xp.where / _nanmedian reproduce the numpy in-place writes / masked
-        # median. (numpy keeps the per-element path below because several
-        # potentials' methods only accept scalar inputs.)
-        xp = get_namespace(R)
+    xp = get_namespace(R, z)
+    if xp is not numpy:
+        # Resolved-namespace path (runs on jax/torch): under a forced backend the
+        # numpy inputs are promoted UP to the backend so the whole estimate runs
+        # on the backend instead of falling through to a numpy island. xp.where /
+        # _nanmedian reproduce the numpy in-place writes / masked median.
+        R, z = promote_scalars(xp, R, z)
         z = xp.where(z == 0.0, 1e-4, z)
-        delta2 = (
-            z**2.0
-            - R**2.0  # eqn. (9) has a sign error
-            + (
-                3.0 * R * _evaluatezforces(pot, R, z)
-                - 3.0 * z * _evaluateRforces(pot, R, z)
-                + R
-                * z
-                * (
-                    evaluateR2derivs(pot, R, z, use_physical=False)
-                    - evaluatez2derivs(pot, R, z, use_physical=False)
+
+        def _delta2(Ri, zi):
+            # eqn. (9) has a sign error (hence z^2 - R^2)
+            return (
+                zi**2.0
+                - Ri**2.0
+                + (
+                    3.0 * Ri * _evaluatezforces(pot, Ri, zi)
+                    - 3.0 * zi * _evaluateRforces(pot, Ri, zi)
+                    + Ri
+                    * zi
+                    * (
+                        evaluateR2derivs(pot, Ri, zi, use_physical=False)
+                        - evaluatez2derivs(pot, Ri, zi, use_physical=False)
+                    )
                 )
+                / evaluateRzderivs(pot, Ri, zi, use_physical=False)
             )
-            / evaluateRzderivs(pot, R, z, use_physical=False)
-        )
+
+        try:
+            # array-capable potentials evaluate the whole array at once
+            delta2 = _delta2(R, z)
+        except (TypeError, RuntimeError):
+            # scalar-only potentials (e.g. DoubleExponentialDisk, which rejects
+            # array inputs on every path) evaluate element-by-element; each scalar
+            # is a backend scalar so the migrated scalar path still runs on the
+            # backend.
+            delta2 = xp.stack([_delta2(R[ii], z[ii]) for ii in range(len(R))])
         indx = (delta2 < delta0**2.0) & (
             (delta2 > -(10.0**-10.0)) | bool(pot_includes_scf)
         )

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -350,9 +350,6 @@ torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actions
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
-torch tests/test_actionAngle.py::test_estimateDeltaStaeckel
-torch tests/test_actionAngle.py::test_estimateDeltaStaeckel_no_median
-torch tests/test_actionAngle.py::test_estimateDeltaStaeckel_z_is_0
 torch tests/test_actionAngle.py::test_nullpotential_error
 torch tests/test_actionAngle.py::test_orbit_interface_actionAngleIsochroneApprox
 torch tests/test_actionAngle.py::test_orbit_interface_adiabatic

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -3346,14 +3346,18 @@ def test_estimateDeltaStaeckel_z_is_0():
     n = 11
     rs = numpy.linspace(0.1, 10.0, n)
     for r in rs:
-        delta0 = estimateDeltaStaeckel(MWPotential2014, r, 0.0)
-        deltasmall = estimateDeltaStaeckel(MWPotential2014, r, 5e-4)
+        # as_numpy: estimateDeltaStaeckel returns a backend array under a forced
+        # backend (it now runs on jax/torch), so coerce before the numpy assertion
+        delta0 = as_numpy(estimateDeltaStaeckel(MWPotential2014, r, 0.0))
+        deltasmall = as_numpy(estimateDeltaStaeckel(MWPotential2014, r, 5e-4))
         assert numpy.fabs(delta0 - deltasmall) < 1e-3, (
             "Delta computed with z=0 does not agree with that computed for small z"
         )
     # And an array
-    delta0 = estimateDeltaStaeckel(MWPotential2014, rs, numpy.zeros(n))
-    deltasmall = estimateDeltaStaeckel(MWPotential2014, rs, 5e-4 * numpy.ones(n))
+    delta0 = as_numpy(estimateDeltaStaeckel(MWPotential2014, rs, numpy.zeros(n)))
+    deltasmall = as_numpy(
+        estimateDeltaStaeckel(MWPotential2014, rs, 5e-4 * numpy.ones(n))
+    )
     assert numpy.all(numpy.fabs(delta0 - deltasmall) < 1e-3), (
         "Delta computed with array of z=0 does not agree with that computed for array of small z"
     )

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1545,6 +1545,22 @@ def test_estimateDeltaStaeckel_parity(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_estimateDeltaStaeckel_scalaronly_potential_backend(backend):
+    # A scalar-only potential (DoubleExponentialDisk rejects array inputs on EVERY
+    # path) exercises the per-element backend fallback (xp.stack) of the resolved-
+    # namespace path: each scalar is a backend scalar so its migrated scalar path
+    # still runs on the backend. Result stays on the backend and matches numpy.
+    from galpy.potential import DoubleExponentialDiskPotential
+
+    dp = DoubleExponentialDiskPotential(normalize=1.0)
+    R, z = numpy.array([1.1, 0.9]), numpy.array([0.15, 0.2])
+    ref = numpy.asarray(estimateDeltaStaeckel(dp, R, z, no_median=True))
+    got = estimateDeltaStaeckel(dp, _arr(backend, R), _arr(backend, z), no_median=True)
+    assert _is_backend_array(backend, got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-10, atol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_estimateBIsochrone_parity(backend):
     Rb, zb = _arr(backend, _EST_R), _arr(backend, _EST_Z)
     # array -> (bmin, bmedian, bmax)


### PR DESCRIPTION
**First cluster of the AA resolved-namespace redesign (#113)** — the reviewable "shape" for the pattern before scaling out.

## What changed
Replaces the `is_backend_array(R)` data-guard in `estimateDeltaStaeckel` — which kept numpy inputs on **numpy even under a forced backend** (a numpy island that passed the test *without* exercising the backend) — with **resolved-namespace + promote**:

```python
xp = get_namespace(R, z)
if xp is not numpy:
    R, z = promote_scalars(xp, R, z)   # numpy inputs promoted UP to the forced backend
    ... run on jax/torch ...
# else: byte-identical numpy per-element path (unchanged)
```

So under a forced backend the whole estimate **genuinely runs on jax/torch**; the numpy production path is byte-identical.

## Both potential kinds run on the backend
- **Array-capable** potentials evaluate vectorised.
- **Scalar-only** potentials (`DoubleExponentialDiskPotential`, which rejects array inputs on *every* path — a pre-existing algorithmic restriction, orthogonal to backends) fall back to a **per-element backend loop** (`xp.stack`), so their migrated scalar path still runs on the backend. No islanding, no ledgering.

## Test
`test_estimateDeltaStaeckel_z_is_0` now `as_numpy()`s the (now-backend) result before its `numpy.all/fabs` assertions — the established `test_actionAngle` pattern (39 existing uses). The 3 now-passing torch ledger entries are removed.

## Verified
All 5 `estimateDeltaStaeckel` tests pass on **numpy (byte-identical) + torch + jax**, genuinely returning backend arrays under forced context (array-capable → vectorised `Tensor`; scalar-only → per-element `Tensor`).

Note: touches `actionAngleStaeckel.py` — will rebase after #1063/#1065 merge. This is cluster 1; the pattern scales to the rest of the AA chain (Staeckel c=True/c=False, Spherical, potentials' direct calls, coords, Orbits) with leaf guards removed throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm