### PR TITLE
IsothermalDiskPotential: backend-aware amp sqrt (torch/jax amp-grad)

### DIFF
--- a/galpy/potential/IsothermalDiskPotential.py
+++ b/galpy/potential/IsothermalDiskPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import get_namespace, is_backend_array
 from ..util import conversion
 from .linearPotential import linearPotential
 
@@ -43,7 +43,13 @@ class IsothermalDiskPotential(linearPotential):
         linearPotential.__init__(self, amp=amp, ro=ro, vo=vo)
         sigma = conversion.parse_velocity(sigma, vo=self._vo)
         self._sigma2 = sigma**2.0
-        self._H = sigma / numpy.sqrt(8.0 * numpy.pi * self._amp)
+        # amp is folded into the scale height H; make the sqrt backend-aware so a
+        # jax/torch amp differentiates through H. Dispatch on is_backend_array
+        # (NOT get_namespace): a plain numpy amp must stay numpy even under a
+        # forced backend (torch.sqrt rejects a bare python/numpy scalar), so the
+        # numpy path is byte-identical.
+        xp = get_namespace(self._amp) if is_backend_array(self._amp) else numpy
+        self._H = sigma / xp.sqrt(8.0 * numpy.pi * self._amp)
         self._amp = 1.0  # Need to manually set to 1, because amp is now contained in the combination of H and sigma^2
         self.hasC = True
         self.hasC_dxdv = True  # 1D variational (dxdv) second derivative in C

--- a/tests/test_backend_linearpotential.py
+++ b/tests/test_backend_linearpotential.py
@@ -210,3 +210,39 @@ def test_torch_eager_and_value(name, fn, pt, p):
 @pytest.mark.parametrize("name,fn,pt,p", FLAT, ids=IDS)
 def test_torch_autograd_matches_fd(name, fn, pt, p):
     _torch_grad_fd(fn, p, pt)
+
+
+# ==================== amp as a backend array =============================== #
+# IsothermalDiskPotential folds amp into the scale height H via a backend-aware
+# sqrt (the is_backend_array(self._amp) branch in __init__). A jax/torch amp
+# must therefore differentiate through H -- exercise d(force)/d(amp) and pin it
+# to a central finite difference. The numpy FD reference builds with a plain
+# python-float amp, so it also guards that path staying byte-identical.
+def _isodisk_force_of_amp(amp, x):
+    return IsothermalDiskPotential(amp=amp, sigma=0.5).force(x, use_physical=False)
+
+
+def _amp_fd(a, x0, h=1e-6):
+    fp = float(_isodisk_force_of_amp(a + h, x0))
+    fm = float(_isodisk_force_of_amp(a - h, x0))
+    return (fp - fm) / (2.0 * h)
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="jax not installed")
+def test_jax_amp_grad_matches_fd():
+    a0, x0 = 1.3, 0.7
+    grad = float(
+        jax.grad(lambda a: _isodisk_force_of_amp(a, jnp.asarray(x0)))(jnp.asarray(a0))
+    )
+    fd = _amp_fd(a0, x0)
+    assert numpy.isclose(grad, fd, rtol=1e-4, atol=1e-6), (grad, fd)
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+def test_torch_amp_grad_matches_fd():
+    a0, x0 = 1.3, 0.7
+    at = torch.as_tensor(a0, dtype=torch.float64).requires_grad_(True)
+    _isodisk_force_of_amp(at, torch.as_tensor(x0, dtype=torch.float64)).backward()
+    grad = float(at.grad)
+    fd = _amp_fd(a0, x0)
+    assert numpy.isclose(grad, fd, rtol=1e-4, atol=1e-6), (grad, fd)


### PR DESCRIPTION
The last amp-gradient gap in the backend differentiability sweep (#1122).

`IsothermalDiskPotential` folds amp into the scale height `H = sigma/sqrt(8 pi amp)`
and resets `_amp` to 1, but the `sqrt` was raw `numpy.sqrt`, so a jax/torch amp
raised `Can't call numpy() on a Tensor that requires grad`. Resolve the sqrt
through the amp's namespace (`get_namespace`, already imported).

- numpy path **byte-identical** (`xp is numpy` -> `numpy.sqrt`); the 3 numpy
  IsothermalDisk tests pass.
- `d(force)/d(amp)` matches central finite differences under **both torch and
  jax** (grad-vs-FD).

With this landed (plus AnySpherical #1113), the sweep's `KNOWN_JIT_GAPS` and
`KNOWN_AMP_GAPS` both go empty, so #1122 can be rebased to a fully-green sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm