### PR TITLE
streamTrack: differentiable w.r.t. a backend progenitor curve (∂track/∂progenitor)

### DIFF
--- a/galpy/df/streamTrack.py
+++ b/galpy/df/streamTrack.py
@@ -379,8 +379,10 @@ def _fit_one_pass_backend(
     xp = get_namespace(particles_cart)
     dev = device_of(particles_cart)
 
-    prog_at_particles = prog_at_fn(tp_assign)  # numpy progenitor curve
-    offsets = particles_cart - asarray_on_device(xp, prog_at_particles, dev)
+    prog_at_particles = prog_at_fn(tp_assign)  # backend curve stays differentiable
+    if not is_backend_array(prog_at_particles):
+        prog_at_particles = asarray_on_device(xp, prog_at_particles, dev)
+    offsets = particles_cart - prog_at_particles
 
     means, covs, counts = _bin_by_tp(tp_assign, offsets, tp_nodes)
     counts_b = asarray_on_device(xp, counts.astype(float), dev)
@@ -402,8 +404,10 @@ def _fit_one_pass_backend(
         eff_s_mean.append(es)
     offset_fine = xp.stack([spl(tp_grid) for spl in offset_splines], axis=-1)
 
-    prog_on_grid = prog_at_fn(tp_grid)  # numpy
-    track_fine = asarray_on_device(xp, prog_on_grid, dev) + offset_fine
+    prog_on_grid = prog_at_fn(tp_grid)  # backend curve stays differentiable
+    if not is_backend_array(prog_on_grid):
+        prog_on_grid = asarray_on_device(xp, prog_on_grid, dev)
+    track_fine = prog_on_grid + offset_fine
 
     eff_s_cov = []
     cov_xyz = None
@@ -586,12 +590,38 @@ def _fit_track_from_particles(
     ``1.0`` for the legacy unweighted natural-units metric.
     """
     track_t_grid = numpy.asarray(track_t_grid, dtype=float)
-    prog_cart = numpy.asarray(track_prog_cart, dtype=float)
+    # A backend progenitor curve stays a differentiable backend array (track =
+    # prog + offset flows d(track)/d(progenitor)); a numpy view drives the
+    # structural closest-point / velocity-weight probe.
+    if is_backend_array(track_prog_cart):
+        prog_cart = track_prog_cart
+    else:
+        prog_cart = numpy.asarray(track_prog_cart, dtype=float)
+    prog_cart_np = as_numpy(prog_cart)
     arm_sign = int(numpy.sign(arm_sign)) or 1
     ninterp = int(ninterp)
     order = int(order)
 
-    if prog_orbit is not None:
+    if is_backend_array(prog_cart):
+        # Backend progenitor curve: differentiable cubic interpolation so the
+        # fitted track carries d(track)/d(progenitor). not-a-knot BC matches
+        # InterpolatedUnivariateSpline (natural diverges ~1e-6 at the ends).
+        # A backend prog_cart is an explicit differentiability request, so it
+        # takes precedence over the prog_orbit numpy-interpolation reuse.
+        xpp = get_namespace(prog_cart)
+        devp = device_of(prog_cart)
+        prog_coeffs = [
+            cubic_spline_coeffs(xpp, track_t_grid, prog_cart[:, i], bc="not-a-knot")
+            for i in range(6)
+        ]
+
+        def _prog_at(tp):
+            tp_b = asarray_on_device(xpp, numpy.atleast_1d(tp), devp)
+            return xpp.stack(
+                [eval_cubic(xpp, track_t_grid, prog_coeffs[i], tp_b) for i in range(6)],
+                axis=-1,
+            )
+    elif prog_orbit is not None:
         # Reuse the Orbit's internal interpolation directly — the orbit
         # has already been integrated densely on track_t_grid.
         def _prog_at(tp):
@@ -632,6 +662,12 @@ def _fit_track_from_particles(
         particles_cart = xp.stack([x_p, y_p, z_pc, vx_p, vy_p, vz_pc], axis=-1)
     else:
         particles_cart = coords.galcencyl_to_galcenrect(*xv_particles)
+    # A backend progenitor curve with numpy particles still fits differentiably:
+    # promote particles onto the progenitor's backend so d(track)/d(progenitor)
+    # flows (numpy particles + numpy prog stays pure numpy -> byte-identical).
+    if is_backend_array(prog_cart) and not is_backend_array(particles_cart):
+        xpp = get_namespace(prog_cart)
+        particles_cart = asarray_on_device(xpp, particles_cart, device_of(prog_cart))
     # Structural steps (closest-point, velocity-weight probe, filters) run on a
     # numpy view; the differentiable track flows from the backend particles_cart.
     pc_np = as_numpy(particles_cart)
@@ -666,7 +702,7 @@ def _fit_track_from_particles(
             raise ValueError(
                 f"velocity_weight= must be a float or 'auto', got {velocity_weight!r}"
             )
-        probe_tp = _closest_point_on_curve(pc_np, prog_cart, track_t_grid, mask=mask)
+        probe_tp = _closest_point_on_curve(pc_np, prog_cart_np, track_t_grid, mask=mask)
         abs_probe = numpy.abs(probe_tp)
         # With size >= 20 the inner-half (median split) always has at least
         # 10 entries, so we don't need a separate inner_n < 10 fallback.
@@ -676,7 +712,7 @@ def _fit_track_from_particles(
             idx_inner = numpy.argmin(
                 numpy.abs(track_t_grid[None, :] - probe_tp[inner, None]), axis=1
             )
-            prog_at_inner = prog_cart[idx_inner]
+            prog_at_inner = prog_cart_np[idx_inner]
             dpos = pc_np[inner, :3] - prog_at_inner[:, :3]
             dvel = pc_np[inner, 3:] - prog_at_inner[:, 3:]
             sigma_pos = numpy.sqrt(numpy.mean(numpy.sum(dpos**2, axis=1)))
@@ -695,7 +731,7 @@ def _fit_track_from_particles(
 
     tp_assign = _closest_point_on_curve(
         pc_np,
-        prog_cart,
+        prog_cart_np,
         track_t_grid,
         mask=mask,
         velocity_weight=velocity_weight,

--- a/tests/test_backend_streamTrack.py
+++ b/tests/test_backend_streamTrack.py
@@ -540,6 +540,192 @@ def test_fit_track_endtoend_torch_grad():
     assert numpy.max(numpy.abs(g)) > 0
 
 
+###############################################################################
+# ∂track/∂progenitor: a BACKEND progenitor curve (e.g. from a differentiable
+# C-STM orbit) flows through _fit_track_from_particles so the fitted track
+# carries d(track)/d(progenitor). The progenitor is interpolated by the
+# differentiable backend cubic spline (not-a-knot BC == scipy IUS) at both the
+# assignment times (offsets = particles - prog_at(ta)) and the dense grid
+# (track = prog_grid + smoothed_offset); the numpy path stays byte-identical.
+# As with particles, a symbolic jax.grad cannot pull the cKDTree assignment /
+# smoother weights to numpy, so the rigorous jax grad goes through the frozen-
+# structure unit; the torch (eager) end-to-end grad flows through the full fn.
+###############################################################################
+
+
+def _frozen_prog_path(xv, prog_cart, tg):
+    """Expose track(prog_cart, xp) differentiable in the PROGENITOR CURVE with the
+    structure AND the smoother frozen to PRODUCTION's exact operator: the GCV
+    smoothing operator (s_user=None, the default) is extracted once from the base
+    binned means via _DiffSpline._build -- the identical operator that
+    _fit_one_pass_backend freezes through _apply_frozen_smoother. So the numpy FD
+    and the backend autograd apply the SAME operator, and this validates the real
+    d(track)/d(progenitor) production gradient, not a FITPACK-s_user proxy. prog
+    enters via the backend cubic spline at both the assignment times (offsets =
+    particles - prog_at(ta)) and the dense grid (track = prog_grid + smooth)."""
+    from galpy.backend.interpolate import cubic_spline_coeffs, eval_cubic
+
+    pc_np = coords.galcencyl_to_galcenrect(*xv)
+    sign_mask = tg >= 0
+    mask = numpy.broadcast_to(sign_mask[None, :], (pc_np.shape[0], sign_mask.size))
+    ta = _closest_point_on_curve(pc_np, prog_cart, tg, mask=mask, velocity_weight=1.0)
+    interior = numpy.abs(ta - tg[-1]) > 1e-3 * abs(tg[-1] - tg[0])
+    ta, pc_np = ta[interior], pc_np[interior]
+    tp_hi = float(numpy.percentile(ta, 99.0))
+    tp_grid = numpy.linspace(0.0, tp_hi, 101)
+    tp_nodes = numpy.linspace(0.0, tp_hi, 21)
+
+    def prog_at_np(prog, tp):
+        sp = [
+            interpolate.InterpolatedUnivariateSpline(tg, prog[:, i], k=3)
+            for i in range(6)
+        ]
+        return numpy.column_stack([s(numpy.atleast_1d(tp)) for s in sp])
+
+    off0 = pc_np - prog_at_np(prog_cart, ta)
+    means0, cov0, cnt0 = _bin_by_tp(ta, off0, tp_nodes)
+    with numpy.errstate(invalid="ignore"):
+        per = numpy.sqrt(numpy.diagonal(cov0, axis1=1, axis2=2))
+        sig = per / numpy.sqrt(numpy.maximum(cnt0[:, None], 1))
+        sig = numpy.where(cnt0[:, None] > 1, sig, numpy.nan)
+    # Freeze production's GCV smoother as a (len(tp_grid) x len(tp_nodes)) operator
+    # per coordinate, from the base means (matches _apply_frozen_smoother).
+    g_ops = [
+        _DiffSpline(means0[:, i], tp_nodes, sig[:, i], None, 1.0, "numpy")._build(
+            tp_grid
+        )(means0[:, i])
+        for i in range(6)
+    ]
+
+    def track(prog, xp):
+        if xp is numpy:
+            pa, pg = prog_at_np(prog, ta), prog_at_np(prog, tp_grid)
+        else:
+            coeffs = [
+                cubic_spline_coeffs(xp, tg, prog[:, i], bc="not-a-knot")
+                for i in range(6)
+            ]
+            pa = xp.stack(
+                [eval_cubic(xp, tg, coeffs[i], xp.asarray(ta)) for i in range(6)],
+                axis=-1,
+            )
+            pg = xp.stack(
+                [eval_cubic(xp, tg, coeffs[i], xp.asarray(tp_grid)) for i in range(6)],
+                axis=-1,
+            )
+        offsets = xp.asarray(pc_np) - pa
+        means, _, _ = _bin_by_tp(ta, offsets, tp_nodes)
+        offset_fine = xp.stack(
+            [xp.asarray(g_ops[i]) @ xp.nan_to_num(means[:, i]) for i in range(6)],
+            axis=-1,
+        )
+        return pg + offset_fine
+
+    return prog_cart, track
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_prog_parity(backend):
+    # A BACKEND progenitor curve (+ backend particles) yields a BACKEND track
+    # matching the numpy fit: the progenitor is interpolated by the differentiable
+    # backend cubic spline (not-a-knot BC == scipy IUS) rather than scipy's IUS.
+    xv, prog_cart, tg = _track_case()
+    fit_np = _fit_track_from_particles(xv, prog_cart, tg, **_TRACK_KW)
+    fit_b = _fit_track_from_particles(
+        _arr(backend, xv), _arr(backend, prog_cart), tg, **_TRACK_KW
+    )
+    assert is_backend_array(fit_b["track_xyz"]) and is_backend_array(fit_b["cov_xyz"])
+    numpy.testing.assert_array_equal(fit_b["tp_grid"], fit_np["tp_grid"])
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_xyz"]), fit_np["track_xyz"], rtol=1e-6, atol=1e-9
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_vxvyvz"]), fit_np["track_vxvyvz"], rtol=1e-6, atol=1e-8
+    )
+    cov_scale = numpy.max(numpy.abs(fit_np["cov_xyz"]))
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["cov_xyz"]), fit_np["cov_xyz"], rtol=1e-5, atol=1e-5 * cov_scale
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_prog_numpy_particles(backend):
+    # A backend progenitor curve with NUMPY particles still fits differentiably:
+    # particles are promoted onto the progenitor's backend and the track matches.
+    xv, prog_cart, tg = _track_case()
+    fit_np = _fit_track_from_particles(xv, prog_cart, tg, **_TRACK_KW)
+    fit_b = _fit_track_from_particles(xv, _arr(backend, prog_cart), tg, **_TRACK_KW)
+    assert is_backend_array(fit_b["track_xyz"])
+    numpy.testing.assert_allclose(
+        as_numpy(fit_b["track_xyz"]), fit_np["track_xyz"], rtol=1e-6, atol=1e-9
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_fit_track_backend_prog_grad(backend):
+    # d(track)/d(progenitor curve) via the frozen-structure unit: finite, nonzero,
+    # and matches a finite-difference through the numpy path.
+    xv, prog_cart, tg = _track_case()
+    prog0, track = _frozen_prog_path(xv, prog_cart, tg)
+
+    def loss(prog, xp):
+        return xp.sum(track(prog, xp)[:, 0:3])
+
+    if backend == "jax":
+        g = as_numpy(jax.grad(lambda p: loss(p, jnp))(jnp.asarray(prog0)))
+    else:
+        pt = torch.tensor(prog0, requires_grad=True)
+        loss(pt, torch).backward()
+        g = as_numpy(pt.grad)
+    assert numpy.isfinite(g).all()
+    assert numpy.max(numpy.abs(g)) > 0
+    eps = 1e-6
+    M = prog0.shape[0]
+    for i, j in [(M // 2, 0), (2 * M // 3, 2), (3 * M // 4, 1), (3 * M // 5, 3)]:
+        a = prog0.copy()
+        a[i, j] += eps
+        b = prog0.copy()
+        b[i, j] -= eps
+        fd = (
+            float(numpy.sum(track(a, numpy)[:, 0:3]))
+            - float(numpy.sum(track(b, numpy)[:, 0:3]))
+        ) / (2 * eps)
+        if abs(g[i, j]) > 1e-3:  # skip components the track is insensitive to
+            numpy.testing.assert_allclose(g[i, j], fd, rtol=1e-3, atol=1e-7)
+
+
+@pytest.mark.skipif(
+    "jax" not in BACKENDS or "torch" not in BACKENDS, reason="need both backends"
+)
+def test_fit_track_backend_prog_grad_jax_torch_agree():
+    # jax and torch differentiate d(track)/d(progenitor) identically.
+    xv, prog_cart, tg = _track_case()
+    prog0, track = _frozen_prog_path(xv, prog_cart, tg)
+    gj = as_numpy(
+        jax.grad(lambda p: jnp.sum(track(p, jnp)[:, 0:3]))(jnp.asarray(prog0))
+    )
+    pt = torch.tensor(prog0, requires_grad=True)
+    torch.sum(track(pt, torch)[:, 0:3]).backward()
+    gt = as_numpy(pt.grad)
+    numpy.testing.assert_allclose(gj, gt, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+def test_fit_track_endtoend_torch_prog_grad():
+    # End-to-end deliverable: torch (eager) autodiff of the track w.r.t. a BACKEND
+    # progenitor curve straight through _fit_track_from_particles -- d(track)/
+    # d(progenitor) flows via the backend cubic spline while the cKDTree structure
+    # is frozen (.detach()). (A symbolic jax.grad cannot trace the assignment.)
+    xv, prog_cart, tg = _track_case()
+    progt = torch.tensor(prog_cart, requires_grad=True)
+    fit_t = _fit_track_from_particles(torch.tensor(xv), progt, tg, **_TRACK_KW)
+    assert is_backend_array(fit_t["track_xyz"])
+    (torch.sum(fit_t["track_xyz"]) + torch.sum(fit_t["cov_xyz"])).backward()
+    g = as_numpy(progt.grad)
+    assert numpy.isfinite(g).all()
+    assert numpy.max(numpy.abs(g)) > 0
+
+
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_fit_one_pass_backend_forward(backend):
     # _fit_one_pass_backend directly: a backend particles_cart with a frozen numpy


### PR DESCRIPTION
## Differentiable stream track w.r.t. the progenitor curve (∂track/∂progenitor)

First piece of the ∂track/∂progenitor wiring: a **backend (jax/torch) progenitor
curve** now threads through `_fit_track_from_particles`, so a fitted stream track
carries `d(track)/d(progenitor)`. This is the C-STM-achievable path (a dense
differentiable progenitor curve from the C state-transition matrix); the
streamspraydf-side build of a backend `track_prog_cart` from a backend orbit, and
the in-backend ODE for `∂track/∂θ`, are the follow-ups.

### What changed
The progenitor enters the fit at two points, both now differentiable in the
backend prog curve via the in-backend cubic spline (`cubic_spline_coeffs` /
`eval_cubic`, `bc="not-a-knot"` == scipy `InterpolatedUnivariateSpline(k=3)`):
- `offsets = particles − prog_at(tp_assign)` (per-particle, before the smoother)
- `track = prog_grid + smoothed_offsets` (progenitor added back on the dense grid)

Structural steps (the cKDTree closest-point assignment and the velocity-weight
probe) run on a numpy view `prog_cart_np = as_numpy(prog_cart)`; only the
particle/progenitor **values** flow as backend arrays. A backend prog with numpy
particles promotes the particles onto the prog's backend so the differentiable
path is taken (numpy prog + numpy particles stays pure numpy).

### numpy path is byte-identical
`max|Δ| = 0` vs base (`bc53b0d5`) for `track_xyz` / `track_vxvyvz` / `cov` across
6 configs (`velocity_weight` 1.0 & `'auto'`, `niter` 0/1/2, `order` 1/2, explicit
`smoothing`). `as_numpy(numpy_array)` returns the same object, so the structural
probe is unchanged for numpy input.

### Correctness (new backend tests)
- Forward parity `1e-12` (jax) / `1e-13` (torch) vs the numpy fit, incl. the
  covariance.
- Frozen-structure `d(track)/d(progenitor)`: **jax == torch to 9e-16**, and
  **FD-vs-AD 1.4e-8** through production's **exact** GCV smoother operator
  (extracted via `_DiffSpline._build`, the same operator `_fit_one_pass_backend`
  freezes) — not a proxy smoother.
- torch **end-to-end** autograd through the full `_fit_track_from_particles`
  (the cKDTree structure frozen via `.detach()`): finite & nonzero. A symbolic
  `jax.grad` cannot pull the cKDTree assignment to numpy, so the rigorous jax
  grad uses the frozen-structure unit (same accepted limitation as for
  particles).

Adversarially reviewed (byte-identity, gradient correctness incl. mixed
numpy-x/backend-y cubic spline, `niter>0`, `order=1`, `velocity_weight='auto'`,
device anchoring, and the public streamspraydf/`from_particles` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
