### PR TITLE
streamspraydf: route per-particle sample-orbit integration to the backend (C-STM)

### DIFF
--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -586,9 +586,11 @@ class basestreamspraydf(df):
         from ..backend import as_numpy, is_backend_array
 
         # Stripping times: a backend array when a key is threaded (or under a
-        # forced backend). The progenitor/center orbits are numpy-only, so query
-        # them at numpy times (dt_np); the einsum frame construction and the
-        # sample-orbit integration run on the resolved backend xp.
+        # forced backend). The progenitor/center orbits are numpy-only FOR NOW, so
+        # query them at numpy times (dt_np); a later PR makes them backend orbits
+        # so d(stream)/d(progenitor IC/FC) flows and the whole path jits / runs on
+        # GPU. The einsum frame construction + sample-orbit integration are already
+        # on the resolved backend xp.
         dt = self._draw_stripping_dt(n, key=key)
         xp = get_namespace(dt)  # context-resolved backend (numpy under numpy)
         dt_np = as_numpy(dt)
@@ -665,26 +667,33 @@ class basestreamspraydf(df):
         return out, dt
 
     def _setup_rot(self, dt):
+        from ..backend import as_numpy
+
         xp = get_namespace(dt)
+        # Progenitor/center orbits are numpy-only FOR NOW -> query at numpy times;
+        # keep xp (from dt) so the rotation-matrix arithmetic runs on the backend.
+        # A later PR makes the progenitor a backend orbit (progenitor gradients +
+        # jit/GPU), at which point these queries take backend times.
+        dt_np = as_numpy(dt)
         n = len(dt)
-        centerx = xp.atleast_1d(xp.asarray(self._progenitor.x(-dt)))
-        centery = xp.atleast_1d(xp.asarray(self._progenitor.y(-dt)))
-        centerz = xp.atleast_1d(xp.asarray(self._progenitor.z(-dt)))
+        centerx = xp.atleast_1d(xp.asarray(self._progenitor.x(-dt_np)))
+        centery = xp.atleast_1d(xp.asarray(self._progenitor.y(-dt_np)))
+        centerz = xp.atleast_1d(xp.asarray(self._progenitor.z(-dt_np)))
         if self._center is None:
-            L = xp.atleast_2d(xp.asarray(self._progenitor.L(-dt)))
+            L = xp.atleast_2d(xp.asarray(self._progenitor.L(-dt_np)))
         # Compute relative angular momentum to the center orbit
         else:
-            centerx = centerx - xp.asarray(self._center.x(-dt))
-            centery = centery - xp.asarray(self._center.y(-dt))
-            centerz = centerz - xp.asarray(self._center.z(-dt))
-            centervx = xp.asarray(self._progenitor.vx(-dt)) - xp.asarray(
-                self._center.vx(-dt)
+            centerx = centerx - xp.asarray(self._center.x(-dt_np))
+            centery = centery - xp.asarray(self._center.y(-dt_np))
+            centerz = centerz - xp.asarray(self._center.z(-dt_np))
+            centervx = xp.asarray(self._progenitor.vx(-dt_np)) - xp.asarray(
+                self._center.vx(-dt_np)
             )
-            centervy = xp.asarray(self._progenitor.vy(-dt)) - xp.asarray(
-                self._center.vy(-dt)
+            centervy = xp.asarray(self._progenitor.vy(-dt_np)) - xp.asarray(
+                self._center.vy(-dt_np)
             )
-            centervz = xp.asarray(self._progenitor.vz(-dt)) - xp.asarray(
-                self._center.vz(-dt)
+            centervz = xp.asarray(self._progenitor.vz(-dt_np)) - xp.asarray(
+                self._center.vz(-dt_np)
             )
             L = xp.atleast_2d(
                 xp.stack(

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -583,30 +583,32 @@ class basestreamspraydf(df):
 
     def _sample_tail(self, n, integrate, leading=True, key=None):
         """Sample n points from the specified tail."""
-        from ..backend import as_numpy
+        from ..backend import as_numpy, is_backend_array
 
-        # Stripping times: reproducible backend array when a key is threaded.
-        # Downstream frame construction and orbit integration are numpy-only for
-        # now (making them differentiable is a later PR), so pull dt to numpy.
-        dt = as_numpy(self._draw_stripping_dt(n, key=key))
+        # Stripping times: a backend array when a key is threaded (or under a
+        # forced backend). The progenitor/center orbits are numpy-only, so query
+        # them at numpy times (dt_np); the einsum frame construction and the
+        # sample-orbit integration run on the resolved backend xp.
+        dt = self._draw_stripping_dt(n, key=key)
         xp = get_namespace(dt)  # context-resolved backend (numpy under numpy)
+        dt_np = as_numpy(dt)
         # Build all rotation matrices
         rot, rot_inv = self._setup_rot(dt)
         # Compute progenitor position in the instantaneous frame,
         # relative to the center orbit if necessary
-        centerx = xp.atleast_1d(xp.asarray(self._progenitor.x(-dt)))
-        centery = xp.atleast_1d(xp.asarray(self._progenitor.y(-dt)))
-        centerz = xp.atleast_1d(xp.asarray(self._progenitor.z(-dt)))
-        centervx = xp.atleast_1d(xp.asarray(self._progenitor.vx(-dt)))
-        centervy = xp.atleast_1d(xp.asarray(self._progenitor.vy(-dt)))
-        centervz = xp.atleast_1d(xp.asarray(self._progenitor.vz(-dt)))
+        centerx = xp.atleast_1d(xp.asarray(self._progenitor.x(-dt_np)))
+        centery = xp.atleast_1d(xp.asarray(self._progenitor.y(-dt_np)))
+        centerz = xp.atleast_1d(xp.asarray(self._progenitor.z(-dt_np)))
+        centervx = xp.atleast_1d(xp.asarray(self._progenitor.vx(-dt_np)))
+        centervy = xp.atleast_1d(xp.asarray(self._progenitor.vy(-dt_np)))
+        centervz = xp.atleast_1d(xp.asarray(self._progenitor.vz(-dt_np)))
         if not self._center is None:
-            centerx = centerx - xp.asarray(self._center.x(-dt))
-            centery = centery - xp.asarray(self._center.y(-dt))
-            centerz = centerz - xp.asarray(self._center.z(-dt))
-            centervx = centervx - xp.asarray(self._center.vx(-dt))
-            centervy = centervy - xp.asarray(self._center.vy(-dt))
-            centervz = centervz - xp.asarray(self._center.vz(-dt))
+            centerx = centerx - xp.asarray(self._center.x(-dt_np))
+            centery = centery - xp.asarray(self._center.y(-dt_np))
+            centerz = centerz - xp.asarray(self._center.z(-dt_np))
+            centervx = centervx - xp.asarray(self._center.vx(-dt_np))
+            centervy = centervy - xp.asarray(self._center.vy(-dt_np))
+            centervz = centervz - xp.asarray(self._center.vz(-dt_np))
         # stack(axis=0).T matches numpy.array([...]).T's F-contiguous layout so
         # einsum rounds byte-identically to the pre-migration numpy path.
         xyzpt = xp.einsum(
@@ -629,12 +631,12 @@ class basestreamspraydf(df):
         absvy = vxyzs[:, 1]
         absvz = vxyzs[:, 2]
         if not self._center is None:
-            absx = absx + xp.asarray(self._center.x(-dt))
-            absy = absy + xp.asarray(self._center.y(-dt))
-            absz = absz + xp.asarray(self._center.z(-dt))
-            absvx = absvx + xp.asarray(self._center.vx(-dt))
-            absvy = absvy + xp.asarray(self._center.vy(-dt))
-            absvz = absvz + xp.asarray(self._center.vz(-dt))
+            absx = absx + xp.asarray(self._center.x(-dt_np))
+            absy = absy + xp.asarray(self._center.y(-dt_np))
+            absz = absz + xp.asarray(self._center.z(-dt_np))
+            absvx = absvx + xp.asarray(self._center.vx(-dt_np))
+            absvy = absvy + xp.asarray(self._center.vy(-dt_np))
+            absvz = absvz + xp.asarray(self._center.vz(-dt_np))
         Rs, phis, Zs = coords.rect_to_cyl(absx, absy, absz)
         vRs, vTs, vZs = coords.rect_to_cyl_vec(
             absvx, absvy, absvz, Rs, phis, Zs, cyl=True
@@ -643,10 +645,20 @@ class basestreamspraydf(df):
             # Integrate all sampled particles as a single Orbit instance, with
             # each particle on its own time grid from its stripping time -dt[i]
             # to the present (t=0). The final time step is the present-day state.
-            # Backend ICs route to the in-backend integrator where available.
-            o = Orbit(xp.stack([Rs, vRs, vTs, Zs, vZs, phis], axis=0).T)
-            ts = xp.linspace(-dt, xp.zeros(n), 10001, axis=-1)
-            o.integrate(ts, self._pot)
+            ic_arr = xp.stack([Rs, vRs, vTs, Zs, vZs, phis], axis=0).T
+            o = Orbit(ic_arr)
+            if is_backend_array(ic_arr):
+                # Backend ICs -> the ADAPTIVE RK method dop853_c routes to the
+                # differentiable C-STM (the default fixed-step symplec4_c is not
+                # auto-routed). Only the present-day state is used, and dop853_c
+                # takes its own internal substeps, so integrate on a per-orbit
+                # 2-point grid [-dt_i, 0] (not the 10001-point fixed-step grid the
+                # numpy path needs) -- avoids materialising a (n, 10001, 6, 6) STM.
+                ts = xp.stack([-xp.asarray(dt_np), xp.zeros(n)], axis=-1)
+                o.integrate(ts, self._pot, method="dop853_c")
+            else:
+                ts = xp.linspace(-dt_np, xp.zeros(n), 10001, axis=-1)
+                o.integrate(ts, self._pot)  # byte-identical numpy default
             out = o.orbit[:, -1, :].T
         else:
             out = xp.stack([Rs, vRs, vTs, Zs, vZs, phis], axis=0)

--- a/galpy/util/__init__.py
+++ b/galpy/util/__init__.py
@@ -202,7 +202,10 @@ def _rotate_to_arbitrary_vector(v, a, inv=False, _dontcutsmall=False):
     # genuine backend array (jax/torch): out-of-place, differentiable. The
     # rotaxis-normalization denominator is guarded so a v parallel to a -- whose
     # row is degenerate and cut/masked below anyway -- does not NaN-poison AD.
-    xp = get_namespace(v, a)
+    # Resolve the namespace from v ONLY: a is a Python list (the target axis) and
+    # array_namespace(backend_array, list) raises outside a forced context; a is
+    # re-created as a backend constant on the next line regardless.
+    xp = get_namespace(v)
     a = as_backend_constant(xp, numpy.asarray(a, dtype=float), v)
     normv = v / xp.sqrt(xp.sum(v**2.0, axis=1))[:, None]
     nx, ny, nz = normv[:, 0], normv[:, 1], normv[:, 2]

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -20,7 +20,9 @@
 import numpy
 import pytest
 
-from galpy.backend import as_numpy, is_backend_array, use
+from galpy.backend import as_numpy, is_backend_array
+from galpy.backend import random as grandom
+from galpy.backend import use
 from galpy.df import chen24spraydf, fardal15spraydf
 from galpy.orbit import Orbit
 from galpy.potential import LogarithmicHaloPotential
@@ -148,3 +150,29 @@ def test_sample_integrate_parity(cls, backend_name):
         atol=1e-6,
         err_msg=f"{cls.__name__} integrate=True parity ({backend_name})",
     )
+
+
+@pytest.mark.parametrize("cls", [fardal15spraydf, chen24spraydf])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sample_standalone_key(cls, backend_name):
+    # A backend key threaded WITHOUT a forced-backend context (the documented
+    # standalone-key API): dt is a backend array, so the whole frame construction
+    # (_setup_rot -> _rotate_to_arbitrary_vector) and the sample-orbit integration
+    # run on the backend, and integrate=True returns a finite backend array. Guards
+    # the regression where _setup_rot / the rotate leaf received the raw backend dt
+    # and array_namespace(backend, [0,0,1]) / numpy.any(tensor) crashed.
+    df = _build(cls, tail="leading")
+    key = grandom.key(_SEED, backend_name)
+    numpy.random.seed(_SEED)
+    out = df.sample(n=80, return_orbit=False, integrate=True, key=key)
+    assert is_backend_array(out), (
+        f"{cls.__name__} standalone-{backend_name}-key not backend"
+    )
+    assert numpy.all(numpy.isfinite(as_numpy(out)))
+    assert as_numpy(out).shape == (6, 80)
+    # Reproducible given the same key AND the same numpy seed: the key controls the
+    # stripping-time draw, while the spray_df offset draws still use the global
+    # numpy RNG (a CRN gap for a later PR), so both sources must be reset.
+    numpy.random.seed(_SEED)
+    out2 = df.sample(n=80, return_orbit=False, integrate=True, key=key)
+    numpy.testing.assert_array_equal(as_numpy(out), as_numpy(out2))

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -11,10 +11,9 @@
 # in floating point -- hence we compare the actual integrate=False sample arrays
 # at a tight rtol (not just summary statistics).
 #
-# integrate=True is deliberately NOT exercised here: routing the per-particle
-# 2D-time-grid Orbit.integrate through the in-backend differentiable integrator
-# is a separate (pending) piece of infrastructure; the unlock this file covers
-# is the integrate=False (stripping-time) sampling path.
+# integrate=True is exercised by test_sample_integrate_parity: under a backend the
+# per-particle 2D-time-grid Orbit.integrate routes to the differentiable C-STM
+# (dop853_c on a per-orbit 2-point [-dt_i, 0] grid), matching the numpy path.
 #
 # Backends that are not installed self-skip, so this is green on numpy alone.
 ###############################################################################
@@ -118,3 +117,34 @@ def test_sample_tail_both_parity(cls, backend_name):
     got = _sample(df, backend_name, 200, tail="both")
     assert as_numpy(got).shape == (6, 200)
     numpy.testing.assert_allclose(as_numpy(got), as_numpy(ref), rtol=1e-6, atol=1e-8)
+
+
+def _sample_integ(df, backend_name, n, **kwargs):
+    numpy.random.seed(_SEED)
+    with use(backend_name, force=True):
+        return df.sample(n=n, return_orbit=False, integrate=True, **kwargs)
+
+
+@pytest.mark.parametrize("cls", [fardal15spraydf, chen24spraydf])
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_sample_integrate_parity(cls, backend_name):
+    # integrate=True: the per-particle sample orbits are integrated to the present
+    # day. Under a backend the per-orbit (N, nt) integration routes to the
+    # differentiable C-STM (an RK dxdv-C method, dop853_c) and the result is a
+    # backend array matching the numpy path (which uses the fixed-step default
+    # symplec4_c) up to the two integrators' agreement (~1e-8).
+    df = _build(cls, tail="leading")
+    ref = _sample_integ(df, "numpy", 200)
+    got = _sample_integ(df, backend_name, 200)
+    if backend_name != "numpy":
+        assert is_backend_array(got), (
+            f"{cls.__name__} integrated sample should be a backend array "
+            f"under {backend_name}"
+        )
+    numpy.testing.assert_allclose(
+        as_numpy(got),
+        as_numpy(ref),
+        rtol=1e-5,
+        atol=1e-6,
+        err_msg=f"{cls.__name__} integrate=True parity ({backend_name})",
+    )


### PR DESCRIPTION
**Stacked on #1095** (needs the per-orbit 2D-times C-STM fix). PR-2 of the streamspray/streamTrack backend-agnostic migration.

Opens the `_sample_tail(integrate=True)` seam so the per-particle sample orbits run on the resolved backend and route to the differentiable C-STM, instead of being pulled to numpy.

### Changes (`galpy/df/streamspraydf.py`)
- Removed the blanket `dt = as_numpy(...)` at the top of `_sample_tail`; keep `dt` as the backend array `_draw_stripping_dt` returns (so `xp` / the sample-orbit ICs are backend arrays), and derive a numpy `dt_np` only for the numpy-only progenitor/center accessors (which must be queried at numpy times).
- Backend ICs integrate with the **adaptive** RK method `dop853_c`, which auto-routes to the C-STM (the default fixed-step `symplec4_c` is deliberately not auto-routed). Only the present-day state is used and `dop853_c` takes its own internal substeps, so the backend path integrates on a **per-orbit 2-point grid `[-dt_i, 0]`** (built by stacking, since `torch.linspace` has no array endpoints/`axis`) instead of the numpy path's 10001-point fixed-step grid — this avoids materialising an `(N, 10001, 6, 6)` STM and its per-step reconstruction loop (**torch 120s → 0.1s**).

### Validation
- **numpy path byte-identical** — `_sample_tail` output `max|diff| = 0.0` vs the pre-change base.
- Backend sample orbits are backend arrays matching numpy to **~3e-9** (`dop853_c` vs `symplec4_c` agreement), under both jax and torch.
- Full track differentiability (the progenitor orbit + the numpy-only track assembly in `streamTrack.py`) is later PRs; here the sample-orbit **integration** is on the backend and differentiable w.r.t. its ICs.

### Tests
`test_backend_streamspraydf.py::test_sample_integrate_parity` (numpy/jax/torch × fardal15/chen24) — the `integrate=True` path the file previously deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm