### PR TITLE
streamTrack: backend-agnostic binning primitives (_bin_by_tp, _closest_point_on_curve)

### DIFF
--- a/galpy/df/streamTrack.py
+++ b/galpy/df/streamTrack.py
@@ -5,6 +5,7 @@ from matplotlib import pyplot
 from scipy import interpolate
 from scipy.spatial import cKDTree
 
+from ..backend import as_numpy, get_namespace, is_backend_array
 from ..util import config, conversion, coords, galpyWarning
 from ..util._optional_deps import _APY_LOADED, _APY_UNITS
 from ..util.conversion import physical_conversion
@@ -28,20 +29,38 @@ def _bin_by_tp(tp_assign, values, tp_nodes):
             [tp_nodes[-1] + 0.5 * dt_node],
         )
     )
-    idx = numpy.clip(numpy.searchsorted(edges, tp_assign) - 1, 0, M - 1)
+    # The bin ASSIGNMENT (which node each particle falls in) is a non-differentiable
+    # structural index -> numpy. The binned mean/cov VALUES follow ``values``.
+    idx = numpy.clip(numpy.searchsorted(edges, as_numpy(tp_assign)) - 1, 0, M - 1)
     D = values.shape[1]
-    means = numpy.full((M, D), numpy.nan)
-    covs = numpy.zeros((M, D, D))
-    counts = numpy.zeros(M, dtype=int)
-    for m in range(M):
-        sel = idx == m
-        k = int(sel.sum())
-        counts[m] = k
-        if k < 2:
-            continue
-        group = values[sel]
-        means[m] = group.mean(axis=0)
-        covs[m] = numpy.cov(group, rowvar=False)
+    counts = numpy.array([int((idx == m).sum()) for m in range(M)])
+    if is_backend_array(values):
+        # Backend-agnostic segment mean/cov, gathered by the numpy idx one-hot.
+        # ddof=1 (numpy.cov); k<2 bins -> NaN mean / zero cov, as in the loop.
+        xp = get_namespace(values)
+        onehot = numpy.zeros((len(idx), M))
+        onehot[numpy.arange(len(idx)), idx] = 1.0
+        onehot_b = xp.asarray(onehot)
+        counts_b = xp.asarray(counts.astype(float))
+        sums = xp.einsum("nm,nd->md", onehot_b, values)  # (M, D)
+        raw_means = sums / xp.where(counts_b > 0, counts_b, 1.0)[:, None]
+        centered = values - raw_means[xp.asarray(idx)]  # (N, D)
+        outer = centered[:, :, None] * centered[:, None, :]  # (N, D, D)
+        cov_sums = xp.einsum("nm,nij->mij", onehot_b, outer)  # (M, D, D)
+        raw_covs = cov_sums / xp.where(counts_b > 1, counts_b - 1.0, 1.0)[:, None, None]
+        valid = counts_b > 1
+        means = xp.where(valid[:, None], raw_means, float("nan"))
+        covs = xp.where(valid[:, None, None], raw_covs, 0.0)
+    else:
+        means = numpy.full((M, D), numpy.nan)
+        covs = numpy.zeros((M, D, D))
+        for m in range(M):
+            sel = idx == m
+            if counts[m] < 2:
+                continue
+            group = values[sel]
+            means[m] = group.mean(axis=0)
+            covs[m] = numpy.cov(group, rowvar=False)
     return means, covs, counts
 
 
@@ -146,6 +165,11 @@ def _closest_point_on_curve(points, curve, curve_t, mask=None, velocity_weight=1
     components (last 3 columns) by this factor before computing distances.
     See :func:`_fit_track_from_particles` for usage and ``'auto'`` mode.
     """
+    # The closest-node assignment is a non-differentiable structural index
+    # (cKDTree needs numpy); the returned times route the differentiable binning.
+    points = as_numpy(points)
+    curve = as_numpy(curve)
+    curve_t = as_numpy(curve_t)
     if velocity_weight != 1.0 and curve.shape[1] == 6:
         sc = numpy.array(
             [1.0, 1.0, 1.0, velocity_weight, velocity_weight, velocity_weight]

--- a/tests/test_backend_streamTrack.py
+++ b/tests/test_backend_streamTrack.py
@@ -1,0 +1,112 @@
+###############################################################################
+# test_backend_streamTrack.py: backend-agnostic primitives of the stream-track
+# assembly (galpy.df.streamTrack). PR-3 of the streamspray/streamTrack migration:
+# _bin_by_tp (segment mean/cov of per-particle offsets, differentiable in the
+# VALUES; the bin assignment is a numpy structural index) and
+# _closest_point_on_curve (a non-differentiable cKDTree index/time assignment
+# that accepts backend-array inputs). The smoother (_smooth_series) is a later PR.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy, is_backend_array
+from galpy.df.streamTrack import _bin_by_tp, _closest_point_on_curve
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _case(seed=3, n=60, d=6, m=8):
+    rng = numpy.random.RandomState(seed)
+    tp_nodes = numpy.linspace(-5.0, 5.0, m)
+    tp_assign = rng.uniform(-5.0, 5.0, n)
+    values = rng.randn(n, d)
+    return tp_assign, values, tp_nodes
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_bin_by_tp_backend_parity(backend):
+    # the segment mean/cov match the numpy loop to machine precision, the bin
+    # counts are identical, and the mean/cov are backend arrays (differentiable).
+    tp_assign, values, tp_nodes = _case()
+    m_np, c_np, cnt_np = _bin_by_tp(tp_assign, values, tp_nodes)
+    m_b, c_b, cnt_b = _bin_by_tp(tp_assign, _arr(backend, values), tp_nodes)
+    assert is_backend_array(m_b) and is_backend_array(c_b)
+    numpy.testing.assert_array_equal(as_numpy(cnt_b), cnt_np)
+    fin = numpy.isfinite(m_np)  # k>=2 bins
+    numpy.testing.assert_allclose(as_numpy(m_b)[fin], m_np[fin], rtol=1e-12, atol=1e-13)
+    numpy.testing.assert_allclose(
+        as_numpy(c_b), numpy.nan_to_num(c_np), rtol=1e-12, atol=1e-13
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_bin_by_tp_backend_grad(backend):
+    # the binned mean is differentiable w.r.t. the input particle values.
+    tp_assign, values, tp_nodes = _case(n=40)
+
+    def f_np(v):
+        m, _, _ = _bin_by_tp(tp_assign, v, tp_nodes)
+        return numpy.nan_to_num(m).sum()
+
+    eps = 1e-6
+    j = 5
+    gfd = (
+        f_np(values + eps * numpy.eye(values.size)[j].reshape(values.shape))
+        - f_np(values - eps * numpy.eye(values.size)[j].reshape(values.shape))
+    ) / (2 * eps)
+    if backend == "jax":
+
+        def f(v):
+            m, _, _ = _bin_by_tp(tp_assign, v, tp_nodes)
+            return jnp.nan_to_num(m).sum()
+
+        g = as_numpy(jax.grad(f)(jnp.asarray(values))).reshape(-1)[j]
+    else:
+        v = torch.tensor(values, requires_grad=True)
+        m, _, _ = _bin_by_tp(tp_assign, v, tp_nodes)
+        torch.nan_to_num(m).sum().backward()
+        g = as_numpy(v.grad).reshape(-1)[j]
+    numpy.testing.assert_allclose(g, gfd, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_closest_point_backend_inputs(backend):
+    # cKDTree assignment accepts backend-array points/curve and returns the numpy
+    # (non-differentiable) time assignment, identical to the numpy inputs.
+    rng = numpy.random.RandomState(4)
+    points = rng.randn(30, 6)
+    curve = rng.randn(8, 6)
+    curve_t = numpy.linspace(-5.0, 5.0, 8)
+    ref = _closest_point_on_curve(points, curve, curve_t)
+    got = _closest_point_on_curve(_arr(backend, points), _arr(backend, curve), curve_t)
+    assert isinstance(got, numpy.ndarray)
+    numpy.testing.assert_array_equal(got, ref)
+    # velocity_weight path (D==6) also accepts backend inputs
+    got_vw = _closest_point_on_curve(
+        _arr(backend, points), _arr(backend, curve), curve_t, velocity_weight=2.0
+    )
+    ref_vw = _closest_point_on_curve(points, curve, curve_t, velocity_weight=2.0)
+    numpy.testing.assert_array_equal(got_vw, ref_vw)


### PR DESCRIPTION
**Stacked on #1096 → #1095.** PR-3 of the streamspray/streamTrack backend-agnostic migration. Makes the track-assembly binning primitives backend-agnostic + differentiable in the VALUES; the structural (non-differentiable) assignment stays numpy.

### Changes (`galpy/df/streamTrack.py`)
- **`_bin_by_tp`**: the bin *assignment* (which tp-node each particle falls in) is a non-differentiable structural index → numpy (`searchsorted`/`clip`). The binned mean/cov *values* follow `values` via a **data-first dual path** — numpy keeps the byte-identical loop (`mean` / `numpy.cov`); a backend array uses a **one-hot segment mean/cov** (einsum, ddof=1, k<2 bins → NaN mean / zero cov, matching the loop). Backend mean/cov match the numpy loop to **~1e-16** and are differentiable w.r.t. the particle values.
- **`_closest_point_on_curve`**: the cKDTree nearest-node assignment is inherently non-differentiable (index → time); `as_numpy` its inputs so it accepts backend-array `points`/`curve` and returns the numpy time assignment unchanged.

The smoother (`_smooth_series` / `make_smoothing_spline`) still re-numpy-izes the binned means, so the full track stays numpy until the differentiable-smoother PR — this lands the binning primitive it will build on.

### Validation
numpy path byte-identical (`_bin_by_tp` means/covs/counts `array_equal` vs base). Tests in `tests/test_backend_streamTrack.py`: `_bin_by_tp` backend parity + grad-vs-FD, `_closest_point_on_curve` backend-input passthrough (jax + torch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm