### PR TITLE
Set alpha/beta for NFWPotential rmax/conc init paths

### DIFF
--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -845,8 +845,6 @@ class NFWPotential(TwoPowerSphericalPotential):
         a = conversion.parse_length(a, ro=self._ro)
         if conc is None and rmax is None:
             self.a = a
-            self.alpha = 1
-            self.beta = 3
             if normalize or (
                 isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
             ):
@@ -874,6 +872,8 @@ class NFWPotential(TwoPowerSphericalPotential):
             # Turn on physical output, because mass is given in 1e12 Msun (see #465)
             self._roSet = True
             self._voSet = True
+        self.alpha = 1
+        self.beta = 3
         self._scale = self.a
         self.hasC = True
         self.hasC_dxdv = True


### PR DESCRIPTION
`NFWPotential.__init__` only set `self.alpha` and `self.beta` in the plain amp/a branch. Instances built via `rmax`/`vmax` or `conc`/`mvir` were left without those attributes, so any path that falls back to the inherited pure-Python density methods (for example building an `eddingtondf` or `osipkovmerrittdf` from such an instance) raised `AttributeError`.

Moved the `alpha=1`/`beta=3` assignment out of the branch so it applies after all three initialization paths. Reproduced `AttributeError: 'NFWPotential' object has no attribute 'alpha'` on `eddingtondf(NFWPotential(rmax=..., vmax=...))` before the fix. After, all three branches set `alpha`/`beta` and the densities match the closed-form NFW profile. 1217 potential tests plus NFW and orbit subsets pass.
