### PR TITLE
streamgapdf: backend-agnostic analytic impulse kernels (jax/torch, differentiable)

### DIFF
--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -8,6 +8,7 @@ import numpy
 from scipy import integrate, interpolate, special
 
 from ..backend import get_namespace, is_backend_array
+from ..backend._namespaces import namespace_from_arrays
 from ..orbit import Orbit
 from ..potential import MovingObjectPotential, PlummerPotential, evaluateRforces
 from ..potential.Potential import _check_potential_list_and_deprecate
@@ -1308,7 +1309,9 @@ def impulse_deltav_plummer(v, y, b, w, GM, rs):
     -----
     - 2015-04-30 - Written based on Erkal's expressions - Bovy (IAS)
     """
-    xp = get_namespace(v, y, w)
+    xp = (
+        namespace_from_arrays((v, y, w)) or numpy
+    )  # data-first: leaf consumed by numpy streamgapdf setup
     if len(v.shape) == 1:
         v = xp.reshape(v, (1, 3))
         y = xp.reshape(y, (1, 1))
@@ -1378,7 +1381,9 @@ def impulse_deltav_plummer_curvedstream(v, x, b, w, x0, v0, GM, rs):
     -----
     - 2015-05-04 - Written based on above - Sanders (Cambridge)
     """
-    xp = get_namespace(v, x, w, x0, v0)
+    xp = (
+        namespace_from_arrays((v, x, w, x0, v0)) or numpy
+    )  # data-first: leaf consumed by numpy streamgapdf setup
     if len(v.shape) == 1:
         v = xp.reshape(v, (1, 3))
     if len(x.shape) == 1:
@@ -1406,7 +1411,9 @@ def HernquistX(s):
     """
     if not is_backend_array(s) and numpy.ndim(s) == 0 and s < 0.0:
         raise ValueError("s must be positive in Hernquist X function")
-    xp = get_namespace(s)
+    xp = (
+        namespace_from_arrays((s,)) or numpy
+    )  # data-first: leaf consumed by numpy streamgapdf setup
     s2 = s * s
     lt = s < 1.0
     eq = s == 1.0
@@ -1448,7 +1455,9 @@ def impulse_deltav_hernquist(v, y, b, w, GM, rs):
     - 2015-08-13 - Written using Wyn Evans calculation - Sanders (Cambridge)
 
     """
-    xp = get_namespace(v, y, w)
+    xp = (
+        namespace_from_arrays((v, y, w)) or numpy
+    )  # data-first: leaf consumed by numpy streamgapdf setup
     if len(v.shape) == 1:
         v = xp.reshape(v, (1, 3))
     nv = v.shape[0]
@@ -1521,7 +1530,9 @@ def impulse_deltav_hernquist_curvedstream(v, x, b, w, x0, v0, GM, rs):
     - 2015-08-13 - Written using Wyn Evans calculation - Sanders (Cambridge)
 
     """
-    xp = get_namespace(v, x, w, x0, v0)
+    xp = (
+        namespace_from_arrays((v, x, w, x0, v0)) or numpy
+    )  # data-first: leaf consumed by numpy streamgapdf setup
     if len(v.shape) == 1:
         v = xp.reshape(v, (1, 3))
     if len(x.shape) == 1:

--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -7,6 +7,7 @@ from functools import wraps
 import numpy
 from scipy import integrate, interpolate, special
 
+from ..backend import get_namespace, is_backend_array
 from ..orbit import Orbit
 from ..potential import MovingObjectPotential, PlummerPotential, evaluateRforces
 from ..potential.Potential import _check_potential_list_and_deprecate
@@ -1307,45 +1308,42 @@ def impulse_deltav_plummer(v, y, b, w, GM, rs):
     -----
     - 2015-04-30 - Written based on Erkal's expressions - Bovy (IAS)
     """
+    xp = get_namespace(v, y, w)
     if len(v.shape) == 1:
-        v = numpy.reshape(v, (1, 3))
-        y = numpy.reshape(y, (1, 1))
+        v = xp.reshape(v, (1, 3))
+        y = xp.reshape(y, (1, 1))
     nv = v.shape[0]
     # Build the rotation matrices and their inverse
     rot = _rotation_vy(v)
     rotinv = _rotation_vy(v, inv=True)
     # Rotate the Plummer sphere's velocity to the stream frames
-    tilew = numpy.sum(rot * numpy.tile(w, (nv, 3, 1)), axis=-1)
+    tilew = xp.sum(rot * w, axis=-1)
     # Use Denis' expressions
-    wperp = numpy.sqrt(tilew[:, 0] ** 2.0 + tilew[:, 2] ** 2.0)
-    wpar = numpy.sqrt(numpy.sum(v**2.0, axis=1)) - tilew[:, 1]
+    wperp = xp.sqrt(tilew[:, 0] ** 2.0 + tilew[:, 2] ** 2.0)
+    wpar = xp.sqrt(xp.sum(v**2.0, axis=1)) - tilew[:, 1]
     wmag2 = wpar**2.0 + wperp**2.0
-    wmag = numpy.sqrt(wmag2)
-    out = numpy.empty_like(v)
+    wmag = xp.sqrt(wmag2)
     denom = wmag * ((b**2.0 + rs**2.0) * wmag2 + wperp**2.0 * y**2.0)
-    out[:, 0] = (b * wmag2 * tilew[:, 2] / wperp - y * wpar * tilew[:, 0]) / denom
-    out[:, 1] = -(wperp**2.0) * y / denom
-    out[:, 2] = -(b * wmag2 * tilew[:, 0] / wperp + y * wpar * tilew[:, 2]) / denom
-    # deal w/ perpendicular impacts
-    wperp0Indx = numpy.fabs(wperp) < 10.0**-10.0
-    out[wperp0Indx, 0] = (
-        b * wmag2[wperp0Indx] - y[wperp0Indx] * wpar[wperp0Indx] * tilew[wperp0Indx, 0]
-    ) / denom[wperp0Indx]
-    out[wperp0Indx, 2] = (
-        -(
-            b * wmag2[wperp0Indx]
-            + y[wperp0Indx] * wpar[wperp0Indx] * tilew[wperp0Indx, 2]
-        )
-        / denom[wperp0Indx]
+    # perpendicular impacts: guard the dead 1/wperp branch so it does not NaN AD
+    wperp0Indx = xp.abs(wperp) < 10.0**-10.0
+    wperp_safe = xp.where(wperp0Indx, xp.ones_like(wperp), wperp)
+    col0 = xp.where(
+        wperp0Indx,
+        (b * wmag2 - y * wpar * tilew[:, 0]) / denom,
+        (b * wmag2 * tilew[:, 2] / wperp_safe - y * wpar * tilew[:, 0]) / denom,
+    )
+    col1 = -(wperp**2.0) * y / denom
+    col2 = xp.where(
+        wperp0Indx,
+        -(b * wmag2 + y * wpar * tilew[:, 2]) / denom,
+        -(b * wmag2 * tilew[:, 0] / wperp_safe + y * wpar * tilew[:, 2]) / denom,
+    )
+    out = xp.stack(
+        [xp.reshape(col0, (nv,)), xp.reshape(col1, (nv,)), xp.reshape(col2, (nv,))],
+        axis=-1,
     )
     # Rotate back to the original frame
-    return (
-        2.0
-        * GM
-        * numpy.sum(
-            rotinv * numpy.swapaxes(numpy.tile(out.T, (3, 1, 1)).T, 1, 2), axis=-1
-        )
-    )
+    return 2.0 * GM * xp.sum(rotinv * out[:, None, :], axis=-1)
 
 
 def impulse_deltav_plummer_curvedstream(v, x, b, w, x0, v0, GM, rs):
@@ -1380,33 +1378,45 @@ def impulse_deltav_plummer_curvedstream(v, x, b, w, x0, v0, GM, rs):
     -----
     - 2015-05-04 - Written based on above - Sanders (Cambridge)
     """
+    xp = get_namespace(v, x, w, x0, v0)
     if len(v.shape) == 1:
-        v = numpy.reshape(v, (1, 3))
+        v = xp.reshape(v, (1, 3))
     if len(x.shape) == 1:
-        x = numpy.reshape(x, (1, 3))
-    b0 = numpy.cross(w, v0)
-    b0 *= b / numpy.sqrt(numpy.sum(b0**2))
+        x = xp.reshape(x, (1, 3))
+    b0 = xp.stack(
+        [
+            w[1] * v0[2] - w[2] * v0[1],
+            w[2] * v0[0] - w[0] * v0[2],
+            w[0] * v0[1] - w[1] * v0[0],
+        ]
+    )
+    b0 = b0 * (b / xp.sqrt(xp.sum(b0**2)))
     b_ = b0 + x - x0
     w = w - v
-    wmag = numpy.sqrt(numpy.sum(w**2, axis=1))
-    bdotw = numpy.sum(b_ * w, axis=1) / wmag
-    denom = wmag * (numpy.sum(b_**2, axis=1) + rs**2 - bdotw**2)
+    wmag = xp.sqrt(xp.sum(w**2, axis=1))
+    bdotw = xp.sum(b_ * w, axis=1) / wmag
+    denom = wmag * (xp.sum(b_**2, axis=1) + rs**2 - bdotw**2)
     denom = 1.0 / denom
-    return -2.0 * GM * ((b_.T - bdotw * w.T / wmag) * denom).T
+    return -2.0 * GM * ((b_ - bdotw[:, None] * w / wmag[:, None]) * denom[:, None])
 
 
 def HernquistX(s):
     """
     Computes X function from equations (33) & (34) of Hernquist (1990)
     """
-    if s < 0.0:
+    if not is_backend_array(s) and numpy.ndim(s) == 0 and s < 0.0:
         raise ValueError("s must be positive in Hernquist X function")
-    elif s < 1.0:
-        return numpy.log((1 + numpy.sqrt(1 - s * s)) / s) / numpy.sqrt(1 - s * s)
-    elif s == 1.0:
-        return 1.0
-    else:
-        return numpy.arccos(1.0 / s) / numpy.sqrt(s * s - 1)
+    xp = get_namespace(s)
+    s2 = s * s
+    lt = s < 1.0
+    eq = s == 1.0
+    # branchless: guard each regime's argument so dead branches carry no NaN/inf
+    one_m_s2 = xp.where(lt, 1.0 - s2, xp.ones_like(s2))  # >0 only where used (s<1)
+    r_lt = xp.sqrt(one_m_s2)
+    val_lt = xp.log((1.0 + r_lt) / s) / r_lt
+    s_gt = xp.where(s > 1.0, s, 2.0 * xp.ones_like(s2))  # >1 only where used (s>1)
+    val_gt = xp.arccos(1.0 / s_gt) / xp.sqrt(s_gt * s_gt - 1)
+    return xp.where(lt, val_lt, xp.where(eq, xp.ones_like(s2), val_gt))
 
 
 def impulse_deltav_hernquist(v, y, b, w, GM, rs):
@@ -1438,64 +1448,44 @@ def impulse_deltav_hernquist(v, y, b, w, GM, rs):
     - 2015-08-13 - Written using Wyn Evans calculation - Sanders (Cambridge)
 
     """
+    xp = get_namespace(v, y, w)
     if len(v.shape) == 1:
-        v = numpy.reshape(v, (1, 3))
+        v = xp.reshape(v, (1, 3))
     nv = v.shape[0]
     # Build the rotation matrices and their inverse
     rot = _rotation_vy(v)
     rotinv = _rotation_vy(v, inv=True)
     # Rotate the Plummer sphere's velocity to the stream frames
-    tilew = numpy.sum(rot * numpy.tile(w, (nv, 3, 1)), axis=-1)
-    wperp = numpy.sqrt(tilew[:, 0] ** 2.0 + tilew[:, 2] ** 2.0)
-    wpar = numpy.sqrt(numpy.sum(v**2.0, axis=1)) - tilew[:, 1]
+    tilew = xp.sum(rot * w, axis=-1)
+    wperp = xp.sqrt(tilew[:, 0] ** 2.0 + tilew[:, 2] ** 2.0)
+    wpar = xp.sqrt(xp.sum(v**2.0, axis=1)) - tilew[:, 1]
     wmag2 = wpar**2.0 + wperp**2.0
-    wmag = numpy.sqrt(wmag2)
-    B = numpy.sqrt(b**2.0 + wperp**2.0 * y**2.0 / wmag2)
+    wmag = xp.sqrt(wmag2)
+    B = xp.sqrt(b**2.0 + wperp**2.0 * y**2.0 / wmag2)
     denom = wmag * (B**2 - rs**2)
     denom = 1.0 / denom
-    s = numpy.sqrt(2.0 * B / (rs + B))
-    HernquistXv = numpy.vectorize(HernquistX)
-    Xfac = 1.0 - 2.0 * rs / (rs + B) * HernquistXv(s)
-    out = numpy.empty_like(v)
-    out[:, 0] = (
-        (b * tilew[:, 2] / wperp - y * wpar * tilew[:, 0] / wmag2) * denom * Xfac
+    s = xp.sqrt(2.0 * B / (rs + B))
+    Xfac = 1.0 - 2.0 * rs / (rs + B) * HernquistX(s)
+    # perpendicular impacts: guard the dead 1/wperp branch so it does not NaN AD
+    wperp0Indx = xp.abs(wperp) < 10.0**-10.0
+    wperp_safe = xp.where(wperp0Indx, xp.ones_like(wperp), wperp)
+    col0 = xp.where(
+        wperp0Indx,
+        (b - y * wpar * tilew[:, 0] / wmag2) * denom * Xfac,
+        (b * tilew[:, 2] / wperp_safe - y * wpar * tilew[:, 0] / wmag2) * denom * Xfac,
     )
-    out[:, 1] = -(wperp**2.0) * y * denom * Xfac / wmag2
-    out[:, 2] = (
-        -(b * tilew[:, 0] / wperp + y * wpar * tilew[:, 2] / wmag2) * denom * Xfac
+    col1 = -(wperp**2.0) * y * denom * Xfac / wmag2
+    col2 = xp.where(
+        wperp0Indx,
+        -(b + y * wpar * tilew[:, 2] / wmag2) * denom * Xfac,
+        -(b * tilew[:, 0] / wperp_safe + y * wpar * tilew[:, 2] / wmag2) * denom * Xfac,
     )
-    # deal w/ perpendicular impacts
-    wperp0Indx = numpy.fabs(wperp) < 10.0**-10.0
-    out[wperp0Indx, 0] = (
-        (
-            b
-            - y[wperp0Indx]
-            * wpar[wperp0Indx]
-            * tilew[wperp0Indx, 0]
-            / wmag2[wperp0Indx]
-        )
-        * denom[wperp0Indx]
-        * Xfac[wperp0Indx]
-    )
-    out[wperp0Indx, 2] = (
-        -(
-            b
-            + y[wperp0Indx]
-            * wpar[wperp0Indx]
-            * tilew[wperp0Indx, 2]
-            / wmag2[wperp0Indx]
-        )
-        * denom[wperp0Indx]
-        * Xfac[wperp0Indx]
+    out = xp.stack(
+        [xp.reshape(col0, (nv,)), xp.reshape(col1, (nv,)), xp.reshape(col2, (nv,))],
+        axis=-1,
     )
     # Rotate back to the original frame
-    return (
-        2.0
-        * GM
-        * numpy.sum(
-            rotinv * numpy.swapaxes(numpy.tile(out.T, (3, 1, 1)).T, 1, 2), axis=-1
-        )
-    )
+    return 2.0 * GM * xp.sum(rotinv * out[:, None, :], axis=-1)
 
 
 def impulse_deltav_hernquist_curvedstream(v, x, b, w, x0, v0, GM, rs):
@@ -1531,23 +1521,33 @@ def impulse_deltav_hernquist_curvedstream(v, x, b, w, x0, v0, GM, rs):
     - 2015-08-13 - Written using Wyn Evans calculation - Sanders (Cambridge)
 
     """
+    xp = get_namespace(v, x, w, x0, v0)
     if len(v.shape) == 1:
-        v = numpy.reshape(v, (1, 3))
+        v = xp.reshape(v, (1, 3))
     if len(x.shape) == 1:
-        x = numpy.reshape(x, (1, 3))
-    b0 = numpy.cross(w, v0)
-    b0 *= b / numpy.sqrt(numpy.sum(b0**2))
+        x = xp.reshape(x, (1, 3))
+    b0 = xp.stack(
+        [
+            w[1] * v0[2] - w[2] * v0[1],
+            w[2] * v0[0] - w[0] * v0[2],
+            w[0] * v0[1] - w[1] * v0[0],
+        ]
+    )
+    b0 = b0 * (b / xp.sqrt(xp.sum(b0**2)))
     b_ = b0 + x - x0
     w = w - v
-    wmag = numpy.sqrt(numpy.sum(w**2, axis=1))
-    bdotw = numpy.sum(b_ * w, axis=1) / wmag
-    B = numpy.sqrt(numpy.sum(b_**2, axis=1) - bdotw**2)
+    wmag = xp.sqrt(xp.sum(w**2, axis=1))
+    bdotw = xp.sum(b_ * w, axis=1) / wmag
+    B = xp.sqrt(xp.sum(b_**2, axis=1) - bdotw**2)
     denom = wmag * (B**2 - rs**2)
     denom = 1.0 / denom
-    s = numpy.sqrt(2.0 * B / (rs + B))
-    HernquistXv = numpy.vectorize(HernquistX)
-    Xfac = 1.0 - 2.0 * rs / (rs + B) * HernquistXv(s)
-    return -2.0 * GM * ((b_.T - bdotw * w.T / wmag) * Xfac * denom).T
+    s = xp.sqrt(2.0 * B / (rs + B))
+    Xfac = 1.0 - 2.0 * rs / (rs + B) * HernquistX(s)
+    return (
+        -2.0
+        * GM
+        * ((b_ - bdotw[:, None] * w / wmag[:, None]) * Xfac[:, None] * denom[:, None])
+    )
 
 
 def _a_integrand(T, y, b, w, pot, compt):
@@ -2083,4 +2083,7 @@ def impulse_deltav_plummerstream_curvedstream(
 
 
 def _rotation_vy(v, inv=False):
-    return _rotate_to_arbitrary_vector(v, [0, 1, 0], inv)
+    a = [0, 1, 0]  # numpy path: list kept verbatim (byte-identical)
+    if is_backend_array(v):  # backend: anchor the target axis on v's namespace
+        a = get_namespace(v).asarray(a, dtype=v.dtype)
+    return _rotate_to_arbitrary_vector(v, a, inv)

--- a/tests/test_backend_streamgapdf.py
+++ b/tests/test_backend_streamgapdf.py
@@ -1,0 +1,294 @@
+###############################################################################
+# test_backend_streamgapdf.py: backend (jax/torch) coverage for the analytic
+# impulse-approximation kernels of streamgapdf (Plummer / Hernquist, straight &
+# curved-stream, HernquistX, _rotation_vy). The numpy path is byte-identical
+# (test_streamgapdf_impulse unchanged); this exercises the resolved-namespace
+# dispatch:
+#   (a) value parity numpy<->jax<->torch of every kernel (incl. the wperp->0
+#       degenerate perpendicular-impact branch and all three HernquistX
+#       regimes), reusing the test_streamgapdf_impulse configs with FIXED seeds,
+#   (b) grad-vs-FD of ||plummer_curvedstream||^2 w.r.t. b/GM/rs/w and of
+#       HernquistX across regimes (jax.grad / torch.autograd vs central FD).
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+from galpy.backend import as_numpy, is_backend_array
+from galpy.df.streamgapdf import (
+    HernquistX,
+    _rotation_vy,
+    impulse_deltav_hernquist,
+    impulse_deltav_hernquist_curvedstream,
+    impulse_deltav_plummer,
+    impulse_deltav_plummer_curvedstream,
+)
+
+
+def _to_backend(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.asarray(x)
+
+
+# ------- Fixed-seed input configs (mirror test_streamgapdf_impulse) -------
+def _make_cases():
+    numpy.random.seed(12345)
+    xpos = numpy.random.normal(size=20)
+    vb = numpy.zeros((20, 3))
+    vb[:, 0] = 3.4
+    xposc = numpy.array([xpos, numpy.zeros(20), numpy.zeros(20)]).T
+    wperp_nonzero = numpy.array([0.0, numpy.pi / 2.0, 0.0])
+    # s spanning all three HernquistX regimes incl. near s=1
+    sarr = numpy.concatenate(
+        [
+            numpy.linspace(1e-6, 0.999999, 30),
+            numpy.array([1.0 - 1e-11, 1.0, 1.0 + 1e-11]),
+            numpy.linspace(1.000001, numpy.sqrt(2.0), 30),
+        ]
+    )
+    return {
+        "plummer_bunch": (
+            impulse_deltav_plummer,
+            dict(v=vb.copy(), y=xpos.copy(), b=3.0, w=wperp_nonzero, GM=1.5, rs=4.0),
+        ),
+        # perpendicular impact -> wperp==0 degenerate (guarded) branch
+        "plummer_perp": (
+            impulse_deltav_plummer,
+            dict(
+                v=numpy.array([[0.0, numpy.pi, 0.0]]),
+                y=numpy.array([0.0]),
+                b=3.0,
+                w=wperp_nonzero,
+                GM=1.5,
+                rs=4.0,
+            ),
+        ),
+        "plummer_curved_bunch": (
+            impulse_deltav_plummer_curvedstream,
+            dict(
+                v=vb.copy(),
+                x=xposc.copy(),
+                b=3.0,
+                w=wperp_nonzero,
+                x0=numpy.array([0.0, 0.0, 0.0]),
+                v0=numpy.array([3.4, 0.0, 0.0]),
+                GM=numpy.pi,
+                rs=numpy.exp(1.0),
+            ),
+        ),
+        "plummer_curved_single": (
+            impulse_deltav_plummer_curvedstream,
+            dict(
+                v=numpy.array([[3.4, 0.1, 0.2]]),
+                x=numpy.array([[4.0, 0.1, 0.0]]),
+                b=3.0,
+                w=numpy.array([0.2, 1.1, 0.3]),
+                x0=numpy.array([0.0, 0.0, 0.0]),
+                v0=numpy.array([3.4, 0.1, 0.2]),
+                GM=1.5,
+                rs=4.0,
+            ),
+        ),
+        "hernquist_bunch": (
+            impulse_deltav_hernquist,
+            dict(
+                v=vb.copy(), y=xpos.copy(), b=3.0, w=wperp_nonzero, GM=numpy.pi, rs=2.0
+            ),
+        ),
+        # perpendicular impact -> wperp==0 degenerate (guarded) branch
+        "hernquist_perp": (
+            impulse_deltav_hernquist,
+            dict(
+                v=numpy.array([[0.0, numpy.pi, 0.0]]),
+                y=numpy.array([2.0]),
+                b=3.0,
+                w=wperp_nonzero,
+                GM=1.5,
+                rs=4.0,
+            ),
+        ),
+        "hernquist_curved_bunch": (
+            impulse_deltav_hernquist_curvedstream,
+            dict(
+                v=vb.copy(),
+                x=xposc.copy(),
+                b=3.0,
+                w=wperp_nonzero,
+                x0=numpy.array([0.0, 0.0, 0.0]),
+                v0=numpy.array([3.4, 0.0, 0.0]),
+                GM=numpy.pi,
+                rs=numpy.exp(1.0),
+            ),
+        ),
+        "hernquist_curved_single": (
+            impulse_deltav_hernquist_curvedstream,
+            dict(
+                v=numpy.array([[3.4, 0.1, 0.2]]),
+                x=numpy.array([[4.0, 0.1, 0.0]]),
+                b=3.0,
+                w=numpy.array([0.2, 1.1, 0.3]),
+                x0=numpy.array([0.0, 0.0, 0.0]),
+                v0=numpy.array([3.4, 0.1, 0.2]),
+                GM=1.5,
+                rs=4.0,
+            ),
+        ),
+        "hernquistX": (HernquistX, dict(s=sarr)),
+        "rotation_vy_fwd": (_rotation_vy, dict(v=vb.copy(), inv=False)),
+        "rotation_vy_inv": (_rotation_vy, dict(v=vb.copy(), inv=True)),
+    }
+
+
+CASES = _make_cases()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("name", list(CASES))
+def test_kernel_parity(backend, name):
+    fn, kwargs = CASES[name]
+    ref = numpy.asarray(fn(**kwargs))
+    bkwargs = {
+        k: (_to_backend(backend, v) if isinstance(v, numpy.ndarray) else v)
+        for k, v in kwargs.items()
+    }
+    got = fn(**bkwargs)
+    assert is_backend_array(got), f"{name} on {backend} did not return a backend array"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-10, atol=1e-12)
+
+
+# ------- grad-vs-FD: ||plummer_curvedstream||^2 w.r.t. b/GM/rs/w -------
+_GRAD_CFG = dict(
+    v=numpy.array([[3.4, 0.1, 0.2], [3.3, -0.1, 0.15]]),
+    x=numpy.array([[4.0, 0.1, 0.0], [3.5, -0.2, 0.1]]),
+    b=3.0,
+    w=numpy.array([0.2, 1.1, 0.3]),
+    x0=numpy.array([0.0, 0.0, 0.0]),
+    v0=numpy.array([3.4, 0.1, 0.2]),
+    GM=1.5,
+    rs=4.0,
+)
+
+
+def _loss_np(b, GM, rs, w):
+    c = _GRAD_CFG
+    kick = impulse_deltav_plummer_curvedstream(
+        c["v"], c["x"], b, w, c["x0"], c["v0"], GM, rs
+    )
+    return float(numpy.sum(kick**2))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("param", ["b", "GM", "rs"])
+def test_plummer_curved_grad_scalar_vs_fd(backend, param):
+    c = _GRAD_CFG
+    base = dict(b=c["b"], GM=c["GM"], rs=c["rs"], w=c["w"])
+    h = 1e-6
+    lo = dict(base)
+    lo[param] = base[param] - h
+    hi = dict(base)
+    hi[param] = base[param] + h
+    gfd = (_loss_np(**hi) - _loss_np(**lo)) / (2.0 * h)
+
+    def loss_backend(bval, GMval, rsval, wval):
+        kick = impulse_deltav_plummer_curvedstream(
+            _to_backend(backend, c["v"]),
+            _to_backend(backend, c["x"]),
+            bval,
+            wval,
+            _to_backend(backend, c["x0"]),
+            _to_backend(backend, c["v0"]),
+            GMval,
+            rsval,
+        )
+        return (kick**2).sum()
+
+    if backend == "jax":
+        args = dict(
+            bval=jnp.asarray(c["b"]),
+            GMval=jnp.asarray(c["GM"]),
+            rsval=jnp.asarray(c["rs"]),
+            wval=jnp.asarray(c["w"]),
+        )
+        key = {"b": "bval", "GM": "GMval", "rs": "rsval"}[param]
+        g = float(jax.grad(lambda p: loss_backend(**{**args, key: p}))(args[key]))
+    else:
+        vals = {
+            "bval": torch.tensor(c["b"], requires_grad=(param == "b")),
+            "GMval": torch.tensor(c["GM"], requires_grad=(param == "GM")),
+            "rsval": torch.tensor(c["rs"], requires_grad=(param == "rs")),
+            "wval": torch.tensor(c["w"]),
+        }
+        key = {"b": "bval", "GM": "GMval", "rs": "rsval"}[param]
+        loss_backend(**vals).backward()
+        g = float(vals[key].grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_plummer_curved_grad_w_vs_fd(backend):
+    c = _GRAD_CFG
+    h = 1e-6
+    gfd = numpy.empty(3)
+    for i in range(3):
+        wl = c["w"].copy()
+        wl[i] -= h
+        wh = c["w"].copy()
+        wh[i] += h
+        gfd[i] = (
+            _loss_np(c["b"], c["GM"], c["rs"], wh)
+            - _loss_np(c["b"], c["GM"], c["rs"], wl)
+        ) / (2.0 * h)
+
+    def loss_backend(wval):
+        kick = impulse_deltav_plummer_curvedstream(
+            _to_backend(backend, c["v"]),
+            _to_backend(backend, c["x"]),
+            c["b"],
+            wval,
+            _to_backend(backend, c["x0"]),
+            _to_backend(backend, c["v0"]),
+            c["GM"],
+            c["rs"],
+        )
+        return (kick**2).sum()
+
+    if backend == "jax":
+        g = numpy.asarray(jax.grad(loss_backend)(jnp.asarray(c["w"])))
+    else:
+        wt = torch.tensor(c["w"], requires_grad=True)
+        loss_backend(wt).backward()
+        g = wt.grad.detach().cpu().numpy()
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("s0", [0.3, 0.7, 0.95, 1.05, 1.3])
+def test_hernquistX_grad_vs_fd(backend, s0):
+    h = 1e-7
+    gfd = (float(HernquistX(s0 + h)) - float(HernquistX(s0 - h))) / (2.0 * h)
+    if backend == "jax":
+        g = float(jax.grad(lambda s: HernquistX(s))(jnp.asarray(s0)))
+    else:
+        st = torch.tensor(s0, requires_grad=True)
+        HernquistX(st).backward()
+        g = float(st.grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
## streamgapdf: backend-agnostic analytic impulse kernels (jax/torch, differentiable)

Streams PR-4. Migrates the **analytic impulse-approximation kick kernels** in `galpy/df/streamgapdf.py` to numpy/jax/torch backend-agnostic + differentiable, keeping the numpy path **byte-identical**. This is the island-free slice of streamgapdf that stands alone — it needs neither a migrated `streamdf` (the class methods do) nor a migrated `Orbit` (the orbit-integration kernel variants do).

### Migrated
- `impulse_deltav_plummer` / `impulse_deltav_plummer_curvedstream` (the default setup kernel)
- `impulse_deltav_hernquist` / `impulse_deltav_hernquist_curvedstream`
- `HernquistX` — rewritten **branchless** (`numpy.vectorize` dropped; runs natively on arrays via nested `xp.where`, each regime's argument guarded so dead branches carry no NaN/inf into value **or** gradient)
- `_rotation_vy` — thin wrapper over the already-backend-agnostic `_rotate_to_arbitrary_vector` (#1084); keeps `[0,1,0]` as a Python list on numpy (byte-identical), anchors it on `v`'s namespace on the backend path

### numpy byte-identity (verified vs pre-migration baseline)
Data-first `get_namespace` dispatch → numpy inputs keep numpy ops. Confirmed **tobytes-identical** (max diff 0.0) over a battery including the degenerate `wperp→0` branch (plummer **and** hernquist), 1D/2D inputs, and `HernquistX` across all three regimes (`s<1`, `s==1`, `s>1`). The `wperp→0` masked in-place write becomes `xp.where` with a **guarded denominator** (`wperp_safe = where(wperp0Indx, 1, wperp)`) so eager two-branch `where` cannot 0/0-NaN-poison jax/torch autodiff — this also removes the pre-existing numpy "invalid value in divide" RuntimeWarnings.

### Out of scope (later PRs)
- scipy-quad `impulse_deltav_general*` → **PR-2** (dual-path via `galpy.backend.quadrature`)
- `impulse_deltav_{plummerstream,general_orbitintegration,general_fullplummerintegration}` → **PR-3** (need migrated Orbit)
- streamgapdf class methods (`_determine_*`, `_kick_interp*`, `_density_par_approx*`, `meanOmega*`, `minOpar`) → gated on migrating `streamdf` (they need its track to instantiate)

### Tests
New `tests/test_backend_streamgapdf.py`: numpy↔jax↔torch parity (rtol 1e-10) + grad-vs-FD (`jax.grad` / `torch.autograd` of the kick magnitude w.r.t. `b`/`GM`/`rs`/`w`, and `HernquistX` across regimes), with **fixed-seed inputs** (deliberately sidesteps the #66 RNG-flaky pattern). Local: byte-identity 10/10, `test_backend_streamgapdf.py` **40 passed under jax and 40 under torch**, existing `test_streamgapdf_impulse.py` 14 passed unchanged. Ledger untouched (these kernels aren't in the torch xfail ledger — the ledgered `general*`/orbit ones are PR-2/PR-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
