### PR TITLE
KuzminKutuzovStaeckelPotential: jit/grad-safe backend internals (numpy byte-identical)

### DIFF
--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2606,7 +2606,7 @@ def Rz_to_lambdanu(R, z, ac=5.0, Delta=1.0):
     -----
     - 2015-02-13 - Written - Trick (MPIA)
     """
-    xp = get_namespace(R, z)
+    xp = get_namespace(R, z) if is_backend_array(R) or is_backend_array(z) else numpy
     g = Delta**2 / (1.0 - ac**2)
     a = g - Delta**2
     term = R**2 + z**2 - a - g
@@ -2646,7 +2646,7 @@ def Rz_to_lambdanu_jac(R, z, Delta=1.0):
     - 2015-02-13 - Written - Trick (MPIA).
     """
 
-    xp = get_namespace(R, z)
+    xp = get_namespace(R, z) if is_backend_array(R) or is_backend_array(z) else numpy
     discr = (R**2 + z**2 - Delta**2) ** 2 + (4.0 * Delta**2 * R**2)
     dldR = R * (1.0 + (R**2 + z**2 + Delta**2) / xp.sqrt(discr))
     dndR = R * (1.0 - (R**2 + z**2 + Delta**2) / xp.sqrt(discr))

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -80,7 +80,7 @@ from functools import wraps
 
 import numpy
 
-from ..backend import get_namespace, promote_scalars
+from ..backend import get_namespace, is_backend_array, promote_scalars
 from ..util import _rotate_to_arbitrary_vector
 from ..util._optional_deps import _APY_LOADED
 from ..util.config import __config__
@@ -2606,12 +2606,13 @@ def Rz_to_lambdanu(R, z, ac=5.0, Delta=1.0):
     -----
     - 2015-02-13 - Written - Trick (MPIA)
     """
+    xp = get_namespace(R, z)
     g = Delta**2 / (1.0 - ac**2)
     a = g - Delta**2
     term = R**2 + z**2 - a - g
     discr = (R**2 + z**2 - Delta**2) ** 2 + (4.0 * Delta**2 * R**2)
-    l = 0.5 * (term + numpy.sqrt(discr))
-    n = 0.5 * (term - numpy.sqrt(discr))
+    l = 0.5 * (term + xp.sqrt(discr))
+    n = 0.5 * (term - xp.sqrt(discr))
     if isinstance(z, float) and z == 0.0:
         l = R**2 - a
         n = -g
@@ -2645,11 +2646,16 @@ def Rz_to_lambdanu_jac(R, z, Delta=1.0):
     - 2015-02-13 - Written - Trick (MPIA).
     """
 
+    xp = get_namespace(R, z)
     discr = (R**2 + z**2 - Delta**2) ** 2 + (4.0 * Delta**2 * R**2)
-    dldR = R * (1.0 + (R**2 + z**2 + Delta**2) / numpy.sqrt(discr))
-    dndR = R * (1.0 - (R**2 + z**2 + Delta**2) / numpy.sqrt(discr))
-    dldz = z * (1.0 + (R**2 + z**2 - Delta**2) / numpy.sqrt(discr))
-    dndz = z * (1.0 - (R**2 + z**2 - Delta**2) / numpy.sqrt(discr))
+    dldR = R * (1.0 + (R**2 + z**2 + Delta**2) / xp.sqrt(discr))
+    dndR = R * (1.0 - (R**2 + z**2 + Delta**2) / xp.sqrt(discr))
+    dldz = z * (1.0 + (R**2 + z**2 - Delta**2) / xp.sqrt(discr))
+    dndz = z * (1.0 - (R**2 + z**2 - Delta**2) / xp.sqrt(discr))
+    if is_backend_array(R) or is_backend_array(z):
+        return xp.stack(
+            [xp.stack([dldR, dldz], axis=0), xp.stack([dndR, dndz], axis=0)], axis=0
+        )
     dim = numpy.amax([len(numpy.atleast_1d(R)), len(numpy.atleast_1d(z))])
     jac = numpy.zeros((2, 2, dim))
     jac[0, 0, :] = dldR
@@ -2712,6 +2718,27 @@ def Rz_to_lambdanu_hess(R, z, Delta=1.0):
     )
     d2ldRdz = 2.0 * R * z / discr**0.5 * (1.0 - ((R2 + z2) ** 2 - D**4) / discr)
     d2ndRdz = 2.0 * R * z / discr**0.5 * (-1.0 + ((R2 + z2) ** 2 - D**4) / discr)
+    if is_backend_array(R) or is_backend_array(z):
+        xp = get_namespace(R, z)
+        return xp.stack(
+            [
+                xp.stack(
+                    [
+                        xp.stack([d2ldR2, d2ldRdz], axis=0),
+                        xp.stack([d2ldRdz, d2ldz2], axis=0),
+                    ],
+                    axis=0,
+                ),
+                xp.stack(
+                    [
+                        xp.stack([d2ndR2, d2ndRdz], axis=0),
+                        xp.stack([d2ndRdz, d2ndz2], axis=0),
+                    ],
+                    axis=0,
+                ),
+            ],
+            axis=0,
+        )
     dim = numpy.amax([len(numpy.atleast_1d(R)), len(numpy.atleast_1d(z))])
     hess = numpy.zeros((2, 2, 2, dim))
     # Hessian for lambda:

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -182,3 +182,95 @@ def test_grad_through(backend_name):
     numpy.testing.assert_allclose(gR, numpy.sin(theta0), rtol=1e-10)
     numpy.testing.assert_allclose(gvx, numpy.cos(phi0), rtol=1e-10)
     numpy.testing.assert_allclose(gvr, numpy.cos(numpy.arctan2(Y0, X0)), rtol=1e-10)
+
+
+###############################################################################
+# Rz_to_lambdanu / _jac / _hess: the prolate-spheroidal (R,z)->(lambda,nu)
+# transform behind KuzminKutuzovStaeckelPotential. These did raw numpy.sqrt and
+# numpy.zeros + in-place assignment, so a jax/torch trace over the force eval
+# crashed (TracerArrayConversionError). Now they namespace-swap the sqrt (numpy
+# path byte-identical) and take an is_backend_array-gated xp.stack build for
+# backend inputs. z=0 is included as an edge (the general formula is exact and
+# differentiable there; the numpy z==0 special-case is skipped for backends).
+###############################################################################
+_LN_R = numpy.array([0.5, 1.0, 1.2, 2.3, 0.8])
+_LN_Z = numpy.array([0.0, 0.3, -0.7, 1.5, 0.2])
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_lambdanu_value_parity(backend_name):
+    A = lambda a: _asarray(backend_name, a)
+    ref_l, ref_n = coords.Rz_to_lambdanu(_LN_R, _LN_Z, ac=5.0, Delta=1.4)
+    ref_jac = coords.Rz_to_lambdanu_jac(_LN_R, _LN_Z, Delta=1.4)
+    ref_hess = coords.Rz_to_lambdanu_hess(_LN_R, _LN_Z, Delta=1.4)
+    l, n = coords.Rz_to_lambdanu(A(_LN_R), A(_LN_Z), ac=5.0, Delta=1.4)
+    jac = coords.Rz_to_lambdanu_jac(A(_LN_R), A(_LN_Z), Delta=1.4)
+    hess = coords.Rz_to_lambdanu_hess(A(_LN_R), A(_LN_Z), Delta=1.4)
+    numpy.testing.assert_allclose(as_numpy(l), ref_l, rtol=1e-13, atol=1e-14)
+    numpy.testing.assert_allclose(as_numpy(n), ref_n, rtol=1e-13, atol=1e-14)
+    numpy.testing.assert_allclose(as_numpy(jac), ref_jac, rtol=1e-13, atol=1e-14)
+    numpy.testing.assert_allclose(as_numpy(hess), ref_hess, rtol=1e-13, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_kuzminkutuzov_force_traces(backend_name):
+    from galpy.potential import (
+        KuzminKutuzovStaeckelPotential,
+        evaluateR2derivs,
+        evaluateRforces,
+        evaluatezforces,
+    )
+
+    kp = KuzminKutuzovStaeckelPotential(amp=1.3, ac=5.0, Delta=1.0)
+    R0, z0 = 1.2, 0.3
+    if backend_name == "jax":
+        R, z = jnp.asarray(R0), jnp.asarray(z0)
+        assert isinstance(evaluateRforces(kp, R, z), jax.Array)
+        gR = jax.jacfwd(lambda RR: evaluateRforces(kp, RR, z))(R)
+        gz = jax.jacfwd(lambda zz: evaluatezforces(kp, R, zz))(z)
+        assert bool(jnp.isfinite(gR)) and bool(jnp.isfinite(gz))
+        jf = jax.jit(lambda RR, zz: evaluateRforces(kp, RR, zz))
+        assert bool(jnp.isfinite(jf(R, z)))
+        # autodiff self-consistency: d(Rforce)/dR == -R2deriv
+        numpy.testing.assert_allclose(
+            float(gR), -float(evaluateR2derivs(kp, R, z)), rtol=1e-10
+        )
+        # differentiable w.r.t. the Delta parameter (goes through the transform)
+        gd = jax.jacfwd(
+            lambda d: evaluateRforces(
+                KuzminKutuzovStaeckelPotential(amp=1.3, ac=5.0, Delta=d), R, z
+            )
+        )(jnp.asarray(1.0))
+        assert bool(jnp.isfinite(gd))
+    else:
+        R = torch.tensor(R0, requires_grad=True)
+        z = torch.tensor(z0, requires_grad=True)
+        f = evaluateRforces(kp, R, z)
+        assert isinstance(f, torch.Tensor)
+        (gR,) = torch.autograd.grad(f, R, create_graph=True)
+        assert bool(torch.isfinite(gR))
+        r2 = evaluateR2derivs(kp, R.detach(), z.detach())
+        numpy.testing.assert_allclose(float(gR.detach()), -float(r2), rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_kuzminkutuzov_force_grad_fd(backend_name):
+    from galpy.potential import KuzminKutuzovStaeckelPotential, evaluateRforces
+
+    kp = KuzminKutuzovStaeckelPotential(amp=1.3, ac=5.0, Delta=1.2)
+    R0, z0 = 1.3, 0.4
+    if backend_name == "jax":
+        g_ad = float(
+            jax.jacfwd(lambda RR: evaluateRforces(kp, RR, jnp.asarray(z0)))(
+                jnp.asarray(R0)
+            )
+        )
+    else:
+        R = torch.tensor(R0, requires_grad=True)
+        (g,) = torch.autograd.grad(evaluateRforces(kp, R, torch.tensor(z0)), R)
+        g_ad = float(g)
+    # numpy central finite difference must show O(h^2) convergence to the AD grad
+    f = lambda R: float(evaluateRforces(kp, R, z0))
+    errs = [abs((f(R0 + h) - f(R0 - h)) / (2.0 * h) - g_ad) for h in (1e-3, 1e-4)]
+    assert errs[0] < 1e-6
+    assert errs[1] < errs[0] / 50.0


### PR DESCRIPTION
## The gap

`KuzminKutuzovStaeckelPotential` worked **eager** on jax/torch but crashed under a **trace**: `jax.jacfwd`/`jax.jit` over `evaluateRforces` raised `TracerArrayConversionError`. Root cause is the prolate-spheroidal (R,z)→(λ,ν) transform it delegates to in `galpy.util.coords`:

- `Rz_to_lambdanu` used raw `numpy.sqrt(discr)`
- `Rz_to_lambdanu_jac` / `Rz_to_lambdanu_hess` used `numpy.sqrt` **and** built their output with `numpy.zeros(...)` + in-place assignment (plus `numpy.amax(numpy.atleast_1d(...))` for the shape) — none of which survive a trace.

Force eval (`_Rforce`/`_zforce`) uses `Rz_to_lambdanu` + `_jac`; the 2nd derivs use `_hess`; so all three had to become trace-safe.

## The fix (minimal, shared-util-safe)

These are **shared** utils, so the change is a strict namespace-swap plus a dual-path build:

- `Rz_to_lambdanu`: `numpy.sqrt` → `xp.sqrt` with `xp = get_namespace(R, z)`. The `z==0` special-cases are `isinstance(numpy...)`-gated and untouched; for backends the general formula is exact **and** differentiable at z=0.
- `Rz_to_lambdanu_jac` / `_hess`: namespace-swap the sqrt, then an `is_backend_array`-gated `xp.stack` build for backend inputs. The **numpy path** (`numpy.amax`/`numpy.zeros` + in-place assignment) is unchanged — the established **numpy=numpy-build / backend=xp.stack** dual pattern (not a numpy island).

## numpy byte-identical

Verified **bit-for-bit** (`numpy.array_equal`) on a scalar grid (incl. z=0 edges) and array inputs across λ/ν, jac, hess, potential, forces and 2nd derivs. Existing `tests/test_kuzminkutuzov.py` (10) unchanged.

## Traced / differentiable

- `jax.jacfwd`/`jax.jit` over `evaluateRforces`/`evaluatezforces` finite.
- Autodiff self-consistency: `d(Rforce)/dR == -R2deriv`.
- Differentiable w.r.t. the `Delta` parameter (flows through the transform).
- Eager jax + torch still return backend arrays.
- grad-vs-FD h-converges O(h²) for both R and the Delta parameter.

## Tests

Adds per-module coverage to `tests/test_backend_coords.py` (value parity + traced force + grad-vs-FD), green under `-W error::DeprecationWarning -W error::FutureWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm