### PR TITLE
constantbetadf: cover the Emin/potInf forced-backend coercion (line 679)

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -398,21 +398,12 @@ class constantbetadf(_constantbetadf):
         self._gradfunc = _make_gradfunc(
             self._raw_gradfunc(_autodiff_xp()), self._backend
         )
-        # Min and max energy (numpy scalars): under a forced non-numpy backend the
-        # (undecorated) potential rejects the numpy/scalar limits, so coerce the
-        # input and pull the value back to numpy (boundary coercion, not a compute
-        # island -- the differentiable fE is the backend path below).
-        xpc = get_namespace()
-        if xpc is numpy:
-            self._potInf = _evaluatePotentials(self._pot, self._rmax, 0)
-            self._Emin = _evaluatePotentials(self._pot, self._rmin, 0)
-        else:
-            self._potInf = as_numpy(
-                _evaluatePotentials(self._pot, xpc.asarray(self._rmax) * 1.0, 0)
-            )
-            self._Emin = as_numpy(
-                _evaluatePotentials(self._pot, xpc.asarray(self._rmin) * 1.0, 0)
-            )
+        # Min and max energy (numpy scalars): Phi(rmax)/Phi(rmin) as numpy, robust
+        # under a forced non-numpy backend (see _evalpot_asnumpy -- boundary
+        # coercion, not a compute island; the differentiable fE is the backend path
+        # below). numpy is a strict pass-through, so this stays byte-identical.
+        self._potInf = _evalpot_asnumpy(self._pot, self._rmax)
+        self._Emin = _evalpot_asnumpy(self._pot, self._rmin)
         # Build interpolator r(pot), starting at rmin for divergent potentials
         self._rphi = self._setup_rphi_interpolator(
             r_a_min=max(1e-6, self._rmin / self._scale)


### PR DESCRIPTION
Small coverage fix you flagged: PR #892's codecov shows **1 line missing** —
`galpy/df/constantbetadf.py:679`, the forced-backend branch of `_evalpot_asnumpy`.

### Root cause (a rebase artifact)
`_evalpot_asnumpy(pot, r)` = `Phi(r)` as numpy, robust under a forced backend
(numpy pass-through / `as_numpy(evaluatePotentials(xp.asarray(r)*1.0))`). It was
extracted for the numpy `fE` quadrature (`_fEintegrand_raw`, line 686). Its
docstring also says it serves "the construction-time startt calibration" — but a
rebase left that call site (`_Emin`/`_potInf`) on an **inline copy** of the exact
same coercion. So `_evalpot_asnumpy`'s forced branch (679) was only reachable via
`_fEintegrand_raw`, and that only runs under the numpy context (under a forced
backend `fE` uses the backend GL path) → line 679 went uncovered.

### Fix
Route the calibration through the helper it duplicates:
```python
self._potInf = _evalpot_asnumpy(self._pot, self._rmax)
self._Emin   = _evalpot_asnumpy(self._pot, self._rmin)
```
- **Byte-identical numpy path**: `_evalpot_asnumpy` under numpy *is*
  `_evaluatePotentials(pot, r, 0)` — verified `_potInf`/`_Emin` equal the original
  call bit-for-bit.
- Forced branch identical to the removed inline coercion, and now **line 679 is
  covered** by the existing forced-backend construction test
  `test_general_constantbetadf_fE_backend` (verified L679: MISSING → COVERED).
- Removes the duplication (−15/+6).

29 backend + numpy constantbetadf tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm