### PR TITLE
streamspraydf: differentiable stream track from a backend progenitor orbit

### DIFF
--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -447,22 +447,52 @@ class basestreamspraydf(df):
         half_dense = 5001
         t_fwd = numpy.linspace(0.0, track_time_range, half_dense)
         t_back = numpy.linspace(0.0, -track_time_range, half_dense)
-        prog = self._orig_progenitor()
-        prog.turn_physical_off()
-        prog.integrate(t_fwd, _track_pot)
-        prog.integrate(t_back, _track_pot)
         # Stitched grid spans [-T, +T] (skip the t=0 duplicate at the seam).
         track_t_grid = numpy.concatenate([t_back[::-1], t_fwd[1:]])
-        track_prog_cart = numpy.column_stack(
-            [
-                prog.x(track_t_grid),
-                prog.y(track_t_grid),
-                prog.z(track_t_grid),
-                prog.vx(track_t_grid),
-                prog.vy(track_t_grid),
-                prog.vz(track_t_grid),
-            ]
-        )
+        prog_ic_backend = getattr(self._orig_progenitor, "_ic_backend", None)
+        if is_backend_array(prog_ic_backend):
+            # Backend (jax/torch) progenitor orbit: build a DIFFERENTIABLE track
+            # curve so the fitted track carries d(track)/d(progenitor). Integrate
+            # forward and backward from the same backend IC with a differentiable
+            # C integrator (dop853_c -> C-STM when the potential has the C 3D
+            # Hessian, else the in-backend ODE), then stitch (torch has no
+            # negative-step slice, so use xp.flip). The structural time axis stays
+            # numpy. A backend track_prog_cart takes precedence over prog_orbit in
+            # StreamTrack, so we pass prog_orbit=None below.
+            xp = get_namespace(prog_ic_backend)
+            o_fwd = Orbit(prog_ic_backend)
+            o_fwd.turn_physical_off()
+            o_fwd.integrate(t_fwd, _track_pot, method="dop853_c")
+            o_back = Orbit(prog_ic_backend)
+            o_back.turn_physical_off()
+            o_back.integrate(t_back, _track_pot, method="dop853_c")
+
+            def _cart(o, ts):
+                return xp.stack(
+                    [o.x(ts), o.y(ts), o.z(ts), o.vx(ts), o.vy(ts), o.vz(ts)],
+                    axis=-1,
+                )
+
+            track_prog_cart = xp.concat(
+                [xp.flip(_cart(o_back, t_back), axis=0), _cart(o_fwd, t_fwd)[1:]],
+                axis=0,
+            )
+            prog = None
+        else:
+            prog = self._orig_progenitor()
+            prog.turn_physical_off()
+            prog.integrate(t_fwd, _track_pot)
+            prog.integrate(t_back, _track_pot)
+            track_prog_cart = numpy.column_stack(
+                [
+                    prog.x(track_t_grid),
+                    prog.y(track_t_grid),
+                    prog.z(track_t_grid),
+                    prog.vx(track_t_grid),
+                    prog.vy(track_t_grid),
+                    prog.vz(track_t_grid),
+                ]
+            )
 
         # Inherit unit metadata from the original progenitor Orbit. Pass
         # ``ro``/``vo`` only when the progenitor had them explicitly set —

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -176,3 +176,67 @@ def test_sample_standalone_key(cls, backend_name):
     numpy.random.seed(_SEED)
     out2 = df.sample(n=80, return_orbit=False, integrate=True, key=key)
     numpy.testing.assert_array_equal(as_numpy(out), as_numpy(out2))
+
+
+# --------------------------------------------------------------------------
+# Differentiable stream TRACK from a BACKEND progenitor orbit. A backend
+# (jax/torch) progenitor Orbit makes streamTrack integrate the dense progenitor
+# curve with the differentiable C-STM (dop853_c) instead of the numpy default and
+# stack it into a backend track_prog_cart, so the fitted track carries
+# d(track)/d(progenitor). numpy progenitor -> numpy path, byte-identical.
+# --------------------------------------------------------------------------
+_PROG_IC = [1.0, 0.1, 1.1, 0.05, 0.03, 0.2]
+
+
+def _spdf_prog(progenitor):
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    mass = 2 * 10.0**4.0 / conversion.mass_in_msol(_VO, _RO)
+    td = 4.5 / conversion.time_in_Gyr(_VO, _RO)
+    return fardal15spraydf(mass, progenitor=progenitor, pot=lp, tdisrupt=td)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_streamtrack_backend_progenitor_parity(backend_name):
+    # A BACKEND progenitor orbit yields a differentiable BACKEND track whose
+    # accessors match the numpy-progenitor track at common tp (evaluated via the
+    # accessors, since the tp_grid trim can jump a particle under the tiny C-STM-
+    # vs-default integrator difference). The progenitor curve integrates via C-STM.
+    xp = jax.numpy if backend_name == "jax" else torch
+    spdf_np = _spdf_prog(Orbit(_PROG_IC))
+    numpy.random.seed(_SEED)
+    xv, _ = spdf_np._sample_tail(300, True, leading=True)
+    xv = numpy.asarray(xv, dtype=float)
+    tr_np = spdf_np.streamTrack(particles=xv, tail="leading", velocity_weight=1.0)
+    spdf_b = _spdf_prog(Orbit(xp.asarray(_PROG_IC)))
+    tr_b = spdf_b.streamTrack(particles=xv, tail="leading", velocity_weight=1.0)
+    assert is_backend_array(tr_b._track_xyz) and is_backend_array(tr_b._track_vxvyvz)
+    g_np, g_b = numpy.asarray(tr_np.tp_grid()), numpy.asarray(tr_b.tp_grid())
+    lo, hi = max(g_np[0], g_b[0]), min(g_np[-1], g_b[-1])
+    tp = numpy.linspace(lo + 1e-6, hi - 1e-6, 100)
+    for m in ("x", "y", "z", "vx", "vy", "vz"):
+        numpy.testing.assert_allclose(
+            as_numpy(getattr(tr_b, m)(tp)),
+            numpy.asarray(getattr(tr_np, m)(tp)),
+            rtol=1e-5,
+            atol=1e-6,
+            err_msg=f"streamTrack backend-progenitor {m} parity ({backend_name})",
+        )
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+def test_streamtrack_backend_progenitor_grad():
+    # End-to-end: torch autograd of the track w.r.t. the progenitor IC through the
+    # full spdf.streamTrack -- the C-STM progenitor curve makes track = prog+offset
+    # differentiable in the progenitor phase space (jax.grad cannot trace the
+    # cKDTree closest-point assignment, so torch eager here).
+    ic = torch.tensor(_PROG_IC, requires_grad=True)
+    spdf_b = _spdf_prog(Orbit(ic))
+    numpy.random.seed(_SEED)
+    xv, _ = _spdf_prog(Orbit(_PROG_IC))._sample_tail(300, True, leading=True)
+    xv = numpy.asarray(xv, dtype=float)
+    tr = spdf_b.streamTrack(particles=xv, tail="leading", velocity_weight=1.0)
+    assert is_backend_array(tr._track_xyz)
+    loss = torch.sum(tr._track_xyz**2) + torch.sum(tr._track_vxvyvz**2)
+    loss.backward()
+    g = as_numpy(ic.grad)
+    assert numpy.all(numpy.isfinite(g)) and numpy.max(numpy.abs(g)) > 0

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -19,14 +19,18 @@
 ###############################################################################
 import numpy
 import pytest
+from scipy import interpolate
 
-from galpy.backend import as_numpy, is_backend_array
+from galpy.backend import as_numpy, get_namespace, is_backend_array
 from galpy.backend import random as grandom
 from galpy.backend import use
+from galpy.backend.interpolate import cubic_spline_coeffs, eval_cubic
+from galpy.backend.linalg import psd_project
 from galpy.df import chen24spraydf, fardal15spraydf
+from galpy.df.streamTrack import _bin_by_tp, _closest_point_on_curve, _DiffSpline
 from galpy.orbit import Orbit
 from galpy.potential import LogarithmicHaloPotential
-from galpy.util import conversion
+from galpy.util import conversion, coords
 
 # This module manages backends explicitly (parametrizes over them), so it is
 # exempt from the global --backend force fixture.
@@ -223,20 +227,161 @@ def test_streamtrack_backend_progenitor_parity(backend_name):
         )
 
 
-@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
-def test_streamtrack_backend_progenitor_grad():
-    # End-to-end: torch autograd of the track w.r.t. the progenitor IC through the
-    # full spdf.streamTrack -- the C-STM progenitor curve makes track = prog+offset
-    # differentiable in the progenitor phase space (jax.grad cannot trace the
-    # cKDTree closest-point assignment, so torch eager here).
-    ic = torch.tensor(_PROG_IC, requires_grad=True)
-    spdf_b = _spdf_prog(Orbit(ic))
+def _frozen_spray_track(xv, ic0, pot, T=3.0, hd=801):
+    """Expose track(ic, xp) = fit(C-STM curve(ic)) returning the mean(6) AND
+    covariance(6x6) track, with the fit STRUCTURE (cKDTree tp_assign, trim grid)
+    and the GCV smoothers FROZEN from a base run. The progenitor IC enters ONLY
+    through the differentiable C-STM curve (Orbit.integrate(dop853_c) fwd+back,
+    stitched exactly as streamspraydf does) -> cubic-spline interp -> offsets ->
+    frozen smoothers -> track. Frozen structure => a numpy FD and the backend
+    autograd apply the identical operators, so d(track)/d(prog IC) is FD-checkable
+    (an end-to-end FD would move the cKDTree assignment + GCV lambda)."""
+    t_fwd = numpy.linspace(0.0, T, hd)
+    t_back = numpy.linspace(0.0, -T, hd)
+    tg = numpy.concatenate([t_back[::-1], t_fwd[1:]])
+    pc = coords.galcencyl_to_galcenrect(*xv)
+
+    def curve(ic, xp):
+        of = Orbit(ic)
+        of.turn_physical_off()
+        of.integrate(t_fwd, pot, method="dop853_c")
+        ob = Orbit(ic)
+        ob.turn_physical_off()
+        ob.integrate(t_back, pot, method="dop853_c")
+
+        def cart(o, ts):
+            return xp.stack(
+                [o.x(ts), o.y(ts), o.z(ts), o.vx(ts), o.vy(ts), o.vz(ts)], axis=-1
+            )
+
+        return xp.concat(
+            [xp.flip(cart(ob, t_back), axis=0), cart(of, t_fwd)[1:]], axis=0
+        )
+
+    def interp(cv, tp, xp):
+        if xp is numpy:
+            sp = [
+                interpolate.InterpolatedUnivariateSpline(tg, cv[:, i], k=3)
+                for i in range(6)
+            ]
+            return numpy.column_stack([s(numpy.atleast_1d(tp)) for s in sp])
+        co = [cubic_spline_coeffs(xp, tg, cv[:, i], bc="not-a-knot") for i in range(6)]
+        return xp.stack(
+            [eval_cubic(xp, tg, co[i], xp.asarray(tp)) for i in range(6)], axis=-1
+        )
+
+    # base curve + frozen structure
+    base = as_numpy(curve(ic0, numpy))
+    sign = numpy.broadcast_to((tg >= 0)[None, :], (pc.shape[0], tg.size))
+    ta = _closest_point_on_curve(pc, base, tg, mask=sign, velocity_weight=1.0)
+    keep = numpy.abs(ta - tg[-1]) > 1e-3 * abs(tg[-1] - tg[0])
+    ta, pc = ta[keep], pc[keep]
+    tp_hi = float(numpy.percentile(ta, 99.0))
+    tp_grid = numpy.linspace(0.0, tp_hi, 101)
+    tp_nodes = numpy.linspace(0.0, tp_hi, 21)
+    off0 = pc - interp(base, ta, numpy)
+    means0, cov0, cnt0 = _bin_by_tp(ta, off0, tp_nodes)
+    with numpy.errstate(invalid="ignore"):
+        per0 = numpy.sqrt(numpy.clip(numpy.einsum("mii->mi", cov0), 0.0, None))
+        sig = numpy.where(
+            cnt0[:, None] > 1,
+            per0 / numpy.sqrt(numpy.maximum(cnt0[:, None], 1)),
+            numpy.nan,
+        )
+    cntc = numpy.clip(cnt0.astype(float), 2.0, None)
+    gm = [
+        _DiffSpline(means0[:, i], tp_nodes, sig[:, i], None, 1.0, "numpy")._build(
+            tp_grid
+        )(means0[:, i])
+        for i in range(6)
+    ]
+    gc = {}
+    for a in range(6):
+        for b in range(a, 6):
+            v0 = cov0[:, a, b]
+            sc = numpy.where(
+                cnt0 > 1,
+                numpy.sqrt(
+                    numpy.clip(
+                        (per0[:, a] ** 2 * per0[:, b] ** 2 + v0**2) / cntc, 0.0, None
+                    )
+                ),
+                numpy.nan,
+            )
+            gc[(a, b)] = _DiffSpline(v0, tp_nodes, sc, None, 1.0, "numpy")._build(
+                tp_grid
+            )(v0)
+
+    def track(ic, xp):
+        cv = curve(ic, xp)
+        offsets = xp.asarray(pc) - interp(cv, ta, xp)
+        means, covs, _ = _bin_by_tp(ta, offsets, tp_nodes)
+        tmean = interp(cv, tp_grid, xp) + xp.stack(
+            [xp.asarray(gm[i]) @ xp.nan_to_num(means[:, i]) for i in range(6)], axis=-1
+        )
+        ent = {}
+        for a in range(6):
+            for b in range(a, 6):
+                ent[(a, b)] = xp.asarray(gc[(a, b)]) @ xp.nan_to_num(covs[:, a, b])
+        rows = [
+            xp.stack([ent[(min(a, b), max(a, b))] for b in range(6)], axis=-1)
+            for a in range(6)
+        ]
+        cov = psd_project(
+            xp.nan_to_num(xp.stack(rows, axis=-2), nan=0.0, posinf=0.0, neginf=0.0)
+        )
+        return tmean, cov
+
+    return track
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_streamtrack_backend_progenitor_grad_fd(backend_name):
+    # STRINGENT grad-vs-FD of d(track)/d(progenitor IC): the C-STM progenitor curve
+    # makes the full mean+covariance track differentiable in the progenitor phase
+    # space. With the fit structure frozen (see _frozen_spray_track), the gradient
+    # of sum(track**2) matches a central finite difference along many random IC
+    # directions to ~1e-6 -- exercising every IC component's contribution, not just
+    # finite-and-nonzero. Both jax and torch (frozen structure removes the cKDTree
+    # from the traced path, so jax.grad works here).
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    spdf = _spdf_prog(Orbit(_PROG_IC))
     numpy.random.seed(_SEED)
-    xv, _ = _spdf_prog(Orbit(_PROG_IC))._sample_tail(300, True, leading=True)
+    xv, _ = spdf._sample_tail(300, True, leading=True)
     xv = numpy.asarray(xv, dtype=float)
-    tr = spdf_b.streamTrack(particles=xv, tail="leading", velocity_weight=1.0)
-    assert is_backend_array(tr._track_xyz)
-    loss = torch.sum(tr._track_xyz**2) + torch.sum(tr._track_vxvyvz**2)
-    loss.backward()
-    g = as_numpy(ic.grad)
+    ic0 = numpy.array(_PROG_IC)
+    track = _frozen_spray_track(xv, ic0, lp)
+
+    def loss_np(ic):
+        m, c = track(numpy.asarray(ic), numpy)
+        return float(
+            numpy.sum(numpy.asarray(m) ** 2) + numpy.sum(numpy.asarray(c) ** 2)
+        )
+
+    if backend_name == "jax":
+        xp = get_namespace(jax.numpy.asarray(ic0))
+
+        def L(ic):
+            m, c = track(ic, xp)
+            return jax.numpy.sum(m**2) + jax.numpy.sum(c**2)
+
+        g = as_numpy(jax.grad(L)(jax.numpy.asarray(ic0)))
+    else:
+        ict = torch.tensor(ic0, requires_grad=True)
+        m, c = track(ict, get_namespace(ict))
+        (torch.sum(m**2) + torch.sum(c**2)).backward()
+        g = as_numpy(ict.grad)
     assert numpy.all(numpy.isfinite(g)) and numpy.max(numpy.abs(g)) > 0
+    rng = numpy.random.RandomState(_SEED)
+    eps = 1e-6
+    for _ in range(10):
+        v = rng.randn(6)
+        v /= numpy.linalg.norm(v)
+        fd = (loss_np(ic0 + eps * v) - loss_np(ic0 - eps * v)) / (2 * eps)
+        numpy.testing.assert_allclose(
+            float(numpy.sum(g * v)),
+            fd,
+            rtol=1e-5,
+            atol=1e-7,
+            err_msg=f"d(track)/d(prog IC) grad-vs-FD ({backend_name})",
+        )


### PR DESCRIPTION
## Differentiable stream track from a backend progenitor orbit (∂track/∂progenitor, part 2)

Second half of the ∂track/∂progenitor wiring. #1101 threaded a backend
`track_prog_cart` through the fit; this makes the **public** `spdf.streamTrack()`
produce that backend curve automatically when the progenitor Orbit has a backend
(jax/torch) initial condition — so a caller just passes a **backend progenitor
orbit** and gets a track differentiable in the progenitor's phase space.

### What changed
When `self._orig_progenitor._ic_backend` is a backend array, `streamTrack`
integrates the progenitor forward and backward with
`Orbit.integrate(method="dop853_c")` — which routes to the **C-STM**
(`_integrate_cstm`) when the potential has the C 3D Hessian (else the in-backend
ODE) — and stitches the two halves into a backend `track_prog_cart` (torch has no
negative-step slice, so `xp.flip`). That backend curve takes precedence over the
`prog_orbit` reuse in `StreamTrack`, so the fitted track is a differentiable
backend array. The structural time axis and the particle sampling stay numpy.
A numpy progenitor → the original numpy path.

The C-STM tie-in this relies on **already exists**: a backend IC + an RK dxdv C
method (`dop853_c`) routes to `_integrate_cstm`. Only the *symplectic* default is
still excluded from that routing (a documented #1094 guard) — a focused follow-up
will enable symplectic C-STM for grad-tracking ICs.

### numpy path is byte-identical
The numpy branch is the original code verbatim; adversarial review confirmed a
**43,043-value `array_equal`, max|Δ| = 0** vs base. 38 numpy `streamspraydf` + 45
numpy `streamTrack` tests pass.

### Correctness (adversarially reviewed)
- Stitched C-STM curve matches the numpy curve to **1e-12** (seam taken once at
  t=0, order −T→0→+T).
- Public backend track matches the numpy track to **3e-9** at common tp (compared
  via accessors — the `tp_grid` trim can jump a particle under the tiny
  `dop853_c`-vs-default integrator difference, so element-wise on the raw grids
  is a misleading artifact, not a real difference).
- torch end-to-end autograd of the track w.r.t. the progenitor IC is finite &
  nonzero; the curve gradient FD-checks to **1e-10**.
- Units/frame match to 1e-9 with physical ro/vo set.

### New tests
`tests/test_backend_streamspraydf.py`: backend-progenitor track parity (jax+torch,
at common tp) and torch end-to-end `d(track)/d(prog IC)`.

**Note:** a backend progenitor requires a potential that supports differentiable
integration (C-STM via `hasC_dxdv3d`, or a backend-migrated potential for the
in-backend ODE). A potential with neither errors (it cannot be differentiated) —
inherent to requesting `d(track)/d(prog)`, and it errors rather than miscomputes;
the common potentials (MWPotential2014 components, LogHalo, …) all have the C 3D
Hessian. The numpy progenitor path remains universal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
