### PR TITLE
AnyAxisymmetricRazorThinDiskPotential: jit/grad-safe backend internals (numpy byte-identical)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -6,12 +6,32 @@
 import numpy
 from scipy import integrate, special
 
+from ..backend import (
+    asarray_on_device,
+    device_of,
+    get_namespace,
+    is_backend_array,
+    match_input_dtype,
+)
+from ..backend import quadrature as _bquad
+from ..backend import special as _bspecial
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .Potential import Potential, check_potential_inputs_not_arrays
 
 if _APY_LOADED:
     from astropy import units
+
+# Gauss-Legendre nodes per panel on the differentiable backend path (the numpy
+# path keeps scipy's adaptive quad and is byte-identical). The a=R (m->1)
+# singularity is handled by a symmetric plain-GL split at R (0, R, 2R, inf); the
+# principal-value cancellation degrades if nodes cluster too close to R, so a
+# moderate order is deliberate.
+_GLORDER = 100
+# m = 4aR/((a+R)^2+z^2) <= 1 analytically (equality at a=R), but rounding can tip
+# it just above 1 near a=R -> sqrt(1-m) of a negative -> NaN in the AGM elliptic
+# fallback. Clamp strictly below 1 (only fires on the rounding artifact).
+_ELLIP_M_CAP = 1.0 - 1e-15
 
 
 class AnyAxisymmetricRazorThinDiskPotential(Potential):
@@ -47,6 +67,9 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
 
         """
         Potential.__init__(self, amp=amp, ro=ro, vo=vo)
+        # jax/torch-traceable forces (differentiable) via backend Gauss-Legendre
+        # quadrature; the numpy path stays scipy-adaptive and byte-identical.
+        self._backend_compatible = True
         # Parse surface density: does it have units? does it expect them?
         if _APY_LOADED:
             _sdens_unit_input = False
@@ -95,8 +118,67 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         ):  # pragma: no cover
             self.normalize(normalize)
 
+    # -----------------------------------------------------------------------
+    # Backend (jax/torch) helpers
+    #
+    # A backend-array input routes here. When a gradient is actually being taken
+    # -- a jax/functorch tracer, or a grad-tracking torch tensor -- the compute
+    # is in-backend fixed-order Gauss-Legendre so it differentiates. A PLAIN
+    # concrete backend scalar instead reuses scipy's accurate adaptive quad
+    # (byte-consistent with the numpy path; GL cannot resolve the a=R principal
+    # value / small-z sheet structure that the derivative tests FD-probe at
+    # z~1e-8, and cannot form the z=0 Hadamard-type second-derivative), and the
+    # scipy value is wrapped as a backend array so no downstream ``xp.`` op meets
+    # a bare python float.
+    # -----------------------------------------------------------------------
+    def _bk_split_quad(self, integrand, R, xp, dev):
+        # int_0^inf integrand(a) da as [0, R] + [R, 2R] + [2R, inf); the
+        # symmetric plain-GL split at R handles the a=R (m->1) singularity.
+        zero = xp.zeros_like(R)
+        two_R = 2.0 * R
+        return (
+            _bquad.fixed_quad(xp, integrand, zero, R, n=_GLORDER, device=dev)
+            + _bquad.fixed_quad(xp, integrand, R, two_R, n=_GLORDER, device=dev)
+            + _bquad.fixed_quad_semiinfinite(
+                xp, integrand, two_R, n=_GLORDER, device=dev
+            )
+        )
+
+    @staticmethod
+    def _bk_m_aRz(a, R, z2, xp):
+        aRz = (a + R) ** 2.0 + z2
+        m = xp.minimum(4.0 * a * R / aRz, _ELLIP_M_CAP * xp.ones_like(aRz))
+        return m, aRz
+
+    def _bk_dispatch(self, numpy_fn, gl_fn, R, z):
+        xp = get_namespace(R, z)
+        dev = device_of(R, z)
+        if not (
+            getattr(R, "requires_grad", False) or getattr(z, "requires_grad", False)
+        ):
+            try:  # plain concrete backend input: reuse scipy's accurate value
+                Rf, zf = float(R), float(z)
+            except Exception:  # tracer: in-backend differentiable GL
+                pass
+            else:
+                # numpy.asarray keeps scipy's float64 value at full precision
+                # (asarray_on_device of a bare python float would drop to torch's
+                # float32 default, and match_input_dtype's later up-cast cannot
+                # recover the lost digits -> a derivative test's dr=1e-8 FD blows
+                # up); match_input_dtype then honours the input's own dtype.
+                return match_input_dtype(
+                    asarray_on_device(xp, numpy.asarray(numpy_fn(Rf, zf)), dev), R, z
+                )
+        return match_input_dtype(gl_fn(R, z, xp, dev), R, z)  # differentiate: GL
+
+    # ------------------------------ potential ------------------------------
     @check_potential_inputs_not_arrays
     def _evaluate(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._evaluate_numpy, self._evaluate_gl, R, z)
+        return self._evaluate_numpy(R, z)
+
+    def _evaluate_numpy(self, R, z):
         if R == 0 and z == 0:
             return self._pot_zero
         elif numpy.isinf(R**2 + z**2):
@@ -112,8 +194,24 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             + integrate.quad(potint, 2 * R, numpy.inf)[0]
         )
 
+    def _evaluate_gl(self, R, z, xp, dev):
+        z2 = z**2
+        sdens = self._sdens
+
+        def potint(a):
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return a * sdens(a) / xp.sqrt(aRz) * _bspecial.ellipk(m)
+
+        return -4.0 * self._bk_split_quad(potint, R, xp, dev)
+
+    # ------------------------------- Rforce --------------------------------
     @check_potential_inputs_not_arrays
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._Rforce_numpy, self._Rforce_gl, R, z)
+        return self._Rforce_numpy(R, z)
+
+    def _Rforce_numpy(self, R, z):
         R2 = R**2
         z2 = z**2
 
@@ -138,8 +236,36 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             + integrate.quad(rforceint, 2 * R, numpy.inf)[0]
         )
 
+    def _Rforce_gl(self, R, z, xp, dev):
+        R2 = R**2
+        z2 = z**2
+        sdens = self._sdens
+
+        def rforceint(a):
+            a2 = a**2
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return (
+                a
+                * sdens(a)
+                * (
+                    (a2 - R2 + z2) * _bspecial.ellipe(m)
+                    - ((a - R) ** 2 + z2) * _bspecial.ellipk(m)
+                )
+                / R
+                / ((a - R) ** 2 + z2)
+                / xp.sqrt(aRz)
+            )
+
+        return 2.0 * self._bk_split_quad(rforceint, R, xp, dev)
+
+    # ------------------------------- zforce --------------------------------
     @check_potential_inputs_not_arrays
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._zforce_numpy, self._zforce_gl, R, z)
+        return self._zforce_numpy(R, z)
+
+    def _zforce_numpy(self, R, z):
         if z == 0:
             return 0.0
         z2 = z**2
@@ -164,8 +290,30 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             )
         )
 
+    def _zforce_gl(self, R, z, xp, dev):
+        # z==0 is the disk plane (zforce=0 by symmetry) but the integrand has a
+        # non-integrable 1/(a-R)^2 pole there; guard the dead branch with z_safe.
+        z_safe = xp.where(z == 0, xp.ones_like(z), z)
+        z2 = z_safe**2
+        sdens = self._sdens
+
+        def zforceint(a):
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return (
+                a * sdens(a) * _bspecial.ellipe(m) / ((a - R) ** 2 + z2) / xp.sqrt(aRz)
+            )
+
+        integral = self._bk_split_quad(zforceint, R, xp, dev)
+        return xp.where(z == 0, xp.zeros_like(z), -4.0 * z * integral)
+
+    # ------------------------------ R2deriv --------------------------------
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._R2deriv_numpy, self._R2deriv_gl, R, z)
+        return self._R2deriv_numpy(R, z)
+
+    def _R2deriv_numpy(self, R, z):
         R2 = R**2
         z2 = z**2
 
@@ -198,8 +346,44 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             + integrate.quad(r2derivint, 2 * R, numpy.inf)[0]
         )
 
+    def _R2deriv_gl(self, R, z, xp, dev):
+        R2 = R**2
+        z2 = z**2
+        sdens = self._sdens
+
+        def r2derivint(a):
+            a2 = a**2
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return (
+                a
+                * sdens(a)
+                * (
+                    -(
+                        (
+                            (a2 - 3.0 * R2) * (a2 - R2) ** 2
+                            + (3.0 * a2**2 + 2.0 * a2 * R2 + 3.0 * R2**2) * z2
+                            + (3.0 * a2 + 7.0 * R2) * z**4
+                            + z**6
+                        )
+                        * _bspecial.ellipe(m)
+                    )
+                    + ((a - R) ** 2 + z2)
+                    * ((a2 - R2) ** 2 + 2.0 * (a2 + 2.0 * R2) * z2 + z**4)
+                    * _bspecial.ellipk(m)
+                )
+                / (2.0 * R2 * ((a - R) ** 2 + z2) ** 2 * aRz**1.5)
+            )
+
+        return -4.0 * self._bk_split_quad(r2derivint, R, xp, dev)
+
+    # ------------------------------ z2deriv --------------------------------
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._z2deriv_numpy, self._z2deriv_gl, R, z)
+        return self._z2deriv_numpy(R, z)
+
+    def _z2deriv_numpy(self, R, z):
         R2 = R**2
         z2 = z**2
 
@@ -225,8 +409,37 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             + integrate.quad(z2derivint, 2 * R, numpy.inf)[0]
         )
 
+    def _z2deriv_gl(self, R, z, xp, dev):
+        R2 = R**2
+        z2 = z**2
+        sdens = self._sdens
+
+        def z2derivint(a):
+            a2 = a**2
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return (
+                a
+                * sdens(a)
+                * (
+                    -(
+                        ((a2 - R2) ** 2 - 2.0 * (a2 + R2) * z2 - 3.0 * z**4)
+                        * _bspecial.ellipe(m)
+                    )
+                    - z2 * ((a - R) ** 2 + z2) * _bspecial.ellipk(m)
+                )
+                / (((a - R) ** 2 + z2) ** 2 * aRz**1.5)
+            )
+
+        return -4.0 * self._bk_split_quad(z2derivint, R, xp, dev)
+
+    # ------------------------------ Rzderiv --------------------------------
     @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        if is_backend_array(R) or is_backend_array(z):
+            return self._bk_dispatch(self._Rzderiv_numpy, self._Rzderiv_gl, R, z)
+        return self._Rzderiv_numpy(R, z)
+
+    def _Rzderiv_numpy(self, R, z):
         R2 = R**2
         z2 = z**2
 
@@ -265,6 +478,40 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 + integrate.quad(rzderivint, 2 * R, numpy.inf)[0]
             )
         )
+
+    def _Rzderiv_gl(self, R, z, xp, dev):
+        R2 = R**2
+        # z==0 -> Rzderiv=0 by symmetry; guard the 1/(a-R)^2 pole with z_safe.
+        z_safe = xp.where(z == 0, xp.ones_like(z), z)
+        z2 = z_safe**2
+        sdens = self._sdens
+
+        def rzderivint(a):
+            a2 = a**2
+            m, aRz = self._bk_m_aRz(a, R, z2, xp)
+            return (
+                a
+                * sdens(a)
+                * (
+                    -(
+                        (
+                            a**4
+                            - 7.0 * R**4
+                            - 6.0 * R2 * z2
+                            + z2**2
+                            + 2.0 * a2 * (3.0 * R2 + z2)
+                        )
+                        * _bspecial.ellipe(m)
+                    )
+                    + ((a - R) ** 2 + z2) * (a2 - R2 + z2) * _bspecial.ellipk(m)
+                )
+                / R
+                / ((a - R) ** 2 + z2) ** 2
+                / aRz**1.5
+            )
+
+        integral = self._bk_split_quad(rzderivint, R, xp, dev)
+        return xp.where(z == 0, xp.zeros_like(z), -2.0 * z * integral)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         return self._sdens(R)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -813,7 +813,6 @@ torch tests/test_potential.py::test_mass_spher_analytic
 torch tests/test_potential.py::test_mass_spher_z
 torch tests/test_potential.py::test_McMillan17
 torch tests/test_potential.py::test_MWPotential2014
-torch tests/test_potential.py::test_normalize_potential[AnyAxisymmetricRazorThinDiskPotential]
 torch tests/test_potential.py::test_normalize_potential[AnySphericalPotential]
 torch tests/test_potential.py::test_OblateStaeckelWrapperPotential_againstKuzmin
 torch tests/test_potential.py::test_poisson_potential[AnySphericalPotential]

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -1,0 +1,184 @@
+###############################################################################
+# test_backend_anyaxisymdisk.py: multi-backend tests for
+# AnyAxisymmetricRazorThinDiskPotential.
+#
+# This potential integrates an arbitrary surface density Sigma(R) against the
+# razor-thin-disk Green's function (complete elliptic integrals K/E). The numpy
+# path keeps scipy's adaptive quad + scipy.special.ellipk/ellipe and is
+# byte-identical; a jax/torch input routes to the backend split Gauss-Legendre
+# quadrature (galpy.backend.quadrature) with the backend elliptic fallback
+# (galpy.backend.special.ellipk/ellipe), so the FORCES are jit/grad-safe.
+#
+# The eager-only gap this closes: before migration the forces returned a bare
+# python float under a forced backend, so downstream ``xp.sqrt`` (e.g. vcirc)
+# crashed ("sqrt(): argument must be Tensor, not float") and jax.jacfwd could
+# not trace them.
+#
+# Design note: a PLAIN concrete backend scalar reuses scipy's accurate value
+# (wrapped as a backend array); native GL runs only when a gradient is actually
+# taken (a tracer, or a grad-tracking torch tensor). GL cannot resolve the
+# small-z sheet structure the derivative FD-probes hit, so the concrete path
+# stays scipy-accurate while the differentiable path stays native.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import get_namespace, is_backend_array
+from galpy.potential import (
+    AnyAxisymmetricRazorThinDiskPotential,
+    evaluateRforces,
+    evaluatezforces,
+)
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture. The -W error marks are the
+# coverage-shard trap guard: a numpy.<ufunc> on a torch tensor emits a
+# DeprecationWarning, so the namespace-agnostic surface density below must never
+# fall back to bare numpy on the backend path.
+pytestmark = [
+    pytest.mark.backend_managed,
+    pytest.mark.filterwarnings("error::DeprecationWarning"),
+    pytest.mark.filterwarnings("error::FutureWarning"),
+]
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+
+def _surfdens(R):
+    # namespace-agnostic (numpy / jax / torch): differentiable on every backend
+    return 1.5 * get_namespace(R).exp(-3.0 * R)
+
+
+# One instance, shared: __init__ integrates surfdens once (scipy) for _pot_zero.
+_POT = AnyAxisymmetricRazorThinDiskPotential(surfdens=_surfdens)
+
+# Physical (R, z) grid with z != 0 for the differentiable checks; z == 0 is
+# covered by the value-parity / scalar tests (its force is exact by symmetry).
+_RS = [0.5, 0.9, 1.3, 2.1]
+_ZS = [0.15, 0.3, 0.25, 0.4]
+
+
+def _scalar(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.float64(x)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_eager_force_returns_backend_array_matching_numpy(backend_name):
+    # Eager backend force is a backend array (the eager-only-gap fix) whose value
+    # matches the numpy/scipy reference, INCLUDING the z == 0 plane (the vcirc /
+    # normalize crash site).
+    for R in _RS + [1.0]:
+        for z in _ZS + [0.0]:
+            refR = float(evaluateRforces(_POT, numpy.float64(R), numpy.float64(z)))
+            refz = float(evaluatezforces(_POT, numpy.float64(R), numpy.float64(z)))
+            Rb, zb = _scalar(backend_name, R), _scalar(backend_name, z)
+            gotR = evaluateRforces(_POT, Rb, zb)
+            gotz = evaluatezforces(_POT, Rb, zb)
+            assert is_backend_array(gotR) and is_backend_array(gotz)
+            numpy.testing.assert_allclose(float(gotR), refR, rtol=1e-10, atol=1e-12)
+            numpy.testing.assert_allclose(float(gotz), refz, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_jax_traced_force_finite():
+    # The exact failure that defined this gap: jax.jacfwd / jax.jit over the
+    # forces must trace and return finite (they previously returned a bare float).
+    R0, z0 = jnp.asarray(1.2), jnp.asarray(0.3)
+    rf = lambda R: evaluateRforces(_POT, R, z0)
+    zf = lambda z: evaluatezforces(_POT, R0, z)
+    gR = jax.jacfwd(rf)(R0)
+    jR = jax.jit(rf)(R0)
+    gz = jax.jacfwd(zf)(z0)
+    assert jnp.isfinite(gR) and jnp.isfinite(jR) and jnp.isfinite(gz)
+    # jit value matches the eager scipy reference (z>0 -> GL is machine-accurate)
+    numpy.testing.assert_allclose(
+        float(jR), float(evaluateRforces(_POT, numpy.float64(1.2), numpy.float64(0.3)))
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rforce_grad_vs_fd(backend_name):
+    # d(Rforce)/dR via autodiff vs central finite differences, h-converging (not a
+    # finite-and-nonzero check), at physical z > 0.
+    for R0, z0 in zip(_RS, _ZS):
+        znum = numpy.float64(z0)
+
+        def fd(h):
+            fp = float(evaluateRforces(_POT, numpy.float64(R0 + h), znum))
+            fm = float(evaluateRforces(_POT, numpy.float64(R0 - h), znum))
+            return (fp - fm) / (2.0 * h)
+
+        if backend_name == "jax":
+            ad = float(
+                jax.grad(lambda R: evaluateRforces(_POT, R, jnp.asarray(z0)))(
+                    jnp.asarray(R0)
+                )
+            )
+        else:
+            Rt = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+            evaluateRforces(_POT, Rt, torch.tensor(z0, dtype=torch.float64)).backward()
+            ad = float(Rt.grad)
+        # central FD converges O(h^2); the two finest h bracket the AD tightly
+        rels = [abs((ad - fd(h)) / ad) for h in (1e-4, 1e-5)]
+        assert min(rels) < 1e-7, f"R={R0} z={z0} ({backend_name}): rels={rels}"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_zforce_grad_vs_fd(backend_name):
+    # d(zforce)/dz via autodiff vs central FD, h-converging, at physical z > 0.
+    for R0, z0 in zip(_RS, _ZS):
+        Rnum = numpy.float64(R0)
+
+        def fd(h):
+            fp = float(evaluatezforces(_POT, Rnum, numpy.float64(z0 + h)))
+            fm = float(evaluatezforces(_POT, Rnum, numpy.float64(z0 - h)))
+            return (fp - fm) / (2.0 * h)
+
+        if backend_name == "jax":
+            ad = float(
+                jax.grad(lambda z: evaluatezforces(_POT, jnp.asarray(R0), z))(
+                    jnp.asarray(z0)
+                )
+            )
+        else:
+            zt = torch.tensor(z0, dtype=torch.float64, requires_grad=True)
+            evaluatezforces(_POT, torch.tensor(R0, dtype=torch.float64), zt).backward()
+            ad = float(zt.grad)
+        rels = [abs((ad - fd(h)) / ad) for h in (1e-4, 1e-5)]
+        assert min(rels) < 1e-6, f"R={R0} z={z0} ({backend_name}): rels={rels}"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_vcirc_no_longer_crashes(backend_name):
+    # Regression for the reported eager crash: vcirc = xp.sqrt(R * -Rforce) fed a
+    # bare python float under a forced backend. With the migrated (backend-array)
+    # force it evaluates and matches the numpy value.
+    pot = AnyAxisymmetricRazorThinDiskPotential(surfdens=_surfdens)
+    pot.normalize(1.0)
+    ref = float(pot.vcirc(1.3, use_physical=False))
+    got = float(pot.vcirc(_scalar(backend_name, 1.3), use_physical=False))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10)

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -135,10 +135,10 @@ _MIGRATED_SAMPLE = [
     "KuzminKutuzovStaeckelPotential",
     "PseudoIsothermalPotential",
     "RazorThinExponentialDiskPotential",
+    "AnyAxisymmetricRazorThinDiskPotential",
 ]
 _UNMIGRATED_SAMPLE = [
     "AnySphericalPotential",
-    "AnyAxisymmetricRazorThinDiskPotential",
 ]
 
 
@@ -223,16 +223,26 @@ def test_coerce_coords_branches(backend):
 def test_scalar_only_gate_spares_unmigrated_potential(backend):
     # The check_potential_inputs_not_arrays decorator coerces R, z, phi onto the
     # active backend ONLY for _backend_compatible potentials. An UNMIGRATED
-    # scalar-only potential (AnyAxisymmetricRazorThinDiskPotential: bare
-    # scipy.integrate.quad / numpy internals) must keep its plain python-float
-    # inputs even under a forced backend, or those internals crash ("'<' not
-    # supported between numpy.ndarray and Tensor"). Regression guard for the
-    # decorator's _backend_compatible gate.
+    # scalar-only potential must keep its plain python-float inputs even under a
+    # forced backend, or its bare scipy.integrate.quad / numpy internals crash
+    # ("sqrt(): argument must be Tensor, not float" / "'<' not supported between
+    # numpy.ndarray and Tensor"). Regression guard for the decorator's
+    # _backend_compatible gate. AnyAxisymmetricRazorThinDiskPotential is now
+    # migrated (its force is backend-native), so use a forced-flag synthetic that
+    # pins _backend_compatible=False and keeps the scipy scalar path (mirrors the
+    # negative-example-fragility pattern in the auto-memory).
     import galpy.backend
 
-    pot = potential.AnyAxisymmetricRazorThinDiskPotential(normalize=1.0)
+    class _UnmigratedDisk(potential.AnyAxisymmetricRazorThinDiskPotential):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self._backend_compatible = False  # pin: decorator must NOT coerce
+
+    pot = _UnmigratedDisk(normalize=1.0)
     assert potential._check_backend_compatible(pot) is False
     ref = float(pot._evaluate(0.9, 0.1, 0.0, 0.0))
     with galpy.backend.use(backend, force=True):
+        # flag False -> R, z stay python floats -> is_backend_array False ->
+        # the scipy scalar path runs and returns a plain float, no crash.
         got = float(pot._evaluate(0.9, 0.1, 0.0, 0.0))
     numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=0.0)


### PR DESCRIPTION
## What

Makes `AnyAxisymmetricRazorThinDiskPotential`'s forces jit/grad-safe under jax/torch while keeping the numpy path **byte-identical**.

## The eager-only gap

This potential integrates an arbitrary surface density Σ(R) against the razor-thin-disk Green's function (complete elliptic integrals K/E) with `scipy.integrate.quad` + `scipy.special`. Under a forced/eager backend the compute methods returned a **bare python float**, so:

- `jax.jacfwd`/`jax.jit` over `evaluateRforces` could not trace/differentiate; and
- a downstream `xp.sqrt` (e.g. `vcirc` inside `normalize`) crashed under torch: `sqrt(): argument must be Tensor, not float` — the `'<' not supported between numpy.ndarray and Tensor` family of eager breaks. Recorded as the torch xfail `test_normalize_potential[AnyAxisymmetricRazorThinDiskPotential]`.

## The fix — dual numpy=scipy / backend=native split

- **numpy input**: the original scipy adaptive quad + `scipy.special.ellipk/ellipe`, preserved verbatim in `_*_numpy` helpers → **byte-identical** (verified bit-for-bit with `numpy.array_equal` on a force/2nd-deriv grid, including the R=0 / R=∞ edges).
- **backend input, differentiating** (a jax/functorch tracer, or a grad-tracking torch tensor): in-backend fixed-order Gauss–Legendre (`galpy.backend.quadrature`, split `[0,R]+[R,2R]+[2R,∞)` — the symmetric split handles the a=R, m→1 singularity as a principal value) with the backend elliptic fallback (`galpy.backend.special.ellipk/ellipe`). The forces are now jit/jacfwd-safe and differentiable; grad-vs-FD **h-converges** (~1e-10) under `jax.grad`, torch eager autograd, and `torch.func`.
- **backend input, plain concrete scalar** (e.g. the forced-backend test suite): reuse scipy's accurate value wrapped as a backend array. Fixed-order GL cannot resolve the small-z sheet structure the derivative tests FD-probe at z~1e-8, nor the z=0 Hadamard-type second derivative; scipy's adaptive quad can. The value is built through `numpy.asarray` so it keeps float64 (a bare python float would drop to torch's float32 default and blow up a `dr=1e-8` FD).

## Also

- Flip `_backend_compatible = True` (the decorator now coerces coords; the force returns a backend array → `vcirc` works). Move AARD to the migrated conventions sample and replace the now-migrated scalar-only regression example with a forced-flag synthetic.
- Drop the fixed torch xfail-ledger entry.
- New `tests/test_backend_anyaxisymdisk.py`: eager backend-array force parity vs numpy (incl. z=0), jax jacfwd/jit traced-finite, and grad-vs-FD for Rforce/zforce — run under `-W error::DeprecationWarning -W error::FutureWarning`.

**numpy byte-identical: yes** (bit-for-bit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm