### PR TITLE
Backend C-STM: symplectic + planar (4D) + 1D (2D) differentiable orbit integration

### DIFF
--- a/galpy/backend/_jax/orbit_stm.py
+++ b/galpy/backend/_jax/orbit_stm.py
@@ -17,14 +17,16 @@ from .._reference.inbackend_stm import c_stm_forward
 def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
     """Differentiable C-STM orbit integration under jax.
 
-    vxvv: jax array (6,) or (N,6), Orbit order. Returns (nt,6) or (N,nt,6).
-    Differentiable w.r.t. vxvv. pot/ts/method are static (closed over).
+    vxvv: jax array (d,) or (N,d), d in {6,4,2} (3D/planar/1D), Orbit order.
+    Returns (nt,d) or (N,nt,d). Differentiable w.r.t. vxvv. pot/ts/method are
+    static (closed over).
     """
     import jax
     import jax.numpy as jnp
 
     ts_np = numpy.asarray(ts, dtype=numpy.float64)
     nt = ts_np.shape[0]
+    d = vxvv.shape[-1]  # phase-space dim: 6 (3D), 4 (planar), 2 (1D)
 
     def _host(vxvv_np):
         xt, M = c_stm_forward(
@@ -34,11 +36,11 @@ def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
 
     def _call(v):
         single = v.ndim == 1
-        n6 = (nt, 6) if single else (v.shape[0], nt, 6)
-        n66 = (nt, 6, 6) if single else (v.shape[0], nt, 6, 6)
+        nx = (nt, d) if single else (v.shape[0], nt, d)
+        nxx = (nt, d, d) if single else (v.shape[0], nt, d, d)
         return jax.pure_callback(
             _host,
-            (jax.ShapeDtypeStruct(n6, v.dtype), jax.ShapeDtypeStruct(n66, v.dtype)),
+            (jax.ShapeDtypeStruct(nx, v.dtype), jax.ShapeDtypeStruct(nxx, v.dtype)),
             v,
             vmap_method="expand_dims",
         )

--- a/galpy/backend/_reference/inbackend_stm.py
+++ b/galpy/backend/_reference/inbackend_stm.py
@@ -25,35 +25,58 @@ import numpy
 
 from .. import get_namespace
 
-# dxdv-capable C integrators (the variational RHS is wired for these).
-_C_DXDV_METHODS = ("rk4_c", "rk6_c", "dopr54_c", "dop853_c")
+# dxdv-capable C integrators (the variational RHS is wired for these). The
+# Runge-Kutta methods additionally support the fast AUGMENTED 3D STM (all six
+# columns in one 42-state solve); the symplectic methods carry the deviation
+# through the closed-form drift/kick tangent maps and are integrated per column.
+_C_RK_METHODS = ("rk4_c", "rk6_c", "dopr54_c", "dop853_c")
+_C_SYMPLEC_METHODS = ("leapfrog_c", "symplec4_c", "symplec6_c")
+_C_DXDV_METHODS = _C_RK_METHODS + _C_SYMPLEC_METHODS
 
 
 def c_stm_forward(pot, vxvv, ts, method, rtol, atol):
     """Run the C variational integrator and return (x(t), M(t)).
 
     Pure numpy; no autodiff. This is the host-side call wrapped by the jax/torch
-    autodiff rules. Uses the AUGMENTED 42-state integrator -- the base orbit plus
-    all six STM columns in ONE solve (the force + 3D Hessian are evaluated once per
-    step, not six times), ~4-6x faster than re-integrating the base per column. For
-    the adaptive methods (dop853_c/dopr54_c) the joint 42-state error norm accepts a
-    slightly different step sequence than six 12-state solves, so M matches the
-    per-column reference (``_c_stm_forward_loop``) to ~1e-10, not bit-for-bit; the
-    gradient is unchanged. See ``_c_stm_forward_loop`` for the reference path.
+    autodiff rules. Handles 3D (6D phase space), planar (4D) and 1D (2D) orbits and
+    both the Runge-Kutta and symplectic dxdv-capable C integrators. A 3D orbit with
+    a Runge-Kutta method uses the AUGMENTED integrator (``_c_stm_forward_augmented``
+    -- base orbit + all six STM columns in ONE 42-state solve, ~4-6x faster than
+    per-column); every other case (symplectic, planar, or 1D -- for which there is
+    no augmented C STM) uses the per-column reference (``_c_stm_forward_loop``, d
+    separate ``integrate_dxdv`` solves).
 
     Parameters
     ----------
     pot : Potential (or list)
-    vxvv : numpy.ndarray, shape (6,) or (N, 6), Orbit order [R,vR,vT,z,vz,phi].
+    vxvv : numpy.ndarray, shape (d,) or (N, d) with d in {6, 4, 2}: Orbit order
+        [R,vR,vT,z,vz,phi] (3D), [R,vR,vT,phi] (planar), or [x,vx] (1D).
     ts : numpy.ndarray, shape (nt,), output times (ts[0] is the initial time).
     method : str, one of ``_C_DXDV_METHODS``.
     rtol, atol : float
 
     Returns
     -------
-    xt : numpy.ndarray, (nt, 6) or (N, nt, 6) -- the orbit, Orbit order.
-    M : numpy.ndarray, (nt, 6, 6) or (N, nt, 6, 6) -- STM d x(t)/d x(0),
+    xt : numpy.ndarray, (nt, d) or (N, nt, d) -- the orbit, Orbit order.
+    M : numpy.ndarray, (nt, d, d) or (N, nt, d, d) -- STM d x(t)/d x(0),
         M[...,0,:,:] = identity.
+    """
+    d = numpy.asarray(vxvv).shape[-1]
+    if d == 6 and method.lower() in _C_RK_METHODS:
+        return _c_stm_forward_augmented(pot, vxvv, ts, method, rtol, atol)
+    # Symplectic 3D, or any planar/1D orbit: no augmented C STM -> per-column loop.
+    return _c_stm_forward_loop(pot, vxvv, ts, method, rtol, atol)
+
+
+def _c_stm_forward_augmented(pot, vxvv, ts, method, rtol, atol):
+    """Augmented 3D STM forward: the base orbit plus all six STM columns in ONE
+    42-state C solve (the force + 3D Hessian are evaluated once per step, not six
+    times), ~4-6x faster than re-integrating the base per column. For the adaptive
+    methods (dop853_c/dopr54_c) the joint 42-state error norm accepts a slightly
+    different step sequence than six 12-state solves, so M matches the per-column
+    reference (``_c_stm_forward_loop``) to ~1e-10, not bit-for-bit; the gradient is
+    unchanged. 6D orbits + Runge-Kutta methods only. Same signature/return as
+    ``c_stm_forward``.
     """
     from ...orbit.integrateFullOrbit import integrateFullOrbit_stm_c
     from ...util import coords
@@ -110,23 +133,30 @@ def c_stm_forward(pot, vxvv, ts, method, rtol, atol):
 
 
 def _c_stm_forward_loop(pot, vxvv, ts, method, rtol, atol):
-    """Reference STM forward: propagate the six canonical basis deviations with
-    SIX separate ``integrate_dxdv`` solves (re-integrating the base each time), in
-    cyl Orbit order (``rectIn=False, rectOut=False`` -- no cyl<->rect folding here).
-    Kept as the bit-identity reference for the augmented ``c_stm_forward``. Same
-    signature and return contract.
+    """Per-column STM forward for ANY phase-space dim (d in {6, 4, 2}) and any
+    dxdv-capable C method (Runge-Kutta OR symplectic): propagate the d canonical
+    basis deviations with d separate ``integrate_dxdv`` solves (re-integrating the
+    base each time), in cyl/native Orbit order (``rectIn=False, rectOut=False`` --
+    no cyl<->rect folding; the flags are ignored for 1D). This is the bit-identity
+    reference for the augmented 3D path AND the actual forward for the symplectic,
+    planar, and 1D cases (which have no augmented C STM). Same signature/return as
+    ``c_stm_forward``. Note the STM is returned in the (non-canonical) Orbit frame,
+    so ``det M != 1`` for d in {4, 6}; it is nonetheless the exact sensitivity
+    ``d x(t)/d x(0)`` used for the IC gradient (validated by finite-difference of
+    the flow, not by Liouville in the cyl frame).
     """
     from ...orbit import Orbit
 
     vxvv = numpy.asarray(vxvv, dtype=numpy.float64)
     single = vxvv.ndim == 1
     ics = vxvv[None] if single else vxvv
-    basis = numpy.eye(6)
+    d = ics.shape[-1]
+    basis = numpy.eye(d)
     xts, Ms = [], []
     for ic in ics:
         cols = []
         base = None
-        for i in range(6):
+        for i in range(d):
             o = Orbit(list(ic))
             o.integrate_dxdv(
                 basis[i],
@@ -138,11 +168,18 @@ def _c_stm_forward_loop(pot, vxvv, ts, method, rtol, atol):
                 rtol=rtol,
                 atol=atol,
             )
-            cols.append(o.getOrbit_dxdv())  # (nt,6): column i of M
+            cols.append(o.getOrbit_dxdv())  # (nt,d): column i of M
             if base is None:
-                base = o.getOrbit()  # (nt,6): the base orbit, Orbit order
+                base = numpy.array(o.getOrbit())  # (nt,d): base orbit, Orbit order
+                if d in (4, 6):
+                    # Orbit.integrate wraps phi (the last coord) to (-pi, pi];
+                    # planar integrate_dxdv returns it in [0, 2pi) -> wrap to match
+                    # the numpy path (M's delta-phi is a branch-independent deriv).
+                    base[:, -1] = (
+                        numpy.mod(base[:, -1] + numpy.pi, 2.0 * numpy.pi) - numpy.pi
+                    )
         xts.append(base)
-        Ms.append(numpy.asarray(cols).transpose(1, 2, 0))  # (nt,6,6)
+        Ms.append(numpy.asarray(cols).transpose(1, 2, 0))  # (nt,d,d)
     xt = numpy.asarray(xts)
     M = numpy.asarray(Ms)
     if single:
@@ -156,18 +193,21 @@ def integrate_stm(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
     Parameters
     ----------
     pot : Potential (or list).
-    vxvv : backend array, (6,) or (N, 6), Orbit order [R,vR,vT,z,vz,phi]. Its
+    vxvv : backend array, (d,) or (N, d) with d in {6, 4, 2}: Orbit order
+        [R,vR,vT,z,vz,phi] (3D), [R,vR,vT,phi] (planar), or [x,vx] (1D). Its
         namespace (jax/torch) selects the autodiff wrapper.
     ts : array of output times (numpy or backend; ts[0] is the initial time).
-    method : one of rk4_c / rk6_c / dopr54_c / dop853_c.
+    method : one of the dxdv-capable C integrators -- Runge-Kutta
+        (rk4_c / rk6_c / dopr54_c / dop853_c) or symplectic
+        (leapfrog_c / symplec4_c / symplec6_c).
     rtol, atol : C integrator tolerances.
 
     Returns
     -------
-    backend array, (nt, 6) or (N, nt, 6), the orbit in Orbit order, differentiable
+    backend array, (nt, d) or (N, nt, d), the orbit in Orbit order, differentiable
     w.r.t. ``vxvv``.
     """
-    if method not in _C_DXDV_METHODS:
+    if method.lower() not in _C_DXDV_METHODS:
         raise ValueError(
             f"integrate_stm needs a dxdv-capable C integrator {_C_DXDV_METHODS}, got {method!r}"
         )

--- a/galpy/backend/_torch/orbit_stm.py
+++ b/galpy/backend/_torch/orbit_stm.py
@@ -31,9 +31,9 @@ class _CSTMFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_out):
         (M,) = ctx.saved_tensors
-        if ctx.single:  # M (nt,6,6), grad_out (nt,6) -> (6,)
+        if ctx.single:  # M (nt,d,d), grad_out (nt,d) -> (d,)
             vbar = torch.einsum("tab,ta->b", M, grad_out)
-        else:  # M (N,nt,6,6), grad_out (N,nt,6) -> (N,6)
+        else:  # M (N,nt,d,d), grad_out (N,nt,d) -> (N,d)
             vbar = torch.einsum("ntab,nta->nb", M, grad_out)
         # gradients: vxvv only; (pot, ts, method, rtol, atol) are non-differentiable
         return vbar, None, None, None, None, None
@@ -42,7 +42,7 @@ class _CSTMFunction(torch.autograd.Function):
 def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
     """Differentiable C-STM orbit integration under torch.
 
-    vxvv: torch tensor (6,) or (N,6), Orbit order. Returns (nt,6) or (N,nt,6).
-    Differentiable w.r.t. vxvv.
+    vxvv: torch tensor (d,) or (N,d), d in {6,4,2} (3D/planar/1D), Orbit order.
+    Returns (nt,d) or (N,nt,d). Differentiable w.r.t. vxvv.
     """
     return _CSTMFunction.apply(vxvv, pot, ts, method, rtol, atol)

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1743,9 +1743,15 @@ class Orbit:
         # _ic_backend is None and are untouched -> the numpy/C path is unchanged.
         ic_backend = getattr(self, "_ic_backend", None)
         if ic_backend is not None:
-            from ..backend._reference.inbackend_stm import _C_DXDV_METHODS
+            from ..backend._reference.inbackend_stm import _C_RK_METHODS
 
-            if method.lower() in _C_DXDV_METHODS:
+            # Only the Runge-Kutta dxdv methods auto-route here. The symplectic
+            # methods are deliberately excluded: symplec4_c is galpy's DEFAULT
+            # integrator, so routing it would silently reroute every internal
+            # default-method integration (e.g. streamspraydf's sample orbits) to
+            # the C-STM under a forced backend. Symplectic C-STM is still available
+            # explicitly via galpy.backend.integrate_stm / orbit_stm.integrate.
+            if method.lower() in _C_RK_METHODS:
                 _potl = _check_potential_list_and_deprecate(pot)
                 _inbk = (
                     "diffrax"

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1752,10 +1752,16 @@ class Orbit:
                     if "jax" in get_namespace(ic_backend).__name__
                     else "torchdiffeq"
                 )
-                if (
-                    self.phasedim() == 6
-                    and _check_c(_potl)
-                    and _check_c(_potl, dxdv3d=True)
+                # C-STM eligibility by phase-space dim: 6D needs the full C 3D
+                # Hessian (dxdv3d); planar (4D) and 1D (2D) need the C dxdv Hessian
+                # (hasC_dxdv). Otherwise fall back to the in-backend ODE solver.
+                _pdim = self.phasedim()
+                if _check_c(_potl) and (
+                    _check_c(_potl, dxdv3d=True)
+                    if _pdim == 6
+                    else _check_c(_potl, dxdv=True)
+                    if _pdim in (2, 4)
+                    else False
                 ):
                     return self._integrate_cstm(t, _potl, method.lower(), rtol, atol)
                 # Pass the deprecation-checked/composed potential (_potl), matching

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -583,23 +583,26 @@ def test_integrate_concrete_backend_ic_numpy_method_works():
 @pytest.mark.skipif(not HAVE_TORCH, reason="torch/torchdiffeq not installed")
 def test_integrate_gradtracking_backend_ic_numpy_method_raises_torch():
     # a grad-tracking torch IC has no concrete values (self.vxvv is a placeholder),
-    # so a numpy/C method must raise rather than integrate degenerate values
+    # so a non-dxdv numpy/C method (ias15_c has no dxdv) must raise rather than
+    # integrate degenerate values. (The dxdv-capable C methods -- incl. the
+    # symplectic leapfrog_c/symplec4_c/symplec6_c -- instead route to the C-STM.)
     o = Orbit(torch.tensor(_IC, requires_grad=True))
     with pytest.raises(ValueError):
-        o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="leapfrog_c")
+        o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="ias15_c")
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
 def test_integrate_traced_backend_ic_numpy_method_raises_jax():
     # under jax.grad the IC is a tracer -> placeholder self.vxvv -> a non-dxdv
-    # numpy/C method must raise (a differentiable method must be used instead). A
-    # dxdv-capable C method (dop853_c, ...) instead routes to the C-STM and IS
-    # differentiable -- see test_backend_orbit_stm.py.
+    # numpy/C method (ias15_c) must raise (a differentiable method must be used
+    # instead). A dxdv-capable C method (dop853_c, leapfrog_c, symplec4_c, ...)
+    # instead routes to the C-STM and IS differentiable -- see
+    # test_backend_orbit_stm.py.
     pot = PlummerPotential(amp=1.0, b=0.6)
 
     def run(vR0):
         o = Orbit(jnp.array([1.0, vR0, 0.9, 0.2, 0.05, 0.3]))
-        o.integrate(_TS, pot, method="leapfrog_c")
+        o.integrate(_TS, pot, method="ias15_c")
         return o.getOrbit()[-1, 0]
 
     with pytest.raises(ValueError):

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -859,12 +859,14 @@ _LOWDIM_ROUTE_ACCESSORS = {
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
-def test_lowdim_orbit_integrate_routing(backend, method):
-    # Orbit(planar/1D backend IC).integrate(<dxdv C method>) routes to the C-STM:
-    # accessors stay backend arrays and match the numpy orbit.
+def test_lowdim_orbit_integrate_routing(backend):
+    # Orbit(planar/1D backend IC).integrate(<RK dxdv C method>) routes to the C-STM:
+    # accessors stay backend arrays and match the numpy orbit. (Only the Runge-Kutta
+    # methods auto-route -- see test_symplectic_not_autorouted for why symplectic
+    # methods are excluded from Orbit.integrate routing.)
     from galpy.orbit import Orbit
 
+    method = "dop853_c"
     ts = _arr(backend, _LOWDIM_TS)
     for label, pot, ic, dim in _lowdim_cases():
         o = Orbit(_arr(backend, ic))
@@ -882,6 +884,27 @@ def test_lowdim_orbit_integrate_routing(backend, method):
                 atol=1e-6,
                 err_msg=f"{label} {acc} {method} {backend}",
             )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", _SYMPLEC_METHODS)
+def test_symplectic_not_autorouted(backend, method):
+    # The symplectic methods are deliberately NOT auto-routed by Orbit.integrate:
+    # symplec4_c is galpy's DEFAULT integrator, so routing it would silently reroute
+    # every internal default-method integration (e.g. streamspraydf sample orbits)
+    # to the C-STM under a forced backend. So a backend IC + a symplectic method
+    # falls through to the (non-differentiable) numpy/C path -- getOrbit is numpy.
+    # Symplectic C-STM differentiation stays available via orbit_stm.integrate.
+    from galpy.orbit import Orbit
+
+    o = Orbit(_arr(backend, _IC))
+    o.integrate(_arr(backend, _LOWDIM_TS), MWPotential2014, method=method)
+    assert isinstance(o.getOrbit(), numpy.ndarray)
+    # the explicit functional interface still differentiates this same method
+    assert _is_backend(
+        backend,
+        _integ(backend, MWPotential2014, _arr(backend, _IC), _LOWDIM_TS, method),
+    )
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -604,3 +604,351 @@ def test_augmented_stm_dissipative():
         numpy.testing.assert_allclose(
             (xp - xm) / (2 * eps), Ma[:, :, b], rtol=1e-4, atol=1e-5
         )
+
+
+# ===========================================================================
+#   Low-dimensional (planar 4D, 1D 2D) + symplectic C-STM
+#
+#   The augmented 42-state STM is 3D-Runge-Kutta only; symplectic 3D, planar and
+#   1D orbits have no augmented C STM and go through the per-column reference
+#   (_c_stm_forward_loop) for ANY dxdv-capable C method. The wrappers (jax
+#   custom_vjp / torch autograd.Function) and the Orbit.integrate routing are
+#   dimension-generic. NOTE: the STM is returned in the (non-canonical) cyl Orbit
+#   frame, so det M != 1 for planar/3D -- correctness is checked by
+#   finite-difference of the flow (coordinate-agnostic), NOT by Liouville here.
+# ===========================================================================
+from galpy.potential import (  # noqa: E402
+    toPlanarPotential,
+    toVerticalPotential,
+)
+
+_SYMPLEC_METHODS = ["leapfrog_c", "symplec4_c", "symplec6_c"]
+_LOWDIM_TS = numpy.linspace(0.0, 2.0, 11)
+
+
+def _parity_tol(method):
+    # the C-STM forward is the dxdv variant of the C integrator; its augmented
+    # step sequence differs slightly from base Orbit.integrate. The (low-order)
+    # symplectic methods -- leapfrog especially -- diverge a touch more than the
+    # Runge-Kutta ones, so use a looser (but still tight) forward-parity tolerance.
+    return (1e-5, 1e-6) if method in _SYMPLEC_METHODS else (1e-6, 1e-7)
+
+
+# planar (R,vR,vT,phi) and 1D (x,vx) ICs, incl. vR=0 / x=0 / vx=0 / phi=0 edges
+_PLANAR_ICS = [
+    numpy.array([1.0, 0.1, 0.9, 0.2]),  # generic
+    numpy.array([1.1, 0.0, 1.0, 0.0]),  # vR=0, phi=0 edge
+]
+_1D_ICS = [
+    numpy.array([0.1, 0.05]),  # generic
+    numpy.array([0.0, 0.1]),  # x=0 edge
+    numpy.array([0.15, 0.0]),  # vx=0 edge
+]
+
+
+def _planar_pot():
+    return toPlanarPotential(MWPotential2014)
+
+
+def _vert_pot():
+    return toVerticalPotential(MWPotential2014, 1.0)
+
+
+def _lowdim_cases():
+    # (label, pot, ic, dim)
+    return [
+        ("planar", _planar_pot(), _PLANAR_ICS[0], 4),
+        ("1D", _vert_pot(), _1D_ICS[0], 2),
+    ]
+
+
+# --------------------------------------------- method-set / dim-generic contract
+def test_dxdv_method_sets():
+    from galpy.backend._reference.inbackend_stm import (
+        _C_DXDV_METHODS,
+        _C_RK_METHODS,
+        _C_SYMPLEC_METHODS,
+    )
+
+    assert set(_C_RK_METHODS) == {"rk4_c", "rk6_c", "dopr54_c", "dop853_c"}
+    assert set(_C_SYMPLEC_METHODS) == {"leapfrog_c", "symplec4_c", "symplec6_c"}
+    assert set(_C_DXDV_METHODS) == set(_C_RK_METHODS) | set(_C_SYMPLEC_METHODS)
+
+
+@pytest.mark.parametrize(
+    "ic,dim",
+    [(_PLANAR_ICS[0], 4), (_1D_ICS[0], 2), (_IC, 6)],
+    ids=["planar", "1D", "3D"],
+)
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_c_stm_forward_dim_generic_shapes(ic, dim, method):
+    # host-level: c_stm_forward returns (nt,d) / (nt,d,d) for d in {2,4,6}, with
+    # M[0]=identity, for both a Runge-Kutta and a symplectic method.
+    pot = {2: _vert_pot(), 4: _planar_pot(), 6: MWPotential2014}[dim]
+    xt, M = c_stm_forward(pot, ic, _LOWDIM_TS, method, 1e-11, 1e-11)
+    assert xt.shape == (len(_LOWDIM_TS), dim)
+    assert M.shape == (len(_LOWDIM_TS), dim, dim)
+    numpy.testing.assert_allclose(M[0], numpy.eye(dim), atol=1e-12)
+
+
+# ------------------------------------------------- host-level FD-of-flow (numpy)
+@pytest.mark.parametrize(
+    "label,pot,ic,dim",
+    [
+        ("planar-rk", _planar_pot(), _PLANAR_ICS[0], 4),
+        ("planar-symp", _planar_pot(), _PLANAR_ICS[0], 4),
+        ("1D-rk", _vert_pot(), _1D_ICS[0], 2),
+        ("1D-symp", _vert_pot(), _1D_ICS[0], 2),
+        ("3D-symp", MWPotential2014, _IC, 6),
+    ],
+)
+def test_lowdim_stm_fd_of_flow(label, pot, ic, dim):
+    # the STM column b equals d(base)/d(ic_b) by central finite difference of the
+    # flow -- the coordinate-agnostic correctness check (det M != 1 in cyl here).
+    method = "symplec4_c" if "symp" in label else "dop853_c"
+    ts = numpy.linspace(0.0, 2.0, 21)
+    _, M0 = c_stm_forward(pot, ic, ts, method, 1e-12, 1e-12)
+    eps = 1e-6
+    for b in range(dim):
+        icp = ic.copy()
+        icp[b] += eps
+        icm = ic.copy()
+        icm[b] -= eps
+        xp, _ = c_stm_forward(pot, icp, ts, method, 1e-12, 1e-12)
+        xm, _ = c_stm_forward(pot, icm, ts, method, 1e-12, 1e-12)
+        numpy.testing.assert_allclose(
+            (xp - xm) / (2 * eps),
+            M0[:, :, b],
+            rtol=1e-4,
+            atol=1e-5,
+            err_msg=f"{label} column {b}",
+        )
+
+
+# ------------------------------------------------------- forward parity (both be)
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", ["dop853_c", "rk4_c"] + _SYMPLEC_METHODS)
+def test_lowdim_forward_matches_c(backend, method):
+    # planar + 1D wrapper forward (Runge-Kutta AND symplectic) matches the numpy C
+    # orbit across every phase-space accessor -- incl. phi wrapped to (-pi,pi].
+    from galpy.orbit import Orbit
+
+    for label, pot, ic, dim in _lowdim_cases():
+        onp = Orbit(list(ic))
+        onp.integrate(_LOWDIM_TS, pot, method=method)
+        ref = numpy.asarray(onp.getOrbit())  # (nt, dim), Orbit order
+        got = as_numpy(_integ(backend, pot, _arr(backend, ic), _LOWDIM_TS, method))
+        rtol, atol = _parity_tol(method)
+        numpy.testing.assert_allclose(
+            got, ref, rtol=rtol, atol=atol, err_msg=f"{label} {method} {backend}"
+        )
+
+
+# --------------------------------------------------------- symplectic 3D parity
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", _SYMPLEC_METHODS)
+def test_symplectic_3d_forward_matches_c(backend, method):
+    from galpy.orbit import Orbit
+
+    for name, pot in _pots().items():
+        o = Orbit(list(_IC))
+        o.integrate(_LOWDIM_TS, pot, method=method)
+        ref = numpy.asarray(o.getOrbit())
+        got = as_numpy(_integ(backend, pot, _arr(backend, _IC), _LOWDIM_TS, method))
+        rtol, atol = _parity_tol(method)
+        numpy.testing.assert_allclose(
+            got, ref, rtol=rtol, atol=atol, err_msg=f"{name} {method} {backend}"
+        )
+
+
+# ---------------------------------------------------------- grad vs finite-diff
+def _fd_grad_final0(pot, ic, method, ts, eps=1e-6):
+    from galpy.orbit import Orbit
+
+    def f0(x):
+        o = Orbit(list(x))
+        o.integrate(ts, pot, method=method)
+        return numpy.asarray(o.getOrbit())[-1, 0]
+
+    d = len(ic)
+    return numpy.array(
+        [
+            (f0(ic + eps * numpy.eye(d)[j]) - f0(ic - eps * numpy.eye(d)[j]))
+            / (2 * eps)
+            for j in range(d)
+        ]
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_lowdim_grad_final_vs_fd(backend, method):
+    # d(final coord 0)/d(IC) for planar + 1D, Runge-Kutta AND symplectic.
+    for label, pot, ic, dim in _lowdim_cases():
+        gfd = _fd_grad_final0(pot, ic, method, _LOWDIM_TS)
+        if backend == "jax":
+            g = as_numpy(
+                jax.grad(lambda v: _integ("jax", pot, v, _LOWDIM_TS, method)[-1, 0])(
+                    jnp.asarray(ic)
+                )
+            )
+        else:
+            v = torch.tensor(ic, requires_grad=True)
+            _integ("torch", pot, v, _LOWDIM_TS, method)[-1, 0].backward()
+            g = as_numpy(v.grad)
+        numpy.testing.assert_allclose(
+            g, gfd, rtol=1e-4, atol=1e-5, err_msg=f"{label} {method} {backend}"
+        )
+
+
+# ------------------------------------------------ jacrev == assembled STM (jax)
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_lowdim_jacrev_equals_stm(method):
+    # jacrev of the wrapper IS the custom-vjp residual M, so it must equal
+    # c_stm_forward's M exactly when computed at the SAME tolerance (1e-10 = the
+    # wrapper default; tol sets the symplectic substep count so it must match).
+    for label, pot, ic, dim in _lowdim_cases():
+        _, M = c_stm_forward(pot, ic, _LOWDIM_TS, method, 1e-10, 1e-10)
+        J = jax.jacrev(lambda v: _integ("jax", pot, v, _LOWDIM_TS, method))(
+            jnp.asarray(ic)
+        )
+        numpy.testing.assert_allclose(
+            as_numpy(J), M, rtol=1e-10, atol=1e-12, err_msg=f"{label} {method}"
+        )
+
+
+# --------------------------------------------------------------- torch gradcheck
+@pytest.mark.skipif("torch" not in BACKENDS, reason="needs torch")
+@pytest.mark.parametrize(
+    "ic,pot_key", [(_PLANAR_ICS[0], "planar"), (_1D_ICS[0], "1D")], ids=["planar", "1D"]
+)
+def test_lowdim_torch_gradcheck(ic, pot_key):
+    pot = _planar_pot() if pot_key == "planar" else _vert_pot()
+    ts = numpy.linspace(0.0, 1.0, 5)
+    v = torch.tensor(ic, requires_grad=True)
+    assert torch.autograd.gradcheck(
+        lambda vv: _integ("torch", pot, vv, ts, "rk4_c"), (v,), eps=1e-6, atol=1e-4
+    )
+
+
+# ------------------------------------------------- cross-backend agreement (jax/torch)
+@pytest.mark.skipif(
+    "jax" not in BACKENDS or "torch" not in BACKENDS, reason="needs both"
+)
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_lowdim_torch_grad_matches_jax(method):
+    for label, pot, ic, dim in _lowdim_cases():
+        g_jax = as_numpy(
+            jax.grad(lambda v: _integ("jax", pot, v, _LOWDIM_TS, method)[-1, 0])(
+                jnp.asarray(ic)
+            )
+        )
+        v = torch.tensor(ic, requires_grad=True)
+        _integ("torch", pot, v, _LOWDIM_TS, method)[-1, 0].backward()
+        numpy.testing.assert_allclose(
+            as_numpy(v.grad), g_jax, rtol=1e-8, atol=1e-10, err_msg=f"{label} {method}"
+        )
+
+
+# --------------------------------------- Orbit.integrate routing (planar / 1D)
+_LOWDIM_ROUTE_ACCESSORS = {
+    4: ["R", "vR", "vT", "phi", "x", "y", "vx", "vy"],
+    2: ["x", "vx"],
+}
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_lowdim_orbit_integrate_routing(backend, method):
+    # Orbit(planar/1D backend IC).integrate(<dxdv C method>) routes to the C-STM:
+    # accessors stay backend arrays and match the numpy orbit.
+    from galpy.orbit import Orbit
+
+    ts = _arr(backend, _LOWDIM_TS)
+    for label, pot, ic, dim in _lowdim_cases():
+        o = Orbit(_arr(backend, ic))
+        o.integrate(ts, pot, method=method)
+        assert _is_backend(backend, o.getOrbit()), f"{label} getOrbit left {backend}"
+        onp = Orbit(list(ic))
+        onp.integrate(_LOWDIM_TS, pot, method=method)
+        for acc in _LOWDIM_ROUTE_ACCESSORS[dim]:
+            val = getattr(o, acc)(ts, use_physical=False)
+            assert _is_backend(backend, val), f"{label}.{acc} left {backend}"
+            numpy.testing.assert_allclose(
+                as_numpy(val),
+                numpy.asarray(getattr(onp, acc)(_LOWDIM_TS, use_physical=False)),
+                rtol=1e-5,
+                atol=1e-6,
+                err_msg=f"{label} {acc} {method} {backend}",
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_lowdim_orbit_integrate_full_jacobian_vs_fd(backend):
+    # the full d(final state)/d(IC) STM via reverse-mode AD of the ROUTED planar
+    # Orbit.integrate, vs central finite difference.
+    from galpy.orbit import Orbit
+
+    pot = _planar_pot()
+    ic = _PLANAR_ICS[0]
+
+    def final_np(x):
+        o = Orbit(list(x))
+        o.integrate(_LOWDIM_TS, pot, method="dop853_c")
+        return numpy.asarray(o.getOrbit())[-1]
+
+    eps = 1e-6
+    jfd = numpy.array(
+        [
+            (
+                final_np(ic + eps * numpy.eye(4)[j])
+                - final_np(ic - eps * numpy.eye(4)[j])
+            )
+            / (2 * eps)
+            for j in range(4)
+        ]
+    ).T
+
+    def final_b(v):
+        o = Orbit(v)
+        o.integrate(_arr(backend, _LOWDIM_TS), pot, method="dop853_c")
+        return o.getOrbit()[-1]
+
+    if backend == "jax":
+        jac = as_numpy(jax.jacrev(final_b)(jnp.asarray(ic)))
+    else:
+        jac = as_numpy(torch.autograd.functional.jacobian(final_b, torch.tensor(ic)))
+    numpy.testing.assert_allclose(jac, jfd, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_lowdim_numpy_ic_unaffected(backend):
+    # a numpy/list planar or 1D IC + a dxdv C method stays the byte-identical numpy
+    # path (no routing), for a Runge-Kutta and a symplectic method.
+    from galpy.orbit import Orbit
+
+    for method in ("dop853_c", "symplec4_c"):
+        for label, pot, ic, dim in _lowdim_cases():
+            o = Orbit(list(ic))
+            o.integrate(_LOWDIM_TS, pot, method=method)
+            assert isinstance(o.getOrbit(), numpy.ndarray)
+
+
+# ----------------------------------- symplectic 3D routing + grad accessor (fd)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_symplectic_3d_grad_vs_fd(backend):
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    ts = _LOWDIM_TS
+    gfd = _fd_grad_final0(pot, _IC, "symplec4_c", ts)
+    if backend == "jax":
+        g = as_numpy(
+            jax.grad(lambda v: _integ("jax", pot, v, ts, "symplec4_c")[-1, 0])(
+                jnp.asarray(_IC)
+            )
+        )
+    else:
+        v = torch.tensor(_IC, requires_grad=True)
+        _integ("torch", pot, v, ts, "symplec4_c")[-1, 0].backward()
+        g = as_numpy(v.grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
Extends the fast C-STM (state-transition-matrix) differentiable orbit path — `galpy.backend._{jax,torch}.orbit_stm` + `_reference.inbackend_stm` — from **3D Runge–Kutta only** to also cover the **symplectic** C integrators (`leapfrog_c`/`symplec4_c`/`symplec6_c`) and **planar (4D)** + **1D (2D)** orbits, under both jax and torch. Every dxdv-capable C integrator is now differentiable w.r.t. the initial conditions via the explicit functional interface. This is the [[cstm-all-c-integrators]] directive.

**No new C** — reuses the single-column `integrate_dxdv` C entry points added by #1086 (symplectic 3D + planar dxdv) and #1091 (1D dxdv).

### Changes
- **`inbackend_stm.py`**: split `_C_DXDV_METHODS` into `_C_RK_METHODS` (augmented-capable) + `_C_SYMPLEC_METHODS`. `c_stm_forward` dispatches **3D + Runge–Kutta** to the fast augmented 42-state solve (`_c_stm_forward_augmented`, unchanged) and **everything else** (symplectic 3D, planar, 1D — no augmented C STM) to the per-column reference `_c_stm_forward_loop`, generalized from hardcoded 6 to any dim `d`.
- **phi wrapping**: the per-column loop wraps the base orbit's phi to `(-π, π]` to match `Orbit.integrate` (planar `integrate_dxdv` returns phi in `[0, 2π)`). The STM's δφ is a branch-independent derivative, so only the base needs it.
- **jax/torch wrappers**: derive the phase-space dim from the input (was hardcoded 6).
- **`Orbits.py`**: `Orbit(planar/1D backend-IC).integrate(<**Runge–Kutta** dxdv-C-method>)` auto-routes to the C-STM (eligibility: 6D needs `dxdv3d`, planar/1D need `hasC_dxdv`). **The symplectic methods are deliberately excluded from auto-routing** — `symplec4_c` is galpy's *default* integrator, so routing it would silently reroute every internal default-method integration (e.g. streamspraydf's sample orbits) to the C-STM under a forced backend. Default `Orbit.integrate` behavior is therefore unchanged; symplectic C-STM differentiation is available explicitly via `integrate_stm`/`orbit_stm.integrate`. numpy ICs are untouched.

### Correctness / validation
The STM is returned in the **non-canonical cyl Orbit frame**, so `det M ≠ 1` for planar/3D — correctness is validated by **finite-difference of the flow** (coordinate-agnostic), not by Liouville. (Symplectic phase-space-volume conservation `det M = 1` holds to ~1e-12 in the canonical/rectangular frame in all of 3D/2D/1D.)

**+50 tests** in `tests/test_backend_orbit_stm.py`: forward parity vs `Orbit.integrate`, grad-vs-FD, `jacrev == assembled STM`, torch `gradcheck`, cross-backend agreement, host-level FD-of-flow, dim-generic shapes, RK auto-routing, and `test_symplectic_not_autorouted` (a backend IC + a symplectic method stays on the numpy path while the functional interface still differentiates it) — for planar/1D and the symplectic methods, both jax and torch.

Two adversarial-verification passes confirmed: grad-vs-FD ≤ 4.4e-8 across non-axisymmetric potentials + edge ICs (vR=0/x=0/vx=0/phi=0) + a phi=π-crossing orbit; `jacrev == M` bit-identical; numpy path byte-identical (46-array two-build diff); patch coverage complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm