### PR TITLE
Orbit.integrate: route grad-tracking symplectic ICs to the C-STM (#1094-safe)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1743,15 +1743,23 @@ class Orbit:
         # _ic_backend is None and are untouched -> the numpy/C path is unchanged.
         ic_backend = getattr(self, "_ic_backend", None)
         if ic_backend is not None:
-            from ..backend._reference.inbackend_stm import _C_RK_METHODS
+            from ..backend._reference.inbackend_stm import (
+                _C_RK_METHODS,
+                _C_SYMPLEC_METHODS,
+            )
 
-            # Only the Runge-Kutta dxdv methods auto-route here. The symplectic
-            # methods are deliberately excluded: symplec4_c is galpy's DEFAULT
-            # integrator, so routing it would silently reroute every internal
-            # default-method integration (e.g. streamspraydf's sample orbits) to
-            # the C-STM under a forced backend. Symplectic C-STM is still available
-            # explicitly via galpy.backend.integrate_stm / orbit_stm.integrate.
-            if method.lower() in _C_RK_METHODS:
+            # Runge-Kutta dxdv methods auto-route for ANY backend IC. Symplectic
+            # dxdv methods (incl. galpy's DEFAULT symplec4_c) route ONLY for a
+            # grad-tracking IC: a CONCRETE backend IC has real values in self.vxvv
+            # and keeps the numpy/C path below, so a forced-backend internal
+            # default-method integration is never silently rerouted to the C-STM
+            # (bit #1094). A grad-tracking IC has no concrete values to integrate on
+            # numpy, so it needs the differentiable C-STM -- which supports the
+            # symplectic dxdv integrators via the per-column drift/kick tangent maps
+            # (the alternative for these was to raise below).
+            _ml = method.lower()
+            _concrete = getattr(self, "_ic_backend_concrete", True)
+            if _ml in _C_RK_METHODS or (_ml in _C_SYMPLEC_METHODS and not _concrete):
                 _potl = _check_potential_list_and_deprecate(pot)
                 _inbk = (
                     "diffrax"
@@ -1769,7 +1777,7 @@ class Orbit:
                     if _pdim in (2, 4)
                     else False
                 ):
-                    return self._integrate_cstm(t, _potl, method.lower(), rtol, atol)
+                    return self._integrate_cstm(t, _potl, _ml, rtol, atol)
                 # Pass the deprecation-checked/composed potential (_potl), matching
                 # the C-STM and numpy paths, so a legacy list reaches the in-backend
                 # integrator as a composite rather than a raw list.

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -18,6 +18,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy, is_backend_array
 from galpy.orbit import Orbit
 from galpy.potential import (
     BurkertPotential,
@@ -589,6 +590,54 @@ def test_integrate_gradtracking_backend_ic_numpy_method_raises_torch():
     o = Orbit(torch.tensor(_IC, requires_grad=True))
     with pytest.raises(ValueError):
         o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="ias15_c")
+
+
+# --------- grad-tracking IC + SYMPLECTIC dxdv C method auto-routes to the C-STM
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("method", ["symplec4_c", "leapfrog_c", "symplec6_c"])
+def test_integrate_gradtracking_symplectic_routes_to_cstm_torch(method):
+    # A grad-tracking IC + a symplectic dxdv C method now auto-routes to the C-STM
+    # (previously raised): the orbit is a differentiable backend array matching the
+    # numpy symplectic integration to machine precision (same C integrator). A
+    # CONCRETE backend IC keeps the numpy/C path (see
+    # test_integrate_concrete_backend_ic_numpy_method_works), so a forced-backend
+    # internal default (symplec4_c) integration is never silently rerouted (#1094).
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    ic = torch.tensor(_IC, requires_grad=True)
+    o = Orbit(ic)
+    o.integrate(_TS, pot, method=method)
+    assert is_backend_array(o.x(_TS))
+    ref = Orbit(list(_IC))
+    ref.integrate(_TS, pot, method=method)
+    numpy.testing.assert_allclose(
+        as_numpy(o.R(_TS)), ref.R(_TS), rtol=1e-10, atol=1e-11
+    )
+    loss = torch.sum(o.R(_TS) ** 2) + torch.sum(o.vx(_TS) ** 2)
+    loss.backward()
+    g = as_numpy(ic.grad)
+    assert numpy.all(numpy.isfinite(g)) and numpy.max(numpy.abs(g)) > 0
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax not installed")
+def test_integrate_gradtracking_symplectic_routes_to_cstm_jax():
+    # Under jax.grad the symplec4_c default now routes to the differentiable C-STM
+    # (was a ValueError). Gradient of the final R w.r.t. an IC component is finite
+    # and matches a finite difference.
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    ts = numpy.linspace(0.0, 3.0, 60)
+
+    def final_R(vR0):
+        o = Orbit(jnp.array([1.0, vR0, 0.9, 0.2, 0.05, 0.3]))
+        o.integrate(ts, pot, method="symplec4_c")
+        return o.R(ts)[-1]
+
+    import jax
+
+    g = float(jax.grad(final_R)(0.1))
+    eps = 1e-6
+    fd = (float(final_R(0.1 + eps)) - float(final_R(0.1 - eps))) / (2 * eps)
+    assert numpy.isfinite(g)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-4, atol=1e-6)
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -615,7 +615,30 @@ def test_integrate_gradtracking_symplectic_routes_to_cstm_torch(method):
     loss = torch.sum(o.R(_TS) ** 2) + torch.sum(o.vx(_TS) ** 2)
     loss.backward()
     g = as_numpy(ic.grad)
-    assert numpy.all(numpy.isfinite(g)) and numpy.max(numpy.abs(g)) > 0
+    assert numpy.all(numpy.isfinite(g))
+
+    # grad-vs-FD: the C-STM IC gradient matches a central finite difference along
+    # random directions (the orbit is a smooth function of the IC -- no structural
+    # discontinuity), to the FD truncation floor.
+    def loss_np(ic_np):
+        oo = Orbit(list(ic_np))
+        oo.integrate(_TS, pot, method=method)
+        return float(numpy.sum(oo.R(_TS) ** 2) + numpy.sum(oo.vx(_TS) ** 2))
+
+    ic0 = numpy.asarray(_IC, dtype=float)
+    rng = numpy.random.RandomState(43)
+    eps = 1e-6
+    for _ in range(4):
+        v = rng.randn(6)
+        v /= numpy.linalg.norm(v)
+        fd = (loss_np(ic0 + eps * v) - loss_np(ic0 - eps * v)) / (2 * eps)
+        numpy.testing.assert_allclose(
+            float(numpy.sum(g * v)),
+            fd,
+            rtol=1e-5,
+            atol=1e-6,
+            err_msg=f"symplectic C-STM grad-vs-FD ({method})",
+        )
 
 
 @pytest.mark.skipif(not HAVE_JAX, reason="jax not installed")


### PR DESCRIPTION
## Orbit.integrate: route grad-tracking symplectic ICs to the C-STM (#1094-safe)

A backend (jax/torch) IC + a **symplectic** dxdv C method (`symplec4_c` /
`leapfrog_c` / `symplec6_c`) now auto-routes to the differentiable C-STM.
Previously only the Runge-Kutta dxdv methods routed, and a grad-tracking
symplectic IC just **raised**. The C-STM already supports the symplectic
integrators (`c_stm_forward` carries the deviation through the per-column
drift/kick tangent maps); only `Orbit.integrate`'s auto-routing excluded them.

### Why it was excluded, and how the fix stays safe
`symplec4_c` is galpy's **default** integrator, so auto-routing it would silently
reroute *internal* forced-backend integrations to the C-STM (bug **#1094**,
streamspraydf). The fix preserves that protection by gating symplectic routing on
`not _ic_backend_concrete`:

- A **concrete** backend IC (real values in `self.vxvv`, as used when the existing
  suite runs under `use(backend, force=True)`) keeps the numpy/C path — an internal
  default integration is **never** rerouted.
- Only a **grad-tracking** IC (jax tracer / `requires_grad` tensor) — which has no
  concrete values to integrate on numpy and today just errors — routes to the C-STM.

RK routing is unchanged (a pure `method.lower()` → `_ml` rename).

### Validation (adversarially reviewed)
- Grad-tracking `symplec4_c`/`leapfrog_c`/`symplec6_c` match the numpy symplectic
  orbit to machine precision (diff **0.0** vs numpy `symplec4_c`) and FD-match the
  gradient (jax + torch, relerr ~1e-9).
- **#1094 not reintroduced**: under a forced jax/torch backend, a `fardal15spraydf`
  `.sample(integrate=True)` routes only `dop853_c` (RK) — **identical to base**; the
  50 default-`symplec4_c` sample-orbit integrations stay on numpy/C.
- A potential without the C 3D Hessian falls back to the in-backend ODE (still
  differentiable, FD-matches); non-equispaced times error cleanly.
- 282 backend-orbit + 112 numpy-orbit tests pass; numpy path untouched (the change
  is entirely inside `if ic_backend is not None`).

### Known pre-existing GPU-only edge (not introduced here)
A concrete CUDA torch tensor without grad fails `numpy.asarray` → mislabeled
non-concrete; under a forced torch backend with a **CUDA default device** a
concrete-CUDA default integration would route (then fail at the host numpy
conversion). galpy's forced backend creates CPU tensors, so it does not manifest.
A robust follow-up would base `_ic_backend_concrete` on is-traced detection rather
than `numpy.asarray` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
