### PR TITLE
actionAngleAdiabatic: c=True EccZmaxRperiRap differentiable on backends (#131 PR-2, Adiabatic)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabatic.py
+++ b/galpy/actionAngle/actionAngleAdiabatic.py
@@ -428,7 +428,12 @@ class actionAngleAdiabatic(actionAngle):
             (self._c and not ("c" in kwargs and not kwargs["c"]))
             or (ext_loaded and ("c" in kwargs and kwargs["c"]))
         ) and _check_c(self._pot)
-        if not use_c and xp is not numpy:
+        if xp is not numpy:
+            # Any backend array (c=True or c=False) uses the differentiable
+            # Spherical (radial) + Vertical (zmax) backend path: the numpy/C
+            # turning-point solve cannot take jax/torch arrays, and there is no
+            # Adiabatic-specific C custom_vjp -- the migrated Spherical+Vertical
+            # ARE the differentiable natives. numpy stays on the C path below.
             R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
             return self._EccZmaxRperiRap_backend(R, vR, vT, z, vz)
         if use_c:

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1693,6 +1693,25 @@ def test_adiabatic_ecczmaxrperirap_parity(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmaxrperirap_c_backend(backend):
+    # A c=True object with backend arrays routes to the differentiable
+    # Spherical(radial)+Vertical(zmax) backend path (the numpy/C turning-point
+    # solve cannot take jax/torch arrays, and there is no Adiabatic-specific C
+    # custom_vjp -- the migrated Spherical+Vertical ARE the differentiable
+    # natives). Pre-fix this crashed; now it matches the numpy backend-path
+    # computation and returns backend arrays.
+    aC = actionAngleAdiabatic(pot=MWPotential2014, c=True)
+    aF = actionAngleAdiabatic(pot=MWPotential2014, c=False)
+    ref = aF._EccZmaxRperiRap(*_ADB)  # numpy Spherical+Vertical
+    got = aC._EccZmaxRperiRap(*[_arr(backend, v) for v in _ADB])  # c=True + backend
+    for r, g in zip(ref, got):
+        assert _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(
+            as_numpy(g), numpy.asarray(r), rtol=1e-8, atol=1e-9
+        )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_adiabatic_actions_vs_c(backend):
     # the vectorised backend actions are consistent with the C path (c=True) to
     # the inherent adiabatic Python-vs-C floor (the SAME floor the numpy c=False


### PR DESCRIPTION
Companion to the Staeckel C-native EccZmax (#1068). Previously a **c=True Adiabatic** object *crashed* on jax/torch arrays in `EccZmaxRperiRap` (the numpy/C turning-point solve can't take backend arrays).

## Why this is a routing fix, not a C-native Jacobian
Unlike Staeckel — whose confocal turning-point solve has a fast C path worth a C-native Jacobian — the **Adiabatic EccZmax decomposes into Spherical (radial `rperi/rap`) + Vertical (`zmax`)**, and `_EccZmaxRperiRap_backend` already computes both via the **already-migrated, differentiable** Spherical (`self._aAS._EccZmaxRperiRap`) + Vertical (batched vertical potential) backend paths. So there is **no Adiabatic-specific C custom_vjp** — the migrated Spherical+Vertical *are* the differentiable natives, and routing backend arrays there is the correct resolved-namespace fix, **not** the "avoid C" anti-pattern.

## Fix
The dispatch gate becomes `if xp is not numpy:` (any backend array — c=True or c=False — → the differentiable Spherical+Vertical backend path) instead of only c=False. **numpy stays on the C path — byte-identical** (the numpy branch is untouched). Under a forced backend, numpy inputs promote up and run on the backend too (Pillar 1).

## Verified
- c=True object + jax/torch arrays now return backend arrays matching the numpy Spherical+Vertical computation, and are **differentiable** (grad-vs-FD match).
- numpy Adiabatic path unchanged (byte-identical).
- `test_backend_actionAngle.py` adds `test_adiabatic_ecczmaxrperirap_c_backend`.

Together with #1068, **`Orbit.rap/rperi/zmax/e` are now differentiable on backends for both Staeckel and adiabatic `aA`**. This completes the EccZmax thread of #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm