### PR TITLE
actionAngleAdiabatic: C-native differentiable actions (jax/torch backend)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabatic.py
+++ b/galpy/actionAngle/actionAngleAdiabatic.py
@@ -30,6 +30,38 @@ from .actionAngleSpherical import actionAngleSpherical
 from .actionAngleVertical import actionAngleVertical
 
 
+def _adiabatic_c_grad_actions(pot, gamma, R, vR, vT, z, vz, order=10):
+    """Differentiable (jr, jz) via the C-native Adiabatic action Jacobian.
+
+    For jax/torch inputs, wraps the compiled 2x5 d(jr,jz)/d(R,vR,vT,z,vz) C entry
+    (actionAngleAdiabatic_actionsJac_c) in the backend custom_vjp / autograd.Function
+    (galpy.backend._{jax,torch}.adiabatic_c): the forward is the plain round-trip C
+    action value; the backward is a matvec of the C-computed Jacobian. numpy inputs
+    never reach here. gamma is a fixed scalar (no gradient); the vertical action is
+    injected into the radial Lz internally in C (Lz -> |R vT| + gamma*Jz), so the
+    (z,vz) gradients of jr are nonzero for gamma!=0. First-order only.
+    """
+
+    def host_jac(Rn, vRn, vTn, zn, vzn):
+        jr, jz, jac, err = actionAngleAdiabatic_c.actionAngleAdiabatic_actionsJac_c(
+            pot, gamma, Rn, vRn, vTn, zn, vzn, order=order
+        )
+        return jr, jz, jac
+
+    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
+    if "jax" in name:
+        from ..backend._jax.adiabatic_c import actions_with_jac
+
+        return actions_with_jac(host_jac, (R, vR, vT, z, vz))
+    if "torch" in name:
+        from ..backend._torch.adiabatic_c import actions_with_jac
+
+        return actions_with_jac(host_jac, R, vR, vT, z, vz)
+    raise NotImplementedError(  # pragma: no cover
+        "C-native Adiabatic action gradients require a jax or torch input array."
+    )
+
+
 class actionAngleAdiabatic(actionAngle):
     """Action-angle formalism for axisymmetric potentials using the adiabatic approximation"""
 
@@ -133,6 +165,20 @@ class actionAngleAdiabatic(actionAngle):
             (self._c and not ("c" in kwargs and not kwargs["c"]))
             or (ext_loaded and ("c" in kwargs and kwargs["c"]))
         ) and _check_c(self._pot)
+        _special = (
+            kwargs.get("_justjr", False)
+            or kwargs.get("_justjz", False)
+            or "_Jz" in kwargs
+        )
+        if use_c and xp is not numpy and not _special:
+            # C-native differentiable path: backend inputs route to the fused C
+            # (jr,jz) Jacobian (custom_vjp / autograd.Function), running the C
+            # actions on the backend with first-order gradients (#131 PR-2a). Lz
+            # (=R*vT) is differentiated trivially by the backend. numpy path is
+            # byte-identical (never reaches here).
+            R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+            jr, jz = _adiabatic_c_grad_actions(self._pot, self._gamma, R, vR, vT, z, vz)
+            return (jr, R * vT, jz)
         if not use_c and xp is not numpy:
             # Backend path: runs under a forced backend even for numpy inputs
             # (promote first), exercising the backend for real -- unless the C

--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -14,7 +14,7 @@ import numpy
 from scipy import interpolate
 
 from .. import potential
-from ..backend import get_namespace
+from ..backend import as_numpy, get_namespace
 from ..backend import interpolate as backend_interpolate
 from ..backend import promote_scalars
 from ..potential.Potential import (
@@ -114,6 +114,12 @@ class actionAngleAdiabaticGrid(actionAngle):
                 numpy.sqrt(2.0 * this * thisEzZmaxs),
                 **kwargs,
             )[2]
+            # the c=True vectorized aA (no _justjz) returns a backend array under a
+            # forced backend; the grid precompute must be a WRITABLE numpy array
+            # (it feeds scipy splines + in-place table fills like jz[ii,:]/=...).
+            # as_numpy of an immutable backend array is read-only -> numpy.array
+            # copies it writable. numpy path: numpy.array(numpy) is a plain copy.
+            jz = numpy.array(as_numpy(jz))
             jz = numpy.reshape(jz, (nR, nEz))
             jzEzzmax[0:nR] = jz[:, nEz - 1]
         else:
@@ -215,6 +221,7 @@ class actionAngleAdiabaticGrid(actionAngle):
                 numpy.zeros(len(thisRL)),
                 **kwargs,
             )[0]
+            mjr = numpy.array(as_numpy(mjr))  # writable numpy precompute; see above
             jr[:, 0:-1] = numpy.reshape(mjr, (nLz, nEr - 1))
             jrERRa[0:nLz] = jr[:, 0]
         else:

--- a/galpy/actionAngle/actionAngleAdiabatic_c.py
+++ b/galpy/actionAngle/actionAngleAdiabatic_c.py
@@ -121,6 +121,105 @@ def actionAngleAdiabatic_c(pot, gamma, R, vR, vT, z, vz):
     return (jr, jz, err.value)
 
 
+def actionAngleAdiabatic_actionsJac_c(pot, gamma, R, vR, vT, z, vz, order=10):
+    """
+    Use C to compute adiabatic actions (jr,jz) AND the fused (N,2,5) Jacobian
+    d(jr,jz)/d(R,vR,vT,z,vz), assembled analytically in C (#131 Adiabatic PR-2a).
+
+    Parameters
+    ----------
+    pot : Potential or a combined potential formed using addition (pot1+pot2+…)
+        Gravitational potential to compute actions in.
+    gamma : float
+        as in Lz -> Lz+gamma * J_z.
+    R, vR, vT, z, vz : numpy.ndarray
+        Phase-space coordinates.
+    order : int, optional
+        Gauss-Legendre order for the action + derivative-integral quadratures.
+
+    Returns
+    -------
+    tuple
+        (jr, jz, jac, err) with jr,jz (N,), jac (N,2,5), and error code.
+    """
+    from ..orbit.integrateFullOrbit import _parse_pot
+    from ..orbit.integratePlanarOrbit import _prep_tfuncs
+
+    npot, pot_type, pot_args, pot_tfuncs = _parse_pot(pot, potforactions=True)
+    pot_tfuncs = _prep_tfuncs(pot_tfuncs)
+
+    jr = numpy.empty(len(R))
+    jz = numpy.empty(len(R))
+    jac = numpy.empty(len(R) * 2 * 5)
+    err = ctypes.c_int(0)
+
+    ndarrayFlags = ("C_CONTIGUOUS", "WRITEABLE")
+    func = _lib.actionAngleAdiabatic_actionsJac
+    func.argtypes = [
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ndpointer(dtype=numpy.int32, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_void_p,
+        ctypes.c_double,
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.POINTER(ctypes.c_int),
+    ]
+
+    f_cont = [
+        R.flags["F_CONTIGUOUS"],
+        vR.flags["F_CONTIGUOUS"],
+        vT.flags["F_CONTIGUOUS"],
+        z.flags["F_CONTIGUOUS"],
+        vz.flags["F_CONTIGUOUS"],
+    ]
+    R = numpy.require(R, dtype=numpy.float64, requirements=["C", "W"])
+    vR = numpy.require(vR, dtype=numpy.float64, requirements=["C", "W"])
+    vT = numpy.require(vT, dtype=numpy.float64, requirements=["C", "W"])
+    z = numpy.require(z, dtype=numpy.float64, requirements=["C", "W"])
+    vz = numpy.require(vz, dtype=numpy.float64, requirements=["C", "W"])
+
+    func(
+        len(R),
+        R,
+        vR,
+        vT,
+        z,
+        vz,
+        ctypes.c_int(npot),
+        pot_type,
+        pot_args,
+        pot_tfuncs,
+        ctypes.c_double(gamma),
+        ctypes.c_int(order),
+        jr,
+        jz,
+        jac,
+        ctypes.byref(err),
+    )
+
+    if f_cont[0]:
+        R = numpy.asfortranarray(R)
+    if f_cont[1]:
+        vR = numpy.asfortranarray(vR)
+    if f_cont[2]:
+        vT = numpy.asfortranarray(vT)
+    if f_cont[3]:
+        z = numpy.asfortranarray(z)
+    if f_cont[4]:
+        vz = numpy.asfortranarray(vz)
+
+    return (jr, jz, jac.reshape((len(R), 2, 5)), err.value)
+
+
 def actionAngleRperiRapZmaxAdiabatic_c(pot, gamma, R, vR, vT, z, vz):
     """
     Calculate planar (Rperi,Rap) and the maximum height Zmax using the adiabatic approximation (rap = sqrt(Rap^2+Zmax^2))

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
@@ -54,6 +54,15 @@ EXPORT void actionAngleAdiabatic_RperiRapZmax(int,double *,double *,double *,dou
 EXPORT void actionAngleAdiabatic_actions(int,double *,double *,double *,double *,
 				 double *,int,int *,double *,tfuncs_type_arr,double,
 				 double *,double *,int *);
+// C-native differentiable actions: (jr,jz) + the fused (ndata,2,5) Jacobian
+// d(jr,jz)/d(R,vR,vT,z,vz), assembled analytically (#131 Adiabatic PR-2a).
+EXPORT void actionAngleAdiabatic_actionsJac(int,double *,double *,double *,double *,
+				 double *,int,int *,double *,tfuncs_type_arr,double,int,
+				 double *,double *,double *,int *);
+void calcdJRAdiabatic(int,double *,double *,double *,double *,double *,double *,
+		      int,struct potentialArg *,int);
+void calcdJzAdiabatic(int,double *,double *,double *,double *,double *,
+		      int,struct potentialArg *,int);
 void calcJRAdiabatic(int,double *,double *,double *,double *,double *,
 		     int,struct potentialArg *,int);
 void calcJzAdiabatic(int,double *,double *,double *,double *,int,
@@ -189,6 +198,197 @@ void actionAngleAdiabatic_actions(int ndata,
   free(rperi);
   free(rap);
   free(zmax);
+}
+// C-native differentiable actions: forward (jr,jz) via the existing self-contained
+// quadratures, plus the fused (ndata,2,5) Jacobian d(jr,jz)/d(R,vR,vT,z,vz).
+// Adiabatic is separable EXCEPT the vertical action is injected into the radial
+// Lz (Lz = |R vT| + gamma*Jz; gamma=1 by default), so the vertical block
+// (Ez,zmax,Jz + its derivatives) is Lz-independent and computed first, then fed
+// into the radial Lz/E_radial. Boundary terms vanish (p=0 at every turning point)
+// so each dJ/dparam is a pure interior integral (Leibniz). First-order only.
+void actionAngleAdiabatic_actionsJac(int ndata,
+				     double *R,
+				     double *vR,
+				     double *vT,
+				     double *z,
+				     double *vz,
+				     int npot,
+				     int * pot_type,
+				     double * pot_args,
+				     tfuncs_type_arr pot_tfuncs,
+				     double gamma,
+				     int order,
+				     double *jr,
+				     double *jz,
+				     double *jac,
+				     int * err){
+  int ii;
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
+  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  double *ER= (double *) malloc ( ndata * sizeof(double) );
+  double *Ez= (double *) malloc ( ndata * sizeof(double) );
+  double *Lz= (double *) malloc ( ndata * sizeof(double) );
+  double *rperi= (double *) malloc ( ndata * sizeof(double) );
+  double *rap= (double *) malloc ( ndata * sizeof(double) );
+  double *zmax= (double *) malloc ( ndata * sizeof(double) );
+  // vertical block first (Lz-independent)
+  calcEREzL(ndata,R,vR,vT,z,vz,ER,Ez,Lz,npot,actionAngleArgs);
+  calcZmax(ndata,zmax,z,R,Ez,npot,actionAngleArgs);
+  calcJzAdiabatic(ndata,jz,zmax,R,Ez,npot,actionAngleArgs,order);
+  double *djzdEz= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdR=  (double *) malloc ( ndata * sizeof(double) );
+  calcdJzAdiabatic(ndata,djzdEz,djzdR,zmax,R,Ez,npot,actionAngleArgs,order);
+  // gamma injection: Lz = |R vT| + gamma*Jz, then radial effective energy
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk) private(ii)
+  for (ii=0; ii < ndata; ii++){
+    *(Lz+ii)= fabs( *(Lz+ii) ) + gamma * *(jz+ii);
+    *(ER+ii)+= 0.5 * *(Lz+ii) * *(Lz+ii) / *(R+ii) / *(R+ii)
+      - 0.5 * *(vT+ii) * *(vT+ii);
+  }
+  // radial block (uses the gamma-adjusted ER,Lz)
+  calcRapRperi(ndata,rperi,rap,R,ER,Lz,npot,actionAngleArgs);
+  calcJRAdiabatic(ndata,jr,rperi,rap,ER,Lz,npot,actionAngleArgs,order);
+  double *djrdER= (double *) malloc ( ndata * sizeof(double) );
+  double *djrdLz= (double *) malloc ( ndata * sizeof(double) );
+  calcdJRAdiabatic(ndata,djrdER,djrdLz,rperi,rap,ER,Lz,npot,actionAngleArgs,order);
+  // assemble the (2,5) Jacobian per orbit from the elementary chains
+#pragma omp parallel for schedule(static,chunk) private(ii)
+  for (ii=0; ii < ndata; ii++){
+    int kk;
+    double tR= *(R+ii), tvR= *(vR+ii), tvT= *(vT+ii), tz= *(z+ii), tvz= *(vz+ii);
+    if ( *(rperi+ii) == -9999.99 || *(rap+ii) == -9999.99
+	 || *(zmax+ii) == -9999.99 ){
+      for (kk=0;kk<10;kk++) *(jac+ii*10+kk)= 0.;
+      continue;
+    }
+    double tLz= *(Lz+ii), tER= *(ER+ii);
+    double s= ( tR * tvT >= 0. ) ? 1. : -1.;  // sign(R vT); Lz used fabs(R vT)
+    // forces for the elementary Ez-chain (at the INITIAL z)
+    double FR_R0= calcRforce(tR,0.,0.,0.,npot,actionAngleArgs);
+    double FR_Rz= calcRforce(tR,tz,0.,0.,npot,actionAngleArgs);
+    double Fz_Rz= calczforce(tR,tz,0.,0.,npot,actionAngleArgs);
+    double dEz[5]= { FR_R0 - FR_Rz, 0., 0., -Fz_Rz, tvz };
+    // dJz/dcoord = dJz/dEz * dEz/dcoord + dJz/dR|_Ez * e_R
+    double bE= *(djzdEz+ii), bR= *(djzdR+ii);
+    double dJz[5];
+    for (kk=0;kk<5;kk++) dJz[kk]= bE*dEz[kk];
+    dJz[0]+= bR;
+    // dLz/dcoord = [s vT + gamma dJz/dR, 0, s R, gamma dJz/dz, gamma dJz/dvz]
+    double dLz[5]= { s*tvT + gamma*dJz[0], 0., s*tR, gamma*dJz[3], gamma*dJz[4] };
+    // dE_radial/dcoord (E_R = Phi(R,0) + vR^2/2 + Lz^2/(2R^2))
+    double LzR2= tLz/(tR*tR);
+    double dER[5];
+    dER[0]= -FR_R0 - tLz*tLz/(tR*tR*tR) + LzR2*dLz[0];
+    dER[1]= tvR;
+    dER[2]= LzR2*dLz[2];
+    dER[3]= LzR2*dLz[3];
+    dER[4]= LzR2*dLz[4];
+    // dJr/dcoord = dJr/dER * dER/dcoord + dJr/dLz * dLz/dcoord
+    double aE= *(djrdER+ii), aL= *(djrdLz+ii);
+    for (kk=0;kk<5;kk++){
+      *(jac+ii*10+0*5+kk)= aE*dER[kk] + aL*dLz[kk];  // jr row
+      *(jac+ii*10+1*5+kk)= dJz[kk];                  // jz row
+    }
+    (void) tER;
+  }
+  free_potentialArgs(npot,actionAngleArgs);
+  free(actionAngleArgs);
+  free(ER); free(Ez); free(Lz);
+  free(rperi); free(rap); free(zmax);
+  free(djzdEz); free(djzdR); free(djrdER); free(djrdLz);
+}
+// dJr/dE_radial = (1/(sqrt2 pi)) int_rperi^Rap dr/sqrt(F_R),
+// dJr/dLz       = -(Lz/(sqrt2 pi)) int_rperi^Rap dr/(r^2 sqrt(F_R)),
+// F_R(r)= E_radial - Phi(r,0) - Lz^2/(2 r^2). Both 1/sqrt-singular at BOTH turning
+// points -> the theta-substitution r = cc - rr*cos(theta), theta in [0,pi]
+// (dr = rr sin(theta) dtheta) regularizes both ends in one GL pass. Degenerate
+// (unbound sentinel / circular) -> 0.
+void calcdJRAdiabatic(int ndata,
+		      double * djrdER,
+		      double * djrdLz,
+		      double * rperi,
+		      double * rap,
+		      double * ER,
+		      double * Lz,
+		      int nargs,
+		      struct potentialArg * actionAngleArgs,
+		      int order){
+  int ii, gi;
+  gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk) private(ii,gi) \
+  shared(djrdER,djrdLz,rperi,rap,ER,Lz,T)
+  for (ii=0; ii < ndata; ii++){
+    if ( *(rperi+ii) == -9999.99 || *(rap+ii) == -9999.99 ){
+      *(djrdER+ii)= 0.; *(djrdLz+ii)= 0.; continue;
+    }
+    if ( ( *(rap+ii) - *(rperi+ii) ) / *(rap+ii) < 0.000001 ){ //circular
+      *(djrdER+ii)= 0.; *(djrdLz+ii)= 0.; continue;
+    }
+    double tER= *(ER+ii), tLz= *(Lz+ii);
+    double Lz22= 0.5*tLz*tLz;
+    double cc= 0.5*( *(rap+ii) + *(rperi+ii) );
+    double rr= 0.5*( *(rap+ii) - *(rperi+ii) );
+    double accE= 0., accL= 0., xi, wi;
+    for (gi=0; gi < order; gi++){
+      gsl_integration_glfixed_point(0.,M_PI,gi,&xi,&wi,T);
+      double sinth= sin(xi), costh= cos(xi);
+      double r= cc - rr*costh;
+      double FR= tER - evaluatePotentials(r,0.,nargs,actionAngleArgs)
+	- Lz22/(r*r);
+      if ( FR <= 0. ) continue;
+      double w= wi*rr*sinth/sqrt(FR);
+      accE+= w;
+      accL+= w/(r*r);
+    }
+    *(djrdER+ii)= accE / ( sqrt(2.)*M_PI );
+    *(djrdLz+ii)= -tLz*accL / ( sqrt(2.)*M_PI );
+  }
+  gsl_integration_glfixed_table_free ( T );
+}
+// dJz/dEz    = (sqrt2/pi) int_0^zmax dz/sqrt(F_z),
+// dJz/dR|_Ez = (sqrt2/pi) int_0^zmax [Rforce(R,z)-Rforce(R,0)]/sqrt(F_z) dz,
+// F_z(z)= Ez - [Phi(R,z)-Phi(R,0)]. 1/sqrt-singular only at the upper end zmax
+// (F_z(0)=Ez>0) -> z = zmax*sin(phi), phi in [0,pi/2] (dz = zmax cos(phi) dphi)
+// regularizes zmax. Degenerate (unbound sentinel / planar) -> 0.
+void calcdJzAdiabatic(int ndata,
+		      double * djzdEz,
+		      double * djzdR,
+		      double * zmax,
+		      double * R,
+		      double * Ez,
+		      int nargs,
+		      struct potentialArg * actionAngleArgs,
+		      int order){
+  int ii, gi;
+  gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk) private(ii,gi) \
+  shared(djzdEz,djzdR,zmax,R,Ez,T)
+  for (ii=0; ii < ndata; ii++){
+    if ( *(zmax+ii) == -9999.99 ){ *(djzdEz+ii)= 0.; *(djzdR+ii)= 0.; continue; }
+    if ( *(zmax+ii) < 0.000001 ){ //planar (J_z=0)
+      *(djzdEz+ii)= 0.; *(djzdR+ii)= 0.; continue;
+    }
+    double tR= *(R+ii), tEz= *(Ez+ii), tzmax= *(zmax+ii);
+    double FR_R0= calcRforce(tR,0.,0.,0.,nargs,actionAngleArgs);
+    double accEz= 0., accR= 0., xi, wi;
+    for (gi=0; gi < order; gi++){
+      gsl_integration_glfixed_point(0.,0.5*M_PI,gi,&xi,&wi,T);
+      double sph= sin(xi), cph= cos(xi);
+      double zz= tzmax*sph;
+      double Fz= tEz - evaluateVerticalPotentials(tR,zz,nargs,actionAngleArgs);
+      if ( Fz <= 0. ) continue;
+      double w= wi*tzmax*cph/sqrt(Fz);  // dz/dphi = zmax cos(phi)
+      accEz+= w;
+      double FR_Rz= calcRforce(tR,zz,0.,0.,nargs,actionAngleArgs);
+      accR+= w*(FR_Rz - FR_R0);
+    }
+    *(djzdEz+ii)= sqrt(2.)/M_PI * accEz;
+    *(djzdR+ii)=  sqrt(2.)/M_PI * accR;
+  }
+  gsl_integration_glfixed_table_free ( T );
 }
 void calcJRAdiabatic(int ndata,
 		     double * jr,

--- a/galpy/backend/_jax/adiabatic_c.py
+++ b/galpy/backend/_jax/adiabatic_c.py
@@ -1,0 +1,60 @@
+###############################################################################
+#   galpy.backend._jax.adiabatic_c
+#
+#   jax wrapper for the compiled Adiabatic C actions. actions_with_jac is a
+#   jax.custom_vjp whose forward is a pure_callback to the C entry returning
+#   (jr, jz) AND the fused 2x5 Jacobian d(jr,jz)/d(R,vR,vT,z,vz) (assembled
+#   natively in C); the backward is a matvec of that Jacobian. Mirrors the
+#   Staeckel staeckel_c.actions_with_jac (#131 Adiabatic PR-2a). First-order.
+###############################################################################
+import numpy
+
+
+def actions_with_jac(host_jac, coords):
+    """Differentiable (jr, jz) with the native-C Jacobian as the vjp residual.
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (jr, jz, jac) with jr,jz (N,) and jac (N,2,5). coords : tuple of 5
+        traced jax (N,) arrays (R,vR,vT,z,vz).
+    """
+    import jax
+
+    shape, dtype = coords[0].shape, coords[0].dtype
+
+    def _host(*cs):
+        jr, jz, jac = host_jac(*(numpy.asarray(c, dtype=numpy.float64) for c in cs))
+        return (
+            numpy.asarray(jr, dtype=dtype),
+            numpy.asarray(jz, dtype=dtype),
+            numpy.asarray(jac, dtype=dtype),
+        )
+
+    def _call(cs):
+        cs = tuple(jax.lax.stop_gradient(c) for c in cs)
+        return jax.pure_callback(
+            _host,
+            (
+                jax.ShapeDtypeStruct(shape, dtype),
+                jax.ShapeDtypeStruct(shape, dtype),
+                jax.ShapeDtypeStruct(shape + (2, 5), dtype),
+            ),
+            *cs,
+            vmap_method="sequential",
+        )
+
+    @jax.custom_vjp
+    def _actions(cs):
+        jr, jz, _ = _call(cs)
+        return jr, jz
+
+    def _fwd(cs):
+        jr, jz, jac = _call(cs)
+        return (jr, jz), jac  # residual = the 2x5 Jacobian
+
+    def _bwd(jac, ct):
+        ct_jr, ct_jz = ct  # each (N,)
+        g = ct_jr[:, None] * jac[:, 0, :] + ct_jz[:, None] * jac[:, 1, :]  # (N,5)
+        return (tuple(g[:, k] for k in range(5)),)
+
+    _actions.defvjp(_fwd, _bwd)
+    return _actions(coords)

--- a/galpy/backend/_torch/adiabatic_c.py
+++ b/galpy/backend/_torch/adiabatic_c.py
@@ -1,0 +1,39 @@
+###############################################################################
+#   galpy.backend._torch.adiabatic_c
+#
+#   torch wrapper for the compiled Adiabatic C actions. actions_with_jac is a
+#   torch.autograd.Function whose forward runs the C entry returning (jr, jz)
+#   AND the fused 2x5 Jacobian d(jr,jz)/d(R,vR,vT,z,vz) (assembled natively in
+#   C), saving the Jacobian; backward is a matvec of that Jacobian. Mirrors the
+#   Staeckel staeckel_c.actions_with_jac (#131 Adiabatic PR-2a). First-order.
+###############################################################################
+import torch
+
+
+class _ActionsJacFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, host_jac, R, vR, vT, z, vz):
+        # The C entry is CPU/float64; move off-device + to numpy for the call.
+        cs = [t.detach().to("cpu", torch.float64).numpy() for t in (R, vR, vT, z, vz)]
+        jr, jz, jac = host_jac(*cs)
+        dev, dt = R.device, R.dtype
+        ctx.save_for_backward(torch.as_tensor(jac, dtype=dt, device=dev))  # (N,2,5)
+        return (
+            torch.as_tensor(jr, dtype=dt, device=dev),
+            torch.as_tensor(jz, dtype=dt, device=dev),
+        )
+
+    @staticmethod
+    def backward(ctx, g_jr, g_jz):
+        (jac,) = ctx.saved_tensors  # (N,2,5)
+        g = g_jr[:, None] * jac[:, 0, :] + g_jz[:, None] * jac[:, 1, :]  # (N,5)
+        return (None,) + tuple(g[:, k] for k in range(5))
+
+
+def actions_with_jac(host_jac, R, vR, vT, z, vz):
+    """Differentiable (jr, jz) with the native-C Jacobian as the backward matvec.
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (jr, jz, jac) with jr,jz (N,) and jac (N,2,5).
+    """
+    return _ActionsJacFunction.apply(host_jac, R, vR, vT, z, vz)

--- a/tests/test_backend_adiabatic_actions_grad.py
+++ b/tests/test_backend_adiabatic_actions_grad.py
@@ -1,0 +1,177 @@
+###############################################################################
+# test_backend_adiabatic_actions_grad.py: c=True C-native Adiabatic action
+# gradients (#131 PR-2a). For a jax/torch input, a c=True actionAngleAdiabatic
+# object returns differentiable (jr, jz) via the fused C-native (2,5) Jacobian
+# d(jr,jz)/d(R,vR,vT,z,vz): analytic Leibniz derivative integrals for
+# dJr/dE_radial, dJr/dLz, dJz/dEz, dJz/dR (theta-substituted GL), chained
+# through the elementary d(E_radial,Lz,Ez)/dcoord blocks -- with the vertical
+# action injected into the radial Lz (Lz -> |R vT| + gamma*Jz, gamma=1 default),
+# so jr's (z,vz) grads are nonzero. First-order only. numpy path byte-identical.
+# Mirrors test_backend_staeckel_grad.py. The grad-vs-FD floor is the order-10
+# value quadrature (value plain-GL vs derivative theta-sub); the C Jacobian
+# itself is accurate to ~2.5e-5 (verified vs high-order self-FD).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.actionAngle import actionAngleAdiabatic
+from galpy.potential import MiyamotoNagaiPotential
+
+_MP = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.1)
+_AA = actionAngleAdiabatic(pot=_MP, gamma=1.0, c=True)  # C-native path
+_AA0 = actionAngleAdiabatic(pot=_MP, gamma=0.0, c=True)  # decoupled (no gamma*Jz)
+
+# interior orbits for grad-vs-FD.
+_ORBITS = {
+    "generic": (1.0, 0.2, 1.1, 0.1, 0.15),
+    "eccentric": (1.2, 0.35, 0.85, 0.25, -0.2),
+    "generic2": (0.8, -0.1, 1.2, 0.05, 0.1),
+}
+# edge orbits: finiteness only (planar z=vz=0 -> Jz=0; radially circular vR=0).
+_EDGE_ORBITS = {
+    "planar": (1.0, 0.2, 1.1, 0.0, 0.0),
+    "edge_vR0": (1.0, 0.0, 1.1, 0.1, 0.15),
+    "edge_vz0": (1.0, 0.2, 1.1, 0.1, 0.0),
+}
+# unbound: turning-point solve fails (sentinel) -> C zeroes the Jacobian rows.
+_DEGEN_ORBIT = (1.0, 0.3, 1.1, 0.2, 1.8)
+
+
+def _np_actions(aA, orbit):
+    jr, lz, jz = aA(*[numpy.array([c]) for c in orbit])  # (Jr, Lz, Jz)
+    return float(jr[0]), float(jz[0])
+
+
+_FD_CACHE = {}
+
+
+def _fd_grad(aA, orbit, eps=1e-6):
+    key = (id(aA), orbit)
+    if key in _FD_CACHE:
+        return _FD_CACHE[key]
+    g = [[], []]
+    for i in range(5):
+        up, dn = list(orbit), list(orbit)
+        up[i] += eps
+        dn[i] -= eps
+        fu = _np_actions(aA, tuple(up))
+        fd = _np_actions(aA, tuple(dn))
+        for o in range(2):
+            g[o].append((fu[o] - fd[o]) / (2.0 * eps))
+    _FD_CACHE[key] = g
+    return g
+
+
+def _backend_grads(aA, backend, orbit):
+    # rows: [jr, jz] (outputs 0 and 2 of the (Jr,Lz,Jz) tuple)
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in orbit]
+        return [
+            [
+                float(g[0])
+                for g in jax.grad(
+                    lambda *a: jnp.sum(aA(*a)[o]), argnums=(0, 1, 2, 3, 4)
+                )(*args)
+            ]
+            for o in (0, 2)
+        ]
+    args = [torch.tensor([x], requires_grad=True) for x in orbit]
+    out = aA(*args)
+    return [
+        [
+            float(g[0])
+            for g in torch.autograd.grad(out[o].sum(), args, retain_graph=True)
+        ]
+        for o in (0, 2)
+    ]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_actions_value_parity(backend):
+    # c=True backend (jr,jz) VALUES equal numpy c=True (same C path).
+    arr = jnp.asarray if backend == "jax" else (lambda x: torch.tensor(x))
+    for orbit in list(_ORBITS.values()) + list(_EDGE_ORBITS.values()):
+        ref = _np_actions(_AA, orbit)
+        out = _AA(*[arr([x]) for x in orbit])
+        got = (float(numpy.asarray(out[0][0])), float(numpy.asarray(out[2][0])))
+        numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_adiabatic_actions_grad_vs_fd(backend, orbit):
+    # d(jr,jz)/d(R,vR,vT,z,vz) via c=True C-native backend AD vs numpy central FD.
+    # rtol 3e-3: the FD gold uses the order-10 value quadrature (plain-GL) while
+    # the analytic C Jacobian uses the theta-substituted derivative quadrature;
+    # they agree to the ~6e-4 order-10 truncation floor (the C Jacobian itself is
+    # ~2.5e-5-accurate vs a high-order reference).
+    coords = _ORBITS[orbit]
+    fd = _fd_grad(_AA, coords)
+    g = _backend_grads(_AA, backend, coords)
+    for o in range(2):
+        numpy.testing.assert_allclose(g[o], fd[o], rtol=3e-3, atol=2e-6)
+        assert numpy.all(numpy.isfinite(g[o]))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_actions_gamma0_decoupled(backend):
+    # gamma=0: the vertical action is NOT injected into Lz, so jr is independent
+    # of (z,vz) -> the jr-row z/vz columns are exactly 0, and the grad matches FD.
+    coords = _ORBITS["generic"]
+    fd = _fd_grad(_AA0, coords)
+    g = _backend_grads(_AA0, backend, coords)
+    assert g[0][3] == 0.0 and g[0][4] == 0.0  # djr/dz, djr/dvz == 0
+    for o in range(2):
+        numpy.testing.assert_allclose(g[o], fd[o], rtol=3e-3, atol=2e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_EDGE_ORBITS))
+def test_adiabatic_actions_grad_finite_edges(backend, orbit):
+    # planar / near-circular edge orbits: grad must be FINITE (guarded, not
+    # NaN/inf) -- the C zeros the degenerate rows (planar zmax~0 / circular).
+    g = _backend_grads(_AA, backend, _EDGE_ORBITS[orbit])
+    for o in range(2):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_actions_grad_degenerate(backend):
+    # unbound orbit -> turning-point solve fails -> C degenerate guard zeroes the
+    # Jacobian rows. The grad must be FINITE (not NaN/inf).
+    g = _backend_grads(_AA, backend, _DEGEN_ORBIT)
+    for o in range(2):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+def test_adiabatic_actions_grad_jit():
+    # jax jit survival of the C-native custom_vjp action gradient.
+    if "jax" not in BACKENDS:  # pragma: no cover
+        pytest.skip("jax not installed")
+    coords = _ORBITS["generic"]
+    f = jax.jit(lambda *a: jnp.sum(_AA(*a)[0]))
+    g = jax.jit(jax.grad(lambda *a: jnp.sum(_AA(*a)[0]), argnums=0))
+    args = [jnp.asarray([x]) for x in coords]
+    assert numpy.isfinite(float(f(*args)))
+    assert numpy.all(numpy.isfinite(numpy.asarray(g(*args))))

--- a/tests/test_backend_adiabatic_actions_grad.py
+++ b/tests/test_backend_adiabatic_actions_grad.py
@@ -53,6 +53,9 @@ _EDGE_ORBITS = {
     "planar": (1.0, 0.2, 1.1, 0.0, 0.0),
     "edge_vR0": (1.0, 0.0, 1.1, 0.1, 0.15),
     "edge_vz0": (1.0, 0.2, 1.1, 0.1, 0.0),
+    # radially circular (vR=0, vT=vc=1 for normalize=1, planar) -> rperi==rap and
+    # zmax==0, exercising the C circular (dJr row) + planar (dJz row) zero-guards.
+    "circular": (1.0, 0.0, 1.0, 0.0, 0.0),
 }
 # unbound: turning-point solve fails (sentinel) -> C zeroes the Jacobian rows.
 _DEGEN_ORBIT = (1.0, 0.3, 1.1, 0.2, 1.8)


### PR DESCRIPTION
## Adiabatic C-native differentiable actions — #131 PR-2a (Adiabatic arc, actions first)

First step of making `actionAngleAdiabatic` differentiable under jax/torch **using its C backend** (like the Staeckel arc), per the agreed sequence **actions → freqs/angles → EccZmax**. For a jax/torch input, a `c=True` object now returns differentiable `(jr, jz)` via a fused C-native **(2,5) Jacobian** `d(jr,jz)/d(R,vR,vT,z,vz)`, wrapped in `jax.custom_vjp` / `torch.autograd.Function` (forward = round-trip C value, backward = Jacobian matvec). **First-order only; numpy path byte-identical.**

### Key structure
Adiabatic actions are separable **except** the vertical action is injected into the radial `Lz` (`Lz → |R·vT| + γ·Jz`, **γ=1 by default**), so the vertical block (`Ez, zmax, Jz` + derivatives) is `Lz`-independent and computed first, then fed into the radial `Lz`/`E_radial`. Hence `jr`'s `(z,vz)` gradients are nonzero for γ≠0 (and exactly 0 for γ=0).

The `(2,5)` Jacobian is assembled analytically in C from:
- **New θ-substituted GL derivative integrals** (Leibniz; boundary terms vanish since `p=0` at the turning points): `dJr/dE_radial`, `dJr/dLz` (singular at both radial roots → `r = cc − rr·cos θ`, θ∈[0,π]); `dJz/dEz`, `dJz/dR|Ez` (singular only at `zmax` → `z = zmax·sin φ`, φ∈[0,π/2]);
- the elementary `d(Ez, Jz, Lz, E_radial)/d(coord)` chains, all from `evaluatePotentials`/`calcRforce`/`calczforce` (already in the file).

Degenerate guards mirror the value path: circular (`rap≈rperi`), planar (`zmax≈0`), unbound (`−9999.99` sentinel) → zero the affected rows.

### Pieces
`actionAngleAdiabatic_actionsJac` (C) + `calcdJRAdiabatic`/`calcdJzAdiabatic`; `actionAngleAdiabatic_actionsJac_c` (ctypes); `backend._{jax,torch}.adiabatic_c` (`actions_with_jac`); `_adiabatic_c_grad_actions` host bridge + `_evaluate` dispatch (`use_c and xp is not numpy`); `tests/test_backend_adiabatic_actions_grad.py`.

### Validation
- **Value parity exact** vs numpy `c=True`.
- **C Jacobian converges to the true analytic derivative**: ~2.5e-5 at order 10, 5e-8 at order 80 (vs a high-order self-FD reference). The grad-vs-FD floor (~6e-4) is purely the order-10 *value* quadrature (plain-GL) vs the θ-sub *derivative* quadrature — same value≠gradient story as Staeckel.
- γ=0 decouples `jr`'s `(z,vz)` grads to exactly 0; planar/circular/unbound grads finite; composite `MWPotential2014` + batches work; jax `jit`-safe.
- 26 numpy Adiabatic tests pass (no regression).

Follow-ups: **PR-2b** freqs/angles (reuse these derivative integrals = frequencies), then **PR-2c** EccZmax (implicit-diff, reuses this elementary block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm