### PR TITLE
actionAngleAdiabatic: c=True C-native EccZmaxRperiRap gradients — Orbit ecc/zmax/rperi/rap differentiable (#131, PR-2c Adiabatic)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabatic.py
+++ b/galpy/actionAngle/actionAngleAdiabatic.py
@@ -62,6 +62,39 @@ def _adiabatic_c_grad_actions(pot, gamma, R, vR, vT, z, vz, order=10):
     )
 
 
+def _adiabatic_c_grad_ecczmax(pot, gamma, R, vR, vT, z, vz, order=10):
+    """Differentiable (ecc, zmax, rperi, rap) via the C-native Adiabatic EccZmax
+    Jacobian. For jax/torch inputs, wraps the compiled (4,5)
+    d(ecc,zmax,rperi,rap)/d(R,vR,vT,z,vz) C entry
+    (actionAngleEccZmaxRperiRapAdiabaticJac_c) in the backend custom_vjp /
+    autograd.Function: forward = the round-trip turning-point values; backward =
+    a matvec of the C Jacobian. numpy inputs never reach here. gamma is a fixed
+    scalar (no gradient); the gamma*Jz coupling into the radial Lz is handled
+    internally in C. First-order only. Mirrors _adiabatic_c_grad_actions.
+    """
+
+    def host_jac(Rn, vRn, vTn, zn, vzn):
+        ecc, zmax, rperi, rap, jac, err = (
+            actionAngleAdiabatic_c.actionAngleEccZmaxRperiRapAdiabaticJac_c(
+                pot, gamma, Rn, vRn, vTn, zn, vzn, order=order
+            )
+        )
+        return ecc, zmax, rperi, rap, jac
+
+    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
+    if "jax" in name:
+        from ..backend._jax.adiabatic_c import ecczmax_with_jac
+
+        return ecczmax_with_jac(host_jac, (R, vR, vT, z, vz))
+    if "torch" in name:
+        from ..backend._torch.adiabatic_c import ecczmax_with_jac
+
+        return ecczmax_with_jac(host_jac, R, vR, vT, z, vz)
+    raise NotImplementedError(  # pragma: no cover
+        "C-native Adiabatic EccZmax gradients require a jax or torch input array."
+    )
+
+
 class actionAngleAdiabatic(actionAngle):
     """Action-angle formalism for axisymmetric potentials using the adiabatic approximation"""
 
@@ -474,6 +507,14 @@ class actionAngleAdiabatic(actionAngle):
             (self._c and not ("c" in kwargs and not kwargs["c"]))
             or (ext_loaded and ("c" in kwargs and kwargs["c"]))
         ) and _check_c(self._pot)
+        if use_c and xp is not numpy:
+            # C-native differentiable (ecc,zmax,rperi,rap) via the fused (4,5) C
+            # Jacobian; numpy path below is byte-identical (#131 Adiabatic PR-2c).
+            R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
+            ecc, zmax, rperi, rap = _adiabatic_c_grad_ecczmax(
+                self._pot, self._gamma, R, vR, vT, z, vz
+            )
+            return (ecc, zmax, rperi, rap)
         if not use_c and xp is not numpy:
             R, vR, vT, z, vz = promote_scalars(xp, R, vR, vT, z, vz)
             return self._EccZmaxRperiRap_backend(R, vR, vT, z, vz)

--- a/galpy/actionAngle/actionAngleAdiabatic_c.py
+++ b/galpy/actionAngle/actionAngleAdiabatic_c.py
@@ -220,6 +220,113 @@ def actionAngleAdiabatic_actionsJac_c(pot, gamma, R, vR, vT, z, vz, order=10):
     return (jr, jz, jac.reshape((len(R), 2, 5)), err.value)
 
 
+def actionAngleEccZmaxRperiRapAdiabaticJac_c(pot, gamma, R, vR, vT, z, vz, order=10):
+    """
+    Use C to compute adiabatic (ecc,zmax,rperi,rap) AND the fused (N,4,5) Jacobian
+    d(ecc,zmax,rperi,rap)/d(R,vR,vT,z,vz), assembled analytically in C
+    (#131 Adiabatic PR-2c). rap here is the spherical apocenter sqrt(Rap^2+zmax^2).
+
+    Parameters
+    ----------
+    pot : Potential or a combined potential formed using addition (pot1+pot2+…)
+        Gravitational potential to compute the orbit boundaries in.
+    gamma : float
+        as in Lz -> Lz+gamma * J_z.
+    R, vR, vT, z, vz : numpy.ndarray
+        Phase-space coordinates.
+    order : int, optional
+        Gauss-Legendre order for the dJz derivative integrals (gamma coupling).
+
+    Returns
+    -------
+    tuple
+        (ecc, zmax, rperi, rap, jac, err) with the 4 values (N,), jac (N,4,5),
+        and error code.
+    """
+    from ..orbit.integrateFullOrbit import _parse_pot
+    from ..orbit.integratePlanarOrbit import _prep_tfuncs
+
+    npot, pot_type, pot_args, pot_tfuncs = _parse_pot(pot, potforactions=True)
+    pot_tfuncs = _prep_tfuncs(pot_tfuncs)
+
+    ecc = numpy.empty(len(R))
+    zmax = numpy.empty(len(R))
+    rperi = numpy.empty(len(R))
+    rap = numpy.empty(len(R))
+    jac = numpy.empty(len(R) * 4 * 5)
+    err = ctypes.c_int(0)
+
+    ndarrayFlags = ("C_CONTIGUOUS", "WRITEABLE")
+    func = _lib.actionAngleAdiabatic_EccZmaxRperiRapJac
+    func.argtypes = [
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ndpointer(dtype=numpy.int32, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_void_p,
+        ctypes.c_double,
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.POINTER(ctypes.c_int),
+    ]
+
+    f_cont = [
+        R.flags["F_CONTIGUOUS"],
+        vR.flags["F_CONTIGUOUS"],
+        vT.flags["F_CONTIGUOUS"],
+        z.flags["F_CONTIGUOUS"],
+        vz.flags["F_CONTIGUOUS"],
+    ]
+    R = numpy.require(R, dtype=numpy.float64, requirements=["C", "W"])
+    vR = numpy.require(vR, dtype=numpy.float64, requirements=["C", "W"])
+    vT = numpy.require(vT, dtype=numpy.float64, requirements=["C", "W"])
+    z = numpy.require(z, dtype=numpy.float64, requirements=["C", "W"])
+    vz = numpy.require(vz, dtype=numpy.float64, requirements=["C", "W"])
+
+    func(
+        len(R),
+        R,
+        vR,
+        vT,
+        z,
+        vz,
+        ctypes.c_int(npot),
+        pot_type,
+        pot_args,
+        pot_tfuncs,
+        ctypes.c_double(gamma),
+        ctypes.c_int(order),
+        ecc,
+        zmax,
+        rperi,
+        rap,
+        jac,
+        ctypes.byref(err),
+    )
+
+    if f_cont[0]:
+        R = numpy.asfortranarray(R)
+    if f_cont[1]:
+        vR = numpy.asfortranarray(vR)
+    if f_cont[2]:
+        vT = numpy.asfortranarray(vT)
+    if f_cont[3]:
+        z = numpy.asfortranarray(z)
+    if f_cont[4]:
+        vz = numpy.asfortranarray(vz)
+
+    return (ecc, zmax, rperi, rap, jac.reshape((len(R), 4, 5)), err.value)
+
+
 def actionAngleRperiRapZmaxAdiabatic_c(pot, gamma, R, vR, vT, z, vz):
     """
     Calculate planar (Rperi,Rap) and the maximum height Zmax using the adiabatic approximation (rap = sqrt(Rap^2+Zmax^2))

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
@@ -59,6 +59,11 @@ EXPORT void actionAngleAdiabatic_actions(int,double *,double *,double *,double *
 EXPORT void actionAngleAdiabatic_actionsJac(int,double *,double *,double *,double *,
 				 double *,int,int *,double *,tfuncs_type_arr,double,int,
 				 double *,double *,double *,int *);
+// C-native differentiable EccZmax/Rperi/Rap: (ecc,zmax,rperi,rap) + the fused
+// (ndata,4,5) Jacobian d(ecc,zmax,rperi,rap)/d(R,vR,vT,z,vz) (#131 Adiabatic PR-2c).
+EXPORT void actionAngleAdiabatic_EccZmaxRperiRapJac(int,double *,double *,double *,
+				 double *,double *,int,int *,double *,tfuncs_type_arr,double,int,
+				 double *,double *,double *,double *,double *,int *);
 void calcdJRAdiabatic(int,double *,double *,double *,double *,double *,double *,
 		      int,struct potentialArg *,int);
 void calcdJzAdiabatic(int,double *,double *,double *,double *,double *,
@@ -297,6 +302,144 @@ void actionAngleAdiabatic_actionsJac(int ndata,
   free(ER); free(Ez); free(Lz);
   free(rperi); free(rap); free(zmax);
   free(djzdEz); free(djzdR); free(djrdER); free(djrdLz);
+}
+// C-native differentiable EccZmax/Rperi/Rap: forward (ecc,zmax,rperi,rap) via the
+// existing turning-point solves, plus the fused (ndata,4,5) Jacobian
+// d(ecc,zmax,rperi,rap)/d(R,vR,vT,z,vz). rperi/Rap (planar apo) and zmax are 1D
+// turning-point roots, so their coord-sensitivities follow from the implicit
+// function theorem d(tp)/dcoord= -F_coord/F_r|tp -- NO action integrals. The
+// gamma*Jz coupling into the radial Lz reuses calcdJzAdiabatic (only bites when
+// gamma!=0). rap=sqrt(Rap^2+zmax^2), ecc=(rap-rperi)/(rap+rperi) chain both blocks.
+// First-order only. Degenerate rows (unbound sentinel / circular radial /
+// planar vertical) are zeroed. Mirrors actionAngleStaeckel_EccZmaxRperiRapJac.
+void actionAngleAdiabatic_EccZmaxRperiRapJac(int ndata,
+					     double *R,
+					     double *vR,
+					     double *vT,
+					     double *z,
+					     double *vz,
+					     int npot,
+					     int * pot_type,
+					     double * pot_args,
+					     tfuncs_type_arr pot_tfuncs,
+					     double gamma,
+					     int order,
+					     double *ecc,
+					     double *zmaxout,
+					     double *rperiout,
+					     double *rapout,
+					     double *jac,
+					     int * err){
+  int ii;
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
+  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  double *ER= (double *) malloc ( ndata * sizeof(double) );
+  double *Ez= (double *) malloc ( ndata * sizeof(double) );
+  double *Lz= (double *) malloc ( ndata * sizeof(double) );
+  double *rperi= (double *) malloc ( ndata * sizeof(double) );
+  double *Rap= (double *) malloc ( ndata * sizeof(double) );
+  double *zmax= (double *) malloc ( ndata * sizeof(double) );
+  double *jz= (double *) malloc ( ndata * sizeof(double) );
+  // vertical block first (Lz-independent)
+  calcEREzL(ndata,R,vR,vT,z,vz,ER,Ez,Lz,npot,actionAngleArgs);
+  calcZmax(ndata,zmax,z,R,Ez,npot,actionAngleArgs);
+  calcJzAdiabatic(ndata,jz,zmax,R,Ez,npot,actionAngleArgs,order);
+  double *djzdEz= (double *) malloc ( ndata * sizeof(double) );
+  double *djzdR=  (double *) malloc ( ndata * sizeof(double) );
+  calcdJzAdiabatic(ndata,djzdEz,djzdR,zmax,R,Ez,npot,actionAngleArgs,order);
+  // gamma injection: Lz = |R vT| + gamma*Jz, then radial effective energy
+  UNUSED int chunk= CHUNKSIZE;
+#pragma omp parallel for schedule(static,chunk) private(ii)
+  for (ii=0; ii < ndata; ii++){
+    *(Lz+ii)= fabs( *(Lz+ii) ) + gamma * *(jz+ii);
+    *(ER+ii)+= 0.5 * *(Lz+ii) * *(Lz+ii) / *(R+ii) / *(R+ii)
+      - 0.5 * *(vT+ii) * *(vT+ii);
+  }
+  // radial block (uses the gamma-adjusted ER,Lz); Rap is the PLANAR apocenter
+  calcRapRperi(ndata,rperi,Rap,R,ER,Lz,npot,actionAngleArgs);
+  // assemble the (4,5) Jacobian per orbit
+#pragma omp parallel for schedule(static,chunk) private(ii)
+  for (ii=0; ii < ndata; ii++){
+    int kk;
+    double tR= *(R+ii), tvR= *(vR+ii), tvT= *(vT+ii), tz= *(z+ii), tvz= *(vz+ii);
+    double trperi= *(rperi+ii), tRap= *(Rap+ii), tzmax= *(zmax+ii);
+    // forward values computed uniformly (rap=sqrt(Rap^2+zmax^2), ecc from the raw
+    // rperi/Rap/zmax) so they byte-match the numpy c=True path -- INCLUDING the
+    // unbound -9999.99 sentinels (rap->14142, ecc->5.83), whose Jacobian rows the
+    // guard below zeroes.
+    double trap= sqrt(tRap*tRap + tzmax*tzmax);
+    *(ecc+ii)= (trap-trperi)/(trap+trperi);
+    *(zmaxout+ii)= tzmax; *(rperiout+ii)= trperi; *(rapout+ii)= trap;
+    if ( trperi == -9999.99 || tRap == -9999.99 || tzmax == -9999.99 ){
+      for (kk=0;kk<20;kk++) *(jac+ii*20+kk)= 0.;  // unbound -> zeroed Jacobian
+      continue;
+    }
+    double tLz= *(Lz+ii);
+    int circular= ( ( tRap - trperi ) / tRap < 0.000001 );  // radial turning pts merged
+    int planar=   ( tzmax < 0.000001 );                     // z=vz=0 -> zforce(R,0)=0
+    double s= ( tR * tvT >= 0. ) ? 1. : -1.;  // sign(R vT); Lz used fabs(R vT)
+    // forces at the INITIAL z for the elementary Ez/Lz/ER chains (reused from actionsJac)
+    double FR_R0= calcRforce(tR,0.,0.,0.,npot,actionAngleArgs);
+    double FR_Rz= calcRforce(tR,tz,0.,0.,npot,actionAngleArgs);
+    double Fz_Rz= calczforce(tR,tz,0.,0.,npot,actionAngleArgs);
+    double dEz[5]= { FR_R0 - FR_Rz, 0., 0., -Fz_Rz, tvz };
+    double bE= *(djzdEz+ii), bR= *(djzdR+ii);
+    double dJz[5];
+    for (kk=0;kk<5;kk++) dJz[kk]= bE*dEz[kk];
+    dJz[0]+= bR;
+    double dLz[5]= { s*tvT + gamma*dJz[0], 0., s*tR, gamma*dJz[3], gamma*dJz[4] };
+    double LzR2= tLz/(tR*tR);
+    double dER[5];
+    dER[0]= -FR_R0 - tLz*tLz/(tR*tR*tR) + LzR2*dLz[0];
+    dER[1]= tvR;
+    dER[2]= LzR2*dLz[2];
+    dER[3]= LzR2*dLz[3];
+    dER[4]= LzR2*dLz[4];
+    // radial turning-point sensitivities: F_R(r)= E_R - Phi(r,0) - Lz^2/(2r^2);
+    // dF_R/dr= Rforce(r,0)+Lz^2/r^3; dF_R/dcoord|_r= dER - (Lz/r^2) dLz;
+    // d(tp)/dcoord= -dF_R/dcoord / dF_R/dr. Circular (rperi==Rap) -> dF_R/dr->0: zero.
+    double drperi[5]= {0.,0.,0.,0.,0.}, dRapc[5]= {0.,0.,0.,0.,0.};
+    if ( !circular ){
+      // plunging (Lz->0 radial): rperi->0 EXACTLY (calcRapRperi assigns 0, not the
+      // -9999.99 sentinel) -> the drperi implicit-diff is 0/0; zero that row (Rap
+      // stays regular). Threshold matches calcRapRperi's own 1e-9 zero-assign.
+      int plunging= ( trperi < 1e-9 );
+      double dFRdr_ra= calcRforce(tRap,0.,0.,0.,npot,actionAngleArgs)
+	+ tLz*tLz/(tRap*tRap*tRap);
+      double dFRdr_rp= plunging ? 1. : ( calcRforce(trperi,0.,0.,0.,npot,actionAngleArgs)
+	+ tLz*tLz/(trperi*trperi*trperi) );
+      for (kk=0;kk<5;kk++){
+	dRapc[kk]= -( dER[kk] - tLz/(tRap*tRap)*dLz[kk] ) / dFRdr_ra;
+	if ( !plunging )
+	  drperi[kk]= -( dER[kk] - tLz/(trperi*trperi)*dLz[kk] ) / dFRdr_rp;
+      }
+    }
+    // vertical turning-point sensitivity: F_z(z')= Phi(R,z)-Phi(R,z')+vz^2/2;
+    // dF_z/dz'= zforce(R,zmax); dF_z/dcoord= {Rforce(R,zmax)-Rforce(R,z),0,0,-zforce(R,z),vz}.
+    // Planar (zmax->0) -> zforce(R,0)=0: zero.
+    double dzmaxc[5]= {0.,0.,0.,0.,0.};
+    if ( !planar ){
+      double dFzdz= calczforce(tR,tzmax,0.,0.,npot,actionAngleArgs);
+      double dFz[5]= { calcRforce(tR,tzmax,0.,0.,npot,actionAngleArgs) - FR_Rz,
+		       0., 0., -Fz_Rz, tvz };
+      for (kk=0;kk<5;kk++) dzmaxc[kk]= -dFz[kk]/dFzdz;
+    }
+    // geometry: rap=sqrt(Rap^2+zmax^2), ecc=(rap-rperi)/(rap+rperi)
+    double rr= (trap+trperi)*(trap+trperi);
+    double de_drperi= -2.*trap/rr, de_drap= 2.*trperi/rr;
+    for (kk=0;kk<5;kk++){
+      double drapk= ( tRap*dRapc[kk] + tzmax*dzmaxc[kk] ) / trap;
+      *(jac+ii*20+ 0*5+kk)= de_drperi*drperi[kk] + de_drap*drapk;  // ecc
+      *(jac+ii*20+ 1*5+kk)= dzmaxc[kk];                            // zmax
+      *(jac+ii*20+ 2*5+kk)= drperi[kk];                            // rperi
+      *(jac+ii*20+ 3*5+kk)= drapk;                                 // rap
+    }
+  }
+  free_potentialArgs(npot,actionAngleArgs);
+  free(actionAngleArgs);
+  free(ER); free(Ez); free(Lz);
+  free(rperi); free(Rap); free(zmax); free(jz);
+  free(djzdEz); free(djzdR);
 }
 // dJr/dE_radial = (1/(sqrt2 pi)) int_rperi^Rap dr/sqrt(F_R),
 // dJr/dLz       = -(Lz/(sqrt2 pi)) int_rperi^Rap dr/(r^2 sqrt(F_R)),

--- a/galpy/backend/_jax/adiabatic_c.py
+++ b/galpy/backend/_jax/adiabatic_c.py
@@ -58,3 +58,45 @@ def actions_with_jac(host_jac, coords):
 
     _actions.defvjp(_fwd, _bwd)
     return _actions(coords)
+
+
+def ecczmax_with_jac(host_jac, coords):
+    """Differentiable (ecc, zmax, rperi, rap) with the native-C (N,4,5) Jacobian
+    as the vjp residual. Mirrors actions_with_jac (#131 Adiabatic PR-2c).
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (ecc, zmax, rperi, rap, jac) with the 4 values (N,) and jac (N,4,5).
+    coords : tuple of 5 traced jax (N,) arrays (R,vR,vT,z,vz).
+    """
+    import jax
+
+    shape, dtype = coords[0].shape, coords[0].dtype
+
+    def _host(*cs):
+        out = host_jac(*(numpy.asarray(c, dtype=numpy.float64) for c in cs))
+        return tuple(numpy.asarray(o, dtype=dtype) for o in out)
+
+    def _call(cs):
+        cs = tuple(jax.lax.stop_gradient(c) for c in cs)
+        return jax.pure_callback(
+            _host,
+            tuple(jax.ShapeDtypeStruct(shape, dtype) for _ in range(4))
+            + (jax.ShapeDtypeStruct(shape + (4, 5), dtype),),
+            *cs,
+            vmap_method="sequential",
+        )
+
+    @jax.custom_vjp
+    def _ez(cs):
+        return _call(cs)[:4]
+
+    def _fwd(cs):
+        out = _call(cs)
+        return out[:4], out[4]  # residual = the (N,4,5) Jacobian
+
+    def _bwd(jac, ct):
+        g = sum(ct[o][:, None] * jac[:, o, :] for o in range(4))  # (N,5)
+        return (tuple(g[:, k] for k in range(5)),)
+
+    _ez.defvjp(_fwd, _bwd)
+    return _ez(coords)

--- a/galpy/backend/_torch/adiabatic_c.py
+++ b/galpy/backend/_torch/adiabatic_c.py
@@ -37,3 +37,32 @@ def actions_with_jac(host_jac, R, vR, vT, z, vz):
         (jr, jz, jac) with jr,jz (N,) and jac (N,2,5).
     """
     return _ActionsJacFunction.apply(host_jac, R, vR, vT, z, vz)
+
+
+class _EccZmaxJacFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, host_jac, R, vR, vT, z, vz):
+        cs = [t.detach().to("cpu", torch.float64).numpy() for t in (R, vR, vT, z, vz)]
+        ecc, zmax, rperi, rap, jac = host_jac(*cs)
+        dev, dt = R.device, R.dtype
+        ctx.save_for_backward(torch.as_tensor(jac, dtype=dt, device=dev))  # (N,4,5)
+        return tuple(
+            torch.as_tensor(x, dtype=dt, device=dev) for x in (ecc, zmax, rperi, rap)
+        )
+
+    @staticmethod
+    def backward(ctx, g_ecc, g_zmax, g_rperi, g_rap):
+        (jac,) = ctx.saved_tensors  # (N,4,5)
+        gs = (g_ecc, g_zmax, g_rperi, g_rap)
+        g = sum(gs[o][:, None] * jac[:, o, :] for o in range(4))  # (N,5)
+        return (None,) + tuple(g[:, k] for k in range(5))
+
+
+def ecczmax_with_jac(host_jac, R, vR, vT, z, vz):
+    """Differentiable (ecc, zmax, rperi, rap) with the native-C (N,4,5) Jacobian
+    as the backward matvec. Mirrors actions_with_jac (#131 Adiabatic PR-2c).
+
+    host_jac : callable taking 5 numpy (N,) coord arrays, returning
+        (ecc, zmax, rperi, rap, jac) with the 4 values (N,) and jac (N,4,5).
+    """
+    return _EccZmaxJacFunction.apply(host_jac, R, vR, vT, z, vz)

--- a/tests/test_backend_adiabatic_ecczmax_grad.py
+++ b/tests/test_backend_adiabatic_ecczmax_grad.py
@@ -1,0 +1,224 @@
+###############################################################################
+# test_backend_adiabatic_ecczmax_grad.py: c=True C-native Adiabatic
+# EccZmaxRperiRap gradients (#131 PR-2c). For a jax/torch input, a c=True
+# actionAngleAdiabatic object returns differentiable (e,zmax,rperi,rap) via the
+# fused C-native (4,5) Jacobian d(e,zmax,rperi,rap)/d(R,vR,vT,z,vz): implicit
+# differentiation of the 1D radial (rperi,Rap) and vertical (zmax) turning-point
+# roots (d(tp)/dcoord = -F_coord/F_r), chained through rap=sqrt(Rap^2+zmax^2) and
+# ecc=(rap-rperi)/(rap+rperi). The gamma*Jz coupling into the radial Lz reuses the
+# vertical action derivative (Lz = |R vT| + gamma*Jz, gamma=1 default), so the
+# radial outputs' (z,vz) grads are nonzero for gamma!=0. First-order only. numpy
+# path byte-identical. Mirrors test_backend_staeckel_ecczmax_grad.py.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.actionAngle import actionAngleAdiabatic
+from galpy.potential import MiyamotoNagaiPotential
+
+_MP = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.1)
+_AA = actionAngleAdiabatic(pot=_MP, gamma=1.0, c=True)  # C-native path
+_AA0 = actionAngleAdiabatic(pot=_MP, gamma=0.0, c=True)  # decoupled (no gamma*Jz)
+
+# interior orbits for grad-vs-FD (retrograde vT<0 exercises the s=-1 sign of the
+# Lz=|R vT|+gamma*Jz derivative).
+_ORBITS = {
+    "generic": (1.0, 0.2, 1.1, 0.1, 0.15),
+    "eccentric": (1.2, 0.35, 0.85, 0.25, -0.2),
+    "generic2": (0.8, -0.1, 1.2, 0.05, 0.1),
+    "retrograde": (1.1, 0.2, -1.0, 0.1, 0.15),
+}
+# edge orbits: finiteness only (planar z=vz=0 -> zmax=0 vertical guard;
+# radially circular vR=0,vT=vc -> rperi==Rap radial guard).
+_EDGE_ORBITS = {
+    "edge_vR0": (1.0, 0.0, 1.1, 0.1, 0.15),
+    "edge_vz0": (1.0, 0.2, 1.1, 0.1, 0.0),
+    "edge_z0": (1.0, 0.2, 1.1, 0.0, 0.15),  # z=0 but vz!=0 -> zmax>0
+}
+# unbound: turning-point solve fails (sentinel) -> C zeroes the Jacobian rows.
+_DEGEN_ORBIT = (1.0, 3.0, 0.05, 0.0, 3.0)
+
+
+def _np_ecczmax(aA, orbit):
+    out = aA.EccZmaxRperiRap(*[numpy.array([c]) for c in orbit])
+    return [float(numpy.asarray(out[o][0])) for o in range(4)]
+
+
+_FD_CACHE = {}
+
+
+def _fd_grad(aA, orbit, eps=1e-6):
+    # central FD of the c=True numpy (e,zmax,rperi,rap) over the 5 coords.
+    key = (id(aA), orbit)
+    if key in _FD_CACHE:
+        return _FD_CACHE[key]
+    g = [[], [], [], []]
+    for i in range(5):
+        up, dn = list(orbit), list(orbit)
+        up[i] += eps
+        dn[i] -= eps
+        fu = _np_ecczmax(aA, tuple(up))
+        fd = _np_ecczmax(aA, tuple(dn))
+        for o in range(4):
+            g[o].append((fu[o] - fd[o]) / (2.0 * eps))
+    _FD_CACHE[key] = g
+    return g
+
+
+def _backend_grads(aA, backend, orbit):
+    if backend == "jax":
+        args = [jnp.asarray([x]) for x in orbit]
+        return [
+            [
+                float(g[0])
+                for g in jax.grad(
+                    lambda *a: jnp.sum(aA.EccZmaxRperiRap(*a)[o]),
+                    argnums=(0, 1, 2, 3, 4),
+                )(*args)
+            ]
+            for o in range(4)
+        ]
+    args = [torch.tensor([x], requires_grad=True) for x in orbit]
+    out = aA.EccZmaxRperiRap(*args)
+    return [
+        [
+            float(g[0])
+            for g in torch.autograd.grad(out[o].sum(), args, retain_graph=True)
+        ]
+        for o in range(4)
+    ]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_value_parity(backend):
+    # c=True backend (e,zmax,rperi,rap) VALUES equal numpy c=True (same C path).
+    arr = jnp.asarray if backend == "jax" else (lambda x: torch.tensor(x))
+    for orbit in list(_ORBITS.values()) + list(_EDGE_ORBITS.values()):
+        ref = _np_ecczmax(_AA, orbit)
+        out = _AA.EccZmaxRperiRap(*[arr([x]) for x in orbit])
+        got = [float(numpy.asarray(out[o][0])) for o in range(4)]
+        numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_ORBITS))
+def test_adiabatic_ecczmax_grad_vs_fd(backend, orbit):
+    # d(e,zmax,rperi,rap)/d(R,vR,vT,z,vz) via c=True C-native backend AD vs numpy
+    # central FD, on interior orbits. rtol 3e-3: the (R,vR,vT) columns and the
+    # whole zmax row are exact implicit-diff, but the (z,vz) columns of the radial
+    # outputs flow through the gamma*Jz coupling, whose dJz/dcoord is the order-10
+    # calcdJzAdiabatic derivative integral -- it agrees with the order-10 forward
+    # Jz used by the FD gold only to that quadrature-truncation floor (~1e-4). The
+    # gamma=0 decoupled test below (no dJz) holds at 1e-4. (Same floor as the
+    # sibling action gradients; see test_backend_adiabatic_actions_grad.py.)
+    coords = _ORBITS[orbit]
+    fd = _fd_grad(_AA, coords)
+    g = _backend_grads(_AA, backend, coords)
+    for o in range(4):
+        numpy.testing.assert_allclose(g[o], fd[o], rtol=3e-3, atol=2e-6)
+        assert numpy.all(numpy.isfinite(g[o]))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_gamma0_decoupled(backend):
+    # gamma=0: the vertical action is NOT injected into Lz, so the radial rperi
+    # (index 2) is independent of (z,vz) -> its z/vz columns are exactly 0, and
+    # all four grads still match FD.
+    coords = _ORBITS["generic"]
+    fd = _fd_grad(_AA0, coords)
+    g = _backend_grads(_AA0, backend, coords)
+    assert g[2][3] == 0.0 and g[2][4] == 0.0  # drperi/dz, drperi/dvz == 0
+    for o in range(4):
+        numpy.testing.assert_allclose(g[o], fd[o], rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("orbit", list(_EDGE_ORBITS))
+def test_adiabatic_ecczmax_grad_finite_edges(backend, orbit):
+    # planar / near-turning-point edge orbits: the grad must be FINITE (guarded,
+    # not NaN/inf) -- the C zeros the degenerate radial/vertical rows.
+    g = _backend_grads(_AA, backend, _EDGE_ORBITS[orbit])
+    for o in range(4):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_grad_degenerate(backend):
+    # unbound orbit -> turning-point solve fails (-9999.99 sentinel) -> C zeroes
+    # the Jacobian rows (grads EXACTLY 0), AND the forward VALUES still byte-match
+    # the numpy c=True path (computed from the raw sentinels: rap->14142, ecc->5.83).
+    arr = jnp.asarray if backend == "jax" else (lambda x: torch.tensor(x))
+    ref = _np_ecczmax(_AA, _DEGEN_ORBIT)
+    out = _AA.EccZmaxRperiRap(*[arr([x]) for x in _DEGEN_ORBIT])
+    got = [float(numpy.asarray(out[o][0])) for o in range(4)]
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-12)  # value parity
+    g = _backend_grads(_AA, backend, _DEGEN_ORBIT)
+    for o in range(4):
+        numpy.testing.assert_array_equal(g[o], [0.0] * 5)  # sentinel -> zeroed rows
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_radial_grad_finite(backend):
+    # a radially plunging orbit (vT=0 -> Lz=0 -> rperi==0 EXACTLY, a bound orbit,
+    # NOT the -9999.99 sentinel) exercises the C plunging guard: the drperi
+    # implicit-diff would be 0/0 without it. Grad must be FINITE (not NaN).
+    radial = (1.0, 0.3, 0.0, 0.0, 0.0)
+    g = _backend_grads(_AA, backend, radial)
+    for o in range(4):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_planar_grad_finite(backend):
+    # a truly planar orbit (z=vz=0 -> zmax=0) exercises the C Jacobian's planar
+    # guard (dzmax row zeroed, zforce(R,0)=0); grad must stay finite.
+    planar = (1.0, 0.2, 1.1, 0.0, 0.0)
+    g = _backend_grads(_AA, backend, planar)
+    for o in range(4):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabatic_ecczmax_circular_grad_finite(backend):
+    # a radially circular orbit (vR=0, vT=vc -> rperi==Rap) exercises the C
+    # Jacobian's circular guard (drperi/dRap rows zeroed); grad must stay finite.
+    from galpy.potential import vcirc
+
+    vc = float(vcirc(_MP, 1.0, use_physical=False))
+    circular = (1.0, 0.0, vc, 0.0, 0.0)
+    g = _backend_grads(_AA, backend, circular)
+    for o in range(4):
+        assert numpy.all(numpy.isfinite(g[o])), f"non-finite grad row {o}"
+
+
+def test_adiabatic_ecczmax_grad_jit():
+    # jax jit survival of the C-native custom_vjp EccZmax gradient.
+    if "jax" not in BACKENDS:  # pragma: no cover
+        pytest.skip("jax not installed")
+    coords = _ORBITS["generic"]
+    f = jax.jit(lambda *a: jnp.sum(_AA.EccZmaxRperiRap(*a)[0]))
+    g = jax.jit(jax.grad(lambda *a: jnp.sum(_AA.EccZmaxRperiRap(*a)[0]), argnums=0))
+    args = [jnp.asarray([x]) for x in coords]
+    assert numpy.isfinite(float(f(*args)))
+    assert numpy.all(numpy.isfinite(numpy.asarray(g(*args))))


### PR DESCRIPTION
Completes the Adiabatic C-native differentiable arc: **PR-2a actions** landed in #1070; freqs/angles are skipped (not in the Adiabatic C — they already differentiate via the Python Spherical+Vertical path); this **PR-2c** adds EccZmax/Rperi/Rap. For a jax/torch input, a `c=True` `actionAngleAdiabatic` now returns differentiable `(ecc, zmax, rperi, rap)` via a fused C-native `(N,4,5)` Jacobian `d(ecc,zmax,rperi,rap)/d(R,vR,vT,z,vz)`.

### Math
`rperi`/`Rap` (planar) and `zmax` are 1D turning-point **roots**, so their coordinate sensitivities are closed-form implicit differentiation `d(tp)/dcoord = -F_coord/F_r` — **no action integrals**:
- radial `F_R = E_R - Φ(r,0) - Lz²/(2r²)`, `dF_R/dr = Rforce(r,0)+Lz²/r³`;
- vertical `F_z = Φ(R,z)-Φ(R,z') + vz²/2`, `dF_z/dz' = zforce(R,zmax)`.

The elementary `dEz/dJz/dLz/dER` blocks are reused verbatim from `actionsJac` (#1070); the `γ·Jz` coupling into the radial `Lz` reuses `calcdJzAdiabatic` (only bites `γ≠0`). Geometry `rap=√(Rap²+zmax²)`, `ecc=(rap-rperi)/(rap+rperi)` chains both blocks. First-order.

Degenerate rows are zeroed: unbound sentinel, circular (`rperi==Rap`), planar (`zmax→0`), and **radially plunging** (`Lz→0 ⇒ rperi==0` exactly — a bound orbit, not the sentinel; caught by adversarial review).

### Files
- **C**: `actionAngleAdiabatic_EccZmaxRperiRapJac` in `actionAngleAdiabatic.c`.
- **ctypes**: `actionAngleEccZmaxRperiRapAdiabaticJac_c` → `(N,4,5)` jac.
- **backends**: `ecczmax_with_jac` in `_jax`/`_torch/adiabatic_c.py` (`custom_vjp` / `autograd.Function`).
- **dispatch**: `_adiabatic_c_grad_ecczmax` + a `use_c and xp is not numpy` branch in `_EccZmaxRperiRap`.
- **tests**: `test_backend_adiabatic_ecczmax_grad.py` — value parity (incl. unbound sentinel), grad-vs-FD (incl. retrograde), γ=0 decoupled (tight), edge/planar/circular/radial-plunge/unbound finiteness, jax jit.

### Notes
- **numpy path byte-identical** (the new branch is guarded `use_c and xp is not numpy`; the forward C `RperiRapZmax` routine is untouched).
- grad-vs-FD `rtol 3e-3`: the `(z,vz)` radial columns inherit the order-10 `calcdJzAdiabatic` coupling quadrature floor (~1e-4), same as the sibling action gradients; the γ=0 path (no `dJz`) holds at 1e-4.
- Hardened per an adversarial review pass: fixed a `rperi==0` (radial) `0/0` NaN, made unbound forward values byte-match numpy, and added retrograde + radial-plunge + degenerate-value coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm