### PR TITLE
C-STM: per-orbit 2D time arrays + symplectic equispaced-snap

### DIFF
--- a/galpy/backend/_jax/orbit_stm.py
+++ b/galpy/backend/_jax/orbit_stm.py
@@ -25,7 +25,7 @@ def integrate(pot, vxvv, ts, *, method="dop853_c", rtol=1e-10, atol=1e-10):
     import jax.numpy as jnp
 
     ts_np = numpy.asarray(ts, dtype=numpy.float64)
-    nt = ts_np.shape[0]
+    nt = ts_np.shape[-1]  # per-orbit length: works for a shared (nt,) or (N, nt) grid
     d = vxvv.shape[-1]  # phase-space dim: 6 (3D), 4 (planar), 2 (1D)
 
     def _host(vxvv_np):

--- a/galpy/backend/_reference/inbackend_stm.py
+++ b/galpy/backend/_reference/inbackend_stm.py
@@ -34,6 +34,25 @@ _C_SYMPLEC_METHODS = ("leapfrog_c", "symplec4_c", "symplec6_c")
 _C_DXDV_METHODS = _C_RK_METHODS + _C_SYMPLEC_METHODS
 
 
+def _snap_equispaced(ts, method):
+    """Symplectic integrators require EXACTLY equispaced times. An equispaced grid
+    that passed through a lower-precision (e.g. float32) backend op arrives slightly
+    non-equispaced -- ``integrate_dxdv`` then rejects it, though the numpy path
+    (float64) never sees the drift. Snap an approximately-equispaced grid back to
+    its intended ``linspace`` (a no-op for an exact grid, and only applied to the
+    symplectic methods -- the Runge-Kutta ones accept arbitrary times). Genuinely
+    non-equispaced input deviates far more than float rounding and is returned
+    unchanged, so ``integrate_dxdv`` still rejects it exactly as numpy does.
+    """
+    if method.lower() not in _C_SYMPLEC_METHODS or ts.ndim != 1 or len(ts) < 3:
+        return ts
+    ts_lin = numpy.linspace(ts[0], ts[-1], len(ts))
+    tol = 1e-6 * max(abs(float(ts[0])), abs(float(ts[-1])), 1.0)
+    if numpy.max(numpy.abs(ts - ts_lin)) < tol:
+        return ts_lin
+    return ts
+
+
 def c_stm_forward(pot, vxvv, ts, method, rtol, atol):
     """Run the C variational integrator and return (x(t), M(t)).
 
@@ -85,11 +104,14 @@ def _c_stm_forward_augmented(pot, vxvv, ts, method, rtol, atol):
     single = vxvv.ndim == 1
     ics = vxvv[None] if single else vxvv
     ts = numpy.asarray(ts, dtype=numpy.float64)
-    nt = len(ts)
+    # ts is either a shared (nt,) grid or a per-orbit (N, nt) grid.
+    per_orbit_ts = ts.ndim == 2
+    nt = ts.shape[-1]
     eye6 = numpy.eye(6)
     int_method = method.lower()
     xts, Ms = [], []
-    for ic in ics:
+    for oi, ic in enumerate(ics):
+        ts_o = ts[oi] if per_orbit_ts else ts
         R, vR, vT, z, vz, phi = ic
         # cyl -> rect base, and the six cyl basis deviations folded to rect =
         # the columns of the cyl->rect Jacobian (basis=I), packed as the 36-block.
@@ -99,7 +121,7 @@ def _c_stm_forward_augmented(pot, vxvv, ts, method, rtol, atol):
         jac0 = coords.cyl_to_rect_jac(R, vR, vT, z, vz, phi)  # (6,6)
         dyo_block = jac0.T.reshape(-1)  # column k at offset 6k
         out, _err = integrateFullOrbit_stm_c(
-            pot, yo_rect, dyo_block, ts, int_method, rtol=rtol, atol=atol
+            pot, yo_rect, dyo_block, ts_o, int_method, rtol=rtol, atol=atol
         )  # (nt, 42)
         # base rect -> cyl (Orbit order); copy Z/vz before any reuse (views).
         Rout, phiout, Zout = coords.rect_to_cyl(
@@ -150,17 +172,20 @@ def _c_stm_forward_loop(pot, vxvv, ts, method, rtol, atol):
     vxvv = numpy.asarray(vxvv, dtype=numpy.float64)
     single = vxvv.ndim == 1
     ics = vxvv[None] if single else vxvv
+    ts = numpy.asarray(ts, dtype=numpy.float64)
+    per_orbit_ts = ts.ndim == 2  # shared (nt,) vs per-orbit (N, nt) grid
     d = ics.shape[-1]
     basis = numpy.eye(d)
     xts, Ms = [], []
-    for ic in ics:
+    for oi, ic in enumerate(ics):
+        ts_o = _snap_equispaced(ts[oi] if per_orbit_ts else ts, method)
         cols = []
         base = None
         for i in range(d):
             o = Orbit(list(ic))
             o.integrate_dxdv(
                 basis[i],
-                ts,
+                ts_o,
                 pot,
                 method=method,
                 rectIn=False,

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -975,3 +975,86 @@ def test_symplectic_3d_grad_vs_fd(backend):
         _integ("torch", pot, v, ts, "symplec4_c")[-1, 0].backward()
         g = as_numpy(v.grad)
     numpy.testing.assert_allclose(g, gfd, rtol=1e-4, atol=1e-5)
+
+
+# ============================================================================
+#   Per-orbit 2D time arrays + the symplectic equispaced-snap (streamTrack
+#   prerequisites). c_stm_forward accepts a per-orbit (N, nt) time grid (each
+#   orbit integrated over its own times), and snaps an approximately-equispaced
+#   (float-rounded) grid back to an exact linspace for the symplectic methods.
+# ============================================================================
+from galpy.backend._reference.inbackend_stm import _snap_equispaced  # noqa: E402
+
+_ICS2 = numpy.array([[1.0, 0.1, 1.1, 0.05, 0.1, 0.2], [1.05, 0.0, 1.0, 0.0, 0.05, 0.4]])
+_TS2D = numpy.array([numpy.linspace(0.0, 2.0, 11), numpy.linspace(0.0, 3.0, 11)])
+
+
+@pytest.mark.parametrize("method", ["dop853_c", "symplec4_c"])
+def test_c_stm_forward_per_orbit_2d_times(method):
+    # a per-orbit (N, nt) time grid: c_stm_forward returns (N, nt, d)/(N, nt, d, d)
+    # and each orbit matches the single-orbit solve over that orbit's own times.
+    xt, M = c_stm_forward(MWPotential2014, _ICS2, _TS2D, method, 1e-10, 1e-10)
+    assert xt.shape == (2, 11, 6)
+    assert M.shape == (2, 11, 6, 6)
+    for k in range(2):
+        xk, Mk = c_stm_forward(
+            MWPotential2014, _ICS2[k], _TS2D[k], method, 1e-10, 1e-10
+        )
+        numpy.testing.assert_allclose(xt[k], xk, rtol=1e-9, atol=1e-10)
+        numpy.testing.assert_allclose(M[k], Mk, rtol=1e-9, atol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_orbit_integrate_per_orbit_2d_times_routing(backend):
+    # Orbit(N backend ICs).integrate(per-orbit 2D ts, dop853_c) routes to the C-STM
+    # and honors the per-orbit times: getOrbit is (N, nt, 6), matching per-orbit
+    # numpy, and stays a differentiable backend array.
+    from galpy.orbit import Orbit
+
+    o = Orbit(_arr(backend, _ICS2))
+    o.integrate(_arr(backend, _TS2D), MWPotential2014, method="dop853_c")
+    got = as_numpy(o.getOrbit())
+    assert got.shape == (2, 11, 6)
+    assert _is_backend(backend, o.getOrbit())
+    for k in range(2):
+        onp = Orbit(list(_ICS2[k]))
+        onp.integrate(_TS2D[k], MWPotential2014, method="dop853_c")
+        numpy.testing.assert_allclose(got[k], onp.getOrbit(), rtol=1e-6, atol=1e-7)
+
+
+def test_snap_equispaced_behavior():
+    # a float32-rounded fine grid is not exactly equispaced (fails galpy's isclose
+    # check); the snap restores the exact linspace for the symplectic methods, is a
+    # no-op for the Runge-Kutta methods, and leaves a genuinely non-equispaced grid
+    # (deviation >> float rounding) unchanged so integrate_dxdv still rejects it.
+    ts_f32 = (
+        numpy.linspace(-74.4, 0.0, 2001).astype(numpy.float32).astype(numpy.float64)
+    )
+    diffs = numpy.diff(ts_f32)
+    assert not numpy.all(numpy.isclose(diffs, diffs[0]))  # not exactly equispaced
+    snapped = _snap_equispaced(ts_f32, "symplec4_c")
+    numpy.testing.assert_array_equal(
+        snapped, numpy.linspace(ts_f32[0], ts_f32[-1], len(ts_f32))
+    )
+    # Runge-Kutta: no snap (accepts arbitrary times)
+    numpy.testing.assert_array_equal(_snap_equispaced(ts_f32, "dop853_c"), ts_f32)
+    # genuine non-equispaced: unchanged
+    ts_gen = numpy.array([0.0, 0.1, 0.35, 0.9, 2.0])
+    numpy.testing.assert_array_equal(_snap_equispaced(ts_gen, "symplec4_c"), ts_gen)
+
+
+def test_c_stm_forward_symplectic_float32_grid():
+    # a symplectic C-STM solve over a float32-rounded (approximately-equispaced)
+    # grid succeeds via the snap, where a raw integrate_dxdv would reject it.
+    from galpy.orbit import Orbit
+
+    ts_f32 = (
+        numpy.linspace(-40.0, 0.0, 1001).astype(numpy.float32).astype(numpy.float64)
+    )
+    ic = numpy.array([1.0, 0.1, 1.1, 0.05, 0.1, 0.2])
+    with pytest.raises(ValueError):  # raw path rejects the float-rounded grid
+        Orbit(list(ic)).integrate_dxdv(
+            numpy.eye(6)[0], ts_f32, MWPotential2014, method="symplec4_c"
+        )
+    xt, M = c_stm_forward(MWPotential2014, ic, ts_f32, "symplec4_c", 1e-10, 1e-10)
+    assert xt.shape == (1001, 6) and M.shape == (1001, 6, 6)


### PR DESCRIPTION
Foundational C-STM fixes toward routing internal, per-orbit-time integrations (e.g. streamspraydf's sample orbits) through the differentiable C-STM. Standalone C-STM correctness improvements, independent of any streamTrack work.

### 1. Per-orbit 2D time arrays
`c_stm_forward` now accepts a **per-orbit `(N, nt)`** time grid (each of N orbits integrated over its own times), not just a shared `(nt,)` grid. Previously the jax wrapper took `nt = ts.shape[0]`, so `Orbit(N).integrate(2D_ts)` **silently** returned the wrong shape `(N, N, d)` with *no error* — a latent bug affecting any multi-orbit per-orbit-times backend integration. Fixed: `nt = ts.shape[-1]`; `_c_stm_forward_{augmented,loop}` index `ts[oi]` per orbit. The torch wrapper already used `c_stm_forward`'s returned shapes. Verified: `Orbit(N).integrate(per-orbit-ts, dop853_c)` gives `(N, nt, 6)` matching the per-orbit numpy solve to ~1e-12.

### 2. Symplectic equispaced-snap
Symplectic integrators require **exactly** equispaced times. An equispaced grid that passes through a lower-precision (float32) backend op arrives slightly non-equispaced, and `integrate_dxdv` rejects it (the numpy float64 path never drifts). `_snap_equispaced` snaps an approximately-equispaced grid back to its intended `linspace` for the symplectic methods only; a genuinely non-equispaced grid (deviation ≫ float rounding) is left unchanged, so `integrate_dxdv` still rejects it exactly as numpy does.

### Tests
`tests/test_backend_orbit_stm.py` (+6): per-orbit `c_stm_forward` parity, per-orbit `Orbit.integrate(dop853_c)` routing vs numpy (jax + torch), snap behavior, and a symplectic C-STM solve over a float32-rounded grid.

Part of the streamspraydf/streamTrack backend-agnostic migration (enables the C-STM route for streams' per-orbit-time integrations); useful standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm