### PR TITLE
ledger: slow-skip 2 jax NonInertial func/vec-omega tests (eager-XLA timeout)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -332,6 +332,16 @@ jax tests/test_orbits.py::test_bruteSOS_3D
 jax tests/test_orbits.py::test_energy_jacobi_angmom
 jax tests/test_orbits.py::test_rguiding
 
+# --- jax NonInertialFrameForce func/vec-omega (eager-XLA timeout) ---
+# The func/vec omega_z frame-force variants build a per-timestep interpolation of
+# the frame acceleration; under jax eager-XLA that evaluation is pathologically
+# slow (a local run did not finish in >500 s) and blows the 300 s per-test CI
+# timeout -> recorded as un-ledgered FAILED. The numpy/C paths are unaffected and
+# byte-identical; the faster scalar-omega variants are xfail-ledgered separately.
+# Skip until the frame-force path is vectorized (own burndown bucket).
+jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz
+jax tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz
+
 # --- streamdf under jax (Track F streamdf vectorization) ---
 # The closed-form actionAngleIsochrone backend migration (same PR) makes
 # streamdf's IsochroneApprox track-assembly path compute in real eager jax; it


### PR DESCRIPTION
The `backend jax ...test_noninertial` shard fails on #1114 with **2 un-ledgered failures**:

- `jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz`
- `jax tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz`

**Root cause — a runner-speed boundary timeout, not a #1114 defect** (#1114 touches zero
NonInertial code). These tests are functionally correct under jax (`funcomegaz` PASSES
with no per-test timeout) but sit right at the **300s per-test CI timeout boundary** under
jax eager-XLA. The same shard's wall-time varies **~23–67 min across runners** (identical
code):

| PR | shard | duration |
|----|-------|----------|
| #1119 | success | 23 min |
| #1116 | success | 30 min |
| #1121 | success | 30 min |
| #1117 | success | 57 min |
| #1113 | success | 58 min |
| **#1114** | **FAILURE** | **67 min** |

On a fast runner the tests finish <300s (pass → never ledgered); #1114 drew the slowest
runner of the batch and they tipped over 300s → un-ledgered FAILED.

**Slow-skip, not xfail:** a timeout is recorded FAILED even for an xfail-marked test, so
only a skip keeps the per-test timeout from being spent (the "timeout overrides xfail"
rule). numpy/C paths are unaffected and byte-identical; the faster `scalar`-omega variants
fail *functionally* and are xfail-ledgered separately. Own "deferred" burndown bucket until
the frame-force path is vectorized.

This PR's own `backend jax` shard goes green (the tests are skipped, so no timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm