### PR TITLE
assoc_legendre: roll the Bonnet recurrence + derivative tables into a jax trace (SCF/Multipole)

### DIFF
--- a/galpy/backend/special/_fallback/assoc_legendre.py
+++ b/galpy/backend/special/_fallback/assoc_legendre.py
@@ -18,7 +18,17 @@
 #   Everything is pure arithmetic built with lists + xp.stack (no in-place
 #   mutation), so it differentiates cleanly under jax and torch -- and the
 #   x-derivatives are also available straight from autodiff.
+#
+#   Under a jax trace the Bonnet l-recurrence is rolled into a single
+#   ``lax.scan`` over l (see ``_bonnet_scan_jax``): the eager Python double loop
+#   would bake all O(L*M) recurrence steps into the user's jaxpr, whereas the
+#   scan traces the recurrence body once. Eager numpy/torch/jax keep the Python
+#   loop unchanged (byte-identical); the scan carries the same values at the same
+#   iteration count, so the traced result matches the unrolled loop to the XLA
+#   fma-fusion floor (the same ~1e-11 that jitting the unrolled loop itself shows
+#   vs the eager per-op result -- the scan adds no error beyond that).
 ###############################################################################
+from ..._namespaces import under_jax_trace
 
 
 def assoc_legendre(xp, L, M, x, deriv=0):
@@ -33,27 +43,33 @@ def assoc_legendre(xp, L, M, x, deriv=0):
     # (1-x^2)^{1/2}; clip keeps it real at |x|=1 (interior x is unaffected).
     somx2 = xp.sqrt(xp.where(x * x < 1.0, 1.0 - x * x, zero))
 
-    # P[l][m] as a list-of-lists of backend arrays (functional, no mutation).
-    P = [[zero for _ in range(M)] for _ in range(L)]
-    pmm = one  # running P_m^m diagonal
-    for m in range(M):
-        if m > 0:
-            pmm = pmm * (-(2 * m - 1)) * somx2
-        if m < L:
-            P[m][m] = pmm
-        if m + 1 < L:
-            P[m + 1][m] = x * (2 * m + 1) * pmm
-        for l in range(m + 2, L):
-            P[l][m] = (x * (2 * l - 1) * P[l - 1][m] - (l + m - 1) * P[l - 2][m]) / (
-                l - m
-            )
-
     def _stack(grid):
         return xp.stack([xp.stack(row, axis=-1) for row in grid], axis=-2)
 
-    Parr = _stack(P)
-    if deriv == 0:
-        return Parr
+    # P[l][m] as a list-of-lists of backend arrays (functional, no mutation).
+    if under_jax_trace(x):  # roll the Bonnet l-recurrence into one lax.scan
+        Parr = _bonnet_scan_jax(L, M, x, somx2, one, zero)  # x.shape + (L, M)
+        if deriv == 0:  # value-only: return the scan output straight (no unstack)
+            return Parr
+        # derivatives read P[l][m]; expose the scanned rows as that list of views.
+        P = [[Parr[..., l, m] for m in range(M)] for l in range(L)]
+    else:  # eager (numpy/torch/jax): keep the unrolled Python double loop
+        P = [[zero for _ in range(M)] for _ in range(L)]
+        pmm = one  # running P_m^m diagonal
+        for m in range(M):
+            if m > 0:
+                pmm = pmm * (-(2 * m - 1)) * somx2
+            if m < L:
+                P[m][m] = pmm
+            if m + 1 < L:
+                P[m + 1][m] = x * (2 * m + 1) * pmm
+            for l in range(m + 2, L):
+                P[l][m] = (
+                    x * (2 * l - 1) * P[l - 1][m] - (l + m - 1) * P[l - 2][m]
+                ) / (l - m)
+        Parr = _stack(P)
+        if deriv == 0:
+            return Parr
 
     den = x * x - 1.0  # (x^2-1); singular only at the poles |x|=1
     pole = x * x >= 1.0  # symmetry-axis poles (cos theta = +-1)
@@ -92,3 +108,42 @@ def assoc_legendre(xp, L, M, x, deriv=0):
                     2.0 * x * dP[l][m] - l * (l + 1) * P[l][m] + (m * m) / om * P[l][m]
                 ) / om
     return Parr, dParr, _stack(d2)
+
+
+def _bonnet_scan_jax(L, M, x, somx2, one, zero):
+    """Traced-only P_l^m via a single ``lax.scan`` over l (carry the two previous
+    full m-rows). Returns ``Parr`` of shape ``x.shape + (L, M)`` (same as the
+    eager list + ``xp.stack``).
+
+    Each scanned row reproduces, element-for-element, the eager arithmetic:
+    interior/sub-diagonal m come from the Bonnet three-term recurrence (the
+    sub-diagonal falls out of it since ``P[l-2][l-1] == 0``), the diagonal m==l is
+    injected from the running P_m^m, and the m>l upper triangle is zeroed. The
+    m==l denominator (l-m == 0) is guarded to 1 so the discarded Bonnet branch
+    stays finite (AD-safe); the ``where`` then selects the diagonal value there.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    # Running diagonal P_m^m for all m, via the eager m-recurrence (M small).
+    pmm = one
+    diag = [one]
+    for m in range(1, M):
+        pmm = pmm * (-(2 * m - 1)) * somx2
+        diag.append(pmm)
+    pmm_vec = jnp.stack(diag, axis=-1)  # x.shape + (M,)
+    mvec = jnp.arange(M)  # (M,)
+    xM = x[..., None]  # x.shape + (1,)
+    zeros_row = jnp.broadcast_to(zero[..., None], x.shape + (M,))
+
+    def body(carry, ll):
+        Pm1, Pm2 = carry  # P[l-1][:], P[l-2][:] rows
+        den = jnp.where(mvec == ll, 1.0, ll - mvec)  # guard 0/0 at the diagonal
+        bonnet = (xM * (2 * ll - 1) * Pm1 - (ll + mvec - 1) * Pm2) / den
+        row = jnp.where(mvec == ll, pmm_vec, bonnet)  # inject P_m^m diagonal
+        row = jnp.where(mvec > ll, zeros_row, row)  # exact 0 upper triangle
+        return (row, Pm1), row
+
+    _, Prows = jax.lax.scan(body, (zeros_row, zeros_row), jnp.arange(L))
+    # Prows: (L,) + x.shape + (M,) -> x.shape + (L, M) (matches eager _stack).
+    return jnp.moveaxis(Prows, 0, -2)

--- a/galpy/backend/special/_fallback/assoc_legendre.py
+++ b/galpy/backend/special/_fallback/assoc_legendre.py
@@ -46,30 +46,35 @@ def assoc_legendre(xp, L, M, x, deriv=0):
     def _stack(grid):
         return xp.stack([xp.stack(row, axis=-1) for row in grid], axis=-2)
 
-    # P[l][m] as a list-of-lists of backend arrays (functional, no mutation).
-    if under_jax_trace(x):  # roll the Bonnet l-recurrence into one lax.scan
+    # Traced: roll the value recurrence into one lax.scan and compute the
+    # derivative tables (which are pointwise in Parr, not recurrences) by
+    # vectorized ops over static (l, m) grids. Eager keeps the Python loops below.
+    if under_jax_trace(x):
         Parr = _bonnet_scan_jax(L, M, x, somx2, one, zero)  # x.shape + (L, M)
-        if deriv == 0:  # value-only: return the scan output straight (no unstack)
-            return Parr
-        # derivatives read P[l][m]; expose the scanned rows as that list of views.
-        P = [[Parr[..., l, m] for m in range(M)] for l in range(L)]
-    else:  # eager (numpy/torch/jax): keep the unrolled Python double loop
-        P = [[zero for _ in range(M)] for _ in range(L)]
-        pmm = one  # running P_m^m diagonal
-        for m in range(M):
-            if m > 0:
-                pmm = pmm * (-(2 * m - 1)) * somx2
-            if m < L:
-                P[m][m] = pmm
-            if m + 1 < L:
-                P[m + 1][m] = x * (2 * m + 1) * pmm
-            for l in range(m + 2, L):
-                P[l][m] = (
-                    x * (2 * l - 1) * P[l - 1][m] - (l + m - 1) * P[l - 2][m]
-                ) / (l - m)
-        Parr = _stack(P)
         if deriv == 0:
             return Parr
+        dParr = _legendre_dP_jax(L, M, x, Parr)
+        if deriv == 1:
+            return Parr, dParr
+        return Parr, dParr, _legendre_d2_jax(L, M, x, Parr, dParr)
+
+    # Eager (numpy/torch/jax): the original unrolled Python double loops.
+    P = [[zero for _ in range(M)] for _ in range(L)]
+    pmm = one  # running P_m^m diagonal
+    for m in range(M):
+        if m > 0:
+            pmm = pmm * (-(2 * m - 1)) * somx2
+        if m < L:
+            P[m][m] = pmm
+        if m + 1 < L:
+            P[m + 1][m] = x * (2 * m + 1) * pmm
+        for l in range(m + 2, L):
+            P[l][m] = (x * (2 * l - 1) * P[l - 1][m] - (l + m - 1) * P[l - 2][m]) / (
+                l - m
+            )
+    Parr = _stack(P)
+    if deriv == 0:
+        return Parr
 
     den = x * x - 1.0  # (x^2-1); singular only at the poles |x|=1
     pole = x * x >= 1.0  # symmetry-axis poles (cos theta = +-1)
@@ -147,3 +152,67 @@ def _bonnet_scan_jax(L, M, x, somx2, one, zero):
     _, Prows = jax.lax.scan(body, (zeros_row, zeros_row), jnp.arange(L))
     # Prows: (L,) + x.shape + (M,) -> x.shape + (L, M) (matches eager _stack).
     return jnp.moveaxis(Prows, 0, -2)
+
+
+def _legendre_dP_jax(L, M, x, Parr):
+    """Traced-only dP/dx table, vectorized over static (l, m) grids.
+
+    Each entry is pointwise in ``Parr`` (not a recurrence): reproduces the eager
+    per-(l, m) formula element-for-element -- interior/m>=1 from ``num / (x^2-1)``
+    (diverging at the poles, as scipy does), the m==0 column from the guarded
+    ``num / (x^2-1)_safe`` with the closed pole form P_l'(+-1) = x^{l+1} l(l+1)/2.
+    P[l-1][m] comes from a 1-shifted ``Parr`` (the upper-triangle zeros make the
+    l==m edge fall out). The poles are guarded so the discarded m==0 branch stays
+    finite (AD-safe); ``x^{l+1}`` at the poles is taken by parity, not a
+    negative-base float power (which would NaN under vectorization).
+    """
+    import jax.numpy as jnp
+
+    lg = jnp.arange(L)[:, None]  # (L, 1)
+    mg = jnp.arange(M)[None, :]  # (1, M)
+    xg = x[..., None, None]  # x.shape + (1, 1)
+    onef = jnp.ones_like(xg)
+    den = xg * xg - 1.0
+    pole = xg * xg >= 1.0
+    den_safe = jnp.where(pole, onef, den)
+    # P[l-1][m]: shift Parr down one along l, zero-fill l=0 (matches the eager
+    # ``plm1 = P[l-1][m] if l-1>=m else zero`` via Parr's upper-triangle zeros).
+    Pm1 = jnp.concatenate(
+        [jnp.zeros_like(Parr[..., :1, :]), Parr[..., :-1, :]], axis=-2
+    )
+    num = lg * xg * Parr - (lg + mg) * Pm1
+    # m==0 uses den_safe (also finite in its dead branch), m>=1 uses den.
+    dP_gen = num / jnp.where(mg == 0, den_safe, den)
+    # (+-1)^{l+1} at the poles = x^{l+1} there, by parity (avoids a NaN power).
+    xpow = jnp.where((x < 0)[..., None, None] & ((lg + 1) % 2 == 1), -onef, onef)
+    dP_m0 = jnp.where(pole, xpow * (lg * (lg + 1) / 2.0), dP_gen)
+    dP = jnp.where(mg == 0, dP_m0, dP_gen)
+    return jnp.where(lg < mg, jnp.zeros_like(dP), dP)  # upper triangle -> 0
+
+
+def _legendre_d2_jax(L, M, x, Parr, dParr):
+    """Traced-only d2P/dx2 table, vectorized over static (l, m) grids.
+
+    Pointwise in ``Parr`` and ``dParr`` (the Legendre ODE), reproducing the eager
+    per-(l, m) formula: m==0 from ``(2x dP - l(l+1) P) / (1-x^2)_safe`` with the
+    closed pole limit (l-1)l(l+1)(l+2)/8, m>=1 from the full ODE over ``(1-x^2)``
+    (diverging at the poles). The m==0 denominator is guarded (om_safe) so its
+    dead branch stays finite (AD-safe).
+    """
+    import jax.numpy as jnp
+
+    lg = jnp.arange(L)[:, None]
+    mg = jnp.arange(M)[None, :]
+    xg = x[..., None, None]
+    onef = jnp.ones_like(xg)
+    om = 1.0 - xg * xg
+    pole = xg * xg >= 1.0
+    om_safe = jnp.where(pole, onef, om)
+    om_col = jnp.where(mg == 0, om_safe, om)  # guard the dead m==0 branch
+    base = 2.0 * xg * dParr - lg * (lg + 1) * Parr
+    gen = base / om_safe
+    coef_pole = (lg - 1) * lg * (lg + 1) * (lg + 2) / 8.0
+    d2_m0 = jnp.where(pole, coef_pole * onef, gen)
+    d2_mge1 = (base + (mg * mg) / om_col * Parr) / om_col
+    d2 = jnp.where(mg == 0, d2_m0, d2_mge1)
+    return jnp.where(lg < mg, jnp.zeros_like(d2), d2)  # upper triangle -> 0

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -641,23 +641,37 @@ def test_assoc_legendre_autodiff_matches_analytic(backend):
 
 @pytest.mark.skipif("jax" not in BACKENDS, reason="lax.scan Bonnet roll is jax-only")
 def test_assoc_legendre_traced_bonnet_scan():
-    # Under a jax trace the Bonnet l-recurrence is rolled into ONE lax.scan
-    # (_fallback.assoc_legendre._bonnet_scan_jax); eager numpy/torch/jax keep the
-    # unrolled Python loop (byte-identical, verified by the parity tests above).
-    # This asserts: (a) the roll fires (jaxpr has a scan primitive and the
-    # value-path graph is an order of magnitude smaller than the unrolled loop),
-    # (b) the traced result matches the eager loop to the XLA fma-fusion floor for
-    # every deriv level, and (c) grad-through-the-scan matches central FD.
+    # Under a jax trace the value Bonnet l-recurrence is rolled into ONE lax.scan
+    # (_bonnet_scan_jax) and the derivative tables are computed by vectorized ops
+    # over static (l, m) grids (_legendre_dP_jax/_legendre_d2_jax); eager
+    # numpy/torch/jax keep the unrolled Python loops (byte-identical, verified by
+    # the parity tests above + the origin byte-diff harness). This asserts: (a) the
+    # value roll fires (scan primitive; small deriv=0 graph) and the derivative
+    # tables are rolled (deriv=1/2 graphs an order of magnitude below the unrolled
+    # loop), (b) the traced result matches the eager loop to the XLA fma floor for
+    # every deriv level, (c) parity holds AT the poles x=+-1 (m==0 finite entries
+    # exact, m>=1 NaN positions match), and (d) grad through the traced derivative
+    # tables matches central FD.
     L, M = 10, 5
     x = jnp.asarray(numpy.linspace(-0.9, 0.9, 7), dtype=jnp.float64)
 
-    # (a) rolled: a scan primitive is present and the deriv=0 graph is small
-    #     (the eager double loop unrolls to ~200 eqns for these L, M).
-    eqns = jax.make_jaxpr(lambda xx: gsp.assoc_legendre(L, M, xx))(x).jaxpr.eqns
-    assert any(e.primitive.name == "scan" for e in eqns), "lax.scan roll did not fire"
-    assert len(eqns) < 60, f"deriv=0 jaxpr not rolled ({len(eqns)} eqns)"
+    # (a) rolled: scan primitive present; deriv=0 graph small (eager unrolls to
+    #     ~200 eqns) and the deriv=1/2 derivative-table graphs are far below the
+    #     eager-unrolled ~600/~1000 eqns.
+    def _neqns(d):
+        def f(xx):
+            out = gsp.assoc_legendre(L, M, xx, deriv=d)
+            return out if d == 0 else sum(o.sum() for o in out)
 
-    # (b) traced (jit -> scan) vs eager (Python loop) to the XLA fma floor.
+        return len(jax.make_jaxpr(f)(x).jaxpr.eqns)
+
+    eqns0 = jax.make_jaxpr(lambda xx: gsp.assoc_legendre(L, M, xx))(x).jaxpr.eqns
+    assert any(e.primitive.name == "scan" for e in eqns0), "lax.scan roll did not fire"
+    assert len(eqns0) < 60, f"deriv=0 jaxpr not rolled ({len(eqns0)} eqns)"
+    assert _neqns(1) < 150, "deriv=1 derivative table not rolled"
+    assert _neqns(2) < 250, "deriv=2 derivative table not rolled"
+
+    # (b) traced (jit) vs eager (Python loop) to the XLA fma floor, all deriv.
     for d in (0, 1, 2):
         eager = gsp.assoc_legendre(L, M, x, deriv=d)
         traced = jax.jit(lambda xx, d=d: gsp.assoc_legendre(L, M, xx, deriv=d))(x)
@@ -668,14 +682,27 @@ def test_assoc_legendre_traced_bonnet_scan():
                 as_numpy(t), as_numpy(e), rtol=1e-6, atol=1e-6
             )
 
-    # (c) grad-vs-FD through the traced scan (random direction, quadratic loss).
+    # (c) parity at the poles x=+-1: m==0 derivative columns are finite (exact
+    #     closed form) and the m>=1 NaN pattern matches the eager loop.
+    xp1 = jnp.asarray([1.0, -1.0], dtype=jnp.float64)
+    for d in (1, 2):
+        eager = gsp.assoc_legendre(L, M, xp1, deriv=d)
+        traced = jax.jit(lambda xx, d=d: gsp.assoc_legendre(L, M, xx, deriv=d))(xp1)
+        for e, t in zip(eager, traced):
+            en, tn = as_numpy(e), as_numpy(t)
+            assert numpy.array_equal(numpy.isnan(en), numpy.isnan(tn))  # NaN pattern
+            fin = ~numpy.isnan(en)
+            assert numpy.array_equal(tn[fin], en[fin])  # finite entries bit-exact
+
+    # (d) grad-vs-FD through the traced derivative tables (random direction,
+    #     quadratic loss mixing P, dP and d2), interior x (no poles).
     x0 = jnp.asarray(numpy.linspace(-0.75, 0.8, 7), dtype=jnp.float64)
     dirn = jax.random.normal(jax.random.PRNGKey(1), x0.shape, dtype=jnp.float64)
     w = jnp.asarray(numpy.arange(1, L * M + 1, dtype=float)).reshape(L, M)
 
     def loss(t):
-        P, dP = gsp.assoc_legendre(L, M, x0 + t * dirn, deriv=1)
-        return jnp.sum(w * P**2) + jnp.sum(dP[..., 4, 2] ** 2)
+        P, dP, d2 = gsp.assoc_legendre(L, M, x0 + t * dirn, deriv=2)
+        return jnp.sum(w * dP**2) + jnp.sum(d2[..., 5, 1] ** 2) + jnp.sum(P[..., 4, 2])
 
     g = float(jax.grad(loss)(0.0))
     errs = [abs((float(loss(h)) - float(loss(-h))) / (2 * h) - g) for h in (1e-4, 1e-6)]

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -639,6 +639,52 @@ def test_assoc_legendre_autodiff_matches_analytic(backend):
         )
 
 
+@pytest.mark.skipif("jax" not in BACKENDS, reason="lax.scan Bonnet roll is jax-only")
+def test_assoc_legendre_traced_bonnet_scan():
+    # Under a jax trace the Bonnet l-recurrence is rolled into ONE lax.scan
+    # (_fallback.assoc_legendre._bonnet_scan_jax); eager numpy/torch/jax keep the
+    # unrolled Python loop (byte-identical, verified by the parity tests above).
+    # This asserts: (a) the roll fires (jaxpr has a scan primitive and the
+    # value-path graph is an order of magnitude smaller than the unrolled loop),
+    # (b) the traced result matches the eager loop to the XLA fma-fusion floor for
+    # every deriv level, and (c) grad-through-the-scan matches central FD.
+    L, M = 10, 5
+    x = jnp.asarray(numpy.linspace(-0.9, 0.9, 7), dtype=jnp.float64)
+
+    # (a) rolled: a scan primitive is present and the deriv=0 graph is small
+    #     (the eager double loop unrolls to ~200 eqns for these L, M).
+    eqns = jax.make_jaxpr(lambda xx: gsp.assoc_legendre(L, M, xx))(x).jaxpr.eqns
+    assert any(e.primitive.name == "scan" for e in eqns), "lax.scan roll did not fire"
+    assert len(eqns) < 60, f"deriv=0 jaxpr not rolled ({len(eqns)} eqns)"
+
+    # (b) traced (jit -> scan) vs eager (Python loop) to the XLA fma floor.
+    for d in (0, 1, 2):
+        eager = gsp.assoc_legendre(L, M, x, deriv=d)
+        traced = jax.jit(lambda xx, d=d: gsp.assoc_legendre(L, M, xx, deriv=d))(x)
+        eager = eager if isinstance(eager, tuple) else (eager,)
+        traced = traced if isinstance(traced, tuple) else (traced,)
+        for e, t in zip(eager, traced):
+            numpy.testing.assert_allclose(
+                as_numpy(t), as_numpy(e), rtol=1e-6, atol=1e-6
+            )
+
+    # (c) grad-vs-FD through the traced scan (random direction, quadratic loss).
+    x0 = jnp.asarray(numpy.linspace(-0.75, 0.8, 7), dtype=jnp.float64)
+    dirn = jax.random.normal(jax.random.PRNGKey(1), x0.shape, dtype=jnp.float64)
+    w = jnp.asarray(numpy.arange(1, L * M + 1, dtype=float)).reshape(L, M)
+
+    def loss(t):
+        P, dP = gsp.assoc_legendre(L, M, x0 + t * dirn, deriv=1)
+        return jnp.sum(w * P**2) + jnp.sum(dP[..., 4, 2] ** 2)
+
+    g = float(jax.grad(loss)(0.0))
+    errs = [abs((float(loss(h)) - float(loss(-h))) / (2 * h) - g) for h in (1e-4, 1e-6)]
+    assert errs[1] < errs[0], f"FD did not converge to the grad: {errs}"
+    numpy.testing.assert_allclose(
+        (float(loss(1e-6)) - float(loss(-1e-6))) / 2e-6, g, rtol=1e-5
+    )
+
+
 # --- Tier 4b: Gegenbauer C_n^alpha (SCF radial basis) -------------------------
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_gegenbauer_value_parity(backend):


### PR DESCRIPTION
## What

Roadmap **P1 #10** (`logs/backend_speedup_audit/roadmap.md`). The associated-Legendre fallback (`galpy/backend/special/_fallback/assoc_legendre.py`) — the SCF / MultipoleExpansion hot path — built `P_l^m` and its `dP`/`d2` tables with **unrolled Python double loops**. Under a user `jax.jit`/`jax.grad` that bakes all `O(L*M)` ops into the jaxpr.

Two commits, both **traced-only** (gated on the shared `under_jax_trace` predicate — the same eager/traced split established by the merged #1026 `bisect_root` and #1040 Staeckel-loop PRs), leaving the eager path untouched:

1. **Value Bonnet recurrence → one `lax.scan`** over `l` (carrying the two previous full `m`-rows).
2. **`dP`/`d2` derivative tables → vectorized ops** over static `(l, m)` index grids. The tables are *not* recurrences — each entry is pointwise in the already-computed `Parr` (`P[l][m]`, a 1-shifted `P[l-1][m]`, and static `l/m` coefficients) — so they broadcast in one shot instead of unrolling.

## Why it's byte-identity-safe

The eager path (numpy, torch, **and** eager-jax/CI) keeps the unrolled Python loops **unchanged**:

- **numpy stays byte-identical** — the router sends numpy to `scipy.special.assoc_legendre_p_all`; the fallback is only ever reached by jax/torch.
- **the whole eager path is byte-identical to `origin/feat/backends`** — verified bit-for-bit (`numpy.array_equal`, `equal_nan`) across 54 numpy/jax/torch × (L,M) × deriv cases **including the poles x=±1**.
- A naive *unconditional* roll would regress eager ~9× (CI runs eager) — hence the traced-only gate, exactly as #1026/#1040 established.

The traced forms reproduce the eager arithmetic **element-for-element**:
- **value scan**: interior + the sub-diagonal fall out of the Bonnet recurrence (`P[l-2][l-1]==0`), the diagonal is injected from the running `P_m^m`, the upper triangle is zeroed; the `m==l` denominator is guarded so the discarded branch stays finite (AD-safe).
- **derivative tables**: interior/`m>=1` from `num/(x²-1)` (diverging at the poles as scipy does → the `m>=1` **NaN pattern is reproduced exactly**); the `m==0` column from the guarded `num/(x²-1)_safe` with the closed pole form `x^{l+1}·l(l+1)/2` — taken by **parity** at ±1, not a negative-base float power (which would NaN under vectorization); `P[l-1][m]` from a 1-shifted `Parr` (upper-triangle zeros make the `l==m` edge fall out); `den_safe`/`om_safe` keep each discarded `m==0` branch finite (AD-safe).

`lax.scan` lowers through XLA, so the traced result matches the unrolled loop to the **XLA fma-fusion floor** — the same `~1e-11` that jitting the *unrolled* loop itself shows vs the eager per-op result (the roll adds no error beyond that); at a scalar SCF eval it round-trips to `~1e-16`.

## Measured win (L=12, M=6, jaxpr eqns)

| deriv | original (unrolled) | value scan only | + vectorized derivs | overall |
|------:|--------------------:|----------------:|--------------------:|--------:|
| 0 (value / potential) | 269 | **27** | 27 | ~10× |
| 1 (forces)            | 612 | 514 | **80** | ~7.7× |
| 2 (Hessian)           | 1074 | 976 | **128** | ~8.4× |

End-to-end SCF: `_evaluate` 203, `_Rforce` **707→601**, `_R2deriv` (Hessian) **1415→1227** eqns; all match numpy to `~1e-16` under jit, and the Hessian AD identity `-d(Rforce)/dR == R2deriv` is **exact** (0.0 diff).

## Validation

- **numpy byte-identity**: proven bit-for-bit vs origin (incl. poles); existing `test_assoc_legendre_value_parity[numpy]` (`array_equal` vs scipy) unchanged.
- **traced == eager**: to the XLA fma floor for deriv 0/1/2 (dP ~6e-10, d2 ~3e-9); at the poles the m==0 finite entries are **bit-exact** and the m>=1 NaN positions match.
- **grad-vs-FD**: h-converges quadratically through both the traced scan and the traced derivative tables.
- **Regression**: `test_backend_special.py` 145 passed; `test_backend_scf.py` + `test_backend_multipole.py` 179 passed. Extended `test_assoc_legendre_traced_bonnet_scan` (scan primitive fires + deriv=1/2 graphs rolled + trace/eager parity incl. poles + grad-vs-FD) passes, including under `-W error::DeprecationWarning -W error::FutureWarning`.
- **torch unaffected** (keeps the eager loops).

No internal `jax.jit`/`torch.compile` — the code is made jit-*compatible*, not jitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm