### PR TITLE
AnyAxisymmetricRazorThinDiskPotential: backend-agnostic default surfdens (jit/trace-safe)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -34,13 +34,24 @@ _GLORDER = 100
 _ELLIP_M_CAP = 1.0 - 1e-15
 
 
+def _default_surfdens(R):
+    # Backend-agnostic default so the GL/backend force path is jit/trace-safe: the
+    # surface density is evaluated on the (traced) GL nodes, and bare ``numpy.exp`` calls
+    # ``__array__()`` on a jax tracer. Dispatch on is_backend_array (NOT get_namespace):
+    # a numpy / python-float / Quantity R stays on ``numpy.exp`` -> byte-identical and the
+    # constructor's unit-detection probe is unchanged; only a genuine backend array takes
+    # the namespace's exp.
+    xp = get_namespace(R) if is_backend_array(R) else numpy
+    return 1.5 * xp.exp(-3.0 * R)
+
+
 class AnyAxisymmetricRazorThinDiskPotential(Potential):
     """Class that implements the potential of an arbitrary axisymmetric, razor-thin disk with surface density :math:`\\Sigma(R)`"""
 
     def __init__(
         self,
         amp=1.0,
-        surfdens=lambda R: 1.5 * numpy.exp(-3.0 * R),
+        surfdens=_default_surfdens,
         normalize=False,
         ro=None,
         vo=None,

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -28,7 +28,11 @@ import pytest
 from galpy.backend import get_namespace, is_backend_array
 from galpy.potential import (
     AnyAxisymmetricRazorThinDiskPotential,
+    evaluatePotentials,
+    evaluateR2derivs,
     evaluateRforces,
+    evaluateRzderivs,
+    evaluatez2derivs,
     evaluatezforces,
 )
 
@@ -101,6 +105,36 @@ def test_eager_force_returns_backend_array_matching_numpy(backend_name):
             assert is_backend_array(gotR) and is_backend_array(gotz)
             numpy.testing.assert_allclose(float(gotR), refR, rtol=1e-10, atol=1e-12)
             numpy.testing.assert_allclose(float(gotz), refz, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_traced_potential_and_2ndderivs_backend(backend_name):
+    # The backend GL path for the POTENTIAL and the three SECOND derivatives
+    # (_evaluate_gl / _R2deriv_gl / _z2deriv_gl / _Rzderiv_gl) is taken only for a TRACER
+    # (jax) or a requires_grad tensor (torch) -- a CONCRETE backend scalar reuses scipy
+    # via _bk_dispatch. #1121 landed these ~36 GL lines with NO traced backend test (only
+    # the forces were traced), so feat/backends coverage jumped 15->51. Trace over each
+    # (jit for jax, requires_grad for torch) so the GL branch runs, and check the value
+    # matches the numpy/scipy reference (z != 0: the 2nd derivs are singular in the plane).
+    R0, z0 = 1.3, 0.25
+    for fn in (
+        evaluatePotentials,
+        evaluateR2derivs,
+        evaluatez2derivs,
+        evaluateRzderivs,
+    ):
+        ref = float(fn(_POT, numpy.float64(R0), numpy.float64(z0)))
+        if backend_name == "jax":
+            got = jax.jit(lambda R, fn=fn: fn(_POT, R, jnp.asarray(z0)))(
+                jnp.asarray(R0)
+            )
+        else:
+            Rt = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+            got = fn(_POT, Rt, torch.tensor(z0, dtype=torch.float64))
+        assert is_backend_array(got), (fn.__name__, backend_name)
+        numpy.testing.assert_allclose(
+            float(got), ref, rtol=1e-6, atol=1e-8, err_msg=fn.__name__
+        )
 
 
 @pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -120,6 +120,22 @@ def test_jax_traced_force_finite():
     )
 
 
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_default_surfdens_jit_safe():
+    # The DEFAULT surfdens is now backend-agnostic (was a bare ``numpy.exp`` that calls
+    # __array__ on a jit tracer), so a DEFAULT-constructed disk -- how the potential-zoo
+    # differentiability sweep builds it -- is jit/jacfwd-safe too. numpy path unchanged
+    # (is_backend_array guard: numpy / python-float / Quantity R keep numpy.exp).
+    pot = AnyAxisymmetricRazorThinDiskPotential()  # default surfdens
+    R0, z0 = 1.1, 0.3
+    ref = float(evaluateRforces(pot, numpy.float64(R0), numpy.float64(z0)))
+    rf = lambda R: evaluateRforces(pot, R, jnp.asarray(z0))
+    jR = float(jax.jit(rf)(jnp.asarray(R0)))
+    gR = float(jax.jacfwd(rf)(jnp.asarray(R0)))
+    assert numpy.isfinite(jR) and numpy.isfinite(gR)
+    numpy.testing.assert_allclose(jR, ref, rtol=1e-10, atol=1e-12)
+
+
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)
 def test_rforce_grad_vs_fd(backend_name):
     # d(Rforce)/dR via autodiff vs central finite differences, h-converging (not a

--- a/tests/test_backend_potential_diff.py
+++ b/tests/test_backend_potential_diff.py
@@ -102,12 +102,10 @@ _R0, _Z0, _PHI0 = 1.1, 0.13, 0.2
 
 # jit / trace-safety: raw-numpy potentials that cannot be traced (identical set
 # on jax and torch). Matches the audit jit-gap list (constructible subset).
-KNOWN_JIT_GAP_NAMES = {
-    # Only AnyAxisym remains eager-only under a trace (its recip / AGM-elliptic
-    # fallback path still hits raw numpy). AnySpherical / Ferrers / KuzminKutuzov
-    # / Ring burned down as the fix/backend-* PRs landed -- verified by the sweep.
-    "AnyAxisymmetricRazorThinDiskPotential",
-}
+# FULLY BURNED DOWN: every constructible potential in the zoo is now jit-safe. The
+# last entry, AnyAxisymmetricRazorThinDiskPotential, was fixed in #1127 (its default
+# surfdens made backend-agnostic so it no longer hits raw numpy.exp on a traced GL node).
+KNOWN_JIT_GAP_NAMES = set()
 KNOWN_JIT_GAPS = {(name, b) for name in KNOWN_JIT_GAP_NAMES for b in AD_BACKENDS}
 
 # amp-gradient gaps -- ALL burned down. The in-place `self._amp *= ...`


### PR DESCRIPTION
The last remaining eager-only potential gap (the lone entry in the differentiability sweep's `KNOWN_JIT_GAP_NAMES`): `AnyAxisymmetricRazorThinDiskPotential` passed *eager* backend but failed under a **trace**.

## Root cause
The GL/backend force path evaluates `surfdens` on the (traced) GL nodes. The **default** `surfdens=lambda R: 1.5 * numpy.exp(-3.0 * R)` uses a bare `numpy.exp`, which calls `__array__()` on a jax tracer → `TracerArrayConversionError` under `jax.jit` / `jax.jacfwd`. Everything else (`_bspecial.ellipk/ellipe`, the split GL quadrature) was already backend-native.

## Fix
A backend-agnostic default surfdens using the leaf-migration-data-guard pattern — dispatch on `is_backend_array`, so a numpy / python-float / Quantity `R` keeps `numpy.exp` (byte-identical, unit-detection unchanged), while a genuine backend array uses the namespace's `exp` (jit-safe). One helper function; the default only.

## Verified
- **numpy byte-identical** — empirical `0.0` across `evaluate`/`Rforce`/`zforce` + the three second derivatives.
- **jit-safe** for all 5 force/2nd-deriv methods (was `TracerArrayConversionError`); jit matches numpy to **6.7e-16**.
- `d(Rforce)/dR` grad-vs-FD **2.8e-12** (h-converged).
- New test `test_default_surfdens_jit_safe`; `test_backend_anyaxisymdisk.py` green (10 passed).

## Zero-gap sweep (included, rebased on merged #1122)
Drops AnyAxisym from `KNOWN_JIT_GAP_NAMES` → the potential-zoo differentiability sweep now **asserts jit-safety + amp-grad across the whole constructible zoo with no remaining gaps** (206 passed, 0 xfail, 0 xpass). This closes the eager-only-potential-gap audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm