### PR TITLE
Backend-agnostic RNG shim (galpy.backend.random) + streamspray draw pilot — #130 PR-1

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -24,6 +24,7 @@ from ._namespaces import (
     exit_cast,
     is_backend_array,
     match_input_dtype,
+    name_of_namespace,
     resolve_namespace,
 )
 from ._resolver import (
@@ -46,6 +47,7 @@ __all__ = [
     "set_default_backend",
     "is_backend_array",
     "match_input_dtype",
+    "name_of_namespace",
     "device_of",
     "asarray_on_device",
     "as_numpy",

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -307,6 +307,23 @@ def namespace_for_name(name):
     raise ValueError(f"unknown galpy backend '{name}'")
 
 
+def name_of_namespace(xp):
+    """Map a resolved array namespace module to its canonical backend name.
+
+    The inverse of ``namespace_for_name``: the plain ``numpy`` module -> "numpy",
+    the ``jax.numpy`` namespace -> "jax", the array-api-compat torch namespace ->
+    "torch"; an unrecognized namespace defaults to "numpy" (defensive).
+    """
+    if xp is numpy:
+        return "numpy"
+    name = getattr(xp, "__name__", "")
+    if "jax" in name:
+        return "jax"
+    if "torch" in name:
+        return "torch"
+    return "numpy"
+
+
 def namespace_from_arrays(arrays):
     """Infer the array namespace from the (non-scalar) array arguments.
 

--- a/galpy/backend/random.py
+++ b/galpy/backend/random.py
@@ -1,0 +1,327 @@
+###############################################################################
+#   galpy.backend.random: a backend-agnostic random-number shim.
+#
+#   The single home for galpy's random draws so the same sampling code runs on
+#   numpy, jax, and torch. It exists to unblock differentiable/jit-able sampling
+#   (the reparameterization / common-random-numbers trick) while keeping the
+#   numpy path byte-identical to galpy's historical behaviour.
+#
+#   DISPATCH is on the KEY, not on get_namespace:
+#     * key is None            -> the GLOBAL ``numpy.random.*`` (stateful,
+#                                 byte-identical: the shim calls the exact same
+#                                 ``numpy.random.<fn>`` the code called before).
+#     * key is a jax key       -> ``jax.random.*`` (a key is explicit data; the
+#                                 draw is a pure deterministic function of it).
+#     * key is a ``_TorchKey`` -> a ``torch.Generator`` seeded from the key, so
+#                                 a draw is reproducible given the key and the
+#                                 drawn noise tensor is a constant that a
+#                                 reparameterized transform differentiates through.
+#
+#   The numpy path is DELIBERATELY stateful/global: numpy is never
+#   differentiated or jit'd here, so it keeps its current behaviour exactly.
+#   jax's stateless key model gives fixed-noise derivatives natively; torch does
+#   it via draw-once-fixed-noise.
+###############################################################################
+import numpy
+
+from ..util._optional_deps import _JAX_LOADED
+from ._namespaces import namespace_for_name
+from ._resolver import get_namespace
+
+__all__ = [
+    "key",
+    "split",
+    "uniform",
+    "normal",
+    "random",
+    "randint",
+    "choice",
+    "multivariate_normal",
+]
+
+
+class _TorchKey:
+    """A stateless torch key: a 64-bit seed a ``torch.Generator`` is built from.
+
+    torch has no native stateless key model, so a key is represented as a
+    Python int seed. ``split`` derives independent child seeds deterministically
+    from it (via a Generator seeded by this seed), and every draw builds a fresh
+    ``torch.Generator().manual_seed(seed)`` -- so a draw is a pure function of
+    the key (reproducible), and the drawn tensor is a constant (no grad) that a
+    reparameterized transform differentiates through.
+    """
+
+    __slots__ = ("seed",)
+
+    def __init__(self, seed):
+        self.seed = int(seed) & 0xFFFFFFFFFFFFFFFF
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return f"_TorchKey(seed={self.seed})"
+
+
+# --- backend/name/shape helpers ----------------------------------------------
+def _name_of_namespace(xp):
+    """Map a resolved namespace module to a backend name ('numpy'|'jax'|'torch')."""
+    if xp is numpy:
+        return "numpy"
+    name = getattr(xp, "__name__", "")
+    if "jax" in name:
+        return "jax"
+    if "torch" in name:
+        return "torch"
+    return "numpy"  # pragma: no cover - defensive
+
+
+def _resolve_backend_name(backend):
+    """Backend name for ``key(...)``: explicit ``backend=`` or the active default."""
+    if backend is None:
+        return _name_of_namespace(get_namespace())
+    return _name_of_namespace(namespace_for_name(backend))
+
+
+def _backend_of_key(key):
+    """Dispatch: which backend a draw for ``key`` uses (numpy for ``key is None``)."""
+    if key is None:
+        return "numpy"
+    if isinstance(key, _TorchKey):
+        return "torch"
+    if _JAX_LOADED:
+        import jax
+
+        if isinstance(key, jax.Array):
+            return "jax"
+    raise TypeError(
+        "galpy.backend.random: unrecognized key; pass None (numpy), a jax "
+        "key from key(seed, 'jax'), or a _TorchKey from key(seed, 'torch')"
+    )
+
+
+def _tuple_shape(shape):
+    """Normalize a shape to a tuple for jax/torch (``None`` -> scalar ``()``)."""
+    if shape is None:
+        return ()
+    if isinstance(shape, (int, numpy.integer)):
+        return (int(shape),)
+    return tuple(shape)
+
+
+def _torch_generator(key):
+    import torch
+
+    g = torch.Generator()
+    g.manual_seed(key.seed)
+    return g
+
+
+# --- key management ----------------------------------------------------------
+def key(seed, backend=None):
+    """Create a random key for the resolved backend.
+
+    Parameters
+    ----------
+    seed : int
+        The seed.
+    backend : {None, 'numpy', 'jax', 'torch'} or namespace module, optional
+        Which backend to make a key for. ``None`` (default) uses the active
+        galpy backend (``galpy.backend.get_namespace`` context/global default),
+        so ``key(s)`` under a numpy default seeds ``numpy.random`` and returns
+        ``None``, under a jax default returns a ``jax.random`` key, etc.
+
+    Returns
+    -------
+    key
+        ``None`` for numpy (having seeded the global ``numpy.random``), a
+        ``jax.random`` key for jax, or a ``_TorchKey`` for torch.
+
+    Notes
+    -----
+    numpy is stateful by design: ``key(seed)`` seeds the global generator and
+    returns ``None`` (the "use the global ``numpy.random``" sentinel), which is
+    exactly what keeps the numpy path byte-identical. jax/torch keys are
+    explicit stateless data threaded through ``split`` and the draw functions.
+    """
+    name = _resolve_backend_name(backend)
+    if name == "numpy":
+        numpy.random.seed(seed)
+        return None
+    if name == "jax":
+        import jax
+
+        return jax.random.key(int(seed))
+    return _TorchKey(seed)  # torch
+
+
+def split(key, num=2):
+    """Split ``key`` into ``num`` independent sub-keys.
+
+    Returns a tuple of ``num`` keys. For numpy this is ``(None,) * num`` -- the
+    global generator produces independent sequential draws with no substreams
+    needed. For jax it is ``jax.random.split``; for torch the child seeds are
+    drawn deterministically from ``key`` (so the split is reproducible).
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return (None,) * num
+    if name == "jax":
+        import jax
+
+        return tuple(jax.random.split(key, num))
+    # torch: derive num child seeds deterministically from the parent key
+    import torch
+
+    g = _torch_generator(key)
+    child = torch.randint(0, 2**62, (num,), generator=g, dtype=torch.int64)
+    return tuple(_TorchKey(int(c)) for c in child)
+
+
+# --- draw functions ----------------------------------------------------------
+def uniform(key, shape, low=0.0, high=1.0):
+    """Draw from Uniform[low, high).
+
+    numpy path (``key is None``) is ``numpy.random.uniform(low, high, size=shape)``
+    (byte-identical to the historical call). jax/torch draw a backend array that
+    is a deterministic function of ``key``.
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.uniform(low, high, size=shape)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return jrandom.uniform(key, shape=_tuple_shape(shape), minval=low, maxval=high)
+    import torch
+
+    g = _torch_generator(key)
+    out = torch.rand(_tuple_shape(shape), generator=g, dtype=torch.get_default_dtype())
+    return low + (high - low) * out
+
+
+def normal(key, shape, loc=0.0, scale=1.0):
+    """Draw from Normal(loc, scale).
+
+    numpy path is ``numpy.random.normal(loc, scale, size=shape)`` (byte-
+    identical). ``shape=None`` gives a scalar on numpy (matching a bare
+    ``numpy.random.normal()``) and a 0-d array on jax/torch.
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.normal(loc, scale, size=shape)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return loc + scale * jrandom.normal(key, shape=_tuple_shape(shape))
+    import torch
+
+    g = _torch_generator(key)
+    z = torch.randn(_tuple_shape(shape), generator=g, dtype=torch.get_default_dtype())
+    return loc + scale * z
+
+
+def random(key, shape=None):
+    """Draw from Uniform[0, 1).
+
+    numpy path is ``numpy.random.random(size=shape)`` (byte-identical; kept as a
+    distinct call from ``uniform`` so the exact historical draw sequence is
+    reproduced). jax/torch return a backend array function of ``key``.
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.random(size=shape)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return jrandom.uniform(key, shape=_tuple_shape(shape))
+    import torch
+
+    g = _torch_generator(key)
+    return torch.rand(_tuple_shape(shape), generator=g, dtype=torch.get_default_dtype())
+
+
+def randint(key, shape, low, high):
+    """Draw integers from [low, high) (``high`` exclusive on every backend).
+
+    numpy path is ``numpy.random.randint(low, high, size=shape)`` (byte-
+    identical). ``shape=None`` gives a scalar on numpy.
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.randint(low, high, size=shape)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return jrandom.randint(key, shape=_tuple_shape(shape), minval=low, maxval=high)
+    import torch
+
+    g = _torch_generator(key)
+    return torch.randint(
+        int(low), int(high), _tuple_shape(shape), generator=g, dtype=torch.int64
+    )
+
+
+def choice(key, a, shape=None, p=None):
+    """Draw from ``a`` (an array/list, or an int meaning ``arange(a)``) with
+    replacement, optionally weighted by ``p``.
+
+    numpy path is ``numpy.random.choice(a, size=shape, p=p)`` (byte-identical).
+    jax uses ``jax.random.choice``; torch maps to ``randint`` (unweighted) or
+    ``multinomial`` (weighted) over the elements of ``a``.
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.choice(a, size=shape, p=p)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return jrandom.choice(key, a, shape=_tuple_shape(shape), replace=True, p=p)
+    import torch
+
+    g = _torch_generator(key)
+    a_t = (
+        torch.arange(int(a))
+        if isinstance(a, (int, numpy.integer))
+        else torch.as_tensor(a)
+    )
+    n = a_t.shape[0]
+    tshape = _tuple_shape(shape)
+    count = 1
+    for s in tshape:
+        count *= s
+    if p is None:
+        idx = torch.randint(0, n, (count,), generator=g, dtype=torch.int64)
+    else:
+        p_t = torch.as_tensor(p, dtype=torch.get_default_dtype())
+        idx = torch.multinomial(p_t, count, replacement=True, generator=g)
+    return a_t[idx].reshape(tshape)
+
+
+def multivariate_normal(key, mean, cov, shape=None):
+    """Draw from a multivariate normal N(mean, cov).
+
+    numpy path is ``numpy.random.multivariate_normal(mean, cov, size=shape)``
+    (byte-identical). jax uses ``jax.random.multivariate_normal`` with the SVD
+    method (robust to the singular covariances galpy's spray DFs use); torch
+    reparameterizes an eigendecomposition of ``cov`` (also singular-safe).
+    """
+    name = _backend_of_key(key)
+    if name == "numpy":
+        return numpy.random.multivariate_normal(mean, cov, size=shape)
+    if name == "jax":
+        from jax import random as jrandom
+
+        return jrandom.multivariate_normal(
+            key, mean, cov, shape=_tuple_shape(shape), method="svd"
+        )
+    import torch
+
+    g = _torch_generator(key)
+    mean_t = torch.as_tensor(mean, dtype=torch.get_default_dtype())
+    cov_t = torch.as_tensor(cov, dtype=torch.get_default_dtype())
+    d = mean_t.shape[0]
+    # Singular-safe factor via symmetric eigendecomposition: cov = V diag(w) V^T,
+    # L = V sqrt(max(w, 0)); a standard-normal z gives mean + z @ L^T ~ N(mean, cov).
+    w, V = torch.linalg.eigh(cov_t)
+    L = V * torch.sqrt(torch.clamp(w, min=0.0))
+    tshape = _tuple_shape(shape)
+    z = torch.randn(tshape + (d,), generator=g, dtype=torch.get_default_dtype())
+    return mean_t + z @ L.T

--- a/galpy/backend/random.py
+++ b/galpy/backend/random.py
@@ -10,6 +10,10 @@
 #     * key is None            -> the GLOBAL ``numpy.random.*`` (stateful,
 #                                 byte-identical: the shim calls the exact same
 #                                 ``numpy.random.<fn>`` the code called before).
+#     * key is a ``_NumpyKey`` -> a LOCAL ``numpy.random.Generator`` (opt-in,
+#                                 jax-like: same seed reproduces the same draws
+#                                 independent of the global state; its stream is
+#                                 intentionally NOT byte-identical to the global).
 #     * key is a jax key       -> ``jax.random.*`` (a key is explicit data; the
 #                                 draw is a pure deterministic function of it).
 #     * key is a ``_TorchKey`` -> a ``torch.Generator`` seeded from the key, so
@@ -25,7 +29,7 @@
 import numpy
 
 from ..util._optional_deps import _JAX_LOADED
-from ._namespaces import namespace_for_name
+from ._namespaces import name_of_namespace, namespace_for_name
 from ._resolver import get_namespace
 
 __all__ = [
@@ -60,29 +64,44 @@ class _TorchKey:
         return f"_TorchKey(seed={self.seed})"
 
 
+class _NumpyKey:
+    """A LOCAL, reproducible numpy key: wraps a ``numpy.random.Generator``.
+
+    In contrast to ``key is None`` (which draws from the GLOBAL, stateful
+    ``numpy.random.*`` and is byte-identical to galpy's historical behaviour), a
+    ``_NumpyKey`` draws from its own ``numpy.random.default_rng(seed)`` Generator.
+    That gives numpy the same "same seed => same draws, independent of the
+    surrounding code" property jax has -- opt-in reproducibility for sampling and
+    tests -- without ever touching the global generator. Its stream is
+    DELIBERATELY different from the global legacy ``numpy.random`` (only
+    ``key is None`` is byte-identical); ``split`` spawns independent children.
+    """
+
+    __slots__ = ("gen",)
+
+    def __init__(self, gen):
+        self.gen = gen
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return f"_NumpyKey({self.gen!r})"
+
+
 # --- backend/name/shape helpers ----------------------------------------------
-def _name_of_namespace(xp):
-    """Map a resolved namespace module to a backend name ('numpy'|'jax'|'torch')."""
-    if xp is numpy:
-        return "numpy"
-    name = getattr(xp, "__name__", "")
-    if "jax" in name:
-        return "jax"
-    if "torch" in name:
-        return "torch"
-    return "numpy"  # pragma: no cover - defensive
-
-
 def _resolve_backend_name(backend):
     """Backend name for ``key(...)``: explicit ``backend=`` or the active default."""
     if backend is None:
-        return _name_of_namespace(get_namespace())
-    return _name_of_namespace(namespace_for_name(backend))
+        return name_of_namespace(get_namespace())
+    return name_of_namespace(namespace_for_name(backend))
 
 
 def _backend_of_key(key):
-    """Dispatch: which backend a draw for ``key`` uses (numpy for ``key is None``)."""
-    if key is None:
+    """Dispatch: which backend a draw for ``key`` uses.
+
+    Both ``key is None`` (global numpy) and a ``_NumpyKey`` (local numpy
+    Generator) resolve to "numpy"; the draw functions then pick the global module
+    vs the local generator by ``isinstance(key, _NumpyKey)``.
+    """
+    if key is None or isinstance(key, _NumpyKey):
         return "numpy"
     if isinstance(key, _TorchKey):
         return "torch"
@@ -92,9 +111,23 @@ def _backend_of_key(key):
         if isinstance(key, jax.Array):
             return "jax"
     raise TypeError(
-        "galpy.backend.random: unrecognized key; pass None (numpy), a jax "
-        "key from key(seed, 'jax'), or a _TorchKey from key(seed, 'torch')"
+        "galpy.backend.random: unrecognized key; pass None (global numpy), a "
+        "_NumpyKey / jax key / _TorchKey from key(seed, backend)"
     )
+
+
+def _spawn_numpy(gen, num):
+    """Spawn ``num`` independent child Generators from a local numpy ``gen``.
+
+    Uses ``Generator.spawn`` (numpy>=1.25, SeedSequence-based independence); on
+    older numpy it derives ``num`` independent child seeds from ``gen`` (drawn
+    from the parent, so the split stays reproducible given the parent state).
+    """
+    spawn = getattr(gen, "spawn", None)
+    if spawn is not None:
+        return spawn(num)
+    child_seeds = gen.integers(0, 2**63 - 1, size=num)
+    return [numpy.random.default_rng(int(s)) for s in child_seeds]
 
 
 def _tuple_shape(shape):
@@ -125,26 +158,38 @@ def key(seed, backend=None):
     backend : {None, 'numpy', 'jax', 'torch'} or namespace module, optional
         Which backend to make a key for. ``None`` (default) uses the active
         galpy backend (``galpy.backend.get_namespace`` context/global default),
-        so ``key(s)`` under a numpy default seeds ``numpy.random`` and returns
-        ``None``, under a jax default returns a ``jax.random`` key, etc.
+        so ``key(s)`` under a numpy default seeds the GLOBAL ``numpy.random`` and
+        returns ``None`` (byte-identical), under a jax default returns a
+        ``jax.random`` key, etc. Passing ``backend='numpy'`` EXPLICITLY instead
+        opts into a local, reproducible ``_NumpyKey`` (see Notes).
 
     Returns
     -------
     key
-        ``None`` for numpy (having seeded the global ``numpy.random``), a
+        ``None`` for the active numpy default (having seeded the global
+        ``numpy.random``), a ``_NumpyKey`` for an explicit ``backend='numpy'``, a
         ``jax.random`` key for jax, or a ``_TorchKey`` for torch.
 
     Notes
     -----
-    numpy is stateful by design: ``key(seed)`` seeds the global generator and
-    returns ``None`` (the "use the global ``numpy.random``" sentinel), which is
-    exactly what keeps the numpy path byte-identical. jax/torch keys are
+    The numpy DEFAULT is stateful by design: ``key(seed)`` (``backend=None``)
+    under a numpy default seeds the global generator and returns ``None`` (the
+    "use the global ``numpy.random``" sentinel), which is exactly what keeps the
+    numpy path byte-identical. An EXPLICIT ``key(seed, backend='numpy')`` instead
+    returns a ``_NumpyKey`` wrapping a local ``numpy.random.default_rng(seed)`` --
+    giving numpy jax-like reproducibility (same seed => same draws, independent
+    of the global state) without touching the global generator; its stream is
+    intentionally not byte-identical to the global one. jax/torch keys are
     explicit stateless data threaded through ``split`` and the draw functions.
     """
     name = _resolve_backend_name(backend)
     if name == "numpy":
-        numpy.random.seed(seed)
-        return None
+        if backend is None:
+            # Active numpy default: seed the global generator, byte-identical.
+            numpy.random.seed(seed)
+            return None
+        # Explicit backend='numpy': a local, reproducible Generator key.
+        return _NumpyKey(numpy.random.default_rng(seed))
     if name == "jax":
         import jax
 
@@ -155,14 +200,18 @@ def key(seed, backend=None):
 def split(key, num=2):
     """Split ``key`` into ``num`` independent sub-keys.
 
-    Returns a tuple of ``num`` keys. For numpy this is ``(None,) * num`` -- the
-    global generator produces independent sequential draws with no substreams
-    needed. For jax it is ``jax.random.split``; for torch the child seeds are
-    drawn deterministically from ``key`` (so the split is reproducible).
+    Returns a tuple of ``num`` keys. For the global numpy key (``None``) this is
+    ``(None,) * num`` -- the global generator produces independent sequential
+    draws with no substreams needed. For a local ``_NumpyKey`` it spawns ``num``
+    independent child generators (reproducible from the parent). For jax it is
+    ``jax.random.split``; for torch the child seeds are drawn deterministically
+    from ``key`` (so the split is reproducible).
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return (None,) * num
+        if key is None:
+            return (None,) * num
+        return tuple(_NumpyKey(child) for child in _spawn_numpy(key.gen, num))
     if name == "jax":
         import jax
 
@@ -185,7 +234,9 @@ def uniform(key, shape, low=0.0, high=1.0):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.uniform(low, high, size=shape)
+        if key is None:
+            return numpy.random.uniform(low, high, size=shape)
+        return key.gen.uniform(low, high, size=shape)
     if name == "jax":
         from jax import random as jrandom
 
@@ -206,7 +257,9 @@ def normal(key, shape, loc=0.0, scale=1.0):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.normal(loc, scale, size=shape)
+        if key is None:
+            return numpy.random.normal(loc, scale, size=shape)
+        return key.gen.normal(loc, scale, size=shape)
     if name == "jax":
         from jax import random as jrandom
 
@@ -227,7 +280,9 @@ def random(key, shape=None):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.random(size=shape)
+        if key is None:
+            return numpy.random.random(size=shape)
+        return key.gen.random(size=shape)
     if name == "jax":
         from jax import random as jrandom
 
@@ -246,7 +301,9 @@ def randint(key, shape, low, high):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.randint(low, high, size=shape)
+        if key is None:
+            return numpy.random.randint(low, high, size=shape)
+        return key.gen.integers(low, high, size=shape)
     if name == "jax":
         from jax import random as jrandom
 
@@ -269,7 +326,9 @@ def choice(key, a, shape=None, p=None):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.choice(a, size=shape, p=p)
+        if key is None:
+            return numpy.random.choice(a, size=shape, p=p)
+        return key.gen.choice(a, size=shape, p=p)
     if name == "jax":
         from jax import random as jrandom
 
@@ -305,7 +364,9 @@ def multivariate_normal(key, mean, cov, shape=None):
     """
     name = _backend_of_key(key)
     if name == "numpy":
-        return numpy.random.multivariate_normal(mean, cov, size=shape)
+        if key is None:
+            return numpy.random.multivariate_normal(mean, cov, size=shape)
+        return key.gen.multivariate_normal(mean, cov, size=shape)
     if name == "jax":
         from jax import random as jrandom
 

--- a/galpy/backend/special/_router.py
+++ b/galpy/backend/special/_router.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from .._namespaces import match_input_dtype
+from .._namespaces import match_input_dtype, name_of_namespace
 from .._resolver import get_namespace
 
 # Per-backend functions whose NATIVE implementation is simply absent, so the
@@ -60,23 +60,18 @@ def _backend_special(xp):
     numpy -> scipy.special, jax.numpy -> jax.scipy.special,
     array_api_compat.torch -> torch.special.
     """
-    name = getattr(xp, "__name__", "")
-    if name in ("numpy", "np"):
-        import scipy.special as _sp
-
-        return "numpy", _sp
-    if name in ("jax.numpy", "jax"):
+    name = name_of_namespace(xp)  # unknown namespace -> "numpy" (defensive)
+    if name == "jax":
         import jax.scipy.special as _sp
 
         return "jax", _sp
-    if "torch" in name:
+    if name == "torch":
         import torch.special as _sp
 
         return "torch", _sp
-    # Unknown namespace: treat as numpy/scipy (defensive).
-    import scipy.special as _sp  # pragma: no cover
+    import scipy.special as _sp
 
-    return "numpy", _sp  # pragma: no cover
+    return "numpy", _sp
 
 
 def _dispatch(fnname, args, fallback, ns_args=None):

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -11,6 +11,7 @@ from ..backend import (
     autodiff_ops,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
     resolve_namespace,
     use,
 )
@@ -35,12 +36,7 @@ _QUAD_N_FE = 100
 
 def _active_backend_name():
     """'torch'|'jax'|'numpy' for the active galpy backend (context/forced default)."""
-    name = getattr(get_namespace(), "__name__", "")
-    if "torch" in name:
-        return "torch"
-    if name in ("jax", "jax.numpy"):
-        return "jax"
-    return "numpy"
+    return name_of_namespace(get_namespace())
 
 
 def _autodiff_xp():

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -168,7 +168,9 @@ class basestreamspraydf(df):
 
         return None
 
-    def sample(self, n, return_orbit=True, returndt=False, integrate=True, tail=None):
+    def sample(
+        self, n, return_orbit=True, returndt=False, integrate=True, tail=None, key=None
+    ):
         """
         Sample from the DF
 
@@ -184,6 +186,8 @@ class basestreamspraydf(df):
             If True, integrate the orbits to the present time. If False, return positions at stripping (probably want to combine with returndt=True then to make sense of them!). Default is True.
         tail : str, optional
             ``'leading'``, ``'trailing'``, or ``'both'`` to override the default set at class initialization. Default is None (use the value of ``tail=`` from ``__init__``). The progenitor is integrated identically for either arm, so any override value works regardless of the initialization choice.
+        key : optional
+            Backend random key from :func:`galpy.backend.random.key`. Default None uses the global ``numpy.random`` draws (byte-identical to previous behaviour). A jax/torch key makes the stripping-time draws reproducible backend arrays from the key (common-random-numbers), the seam a future differentiable-sampling PR builds on.
 
         Returns
         -------
@@ -205,15 +209,26 @@ class basestreamspraydf(df):
         if tail == "both":
             n_leading = n // 2
             n_trailing = n - n_leading
-            out_l, dt_l = self._sample_tail(n_leading, integrate, leading=True)
-            out_t, dt_t = self._sample_tail(n_trailing, integrate, leading=False)
+            # Independent sub-keys per arm (numpy: split -> (None, None), so each
+            # arm draws sequentially from the global generator: byte-identical).
+            from ..backend import random as grandom
+
+            key_l, key_t = grandom.split(key, 2)
+            out_l, dt_l = self._sample_tail(
+                n_leading, integrate, leading=True, key=key_l
+            )
+            out_t, dt_t = self._sample_tail(
+                n_trailing, integrate, leading=False, key=key_t
+            )
             if is_backend_array(out_l):
                 out = get_namespace(out_l).hstack([out_l, out_t])
             else:
                 out = numpy.hstack([out_l, out_t])
             dt = numpy.concatenate([dt_l, dt_t])
         else:
-            out, dt = self._sample_tail(n, integrate, leading=tail == "leading")
+            out, dt = self._sample_tail(
+                n, integrate, leading=tail == "leading", key=key
+            )
         if return_orbit:
             # Output Orbit ro/vo/zo/solarmotion/roSet/voSet match progenitor
             o = Orbit(
@@ -514,15 +529,18 @@ class basestreamspraydf(df):
             def pdf_internal(t):
                 out = stripping_pdf(t * time_in_gyr * units.Gyr)
                 return out.to(1.0 / units.Gyr).value * time_in_gyr
+
         elif _t_unit_input:
 
             def pdf_internal(t):
                 return numpy.asarray(stripping_pdf(t * time_in_gyr * units.Gyr))
+
         elif _t_unit_output:
 
             def pdf_internal(t):
                 out = stripping_pdf(t)
                 return out.to(1.0 / units.Gyr).value * time_in_gyr
+
         else:
 
             def pdf_internal(t):
@@ -544,14 +562,33 @@ class basestreamspraydf(df):
             cdf_vals[unique_idx], t_grid[unique_idx], k=1, ext=3
         )
 
-    def _sample_tail(self, n, integrate, leading=True):
-        """Sample n points from the specified tail."""
-        # First sample times (RNG stays numpy; coerced to the backend below)
+    def _draw_stripping_dt(self, n, key=None):
+        """Draw n stripping-time offsets ``dt >= 0``.
+
+        The single random seam of the spray's stripping-time sampling. numpy
+        (``key is None``) is byte-identical to the historical
+        ``numpy.random.uniform`` draw; a jax/torch ``key`` from
+        :func:`galpy.backend.random.key` returns a reproducible backend array
+        (the default uniform-stripping path). The ``stripping_pdf`` inverse-CDF
+        is a scipy spline, so that path evaluates on the numpy sample for now (a
+        backend-native inverse-CDF is a later PR).
+        """
+        from ..backend import as_numpy
+        from ..backend import random as grandom
+
         if self._stripping_inv_cdf is None:
-            dt = numpy.random.uniform(size=n) * self._tdisrupt
-        else:
-            u_samples = numpy.random.uniform(size=n)
-            dt = -self._stripping_inv_cdf(u_samples)
+            return grandom.uniform(key, (n,)) * self._tdisrupt
+        u_samples = grandom.uniform(key, (n,))
+        return -self._stripping_inv_cdf(as_numpy(u_samples))
+
+    def _sample_tail(self, n, integrate, leading=True, key=None):
+        """Sample n points from the specified tail."""
+        from ..backend import as_numpy
+
+        # Stripping times: reproducible backend array when a key is threaded.
+        # Downstream frame construction and orbit integration are numpy-only for
+        # now (making them differentiable is a later PR), so pull dt to numpy.
+        dt = as_numpy(self._draw_stripping_dt(n, key=key))
         xp = get_namespace(dt)  # context-resolved backend (numpy under numpy)
         # Build all rotation matrices
         rot, rot_inv = self._setup_rot(dt)
@@ -798,11 +835,13 @@ class basestreamspraydf(df):
                 return conversion.parse_mass(
                     progenitor_mass(t_q), ro=self._ro, vo=self._vo
                 )
+
         elif _mass_unit_input:
 
             def _mass_fn(t):
                 t_q = numpy.asarray(t, dtype=float) * _time_to_quantity
                 return numpy.asarray(progenitor_mass(t_q), dtype=float)
+
         elif _mass_unit_output:
 
             def _mass_fn(t):
@@ -811,6 +850,7 @@ class basestreamspraydf(df):
                     ro=self._ro,
                     vo=self._vo,
                 )
+
         else:
 
             def _mass_fn(t):

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -153,6 +153,136 @@ def test_numpy_split_is_none_tuple():
 
 
 # ----------------------------------------------------------------------------
+# de-dup: the canonical namespace->name helper (galpy.backend.name_of_namespace)
+# now shared by random.py, the special router, and constantbetadf.
+# ----------------------------------------------------------------------------
+def test_name_of_namespace_numpy_and_default():
+    from galpy.backend import name_of_namespace
+
+    assert name_of_namespace(numpy) == "numpy"
+
+    # an unrecognized namespace defaults to "numpy" (defensive branch)
+    class _Weird:
+        __name__ = "not_a_backend"
+
+    assert name_of_namespace(_Weird()) == "numpy"
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_name_of_namespace_jax():
+    from galpy.backend import name_of_namespace
+
+    # the resolved jax namespace is jax.numpy (__name__ == 'jax.numpy')
+    assert name_of_namespace(jnp) == "jax"
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_name_of_namespace_torch():
+    import array_api_compat.torch as txp
+
+    from galpy.backend import name_of_namespace
+
+    assert name_of_namespace(txp) == "torch"
+
+
+# ----------------------------------------------------------------------------
+# numpy LOCAL (jax-like) seed: key(seed, 'numpy') -> a _NumpyKey drawing from a
+# local numpy.random.Generator -- reproducible, independent of the global state,
+# and intentionally NOT byte-identical to the global stream (only key=None is).
+# ----------------------------------------------------------------------------
+def _local_draws(k):
+    return [
+        numpy.asarray(gr.uniform(k, (7,))),
+        numpy.asarray(gr.normal(k, (7,))),
+        numpy.asarray(gr.random(k, 7)),
+        numpy.asarray(gr.randint(k, (7,), 0, 50)),
+        numpy.asarray(gr.choice(k, [1.0, 2.0, 3.0, 4.0], shape=7)),
+        numpy.asarray(gr.multivariate_normal(k, _MEAN6, _SINGULAR_COV, shape=7)),
+    ]
+
+
+def test_numpy_local_key_type_not_none():
+    # explicit backend='numpy' opts into a local _NumpyKey (NOT the None sentinel)
+    from galpy.backend.random import _NumpyKey
+
+    k = gr.key(123, "numpy")
+    assert isinstance(k, _NumpyKey)
+    assert k is not None
+    # backend=None under the numpy default still returns None (byte-identical path)
+    assert gr.key(123) is None
+
+
+def test_numpy_local_key_reproducible_all_fns():
+    # same seed => identical draws across all six draw functions
+    first = _local_draws(gr.key(2024, "numpy"))
+    second = _local_draws(gr.key(2024, "numpy"))
+    for a, b in zip(first, second):
+        numpy.testing.assert_array_equal(a, b)
+
+
+def test_numpy_local_key_independent_of_global():
+    # reproducible even with intervening GLOBAL numpy.random churn between draws
+    ref = _local_draws(gr.key(2024, "numpy"))
+    k2 = gr.key(2024, "numpy")
+    numpy.random.seed(999)
+    numpy.random.random(1234)
+    numpy.random.normal(size=77)
+    got = _local_draws(k2)
+    for a, b in zip(ref, got):
+        numpy.testing.assert_array_equal(a, b)
+
+
+def test_numpy_local_key_different_seeds_differ():
+    a = numpy.asarray(gr.uniform(gr.key(1, "numpy"), (200,)))
+    b = numpy.asarray(gr.uniform(gr.key(2, "numpy"), (200,)))
+    assert not numpy.allclose(a, b)
+
+
+def test_numpy_local_split_independent_and_reproducible():
+    ka, kb = gr.split(gr.key(7, "numpy"), 2)
+    a = numpy.asarray(gr.uniform(ka, (20000,)))
+    b = numpy.asarray(gr.uniform(kb, (20000,)))
+    # distinct, essentially-uncorrelated child streams
+    assert not numpy.allclose(a, b)
+    assert abs(numpy.corrcoef(a, b)[0, 1]) < 0.05
+    # split reproducible from the same parent seed
+    ka2, kb2 = gr.split(gr.key(7, "numpy"), 2)
+    numpy.testing.assert_array_equal(a, numpy.asarray(gr.uniform(ka2, (20000,))))
+    numpy.testing.assert_array_equal(b, numpy.asarray(gr.uniform(kb2, (20000,))))
+
+
+def test_numpy_local_split_fallback_derives_seeds():
+    # numpy<1.25 lacks Generator.spawn: _spawn_numpy derives child seeds from the
+    # parent -> still independent AND reproducible (covers the fallback branch).
+    from galpy.backend.random import _spawn_numpy
+
+    class _NoSpawn:  # a Generator-like exposing only .integers (no .spawn)
+        def __init__(self, gen):
+            self._gen = gen
+
+        def integers(self, *args, **kwargs):
+            return self._gen.integers(*args, **kwargs)
+
+    kids = _spawn_numpy(_NoSpawn(numpy.random.default_rng(5)), 3)
+    assert len(kids) == 3
+    a = [numpy.asarray(g.uniform(size=8)) for g in kids]
+    assert not numpy.allclose(a[0], a[1])  # children independent
+    kids2 = _spawn_numpy(_NoSpawn(numpy.random.default_rng(5)), 3)
+    b = [numpy.asarray(g.uniform(size=8)) for g in kids2]
+    for x, y in zip(a, b):
+        numpy.testing.assert_array_equal(x, y)  # reproducible from parent seed
+
+
+def test_numpy_local_stream_differs_from_global():
+    # the local stream is DELIBERATELY not byte-identical to key=None (global);
+    # only key=None reproduces galpy's historical numpy.random draw sequence.
+    local = numpy.asarray(gr.uniform(gr.key(321, "numpy"), (10,)))
+    numpy.random.seed(321)
+    glob = numpy.asarray(gr.uniform(None, (10,)))
+    assert not numpy.array_equal(local, glob)
+
+
+# ----------------------------------------------------------------------------
 # 2. key reproducibility (jax + torch): same key => identical draws
 # ----------------------------------------------------------------------------
 @pytest.mark.parametrize("backend", AD_BACKENDS)

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -1,0 +1,343 @@
+###############################################################################
+# test_backend_random.py: the backend-agnostic RNG shim (galpy.backend.random).
+#
+# Acceptance bar:
+#   1. numpy byte-identity: the shim's numpy path (key=None) is tobytes-equal to
+#      the raw numpy.random.<fn> call it replaces (so seeded outputs are byte-
+#      for-byte unchanged), and the streamspraydf pilot's numpy draws / sample()
+#      are byte-identical / deterministic.
+#   2. key reproducibility (jax + torch): same key => identical draws; split
+#      gives independent (statistically distinct) sub-keys.
+#   3. fixed-noise derivative: a reparameterized example mu(θ)+σ(θ)*normal(key)
+#      (and a uniform inverse-CDF example) has jax.grad / torch.func.grad w.r.t.
+#      θ matching finite differences with the key held fixed; two calls with the
+#      same key+θ are identical, different θ differ smoothly.
+#   4. jit: the jax example is jax.jit-able and gives the same result.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy as _np
+from galpy.backend import is_backend_array
+from galpy.backend import random as gr
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# A singular covariance (chen24spraydf's default: two all-zero rows/cols) to
+# exercise the singular-safe multivariate_normal path on every backend.
+_SINGULAR_COV = numpy.array(
+    [
+        [0.1225, 0, 0, 0, -0.085521, 0],
+        [0, 0.161143, 0, 0, 0, 0],
+        [0, 0, 0.043865, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+        [-0.085521, 0, 0, 0, 0.121847, 0],
+        [0, 0, 0, 0, 0, 0.147435],
+    ]
+)
+_MEAN6 = numpy.array([1.6, -0.523599, 0.0, 1.0, 0.349066, 0.0])
+
+
+# ----------------------------------------------------------------------------
+# 1. numpy byte-identity: the shim's key=None path == the raw numpy.random call
+# ----------------------------------------------------------------------------
+def _bytes_equal(a, b):
+    return numpy.asarray(a).tobytes() == numpy.asarray(b).tobytes()
+
+
+def test_numpy_uniform_byte_identical():
+    numpy.random.seed(7)
+    a = gr.uniform(None, (13,))
+    numpy.random.seed(7)
+    b = numpy.random.uniform(size=13)
+    assert _bytes_equal(a, b)
+    # explicit low/high must reproduce the historical scaled draw too
+    numpy.random.seed(7)
+    a = gr.uniform(None, (5,), low=-2.0, high=3.0)
+    numpy.random.seed(7)
+    b = numpy.random.uniform(-2.0, 3.0, size=5)
+    assert _bytes_equal(a, b)
+
+
+def test_numpy_normal_byte_identical():
+    numpy.random.seed(3)
+    a = gr.normal(None, (9,))
+    numpy.random.seed(3)
+    b = numpy.random.normal(size=9)
+    assert _bytes_equal(a, b)
+    # shape=None reproduces a scalar numpy.random.normal() (python float, not 0-d)
+    numpy.random.seed(3)
+    a = gr.normal(None, None)
+    numpy.random.seed(3)
+    b = numpy.random.normal()
+    assert a == b and isinstance(a, float)
+
+
+def test_numpy_random_byte_identical():
+    # random() must stay a DISTINCT numpy.random.random call (not aliased to
+    # uniform) so the historical draw sequence is reproduced bit-for-bit.
+    numpy.random.seed(11)
+    a = gr.random(None, 8)
+    numpy.random.seed(11)
+    b = numpy.random.random(size=8)
+    assert _bytes_equal(a, b)
+    numpy.random.seed(11)
+    a = gr.random(None)  # scalar
+    numpy.random.seed(11)
+    b = numpy.random.random()
+    assert a == b
+
+
+def test_numpy_randint_byte_identical():
+    numpy.random.seed(1)
+    a = gr.randint(None, (6,), 0, 100)
+    numpy.random.seed(1)
+    b = numpy.random.randint(0, 100, size=6)
+    assert _bytes_equal(a, b)
+    numpy.random.seed(1)
+    a = gr.randint(None, None, 0, 0xFFFFFF)  # scalar (Orbits.py color hash)
+    numpy.random.seed(1)
+    b = numpy.random.randint(0, 0xFFFFFF)
+    assert a == b
+
+
+def test_numpy_choice_byte_identical():
+    numpy.random.seed(2)
+    a = gr.choice(None, [1.0, -1.0], shape=17)
+    numpy.random.seed(2)
+    b = numpy.random.choice([1.0, -1.0], size=17)
+    assert _bytes_equal(a, b)
+
+
+def test_numpy_multivariate_normal_byte_identical():
+    numpy.random.seed(4)
+    a = gr.multivariate_normal(None, _MEAN6, _SINGULAR_COV, shape=25)
+    numpy.random.seed(4)
+    b = numpy.random.multivariate_normal(_MEAN6, _SINGULAR_COV, size=25)
+    assert _bytes_equal(a, b)
+
+
+def test_numpy_key_seeds_global_returns_none():
+    # key(seed) on the numpy default seeds the global generator and returns the
+    # None sentinel; the subsequent shim draw matches the raw seeded call.
+    k = gr.key(123)
+    assert k is None
+    a = gr.uniform(None, (4,))
+    numpy.random.seed(123)
+    b = numpy.random.uniform(size=4)
+    assert _bytes_equal(a, b)
+
+
+def test_numpy_split_is_none_tuple():
+    assert gr.split(None, 3) == (None, None, None)
+
+
+# ----------------------------------------------------------------------------
+# 2. key reproducibility (jax + torch): same key => identical draws
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_key_reproducible(backend):
+    k = gr.key(0, backend)
+    draws = [
+        lambda kk: gr.uniform(kk, (7,)),
+        lambda kk: gr.normal(kk, (7,)),
+        lambda kk: gr.random(kk, (7,)),
+        lambda kk: gr.randint(kk, (7,), 0, 50),
+        lambda kk: gr.multivariate_normal(kk, _MEAN6, _SINGULAR_COV, shape=7),
+    ]
+    for fn in draws:
+        first = _np(fn(k))
+        second = _np(fn(k))
+        assert is_backend_array(fn(k))
+        numpy.testing.assert_array_equal(first, second)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_multivariate_normal_singular_cov(backend):
+    # The all-zero row/col (dim 3) must have exactly zero variance on every
+    # backend (singular-safe factorization), matching numpy's SVD method.
+    k = gr.key(1, backend)
+    s = _np(gr.multivariate_normal(k, _MEAN6, _SINGULAR_COV, shape=2000))
+    assert numpy.max(numpy.abs(s[:, 3] - _MEAN6[3])) < 1e-9
+    assert numpy.std(s[:, 0]) > 0.1  # a non-degenerate dim actually varies
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_split_independent_and_reproducible(backend):
+    k = gr.key(2, backend)
+    ka, kb = gr.split(k, 2)
+    a = _np(gr.uniform(ka, (20000,)))
+    b = _np(gr.uniform(kb, (20000,)))
+    # distinct streams: not equal, and essentially uncorrelated
+    assert not numpy.allclose(a, b)
+    assert abs(numpy.corrcoef(a, b)[0, 1]) < 0.05
+    # split itself is reproducible (same parent key => same sub-keys)
+    ka2, kb2 = gr.split(k, 2)
+    numpy.testing.assert_array_equal(a, _np(gr.uniform(ka2, (20000,))))
+    numpy.testing.assert_array_equal(b, _np(gr.uniform(kb2, (20000,))))
+
+
+# ----------------------------------------------------------------------------
+# 3. fixed-noise derivative (the headline) + 4. jit
+# ----------------------------------------------------------------------------
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_jax_fixed_noise_grad_normal():
+    # x(θ) = μ(θ) + σ(θ) * normal(key): grad w.r.t θ with the key FIXED must
+    # match a central finite difference using the SAME key on both sides.
+    key = gr.key(7, "jax")
+
+    def f(theta):
+        mu = theta**2
+        sigma = jnp.exp(0.5 * theta)
+        return jnp.sum(mu + sigma * gr.normal(key, (4,)))
+
+    th = jnp.asarray(0.3)
+    g = float(jax.grad(f)(th))
+    eps = 1e-6
+    fd = float((f(th + eps) - f(th - eps)) / (2 * eps))
+    assert abs(g - fd) < 1e-5
+    # same key + θ => bit-identical; different θ differ smoothly
+    assert float(f(th)) == float(f(th))
+    assert float(f(th)) != float(f(th + 0.1))
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_jax_fixed_noise_grad_uniform_inverse_cdf():
+    # Inverse-CDF reparam: exponential x = -log(1-u)/rate, rate=θ.
+    key = gr.key(9, "jax")
+
+    def f(theta):
+        u = gr.uniform(key, (5,))
+        x = -jnp.log(1.0 - u) / theta
+        return jnp.sum(x)
+
+    th = jnp.asarray(1.7)
+    g = float(jax.grad(f)(th))
+    eps = 1e-6
+    fd = float((f(th + eps) - f(th - eps)) / (2 * eps))
+    assert abs(g - fd) < 1e-5
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_jax_jit():
+    key = gr.key(3, "jax")
+
+    def f(theta):
+        return jnp.sum(theta + jnp.exp(theta) * gr.normal(key, (5,)))
+
+    th = jnp.asarray(0.7)
+    assert abs(float(jax.jit(f)(th)) - float(f(th))) < 1e-12
+    g = jax.grad(f)
+    assert abs(float(jax.jit(g)(th)) - float(g(th))) < 1e-10
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_torch_fixed_noise_grad_normal():
+    # torch analog: draw the noise ONCE (a constant tensor) and differentiate
+    # the reparameterized transform through it with torch.func.grad.
+    key = gr.key(7, "torch")
+    noise = gr.normal(key, (4,))  # fixed drawn noise (no grad)
+
+    def f(theta):
+        mu = theta**2
+        sigma = torch.exp(0.5 * theta)
+        return torch.sum(mu + sigma * noise)
+
+    th = torch.tensor(0.3)
+    g = float(torch.func.grad(f)(th))
+    eps = 1e-6
+    fd = float((f(th + eps) - f(th - eps)) / (2 * eps))
+    assert abs(g - fd) < 1e-5
+    assert float(f(th)) == float(f(th))
+    assert float(f(th)) != float(f(th + 0.1))
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_torch_fixed_noise_grad_uniform_inverse_cdf():
+    key = gr.key(9, "torch")
+    u = gr.uniform(key, (5,))  # fixed drawn uniforms (no grad)
+
+    def f(theta):
+        x = -torch.log(1.0 - u) / theta
+        return torch.sum(x)
+
+    th = torch.tensor(1.7)
+    g = float(torch.func.grad(f)(th))
+    eps = 1e-6
+    fd = float((f(th + eps) - f(th - eps)) / (2 * eps))
+    assert abs(g - fd) < 1e-5
+
+
+# ----------------------------------------------------------------------------
+# streamspraydf pilot: numpy byte-identity + key-threaded backend-array draws
+# ----------------------------------------------------------------------------
+def _make_spray():
+    from galpy.df import fardal15spraydf
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+    from galpy.util import conversion
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    obs = Orbit(
+        [1.56148083, 0.35081535, -1.15481504, 0.88719443, -0.47713334, 0.12019596]
+    )
+    ro, vo = 8.0, 220.0
+    return fardal15spraydf(
+        2 * 10.0**4.0 / conversion.mass_in_msol(vo, ro),
+        progenitor=obs,
+        pot=lp,
+        tdisrupt=4.5 / conversion.time_in_Gyr(vo, ro),
+    )
+
+
+def test_streamspray_numpy_draws_byte_identical():
+    sp = _make_spray()
+    # The single changed line: _draw_stripping_dt(None) == the historical draw.
+    numpy.random.seed(321)
+    got = sp._draw_stripping_dt(20, key=None)
+    numpy.random.seed(321)
+    ref = numpy.random.uniform(size=20) * sp._tdisrupt
+    assert _bytes_equal(got, ref)
+    assert not is_backend_array(got)
+
+
+def test_streamspray_sample_deterministic():
+    sp = _make_spray()
+    numpy.random.seed(1)
+    a = sp.sample(12, return_orbit=False, integrate=False)
+    numpy.random.seed(1)
+    b = sp.sample(12, return_orbit=False, integrate=False)
+    for x, y in zip(a, b):
+        numpy.testing.assert_array_equal(numpy.asarray(x), numpy.asarray(y))
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_streamspray_key_draws_reproducible(backend):
+    sp = _make_spray()
+    k = gr.key(4, backend)
+    dt1 = sp._draw_stripping_dt(15, key=k)
+    dt2 = sp._draw_stripping_dt(15, key=k)
+    assert is_backend_array(dt1)  # reproducible BACKEND array from the key
+    numpy.testing.assert_array_equal(_np(dt1), _np(dt2))
+    dt3 = sp._draw_stripping_dt(15, key=gr.key(5, backend))
+    assert not numpy.allclose(_np(dt1), _np(dt3))  # different key => different draws

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -471,3 +471,36 @@ def test_streamspray_key_draws_reproducible(backend):
     numpy.testing.assert_array_equal(_np(dt1), _np(dt2))
     dt3 = sp._draw_stripping_dt(15, key=gr.key(5, backend))
     assert not numpy.allclose(_np(dt1), _np(dt3))  # different key => different draws
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_choice_backend(backend):
+    # choice on jax/torch: int a (-> range, unweighted) and array a (weighted p).
+    k = gr.key(3, backend)
+    c1 = _np(gr.choice(k, 5, shape=(9,)))
+    assert c1.shape == (9,) and c1.min() >= 0 and c1.max() < 5
+    c2 = _np(
+        gr.choice(
+            k,
+            numpy.array([10.0, 20.0, 30.0]),
+            shape=(8,),
+            p=numpy.array([0.1, 0.2, 0.7]),
+        )
+    )
+    assert c2.shape == (8,) and set(numpy.unique(c2)).issubset({10.0, 20.0, 30.0})
+    assert is_backend_array(gr.choice(k, 3, shape=(2,)))
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_scalar_shape_none(backend):
+    # shape=None -> scalar () on jax/torch (covers _tuple_shape(None)).
+    k = gr.key(4, backend)
+    for fn in (gr.uniform, gr.normal, gr.random):
+        v = fn(k, None)
+        assert is_backend_array(v) and numpy.asarray(_np(v)).shape == ()
+
+
+def test_invalid_key_raises():
+    # an unrecognized key object -> TypeError from _backend_of_key.
+    with pytest.raises(TypeError):
+        gr.uniform("not-a-key", (3,))


### PR DESCRIPTION
## Backend-agnostic RNG shim (`galpy.backend.random`) — #130 PR-1

The foundation for **differentiable, jit-able, fixed-noise sampling** on jax/torch, while keeping numpy byte-identical. First PR of the #130 effort: the shim + a streamspray **draw** pilot; migrating the individual samplers (spherical DFs, streamdf, qdf, diskdf) and making the full sample differentiable are follow-ups.

### Design — dispatch on the *key*, not the ambient backend
| you pass… | behavior |
|---|---|
| `key=None` | the **global `numpy.random.*`** — byte-identical (numpy is never differentiated/jit'd, so it keeps its stateful behaviour exactly) |
| a jax key | `jax.random.*` — a pure function of the key (reproducible, jit-able, differentiable-in-θ with the noise frozen) |
| a `_TorchKey(seed)` | a `torch.Generator` seeded per draw — reproducible; the drawn tensor is a constant a reparameterized transform differentiates through |

API: `key`/`split` + `uniform`/`normal`/`random`/`randint`/`choice`/`multivariate_normal`. `random` is kept distinct from `uniform` so numpy's historical draw sequence is bit-reproduced; MVN forces SVD (jax) / eigh (torch) for the spray DFs' **singular** covariances.

### Pilot: streamspray draws
`sample(..., key=None)` threads a key (`split` per tail arm) via a new `_draw_stripping_dt` seam. numpy path byte-identical; jax/torch draws are reproducible backend arrays (common-random-numbers). Downstream frame construction / orbit integration stay as-is (making them differentiable is a later PR).

### Verified
`tests/test_backend_random.py` (23): numpy byte-identity vs raw `numpy.random`; jax/torch key-reproducibility (+ independent `split` sub-keys); **fixed-noise `jax.grad` / `torch.func.grad` == finite-difference** (`1.52361551229` vs `1.52361551231`); **`jax.jit` + `jax.jit(jax.grad)`**. Existing `tests/test_streamspraydf.py` **38/38** (numpy sample byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
