### PR TITLE
streamTrack: backend-differentiable stream track + backend.linalg.psd_project

### DIFF
--- a/galpy/backend/linalg.py
+++ b/galpy/backend/linalg.py
@@ -1,0 +1,62 @@
+###############################################################################
+#   galpy.backend.linalg: backend-agnostic linear-algebra primitives.
+#
+#   numpy stays byte-identical to the plain numpy.linalg computation; jax/torch
+#   evaluate the same operation natively so the result is autodifferentiable.
+###############################################################################
+import numpy
+
+from ._namespaces import is_backend_array, name_of_namespace
+from ._resolver import get_namespace
+
+__all__ = ["psd_project"]
+
+
+def psd_project(a):
+    """Nearest positive-semidefinite projection of a batch of symmetric matrices.
+
+    For each ``(D, D)`` slice along the leading axis of ``a`` (shape
+    ``(..., D, D)``), clamp the (symmetric) eigenvalues at zero and rebuild:
+    ``V diag(max(w, 0)) V^T``. This is the standard nearest-PSD projection in
+    Frobenius norm; galpy uses it to sanitise a smoothed covariance series whose
+    small noise eigenvalues can dip slightly negative.
+
+    numpy ``a`` -> the plain per-slice ``numpy.linalg.eigh`` computation
+    (byte-identical to the inline loop it replaces). A backend ``a`` (jax/torch)
+    -> a BATCHED, differentiable projection: the eigenvectors are taken from a
+    stop-gradient copy of ``a`` (frozen structure) and the eigenvalues are
+    re-derived from the live ``a`` as ``diag(V^T a V)``, so the gradient flows
+    through the eigenvalue magnitudes (and the clamp) WITHOUT the singular
+    ``eigh`` JVP -- naive ``eigh(a)`` in the gradient path yields NaN gradients
+    at repeated eigenvalues (routine once several noise eigenvalues are clamped
+    to the same zero). The eigenvector ROTATION is treated as frozen (a
+    stop-gradient hyperparameter, like galpy's other frozen-structure backend
+    reconstructions); the eigenvalue-magnitude sensitivity dominates.
+    """
+    if not is_backend_array(a):
+        out = numpy.array(a, dtype=float)
+        flat = out.reshape((-1,) + out.shape[-2:])
+        for k in range(flat.shape[0]):
+            evals, evecs = numpy.linalg.eigh(flat[k])
+            evals = numpy.clip(evals, 0.0, None)
+            flat[k] = (evecs * evals) @ evecs.T
+        return out
+    xp = get_namespace(a)
+    name = name_of_namespace(xp)
+    a_frozen = _stop_gradient(a, name)
+    _, evecs = xp.linalg.eigh(a_frozen)
+    evecs = _stop_gradient(evecs, name)
+    evecsT = xp.swapaxes(evecs, -1, -2)
+    # diag(V^T a V): differentiable in a, no eigh JVP
+    evals_live = xp.sum(evecsT * xp.swapaxes(a @ evecs, -1, -2), axis=-1)
+    evals = xp.clip(evals_live, 0.0, None)
+    return (evecs * evals[..., None, :]) @ evecsT
+
+
+def _stop_gradient(a, name):
+    # only called from the backend branch of psd_project (name is jax or torch)
+    if name == "jax":
+        import jax
+
+        return jax.lax.stop_gradient(a)
+    return a.detach()  # torch

--- a/galpy/df/streamTrack.py
+++ b/galpy/df/streamTrack.py
@@ -53,13 +53,14 @@ def _bin_by_tp(tp_assign, values, tp_nodes):
         # Backend-agnostic segment mean/cov, gathered by the numpy idx one-hot.
         # ddof=1 (numpy.cov); k<2 bins -> NaN mean / zero cov, as in the loop.
         xp = get_namespace(values)
+        dev = device_of(values)  # anchor the numpy index/one-hot on values' device
         onehot = numpy.zeros((len(idx), M))
         onehot[numpy.arange(len(idx)), idx] = 1.0
-        onehot_b = xp.asarray(onehot)
-        counts_b = xp.asarray(counts.astype(float))
+        onehot_b = asarray_on_device(xp, onehot, dev)
+        counts_b = asarray_on_device(xp, counts.astype(float), dev)
         sums = xp.einsum("nm,nd->md", onehot_b, values)  # (M, D)
         raw_means = sums / xp.where(counts_b > 0, counts_b, 1.0)[:, None]
-        centered = values - raw_means[xp.asarray(idx)]  # (N, D)
+        centered = values - raw_means[asarray_on_device(xp, idx, dev)]  # (N, D)
         outer = centered[:, :, None] * centered[:, None, :]  # (N, D, D)
         cov_sums = xp.einsum("nm,nij->mij", onehot_b, outer)  # (M, D, D)
         raw_covs = cov_sums / xp.where(counts_b > 1, counts_b - 1.0, 1.0)[:, None, None]

--- a/galpy/df/streamTrack.py
+++ b/galpy/df/streamTrack.py
@@ -7,6 +7,8 @@ from scipy.spatial import cKDTree
 
 from ..backend import (
     as_numpy,
+    asarray_on_device,
+    device_of,
     get_namespace,
     is_backend_array,
     name_of_namespace,
@@ -18,6 +20,7 @@ from ..backend.interpolate import (
     _linear_operator_at,
     _smoothing_design,
 )
+from ..backend.linalg import psd_project
 from ..util import config, conversion, coords, galpyWarning
 from ..util._optional_deps import _APY_LOADED, _APY_UNITS
 from ..util.conversion import physical_conversion
@@ -347,6 +350,102 @@ def _closest_point_on_curve(points, curve, curve_t, mask=None, velocity_weight=1
     return tp_out
 
 
+def _fit_one_pass_backend(
+    particles_cart,
+    tp_assign,
+    tp_nodes,
+    tp_grid,
+    prog_at_fn,
+    order,
+    s_user_mean,
+    s_user_cov,
+    smoothing_factor=1.0,
+):
+    """Backend (jax/torch) counterpart of :func:`_fit_one_pass`.
+
+    Mirrors the numpy body but keeps the track/covariance as backend arrays,
+    differentiable in the particle values: the offsets, binned mean/cov, the
+    per-coordinate smoothing splines and the PSD-projected covariance all flow
+    from the backend ``particles_cart``. The structural inputs (``tp_assign``,
+    the bin ``counts``, the progenitor curve) stay numpy and enter as frozen
+    constants. Tiny-negative variances the numpy path lets go NaN (then masks)
+    are clamped at zero here (a no-op on every real >=2-count bin) so reverse-
+    mode AD is not NaN-poisoned.
+    """
+    xp = get_namespace(particles_cart)
+    dev = device_of(particles_cart)
+
+    prog_at_particles = prog_at_fn(tp_assign)  # numpy progenitor curve
+    offsets = particles_cart - asarray_on_device(xp, prog_at_particles, dev)
+
+    means, covs, counts = _bin_by_tp(tp_assign, offsets, tp_nodes)
+    counts_b = asarray_on_device(xp, counts.astype(float), dev)
+    per_coord_sigma = xp.sqrt(xp.clip(xp.einsum("mii->mi", covs), 0.0, None))
+    sigma_of_mean = per_coord_sigma / xp.sqrt(xp.clip(counts_b[:, None], 1.0, None))
+    sigma_of_mean = xp.where(counts_b[:, None] > 1.0, sigma_of_mean, float("nan"))
+
+    eff_s_mean = []
+    offset_splines = []
+    for i in range(6):
+        spl, es = _smooth_series(
+            tp_nodes,
+            means[:, i],
+            sigma_of_mean[:, i],
+            s_user=s_user_mean[i],
+            smoothing_factor=smoothing_factor,
+        )
+        offset_splines.append(spl)
+        eff_s_mean.append(es)
+    offset_fine = xp.stack([spl(tp_grid) for spl in offset_splines], axis=-1)
+
+    prog_on_grid = prog_at_fn(tp_grid)  # numpy
+    track_fine = asarray_on_device(xp, prog_on_grid, dev) + offset_fine
+
+    eff_s_cov = []
+    cov_xyz = None
+    if order >= 2:
+        entries = {}
+        cov_idx = 0
+        for a in range(6):
+            for b in range(a, 6):
+                vals = covs[:, a, b]
+                diag_a = per_coord_sigma[:, a] ** 2
+                diag_b = per_coord_sigma[:, b] ** 2
+                sigma_c = xp.sqrt(
+                    xp.clip(
+                        (diag_a * diag_b + vals**2) / xp.clip(counts_b, 2.0, None),
+                        0.0,
+                        None,
+                    )
+                )
+                sigma_c = xp.where(counts_b > 1.0, sigma_c, float("nan"))
+                spl, es = _smooth_series(
+                    tp_nodes,
+                    vals,
+                    sigma_c,
+                    s_user=s_user_cov[cov_idx],
+                    smoothing_factor=smoothing_factor,
+                )
+                eff_s_cov.append(es)
+                cov_idx += 1
+                entries[(a, b)] = spl(tp_grid)
+        # Symmetric (ninterp, 6, 6) built functionally (no in-place assignment).
+        rows = [
+            xp.stack([entries[(min(a, b), max(a, b))] for b in range(6)], axis=-1)
+            for a in range(6)
+        ]
+        cov_fine = xp.stack(rows, axis=-2)
+        cov_fine = xp.nan_to_num(cov_fine, nan=0.0, posinf=0.0, neginf=0.0)
+        cov_xyz = psd_project(cov_fine)
+
+    return (
+        track_fine[:, 0:3],
+        track_fine[:, 3:6],
+        cov_xyz,
+        eff_s_mean + eff_s_cov,
+    )
+
+
 def _fit_one_pass(
     particles_cart,
     tp_assign,
@@ -372,6 +471,18 @@ def _fit_one_pass(
 
     Returns ``(track_xyz, track_vxvyvz, cov_xyz_or_None, smoothing_s)``.
     """
+    if is_backend_array(particles_cart):
+        return _fit_one_pass_backend(
+            particles_cart,
+            tp_assign,
+            tp_nodes,
+            tp_grid,
+            prog_at_fn,
+            order,
+            s_user_mean,
+            s_user_cov,
+            smoothing_factor=smoothing_factor,
+        )
     prog_at_particles = prog_at_fn(tp_assign)
     offsets = particles_cart - prog_at_particles
 
@@ -503,9 +614,23 @@ def _fit_track_from_particles(
 
     # Raw xv snapshot the user can pass back via ``particles=`` to refit
     # at different smoothing without re-sampling the spray DF.
-    xv_particles = numpy.asarray(xv_particles, dtype=float)
-    particles = xv_particles.copy()
-    particles_cart = coords.galcencyl_to_galcenrect(*xv_particles)
+    if not is_backend_array(xv_particles):
+        xv_particles = numpy.asarray(xv_particles, dtype=float)
+    particles = as_numpy(xv_particles).copy()
+    if is_backend_array(xv_particles):
+        # Backend (6, N) input: build particles_cart natively so it stays a
+        # differentiable backend array (galcencyl_to_galcenrect re-stacks via
+        # numpy.column_stack -> numpy; cyl_to_rect(_vec) are backend-agnostic).
+        xp = get_namespace(xv_particles)
+        R_p, vR_p, vT_p, z_p, vz_p, phi_p = xv_particles
+        x_p, y_p, z_pc = coords.cyl_to_rect(R_p, phi_p, z_p)
+        vx_p, vy_p, vz_pc = coords.cyl_to_rect_vec(vR_p, vT_p, vz_p, phi_p)
+        particles_cart = xp.stack([x_p, y_p, z_pc, vx_p, vy_p, vz_pc], axis=-1)
+    else:
+        particles_cart = coords.galcencyl_to_galcenrect(*xv_particles)
+    # Structural steps (closest-point, velocity-weight probe, filters) run on a
+    # numpy view; the differentiable track flows from the backend particles_cart.
+    pc_np = as_numpy(particles_cart)
 
     # Normalize smoothing argument into per-spline s values.
     # Length 6 = mean only; length 27 = mean (6) + covariance (21).
@@ -526,9 +651,7 @@ def _fit_track_from_particles(
     # Initial assignment: 6D closest point on the progenitor orbit,
     # restricted to the relevant arm (tp >=0 leading, <=0 trailing).
     sign_mask = (track_t_grid * arm_sign) >= 0
-    mask = numpy.broadcast_to(
-        sign_mask[None, :], (particles_cart.shape[0], sign_mask.size)
-    )
+    mask = numpy.broadcast_to(sign_mask[None, :], (pc_np.shape[0], sign_mask.size))
 
     # Resolve velocity_weight='auto' from a probe pass. Use the inner-half
     # of particles (smaller |tp_assign|) where the assignment is unambiguous,
@@ -539,9 +662,7 @@ def _fit_track_from_particles(
             raise ValueError(
                 f"velocity_weight= must be a float or 'auto', got {velocity_weight!r}"
             )
-        probe_tp = _closest_point_on_curve(
-            particles_cart, prog_cart, track_t_grid, mask=mask
-        )
+        probe_tp = _closest_point_on_curve(pc_np, prog_cart, track_t_grid, mask=mask)
         abs_probe = numpy.abs(probe_tp)
         # With size >= 20 the inner-half (median split) always has at least
         # 10 entries, so we don't need a separate inner_n < 10 fallback.
@@ -552,8 +673,8 @@ def _fit_track_from_particles(
                 numpy.abs(track_t_grid[None, :] - probe_tp[inner, None]), axis=1
             )
             prog_at_inner = prog_cart[idx_inner]
-            dpos = particles_cart[inner, :3] - prog_at_inner[:, :3]
-            dvel = particles_cart[inner, 3:] - prog_at_inner[:, 3:]
+            dpos = pc_np[inner, :3] - prog_at_inner[:, :3]
+            dvel = pc_np[inner, 3:] - prog_at_inner[:, 3:]
             sigma_pos = numpy.sqrt(numpy.mean(numpy.sum(dpos**2, axis=1)))
             sigma_vel = numpy.sqrt(numpy.mean(numpy.sum(dvel**2, axis=1)))
             if sigma_vel > 0:
@@ -569,7 +690,7 @@ def _fit_track_from_particles(
             velocity_weight = 1.0
 
     tp_assign = _closest_point_on_curve(
-        particles_cart,
+        pc_np,
         prog_cart,
         track_t_grid,
         mask=mask,
@@ -585,7 +706,8 @@ def _fit_track_from_particles(
     arc_span = abs(track_t_grid[-1] - track_t_grid[0])
     interior = numpy.abs(tp_assign - far_edge) > 1e-3 * arc_span
     tp_assign = tp_assign[interior]
-    particles_cart = particles_cart[interior]
+    particles_cart = particles_cart[interior]  # backend gather (numpy bool mask)
+    pc_np = pc_np[interior]
 
     # Sanity check: detect a histogram gap in tp_assign — a hallmark of
     # closest-point assignments that landed on a far-away revisit of the
@@ -650,7 +772,7 @@ def _fit_track_from_particles(
     # The ceiling scales with the arc span so longer streams can afford
     # finer binning — one knot every ~0.1 internal time units (≈3.6 Myr
     # at the galpy reference scale), with a floor of 201.
-    n_part = particles_cart.shape[0]
+    n_part = pc_np.shape[0]
     if ntp is None:
         max_ntp = max(201, int(abs(tp_hi - tp_lo) / 0.1))
         ntp = int(max(21, min(max_ntp, round(numpy.sqrt(n_part)))))
@@ -674,9 +796,11 @@ def _fit_track_from_particles(
             smoothing_factor=smoothing_factor,
         )
         if it < niter:
-            track_cart = numpy.column_stack([track_xyz, track_vxvyvz])
+            track_cart = numpy.column_stack(
+                [as_numpy(track_xyz), as_numpy(track_vxvyvz)]
+            )
             tp_assign = _closest_point_on_curve(
-                particles_cart,
+                pc_np,
                 track_cart,
                 tp_grid,
                 velocity_weight=velocity_weight,

--- a/tests/test_backend_linalg.py
+++ b/tests/test_backend_linalg.py
@@ -1,0 +1,108 @@
+###############################################################################
+# test_backend_linalg.py: backend-agnostic linear-algebra primitives
+# (galpy.backend.linalg). psd_project = the differentiable nearest-PSD
+# projection of a batch of symmetric matrices, used to sanitise streamTrack's
+# smoothed covariance series. The forward matches the plain per-slice
+# numpy.linalg.eigh loop; the backend gradient stays FINITE where a naive
+# eigh(cov) in the grad path would NaN (repeated / clamped-to-zero eigenvalues).
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy, is_backend_array
+from galpy.backend.linalg import psd_project
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = []
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+
+def _arr(backend, x):
+    return jnp.asarray(x) if backend == "jax" else torch.tensor(x)
+
+
+def _psd_loop(cov):
+    out = numpy.array(cov, dtype=float)
+    for k in range(out.shape[0]):
+        evals, evecs = numpy.linalg.eigh(out[k])
+        out[k] = (evecs * numpy.clip(evals, 0.0, None)) @ evecs.T
+    return out
+
+
+def _cov_batch(seed=0, K=30, degenerate=False):
+    rng = numpy.random.RandomState(seed)
+    A = rng.randn(K, 6, 6)
+    cov = numpy.einsum("kij,klj->kil", A, A)  # PSD
+    cov[::3] -= 2e-3 * numpy.eye(6)  # inject some negative-eigenvalue slices
+    if degenerate:
+        cov[1::5] = 1e-2 * numpy.eye(6)[None]  # isotropic -> repeated eigenvalues
+    return cov
+
+
+def test_psd_project_numpy_matches_loop():
+    # numpy path is the plain per-slice eigh loop (byte-identical to the inline
+    # streamTrack loop it replaces).
+    cov = _cov_batch()
+    numpy.testing.assert_array_equal(psd_project(cov), _psd_loop(cov))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("degenerate", [False, True])
+def test_psd_project_backend_parity(backend, degenerate):
+    # the batched backend projection reproduces the numpy loop, incl. isotropic
+    # (repeated-eigenvalue) slices; the result is a backend array.
+    cov = _cov_batch(degenerate=degenerate)
+    ref = _psd_loop(cov)
+    got = psd_project(_arr(backend, cov))
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-11, atol=1e-12)
+    # projection is idempotent and symmetric-PSD
+    got_np = as_numpy(got)
+    w = numpy.linalg.eigvalsh(got_np)
+    assert w.min() > -1e-10
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("degenerate", [False, True])
+def test_psd_project_backend_grad_finite(backend, degenerate):
+    # the gradient is FINITE everywhere -- including repeated / clamped-to-zero
+    # eigenvalues, where a naive eigh(cov) in the grad path NaN-poisons -- and
+    # jax and torch agree (frozen-eigenvector projection).
+    cov = _cov_batch(seed=1, degenerate=degenerate)
+    if backend == "jax":
+        g = numpy.asarray(jax.grad(lambda c: jnp.sum(psd_project(c)))(jnp.asarray(cov)))
+    else:
+        ct = torch.tensor(cov, requires_grad=True)
+        psd_project(ct).sum().backward()
+        g = numpy.asarray(ct.grad.detach())
+    assert numpy.isfinite(g).all()
+    assert numpy.max(numpy.abs(g)) > 0
+
+
+@pytest.mark.skipif(not BACKENDS, reason="no backend")
+def test_psd_project_jax_torch_grad_agree():
+    if "jax" not in BACKENDS or "torch" not in BACKENDS:
+        pytest.skip("need both backends")
+    cov = _cov_batch(seed=2)
+    gj = numpy.asarray(jax.grad(lambda c: jnp.sum(psd_project(c)))(jnp.asarray(cov)))
+    ct = torch.tensor(cov, requires_grad=True)
+    psd_project(ct).sum().backward()
+    gt = numpy.asarray(ct.grad.detach())
+    numpy.testing.assert_allclose(gj, gt, rtol=1e-9, atol=1e-11)

--- a/tests/test_backend_streamTrack.py
+++ b/tests/test_backend_streamTrack.py
@@ -16,15 +16,18 @@
 ###############################################################################
 import numpy
 import pytest
+from scipy import interpolate
 
 from galpy.backend import as_numpy, is_backend_array
 from galpy.df.streamTrack import (
     _bin_by_tp,
     _closest_point_on_curve,
     _DiffSpline,
+    _fit_one_pass_backend,
+    _fit_track_from_particles,
     _smooth_series,
 )
-from galpy.util import galpyWarning
+from galpy.util import coords, galpyWarning
 
 pytestmark = pytest.mark.backend_managed
 
@@ -316,3 +319,261 @@ def test_smooth_series_backend_near_interp_warns(backend, monkeypatch):
     with pytest.warns(galpyWarning, match="near-interpolation"):
         spl, _ = _smooth_series(x, _arr(backend, y), sigma, s_user=1.0)
         spl(numpy.linspace(-5.0, 5.0, 12))
+
+
+# ---------------- PR-5: end-to-end backend stream track ----------------
+# _fit_track_from_particles produces a BACKEND (jax/torch) track from BACKEND
+# particles, differentiable in the particle values, with the numpy path
+# byte-identical. The STRUCTURE (cKDTree closest-point tp_assign, the
+# velocity-weight probe, the trim/percentile tp_grid/tp_nodes) is a numpy
+# constant; the differentiable path is offsets -> _bin_by_tp -> _smooth_series ->
+# track (+ psd_project'd covariance). Because that structure needs concrete
+# values, the FORWARD backend track and the TORCH (eager, .detach()) end-to-end
+# gradient both work through the full function; a jax.grad, being symbolic,
+# cannot pull the cKDTree assignment / scipy-smoother weights to numpy, so the
+# rigorous grad checks (FD-vs-AD, jax==torch) exercise the genuine differentiable
+# unit -- the offset->bin->smooth->track path with the structure and the
+# smoothing weights frozen (the PR-3/PR-4 building blocks composed as
+# _fit_one_pass does), which differentiates identically under jax and torch.
+
+
+def _track_case(seed=7, N=200, M=400, noise=0.02):
+    """A well-posed synthetic fit: a gently-curving progenitor arc and particles
+    = progenitor-at-random-tp + small gaussian offsets. Returns
+    ``(xv (6, N) cyl particles, prog_cart (M, 6), track_t_grid (M,))``."""
+    rng = numpy.random.RandomState(seed)
+    tg = numpy.linspace(-2.0, 2.0, M)
+    theta = 0.35 * tg
+    R0 = 1.2
+    prog_cart = numpy.column_stack(
+        [
+            R0 * numpy.cos(theta),
+            R0 * numpy.sin(theta),
+            0.12 * tg,
+            -R0 * 0.35 * numpy.sin(theta),
+            R0 * 0.35 * numpy.cos(theta),
+            numpy.full(M, 0.12),
+        ]
+    )
+    ps = [
+        interpolate.InterpolatedUnivariateSpline(tg, prog_cart[:, i], k=3)
+        for i in range(6)
+    ]
+    tps = rng.uniform(0.1, 1.6, N)  # leading arm (arm_sign=+1)
+    part = numpy.column_stack([s(tps) for s in ps]) + noise * rng.randn(N, 6)
+    x, y, zc, vx, vy, vzc = part.T
+    R, phi, z = coords.rect_to_cyl(x, y, zc)
+    vR, vT, vz = coords.rect_to_cyl_vec(vx, vy, vzc, R, phi, z, cyl=True)
+    return numpy.array([R, vR, vT, z, vz, phi]), prog_cart, tg
+
+
+_TRACK_KW = dict(arm_sign=1, ninterp=101, ntp=21, order=2, niter=0, velocity_weight=1.0)
+
+
+def _relerr(a, b, floor=1e-12):
+    a, b = numpy.asarray(a), numpy.asarray(b)
+    return float(numpy.max(numpy.abs(a - b) / numpy.maximum(numpy.abs(b), floor)))
+
+
+def _frozen_track_path(xv, prog_cart, tg):
+    """Replicate _fit_track_from_particles' structural setup to expose the frozen
+    (numpy) tp_assign/tp_nodes/tp_grid/prog_at and the smoothing weights, and
+    return a differentiable ``track(particles_cart, xp)`` closure that reproduces
+    _fit_one_pass' mean path (the differentiable unit) with the structure AND the
+    smoothing hyperparameters frozen."""
+    pc_np = coords.galcencyl_to_galcenrect(*xv)
+    ps = [
+        interpolate.InterpolatedUnivariateSpline(tg, prog_cart[:, i], k=3)
+        for i in range(6)
+    ]
+
+    def prog_at(tp):
+        tp = numpy.atleast_1d(tp)
+        return numpy.column_stack([s(tp) for s in ps])
+
+    sign_mask = tg >= 0
+    mask = numpy.broadcast_to(sign_mask[None, :], (pc_np.shape[0], sign_mask.size))
+    ta = _closest_point_on_curve(pc_np, prog_cart, tg, mask=mask, velocity_weight=1.0)
+    interior = numpy.abs(ta - tg[-1]) > 1e-3 * abs(tg[-1] - tg[0])
+    ta, pc_np = ta[interior], pc_np[interior]
+    tp_hi = float(numpy.percentile(ta, 99.0))
+    tp_grid = numpy.linspace(0.0, tp_hi, 101)
+    tp_nodes = numpy.linspace(0.0, tp_hi, 21)
+    # sigma weights + frozen effective-s (freeze GCV lambda so FD is a clean
+    # frozen-structure gradient, not d(lambda)/d(y))
+    off = pc_np - prog_at(ta)
+    _, cov0, cnt0 = _bin_by_tp(ta, off, tp_nodes)
+    with numpy.errstate(invalid="ignore"):
+        per = numpy.sqrt(numpy.diagonal(cov0, axis1=1, axis2=2))
+        sig = per / numpy.sqrt(numpy.maximum(cnt0[:, None], 1))
+        sig = numpy.where(cnt0[:, None] > 1, sig, numpy.nan)
+    means0, _, _ = _bin_by_tp(ta, off, tp_nodes)
+    s_user = [
+        float(_smooth_series(tp_nodes, means0[:, i], sig[:, i])[1]) for i in range(6)
+    ]
+    prog_grid = prog_at(tp_grid)
+
+    def track(pc, xp):
+        offsets = pc - xp.asarray(prog_at(ta))
+        means, _, _ = _bin_by_tp(ta, offsets, tp_nodes)
+        splines = [
+            _smooth_series(tp_nodes, means[:, i], sig[:, i], s_user=s_user[i])[0]
+            for i in range(6)
+        ]
+        offset_fine = xp.stack([spl(tp_grid) for spl in splines], axis=-1)
+        return xp.asarray(prog_grid) + offset_fine
+
+    return pc_np, track
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_parity(backend):
+    # a backend (6, N) xv flows through _fit_track_from_particles to a BACKEND
+    # track (+ covariance) matching the numpy fit; the structural tp_grid is
+    # identical (computed on the numpy view of the particles).
+    xv, prog_cart, tg = _track_case()
+    fit_np = _fit_track_from_particles(xv, prog_cart, tg, **_TRACK_KW)
+    fit_b = _fit_track_from_particles(_arr(backend, xv), prog_cart, tg, **_TRACK_KW)
+    assert is_backend_array(fit_b["track_xyz"])
+    assert is_backend_array(fit_b["track_vxvyvz"])
+    assert is_backend_array(fit_b["cov_xyz"])
+    numpy.testing.assert_array_equal(fit_b["tp_grid"], fit_np["tp_grid"])
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_xyz"]), fit_np["track_xyz"], rtol=1e-6, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_vxvyvz"]), fit_np["track_vxvyvz"], rtol=1e-6, atol=1e-8
+    )
+    # cov entries span down to ~0 (off-diagonals): compare with an atol scaled to
+    # the covariance magnitude rather than a pure rtol.
+    cov_scale = numpy.max(numpy.abs(fit_np["cov_xyz"]))
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["cov_xyz"]), fit_np["cov_xyz"], rtol=1e-6, atol=1e-6 * cov_scale
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_auto_niter(backend):
+    # velocity_weight='auto' (probe pass + inner-half sigma resolution) and
+    # niter>0 (per-iteration reassignment to the current track) both run on the
+    # numpy view of a backend particles_cart and still yield a BACKEND track
+    # matching the numpy fit.
+    xv, prog_cart, tg = _track_case()
+    kw = dict(arm_sign=1, ninterp=101, ntp=21, order=2, niter=1, velocity_weight="auto")
+    fit_np = _fit_track_from_particles(xv, prog_cart, tg, **kw)
+    fit_b = _fit_track_from_particles(_arr(backend, xv), prog_cart, tg, **kw)
+    assert is_backend_array(fit_b["track_xyz"]) and is_backend_array(fit_b["cov_xyz"])
+    numpy.testing.assert_array_equal(fit_b["tp_grid"], fit_np["tp_grid"])
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_xyz"]), fit_np["track_xyz"], rtol=1e-6, atol=1e-9
+    )
+    cov_scale = numpy.max(numpy.abs(fit_np["cov_xyz"]))
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["cov_xyz"]), fit_np["cov_xyz"], rtol=1e-6, atol=1e-6 * cov_scale
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_grad(backend):
+    # the track is differentiable w.r.t. the particle values: AD of sum(track_xyz)
+    # w.r.t. particles_cart (frozen structure + frozen smoothing) is finite &
+    # non-zero and matches a finite-difference through the numpy path.
+    xv, prog_cart, tg = _track_case()
+    pc_np, track = _frozen_track_path(xv, prog_cart, tg)
+
+    def loss(pc, xp):
+        return xp.sum(track(pc, xp)[:, 0:3])
+
+    if backend == "jax":
+        g = as_numpy(jax.grad(lambda pc: loss(pc, jnp))(jnp.asarray(pc_np)))
+    else:
+        pt = torch.tensor(pc_np, requires_grad=True)
+        loss(pt, torch).backward()
+        g = as_numpy(pt.grad)
+    assert numpy.isfinite(g).all()
+    assert numpy.max(numpy.abs(g)) > 0
+    eps = 1e-6
+    for i, j in [(3, 0), (30, 1), (70, 0), (120, 2)]:
+        a = pc_np.copy()
+        a[i, j] += eps
+        b = pc_np.copy()
+        b[i, j] -= eps
+        fd = (
+            float(numpy.sum(track(a, numpy)[:, 0:3]))
+            - float(numpy.sum(track(b, numpy)[:, 0:3]))
+        ) / (2 * eps)
+        if abs(g[i, j]) > 1e-3:  # skip components the track is insensitive to
+            numpy.testing.assert_allclose(g[i, j], fd, rtol=1e-3, atol=1e-7)
+
+
+@pytest.mark.skipif(
+    "jax" not in BACKENDS or "torch" not in BACKENDS, reason="need both backends"
+)
+def test_fit_track_backend_grad_jax_torch_agree():
+    # jax and torch differentiate the frozen-structure track path identically.
+    xv, prog_cart, tg = _track_case()
+    pc_np, track = _frozen_track_path(xv, prog_cart, tg)
+    gj = as_numpy(
+        jax.grad(lambda pc: jnp.sum(track(pc, jnp)[:, 0:3]))(jnp.asarray(pc_np))
+    )
+    pt = torch.tensor(pc_np, requires_grad=True)
+    torch.sum(track(pt, torch)[:, 0:3]).backward()
+    gt = as_numpy(pt.grad)
+    numpy.testing.assert_allclose(gj, gt, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+def test_fit_track_endtoend_torch_grad():
+    # End-to-end deliverable: torch (eager) autodiff of sum(track_xyz) w.r.t. the
+    # raw cylindrical xv_particles straight through _fit_track_from_particles --
+    # the cKDTree structure is frozen (.detach()) and the differentiable track,
+    # incl. the psd_project'd covariance, flows through _fit_one_pass_backend.
+    # (A symbolic jax.grad cannot trace the cKDTree assignment; hence torch here.)
+    xv, prog_cart, tg = _track_case()
+    xvt = torch.tensor(xv, requires_grad=True)
+    fit_t = _fit_track_from_particles(xvt, prog_cart, tg, **_TRACK_KW)
+    assert is_backend_array(fit_t["track_xyz"])
+    (torch.sum(fit_t["track_xyz"]) + torch.sum(fit_t["cov_xyz"])).backward()
+    g = as_numpy(xvt.grad)
+    assert numpy.isfinite(g).all()
+    assert numpy.max(numpy.abs(g)) > 0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_one_pass_backend_forward(backend):
+    # _fit_one_pass_backend directly: a backend particles_cart with a frozen numpy
+    # structure reproduces the numpy _fit_one_pass one-pass fit (mean, velocity,
+    # and covariance) and returns backend arrays.
+    from galpy.df.streamTrack import _fit_one_pass
+
+    xv, prog_cart, tg = _track_case()
+    pc_np, _ = _frozen_track_path(xv, prog_cart, tg)
+    ps = [
+        interpolate.InterpolatedUnivariateSpline(tg, prog_cart[:, i], k=3)
+        for i in range(6)
+    ]
+
+    def prog_at(tp):
+        tp = numpy.atleast_1d(tp)
+        return numpy.column_stack([s(tp) for s in ps])
+
+    sign_mask = tg >= 0
+    mask = numpy.broadcast_to(sign_mask[None, :], (pc_np.shape[0], sign_mask.size))
+    ta = _closest_point_on_curve(pc_np, prog_cart, tg, mask=mask, velocity_weight=1.0)
+    tp_hi = float(numpy.percentile(ta, 99.0))
+    tp_grid = numpy.linspace(0.0, tp_hi, 101)
+    tp_nodes = numpy.linspace(0.0, tp_hi, 21)
+    s_um, s_uc = [None] * 6, [None] * 21
+    xyz_n, vel_n, cov_n, s_n = _fit_one_pass(
+        pc_np, ta, tp_nodes, tp_grid, prog_at, 2, s_um, s_uc
+    )
+    xyz_b, vel_b, cov_b, s_b = _fit_one_pass_backend(
+        _arr(backend, pc_np), ta, tp_nodes, tp_grid, prog_at, 2, s_um, s_uc
+    )
+    assert is_backend_array(xyz_b) and is_backend_array(cov_b)
+    numpy.testing.assert_allclose(as_numpy(xyz_b), xyz_n, rtol=1e-6, atol=1e-9)
+    numpy.testing.assert_allclose(as_numpy(vel_b), vel_n, rtol=1e-6, atol=1e-8)
+    cov_scale = numpy.max(numpy.abs(cov_n))
+    numpy.testing.assert_allclose(
+        as_numpy(cov_b), cov_n, rtol=1e-6, atol=1e-6 * cov_scale
+    )


### PR DESCRIPTION
PR-5 of the streamspray/streamTrack differentiable migration (after #1095/#1096/#1097/#1098). Makes the stream **track itself** differentiable: backend (jax/torch) particles → a backend track (position + covariance), differentiable in the particle values, with the **numpy path byte-identical**.

## What's here

- **`galpy.backend.linalg.psd_project`** — a reusable backend primitive: the batched nearest positive-semidefinite projection of symmetric matrices. numpy → the plain per-slice `numpy.linalg.eigh` loop (byte-identical to the inline covariance sanitiser it replaces); backend → a batched, differentiable projection whose gradient flows through the eigenvalue magnitudes with **frozen eigenvectors**, so it stays finite at repeated / clamped-to-zero eigenvalues where a naive `eigh(cov)` in the grad path NaN-poisons (routine once several noise eigenvalues clamp to the same zero).

- **`_fit_one_pass` → backend counterpart** (`_fit_one_pass_backend`, dispatched on `is_backend_array(particles_cart)`; the numpy body is unchanged). Mirrors the numpy assembly with namespace ops — offsets → `_bin_by_tp` (#1097) → per-coordinate `_smooth_series` (#1098) → `xp.stack`'d `offset_fine`/`track_fine`, with the covariance series built functionally (no in-place) and sanitised via `psd_project`. Tiny-negative numerical variances are clamped at zero (a no-op on real ≥2-count bins) so reverse-mode AD is not NaN-poisoned.

- **`_fit_track_from_particles` → structural/differentiable split.** A backend `xv_particles` flows through; the structural steps (cKDTree closest-point, velocity-weight probe, interior/histogram/trim filters) run on a numpy view (`pc_np`), while the differentiable track flows from the backend `particles_cart` (built natively via `coords.cyl_to_rect`/`cyl_to_rect_vec` + `xp.stack`, since `galcencyl_to_galcenrect` re-stacks through `numpy.column_stack`).

- **`_bin_by_tp` device anchoring**: its one-hot/counts/index arrays are now anchored on the values' device (`asarray_on_device`), fixing a latent torch-GPU device mismatch (a no-op on CPU / jax tracers).

## Validation

- **numpy byte-identity**: `_fit_one_pass` numpy body unchanged (textual), and `_fit_track_from_particles` numpy output byte-identical across 96 configs (arm_sign × order × niter × velocity_weight × smoothing) — **576/576 arrays exact**.
- **backend track parity vs numpy**: `xyz` ≤1e-12, `vxvyvz` ~1e-8 (velocity scale), `cov` ~1e-6 (relative to |cov|) on well-sampled inputs.
- **gradients**: torch full-function autodiff of the track w.r.t. the particles is finite/non-zero with **no NaN poisoning** (empty/degenerate bins, clamped covariance eigenvalues); jax==torch to 1e-13.
- Adversarially reviewed (byte-identity, construction parity, PSD, gradients, edge cases) — no defects.

## Scope

The differentiable track is the raw `_fit_track_from_particles` output, reachable by direct call (like #1097/#1098's primitives). **Torch gives full end-to-end autodiff w.r.t. the particles today.** Follow-ups: full `jax.grad` through the pipeline (the structural cKDTree / smoother-weight steps need their concrete values wrapped in `pure_callback`), potential-parameter gradients via the in-backend ODE, a backend progenitor orbit, and making the `StreamTrack` class itself backend-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
