### PR TITLE
evolveddiskdf: differentiable-through-evolution moments (jax/torch) — Track F Pdf.3 PR-2

### DIFF
--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -17,6 +17,7 @@ import warnings
 import numpy
 from scipy import integrate
 
+from ..backend import device_of, get_namespace, is_backend_array
 from ..orbit import Orbit
 from ..potential import calcRotcurve, planarCompositePotential, planarForce
 from ..potential.Potential import _check_c, _check_potential_list_and_deprecate, _dim
@@ -515,14 +516,21 @@ class evolveddiskdf(df):
             nsigma = _NSIGMA
         if _PROFILE:  # pragma: no cover
             start = time_module.time()
+        # TRANSITIONAL data-guard (to be lifted when the hierarchical-grid + direct
+        # paths are backend-migrated, like the diskdf-family guards, task #117): xp
+        # is numpy unless R is actually a backend array, so a *forced* backend does
+        # NOT flip a numpy R (which would break the unmigrated direct/hierarchical
+        # paths and the fast numpy suite). For a backend R the grid velocity bounds
+        # carry R's gradient into the differentiable grid build (_buildvgrid_backend).
+        xp = get_namespace(R) if is_backend_array(R) else numpy
         if (
             hasattr(self._initdf, "_estimatemeanvR")
             and hasattr(self._initdf, "_estimatemeanvT")
             and hasattr(self._initdf, "_estimateSigmaR2")
             and hasattr(self._initdf, "_estimateSigmaT2")
         ):
-            sigmaR1 = numpy.sqrt(self._initdf._estimateSigmaR2(R, phi=az))
-            sigmaT1 = numpy.sqrt(self._initdf._estimateSigmaT2(R, phi=az))
+            sigmaR1 = xp.sqrt(self._initdf._estimateSigmaR2(R, phi=az))
+            sigmaT1 = xp.sqrt(self._initdf._estimateSigmaT2(R, phi=az))
             meanvR = self._initdf._estimatemeanvR(R, phi=az)
             meanvT = self._initdf._estimatemeanvT(R, phi=az)
         else:
@@ -530,8 +538,8 @@ class evolveddiskdf(df):
                 "No '_estimateSigmaR2' etc. functions found for initdf in evolveddf; thus using potentially slow sigmaR2 etc functions",
                 galpyWarning,
             )
-            sigmaR1 = numpy.sqrt(self._initdf.sigmaR2(R, phi=az, use_physical=False))
-            sigmaT1 = numpy.sqrt(self._initdf.sigmaT2(R, phi=az, use_physical=False))
+            sigmaR1 = xp.sqrt(self._initdf.sigmaR2(R, phi=az, use_physical=False))
+            sigmaT1 = xp.sqrt(self._initdf.sigmaT2(R, phi=az, use_physical=False))
             meanvR = self._initdf.meanvR(R, phi=az, use_physical=False)
             meanvT = self._initdf.meanvT(R, phi=az, use_physical=False)
         if _PROFILE:  # pragma: no cover
@@ -772,14 +780,17 @@ class evolveddiskdf(df):
             "In versions >1.3, the output unit of evolveddiskdf.vertexdev has been changed to radian (from degree before)",
             galpyWarning,
         )
+        # backend-agnostic arctan combiner (numpy for numpy moments -> byte-identical;
+        # the backend when the moments are backend arrays, i.e. from a backend grid)
+        xp = get_namespace(sigmaRT) if is_backend_array(sigmaRT) else numpy
         if returnGrid and (
             (isinstance(grid, bool) and grid)
             or isinstance(grid, evolveddiskdfGrid)
             or isinstance(grid, evolveddiskdfHierarchicalGrid)
         ):
-            return (-numpy.arctan(2.0 * sigmaRT / (sigmaR2 - sigmaT2)) / 2.0, grido)
+            return (-xp.arctan(2.0 * sigmaRT / (sigmaR2 - sigmaT2)) / 2.0, grido)
         else:
-            return -numpy.arctan(2.0 * sigmaRT / (sigmaR2 - sigmaT2)) / 2.0
+            return -xp.arctan(2.0 * sigmaRT / (sigmaR2 - sigmaT2)) / 2.0
 
     @potential_physical_input
     @physical_conversion("velocity", pop=True)
@@ -2845,6 +2856,13 @@ class evolveddiskdf(df):
     def _vmomentsurfacemassGrid(self, n, m, grid):
         """Internal function to evaluate vmomentsurfacemass using a grid
         rather than direct integration"""
+        # backend-agnostic reduction: numpy for a numpy grid (byte-identical),
+        # jax/torch for a backend grid.df/vRgrid/vTgrid
+        xp = get_namespace(grid.df) if is_backend_array(grid.df) else numpy
+        # matrix-vector contraction: numpy stays on numpy.dot for byte-identity
+        # (numpy.matmul differs from numpy.dot by ~ULP on non-contiguous slices);
+        # torch.dot is 1D-only so the backends use matmul (jax.matmul matches dot).
+        mv = xp.dot if xp is numpy else xp.matmul
         if len(grid.df.shape) == 3:
             tlist = True
         else:
@@ -2854,16 +2872,14 @@ class evolveddiskdf(df):
             out = []
             for ii in range(nt):
                 out.append(
-                    numpy.dot(
-                        grid.vRgrid**n, numpy.dot(grid.df[:, :, ii], grid.vTgrid**m)
-                    )
+                    mv(grid.vRgrid**n, mv(grid.df[:, :, ii], grid.vTgrid**m))
                     * (grid.vRgrid[1] - grid.vRgrid[0])
                     * (grid.vTgrid[1] - grid.vTgrid[0])
                 )
-            return numpy.array(out)
+            return xp.asarray(out)
         else:
             return (
-                numpy.dot(grid.vRgrid**n, numpy.dot(grid.df, grid.vTgrid**m))
+                mv(grid.vRgrid**n, mv(grid.df, grid.vTgrid**m))
                 * (grid.vRgrid[1] - grid.vRgrid[0])
                 * (grid.vTgrid[1] - grid.vTgrid[0])
             )
@@ -2884,6 +2900,25 @@ class evolveddiskdf(df):
         deriv,
     ):
         """Internal function to grid the vDF at a given location"""
+        # Backend-array R: one vectorized multi-orbit integrate (differentiable
+        # through the evolution) instead of the numpy per-gridpoint loop below, which
+        # stays byte-identical. TRANSITIONAL data-guard (gate on is_backend_array, not
+        # a forced backend) so a forced backend with a numpy R keeps the fast numpy
+        # loop -- no diffrax flip in the numpy suite (sigmaR1/meanvR follow R).
+        if is_backend_array(R):
+            return self._buildvgrid_backend(
+                R,
+                phi,
+                nsigma,
+                t,
+                sigmaR1,
+                sigmaT1,
+                meanvR,
+                meanvT,
+                gridpoints,
+                integrate_method,
+                deriv,
+            )
         out = evolveddiskdfGrid()
         out.sigmaR1 = sigmaR1
         out.sigmaT1 = sigmaT1
@@ -2944,6 +2979,112 @@ class evolveddiskdf(df):
             out.df[numpy.isnan(out.df)] = 0.0  # BOVY: for now
             if print_progress:
                 sys.stdout.write("\n")  # pragma: no cover
+        return out
+
+    def _buildvgrid_backend(
+        self,
+        R,
+        phi,
+        nsigma,
+        t,
+        sigmaR1,
+        sigmaT1,
+        meanvR,
+        meanvT,
+        gridpoints,
+        integrate_method,
+        deriv,
+    ):
+        """Backend (jax/torch) build of the velocity grid: ONE vectorized
+        multi-orbit integrate of all gridpoints (each orbit's backward evolution is
+        differentiable via the in-backend ODE solver) instead of the per-gridpoint
+        Python loop in _buildvgrid, so grid.df is a backend array and the moments
+        that reduce it (_vmomentsurfacemassGrid) are differentiable through the
+        orbit evolution -- d<v^n v^m>/dR (and /dparam). Mirrors __call__'s
+        non-deriv, non-marginalize path (scalar t and t-list). The numpy path
+        (_buildvgrid) is byte-identical; this runs only for backend inputs / under
+        a forced backend. deriv= (the finite-difference moment derivative) is
+        unsupported here -- differentiate the moment with autodiff instead."""
+        from .diskdf import vRvTRToEL
+
+        if deriv is not None:
+            raise NotImplementedError(
+                "evolveddiskdf grid deriv= is not supported on the jax/torch "
+                "backend; differentiate the moment with jax.grad / torch.autograd"
+            )
+        xp = get_namespace(R, sigmaR1, sigmaT1, meanvR, meanvT)
+        out = evolveddiskdfGrid()
+        out.sigmaR1 = sigmaR1
+        out.sigmaT1 = sigmaT1
+        out.meanvR = meanvR
+        out.meanvT = meanvT
+        # differentiable, backend-uniform velocity grids: torch.linspace drops the
+        # gradient w.r.t. tensor endpoints, so build lo + (hi-lo)*frac with a static
+        # frac (device-anchored to the inputs for torch CUDA); frac carries R's
+        # gradient into the grid bounds via sigmaR1(R)/meanvR(R).
+        _dev = device_of(meanvR, meanvT, sigmaR1, sigmaT1)
+        frac = xp.linspace(
+            0.0, 1.0, gridpoints, **({"device": _dev} if _dev is not None else {})
+        )
+        out.vRgrid = (meanvR - nsigma * sigmaR1) + 2.0 * nsigma * sigmaR1 * frac
+        out.vTgrid = (meanvT - nsigma * sigmaT1) + 2.0 * nsigma * sigmaT1 * frac
+        # ICs [R, vRgrid[ii], vTgrid[jj], phi], flattened in (ii=vR, jj=vT) order to
+        # match out.df[ii, jj]; R carries the gradient into every orbit's IC.
+        VR, VT = xp.meshgrid(out.vRgrid, out.vTgrid, indexing="ij")
+        vRf = xp.reshape(VR, (-1,))
+        vTf = xp.reshape(VT, (-1,))
+        ones = xp.ones_like(vRf)
+        ic = xp.stack([R * ones, vRf, vTf, phi * ones], axis=-1)  # (N, 4)
+
+        def _idf(vR, vT, Rr):  # initdf.__call__'s array path, backend-array-callable
+            E, L = vRvTRToEL(vR, vT, Rr, self._initdf._beta, self._initdf._dftype)
+            return self._initdf._real(self._initdf.eval(E, L))
+
+        def _nan0(x):
+            return xp.where(xp.isnan(x), 0.0, x)
+
+        # backend orbits integrate with the backend's own solver; a C-method NAME
+        # would route there anyway, but pick it explicitly so a non-C
+        # integrate_method (odeint/leapfrog) works too.
+        bmethod = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+        tlist = isinstance(t, (list, numpy.ndarray))
+        if tlist:
+            t = numpy.atleast_1d(numpy.asarray(t))
+            nt = len(t)
+            if self._to == t[0]:  # no evolution: DF at the ICs, one per output time
+                df1 = _nan0(_idf(vRf, vTf, R * ones))
+                out.df = xp.reshape(
+                    xp.broadcast_to(df1[:, None], (df1.shape[0], nt)),
+                    (gridpoints, gridpoints, nt),
+                )
+            else:
+                # C-style output times (one per requested t) so the trajectory is
+                # sampled exactly at them; the backend solver saves at these times.
+                ts = xp.asarray(self._create_ts_tlist(t, "dopr54_c"))
+                o = Orbit(ic)
+                o.integrate(ts, self._pot, method=bmethod)
+                traj = o.getOrbit()  # (N, len(ts), 4)
+                if nt == 1:  # single time: the evolved endpoint (t -> self._to)
+                    end = traj[:, 1, :]
+                    dfvals = _nan0(_idf(end[:, 1], end[:, 2], end[:, 0]))[:, None]
+                else:  # DF along the trajectory, reversed to ascending-lag t order
+                    dfvals = _nan0(_idf(traj[..., 1], traj[..., 2], traj[..., 0]))
+                    dfvals = xp.flip(dfvals, axis=1)  # torch has no negative-step slice
+                out.df = xp.reshape(dfvals, (gridpoints, gridpoints, nt))
+        else:  # scalar t: DF at the single evolved endpoint (t -> self._to)
+            if self._to == t:  # no evolution
+                out.df = xp.reshape(
+                    _nan0(_idf(vRf, vTf, R * ones)), (gridpoints, gridpoints)
+                )
+            else:
+                ts = xp.asarray(numpy.linspace(float(t), float(self._to), 2))
+                o = Orbit(ic)
+                o.integrate(ts, self._pot, method=bmethod)
+                end = o.getOrbit()[:, -1, :]  # at self._to
+                Ro, vRo, vTo = end[:, 0], end[:, 1], end[:, 2]
+                eps = numpy.finfo(numpy.float64).eps
+                df = xp.where(Ro <= 0.0, eps, _idf(vRo, vTo, Ro))  # R<=0 -> eps
+                out.df = xp.reshape(_nan0(df), (gridpoints, gridpoints))
         return out
 
     def _create_ts_tlist(self, t, integrate_method):
@@ -3387,6 +3528,13 @@ class evolveddiskdfHierarchicalGrid:
 
     def __call__(self, n, m):
         """Call"""
+        # backend-agnostic reduction: numpy for a numpy grid (byte-identical),
+        # jax/torch for a backend grid.df. Data-guard (is_backend_array, not a
+        # forced backend) so a forced backend with a numpy grid stays numpy --
+        # torch.dot rejects a numpy array. matmul on the backends (torch.dot is
+        # 1D-only), numpy.dot on numpy for byte-identity.
+        xp = get_namespace(self.df) if is_backend_array(self.df) else numpy
+        mv = xp.dot if xp is numpy else xp.matmul
         if isinstance(self.t, (list, numpy.ndarray)):
             tlist = True
         else:
@@ -3396,19 +3544,15 @@ class evolveddiskdfHierarchicalGrid:
             out = []
             for ii in range(nt):
                 # We already multiplied in the area
-                out.append(
-                    numpy.dot(
-                        self.vRgrid**n, numpy.dot(self.df[:, :, ii], self.vTgrid**m)
-                    )
-                )
+                out.append(mv(self.vRgrid**n, mv(self.df[:, :, ii], self.vTgrid**m)))
 
             if self.subgrid is None:
-                return numpy.array(out)
+                return xp.asarray(out)
             else:
-                return numpy.array(out) + self.subgrid(n, m)
+                return xp.asarray(out) + self.subgrid(n, m)
         else:
             # We already multiplied in the area
-            thislevel = numpy.dot(self.vRgrid**n, numpy.dot(self.df, self.vTgrid**m))
+            thislevel = mv(self.vRgrid**n, mv(self.df, self.vTgrid**m))
             if self.subgrid is None:
                 return thislevel
             else:

--- a/tests/test_backend_evolveddiskdf.py
+++ b/tests/test_backend_evolveddiskdf.py
@@ -1,0 +1,292 @@
+###############################################################################
+# test_backend_evolveddiskdf.py: Track F Pdf.3 -- backend (jax/torch) coverage
+# for evolveddiskdf's velocity-moment grid, DIFFERENTIABLE THROUGH THE ORBIT
+# EVOLUTION.
+#
+# evolveddiskdf builds f(x,t) = initdf(orbit integrated back to t0) on a velocity
+# grid and reduces that grid to moments <vR^n vT^m Sigma>. Under a backend (or a
+# forced backend), _buildvgrid_backend builds the whole grid in ONE vectorized
+# multi-orbit integrate through the in-backend ODE solver, so grid.df is a backend
+# array and the moment is differentiable w.r.t. R (and potential parameters) THROUGH
+# the orbit evolution. The numpy path (_buildvgrid, per-gridpoint C loop) is
+# byte-identical (test_evolveddiskdf unchanged).
+#
+# Checks:
+#   (a) moment value parity numpy<->backend for every moment method, on scalar-t
+#       and time-list grids, both integrated with the same accurate integrator
+#       (dop853_c / diffrax at rtol=atol=1e-12) so they agree tightly;
+#   (b) grad-vs-FD of a moment w.r.t. R -- differentiability THROUGH the evolution;
+#   (c) deriv= (the finite-difference moment derivative) is rejected on the backend;
+#   (d) the grid reduction (_vmomentsurfacemassGrid) is itself differentiable w.r.t.
+#       the grid df values (closed-form check).
+###############################################################################
+import copy
+
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.backend import as_numpy, is_backend_array, use
+from galpy.df import dehnendf, evolveddiskdf
+from galpy.potential import (
+    EllipticalDiskPotential,
+    LogarithmicHaloPotential,
+    SteadyLogSpiralPotential,
+)
+
+_GP = 9  # small grid for speed
+_R, _PHI = 0.9, 0.2
+# dop853_c on numpy and diffrax/torchdiffeq at rtol=atol=1e-12 on the backend are
+# both ~1e-12-accurate, so the moments agree to ~1e-8 (the integrators are
+# different methods; a looser integrator would show its own truncation, not a bug).
+_IM = "dop853_c"
+
+
+def _make_edf():
+    idf = dehnendf(beta=0.0)
+    # mild non-axisymmetric, C-capable planar composite potential
+    pot = LogarithmicHaloPotential(normalize=1.0) + SteadyLogSpiralPotential(
+        A=-0.005, omegas=0.2
+    )
+    return evolveddiskdf(idf, pot=pot, to=-10.0)
+
+
+def _scalar(backend, x):
+    return jnp.asarray(float(x)) if backend == "jax" else torch.tensor(float(x))
+
+
+# Moment methods, keyed by name -> callable(edf, R) at fixed phi, grid-built.
+_MOMENTS = {
+    "surfacemass": lambda edf, R: edf.vmomentsurfacemass(
+        R, 0, 0, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM
+    ),
+    "sigmaR2": lambda edf, R: edf.sigmaR2(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+    "sigmaT2": lambda edf, R: edf.sigmaT2(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+    "sigmaRT": lambda edf, R: edf.sigmaRT(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+    "meanvR": lambda edf, R: edf.meanvR(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+    "meanvT": lambda edf, R: edf.meanvT(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+    "vertexdev": lambda edf, R: edf.vertexdev(
+        R, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, use_physical=False
+    ),
+}
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("moment", list(_MOMENTS))
+def test_moment_parity_native_backend_grid(backend, moment):
+    # moment on a NATIVELY backend-built scalar-t grid (one vectorized multi-orbit
+    # integrate) vs numpy; both at high accuracy so they agree to integrator tol.
+    edf = _make_edf()
+    ref = numpy.asarray(_MOMENTS[moment](edf, _R))
+    with use(backend, force=True):
+        got = _MOMENTS[moment](edf, _scalar(backend, _R))
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-7, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_moment_parity_tlist_native_backend_grid(backend):
+    # time-list grid -> 3D df; one moment per time, natively backend-built.
+    edf = _make_edf()
+    ts = numpy.array([0.0, -2.5, -5.0])
+    ref = numpy.asarray(
+        edf.vmomentsurfacemass(
+            _R, 1, 0, t=ts, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM
+        )
+    )
+    with use(backend, force=True):
+        got = edf.vmomentsurfacemass(
+            _scalar(backend, _R),
+            1,
+            0,
+            t=ts,
+            phi=_PHI,
+            grid=True,
+            gridpoints=_GP,
+            integrate_method=_IM,
+        )
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-7, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("moment", ["surfacemass", "sigmaR2", "meanvT", "vertexdev"])
+def test_moment_grad_through_evolution_vs_fd(backend, moment):
+    # d(moment)/dR via autodiff THROUGH the orbit evolution vs central FD. FD is on
+    # the backend itself (integrator-consistent), so the floor is autodiff/FD, ~2e-4.
+    edf = _make_edf()
+    fn = _MOMENTS[moment]
+    R0, h = _R, 1e-5
+
+    def val(R):
+        with use(backend, force=True):
+            return as_numpy(
+                jnp.asarray(fn(edf, R)).reshape(())
+                if backend == "jax"
+                else fn(edf, R).reshape(())
+            )
+
+    gfd = (
+        float(val(_scalar(backend, R0 + h))) - float(val(_scalar(backend, R0 - h)))
+    ) / (2.0 * h)
+    if backend == "jax":
+        with use("jax", force=True):
+            g = float(
+                jax.grad(lambda R: jnp.asarray(fn(edf, R)).reshape(()))(jnp.asarray(R0))
+            )
+    else:
+        Rt = torch.tensor(R0, requires_grad=True)
+        with use("torch", force=True):
+            fn(edf, Rt).reshape(()).backward()
+        g = float(Rt.grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=2e-4, atol=1e-7)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_nonaxi_vertexdev_native_backend(backend):
+    # a genuinely non-axisymmetric potential gives sigmaRT != 0, so vertexdev's
+    # arctan combiner is non-trivial; native backend build vs numpy.
+    idf = dehnendf(beta=0.0)
+    pot = LogarithmicHaloPotential(normalize=1.0) + EllipticalDiskPotential(
+        twophio=0.05, phib=25.0 / 180.0 * numpy.pi, p=0.0, tform=-150.0, tsteady=125.0
+    )
+    edf = evolveddiskdf(idf, pot=pot, to=-10.0)
+    ref = float(
+        edf.vertexdev(
+            _R,
+            phi=_PHI,
+            grid=True,
+            gridpoints=_GP,
+            integrate_method=_IM,
+            use_physical=False,
+        )
+    )
+    with use(backend, force=True):
+        got = edf.vertexdev(
+            _scalar(backend, _R),
+            phi=_PHI,
+            grid=True,
+            gridpoints=_GP,
+            integrate_method=_IM,
+            use_physical=False,
+        )
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "tkw",
+    [{"t": -10.0}, {"t": [-10.0]}, {"t": [0.0]}],
+    ids=["scalar-no-evolution", "tlist-len1-no-evolution", "tlist-len1-evolved"],
+)
+def test_no_evolution_and_len1_branches(backend, tkw):
+    # cover the self._to == t (no integration) branches and the tlist len-1
+    # (single evolved endpoint) branch of _buildvgrid_backend; to == -10.0.
+    edf = _make_edf()  # to = -10.0
+    ref = numpy.asarray(
+        edf.vmomentsurfacemass(
+            _R, 0, 0, phi=_PHI, grid=True, gridpoints=_GP, integrate_method=_IM, **tkw
+        )
+    )
+    with use(backend, force=True):
+        got = edf.vmomentsurfacemass(
+            _scalar(backend, _R),
+            0,
+            0,
+            phi=_PHI,
+            grid=True,
+            gridpoints=_GP,
+            integrate_method=_IM,
+            **tkw,
+        )
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-7, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_grid_deriv_rejected_on_backend(backend):
+    # the finite-difference moment derivative (deriv=) is not supported on the
+    # backend -- autodiff replaces it; the grid build must raise a clear error.
+    edf = _make_edf()
+    with use(backend, force=True):
+        with pytest.raises(NotImplementedError):
+            edf.vmomentsurfacemass(
+                _scalar(backend, _R),
+                0,
+                0,
+                phi=_PHI,
+                grid=True,
+                gridpoints=_GP,
+                integrate_method=_IM,
+                deriv="R",
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_reduction_grad_vs_df(backend):
+    # the grid reduction _vmomentsurfacemassGrid is differentiable w.r.t. the grid
+    # df values (closed form for <vR^1 vT^1 Sigma>: grad = vR_i vT_j dvR dvT).
+    edf = _make_edf()
+    _, g_np = edf.vmomentsurfacemass(
+        _R,
+        0,
+        0,
+        phi=_PHI,
+        integrate_method="rk6_c",
+        grid=True,
+        gridpoints=_GP,
+        returnGrid=True,
+    )
+    df0 = numpy.asarray(g_np.df)
+    vR = numpy.asarray(g_np.vRgrid)
+    vT = numpy.asarray(g_np.vTgrid)
+
+    def moment_of_df(df_arr):
+        g = copy.copy(g_np)
+        g.df = df_arr
+        g.vRgrid = jnp.asarray(vR) if backend == "jax" else torch.as_tensor(vR)
+        g.vTgrid = jnp.asarray(vT) if backend == "jax" else torch.as_tensor(vT)
+        with use(backend, force=True):
+            return edf._vmomentsurfacemassGrid(1, 1, g)
+
+    idx = (_GP // 3, _GP // 3)  # off-centre so vR_i*vT_j != 0
+    expect = vR[idx[0]] * vT[idx[1]] * (vR[1] - vR[0]) * (vT[1] - vT[0])
+    if backend == "jax":
+        grad = jax.grad(lambda d: moment_of_df(d))(jnp.asarray(df0))
+        g_elem = float(as_numpy(grad)[idx])
+    else:
+        dt = torch.tensor(df0, requires_grad=True)
+        moment_of_df(dt).backward()
+        g_elem = float(dt.grad[idx])
+    numpy.testing.assert_allclose(g_elem, expect, rtol=1e-8)


### PR DESCRIPTION
> **Stacked on #1075** (in-backend planar/composite support). Base will retarget to `feat/backends` once #1075 merges; review the second commit (`evolveddiskdf: …`) here.

## What

Make `evolveddiskdf`'s velocity-moment grid backend-agnostic **and differentiable through the orbit evolution**. A backend-array `R` (or a potential parameter) now flows through the *entire* moment — the grid velocity bounds `sigmaR1(R)`/`meanvR(R)`, each gridpoint's IC, and the backward orbit integration — so `d<vR^n vT^m Σ>/dR` falls out of autodiff. This is the disk-DF secular-evolution showpiece: `jax.grad`/`torch.autograd` of `sigmaR2`, `meanvT`, `vertexdev`, … w.r.t. `R`, matching finite difference.

## How

- **`_buildvgrid_backend`**: builds the whole velocity grid in **one vectorized multi-orbit in-backend integrate** (all `nvR·nvT` gridpoints as an `(N,4)` backend IC array) instead of the per-gridpoint Python/C loop, so `grid.df` is a backend array. Mirrors `__call__`'s non-deriv path (scalar-t + t-list, no-evolution and len-1 branches). Rides on #1075's in-backend planar-potential support (`evolveddiskdf._pot` is a `planarCompositePotential`). `deriv=` (the finite-difference moment derivative) is rejected on the backend — autodiff replaces it.
- **Data-guarded dispatch** (`_data_namespace`): the grid bounds, the `_vmomentsurfacemassGrid` reduction, and the `vertexdev` arctan combiner go to the backend only when a backend array is actually present. So a **forced** backend with numpy inputs keeps the fast numpy loop (no diffrax flip in `test_evolveddiskdf`) and the numpy path is byte-identical (the diskdf-family `is_backend_array` pattern from #1073).

## Backend-op portability (torch ≠ numpy/jax — all torch-smoke-caught)

- reduction uses `matmul` on the backends (`torch.dot` is 1D-only) but keeps `numpy.dot` on numpy (`numpy.matmul` differs by ~ULP on non-contiguous slices → byte-identity);
- velocity grids as `lo + (hi-lo)*frac` (`torch.linspace` silently drops the endpoint gradient), `frac` device-anchored for torch CUDA;
- t-list reversal via `xp.flip` (torch has no negative-step slicing).

## Verification

- **numpy byte-identical**: `test_evolveddiskdf` 35 passed; migrated ops are numpy on the numpy path.
- **jax**: `test_backend_evolveddiskdf` 18 passed — parity vs numpy `dop853_c` ~1e-11, grad-vs-FD-through-evolution match.
- **torch**: grad-vs-FD-through-evolution tests pass + torch-vs-jax value cross-check exact.
- **forced-backend numpy**: `test_evolveddiskdf --backend=jax` grid tests stay on the fast numpy loop (2–6s, no diffrax flip).

New `tests/test_backend_evolveddiskdf.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm