### PR TITLE
streamdf: backend-native stripping-time moments meantdAngle/sigtdAngle (jax/torch) [Phase A.2]

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -19,6 +19,7 @@ else:
 from ..actionAngle.actionAngleIsochroneApprox import dePeriod
 from ..backend import as_backend_constant, get_namespace, is_backend_array
 from ..backend import special as _bspecial
+from ..backend.quadrature import quad as _backend_quad
 from ..orbit import Orbit
 from ..potential.Potential import _check_potential_list_and_deprecate
 from ..util import (
@@ -41,6 +42,11 @@ if _APY_LOADED:
 _INTERPDURINGSETUP = True
 _USEINTERP = True
 _USESIMPLE = True
+# Fixed Gauss-Legendre order for the backend (jax/torch) path of the stripping-
+# time moments (meantdAngle/sigtdAngle); the numpy path keeps scipy's adaptive
+# quad (byte-identical). High enough that the smooth p(t|dangle) integrand
+# reproduces the adaptive result within the physical regime.
+_MOMENT_QUAD_N = 100
 # cast a wide net
 _TWOPIWRAPS = numpy.arange(-4, 5) * 2.0 * numpy.pi
 
@@ -2751,6 +2757,34 @@ class streamdf(df):
         - 2013-12-05 - Written - Bovy (IAS)
 
         """
+        # backend (jax/torch) dangle -> in-backend GL quad (the numpy branch's
+        # scipy adaptive quad is kept byte-identical). The denom==0 progenitor /
+        # far-field control flow becomes xp.where; num/denom is dead-branch guarded.
+        if is_backend_array(dangle):
+            xp = get_namespace(dangle)
+            meandO = as_backend_constant(xp, self._meandO, dangle)
+            sig = as_backend_constant(xp, self._sortedSigOEig[2], dangle)
+            tdis = as_backend_constant(xp, self._tdisrupt, dangle)
+            Tlow = dangle / (meandO + 3.0 * xp.sqrt(sig))
+            # ptdAngle is exactly 0 for t >= tdisrupt, so clamp the upper limit
+            # there: the integral is unchanged but the t=tdisrupt jump leaves the
+            # GL interval, restoring fast convergence of the smooth peak.
+            Thigh = xp.minimum(dangle / (meandO - 3.0 * xp.sqrt(sig)), tdis)
+            num = _backend_quad(
+                lambda x: x * self.ptdAngle(x, dangle), Tlow, Thigh, n=_MOMENT_QUAD_N
+            )
+            denom = _backend_quad(
+                self.ptdAngle, Tlow, Thigh, (dangle,), n=_MOMENT_QUAD_N
+            )
+            denom_zero = denom == 0.0
+            denom_safe = xp.where(denom_zero, xp.ones_like(denom), denom)
+            ratio = num / denom_safe
+            # denom==0 -> 0 near the progenitor, tdisrupt far from it
+            near_prog = dangle / meandO < self._tdisrupt / 10.0
+            zero_case = xp.where(
+                near_prog, xp.zeros_like(ratio), tdis + xp.zeros_like(ratio)
+            )
+            return xp.where(denom_zero, zero_case, ratio)
         Tlow = dangle / (self._meandO + 3.0 * numpy.sqrt(self._sortedSigOEig[2]))
         Thigh = dangle / (self._meandO - 3.0 * numpy.sqrt(self._sortedSigOEig[2]))
         num = integrate.quad(lambda x: x * self.ptdAngle(x, dangle), Tlow, Thigh)[0]
@@ -2784,6 +2818,37 @@ class streamdf(df):
         - 2013-12-05 - Written - Bovy (IAS)
 
         """
+        # backend (jax/torch) dangle -> in-backend GL quad; numpy keeps scipy's
+        # adaptive quad byte-identical. sqrt(var) is dead-branch guarded so a
+        # round-off-negative var or denom==0 does not NaN-poison AD.
+        if is_backend_array(dangle):
+            xp = get_namespace(dangle)
+            meandO = as_backend_constant(xp, self._meandO, dangle)
+            sig = as_backend_constant(xp, self._sortedSigOEig[2], dangle)
+            tdis = as_backend_constant(xp, self._tdisrupt, dangle)
+            Tlow = dangle / (meandO + 3.0 * xp.sqrt(sig))
+            # clamp the upper limit at tdisrupt (ptdAngle==0 beyond it) to keep the
+            # jump out of the GL interval -- see meantdAngle
+            Thigh = xp.minimum(dangle / (meandO - 3.0 * xp.sqrt(sig)), tdis)
+            numsig2 = _backend_quad(
+                lambda x: x**2.0 * self.ptdAngle(x, dangle),
+                Tlow,
+                Thigh,
+                n=_MOMENT_QUAD_N,
+            )
+            nummean = _backend_quad(
+                lambda x: x * self.ptdAngle(x, dangle), Tlow, Thigh, n=_MOMENT_QUAD_N
+            )
+            denom = _backend_quad(
+                self.ptdAngle, Tlow, Thigh, (dangle,), n=_MOMENT_QUAD_N
+            )
+            denom_zero = denom == 0.0
+            denom_safe = xp.where(denom_zero, xp.ones_like(denom), denom)
+            var = numsig2 / denom_safe - (nummean / denom_safe) ** 2.0
+            var_pos = var > 0.0
+            var_safe = xp.where(var_pos, var, xp.ones_like(var))
+            s = xp.where(var_pos, xp.sqrt(var_safe), xp.zeros_like(var))
+            return xp.where(denom_zero, xp.zeros_like(s), s)
         Tlow = dangle / (self._meandO + 3.0 * numpy.sqrt(self._sortedSigOEig[2]))
         Thigh = dangle / (self._meandO - 3.0 * numpy.sqrt(self._sortedSigOEig[2]))
         numsig2 = integrate.quad(

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -206,3 +206,71 @@ def test_meanOmega_3d_value_parity_and_grad(sdf, backend_name):
     assert best < 1e-5 * abs(ad) + 1e-8, (
         f"meanOmega3D grad {backend_name}: best={best:.2e}"
     )
+
+
+###############################################################################
+# Phase A.2: the stripping-time moments meantdAngle / sigtdAngle.
+#
+# Both integrate the (Phase-A.1) p(t|dangle) over [Tlow, Thigh]. The numpy path
+# keeps scipy's adaptive quad (byte-identical -- the else-branch is verbatim); a
+# jax/torch dangle routes to in-backend fixed-order Gauss-Legendre (galpy.backend
+# .quadrature.quad) with the upper limit clamped at tdisrupt, where p(t|dangle)
+# jumps to 0 -- so the GL interval stays smooth and converges fast. The denom==0
+# progenitor/far-field control flow becomes xp.where and num/denom (and the
+# sqrt(var) in sigtdAngle) are dead-branch guarded so AD stays finite.
+#
+# Value parity floors at ~1e-6 in the clamped far field: that residual is scipy's
+# OWN adaptive error at the t=tdisrupt jump (the clamped-GL integrand is smooth
+# and more accurate), so this is the expected adaptive-vs-GL floor, not a backend
+# error. Below dangle~0.43 (Thigh < tdisrupt, no clamp) parity is ~1e-15.
+###############################################################################
+_TDMOMENTS = [
+    ("meantdAngle", lambda s, d: s.meantdAngle(d, use_physical=False)),
+    ("sigtdAngle", lambda s, d: s.sigtdAngle(d, use_physical=False)),
+]
+# 0.3 = unclamped (Thigh < tdisrupt, GL ~machine-precise); 0.8 = clamped far field.
+_TDMOMENT_DANGLES = [0.3, 0.8]
+
+
+@pytest.mark.parametrize("dangle", _TDMOMENT_DANGLES)
+@pytest.mark.parametrize("name,fn", _TDMOMENTS, ids=[m[0] for m in _TDMOMENTS])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_tdmoment_value_parity(sdf, backend_name, name, fn, dangle):
+    ref = float(fn(sdf, dangle))
+    got = float(fn(sdf, _arr(backend_name, dangle)))
+    # rtol 1e-5: fixed-GL vs scipy adaptive; the ~1e-6 clamped-field floor is
+    # scipy's error at the t=tdisrupt jump, not the backend's.
+    numpy.testing.assert_allclose(
+        got, ref, rtol=1e-5, atol=1e-8, err_msg=f"{name} {backend_name} dangle={dangle}"
+    )
+
+
+@pytest.mark.parametrize("dangle", _TDMOMENT_DANGLES)
+@pytest.mark.parametrize("name,fn", _TDMOMENTS, ids=[m[0] for m in _TDMOMENTS])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_tdmoment_grad_vs_fd(sdf, backend_name, name, fn, dangle):
+    # d(moment)/d(dangle) AD must h-converge to a central FD of the SAME backend
+    # (GL) path. The forward values feeding the FD are value-parity-validated
+    # above, so this is a stringent check of the gradient (FD-of-scipy is noisier
+    # than the AD near the jump, so it is not the reference here).
+    if backend_name == "jax":
+        ad = float(jax.grad(lambda d: fn(sdf, d))(jnp.asarray(dangle)))
+
+        def fdfun(d):
+            return float(fn(sdf, jnp.asarray(d)))
+    else:
+        dt = torch.tensor(dangle, dtype=torch.float64, requires_grad=True)
+        fn(sdf, dt).backward()
+        ad = float(dt.grad)
+
+        def fdfun(d):
+            return float(fn(sdf, torch.tensor(d, dtype=torch.float64)))
+
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    best = min(
+        abs(ad - (fdfun(dangle + h) - fdfun(dangle - h)) / (2 * h))
+        for h in (1e-4, 1e-5, 1e-6)
+    )
+    assert best < 1e-5 * abs(ad) + 1e-6, (
+        f"{name} {backend_name} dangle={dangle} grad-vs-FD best={best:.2e}"
+    )


### PR DESCRIPTION
## What

Phase A.2 of the streamdf backend migration (follows #1129). Migrates the two stripping-time moments `meantdAngle` and `sigtdAngle` to the `galpy.backend` namespace layer, building on the Phase-A.1 `p(t|dangle)` leaf (`ptdAngle`).

**Dual-path:** a numpy `dangle` keeps scipy's adaptive `quad` (byte-identical — the else-branch is verbatim); a jax/torch `dangle` routes to in-backend fixed-order Gauss-Legendre (`galpy.backend.quadrature.quad`) so `d(moment)/d(dangle)` flows and jits.

**Key numeric trick:** `p(t|dangle)` jumps to 0 at `t=tdisrupt`, so the backend path clamps the upper GL limit there (`xp.minimum(Thigh, tdisrupt)`). The integral is unchanged (the integrand is exactly 0 beyond it), but the jump leaves the GL interval, restoring fast convergence of the smooth peak. The `denom==0` progenitor/far-field control flow becomes `xp.where`, and `num/denom` and `sqrt(var)` are dead-branch guarded so AD stays finite.

## Validation (jax + torch, CPU-forced)

- **numpy byte-identical** — verified via `repr()` across dangle 0.1–1.2 (verbatim else-branch); existing `test_meantdAngle`/`test_sigtdAngle` pass.
- **Backend value parity** ~1e-15 (unclamped, dangle<0.43) to ~1e-6 (clamped far field — and that residual is *scipy's own* adaptive error at the `t=tdisrupt` jump, not the backend's; the clamped-GL integrand is smoother/more accurate).
- **Gradient** AD-vs-FD(backend) h-converges to ~1e-9; `jax.jit`, `jit(grad)`, and torch autograd all clean.
- 16 tests added to `tests/test_backend_streamdf.py` (value parity + grad-vs-FD, 2 methods × 2 dangles [unclamped 0.3 / clamped 0.8] × jax/torch). Full file: **34 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm