### PR TITLE
util: backend-agnostic _rotate_to_arbitrary_vector (streams prereq)

### DIFF
--- a/galpy/util/__init__.py
+++ b/galpy/util/__init__.py
@@ -169,26 +169,70 @@ def fast_cholesky_invert(A, logdet=False, tiny=_TINY):
 def _rotate_to_arbitrary_vector(v, a, inv=False, _dontcutsmall=False):
     r"""Return a rotation matrix that rotates v to align with unit vector a
     i.e. R . v = |v|\hat{a}"""
-    normv = v / numpy.tile(numpy.sqrt(numpy.sum(v**2.0, axis=1)), (3, 1)).T
-    rotaxis = numpy.cross(normv, a)
-    rotaxis /= numpy.tile(numpy.sqrt(numpy.sum(rotaxis**2.0, axis=1)), (3, 1)).T
-    crossmatrix = numpy.empty((len(v), 3, 3))
-    crossmatrix[:, 0, :] = numpy.cross(rotaxis, [1, 0, 0])
-    crossmatrix[:, 1, :] = numpy.cross(rotaxis, [0, 1, 0])
-    crossmatrix[:, 2, :] = numpy.cross(rotaxis, [0, 0, 1])
-    costheta = numpy.dot(normv, a)
-    sintheta = numpy.sqrt(1.0 - costheta**2.0)
-    if inv:
-        sgn = 1.0
-    else:
-        sgn = -1.0
+    from ..backend import as_backend_constant, get_namespace, is_backend_array
+
+    # Dispatch DATA-first (not via the forced-context get_namespace): this leaf is
+    # called from numpy-context code (streamspraydf/streamgapdf/rotated potentials)
+    # that may feed it a numpy v even under a forced backend, so numpy v must take
+    # the byte-identical numpy branch regardless of the forced default.
+    if not is_backend_array(v):
+        normv = v / numpy.tile(numpy.sqrt(numpy.sum(v**2.0, axis=1)), (3, 1)).T
+        rotaxis = numpy.cross(normv, a)
+        rotaxis /= numpy.tile(numpy.sqrt(numpy.sum(rotaxis**2.0, axis=1)), (3, 1)).T
+        crossmatrix = numpy.empty((len(v), 3, 3))
+        crossmatrix[:, 0, :] = numpy.cross(rotaxis, [1, 0, 0])
+        crossmatrix[:, 1, :] = numpy.cross(rotaxis, [0, 1, 0])
+        crossmatrix[:, 2, :] = numpy.cross(rotaxis, [0, 0, 1])
+        costheta = numpy.dot(normv, a)
+        sintheta = numpy.sqrt(1.0 - costheta**2.0)
+        if inv:
+            sgn = 1.0
+        else:
+            sgn = -1.0
+        out = (
+            numpy.tile(costheta, (3, 3, 1)).T * numpy.tile(numpy.eye(3), (len(v), 1, 1))
+            + sgn * numpy.tile(sintheta, (3, 3, 1)).T * crossmatrix
+            + numpy.tile(1.0 - costheta, (3, 3, 1)).T
+            * (rotaxis[:, :, numpy.newaxis] * rotaxis[:, numpy.newaxis, :])
+        )
+        if not _dontcutsmall:
+            out[numpy.fabs(costheta - 1.0) < 10.0**-10.0] = numpy.eye(3)
+            out[numpy.fabs(costheta + 1.0) < 10.0**-10.0] = -numpy.eye(3)
+        return out
+    # genuine backend array (jax/torch): out-of-place, differentiable. The
+    # rotaxis-normalization denominator is guarded so a v parallel to a -- whose
+    # row is degenerate and cut/masked below anyway -- does not NaN-poison AD.
+    xp = get_namespace(v, a)
+    a = as_backend_constant(xp, numpy.asarray(a, dtype=float), v)
+    normv = v / xp.sqrt(xp.sum(v**2.0, axis=1))[:, None]
+    nx, ny, nz = normv[:, 0], normv[:, 1], normv[:, 2]
+    rotaxis = xp.stack(
+        [ny * a[2] - nz * a[1], nz * a[0] - nx * a[2], nx * a[1] - ny * a[0]], axis=-1
+    )
+    raxnorm = xp.sqrt(xp.sum(rotaxis**2.0, axis=1))
+    rotaxis = (
+        rotaxis / xp.where(raxnorm == 0.0, xp.ones_like(raxnorm), raxnorm)[:, None]
+    )
+    rx, ry, rz = rotaxis[:, 0], rotaxis[:, 1], rotaxis[:, 2]
+    zero = xp.zeros_like(rx)
+    crossmatrix = xp.stack(
+        [
+            xp.stack([zero, rz, -ry], axis=-1),
+            xp.stack([-rz, zero, rx], axis=-1),
+            xp.stack([ry, -rx, zero], axis=-1),
+        ],
+        axis=1,
+    )
+    costheta = xp.sum(normv * a, axis=1)
+    sintheta = xp.sqrt(1.0 - costheta**2.0)
+    sgn = 1.0 if inv else -1.0
+    eye = as_backend_constant(xp, numpy.eye(3), v)
     out = (
-        numpy.tile(costheta, (3, 3, 1)).T * numpy.tile(numpy.eye(3), (len(v), 1, 1))
-        + sgn * numpy.tile(sintheta, (3, 3, 1)).T * crossmatrix
-        + numpy.tile(1.0 - costheta, (3, 3, 1)).T
-        * (rotaxis[:, :, numpy.newaxis] * rotaxis[:, numpy.newaxis, :])
+        costheta[:, None, None] * eye
+        + sgn * sintheta[:, None, None] * crossmatrix
+        + (1.0 - costheta)[:, None, None] * (rotaxis[:, :, None] * rotaxis[:, None, :])
     )
     if not _dontcutsmall:
-        out[numpy.fabs(costheta - 1.0) < 10.0**-10.0] = numpy.eye(3)
-        out[numpy.fabs(costheta + 1.0) < 10.0**-10.0] = -numpy.eye(3)
+        out = xp.where((xp.abs(costheta - 1.0) < 1e-10)[:, None, None], eye, out)
+        out = xp.where((xp.abs(costheta + 1.0) < 1e-10)[:, None, None], -eye, out)
     return out

--- a/tests/test_backend_util.py
+++ b/tests/test_backend_util.py
@@ -1,0 +1,149 @@
+###############################################################################
+# test_backend_util.py: multi-backend tests for galpy.util helpers that the
+# stream DFs / rotated potentials sit on -- currently _rotate_to_arbitrary_vector,
+# the batched "rotate v onto unit vector a" matrix builder used by
+# streamspraydf._setup_rot, streamgapdf, EllipsoidalPotential, and
+# RotateAndTiltWrapperPotential.
+#
+# It used numpy.tile / numpy.cross / a preallocated numpy.empty with row-wise
+# in-place assignment / boolean masked assignment, all of which reject torch
+# tensors. The migration keeps the numpy path byte-identical (a verbatim branch)
+# and adds an out-of-place, differentiable backend branch whose rotaxis-norm
+# denominator is guarded so a v parallel to a does not NaN-poison gradients.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy
+from galpy.util import _rotate_to_arbitrary_vector
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+_rng = numpy.random.default_rng(314159)
+# generic rows + one nearly-aligned and one nearly-anti-aligned with a to hit
+# the |costheta -+ 1| < 1e-10 masked branches.
+_V = numpy.vstack([_rng.normal(size=(5, 3)), [1e-13, 1.0, 1e-13], [1e-13, -1.0, 1e-13]])
+_A = numpy.array([0.0, 1.0, 0.0])
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("inv", [False, True])
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_rotate_value_parity(backend_name, inv):
+    ref = _rotate_to_arbitrary_vector(numpy.asarray(_V), numpy.asarray(_A), inv=inv)
+    got = _rotate_to_arbitrary_vector(
+        _asarray(backend_name, _V), _asarray(backend_name, _A), inv=inv
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(got),
+        ref,
+        rtol=1e-12,
+        atol=1e-13,
+        err_msg=f"inv={inv} ({backend_name})",
+    )
+    # the two degenerate rows must be exactly +/- I (masked branch)
+    numpy.testing.assert_allclose(as_numpy(got)[-2], numpy.eye(3), atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got)[-1], -numpy.eye(3), atol=1e-12)
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_rotate_dontcutsmall_parity(backend_name):
+    # _dontcutsmall=True path (used for the module-level galcen rotations); pass
+    # only non-degenerate rows so both paths are finite.
+    v = _V[:5]
+    ref = _rotate_to_arbitrary_vector(
+        numpy.asarray(v), numpy.asarray(_A), _dontcutsmall=True
+    )
+    got = _rotate_to_arbitrary_vector(
+        _asarray(backend_name, v), _asarray(backend_name, _A), _dontcutsmall=True
+    )
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_rotate_is_a_rotation(backend_name):
+    # R must actually rotate each v onto |v|*a: R . v_hat == a.
+    v = _V[:5]
+    R = _rotate_to_arbitrary_vector(
+        _asarray(backend_name, v), _asarray(backend_name, _A)
+    )
+    R = as_numpy(R)
+    for i in range(len(v)):
+        vhat = v[i] / numpy.linalg.norm(v[i])
+        numpy.testing.assert_allclose(R[i] @ vhat, _A, atol=1e-10)
+        # orthogonal: R R^T == I
+        numpy.testing.assert_allclose(R[i] @ R[i].T, numpy.eye(3), atol=1e-10)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rotate_grad_through(backend_name):
+    # d out[0,0,0] / d v[0,0] must be finite (the guarded denominator prevents
+    # NaN poisoning even with degenerate rows present in the batch) and match FD.
+    eps = 1e-6
+    vp = _V.copy()
+    vp[0, 0] += eps
+    vm = _V.copy()
+    vm[0, 0] -= eps
+    fd = (
+        _rotate_to_arbitrary_vector(vp, _A)[0, 0, 0]
+        - _rotate_to_arbitrary_vector(vm, _A)[0, 0, 0]
+    ) / (2 * eps)
+    if backend_name == "jax":
+
+        def f(x):
+            vv = jnp.asarray(_V).at[0, 0].set(x)
+            return _rotate_to_arbitrary_vector(vv, jnp.asarray(_A))[0, 0, 0]
+
+        g = float(jax.grad(f)(jnp.asarray(_V[0, 0])))
+    else:
+        vt = torch.tensor(_V, dtype=torch.float64, requires_grad=True)
+        _rotate_to_arbitrary_vector(vt, torch.tensor(_A, dtype=torch.float64))[
+            0, 0, 0
+        ].backward()
+        g = float(vt.grad[0, 0])
+    assert not numpy.isnan(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rotate_numpy_data_under_forced_backend(backend_name):
+    # Dispatch is DATA-first: a genuine numpy v must take the byte-identical numpy
+    # branch even under a forced non-numpy default (the sampler leaves feed numpy
+    # arrays through here while the forced default is torch/jax). Regression for the
+    # as_backend_constant(numpy dtype -> torch.asarray) crash.
+    from galpy.backend import use
+
+    ref = _rotate_to_arbitrary_vector(numpy.asarray(_V), numpy.asarray(_A))
+    with use(backend_name, force=True):
+        got = _rotate_to_arbitrary_vector(numpy.asarray(_V), numpy.asarray(_A))
+    assert isinstance(got, numpy.ndarray)
+    numpy.testing.assert_array_equal(got, ref)


### PR DESCRIPTION
## What

Make `galpy.util._rotate_to_arbitrary_vector` (the batched "rotate v onto unit vector a" rotation-matrix builder) backend-agnostic.

## Why

It built its matrices with `numpy.tile` / `numpy.cross` / a preallocated `numpy.empty` with row-wise **in-place** assignment, plus boolean masked assignment for the degenerate (v ∥ a) rows — all of which reject torch tensors. It's on the path of `streamspraydf._setup_rot`, `streamgapdf`, `EllipsoidalPotential`, and `RotateAndTiltWrapperPotential`, so it crashes the moment a backend array flows in. This is the second leaf prereq (disjoint file, lands concurrently with #1083) for the streamspraydf sampler-core migration.

## Approach

- **numpy path byte-identical**: a verbatim `if xp is numpy:` branch (verified `array_equal`, including the masked-degenerate and `_dontcutsmall=True` paths).
- **backend branch**: out-of-place, differentiable — `xp.stack` for the cross-product matrix, `xp.where` for the ±I mask. The rotaxis-normalization denominator is **guarded** (`where(norm==0, 1, norm)`) so a v parallel to a — whose row is cut/masked anyway — does not NaN-poison AD gradients.
- `get_namespace`/`as_backend_constant` imported **lazily** inside the function to avoid a `util`↔`backend` import cycle (`galpy.backend._namespaces` imports `galpy.util._optional_deps` at load).

## Tests

New `tests/test_backend_util.py`: numpy/jax/torch value parity (including degenerate rows → ±I), that R is an actual rotation (`R·v̂ == a`, orthogonality), and grad-through with no NaN even with degenerate rows in the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm