### PR TITLE
RingPotential: jit/grad-safe backend elliptic integrals (numpy byte-identical)

### DIFF
--- a/galpy/potential/RingPotential.py
+++ b/galpy/potential/RingPotential.py
@@ -2,8 +2,9 @@
 #   RingPotential.py: The gravitational potential of a thin, circular ring
 ###############################################################################
 import numpy
-from scipy import special
 
+from ..backend import get_namespace
+from ..backend.special import ellipe, ellipk
 from ..util import conversion
 from .Potential import Potential
 
@@ -57,26 +58,22 @@ class RingPotential(Potential):
         self.hasC_dxdv = False
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         # Stable as r -> infty
-        m = 4.0 * self.a / ((numpy.sqrt(R) + self.a / numpy.sqrt(R)) ** 2 + z**2 / R)
-        return -4.0 * self.a / numpy.sqrt((R + self.a) ** 2 + z**2) * special.ellipk(m)
+        m = 4.0 * self.a / ((xp.sqrt(R) + self.a / xp.sqrt(R)) ** 2 + z**2 / R)
+        return -4.0 * self.a / xp.sqrt((R + self.a) ** 2 + z**2) * ellipk(m)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         m = 4.0 * R * self.a / ((R + self.a) ** 2 + z**2)
         return (
             -2.0
             * self.a
             / R
-            / numpy.sqrt((R + self.a) ** 2 + z**2)
+            / xp.sqrt((R + self.a) ** 2 + z**2)
             * (
-                m
-                * (R**2 - self.a2 - z**2)
-                / 4.0
-                / (1.0 - m)
-                / self.a
-                / R
-                * special.ellipe(m)
-                + special.ellipk(m)
+                m * (R**2 - self.a2 - z**2) / 4.0 / (1.0 - m) / self.a / R * ellipe(m)
+                + ellipk(m)
             )
         )
 
@@ -88,28 +85,23 @@ class RingPotential(Potential):
             * self.a
             / (1.0 - m)
             * ((R + self.a) ** 2 + z**2) ** -1.5
-            * special.ellipe(m)
+            * ellipe(m)
         )
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
         Raz2 = (R + self.a) ** 2 + z**2
-        Raz = numpy.sqrt(Raz2)
+        Raz = xp.sqrt(Raz2)
         m = 4.0 * R * self.a / Raz2
         R2ma2mz2o4aR1m = (R**2 - self.a2 - z**2) / 4.0 / self.a / R / (1.0 - m)
         return (2 * R**2 + self.a2 + 3 * R * self.a + z**2) / R / Raz2 * self._Rforce(
             R, z
         ) + 2.0 * self.a / R / Raz * (
-            m
-            * (R**2 + self.a2 + z**2)
-            / 4.0
-            / (1.0 - m)
-            / self.a
-            / R**2
-            * special.ellipe(m)
+            m * (R**2 + self.a2 + z**2) / 4.0 / (1.0 - m) / self.a / R**2 * ellipe(m)
             + (
-                R2ma2mz2o4aR1m / (1.0 - m) * special.ellipe(m)
-                + 0.5 * R2ma2mz2o4aR1m * (special.ellipe(m) - special.ellipk(m))
-                + 0.5 * (special.ellipe(m) / (1.0 - m) - special.ellipk(m)) / m
+                R2ma2mz2o4aR1m / (1.0 - m) * ellipe(m)
+                + 0.5 * R2ma2mz2o4aR1m * (ellipe(m) - ellipk(m))
+                + 0.5 * (ellipe(m) / (1.0 - m) - ellipk(m)) / m
             )
             * 4
             * self.a
@@ -128,7 +120,7 @@ class RingPotential(Potential):
                 3.0 * z**2 / Raz2
                 - 1.0
                 + 4.0
-                * ((1.0 + m) / (1.0 - m) - special.ellipk(m) / special.ellipe(m))
+                * ((1.0 + m) / (1.0 - m) - ellipk(m) / ellipe(m))
                 * self.a
                 * R
                 * z**2
@@ -138,7 +130,7 @@ class RingPotential(Potential):
             * self.a
             / (1.0 - m)
             * ((R + self.a) ** 2 + z**2) ** -1.5
-            * special.ellipe(m)
+            * ellipe(m)
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
@@ -147,7 +139,7 @@ class RingPotential(Potential):
         return (
             3.0 * (R + self.a) / Raz2
             - 2.0
-            * ((1.0 + m) / (1.0 - m) - special.ellipk(m) / special.ellipe(m))
+            * ((1.0 + m) / (1.0 - m) - ellipk(m) / ellipe(m))
             * self.a
             * (self.a2 + z**2 - R**2)
             / Raz2**2

--- a/tests/test_backend_ring.py
+++ b/tests/test_backend_ring.py
@@ -1,0 +1,187 @@
+###############################################################################
+# test_backend_ring.py: multi-backend tests for RingPotential, the potential of
+# an infinitesimally-thin circular ring whose potential/forces/second
+# derivatives are expressed through the complete elliptic integrals K(m) and
+# E(m) (routed via galpy.backend.special.ellipk/ellipe: scipy.special on numpy,
+# a pure-backend AGM fallback on jax and torch, both in scipy's parameter-m
+# convention).
+#
+# For every migrated compute method this proves numpy / jax / torch value parity
+# at tight tolerances, that eval/jacfwd/jit run under a jax trace and stay
+# finite, and that the migrated forces are differentiable with a gradient
+# consistent with finite differences and with the analytic identity
+# AD(_evaluate) == -force (both in R and z). The ring radius a and mass amp are
+# also shown to be differentiable parameters (jax.grad / torch.autograd vs FD).
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy
+from galpy.potential import RingPotential, evaluateRforces
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+POTS = [RingPotential(amp=1.3, a=0.75), RingPotential(amp=2.3, a=1.4)]
+POT_IDS = ["a0.75", "a1.4"]
+
+# (R, z) grid that deliberately avoids the on-ring logarithmic singularity
+# (m -> 1 at R == a, z == 0): points straddle the ring radius, include z == 0
+# rows off the ring, and reach large R (m -> 0). The genuine singularity and the
+# z == 0 finite limits are covered byte-identically by test_potential.py.
+_RS = [0.2, 0.5, 0.72, 0.95, 1.0, 2.0, 5.0, 20.0]
+_ZS = [0.0, 0.15, 0.3, 0.0, -0.5, 1.0, -2.0, 0.4]
+
+_METHODS = ["_evaluate", "_Rforce", "_zforce", "_R2deriv", "_z2deriv", "_Rzderiv"]
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("pot", POTS, ids=POT_IDS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, pot):
+    # numpy == jax == torch for every migrated compute method (backend value vs
+    # scipy reference), and the results are genuine backend arrays.
+    R = _asarray(backend_name, _RS)
+    z = _asarray(backend_name, _ZS)
+    for method in _METHODS:
+        ref = numpy.asarray(
+            getattr(pot, method)(numpy.asarray(_RS), numpy.asarray(_ZS))
+        )
+        got = as_numpy(getattr(pot, method)(R, z))
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-12, atol=1e-14, err_msg=f"{method} ({backend_name})"
+        )
+
+
+@pytest.mark.parametrize("pot", POTS, ids=POT_IDS)
+def test_public_force_parity_jax(pot):
+    # The public evaluate* entry points route the elliptic integrals to the jax
+    # AGM fallback; check them against scipy to <=1e-10 (the traced-safety gate).
+    if jax is None:  # pragma: no cover
+        pytest.skip("jax not installed")
+    R, z = numpy.asarray(_RS), numpy.asarray(_ZS)
+    ref = numpy.asarray(evaluateRforces(pot, R, z))
+    got = as_numpy(evaluateRforces(pot, jnp.asarray(R), jnp.asarray(z)))
+    assert numpy.max(numpy.abs(got - ref)) < 1e-10
+
+
+def test_jit_and_jacfwd_finite():
+    # A jax trace over the elliptic-integral force path compiles, and its forward
+    # jacobian d(Rforce)/dR is finite (no scipy call escapes into the trace).
+    if jax is None:  # pragma: no cover
+        pytest.skip("jax not installed")
+    pot = POTS[0]
+    R0, z0 = jnp.asarray(1.3), jnp.asarray(0.4)
+    val = jax.jit(lambda R, z: evaluateRforces(pot, R, z))(R0, z0)
+    assert numpy.isfinite(as_numpy(val))
+    jac = jax.jacfwd(lambda R: evaluateRforces(pot, R, z0))(R0)
+    assert numpy.isfinite(as_numpy(jac))
+
+
+@pytest.mark.parametrize("component", ["R", "z"])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_grad_evaluate_is_minus_force(backend_name, component):
+    # Exact analytic identity: AD(_evaluate) == -force, separately in R and z.
+    pot = POTS[0]
+    R0, z0 = 1.3, 0.4
+    if component == "R":
+        ref = -float(pot._Rforce(numpy.asarray(R0), numpy.asarray(z0)))
+        f = lambda R, z: pot._evaluate(R, z)  # noqa: E731
+        x0, other = R0, z0
+    else:
+        ref = -float(pot._zforce(numpy.asarray(R0), numpy.asarray(z0)))
+        f = lambda z, R: pot._evaluate(R, z)  # noqa: E731
+        x0, other = z0, R0
+    if backend_name == "jax":
+        ad = float(jax.grad(lambda x: f(x, jnp.asarray(other)))(jnp.asarray(x0)))
+    else:
+        xt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        f(xt, torch.tensor(other, dtype=torch.float64)).backward()
+        ad = float(xt.grad)
+    assert not numpy.isnan(ad)
+    numpy.testing.assert_allclose(ad, ref, rtol=1e-9)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rforce_grad_vs_fd(backend_name):
+    # d(Rforce)/dR via autodiff (through K(m), E(m)) vs central finite difference,
+    # at a few off-ring points.
+    pot = POTS[0]
+    eps = 1e-6
+    for R0, z0 in ((1.3, 0.4), (0.4, 0.2), (2.5, 1.0)):
+        fd = (
+            float(pot._Rforce(numpy.asarray(R0 + eps), numpy.asarray(z0)))
+            - float(pot._Rforce(numpy.asarray(R0 - eps), numpy.asarray(z0)))
+        ) / (2.0 * eps)
+        if backend_name == "jax":
+            ad = float(
+                jax.grad(lambda R: pot._Rforce(R, jnp.asarray(z0)))(jnp.asarray(R0))
+            )
+        else:
+            Rt = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+            pot._Rforce(Rt, torch.tensor(z0, dtype=torch.float64)).backward()
+            ad = float(Rt.grad)
+        assert not numpy.isnan(ad), f"NaN grad at R={R0} ({backend_name})"
+        numpy.testing.assert_allclose(
+            ad, fd, rtol=1e-5, err_msg=f"R={R0} ({backend_name})"
+        )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_param_grad_vs_fd(backend_name):
+    # d(Rforce)/d(ring radius a): the shape parameter flows through construction
+    # into the elliptic modulus m and stays differentiable vs central finite
+    # difference (the point of routing K/E through the backend special functions).
+    R0, z0, a0, eps = 1.3, 0.4, 0.75, 1e-6
+
+    def rf_b(a):
+        return evaluateRforces(
+            RingPotential(amp=1.3, a=a),
+            _asarray(backend_name, R0),
+            _asarray(backend_name, z0),
+        )
+
+    fd = (
+        float(evaluateRforces(RingPotential(amp=1.3, a=a0 + eps), R0, z0))
+        - float(evaluateRforces(RingPotential(amp=1.3, a=a0 - eps), R0, z0))
+    ) / (2.0 * eps)
+    if backend_name == "jax":
+        ad = float(jax.grad(rf_b)(jnp.asarray(a0)))
+    else:
+        pt = torch.tensor(a0, dtype=torch.float64, requires_grad=True)
+        rf_b(pt).backward()
+        ad = float(pt.grad)
+    assert not numpy.isnan(ad)
+    numpy.testing.assert_allclose(
+        ad, fd, rtol=1e-5, err_msg=f"d(Rforce)/da ({backend_name})"
+    )


### PR DESCRIPTION
## Summary

`RingPotential`'s potential, forces, and second derivatives are expressed through the complete elliptic integrals `K(m)` and `E(m)`, previously called directly on `scipy.special.ellipk`/`ellipe`. Those scipy calls break under a jax/torch trace — an **eager-only gap**: the potential could not be `jit`/`grad`-ed and returned non-backend arrays.

This routes the elliptic integrals through **`galpy.backend.special.ellipk`/`ellipe`** (native `scipy.special` on numpy, a pure-backend AGM fallback on jax/torch, both in scipy's parameter-`m = k^2` convention) and the surrounding `sqrt` through the data-resolved namespace (`get_namespace(R, z)`).

## numpy byte-identical

The backend `ellipk`/`ellipe` are **byte-identical to `scipy.special`** on numpy inputs (verified: max diff 0.0), so the numpy path stays a single path and is **bit-for-bit unchanged**. Verified by stash-compare of `_evaluate`/`_Rforce`/`_zforce`/`_R2deriv`/`_z2deriv`/`_Rzderiv` on an `(R, z)` grid including `z = 0` rows and the on-ring `m -> 1` singularity (18/18 arrays `array_equal`). Existing numpy `test_potential.py` RingPotential tests pass unchanged.

## Backend behavior

- Eager jax and torch return backend arrays matching scipy to ~1e-15.
- `jax.jit` and `jax.jacfwd` over `evaluateRforces` are finite.
- Differentiable: grad-vs-FD h-converges quadratically for `d(Rforce)/dR` and for `d(Rforce)/d(ring radius a)`; the `AD(_evaluate) == -force` identity holds in both `R` and `z` to ~1e-9.

## Tests

New `tests/test_backend_ring.py` (numpy/jax/torch): value parity, traced `jit`/`jacfwd`, `AD(_evaluate) == -force` in R and z, and grad-vs-FD for `d(Rforce)/dR` and `d(Rforce)/da`. Green under `-W error::DeprecationWarning -W error::FutureWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm