### PR TITLE
backend orbit interp: batch the off-grid cubic spline into one multi-RHS solve

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -135,6 +135,11 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         r = xp.clip(r, xb[0], xb[-1])
     idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, cb.shape[1] - 1)
     dr = r - xb[idx]
+    if cb.ndim == 3:
+        # Batched coefficients (4, n-1, m): m independent splines on the SAME grid
+        # (see cubic_spline_coeffs with 2-D y). cb[j, idx] carries the trailing m
+        # axis; give dr a matching trailing axis so the Horner step broadcasts.
+        dr = dr[..., None]
     k = cb.shape[0] - 1  # polynomial degree
     if nu == 0:
         out = cb[0, idx]
@@ -193,8 +198,13 @@ def cubic_spline_coeffs(xp, x, y, bc="natural"):
     if n < 3:
         raise ValueError("cubic_spline_coeffs requires at least 3 points")
     h = xb[1:] - xb[:-1]  # (n-1,)
+    # A 2-D y of shape (n, m) means m independent splines on the SAME grid -> one
+    # multi-RHS solve (xp.linalg.solve handles the (n, m) rhs), m-fold fewer dense
+    # factorizations. Broadcast the (n-1,) geometry factor h over the m columns;
+    # a 1-D y keeps h unchanged, so that path is byte-identical.
+    hh = h[:, None] if yb.ndim == 2 else h
     # slopes of the secants
-    dslope = (yb[1:] - yb[:-1]) / h  # (n-1,)
+    dslope = (yb[1:] - yb[:-1]) / hh  # (n-1,) or (n-1, m)
 
     # Tridiagonal system A M = rhs for the second derivatives M (length n).
     # Interior rows i=1..n-2:  h[i-1] M[i-1] + 2(h[i-1]+h[i]) M[i] + h[i] M[i+1]
@@ -239,11 +249,11 @@ def cubic_spline_coeffs(xp, x, y, bc="natural"):
 
     # power-basis coefficients on each interval (descending degree to match
     # spline_to_ppoly / Horner in eval_ppoly): c[0]=cubic, c[3]=constant.
-    a3 = (M[1:] - M[:-1]) / (6.0 * h)
+    a3 = (M[1:] - M[:-1]) / (6.0 * hh)
     a2 = M[:-1] / 2.0
-    a1 = dslope - h * (2.0 * M[:-1] + M[1:]) / 6.0
+    a1 = dslope - hh * (2.0 * M[:-1] + M[1:]) / 6.0
     a0 = yb[:-1]
-    return xp.stack([a3, a2, a1, a0], axis=0)  # (4, n-1)
+    return xp.stack([a3, a2, a1, a0], axis=0)  # (4, n-1) or (4, n-1, m)
 
 
 def eval_cubic(xp, x, coeffs, r, *, nu=0, extrapolate=True):

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -7099,24 +7099,37 @@ class Orbit:
         Differentiable w.r.t. ``orb``; shared by the shared-grid
         (``_call_internal_backend_interp``) and per-orbit-grid
         (``_indiv_t_backend_interp``) backend off-grid evaluators."""
-        from ..backend.interpolate import Spline1D
+        from ..backend.interpolate import Spline1D, cubic_spline_coeffs, eval_ppoly
 
         xp = get_namespace(orb)
         pd = self.phasedim()
         k = 3 if grid.shape[0] > 3 else 1
         bc = "not-a-knot" if k == 3 else "natural"
 
-        def _spl(y):
-            return Spline1D(grid, y, k=k, ext=0, bc=bc)(tq)
-
-        if pd == 4 or pd == 6:  # interpolate x,y (not R,phi) -> dodge the 2pi wrap
-            xv = _spl(orb[:, 0] * xp.cos(orb[:, -1]))
-            yv = _spl(orb[:, 0] * xp.sin(orb[:, -1]))
-            cols = [xp.sqrt(xv * xv + yv * yv)]
-            cols += [_spl(orb[:, ii]) for ii in range(1, pd - 1)]
-            cols.append(xp.arctan2(yv, xv))
+        # The columns to spline (x,y instead of R,phi for pd 4/6 to dodge the 2pi
+        # wrap), all on the SAME grid.
+        if pd == 4 or pd == 6:
+            ycols = [orb[:, 0] * xp.cos(orb[:, -1]), orb[:, 0] * xp.sin(orb[:, -1])]
+            ycols += [orb[:, ii] for ii in range(1, pd - 1)]
         else:
-            cols = [_spl(orb[:, ii]) for ii in range(pd)]
+            ycols = [orb[:, ii] for ii in range(pd)]
+
+        if k == 3:
+            # One multi-RHS cubic solve for ALL columns at once (the tridiagonal
+            # matrix is grid-geometry only, shared across columns) -> pd-fold fewer
+            # dense factorizations than one Spline1D per column. ext=0 is the
+            # eval_ppoly default (extrapolate=True).
+            coeffs = cubic_spline_coeffs(xp, grid, xp.stack(ycols, axis=-1), bc=bc)
+            vals = eval_ppoly(xp, grid, coeffs, tq)  # (nt_q, len(ycols))
+            splined = [vals[..., j] for j in range(len(ycols))]
+        else:
+            splined = [Spline1D(grid, y, k=k, ext=0, bc=bc)(tq) for y in ycols]
+
+        if pd == 4 or pd == 6:
+            xv, yv = splined[0], splined[1]
+            cols = [xp.sqrt(xv * xv + yv * yv), *splined[2:], xp.arctan2(yv, xv)]
+        else:
+            cols = splined
         return xp.stack(cols)  # (phasedim, nt_q)
 
     def _indiv_t_backend_interp(self, t_arr, has_time_axis):

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -494,6 +494,32 @@ def test_integrate_multiorbit_inbackend_offgrid_scalar_and_call():
     numpy.testing.assert_allclose(numpy.asarray(osnap.R()), Rs, rtol=1e-10)
 
 
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_integrate_inbackend_offgrid_phasedim5_no_phi():
+    # Off-grid eval of a phasedim-5 (R,vR,vT,z,vz -- no phi) in-backend orbit hits
+    # the non-(4/6) branch of _backend_spline_orbit (no x/y-wrap reconstruction):
+    # all columns are splined directly. The batched cubic must match a scipy
+    # not-a-knot CubicSpline of the SAME backend trajectory (isolates the interp).
+    from scipy.interpolate import CubicSpline
+
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    o = Orbit(jnp.asarray([1.0, 0.1, 1.1, 0.05, 0.02]))
+    o.integrate(jnp.asarray(_TS), pot, method="diffrax")
+    assert o.phasedim() == 5
+    toff = jnp.asarray([0.37, 2.15, 4.9])
+    assert "jax" in type(o.R(toff)).__module__  # stayed on the backend
+    traj = numpy.asarray(o.getOrbit())  # (nt, 5): R, vR, vT, z, vz
+    for col, acc in [(0, "R"), (1, "vR"), (3, "z"), (4, "vz")]:
+        cs = CubicSpline(numpy.asarray(_TS), traj[:, col], bc_type="not-a-knot")
+        numpy.testing.assert_allclose(
+            numpy.asarray(getattr(o, acc)(toff)),
+            cs(numpy.asarray(toff)),
+            rtol=1e-6,
+            atol=1e-7,
+            err_msg=f"phasedim-5 off-grid {acc}",
+        )
+
+
 # ----------------------------------------- all phase-space dimensions (not just 6)
 @pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

The in-backend off-grid orbit interpolator (`_backend_spline_orbit`) splined each phase-space column with its **own** `Spline1D` — one dense `(n,n)` tridiagonal LU factorization **per column** (up to 6 per orbit, up to 36 via `L()` on a 6-orbit batch) of the **same** grid-geometry matrix.

The tridiagonal `A` is built from grid geometry only (column-independent), so all columns share one factorization. This batches them: stack the columns into a 2-D `y` `(n, m)` and do **one multi-RHS `xp.linalg.solve`** → `m`-fold fewer factorizations. This helps **both eager and jit** (XLA does not merge the separate `solve` calls). Part of the backend speed-up roadmap.

## Changes

- **`cubic_spline_coeffs`**: accepts 2-D `y` `(n, m)` → coeffs `(4, n-1, m)` via a single multi-RHS solve (broadcasts the geometry factor `h` over columns). 1-D `y` is unchanged.
- **`eval_ppoly`**: coeffs `(4, n-1, m)` → gives `dr` a trailing axis so the Horner step broadcasts. `cb.ndim==2` (single spline) unchanged.
- **`_backend_spline_orbit`**: assembles all columns, one cubic solve, then reconstructs `R,phi` from the splined `x,y` for phasedim 4/6. The `k==1` (≤3-point grid) case keeps the per-column `Spline1D`.

## numpy byte-identical

The single-spline path (`y.ndim==1` / `cb.ndim==2`) is untouched — verified **byte-identical** via a stash compare of numpy `cubic_spline_coeffs` + `eval_ppoly` (nu=0,1,2, both BCs).

## Validation (jax + torch, CPU-forced)

- **Multi-column batched == per-column** to ~1e-14 (numpy/jax/torch, both BCs); grad jit==eager
- Existing **`test_backend_orbit_integrate.py` (82 tests) pass** — validates the pd-4/6 x/y reconstruction + off-grid correctness against per-orbit references
- New `test_integrate_inbackend_offgrid_phasedim5_no_phi` covers the non-(4/6) branch (batched cubic vs scipy not-a-knot spline of the same trajectory)
- Measured: a 2-orbit phasedim-6 off-grid `o.R` jaxpr **1056 → 256 (~4×)**; scales with `N_orbits × phasedim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm