### PR TITLE
potentials: out-of-place _amp rescaling for torch/jax amp-gradients (numpy byte-identical)

### DIFF
--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -153,7 +153,7 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
             self._lnLambda = const_lnLambda
         else:
             self._lnLambda = False
-        self._amp *= 4.0 * numpy.pi
+        self._amp = self._amp * (4.0 * numpy.pi)
         self._force_hash = None
         self.hasC = _check_c(self._dens_pot, dens=True)
         # The rectangular force Jacobian (dF/dx, dF/dv) for the 3D variational
@@ -169,7 +169,7 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
 
     def GMs(self, gms):
         gms = conversion.parse_mass(gms, ro=self._ro, vo=self._vo)
-        self._amp *= gms / self._ms
+        self._amp = self._amp * (gms / self._ms)
         self._ms = gms
         # Reset the hash
         self._force_hash = None

--- a/galpy/potential/CosmphiDiskPotential.py
+++ b/galpy/potential/CosmphiDiskPotential.py
@@ -82,7 +82,7 @@ class CosmphiDiskPotential(planarPotential):
         sp = conversion.parse_energy(sp, vo=self._vo)
         # Back to old definition
         self._r1p = r1**p
-        self._amp /= self._r1p
+        self._amp = self._amp / (self._r1p)
         self.hasC = False
         self._m = int(m)  # make sure this is an int
         if cp is None or sp is None:

--- a/galpy/potential/EllipticalDiskPotential.py
+++ b/galpy/potential/EllipticalDiskPotential.py
@@ -79,7 +79,7 @@ class EllipticalDiskPotential(planarPotential):
         cp = conversion.parse_energy(cp, vo=self._vo)
         sp = conversion.parse_energy(sp, vo=self._vo)
         # Back to old definition
-        self._amp /= r1**p
+        self._amp = self._amp / (r1**p)
         self.hasC = True
         self._backend_compatible = True
         self.hasC_dxdv = True

--- a/galpy/potential/FlattenedPowerPotential.py
+++ b/galpy/potential/FlattenedPowerPotential.py
@@ -72,7 +72,7 @@ class FlattenedPowerPotential(Potential):
         self.q2 = q**2.0
         self.core2 = core**2.0
         # Back to old definition
-        self._amp *= r1**self.alpha
+        self._amp = self._amp * (r1**self.alpha)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/MN3ExponentialDiskPotential.py
+++ b/galpy/potential/MN3ExponentialDiskPotential.py
@@ -75,7 +75,7 @@ class MN3ExponentialDiskPotential(Potential):
         self._hz = hz
         self._scale = self._hr
         # Adjust amp for definition
-        self._amp *= 4.0 * numpy.pi * self._hr**2.0 * self._hz
+        self._amp = self._amp * (4.0 * numpy.pi * self._hr**2.0 * self._hz)
         # First determine b/rd
         if sech:
             self._brd = _b_sechhz(self._hz / self._hr)

--- a/galpy/potential/PerfectEllipsoidPotential.py
+++ b/galpy/potential/PerfectEllipsoidPotential.py
@@ -85,7 +85,7 @@ class PerfectEllipsoidPotential(EllipsoidalPotential):
         self.a2 = self.a**2
         self._scale = self.a
         # Adjust amp
-        self._amp *= self.a / (numpy.pi**2 * self._b * self._c)
+        self._amp = self._amp * (self.a / (numpy.pi**2 * self._b * self._c))
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -980,7 +980,7 @@ class Potential(Force):
         """
         # abs() (via __abs__) is backend-agnostic and byte-identical to the old
         # numpy.fabs on the numpy scalar Rforce returns.
-        self._amp *= norm / abs(self.Rforce(1.0, 0.0, use_physical=False))
+        self._amp = self._amp * (norm / abs(self.Rforce(1.0, 0.0, use_physical=False)))
 
     def toPlanar(self):
         """

--- a/galpy/potential/PowerSphericalPotential.py
+++ b/galpy/potential/PowerSphericalPotential.py
@@ -53,7 +53,9 @@ class PowerSphericalPotential(Potential):
         self.alpha = alpha
         # Back to old definition
         if self.alpha != 3.0:
-            self._amp *= r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
+            self._amp = self._amp * (
+                r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
+            )
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -58,7 +58,7 @@ class PowerSphericalPotentialwCutoff(Potential):
         rc = conversion.parse_length(rc, ro=self._ro)
         self.alpha = alpha
         # Back to old definition
-        self._amp *= r1**self.alpha
+        self._amp = self._amp * (r1**self.alpha)
         self.rc = rc
         self._scale = self.rc
         self._backend_compatible = True

--- a/galpy/potential/PowerTriaxialPotential.py
+++ b/galpy/potential/PowerTriaxialPotential.py
@@ -85,9 +85,11 @@ class PowerTriaxialPotential(EllipsoidalPotential):
         self.alpha = alpha
         # Back to old definition
         if self.alpha != 3.0:
-            self._amp *= r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
+            self._amp = self._amp * (
+                r1 ** (self.alpha - 3.0) * 4.0 * numpy.pi / (3.0 - self.alpha)
+            )
         # Multiply in constants
-        self._amp *= (3.0 - self.alpha) / 4.0 / numpy.pi
+        self._amp = self._amp * ((3.0 - self.alpha) / 4.0 / numpy.pi)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/RingPotential.py
+++ b/galpy/potential/RingPotential.py
@@ -43,7 +43,7 @@ class RingPotential(Potential):
         a = conversion.parse_length(a, ro=self._ro)
         self.a = a
         self.a2 = self.a**2
-        self._amp /= 2.0 * numpy.pi * self.a
+        self._amp = self._amp / (2.0 * numpy.pi * self.a)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/TriaxialGaussianPotential.py
+++ b/galpy/potential/TriaxialGaussianPotential.py
@@ -86,7 +86,9 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
         self._twosigma2 = 2.0 * self._sigma**2
         self._scale = self._sigma
         # Adjust amp
-        self._amp /= (2.0 * numpy.pi) ** 1.5 * self._sigma**3.0 * self._b * self._c
+        self._amp = self._amp / (
+            (2.0 * numpy.pi) ** 1.5 * self._sigma**3.0 * self._b * self._c
+        )
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -121,7 +121,7 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
                 / special.gamma(self.betaminusalpha)
             )
         # Adjust amp
-        self._amp /= 4.0 * numpy.pi * self.a**3
+        self._amp = self._amp / (4.0 * numpy.pi * self.a**3)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
@@ -276,7 +276,7 @@ class TriaxialHernquistPotential(EllipsoidalPotential):
         self._scale = self.a
         # Adjust amp
         self.a4 = self.a**4
-        self._amp /= 4.0 * numpy.pi * self.a**3
+        self._amp = self._amp / (4.0 * numpy.pi * self.a**3)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
@@ -396,7 +396,7 @@ class TriaxialJaffePotential(EllipsoidalPotential):
         self._scale = self.a
         # Adjust amp
         self.a2 = self.a**2
-        self._amp /= 4.0 * numpy.pi * self.a2 * self.a
+        self._amp = self._amp / (4.0 * numpy.pi * self.a2 * self.a)
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
@@ -555,7 +555,7 @@ class TriaxialNFWPotential(EllipsoidalPotential):
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         # Adjust amp
         self.a3 = self.a**3
-        self._amp /= 4.0 * numpy.pi * self.a3
+        self._amp = self._amp / (4.0 * numpy.pi * self.a3)
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):

--- a/tests/test_backend_amp_grad.py
+++ b/tests/test_backend_amp_grad.py
@@ -1,0 +1,219 @@
+###############################################################################
+# test_backend_amp_grad.py: autodiff w.r.t. the potential amplitude (d/damp)
+# for potentials whose __init__ rescales self._amp.
+#
+# Many potentials adjust their amplitude in __init__ (e.g. self._amp /= 4 pi a^3)
+# to convert a density normalization into the internal amplitude. When that
+# rescaling is done *in place* (self._amp /= X), building the potential with a
+# torch leaf tensor amp (requires_grad=True) raises
+#     RuntimeError: a leaf Variable that requires grad is being used in an
+#                   in-place operation
+# and blocks amp-gradients entirely. Rewriting each rescaling out of place
+# (self._amp = self._amp / (X), parentheses preserving the exact numpy value)
+# unblocks jax/torch amp-gradients while staying byte-identical on numpy.
+#
+# The amplitude enters every force/potential as the outer factor
+# (self._amp * self._Rforce(...)), so the amp-gradient equals the amp-free base
+# force -- exactly reproduced by a finite difference. We assert AD == central FD
+# (Richardson-extrapolated reference) for both jax and torch, plus a
+# finite-difference-independent jax-vs-torch agreement check.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.potential import (
+    CosmphiDiskPotential,
+    EllipticalDiskPotential,
+    FlattenedPowerPotential,
+    MN3ExponentialDiskPotential,
+    PerfectEllipsoidPotential,
+    PowerSphericalPotential,
+    PowerSphericalPotentialwCutoff,
+    PowerTriaxialPotential,
+    TriaxialGaussianPotential,
+    TriaxialHernquistPotential,
+    TriaxialJaffePotential,
+    TriaxialNFWPotential,
+    TwoPowerTriaxialPotential,
+)
+
+# This module manages backends explicitly, so it is exempt from the global
+# --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# Evaluation point: (R, z) for 3D potentials, (R, phi) for planar potentials.
+_R0, _Z0, _PHI0 = 1.3, 0.4, 0.7
+
+
+def _rforce_3d(pot):
+    return pot.Rforce(_R0, _Z0, use_physical=False)
+
+
+def _rforce_planar(pot):
+    return pot.Rforce(_R0, phi=_PHI0, use_physical=False)
+
+
+# (id, builder(amp) -> potential, force(pot) -> scalar, amp0). Each fixed file
+# is represented; the four TwoPowerTriaxial-family rescalings (base class + the
+# NFW/Hernquist/Jaffe subclasses) are covered by distinct entries. Ring and the
+# Chandrasekhar dynamical-friction forces are intentionally excluded: their
+# force evaluation is eager-only (a separate backend gap), so their amp-gradient
+# is not yet meaningful here.
+SPECS = [
+    (
+        "TriaxialGaussian",
+        lambda a: TriaxialGaussianPotential(amp=a, sigma=0.9, b=0.8, c=0.7),
+        _rforce_3d,
+        1.1,
+    ),
+    (
+        "MN3ExponentialDisk-sech",
+        lambda a: MN3ExponentialDiskPotential(amp=a, hr=1.0, hz=0.3, sech=True),
+        _rforce_3d,
+        1.2,
+    ),
+    (
+        "MN3ExponentialDisk-exp",
+        lambda a: MN3ExponentialDiskPotential(amp=a, hr=1.0, hz=0.3, sech=False),
+        _rforce_3d,
+        1.2,
+    ),
+    (
+        "FlattenedPower",
+        lambda a: FlattenedPowerPotential(amp=a, alpha=0.6, q=0.9, r1=1.2),
+        _rforce_3d,
+        1.3,
+    ),
+    (
+        "PowerSpherical",
+        lambda a: PowerSphericalPotential(amp=a, alpha=1.5, r1=1.1),
+        _rforce_3d,
+        1.4,
+    ),
+    (
+        "PowerSphericalwCutoff",
+        lambda a: PowerSphericalPotentialwCutoff(amp=a, alpha=1.3, rc=1.4, r1=1.2),
+        _rforce_3d,
+        1.5,
+    ),
+    (
+        "PowerTriaxial",
+        lambda a: PowerTriaxialPotential(amp=a, alpha=1.7, r1=1.1, b=0.85, c=0.7),
+        _rforce_3d,
+        1.6,
+    ),
+    (
+        "PerfectEllipsoid",
+        lambda a: PerfectEllipsoidPotential(amp=a, a=1.3, b=0.9, c=0.75),
+        _rforce_3d,
+        1.7,
+    ),
+    (
+        "TwoPowerTriaxial",
+        lambda a: TwoPowerTriaxialPotential(
+            amp=a, a=1.2, alpha=1.5, beta=3.5, b=0.9, c=0.7
+        ),
+        _rforce_3d,
+        1.8,
+    ),
+    (
+        "TriaxialNFW",
+        lambda a: TriaxialNFWPotential(amp=a, a=1.2, b=0.9, c=0.7),
+        _rforce_3d,
+        1.9,
+    ),
+    (
+        "TriaxialHernquist",
+        lambda a: TriaxialHernquistPotential(amp=a, a=1.1, b=0.85, c=0.65),
+        _rforce_3d,
+        2.0,
+    ),
+    (
+        "TriaxialJaffe",
+        lambda a: TriaxialJaffePotential(amp=a, a=1.05, b=0.8, c=0.6),
+        _rforce_3d,
+        2.1,
+    ),
+    (
+        "CosmphiDisk",
+        lambda a: CosmphiDiskPotential(amp=a, m=2, p=1.0, phib=0.3, r1=1.2),
+        _rforce_planar,
+        1.1,
+    ),
+    (
+        "EllipticalDisk",
+        lambda a: EllipticalDiskPotential(amp=a, p=1.0, twophio=0.02, phib=0.4, r1=1.1),
+        _rforce_planar,
+        1.2,
+    ),
+]
+SPEC_IDS = [s[0] for s in SPECS]
+
+_EPS = 1e-4
+
+
+def _fd_reference(builder, force, amp0):
+    # Richardson-extrapolated central finite difference (O(eps^4)) on numpy.
+    def fnp(a):
+        return float(force(builder(a)))
+
+    d1 = (fnp(amp0 + _EPS) - fnp(amp0 - _EPS)) / (2 * _EPS)
+    d2 = (fnp(amp0 + _EPS / 2) - fnp(amp0 - _EPS / 2)) / _EPS
+    return (4 * d2 - d1) / 3
+
+
+def _ad_grad(backend_name, builder, force, amp0):
+    if backend_name == "jax":
+        return float(jax.grad(lambda a: force(builder(a)))(jnp.asarray(amp0)))
+    at = torch.tensor(amp0, requires_grad=True)
+    force(builder(at)).backward()
+    return float(at.grad)
+
+
+@pytest.mark.parametrize("spec", SPECS, ids=SPEC_IDS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_amp_grad_vs_finite_difference(backend_name, spec):
+    _, builder, force, amp0 = spec
+    fd = _fd_reference(builder, force, amp0)
+    ad = _ad_grad(backend_name, builder, force, amp0)
+    # AD is exact; the limiting error is the finite-difference reference. The
+    # gradient magnitudes here are all >~5e-3, so rtol dominates; rtol=1e-8
+    # keeps a wide margin over the observed ~1e-12 relative agreement while
+    # staying robust to cross-platform float rounding.
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-8, atol=1e-11)
+
+
+@pytest.mark.skipif(
+    "jax" not in BACKENDS or "torch" not in BACKENDS,
+    reason="needs both jax and torch",
+)
+@pytest.mark.parametrize("spec", SPECS, ids=SPEC_IDS)
+def test_amp_grad_jax_vs_torch(spec):
+    # Finite-difference-independent: both backends compute the exact derivative
+    # by autodiff, so they must agree to ~machine precision.
+    _, builder, force, amp0 = spec
+    g_jax = _ad_grad("jax", builder, force, amp0)
+    g_torch = _ad_grad("torch", builder, force, amp0)
+    numpy.testing.assert_allclose(g_jax, g_torch, rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
## Problem: in-place `_amp` rescaling blocks amp-gradients

Many potentials rescale `self._amp` in `__init__` to convert a density
normalization into the internal amplitude (e.g. `self._amp /= 4 pi a^3`), and the
base `Potential.normalize` rescales it too. When this is done **in place**
(`self._amp /= X` / `self._amp *= X`) and the potential is built with a torch leaf
tensor amplitude (`amp=torch.tensor(..., requires_grad=True)`), it raises:

```
RuntimeError: a leaf Variable that requires grad is being used in an in-place operation
```

which blocks gradients w.r.t. `amp` entirely (the same in-place mutation is also
hostile to jax's functional model).

## Fix: paren-preserving out-of-place rescaling

Every rescaling is rewritten out of place with the **entire RHS wrapped in
parentheses**:

```
self._amp /= EXPR   ->   self._amp = self._amp / (EXPR)
self._amp *= EXPR   ->   self._amp = self._amp * (EXPR)
```

The parentheses are mandatory for byte-identity: floating-point `*` and `/` are not
associative, so `self._amp = self._amp / a * b` (no parens) regroups as
`(self._amp / a) * b` and differs bit-for-bit from the original `self._amp / (a*b)`.
Wrapping the whole RHS reproduces the exact original value.

**18 rescalings across 13 files**: CosmphiDisk, TriaxialGaussian, MN3ExponentialDisk,
FlattenedPower, PowerSpherical, EllipticalDisk, PowerSphericalwCutoff, PowerTriaxial
(x2), PerfectEllipsoid, the TwoPowerTriaxial family (TwoPowerTriaxial /
TriaxialNFW / TriaxialHernquist / TriaxialJaffe, x4), ChandrasekharDynamicalFrictionForce
(x2, incl. the `GMs=` setter), RingPotential, and `Potential.normalize`.
`SnapshotRZPotential` is intentionally left untouched (out of scope, pynbody).

## numpy is byte-identical

For 19 representative potentials, `_evaluate` / `Rforce` / `zforce` / `R2deriv`
(and planar `phitorque`) on an (R,z)/(R,phi) grid are `numpy.array_equal`
bit-for-bit before vs after the change (captured via git-stash of the working tree).
The targeted numpy suite (`-k "normalize or MN3 or PowerSpherical or
TwoPowerTriaxial or PerfectEllipsoid or Ferrers or Ring or forceAsDeriv"`,
`forceAsDeriv` running across **all** potentials) passes: 350 passed, 22 skipped.

## torch + jax amp-gradients now verified (== finite difference)

Without the fix, building any of these with `requires_grad=True` amp raises the
in-place-leaf error (confirmed by stash+rerun). With it, `.backward()` / `jax.grad`
w.r.t. `amp` flow and match a Richardson-extrapolated central finite difference of
the force to ~1e-12 for: TriaxialGaussian, MN3ExponentialDisk (sech & exp),
FlattenedPower, PowerSpherical, PowerSphericalwCutoff, PowerTriaxial,
PerfectEllipsoid, TwoPowerTriaxial, TriaxialNFW, TriaxialHernquist, TriaxialJaffe,
CosmphiDisk, EllipticalDisk. jax and torch also agree with each other to
~machine precision.

New `tests/test_backend_amp_grad.py` parametrizes AD-vs-FD (and jax-vs-torch) over
this set (grad-vs-FD reference match, not finite-and-nonzero); it self-skips
backends that are not installed and passes under `-W error::DeprecationWarning
-W error::FutureWarning`. Ring and the two dynamical-friction forces are excluded
from the grad test because their force evaluation is eager-only (a separate backend
gap); their `_amp` rescaling is still fixed and byte-identity-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm