### PR TITLE
1D (linear-orbit) variational (dxdv) integration — RK + symplectic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             REQUIRES_JAX: false
           - os: ubuntu-latest
             python-version: "3.14"
-            TEST_FILES: tests/test_orbit.py tests/test_orbits.py tests/test_symplectic_dxdv.py -k 'not test_energy_jacobi_conservation'
+            TEST_FILES: tests/test_orbit.py tests/test_orbits.py tests/test_symplectic_dxdv.py tests/test_linear_dxdv.py -k 'not test_energy_jacobi_conservation'
             REQUIRES_PYNBODY: true
             REQUIRES_ASTROPY: true
             REQUIRES_ASTROQUERY: true

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -73,6 +73,7 @@ from .integrateLinearOrbit import (
     _ext_loaded,
     integrateLinearOrbit,
     integrateLinearOrbit_c,
+    integrateLinearOrbit_dxdv,
 )
 from .integratePlanarOrbit import (
     integratePlanarOrbit,
@@ -2363,17 +2364,17 @@ class Orbit:
         - 2026-06-09 - Dissipative-force support in C (3D) - Bovy (UofT)
 
         """
-        if not (self.phasedim() == 4 or self.phasedim() == 6):
+        if not (self.phasedim() == 2 or self.phasedim() == 4 or self.phasedim() == 6):
             raise AttributeError(
-                "integrate_dxdv is only implemented for 4D (planar) and 6D (3D) orbits"
+                "integrate_dxdv is only implemented for 2D (linear), 4D (planar) and 6D (3D) orbits"
             )
         # The C symplectic integrators (leapfrog_c/symplec4_c/symplec6_c) carry
         # the deviation via exact drift/kick tangent maps, so they are allowed
-        # for both planar (4D) and 3D (6D) orbits (allow_c_symplec); the
+        # for linear (2D), planar (4D) and 3D (6D) orbits (allow_c_symplec); the
         # pure-Python 'leapfrog'/'ias15_c' have no dxdv path, so those remain
         # rejected.
         self.check_integrator(
-            method, no_symplec=True, allow_c_symplec=self.phasedim() in (4, 6)
+            method, no_symplec=True, allow_c_symplec=self.phasedim() in (2, 4, 6)
         )
         pot = _check_potential_list_and_deprecate(pot)
         _check_potential_dim(self, pot)
@@ -2442,7 +2443,22 @@ class Orbit:
                     )
         # Implementation with parallel_map in Python
         if True or not "_c" in method or not ext_loaded or force_map:
-            if self.dim() == 2:
+            if self.dim() == 1:
+                # 1D (linear) orbit: the deviation is a raw [dx,dv] 2-vector,
+                # so rectIn/rectOut (cyl<->rect) are moot and not passed.
+                out, msg = integrateLinearOrbit_dxdv(
+                    self._pot,
+                    self.vxvv,
+                    dxdv,
+                    t,
+                    method,
+                    progressbar=progressbar,
+                    numcores=numcores,
+                    dt=dt,
+                    rtol=rtol,
+                    atol=atol,
+                )
+            elif self.dim() == 2:
                 out, msg = integratePlanarOrbit_dxdv(
                     self._pot,
                     self.vxvv,

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -6,7 +6,10 @@ from numpy.ctypeslib import ndpointer
 from scipy import integrate
 
 from .. import potential
-from ..potential.linearPotential import _evaluatelinearForces
+from ..potential.linearPotential import (
+    _evaluatelinearForce2derivs,
+    _evaluatelinearForces,
+)
 from ..potential.verticalPotential import verticalPotential
 from ..util import _load_extension_libs, symplecticode
 from ..util._optional_deps import _TQDM_LOADED
@@ -395,3 +398,227 @@ def _linearEOM(y, t, pot):
 
     """
     return [y[1], _evaluatelinearForces(pot, y[0], t=t)]
+
+
+def integrateLinearOrbit_dxdv_c(
+    pot, yo, dyo, t, int_method, rtol=None, atol=None, dt=None
+):
+    """
+    C integrate an ode for a LinearOrbit + phase-space volume dxdv
+
+    Parameters
+    ----------
+    pot : linearPotential or a combined potential formed using addition (pot1+pot2+…)
+    yo : numpy.ndarray
+        Initial condition [q,p], shape [2]
+    dyo : numpy.ndarray
+        Initial condition [dq,dp], shape [2]
+    t : numpy.ndarray
+        Set of times at which one wants the result
+    int_method : str
+        Integration method. One of 'leapfrog_c', 'rk4_c', 'rk6_c', 'symplec4_c', 'symplec6_c', 'dopr54_c', 'dop853_c'
+    rtol : float, optional
+        Relative tolerance. Default is None
+    atol : float, optional
+        Absolute tolerance. Default is None
+    dt : float, optional
+        Force integrator to use this stepsize (default is to automatically determine one)
+
+    Returns
+    -------
+    tuple
+        (y,err)
+        y,dy : array, shape (len(t),4) = [x,v,dx,dv]
+        err: error message if not zero, 1: maximum step reduction happened for adaptive integrators
+
+    Notes
+    -----
+    - 2026-07-08 - Written - Bovy (UofT)
+
+    """
+    rtol, atol = _parse_tol(rtol, atol)
+    npot, pot_type, pot_args, pot_tfuncs = _parse_pot(pot)
+    pot_tfuncs = _prep_tfuncs(pot_tfuncs)
+    int_method_c = _parse_integrator(int_method)
+    if dt is None:
+        dt = -9999.99
+    yo = numpy.concatenate((yo, dyo))
+
+    # Set up result array
+    result = numpy.empty((len(t), 4))
+    err = ctypes.c_int(0)
+
+    # Set up the C code
+    ndarrayFlags = ("C_CONTIGUOUS", "WRITEABLE")
+    integrationFunc = _lib.integrateLinearOrbit_dxdv
+    integrationFunc.argtypes = [
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_int,
+        ndpointer(dtype=numpy.int32, flags=ndarrayFlags),
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.c_void_p,
+        ctypes.c_double,
+        ctypes.c_double,
+        ctypes.c_double,
+        ndpointer(dtype=numpy.float64, flags=ndarrayFlags),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.c_int,
+    ]
+
+    # Array requirements, first store old order
+    f_cont = [yo.flags["F_CONTIGUOUS"], t.flags["F_CONTIGUOUS"]]
+    yo = numpy.require(yo, dtype=numpy.float64, requirements=["C", "W"])
+    t = numpy.require(t, dtype=numpy.float64, requirements=["C", "W"])
+    result = numpy.require(result, dtype=numpy.float64, requirements=["C", "W"])
+
+    # Run the C code
+    integrationFunc(
+        yo,
+        ctypes.c_int(len(t)),
+        t,
+        ctypes.c_int(npot),
+        pot_type,
+        pot_args,
+        pot_tfuncs,
+        ctypes.c_double(dt),
+        ctypes.c_double(rtol),
+        ctypes.c_double(atol),
+        result,
+        ctypes.byref(err),
+        ctypes.c_int(int_method_c),
+    )
+
+    if err.value == -10:  # pragma: no cover
+        raise KeyboardInterrupt("Orbit integration interrupted by CTRL-C (SIGINT)")
+
+    # Reset input arrays
+    if f_cont[0]:
+        yo = numpy.asfortranarray(yo)
+    if f_cont[1]:
+        t = numpy.asfortranarray(t)
+
+    return (result, err.value)
+
+
+def integrateLinearOrbit_dxdv(
+    pot,
+    yo,
+    dyo,
+    t,
+    int_method,
+    rtol=None,
+    atol=None,
+    progressbar=True,
+    dt=None,
+    numcores=1,
+):
+    """
+    Integrate an ode for a LinearOrbit + phase-space volume dxdv
+
+    Parameters
+    ----------
+    pot : linearPotential or a combined potential formed using addition (pot1+pot2+…)
+    yo : numpy.ndarray
+        Initial condition [q,p], shape [N,2]
+    dyo : numpy.ndarray
+        Initial condition [dq,dp], shape [N,2]
+    t : numpy.ndarray
+        Set of times at which one wants the result
+    int_method : str
+        Integration method
+    rtol : float, optional
+        Relative tolerance. Default is None
+    atol : float, optional
+        Absolute tolerance. Default is None
+    progressbar : bool, optional
+        If True, display a tqdm progress bar when integrating multiple orbits (requires tqdm to be installed!).
+    dt : float, optional
+        Force integrator to use this stepsize (default is to automatically determine one)
+    numcores : int, optional
+        Number of cores to use for multi-processing
+
+    Returns
+    -------
+    tuple
+        (y,err)
+        y,dy : array, shape (N,len(t),4) = [x,v,dx,dv]
+        err: error message if not zero, 1: maximum step reduction happened for adaptive integrators
+
+    Notes
+    -----
+    - 2026-07-08 - Written - Bovy (UofT)
+
+    """
+    # No cyl<->rect transform in 1D: the deviation is the raw [dx,dv]
+    this_yo = numpy.hstack((yo, dyo))
+    if int_method.lower() == "dop853" or int_method.lower() == "odeint":
+        if int_method.lower() == "dop853":
+            if rtol is None:
+                rtol = 1e-12
+            if atol is None:
+                atol = 1e-12
+            integrator = dop853
+            extra_kwargs = {"rtol": rtol, "atol": atol}
+        else:
+            integrator = integrate.odeint
+            extra_kwargs = {"rtol": rtol, "atol": atol}
+
+        def integrate_for_map(vxvv):
+            return integrator(_linearEOM_dxdv, vxvv, t=t, args=(pot,), **extra_kwargs)
+
+    else:  # Assume we are forcing parallel_mapping of a C integrator...
+
+        def integrate_for_map(vxvv):
+            return integrateLinearOrbit_dxdv_c(
+                pot,
+                numpy.copy(vxvv[:2]),
+                numpy.copy(vxvv[2:]),
+                t,
+                int_method,
+                dt=dt,
+                rtol=rtol,
+                atol=atol,
+            )[0]
+
+    if len(this_yo) == 1:  # Can't map a single value...
+        out = numpy.atleast_3d(integrate_for_map(this_yo[0]).T).T
+    else:
+        out = numpy.array(
+            parallel_map(
+                integrate_for_map, this_yo, progressbar=progressbar, numcores=numcores
+            )
+        )
+    return out, numpy.zeros(len(yo))
+
+
+def _linearEOM_dxdv(y, t, pot):
+    """
+    The one-dimensional variational (dxdv) equation-of-motion, state [x,v,dx,dv]
+
+    Parameters
+    ----------
+    y : list or numpy.ndarray
+        Current augmented phase-space position [x,v,dx,dv]
+    t : float
+        Current time
+    pot : linearPotential
+        LinearPotential instance
+
+    Returns
+    -------
+    list
+        dy/dt
+
+    Notes
+    -----
+    - 2026-07-08 - Bovy (UofT)
+
+    """
+    return [
+        y[1],
+        _evaluatelinearForces(pot, y[0], t=t),
+        y[3],
+        -_evaluatelinearForce2derivs(pot, y[0], t=t) * y[2],
+    ]

--- a/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateLinearOrbit.c
@@ -34,6 +34,14 @@ void evalLinearForce(double, double *, double *,
 		     int, struct potentialArg *);
 void evalLinearDeriv(double, double *, double *,
 		     int, struct potentialArg *);
+void evalLinearDeriv_dxdv(double, double *, double *,
+			  int, struct potentialArg *);
+// Augmented force+Hessian evaluator (linear/1D) for the symplectic variational
+// steppers leapfrog_dxdv/symplec4_dxdv/symplec6_dxdv (dim_base=1): the base
+// acceleration and, per deviation column, the kick tangent K.dq_j with
+// K= dF/dx= -linear2deriv (see integrateLinearOrbit_dxdv).
+void evalLinearForce_dxdv(double, double *, double *,
+			  int, struct potentialArg *, int);
 /*
   Actual functions
 */
@@ -47,14 +55,17 @@ void parse_leapFuncArgs_Linear(int npot,struct potentialArg * potentialArgs,
     switch ( *(*pot_type)++ ) {
     default: //verticalPotential
       potentialArgs->linearForce= &verticalPotentialLinearForce;
+      potentialArgs->linear2deriv= &verticalPotentialLinear2deriv;
       break;
     case 31: // KGPotential
       potentialArgs->linearForce= &KGPotentialLinearForce;
+      potentialArgs->linear2deriv= &KGPotentialLinear2deriv;
       potentialArgs->nargs= 4;
       potentialArgs->ntfuncs= 0;
       break;
     case 32: // IsothermalDiskPotential
       potentialArgs->linearForce= &IsothermalDiskPotentialLinearForce;
+      potentialArgs->linear2deriv= &IsothermalDiskPotentialLinear2deriv;
       potentialArgs->nargs= 2;
       potentialArgs->ntfuncs= 0;
       break;
@@ -224,4 +235,109 @@ void evalLinearDeriv(double t, double *q, double *a,
 		     int nargs, struct potentialArg * potentialArgs){
   *a++= *(q+1);
   *a= calcLinearForce(*q,t,nargs,potentialArgs);
+}
+
+/*
+  1D (linear) variational (state-transition/dxdv) integration. Mirrors
+  integratePlanarOrbit_dxdv: the RK integrators propagate the 4D state
+  [x,v,dx,dv] via the variational RHS evalLinearDeriv_dxdv (dim=4); the
+  symplectic ones (leapfrog=0/symplec4=3/symplec6=4) carry the deviation
+  through the closed-form drift/kick tangent maps of the shared *_dxdv steppers
+  in bovy_symplecticode.c (dim_base=1, nde=1 deviation column). ias15 has no
+  dxdv path and is blocked upstream by Orbit.integrate_dxdv (check_integrator).
+  There is no cyl<->rect transform in 1D, so the deviation is the raw [dx,dv].
+*/
+EXPORT void integrateLinearOrbit_dxdv(double *yo,
+				      int nt,
+				      double *t,
+				      int npot,
+				      int * pot_type,
+				      double * pot_args,
+				      tfuncs_type_arr pot_tfuncs,
+				      double dt,
+				      double rtol,
+				      double atol,
+				      double *result,
+				      int * err,
+				      int odeint_type){
+  //Set up the forces
+  int dim;
+  struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
+  parse_leapFuncArgs_Linear(npot,potentialArgs,&pot_type,&pot_args,&pot_tfuncs);
+  //Integrate
+  void (*odeint_func)(void (*func)(double, double *, double *,
+				   int, struct potentialArg *),
+		      int,
+		      double *,
+		      int, double, double *,
+		      int, struct potentialArg *,
+		      double, double,
+		      double *,int *);
+  void (*odeint_deriv_func)(double, double *, double *,
+			    int,struct potentialArg *);
+  odeint_func= NULL;
+  odeint_deriv_func= &evalLinearDeriv_dxdv;
+  dim= 4;
+  switch ( odeint_type ) {
+  case 1: //RK4
+    odeint_func= &bovy_rk4;
+    break;
+  case 2: //RK6
+    odeint_func= &bovy_rk6;
+    break;
+  case 5: //DOPR54
+    odeint_func= &bovy_dopr54;
+    break;
+  case 6: //DOP853
+    odeint_func= &dop853;
+    break;
+  }
+  switch ( odeint_type ) {
+  case 0: //leapfrog
+    leapfrog_dxdv(&evalLinearForce_dxdv,&evalLinearForce,1,1,yo,nt,dt,t,
+		  npot,potentialArgs,rtol,atol,result,err);
+    break;
+  case 3: //symplec4
+    symplec4_dxdv(&evalLinearForce_dxdv,&evalLinearForce,1,1,yo,nt,dt,t,
+		  npot,potentialArgs,rtol,atol,result,err);
+    break;
+  case 4: //symplec6
+    symplec6_dxdv(&evalLinearForce_dxdv,&evalLinearForce,1,1,yo,nt,dt,t,
+		  npot,potentialArgs,rtol,atol,result,err);
+    break;
+  default: //RK method selected above
+    odeint_func(odeint_deriv_func,dim,yo,nt,dt,t,npot,potentialArgs,rtol,atol,
+		result,err);
+  }
+  //Free allocated memory
+  free_potentialArgs(npot,potentialArgs);
+  free(potentialArgs);
+  //Done!
+}
+
+// RK variational RHS, state dim=4 [x,v,dx,dv]: base [v,F] and deviation
+// [dv, K.dx] with K= dF/dx= -linear2deriv (mirror evalPlanarRectDeriv_dxdv).
+void evalLinearDeriv_dxdv(double t, double *q, double *a,
+			  int nargs, struct potentialArg * potentialArgs){
+  *a++= *(q+1);
+  *a++= calcLinearForce(*q,t,nargs,potentialArgs);
+  *a++= *(q+3);
+  *a= -calcLinear2deriv(*q,t,nargs,potentialArgs) * *(q+2);
+}
+
+// Augmented force for the symplectic variational steppers (dim_base=1): fill
+// the base acceleration (block 0, byte-identical to evalLinearForce) and, per
+// deviation column j, the kick tangent K.dq_j with K= dF/dx= -linear2deriv.
+void evalLinearForce_dxdv(double t, double *q, double *a,
+			  int nargs, struct potentialArg * potentialArgs,
+			  int nde){
+  int jj;
+  double K;
+  //Base acceleration: identical call to evalLinearForce (bit-identical base)
+  *a= calcLinearForce(*q,t,nargs,potentialArgs);
+  if ( nde == 0 ) return;
+  K= -calcLinear2deriv(*q,t,nargs,potentialArgs);
+  //Kick tangent per deviation column: dv_j += h K dx_j
+  for (jj=1; jj <= nde; jj++)
+    *(a+jj)= K * *(q+jj);
 }

--- a/galpy/potential/IsothermalDiskPotential.py
+++ b/galpy/potential/IsothermalDiskPotential.py
@@ -45,9 +45,18 @@ class IsothermalDiskPotential(linearPotential):
         self._H = sigma / numpy.sqrt(8.0 * numpy.pi * self._amp)
         self._amp = 1.0  # Need to manually set to 1, because amp is now contained in the combination of H and sigma^2
         self.hasC = True
+        self.hasC_dxdv = True  # 1D variational (dxdv) second derivative in C
 
     def _evaluate(self, x, t=0.0):
         return 2.0 * self._sigma2 * numpy.log(numpy.cosh(0.5 * x / self._H))
 
     def _force(self, x, t=0.0):
         return -self._sigma2 * numpy.tanh(0.5 * x / self._H) / self._H
+
+    def _force2deriv(self, x, t=0.0):
+        # d^2 Phi / dx^2 = sigma^2 / (2 H^2) sech^2(x/2H)
+        return (
+            self._sigma2
+            / (2.0 * self._H**2.0)
+            * (1.0 - numpy.tanh(0.5 * x / self._H) ** 2.0)
+        )

--- a/galpy/potential/KGPotential.py
+++ b/galpy/potential/KGPotential.py
@@ -66,9 +66,14 @@ class KGPotential(linearPotential):
         self._D = D
         self._D2 = self._D**2.0
         self.hasC = True
+        self.hasC_dxdv = True  # 1D variational (dxdv) second derivative in C
 
     def _evaluate(self, x, t=0.0):
         return self._K * (numpy.sqrt(x**2.0 + self._D2) - self._D) + self._F * x**2.0
 
     def _force(self, x, t=0.0):
         return -x * (self._K / numpy.sqrt(x**2 + self._D2) + 2.0 * self._F)
+
+    def _force2deriv(self, x, t=0.0):
+        # d^2 Phi / dx^2 = K D^2 / (x^2+D^2)^(3/2) + 2F
+        return self._K * self._D2 / (x**2.0 + self._D2) ** 1.5 + 2.0 * self._F

--- a/galpy/potential/linearCompositePotential.py
+++ b/galpy/potential/linearCompositePotential.py
@@ -157,3 +157,22 @@ class linearCompositePotential(baseCompositePotential, linearPotential):
 
         """
         return sum(pot._force_nodecorator(x, t=t) for pot in self._potlist)
+
+    def _force2deriv(self, x, t=0.0):
+        """
+        Evaluate the potential second derivative d^2 Phi / dx^2 at (x,t).
+
+        Parameters
+        ----------
+        x : float
+            Position.
+        t : float, optional
+            Time (default: 0.0).
+
+        Returns
+        -------
+        float
+            d^2 Phi / dx^2 at (x,t).
+
+        """
+        return sum(pot._force2deriv_nodecorator(x, t=t) for pot in self._potlist)

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -293,6 +293,19 @@ class linearPotential:
         except AttributeError:  # pragma: no cover
             raise PotentialError("'_force' function not implemented for this potential")
 
+    def _force2deriv_nodecorator(self, x, t=0.0):
+        # Second derivative of the potential, d^2 Phi / dx^2 (the potential
+        # second derivative, matching the R2deriv/z2deriv convention). Used by
+        # the 1D variational (dxdv) equations; the RHS applies the sign to get
+        # the force gradient dF/dx = -d^2 Phi / dx^2. Separate, so it can be
+        # used during orbit integration.
+        try:
+            return self._amp * self._force2deriv(x, t=t)
+        except AttributeError:  # pragma: no cover
+            raise PotentialError(
+                "'_force2deriv' function not implemented for this potential"
+            )
+
     def plot(self, t=0.0, min=-15.0, max=15, ns=21, savefilename=None):
         """
         Plot the potential
@@ -417,6 +430,11 @@ def evaluatelinearForces(Pot, x, t=0.0):
 def _evaluatelinearForces(Pot, x, t=0.0):
     """Raw, undecorated function for internal use"""
     return Pot._force_nodecorator(x, t=t)
+
+
+def _evaluatelinearForce2derivs(Pot, x, t=0.0):
+    """Raw, undecorated d^2 Phi / dx^2 for internal use (1D variational eqns)"""
+    return Pot._force2deriv_nodecorator(x, t=t)
 
 
 @potential_list_of_potentials_input

--- a/galpy/potential/potential_c_ext/IsothermalDiskPotential.c
+++ b/galpy/potential/potential_c_ext/IsothermalDiskPotential.c
@@ -6,3 +6,11 @@ double IsothermalDiskPotentialLinearForce(double x, double t,
   double * args= potentialArgs->args;
   return - *args * tanh ( x / *(args+1) );
 }
+// d^2 Phi / dx^2 = amp / (2H) * sech^2(x/2H) = amp/args[1] * (1-tanh^2(x/args[1]))
+// (args[0]=amp=sigma^2/H, args[1]=2H); differentiating -Force=amp tanh(x/2H).
+double IsothermalDiskPotentialLinear2deriv(double x, double t,
+					   struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  double tx= tanh ( x / *(args+1) );
+  return *args / *(args+1) * ( 1. - tx * tx );
+}

--- a/galpy/potential/potential_c_ext/KGPotential.c
+++ b/galpy/potential/potential_c_ext/KGPotential.c
@@ -12,3 +12,11 @@ double KGPotentialLinearForce(double x, double t,
   //double F= *(args+3);
   return - *args * x * ( *(args+1) / sqrt ( x * x + *(args+2) ) + *(args+3) );
 }
+// d^2 Phi / dx^2 = amp * ( K D^2 / (x^2+D^2)^(3/2) + 2F ) (args+3 holds 2F);
+// differentiating -Force = amp x (K/sqrt(x^2+D^2)+2F).
+double KGPotentialLinear2deriv(double x, double t,
+			       struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  return *args * ( *(args+1) * *(args+2) / pow( x * x + *(args+2), 1.5 )
+		   + *(args+3) );
+}

--- a/galpy/potential/potential_c_ext/galpy_potentials.c
+++ b/galpy/potential/potential_c_ext/galpy_potentials.c
@@ -11,6 +11,9 @@ void init_potentialArgs(int npot, struct potentialArg * potentialArgs){
     (potentialArgs+ii)->z2deriv= NULL;
     (potentialArgs+ii)->Rzderiv= NULL;
     (potentialArgs+ii)->zphideriv= NULL;
+    // Linear (1D) second derivative for the 1D variational equations; set in
+    // the linear parse for every linear potential (verticalPotential/KG/IsoDisk).
+    (potentialArgs+ii)->linear2deriv= NULL;
     // Rectangular dissipative-force Jacobian: NULL for conservative
     // potentials and for dissipative forces without a C Jacobian; set in
     // parse_* only for dissipative forces that provide it.
@@ -359,6 +362,20 @@ double calcLinearForce(double x, double t,
   }
   potentialArgs-= nargs;
   return force;
+}
+// 1D potential second derivative d^2 Phi / dx^2, summed over components, for
+// the 1D variational (dxdv) equations. Mirrors calcLinearForce: every linear
+// potential wires linear2deriv in the linear parse, so no NULL guard is needed.
+double calcLinear2deriv(double x, double t,
+			int nargs, struct potentialArg * potentialArgs){
+  int ii;
+  double deriv= 0.;
+  for (ii=0; ii < nargs; ii++){
+    deriv+= potentialArgs->linear2deriv(x,t,potentialArgs);
+    potentialArgs++;
+  }
+  potentialArgs-= nargs;
+  return deriv;
 }
 double calcDensity(double R, double Z, double phi, double t,
 		   int nargs, struct potentialArg * potentialArgs){

--- a/galpy/potential/potential_c_ext/galpy_potentials.h
+++ b/galpy/potential/potential_c_ext/galpy_potentials.h
@@ -47,6 +47,11 @@ struct potentialArg{
 			    struct potentialArg *);
   double (*linearForce)(double x, double t,
 			 struct potentialArg *);
+  // Linear (1D) potential second derivative d^2 Phi / dx^2, for the 1D
+  // variational (dxdv) equations; the RHS applies the sign to get the force
+  // gradient K = dF/dx = -d^2 Phi / dx^2.
+  double (*linear2deriv)(double x, double t,
+			 struct potentialArg *);
   double (*dens)(double R, double Z, double phi, double t,
 		 struct potentialArg *);
   // For forces that require velocity input (e.g., dynam fric)
@@ -201,6 +206,7 @@ double calcPlanarphi2deriv(double, double, double,
 double calcPlanarRphideriv(double, double, double,
 			   int, struct potentialArg *);
 double calcLinearForce(double, double, int, struct potentialArg *);
+double calcLinear2deriv(double, double, int, struct potentialArg *);
 double calcDensity(double, double, double,double, int, struct potentialArg *);
 void rotate(double *, double *, double *, double *);
 void rotate_force(double *, double *, double *,double *);
@@ -211,6 +217,7 @@ double ZeroForce(double,double,double,double,
 		 struct potentialArg *);
 //verticalPotential
 double verticalPotentialLinearForce(double,double,struct potentialArg *);
+double verticalPotentialLinear2deriv(double,double,struct potentialArg *);
 //LogarithmicHaloPotential
 double LogarithmicHaloPotentialEval(double ,double , double, double,
 				    struct potentialArg *);
@@ -796,9 +803,11 @@ double PerfectEllipsoidPotentialmdensDeriv(double,double *);
 
 //KGPotential
 double KGPotentialLinearForce(double,double,struct potentialArg *);
+double KGPotentialLinear2deriv(double,double,struct potentialArg *);
 
 //IsothermalDiskPotential
 double IsothermalDiskPotentialLinearForce(double,double,struct potentialArg *);
+double IsothermalDiskPotentialLinear2deriv(double,double,struct potentialArg *);
 
 //DehnenSphericalPotential
 double DehnenSphericalPotentialEval(double ,double , double, double,

--- a/galpy/potential/potential_c_ext/verticalPotential.c
+++ b/galpy/potential/potential_c_ext/verticalPotential.c
@@ -9,3 +9,13 @@ double verticalPotentialLinearForce(double x, double t,
 		    potentialArgs->nwrapped,
 		    potentialArgs->wrappedPotentialArg);
 }
+// d^2 Phi / dx^2 = d^2 Phi / dz^2 of the wrapped 3D potential at (R,x,phi),
+// mirroring verticalPotentialLinearForce (which uses the wrapped z-force).
+double verticalPotentialLinear2deriv(double x, double t,
+				     struct potentialArg * potentialArgs){
+  double R= *potentialArgs->args;
+  double phi= *(potentialArgs->args+1);
+  return calcz2deriv(R,x,phi,t,
+		     potentialArgs->nwrapped,
+		     potentialArgs->wrappedPotentialArg);
+}

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -52,6 +52,10 @@ class verticalPotential(linearPotential):
             self._R, 0.0, phi=self._phi, t=t0, use_physical=False
         )
         self.hasC = Pot.hasC
+        # 1D variational (dxdv) second derivative routes to the wrapped 3D
+        # potential's z2deriv in C; that is only wired (in the full-orbit parse)
+        # for potentials with the full 3D Hessian, so gate on hasC_dxdv3d.
+        self.hasC_dxdv = getattr(Pot, "hasC_dxdv3d", False)
         # Also transfer roSet and voSet
         self._roSet = Pot._roSet
         self._voSet = Pot._voSet
@@ -138,6 +142,15 @@ class verticalPotential(linearPotential):
             self._phi if not hasattr(z, "__len__") else self._phi * numpy.ones_like(z)
         )
         return self._Pot.zforce(tR, z, phi=tphi, t=t, use_physical=False)
+
+    def _force2deriv(self, z, t=0.0):
+        # d^2 Phi / dz^2 of the wrapped 3D potential at (R,z,phi), mirroring
+        # _force (which returns the wrapped z-force); for the 1D dxdv equations.
+        tR = self._R if not hasattr(z, "__len__") else self._R * numpy.ones_like(z)
+        tphi = (
+            self._phi if not hasattr(z, "__len__") else self._phi * numpy.ones_like(z)
+        )
+        return self._Pot.z2deriv(tR, z, phi=tphi, t=t, use_physical=False)
 
 
 def RZToverticalPotential(RZPot, R):

--- a/tests/test_linear_dxdv.py
+++ b/tests/test_linear_dxdv.py
@@ -356,3 +356,29 @@ def test_linear_dxdv_multiple_orbits():
             Mmulti[ii], numpy.asarray(os_.getOrbit_dxdv()), rtol=1e-10, atol=1e-12
         )
     return None
+
+
+def test_linear_dxdv_composite_potential():
+    # A composite (sum of) linear potentials: the pure-Python integrator's
+    # variational RHS calls the composite _force2deriv (sum of the components),
+    # which the C integrators bypass. Check it agrees with the C integrator (which
+    # sums the components' C linear2deriv).
+    from galpy.orbit import Orbit
+    from galpy.potential import IsothermalDiskPotential, KGPotential
+
+    comp = [
+        KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8),
+        IsothermalDiskPotential(amp=0.5, sigma=0.4),
+    ]
+    times = numpy.linspace(0.0, 5.0, 101)
+    o = Orbit([0.2, 0.05])
+    o.integrate_dxdv([1.0, 0.0], times, comp, method="dop853")  # Python -> _force2deriv
+    Mpy = numpy.asarray(o.getOrbit_dxdv())
+    assert Mpy.shape == (101, 2)
+    assert numpy.all(numpy.isfinite(Mpy))
+    oc = Orbit([0.2, 0.05])
+    oc.integrate_dxdv([1.0, 0.0], times, comp, method="rk4_c", dt=0.005)
+    numpy.testing.assert_allclose(
+        Mpy[-1], numpy.asarray(oc.getOrbit_dxdv())[-1], rtol=1e-4
+    )
+    return None

--- a/tests/test_linear_dxdv.py
+++ b/tests/test_linear_dxdv.py
@@ -318,3 +318,41 @@ def test_linear_dxdv_pure_python_rejected():
         with pytest.raises(ValueError):
             o.integrate_dxdv([1.0, 0.0], times, pot, method=method)
     return None
+
+
+def test_linear_dxdv_dt_none_autostep():
+    # integrate_dxdv without an explicit dt (dt=None -> the -9999.99 auto-step
+    # sentinel in integrateLinearOrbit_dxdv_c).
+    from galpy.orbit import Orbit
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    times = numpy.linspace(0.0, 5.0, 101)
+    o = Orbit([0.2, 0.05])
+    o.integrate_dxdv([1.0, 0.0], times, pot, method="dopr54_c")  # no dt
+    M = numpy.asarray(o.getOrbit_dxdv())
+    assert M.shape == (101, 2)
+    assert numpy.all(numpy.isfinite(M))
+    return None
+
+
+def test_linear_dxdv_multiple_orbits():
+    # multi-orbit 1D dxdv (the parallel_map branch of integrateLinearOrbit_dxdv);
+    # each orbit's STM must match a single-orbit solve.
+    from galpy.orbit import Orbit
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    times = numpy.linspace(0.0, 5.0, 101)
+    ics = [[0.2, 0.05], [0.3, -0.02]]
+    o = Orbit(ics)
+    o.integrate_dxdv([[1.0, 0.0], [1.0, 0.0]], times, pot, method="rk4_c", dt=0.01)
+    Mmulti = numpy.asarray(o.getOrbit_dxdv())
+    assert Mmulti.shape == (2, 101, 2)
+    for ii, ic in enumerate(ics):
+        os_ = Orbit(ic)
+        os_.integrate_dxdv([1.0, 0.0], times, pot, method="rk4_c", dt=0.01)
+        numpy.testing.assert_allclose(
+            Mmulti[ii], numpy.asarray(os_.getOrbit_dxdv()), rtol=1e-10, atol=1e-12
+        )
+    return None

--- a/tests/test_linear_dxdv.py
+++ b/tests/test_linear_dxdv.py
@@ -366,10 +366,9 @@ def test_linear_dxdv_composite_potential():
     from galpy.orbit import Orbit
     from galpy.potential import IsothermalDiskPotential, KGPotential
 
-    comp = [
-        KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8),
-        IsothermalDiskPotential(amp=0.5, sigma=0.4),
-    ]
+    comp = KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8) + IsothermalDiskPotential(
+        amp=0.5, sigma=0.4
+    )
     times = numpy.linspace(0.0, 5.0, 101)
     o = Orbit([0.2, 0.05])
     o.integrate_dxdv([1.0, 0.0], times, comp, method="dop853")  # Python -> _force2deriv

--- a/tests/test_linear_dxdv.py
+++ b/tests/test_linear_dxdv.py
@@ -1,0 +1,320 @@
+##############################################################################
+# test_linear_dxdv.py: tests of the phase-space-volume (dxdv) variational
+#   integration for 1D (linear) orbits, across the RK integrators
+#   (rk4_c/rk6_c/dopr54_c/dop853_c/dop853/odeint) AND the symplectic ones
+#   (leapfrog_c/symplec4_c/symplec6_c). The 1D variational RHS carries the 2D
+#   deviation [dx,dv] with d(dx)/dt=dv, d(dv)/dt=K*dx and K=dF/dx=-d^2Phi/dx^2
+#   (linear2deriv). The RK methods integrate the 4D state [x,v,dx,dv]; the
+#   symplectic ones carry the deviation through the exact drift/kick tangent
+#   maps of the discrete step (K the 1x1 conservative Hessian). There is no
+#   cyl<->rect transform in 1D, so the deviation is the raw [dx,dv] 2-vector.
+##############################################################################
+import numpy
+import pytest
+
+SYMPLECTIC = ["leapfrog_c", "symplec4_c", "symplec6_c"]
+ORDER = {"leapfrog_c": 2, "symplec4_c": 4, "symplec6_c": 6}
+# Fixed-step methods whose 1D dxdv base is byte-identical to plain integrate
+FIXED_STEP = ["leapfrog_c", "symplec4_c", "symplec6_c", "rk4_c", "rk6_c"]
+# Adaptive/step-controlled: base differs from plain by the step-control tweak
+ADAPTIVE = ["dopr54_c", "dop853_c", "dop853", "odeint"]
+# All RK/pure-Python (non-symplectic) methods with a 1D dxdv path
+RK = ["rk4_c", "rk6_c", "dopr54_c", "dop853_c", "dop853", "odeint"]
+ALL = SYMPLECTIC + RK
+
+# Omega in (x,v) order for the symplecticity check M^T Omega M = Omega
+_Omega = numpy.array([[0.0, 1.0], [-1.0, 0.0]])
+_CANON = numpy.eye(2)
+
+
+def _dt_for(method, dt):
+    """Fixed stepsize only for the C integrators; None for pure-Python."""
+    return dt if "_c" in method else None
+
+
+def _harmonic_STM(omega, t):
+    """Analytic 2x2 STM of the 1D harmonic oscillator a=-omega^2 x."""
+    return numpy.array(
+        [
+            [numpy.cos(omega * t), numpy.sin(omega * t) / omega],
+            [-omega * numpy.sin(omega * t), numpy.cos(omega * t)],
+        ]
+    )
+
+
+def _build_M(ic, times, pot, method, dt=0.005, rtol=1e-12, atol=1e-12):
+    """The 2x2 STM at the final time: integrate the two canonical basis
+    deviation vectors and stack their [dx,dv] endpoints as columns."""
+    from galpy.orbit import Orbit
+
+    cols = []
+    for ii in range(2):
+        o = Orbit(ic)
+        o.integrate_dxdv(
+            _CANON[ii],
+            times,
+            pot,
+            method=method,
+            dt=_dt_for(method, dt),
+            rtol=rtol,
+            atol=atol,
+        )
+        cols.append(o.getOrbit_dxdv()[-1, :])
+    return numpy.array(cols).T
+
+
+def _fd_of_flow_M(ic, times, pot, method, dt=0.005, eps=1e-6):
+    """The 2x2 STM by central finite-difference of the base flow: integrate the
+    unperturbed base orbit and orbits perturbed by +/- eps along x and v, and
+    difference the [x,v] endpoints."""
+    from galpy.orbit import Orbit
+
+    obase = Orbit(ic)
+    obase.integrate(times, pot, method=method, dt=_dt_for(method, dt))
+    y0 = numpy.array([obase.x(times[0]), obase.vx(times[0])])
+    Mfd = numpy.empty((2, 2))
+    for ii in range(2):
+        cols = []
+        for sgn in (+1.0, -1.0):
+            y = y0.copy()
+            y[ii] += sgn * eps
+            op = Orbit([y[0], y[1]])
+            op.integrate(times, pot, method=method, dt=_dt_for(method, dt))
+            cols.append(numpy.array([op.x(times[-1]), op.vx(times[-1])]))
+        Mfd[:, ii] = (cols[0] - cols[1]) / (2.0 * eps)
+    return Mfd
+
+
+# ----------------------------------------------------------------------------
+def test_linear_dxdv_base_bit_identity():
+    """The 1D base orbit carried alongside the deviation (getOrbit, columns 0:2)
+    must match a plain (no-dxdv) integration with the same method/dt/IC. For the
+    fixed-step methods (all symplectic + rk4_c/rk6_c) it is BIT-IDENTICAL (there
+    is no cyl<->rect reconstruction in 1D and the base block is stepped by the
+    same arithmetic); the adaptive integrators tweak their step control from the
+    augmented state, so they match to a loose tolerance only."""
+    from galpy.orbit import Orbit
+    from galpy.potential import IsothermalDiskPotential, KGPotential
+
+    times = numpy.linspace(0.0, 5.0, 251)
+    cases = [
+        ("KG", KGPotential(amp=1.0, K=0.3, F=0.2, D=1.5), [0.3, 0.1]),
+        ("IsoDisk", IsothermalDiskPotential(amp=1.0, sigma=0.2), [0.4, -0.1]),
+    ]
+    for pname, pot, ic in cases:
+        for method in ALL:
+            o1 = Orbit(ic)
+            o1.integrate_dxdv(
+                _CANON[0], times, pot, method=method, dt=_dt_for(method, 0.01)
+            )
+            base_dxdv = numpy.asarray(o1.getOrbit())
+            o2 = Orbit(ic)
+            o2.integrate(times, pot, method=method, dt=_dt_for(method, 0.01))
+            base_plain = numpy.asarray(o2.getOrbit())
+            if method in FIXED_STEP:
+                assert numpy.array_equal(base_dxdv, base_plain), (
+                    f"1D dxdv base not bit-identical to plain integrate for "
+                    f"{pname}, {method}: max|diff|="
+                    f"{numpy.amax(numpy.fabs(base_dxdv - base_plain)):g}"
+                )
+            else:
+                err = numpy.amax(numpy.fabs(base_dxdv - base_plain))
+                assert err < 1e-6, (
+                    f"1D dxdv base differs from plain integrate by {err:g} for "
+                    f"{pname}, {method}"
+                )
+    return None
+
+
+def test_linear_dxdv_closed_form_harmonic():
+    """1D harmonic oscillator a=-omega^2 x (constant K=-omega^2), realized two
+    ways: KGPotential with K=0 (Phi=amp F x^2, omega^2=2 amp F, exact for all x)
+    and a verticalPotential of a HomogeneousSpherePotential (constant z2deriv in
+    the harmonic core). The propagated 2x2 STM must match the analytic flow
+    [[cos wt, sin wt/w],[-w sin wt, cos wt]] -- tightly for the RK/pure-Python
+    methods, and to the method order (2/4/6) for the symplectic ones. This test
+    also fixes the SIGN of K (a wrong sign would give sinh/cosh, not sin/cos)."""
+    from galpy.orbit import Orbit
+    from galpy.potential import (
+        HomogeneousSpherePotential,
+        KGPotential,
+        toVerticalPotential,
+    )
+
+    T = 2.0
+    # (a) KGPotential(K=0): exact harmonic, omega^2 = 2 amp F
+    F = 0.5
+    kg = KGPotential(amp=1.0, K=0.0, F=F, D=1.0)
+    assert kg.hasC_dxdv
+    # (b) verticalPotential(HomogeneousSphere): harmonic core, omega^2 = z2deriv
+    hs = HomogeneousSpherePotential(amp=1.0, R=3.0, normalize=True)
+    vp = toVerticalPotential(hs, R=1.0)
+    assert vp.hasC_dxdv
+    cases = [
+        ("KG_K0", kg, numpy.sqrt(2.0 * F), [0.3, 0.0]),
+        ("vp_HS", vp, numpy.sqrt(hs.z2deriv(1.0, 0.0)), [0.2, 0.0]),
+    ]
+    # order-appropriate absolute tolerances at dt=0.02 for the symplectic methods
+    sabstol = {"leapfrog_c": 1e-3, "symplec4_c": 1e-6, "symplec6_c": 1e-9}
+    for pname, pot, omega, ic in cases:
+        Mana = _harmonic_STM(omega, T)
+        if pname == "vp_HS":
+            # precondition: orbit stays inside the sphere (harmonic core)
+            o = Orbit(ic)
+            tpre = numpy.linspace(0.0, T, 51)
+            o.integrate(tpre, pot, method="dop853_c")
+            assert numpy.amax(numpy.fabs(o.x(tpre))) < 0.9 * hs.R
+        # RK / pure-Python: high-order/adaptive -> tight
+        for method in RK:
+            dt = 0.005
+            tt = numpy.linspace(0.0, T, int(round(T / dt)) + 1)
+            M = _build_M(ic, tt, pot, method, dt=dt)
+            err = numpy.amax(numpy.fabs(M - Mana))
+            assert err < 1e-7, (
+                f"1D harmonic STM error {err:g} exceeds 1e-7 for {pname}, {method}"
+            )
+            assert numpy.fabs(numpy.linalg.det(M) - 1.0) < 1e-8
+        # symplectic: match to the method order at dt=0.02
+        for method in SYMPLECTIC:
+            dt = 0.02
+            tt = numpy.linspace(0.0, T, int(round(T / dt)) + 1)
+            M = _build_M(ic, tt, pot, method, dt=dt)
+            err = numpy.amax(numpy.fabs(M - Mana))
+            assert err < sabstol[method], (
+                f"1D harmonic STM error {err:g} exceeds {sabstol[method]:g} for "
+                f"{pname}, {method}"
+            )
+            assert numpy.fabs(numpy.linalg.det(M) - 1.0) < 1e-10
+    # convergence order for the two lower-order symplectic methods (KG case)
+    for method in ["leapfrog_c", "symplec4_c"]:
+        errs = []
+        for dt in [0.02, 0.01]:
+            tt = numpy.linspace(0.0, T, int(round(T / dt)) + 1)
+            M = _build_M([0.3, 0.0], tt, kg, method, dt=dt)
+            errs.append(
+                numpy.amax(numpy.fabs(M - _harmonic_STM(numpy.sqrt(2.0 * F), T)))
+            )
+        ratio = errs[0] / errs[1]
+        expected = 2.0 ** ORDER[method]
+        assert 0.7 * expected < ratio < 1.3 * expected, (
+            f"1D harmonic convergence ratio {ratio:.2f} not ~{expected:.0f} "
+            f"(order {ORDER[method]}) for {method}"
+        )
+    return None
+
+
+def test_linear_dxdv_liouville_symplecticity():
+    """Liouville det(M)=1 and symplecticity M^T Omega M = Omega (Omega=[[0,1],
+    [-1,0]]) of the 2x2 STM. (For a 2x2 matrix these are equivalent, since
+    M^T Omega M = det(M) Omega identically; both are asserted to match the task
+    spec.) Tested on nonlinear (IsothermalDisk, KGPotential) and vertical
+    (verticalPotential of MiyamotoNagai) 1D potentials; symplectic methods reach
+    machine precision, the RK/pure-Python methods a looser bound."""
+    from galpy.potential import (
+        IsothermalDiskPotential,
+        KGPotential,
+        MiyamotoNagaiPotential,
+        toVerticalPotential,
+    )
+
+    times = numpy.linspace(0.0, 4.0, 201)
+    mn = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.1)
+    cases = [
+        ("IsoDisk", IsothermalDiskPotential(amp=1.0, sigma=0.2), [0.3, 0.1]),
+        ("KG", KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8), [0.4, -0.15]),
+        ("vp_MN", toVerticalPotential(mn, R=1.0), [0.15, 0.08]),
+    ]
+    for pname, pot, ic in cases:
+        for method in ALL:
+            M = _build_M(ic, times, pot, method, dt=0.01)
+            detm1 = numpy.fabs(numpy.linalg.det(M) - 1.0)
+            symperr = numpy.amax(numpy.fabs(M.T @ _Omega @ M - _Omega))
+            tol = 1e-10 if method in SYMPLECTIC else 1e-8
+            assert detm1 < tol, (
+                f"|det(M)-1|={detm1:g} exceeds {tol:g} for {pname}, {method}"
+            )
+            assert symperr < tol, (
+                f"||M^T Omega M - Omega||={symperr:g} exceeds {tol:g} for {pname}, {method}"
+            )
+    return None
+
+
+def test_linear_dxdv_fd_of_flow_per_column():
+    """Per-column finite-difference-of-the-flow: each column of the 1D STM must
+    equal the central difference of the integrated base flow along x and v. This
+    certifies M is the Jacobian of the actual discrete map (independent of the
+    symplecticity/Liouville argument) and, crucially, catches sign/factor errors
+    in K=-linear2deriv that det(M)=1 alone cannot. Tested on nonlinear
+    (IsothermalDisk, KGPotential) and vertical (verticalPotential of
+    MiyamotoNagai) potentials."""
+    from galpy.potential import (
+        IsothermalDiskPotential,
+        KGPotential,
+        MiyamotoNagaiPotential,
+        toVerticalPotential,
+    )
+
+    times = numpy.linspace(0.0, 2.0, 101)
+    mn = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.1)
+    cases = [
+        ("IsoDisk", IsothermalDiskPotential(amp=1.0, sigma=0.2), [0.3, 0.1]),
+        ("KG", KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8), [0.4, -0.15]),
+        ("vp_MN", toVerticalPotential(mn, R=1.0), [0.15, 0.08]),
+    ]
+    for pname, pot, ic in cases:
+        for method in ALL:
+            M = _build_M(ic, times, pot, method, dt=0.01)
+            Mfd = _fd_of_flow_M(ic, times, pot, method, dt=0.01)
+            err = numpy.amax(numpy.fabs(M - Mfd))
+            # odeint's default adaptive tolerance sets a looser FD-of-flow floor
+            tol = 1e-5 if method == "odeint" else 1e-6
+            assert err < tol, (
+                f"1D per-column FD-of-flow differs from the STM by {err:g} for "
+                f"{pname}, {method}"
+            )
+    return None
+
+
+def test_linear_dxdv_method_agreement():
+    """All 1D methods converge to the same continuous STM: at matched (small) dt
+    the symplectic and RK STMs must agree with a tight dop853_c reference, and
+    the symplectic STMs converge to it at their method order as dt->0."""
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.2)
+    ic = [0.3, 0.1]
+    times = numpy.linspace(0.0, 2.0, 101)
+    Mref = _build_M(ic, times, pot, "dop853_c", dt=0.005, rtol=1e-13, atol=1e-13)
+    # all methods agree with the reference at a small stepsize
+    for method in ALL:
+        M = _build_M(ic, times, pot, method, dt=0.005)
+        err = numpy.amax(numpy.fabs(M - Mref))
+        assert err < 1e-3, f"{method} STM differs from dop853_c by {err:g}"
+    # method-order convergence of the two lower-order symplectic methods
+    for method in ["leapfrog_c", "symplec4_c"]:
+        errs = []
+        for dt in [0.02, 0.01, 0.005]:
+            M = _build_M(ic, times, pot, method, dt=dt)
+            errs.append(numpy.amax(numpy.fabs(M - Mref)))
+        expected = 2.0 ** ORDER[method]
+        for ratio in (errs[0] / errs[1], errs[1] / errs[2]):
+            assert 0.7 * expected < ratio < 1.3 * expected, (
+                f"{method} vs dop853_c convergence ratio {ratio:.2f} not ~{expected:.0f}"
+            )
+    return None
+
+
+def test_linear_dxdv_pure_python_rejected():
+    """The pure-Python 'leapfrog' and 'ias15_c' have no dxdv path and must raise
+    for a 1D orbit (only the C symplectic and RK/pure-Python integrators are
+    wired)."""
+    from galpy.orbit import Orbit
+    from galpy.potential import KGPotential
+
+    pot = KGPotential(amp=1.0, K=1.15, F=0.03, D=1.8)
+    times = numpy.linspace(0.0, 2.0, 51)
+    for method in ("leapfrog", "ias15_c"):
+        o = Orbit([0.3, 0.1])
+        with pytest.raises(ValueError):
+            o.integrate_dxdv([1.0, 0.0], times, pot, method=method)
+    return None


### PR DESCRIPTION
## 1D (linear-orbit) variational (dxdv) integration — RK + symplectic

Follow-up to #1086 (**stacked on it** — its modular refactor is the base; retarget to main once #1086 lands). Enables `Orbit.integrate_dxdv` for **phasedim==2 (1D orbits)**, for both the RK integrators (rk4_c/rk6_c/dopr54_c/dop853_c/dop853/odeint) *and* the symplectic ones (leapfrog_c/symplec4_c/symplec6_c) — so 1D orbit integration is now differentiable (state-transition matrix / IC derivatives), consistent with how 4D/6D already work.

### What it adds
- **`linear2deriv` (∂²Φ/∂x²)** on the linear-potential C interface + `calcLinear2deriv` aggregator (analytic, C-native): `verticalPotential` routes to the wrapped 3D potential's on-axis `z2deriv`; `KGPotential` + `IsothermalDiskPotential` get analytic second derivatives. Python `_force2deriv` + `hasC_dxdv`.
- **`integrateLinearOrbit.c`**: `evalLinearDeriv_dxdv` (RK variational RHS, state `[x,v,dx,dv]`, `K = dF/dx = −linear2deriv`) + `evalLinearForce_dxdv` (symplectic augmented force) reusing the generic `bovy_symplecticode.c` dxdv steppers (from #1086) with `dim_base=1`; EXPORT `integrateLinearOrbit_dxdv`.
- **Python/Orbits**: `integrateLinearOrbit_dxdv_c` + dispatcher; `integrate_dxdv` lifts the `phasedim==2` rejection, `allow_c_symplec ∈ (2,4,6)`, routes `dim()==1`.

### Verified
- New `tests/test_linear_dxdv.py` (9 methods): base bit-identity, **closed-form 1D-harmonic 2×2 STM** (K sign confirmed — a wrong sign gives sinh/cosh, an O(1) failure), Liouville `det M=1` / symplecticity, FD-of-flow per-column, RK↔symplectic agreement — **all pass**.
- **Plain 1D integration byte-identical** (10/10 cases, KG + IsothermalDisk × 5 methods, vs pre-change).
- `test_symplectic_dxdv.py` (3D/planar) **12 passed**; `test_orbit.py -k "linear or vertical or dxdv"` unbroken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
