### PR TITLE
streamspraydf: differentiable stripping_pdf (backend inverse-CDF) + pericenter_stripping_pdf backend (jax/torch)

### DIFF
--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -1617,7 +1617,11 @@ def pericenter_stripping_pdf(
         if abs(vo_internal - progenitor._vo) / progenitor._vo > 1e-8:
             raise ValueError("vo inconsistent with progenitor's vo; omit vo to inherit")
     tdisrupt_internal = conversion.parse_time(tdisrupt, ro=ro, vo=vo)
-    sigma_internal = conversion.parse_time(sigma, ro=ro, vo=vo)
+    # A backend sigma is a plain (unitless, internal-unit) array -- keep it on the backend
+    # so the returned pdf is differentiable in it; the unit parser is numpy-only.
+    sigma_internal = (
+        sigma if is_backend_array(sigma) else conversion.parse_time(sigma, ro=ro, vo=vo)
+    )
     # Integrate the progenitor and locate pericenter passages on the grid.
     # The prominence threshold rejects numerical-noise oscillations on
     # near-circular orbits.
@@ -1633,6 +1637,57 @@ def pericenter_stripping_pdf(
             "may be nearly circular; supply a custom stripping_pdf instead."
         )
     peri_times = ts[peaks]
+    # Backend mode: a backend `sigma` (fit the stripping width) -- or a backend pot / IC, so
+    # the pdf composes with a differentiable, jittable backend spdf -- returns a backend
+    # Gaussian-mixture pdf. The pericenter TIMES are found concretely (find_peaks is a
+    # discrete numpy op) and frozen as a backend constant; the mixture is differentiable in
+    # sigma. A pure-numpy call falls through to _pdf_internal below (byte-identical).
+    _peri_xp = None
+    if not sigma_is_quantity:
+        if is_backend_array(sigma):
+            _peri_xp = get_namespace(sigma)
+        elif is_backend_array(getattr(progenitor, "_ic_backend", None)):
+            _peri_xp = get_namespace(progenitor._ic_backend)
+        else:
+            # a genuine backend pot parameter survives a forced-numpy force eval
+            with use("numpy", force=True):
+                _tf = evaluateRforces(
+                    pot,
+                    float(prog_copy.R(0.0)),
+                    float(prog_copy.z(0.0)),
+                    phi=float(prog_copy.phi(0.0)),
+                    v=numpy.array(
+                        [
+                            float(prog_copy.vR(0.0)),
+                            float(prog_copy.vT(0.0)),
+                            float(prog_copy.vz(0.0)),
+                        ]
+                    ),
+                )
+            if is_backend_array(_tf):
+                _peri_xp = get_namespace(_tf)
+    if _peri_xp is not None:
+        _sqrt_2pi = float(numpy.sqrt(2.0 * numpy.pi))
+        peri_b = _peri_xp.asarray(peri_times)
+        sigma_b = (
+            sigma_internal
+            if is_backend_array(sigma_internal)
+            else _peri_xp.asarray(sigma_internal)
+        )
+
+        def _pdf_backend(t):
+            xp = get_namespace(t, sigma_b, peri_b)
+            t_arr = xp.reshape(xp.asarray(t) * 1.0, (-1,))
+            norm = 1.0 / (peri_b.shape[0] * sigma_b * _sqrt_2pi)
+            dx = (t_arr[:, None] - peri_b[None, :]) / sigma_b
+            out = norm * xp.sum(xp.exp(-0.5 * dx * dx), axis=-1)
+            out = xp.where(
+                (t_arr >= -tdisrupt_internal) & (t_arr <= 0.0), out, xp.zeros_like(out)
+            )
+            return out[0] if getattr(t, "ndim", 0) == 0 else out
+
+        _pdf_backend.pericenter_times = peri_b
+        return _pdf_backend
     # Normalized Gaussian mixture, truncated to [-tdisrupt, 0].
     norm = 1.0 / (peri_times.size * sigma_internal * numpy.sqrt(2.0 * numpy.pi))
 

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -571,6 +571,7 @@ class basestreamspraydf(df):
         return _make_track(xv_single, arm_sign=(+1 if tail == "leading" else -1))
 
     def _parse_stripping_pdf(self, stripping_pdf):
+        self._stripping_cdf = None  # backend inverse-CDF grid (a differentiable pdf)
         if stripping_pdf is None:
             self._stripping_inv_cdf = None
             return
@@ -581,6 +582,7 @@ class basestreamspraydf(df):
         time_in_gyr = conversion.time_in_Gyr(self._vo, self._ro)
         _t_unit_input = False
         _t_unit_output = False
+        _pdf_backend = False
         if _APY_LOADED:
             t_probe = -0.5 * self._tdisrupt
             try:
@@ -594,14 +596,14 @@ class basestreamspraydf(df):
             if _t_unit_input:
                 try:
                     stripping_pdf(t_probe * time_in_gyr * units.Gyr).to(1.0 / units.Gyr)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, TypeError, units.UnitConversionError):
                     pass
                 else:
                     _t_unit_output = True
             else:
                 try:
                     stripping_pdf(t_probe).to(1.0 / units.Gyr)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, TypeError, units.UnitConversionError):
                     pass
                 else:
                     _t_unit_output = True
@@ -623,10 +625,37 @@ class basestreamspraydf(df):
                 return out.to(1.0 / units.Gyr).value * time_in_gyr
 
         else:
+            # A differentiable stripping_pdf returns a backend array; keep it on the
+            # backend (no numpy coercion) so the inverse-CDF traces the pdf parameters.
+            _pdf_backend = is_backend_array(stripping_pdf(-0.5 * self._tdisrupt))
+            if _pdf_backend:
 
-            def pdf_internal(t):
-                return numpy.asarray(stripping_pdf(t))
+                def pdf_internal(t):
+                    return stripping_pdf(t)
 
+            else:
+
+                def pdf_internal(t):
+                    return numpy.asarray(stripping_pdf(t))
+
+        if _pdf_backend:
+            # Backend-native inverse-CDF: a cumulative-trapezoid CDF on the fixed grid,
+            # inverted at draw time by searchsorted + linear interp (jit-safe, and
+            # differentiable in the pdf parameters via the CDF values). This is the
+            # differentiable counterpart of the scipy k=1 spline below.
+            xp = get_namespace(pdf_internal(-0.5 * self._tdisrupt))
+            t_grid = xp.asarray(numpy.linspace(-self._tdisrupt, 0.0, 10001))
+            pdf_vals = pdf_internal(t_grid)
+            dtg = t_grid[1:] - t_grid[:-1]
+            # clip increments >= 0 so the CDF is monotonic even if the pdf dips slightly
+            # negative (the numpy path raises; a jit trace cannot, so clamp instead)
+            incr = xp.clip(0.5 * (pdf_vals[1:] + pdf_vals[:-1]) * dtg, 0.0, None)
+            cdf_vals = xp.concat(
+                [xp.zeros(1, dtype=incr.dtype), xp.cumsum(incr, axis=0)]
+            )
+            self._stripping_cdf = (cdf_vals / cdf_vals[-1], t_grid)
+            self._stripping_inv_cdf = None
+            return
         t_grid = numpy.linspace(-self._tdisrupt, 0.0, 10001)
         pdf_vals = numpy.asarray(pdf_internal(t_grid), dtype=float)
         if numpy.any(pdf_vals < 0):
@@ -650,13 +679,29 @@ class basestreamspraydf(df):
         (``key is None``) is byte-identical to the historical
         ``numpy.random.uniform`` draw; a jax/torch ``key`` from
         :func:`galpy.backend.random.key` returns a reproducible backend array
-        (the default uniform-stripping path). The ``stripping_pdf`` inverse-CDF
-        is a scipy spline, so that path evaluates on the numpy sample for now (a
-        backend-native inverse-CDF is a later PR).
+        (the default uniform-stripping path). A numpy ``stripping_pdf`` inverts a
+        scipy spline on the numpy sample; a backend (differentiable) ``stripping_pdf``
+        inverts its backend CDF grid natively (searchsorted + linear interp), so the
+        drawn ``dt`` traces the pdf parameters.
         """
         from ..backend import as_numpy
         from ..backend import random as grandom
 
+        if self._stripping_cdf is not None:
+            cdf_vals, t_grid = self._stripping_cdf
+            xp = get_namespace(cdf_vals)
+            u = grandom.uniform(key, (n,))
+            u = u if is_backend_array(u) else xp.asarray(u)
+            # linear inverse-CDF: bracket u in the (monotonic) CDF, interpolate t; the
+            # bracket index is frozen (piecewise), the interp weight is differentiable.
+            idx = xp.clip(xp.searchsorted(cdf_vals, u), 1, cdf_vals.shape[0] - 1)
+            c0, c1 = cdf_vals[idx - 1], cdf_vals[idx]
+            t0, t1 = t_grid[idx - 1], t_grid[idx]
+            denom = c1 - c0
+            # guard the dead branch's div-by-zero (flat CDF ties) -- eager xp.where
+            # evaluates both sides (see the xp.where dead-branch idiom)
+            w = (u - c0) / xp.where(denom > 0, denom, xp.ones_like(denom))
+            return -(t0 + w * (t1 - t0))
         if self._stripping_inv_cdf is None:
             return grandom.uniform(key, (n,)) * self._tdisrupt
         u_samples = grandom.uniform(key, (n,))
@@ -704,15 +749,22 @@ class basestreamspraydf(df):
         mass_backend = is_backend_array(_mass_probe)
         if mass_backend and xp is None:
             xp = get_namespace(_mass_probe)
-        # numpy/C path (byte-identical): a pure-numpy spdf, OR a backend theta/mass seen
-        # under a merely-FORCED context -- the all-backend suite runs a plain-numpy test
-        # under `use(backend, force=True)`, which coerces plain inputs to backend arrays
-        # with no differentiable intent (and would crash the sample orbit in the
-        # unmigrated MovingObjectPotential under the in-backend ODE). A genuine backend IC
-        # survives even a forced context; a theta/mass under force does not, so
-        # `get_namespace(numpy.zeros(1)) is not numpy` isolates the forced case.
+        # A backend (differentiable) stripping_pdf traces the sampled orbits' STRIPPING
+        # TIMES (its inverse-CDF grid is a backend array) -- again not the progenitor
+        # curve -- so it is its own backend-sampling trigger, exactly like the mass.
+        stripping_backend = self._stripping_cdf is not None
+        if stripping_backend and xp is None:
+            xp = get_namespace(self._stripping_cdf[0])
+        # numpy/C path (byte-identical): a pure-numpy spdf, OR a backend theta/mass/
+        # stripping seen under a merely-FORCED context -- the all-backend suite runs a
+        # plain-numpy test under `use(backend, force=True)`, which coerces plain inputs
+        # to backend arrays with no differentiable intent (and would crash the sample
+        # orbit in the unmigrated MovingObjectPotential under the in-backend ODE). A
+        # genuine backend IC survives even a forced context; a theta/mass/stripping under
+        # force does not, so `get_namespace(numpy.zeros(1)) is not numpy` isolates it.
         _forced = get_namespace(numpy.zeros(1)) is not numpy
-        if not (ic_backend or ((theta_backend or mass_backend) and not _forced)):
+        _backend_trig = theta_backend or mass_backend or stripping_backend
+        if not (ic_backend or (_backend_trig and not _forced)):
             self._progenitor.integrate(self._progenitor_times, self._pot)
             self._bsamp = None
             return
@@ -739,10 +791,10 @@ class basestreamspraydf(df):
         # CONCRETE (eager, preserving the #1102 mechanism); a TRACED IC (under jit)
         # falls to the in-backend ODE (C is not traceable). Concreteness is detected
         # by whether the IC coerces to numpy (the _ic_backend_concrete idiom).
-        if theta_backend or (mass_backend and not ic_backend):
-            # A backend mass alone leaves the progenitor curve mass-independent, but its
-            # sample orbits trace the mass (via rtide) and are queried under jit -> the
-            # progenitor must be a backend orbit too, so integrate it in-backend.
+        if theta_backend or ((mass_backend or stripping_backend) and not ic_backend):
+            # A backend mass / stripping_pdf alone leaves the progenitor curve unchanged,
+            # but its sample orbits trace it (rtide / stripping times) and are queried
+            # under jit -> the progenitor must be a backend orbit too, integrate in-backend.
             method = inbackend
         else:
             try:

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -784,6 +784,97 @@ def test_streamtrack_backend_mass_grad_fd_eager():
     assert best < 1e-6, f"eager d(track)/dM grad-vs-FD best REL={best:.2e}"
 
 
+# --------------------------------------------------------------------------
+# Differentiable stream track w.r.t. the STRIPPING-TIME DISTRIBUTION. A backend
+# (jax/torch) stripping_pdf returns a backend array, so its inverse-CDF is built +
+# inverted natively (cumulative-trapezoid CDF + searchsorted linear interp) instead
+# of via the scipy spline: the drawn stripping times dt trace the pdf parameters,
+# and — like the mass — a backend stripping_pdf is its own backend-sampling trigger.
+# This makes the mass-loss-time HISTORY (e.g. a stripping burst) fittable. Distinct
+# from a numpy stripping_pdf, which keeps the (byte-identical) scipy path.
+# --------------------------------------------------------------------------
+def _build_stripping(pdf):
+    mass = 2 * 10.0**4.0 / conversion.mass_in_msol(_VO, _RO)
+    td = 4.5 / conversion.time_in_Gyr(_VO, _RO)
+    return fardal15spraydf(
+        mass,
+        progenitor=Orbit(_PROG_IC),
+        pot=LogarithmicHaloPotential(amp=1.0, q=0.9),
+        tdisrupt=td,
+        stripping_pdf=pdf,
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_stripping_backend_inv_cdf_matches_scipy(backend_name):
+    # The backend-native inverse-CDF (searchsorted + linear interp of a cumulative-
+    # trapezoid CDF) must reproduce the numpy scipy k=1 inverse-CDF spline for the SAME
+    # pdf: draw at a shared u (same key -> same uniforms) and compare dt to scipy.
+    # Fast (no track) -> the torch coverage of the new inverse-CDF numerics.
+    xp = jax.numpy if backend_name == "jax" else torch
+    td = 4.5 / conversion.time_in_Gyr(_VO, _RO)
+    t0, sig = -0.4 * td, 0.5 * td
+
+    def pdf_np(t):
+        return numpy.exp(-(((t - t0) / sig) ** 2))
+
+    def pdf_b(t):
+        return xp.exp(-(((t - xp.asarray(t0)) / sig) ** 2))
+
+    sp_np = _build_stripping(pdf_np)
+    sp_b = _build_stripping(pdf_b)
+    assert is_backend_array(sp_b._stripping_cdf[0])
+    # a numpy pdf keeps the scipy path untouched (byte-identical)
+    assert sp_np._stripping_cdf is None and sp_np._stripping_inv_cdf is not None
+    key = grandom.key(_SEED, backend=backend_name)
+    u = as_numpy(grandom.uniform(key, (200,)))
+    dt_b = as_numpy(sp_b._draw_stripping_dt(200, key=key))
+    dt_scipy = -sp_np._stripping_inv_cdf(u)
+    numpy.testing.assert_allclose(
+        dt_b, dt_scipy, rtol=1e-9, atol=1e-9, err_msg=f"inverse-CDF ({backend_name})"
+    )
+
+
+def _stripping_track_xyz(t0, key):
+    def pdf(t):
+        return jax.numpy.exp(-(((t - t0) / (0.5 * _JIT_TD)) ** 2))
+
+    spdf = fardal15spraydf(
+        _JIT_MASS,
+        progenitor=Orbit(_JIT_IC),
+        pot=LogarithmicHaloPotential(amp=1.0, q=0.9),
+        tdisrupt=_JIT_TD,
+        stripping_pdf=pdf,
+    )
+    return spdf.streamTrack(
+        n=_JIT_N,
+        tail="leading",
+        velocity_weight=1.0,
+        order=1,
+        key=key,
+        track_time_range=2.0,
+    )._track_xyz
+
+
+@pytest.mark.skipif(jax is None, reason="jax required for jit tests")
+def test_streamtrack_jit_grad_fd_stripping():
+    # jax.jit(streamTrack()) is differentiable in the center t0 of a Gaussian stripping
+    # burst: t0 -> the inverse-CDF -> the stripping times -> the sampled particles -> the
+    # track. Reassignment-invariant functional (mean track radius) -> grad-vs-FD.
+    jnp = jax.numpy
+    key = grandom.key(_SEED, backend="jax")
+
+    def loss(t0):
+        xyz = _stripping_track_xyz(t0, key)
+        return jnp.mean(jnp.sqrt(jnp.sum(xyz**2, axis=1)))
+
+    g, best = _jit_grad_hconv(loss, -0.4 * _JIT_TD)
+    assert numpy.isfinite(g) and abs(g) > 0
+    # AD is essentially exact; the h-converged FD floor is ~8e-8, so 1e-6 is a real
+    # regression detector (the searchsorted inverse-CDF sits a touch above the mass floor)
+    assert best < 1e-6, f"jit streamTrack d/d(t0) grad-vs-FD best REL={best:.2e}"
+
+
 @pytest.mark.skipif(jax is None, reason="jax required for backend-theta construction")
 def test_backend_sampling_center_not_implemented():
     # Differentiable stream sampling (a backend potential parameter -> _bsamp set)

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -875,6 +875,99 @@ def test_streamtrack_jit_grad_fd_stripping():
     assert best < 1e-6, f"jit streamTrack d/d(t0) grad-vs-FD best REL={best:.2e}"
 
 
+# --------------------------------------------------------------------------
+# Differentiable stream track w.r.t. the PERICENTER-STRIPPING width. The built-in
+# pericenter_stripping_pdf helper builds a Gaussian mixture centered on the progenitor's
+# pericenter passages; a backend `sigma` (or a backend pot/IC) makes it return a BACKEND
+# pdf that composes with the backend inverse-CDF above, so the whole stream is jittable and
+# differentiable in the stripping WIDTH. The pericenter TIMES are found concretely (a
+# find_peaks discrete op) and frozen as a backend constant.
+# --------------------------------------------------------------------------
+_PERI_TD, _PERI_SIGMA = 12.0, 2.0  # internal units: ~3 pericenter passages of _PROG_IC
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_pericenter_stripping_pdf_backend_parity(backend_name):
+    # A backend sigma -> a backend Gaussian-mixture pericenter pdf whose VALUES match the
+    # numpy pdf (same concrete pericenter times) and which is a backend array (composes with
+    # the backend inverse-CDF). Fast (no track) -> the torch coverage of the helper.
+    from galpy.df import pericenter_stripping_pdf
+
+    xp = jax.numpy if backend_name == "jax" else torch
+    pot = LogarithmicHaloPotential(amp=1.0, q=0.9)
+    pdf_np = pericenter_stripping_pdf(Orbit(_PROG_IC), pot, _PERI_TD, _PERI_SIGMA)
+    pdf_b = pericenter_stripping_pdf(
+        Orbit(_PROG_IC), pot, _PERI_TD, xp.asarray(_PERI_SIGMA)
+    )
+    assert not is_backend_array(pdf_np(-0.5 * _PERI_TD))
+    tg = numpy.linspace(-_PERI_TD, 0.0, 60)
+    vb = pdf_b(xp.asarray(tg))
+    assert is_backend_array(vb)
+    numpy.testing.assert_allclose(
+        as_numpy(vb), pdf_np(tg), rtol=1e-9, atol=1e-12, err_msg=f"({backend_name})"
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("trigger", ["pot", "ic"])
+def test_pericenter_stripping_pdf_backend_triggers(backend_name, trigger):
+    # Not only a backend sigma: a backend pot PARAMETER (spotted by the forced-numpy force
+    # probe) or a backend progenitor IC also makes the helper return a composable backend
+    # pdf, so it works whenever the caller is already in backend-land.
+    from galpy.df import pericenter_stripping_pdf
+
+    xp = jax.numpy if backend_name == "jax" else torch
+    ic = xp.asarray(_PROG_IC) if trigger == "ic" else _PROG_IC
+    amp = xp.asarray(1.0) if trigger == "pot" else 1.0
+    pdf = pericenter_stripping_pdf(
+        Orbit(ic), LogarithmicHaloPotential(amp=amp, q=0.9), _PERI_TD, _PERI_SIGMA
+    )
+    v = pdf(xp.asarray(numpy.linspace(-_PERI_TD, 0.0, 40)))
+    assert is_backend_array(v)  # numpy sigma, but backend pot/IC -> backend pdf
+    assert numpy.all(numpy.isfinite(as_numpy(v)))
+
+
+@pytest.mark.skipif(jax is None, reason="jax required for jit tests")
+def test_streamtrack_jit_grad_fd_pericenter_sigma():
+    # d(track)/d(stripping-burst-width sigma) through the backend pericenter pdf + the
+    # backend inverse-CDF: the pericenter TIMES are frozen (find_peaks is discrete), the
+    # Gaussian width flows. Reassignment-invariant functional -> grad-vs-FD.
+    from galpy.df import pericenter_stripping_pdf
+
+    jnp = jax.numpy
+    key = grandom.key(_SEED, backend="jax")
+    pot = LogarithmicHaloPotential(amp=1.0, q=0.9)
+
+    def loss(sigma):
+        pdf = pericenter_stripping_pdf(Orbit(_PROG_IC), pot, _PERI_TD, sigma)
+        spdf = fardal15spraydf(
+            _JIT_MASS,
+            progenitor=Orbit(_PROG_IC),
+            pot=pot,
+            tdisrupt=_PERI_TD,
+            stripping_pdf=pdf,
+        )
+        xyz = spdf.streamTrack(
+            n=_JIT_N,
+            tail="leading",
+            velocity_weight=1.0,
+            order=1,
+            key=key,
+            track_time_range=2.0,
+        )._track_xyz
+        return jnp.mean(jnp.sqrt(jnp.sum(xyz**2, axis=1)))
+
+    g, best = _jit_grad_hconv_rel(
+        loss, _PERI_SIGMA
+    )  # sigma is O(1) -> relative FD steps
+    assert numpy.isfinite(g) and abs(g) > 0
+    # AD is essentially exact; the h-converged FD floor is ~2e-7 here (Gaussian-mixture
+    # inverse-CDF), so 1e-5 is a real regression detector with CI-robust margin.
+    assert best < 1e-5, (
+        f"jit streamTrack d/d(sigma) pericenter grad-vs-FD best REL={best:.2e}"
+    )
+
+
 @pytest.mark.skipif(jax is None, reason="jax required for backend-theta construction")
 def test_backend_sampling_center_not_implemented():
     # Differentiable stream sampling (a backend potential parameter -> _bsamp set)


### PR DESCRIPTION
Builds on #1106 + #1109. Two related additions that make the stream **stripping-time** model differentiable + backend-native (jax/torch, jittable, GPU), composing with the existing differentiable sampling/track.

## 1. Differentiable `stripping_pdf` — backend-native inverse-CDF

A backend (jax/torch) `stripping_pdf` now makes the stream track differentiable in the **stripping-time distribution** — e.g. the center/width of a stripping burst — via `d(track)/d(stripping-pdf-params)` (grad-vs-FD ~1e-7). This is the mass-loss **time** history, distinct from the progenitor mass `M(t)` magnitude (#1109).

Previously a custom `stripping_pdf` inverted a scipy `k=1` spline on a numpy sample (the *"backend-native inverse-CDF is a later PR"* path). Now a `stripping_pdf` returning a **backend array**:
- **`_parse_stripping_pdf`**: builds a cumulative-trapezoid CDF (`xp.cumsum(..., axis=0)`; increments clipped `>= 0` for a monotonic CDF — a jit trace can't raise on a negative pdf).
- **`_draw_stripping_dt`**: inverts by `xp.searchsorted` + linear interp — jit-safe (fixed shape) and differentiable in the pdf params via the CDF values (frozen bracket, differentiable weight; the flat-tie div-by-zero is dead-branch guarded). **Matches the scipy inverse-CDF to ~3e-15.**
- **`_integrate_progenitor`**: a backend `stripping_pdf` is its own backend-sampling trigger (like the mass).
- Also **hardens the astropy unit-detection for backend callables**: a torch tensor's `.to()` raises `TypeError` (not `AttributeError`) on a `Quantity` arg, so the `stripping_pdf` **and** progenitor-mass `M(t)` unit-output probes now catch it (jax arrays lack `.to()` → already `AttributeError`).

## 2. `pericenter_stripping_pdf` on the backend

The built-in `pericenter_stripping_pdf` helper (a Gaussian mixture centered on the progenitor's pericenter passages — the physical enhancement of stripping at pericenter) now returns a **backend** pdf when given a backend `sigma` (or a backend pot/IC), composing with §1's inverse-CDF. `d(track)/d(sigma)` flows (grad-vs-FD ~2e-7 through the full stream track).

**Limitation (by design):** the pericenter *times* come from scipy `find_peaks` — a discrete, numpy-only op that can't run on a tracer — so they're found concretely and **frozen** as a backend constant (the peak *selection* is discrete, like the track's closest-point assignment). The pdf is differentiable in the **width `sigma`**, not in the potential parameters *through* the pericenter times (that would need a `pure_callback` + dynamic-peak-count machinery — a later PR). A backend pot/IC is detected by the same forced-numpy force probe as the sampler, so the helper returns a composable backend pdf whenever the caller is in backend-land.

## numpy path byte-identical

A numpy `stripping_pdf` keeps the scipy spline; a numpy `pericenter_stripping_pdf` falls through to the unchanged `_pdf_internal` (backend pdf matches numpy values to ~5e-18). 38 numpy `streamspraydf` + 6 numpy pericenter tests unchanged.

## Tests

New per-module tests in `test_backend_streamspraydf.py`: jax jit grad-vs-FD of `d(track)/d(burst-time)` and `d(track)/d(sigma)`; jax+torch inverse-CDF-vs-scipy and pericenter-pdf-vs-numpy value parity (fast, no track — the torch coverage of the new numerics). All grad-vs-FD thresholds are measure-driven at `1e-6` (pericenter `1e-5`), 3-4 orders tighter than a loose sanity check (measured floors 1.3e-9–2e-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm