### PR TITLE
inbackend ODE: support native-planar & composite potentials (jax/torch)

### DIFF
--- a/galpy/backend/_reference/inbackend_ode.py
+++ b/galpy/backend/_reference/inbackend_ode.py
@@ -31,7 +31,8 @@ def _eom_rhs(y, pot, t, xp, dim=6):
     position, evaluates the (decorator-free) force layer -- which dispatches on the
     array type of its arguments so this runs and differentiates under any backend
     -- and rotates the planar force back to Cartesian. Returns the matching-length
-    tuple of time derivatives.
+    tuple of time derivatives. ``pot`` is a single potential or composite,
+    3D *or* native-planar (dispatched to the matching force layer).
 
     Components are indexed on the TRAILING axis (``y[..., k]``) so the same RHS
     runs for a single state ``(dim,)`` and for a batch ``(N, dim)`` (N orbits in
@@ -39,32 +40,47 @@ def _eom_rhs(y, pot, t, xp, dim=6):
     not the phase-space dimension, once a leading axis is present.
     """
     # Imported lazily so importing this module never forces the potential import
-    # graph at galpy import time.
+    # graph at galpy import time. ``pot`` is a single potential or a composite
+    # (Orbit.integrate converts a legacy list to a CompositePotential before it
+    # reaches here), dispatched below to the 3D or the native-planar force layer.
     if dim == 2:  # 1D linear potential: state [x, vx]
         from ...potential.linearPotential import _evaluatelinearForces
 
         x, vx = y[..., 0], y[..., 1]
         return vx, _evaluatelinearForces(pot, x, t=t)
 
-    from ...potential.Potential import (
-        _evaluatephitorques,
-        _evaluateRforces,
-        _evaluatezforces,
-    )
+    from ...potential.planarPotential import planarForce
 
     x, vx, yy, vy, z, vz = (y[..., i] for i in range(6))
     R = xp.sqrt(x**2 + yy**2)
     phi = xp.arctan2(yy, x)
     cosphi, sinphi = x / R, yy / R
-    # v=[vR, vT, vz]; only used by velocity-dependent/dissipative forces.
     vR = vx * cosphi + vy * sinphi
     vT = -vx * sinphi + vy * cosphi
-    v = [vR, vT, vz]
-    Rforce = _evaluateRforces(pot, R, z, phi=phi, t=t, v=v)
-    phitorque = _evaluatephitorques(pot, R, z, phi=phi, t=t, v=v)
+    if isinstance(pot, planarForce):
+        # native-planar: 2D velocity, and no z-force (the plane is symmetric).
+        from ...potential.planarPotential import (
+            _evaluateplanarphitorques,
+            _evaluateplanarRforces,
+        )
+
+        v = [vR, vT]
+        Rforce = _evaluateplanarRforces(pot, R, phi=phi, t=t, v=v)
+        phitorque = _evaluateplanarphitorques(pot, R, phi=phi, t=t, v=v)
+        az = z * 0.0
+    else:
+        from ...potential.Potential import (
+            _evaluatephitorques,
+            _evaluateRforces,
+            _evaluatezforces,
+        )
+
+        v = [vR, vT, vz]  # only used by velocity-dependent/dissipative forces
+        Rforce = _evaluateRforces(pot, R, z, phi=phi, t=t, v=v)
+        phitorque = _evaluatephitorques(pot, R, z, phi=phi, t=t, v=v)
+        az = _evaluatezforces(pot, R, z, phi=phi, t=t, v=v)
     ax = cosphi * Rforce - sinphi / R * phitorque
     ay = sinphi * Rforce + cosphi / R * phitorque
-    az = _evaluatezforces(pot, R, z, phi=phi, t=t, v=v)
     return vx, ax, vy, ay, vz, az
 
 
@@ -136,8 +152,10 @@ def integrate_orbit(
 
     Parameters
     ----------
-    pot : Potential (or list) -- must be backend-migrated for the chosen backend;
-        a 3D Potential for planar/3D orbits, a linearPotential for 1D.
+    pot : Potential or composite -- must be backend-migrated for the chosen
+        backend; a 3D or native-planar Potential for planar/3D orbits, a
+        linearPotential for 1D (a legacy list is converted to a composite by
+        Orbit.integrate before it reaches here).
     vxvv : backend array of shape (phasedim,) for one orbit, or (N, phasedim) for
         a batch of N orbits integrated in ONE solve, Orbit order -- phasedim one of
         [x,vx] (1D), [R,vR,vT] / [R,vR,vT,phi] (2D), [R,vR,vT,z,vz] /
@@ -168,8 +186,9 @@ def integrate_orbit(
     Differentiable w.r.t. ``vxvv`` (initial conditions) and, when the parameter is
     supplied as a backend array, w.r.t. the potential's parameters. ``phi`` is
     recovered from the Cartesian position, so it is wrapped to [-pi, pi] as in
-    ``Orbit``. Planar orbits are integrated as 3D with z=vz=0 (z-force vanishes in
-    the plane of a symmetric potential) and the z,vz outputs are dropped.
+    ``Orbit``. Planar orbits are integrated as 3D with z=vz=0 (a native-planar
+    component contributes no z-force; a 3D symmetric one vanishes in the plane)
+    and the z,vz outputs are dropped.
     """
     xp = get_namespace(vxvv)
     name = xp.__name__

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1755,8 +1755,11 @@ class Orbit:
                     and _check_c(_potl, dxdv3d=True)
                 ):
                     return self._integrate_cstm(t, _potl, method.lower(), rtol, atol)
+                # Pass the deprecation-checked/composed potential (_potl), matching
+                # the C-STM and numpy paths, so a legacy list reaches the in-backend
+                # integrator as a composite rather than a raw list.
                 return self._integrate_inbackend(
-                    t, pot, _inbk, rtol, atol, inbackend_kwargs
+                    t, _potl, _inbk, rtol, atol, inbackend_kwargs
                 )
         if getattr(self, "_ic_backend", None) is not None and not getattr(
             self, "_ic_backend_concrete", True

--- a/tests/test_backend_inbackend_ode.py
+++ b/tests/test_backend_inbackend_ode.py
@@ -23,6 +23,7 @@ from galpy.potential import (
     DehnenCoreSphericalPotential,
     DehnenSphericalPotential,
     DoubleExponentialDiskPotential,
+    EllipticalDiskPotential,
     FlattenedPowerPotential,
     HernquistPotential,
     IsochronePotential,
@@ -39,6 +40,7 @@ from galpy.potential import (
     SCFPotential,
     SoftenedNeedleBarPotential,
     SpiralArmsPotential,
+    SteadyLogSpiralPotential,
     TriaxialHernquistPotential,
     TriaxialNFWPotential,
     TwoPowerSphericalPotential,
@@ -239,6 +241,125 @@ def test_inbackend_grad_torch_matches_jax():
     g_torch = float(ic.grad[1])
 
     numpy.testing.assert_allclose(g_torch, g_jax, rtol=1e-6, atol=1e-8)
+
+
+# --------------------- native-planar / composite potentials ---------------------
+# The in-backend RHS used to call the 3D force layer on the potential, so a
+# native-planar potential (SteadyLogSpiral/EllipticalDisk -- no z-argument) or a
+# planarCompositePotential crashed. It now dispatches to the planar force layer
+# for a planarForce (planar orbit integrated as 3D with z=vz=0, no z-force) and to
+# the 3D layer otherwise. Covers native-planar, .toPlanar(), the modern
+# planarCompositePotential (pot1+pot2), and a 3D CompositePotential -- all vs
+# galpy's C integrator. (Legacy lists are converted to a composite by
+# Orbit.integrate before reaching the integrator, so they need no special path.)
+_IC_PLANAR = [1.0, 0.1, 0.9, 0.2]  # R, vR, vT, phi
+_SPIRAL = SteadyLogSpiralPotential(amp=1.0, omegas=0.65, A=-0.035)
+_EDISK = EllipticalDiskPotential(
+    twophio=0.05, phib=25.0 / 180.0 * numpy.pi, p=0.0, tform=-150.0, tsteady=125.0
+)
+_PLANAR_POTS = [
+    ("native-SteadyLogSpiral", _SPIRAL),
+    ("native-EllipticalDisk", _EDISK),
+    ("toPlanar-LogHalo", LogarithmicHaloPotential(amp=1.0, q=0.8).toPlanar()),
+    ("composite-planar", LogarithmicHaloPotential(amp=1.0, q=0.8).toPlanar() + _SPIRAL),
+    (
+        "composite-3D",
+        MiyamotoNagaiPotential(amp=0.8, a=0.5, b=0.1)
+        + LogarithmicHaloPotential(amp=0.2, q=0.8),
+    ),
+]
+
+
+def _wrap_phi_planar(a):
+    a = numpy.array(a, dtype=float)
+    a[..., 3] = (a[..., 3] + numpy.pi) % (2 * numpy.pi) - numpy.pi
+    return a
+
+
+def _c_reference_planar(pot, ic=None):
+    o = Orbit(_IC_PLANAR if ic is None else list(ic))
+    o.integrate(_TS, pot, method="dop853_c")
+    return numpy.array([[o.R(t), o.vR(t), o.vT(t), o.phi(t)] for t in _TS])
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+@pytest.mark.parametrize("name,pot", _PLANAR_POTS, ids=[p[0] for p in _PLANAR_POTS])
+def test_inbackend_planar_matches_c_jax(name, pot):
+    ref = _c_reference_planar(pot)
+    got = numpy.asarray(integrate_orbit(pot, jnp.asarray(_IC_PLANAR), jnp.asarray(_TS)))
+    numpy.testing.assert_allclose(
+        _wrap_phi_planar(got), _wrap_phi_planar(ref), rtol=1e-6, atol=1e-7
+    )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch/torchdiffeq not installed")
+@pytest.mark.parametrize("name,pot", _PLANAR_POTS, ids=[p[0] for p in _PLANAR_POTS])
+def test_inbackend_planar_matches_c_torch(name, pot):
+    ref = _c_reference_planar(pot)
+    got = (
+        integrate_orbit(pot, torch.as_tensor(_IC_PLANAR), torch.as_tensor(_TS))
+        .detach()
+        .numpy()
+    )
+    numpy.testing.assert_allclose(
+        _wrap_phi_planar(got), _wrap_phi_planar(ref), rtol=1e-5, atol=1e-6
+    )
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_inbackend_planar_composite_grad_vs_fd_jax():
+    # d(final R)/d(vR0) through a composite-planar orbit solve, autodiff vs FD --
+    # the differentiable-evolution path an evolveddiskdf moment rides on.
+    pot = LogarithmicHaloPotential(amp=1.0, q=0.8).toPlanar() + _SPIRAL
+    ts = jnp.asarray(_TS)
+
+    def final_R(vR0):
+        ic = jnp.array([1.0, vR0, 0.9, 0.2])
+        return integrate_orbit(pot, ic, ts)[-1][0]
+
+    ad = float(jax.grad(final_R)(jnp.asarray(0.1)))
+    eps = 1e-6
+    fd = (float(final_R(0.1 + eps)) - float(final_R(0.1 - eps))) / (2 * eps)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_inbackend_planar_batch_jax():
+    # a batch of planar orbits (N,4) with a composite-planar potential in one solve
+    pot = LogarithmicHaloPotential(amp=1.0, q=0.8).toPlanar() + _SPIRAL
+    ics = numpy.array([_IC_PLANAR, [0.9, 0.0, 1.0, 0.1], [1.1, -0.05, 0.85, 0.4]])
+    ref = numpy.array([_c_reference_planar(pot, ic)[-1] for ic in ics])
+    out = numpy.asarray(integrate_orbit(pot, jnp.asarray(ics), jnp.asarray(_TS)))
+    assert out.shape == (len(_TS), 3, 4)
+    numpy.testing.assert_allclose(
+        _wrap_phi_planar(out[-1]), _wrap_phi_planar(ref), rtol=1e-6, atol=1e-7
+    )
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_orbit_integrate_composite_planar_end_to_end_jax():
+    # end-to-end via Orbit.integrate with a jax IC + composite-planar potential and
+    # a C-method NAME (rk6_c): a backend IC routes a C dxdv method to the
+    # differentiable in-backend integrator, and the composed potential is forwarded
+    # (not the raw list). Planar, so it takes the in-backend path (not 6D C-STM) and
+    # the final coordinate is differentiable w.r.t. the IC.
+    pot = LogarithmicHaloPotential(amp=1.0, q=0.8).toPlanar() + _SPIRAL
+
+    def final_R(vR0):
+        o = Orbit(jnp.array([1.0, vR0, 0.9, 0.2]))
+        o.integrate(jnp.asarray(_TS), pot, method="rk6_c")
+        return o.getOrbit().reshape(-1, 4)[-1, 0]
+
+    ref = _c_reference_planar(pot)[-1, 0]
+    numpy.testing.assert_allclose(
+        float(final_R(jnp.asarray(0.1))), ref, rtol=1e-6, atol=1e-7
+    )
+    ad = float(jax.grad(final_R)(jnp.asarray(0.1)))
+    eps = 1e-6
+    fd = (
+        float(final_R(jnp.asarray(0.1 + eps))) - float(final_R(jnp.asarray(0.1 - eps)))
+    ) / (2 * eps)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-5, atol=1e-7)
 
 
 # ----------------------- in-backend solver/adjoint/max_steps knobs (#102) -------


### PR DESCRIPTION
## What

Make the in-backend differentiable orbit integrator (`galpy.backend._reference.integrate_orbit` → diffrax/torchdiffeq) work for **native-planar** and **composite** potentials, not just single 3D potentials.

## Why

`_eom_rhs` always evaluated forces through the **3D** force layer on the single `pot`, so it crashed on:
- a **native-planar** potential (`SteadyLogSpiralPotential`/`EllipticalDiskPotential`, whose `_Rforce_nodecorator` takes no `z` → `got multiple values for argument 'phi'`), and
- a legacy **list** (`Orbit.integrate` forwarded the raw `pot` → `'list' object has no attribute 'isDissipative'`).

This blocked jax/torch integration of any planar potential — the common case for the disk DFs (`evolveddiskdf`'s potential is a `planarCompositePotential`). It's the prerequisite for making `evolveddiskdf` moments differentiable through the orbit evolution.

## Fix

- **`_eom_rhs`** dispatches on potential type: a `planarForce` (native-planar, `.toPlanar()`, or `planarCompositePotential`) goes through the **planar** force layer (2D velocity, no z-force — the plane is symmetric); everything else through the **3D** layer as before. Planar orbits still integrate as 3D with `z=vz=0`.
- **`Orbits.py`** forwards the deprecation-checked/composed potential (`_potl`) to the in-backend integrator, matching the C-STM and numpy paths, so a legacy list arrives as a composite (galpy already converts list→composite) rather than a raw list — no list-summing needed in the RHS.

**numpy is untouched**: `_eom_rhs` runs only on the jax/torch path, and the `Orbits.py` change is inside the backend-IC branch (numpy orbits never reach it).

## Tests (`test_backend_inbackend_ode.py`)

- native-planar / `.toPlanar()` / composite-planar / composite-3D all match galpy's C integrator (jax + torch)
- grad-vs-FD through a composite-planar orbit
- a planar batch (N,4) integrated in one solve
- end-to-end `Orbit(jax IC).integrate('rk6_c')` routing a C-method name to the differentiable in-backend path

Existing 3D sweep (24 potentials) unchanged: 40 passed locally (jax; torch smoke-checked on CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm