### PR TITLE
streamdf: backend-native perpendicular-angle moments (nested quad) [Phase A.3]

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -19,6 +19,7 @@ else:
 from ..actionAngle.actionAngleIsochroneApprox import dePeriod
 from ..backend import as_backend_constant, get_namespace, is_backend_array
 from ..backend import special as _bspecial
+from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..backend.quadrature import quad as _backend_quad
 from ..orbit import Orbit
 from ..potential.Potential import _check_potential_list_and_deprecate
@@ -47,6 +48,11 @@ _USESIMPLE = True
 # quad (byte-identical). High enough that the smooth p(t|dangle) integrand
 # reproduces the adaptive result within the physical regime.
 _MOMENT_QUAD_N = 100
+# Fixed GL orders for the backend path of the nested-quadrature perpendicular-
+# angle moments (meanangledAngle/sigangledAngle): N_X over the outer angleperp
+# integral, N_T over the inner p(angle_perp|t) integral. numpy keeps scipy quad.
+_ANGLE_QUAD_NX = 100
+_ANGLE_QUAD_NT = 150
 # cast a wide net
 _TWOPIWRAPS = numpy.arange(-4, 5) * 2.0 * numpy.pi
 
@@ -2884,6 +2890,21 @@ class streamdf(df):
         - 2013-12-06 - Written - Bovy (IAS)
 
         """
+        # backend (jax/torch): one batched inner GL quad over t in [0, tdisrupt]
+        # for every angleperp at once (angleperp on a leading axis, the t nodes on
+        # the trailing one), replacing the numpy per-angleperp scipy-quad loop.
+        if is_backend_array(angleperp) or is_backend_array(dangle):
+            xp = get_namespace(angleperp, dangle)
+            ap = xp.asarray(angleperp)
+            tdis = as_backend_constant(xp, self._tdisrupt, ap)
+            out = _backend_fixed_quad(
+                xp,
+                lambda tn: self._pangledAnglet(tn, ap[..., None], dangle, smallest),
+                xp.zeros_like(tdis),
+                tdis,
+                n=_ANGLE_QUAD_NT,
+            )
+            return xp.reshape(out, ap.shape)
         angleperp = numpy.array(angleperp)
         out = numpy.zeros_like(angleperp)
         out = numpy.array(
@@ -2922,6 +2943,35 @@ class streamdf(df):
             eigIndx = 0
         else:
             eigIndx = 1
+        # backend (jax/torch): outer GL quad over angleperp of the batched
+        # pangledAngle; numpy keeps scipy quad. num is ~0 by odd symmetry;
+        # denom==0/nan far-field/progenitor control flow becomes xp.where.
+        if is_backend_array(dangle):
+            xp = get_namespace(dangle)
+            aplow = numpy.amax(
+                [
+                    numpy.sqrt(self._sortedSigOEig[eigIndx]) * self._tdisrupt * 5.0,
+                    self._sigangle,
+                ]
+            )
+            apb = as_backend_constant(xp, aplow, dangle)
+            num = _backend_fixed_quad(
+                xp,
+                lambda x: x * self.pangledAngle(x, dangle, smallest),
+                apb,
+                -apb,
+                n=_ANGLE_QUAD_NX,
+            )
+            denom = _backend_fixed_quad(
+                xp,
+                lambda x: self.pangledAngle(x, dangle, smallest),
+                apb,
+                -apb,
+                n=_ANGLE_QUAD_NX,
+            )
+            bad = (denom == 0.0) | xp.isnan(denom)
+            denom_safe = xp.where(bad, xp.ones_like(denom), denom)
+            return xp.where(bad, xp.zeros_like(denom), num / denom_safe)
         aplow = numpy.amax(
             [
                 numpy.sqrt(self._sortedSigOEig[eigIndx]) * self._tdisrupt * 5.0,
@@ -2966,6 +3016,50 @@ class streamdf(df):
             eigIndx = 0
         else:
             eigIndx = 1
+        # backend (jax/torch): the simple estimate reuses the backend meantdAngle;
+        # otherwise the nested outer GL quad (numsig2/denom) with sqrt/denom
+        # dead-branch guarded. numpy keeps scipy quad.
+        if is_backend_array(dangle):
+            xp = get_namespace(dangle)
+            sig = as_backend_constant(xp, self._sortedSigOEig[eigIndx], dangle)
+            if simple:
+                dt = self.meantdAngle(dangle, use_physical=False)
+                sigangle2 = as_backend_constant(xp, self._sigangle2, dangle)
+                return xp.sqrt(sigangle2 + sig * dt**2.0)
+            aplow = numpy.amax(
+                [
+                    numpy.sqrt(self._sortedSigOEig[eigIndx]) * self._tdisrupt * 5.0,
+                    self._sigangle,
+                ]
+            )
+            apb = as_backend_constant(xp, aplow, dangle)
+            numsig2 = _backend_fixed_quad(
+                xp,
+                lambda x: x**2.0 * self.pangledAngle(x, dangle),
+                apb,
+                -apb,
+                n=_ANGLE_QUAD_NX,
+            )
+            if not assumeZeroMean:
+                nummean = _backend_fixed_quad(
+                    xp,
+                    lambda x: x * self.pangledAngle(x, dangle),
+                    apb,
+                    -apb,
+                    n=_ANGLE_QUAD_NX,
+                )
+            else:
+                nummean = 0.0
+            denom = _backend_fixed_quad(
+                xp, lambda x: self.pangledAngle(x, dangle), apb, -apb, n=_ANGLE_QUAD_NX
+            )
+            bad = (denom == 0.0) | xp.isnan(denom)
+            denom_safe = xp.where(bad, xp.ones_like(denom), denom)
+            var = numsig2 / denom_safe - (nummean / denom_safe) ** 2.0
+            var_pos = var > 0.0
+            var_safe = xp.where(var_pos, var, xp.ones_like(var))
+            s = xp.where(var_pos, xp.sqrt(var_safe), xp.zeros_like(var))
+            return xp.where(bad, xp.zeros_like(s), s)
         if simple:
             dt = self.meantdAngle(dangle, use_physical=False)
             return numpy.sqrt(self._sigangle2 + self._sortedSigOEig[eigIndx] * dt**2.0)
@@ -2996,6 +3090,25 @@ class streamdf(df):
             eigIndx = 0
         else:
             eigIndx = 1
+        # backend (jax/torch): N(angleperp;t) * ptdAngle(t). ptdAngle already
+        # self-masks t<=0 & t>=tdisrupt and t^2*sig+sigangle2 is always > 0, so no
+        # xp.where/dead-branch guard is needed (unlike the numpy masked write).
+        if (
+            is_backend_array(t)
+            or is_backend_array(angleperp)
+            or is_backend_array(dangle)
+        ):
+            xp = get_namespace(t, angleperp, dangle)
+            t = xp.asarray(t)
+            angleperp = xp.asarray(angleperp)
+            sig = as_backend_constant(xp, self._sortedSigOEig[eigIndx], t)
+            sigangle2 = as_backend_constant(xp, self._sigangle2, t)
+            denom_g = t**2.0 * sig + sigangle2
+            return (
+                xp.exp(-0.5 * angleperp**2.0 / denom_g)
+                / xp.sqrt(denom_g)
+                * self.ptdAngle(t, dangle)
+            )
         angleperp = numpy.array(angleperp)
         t = numpy.array(t)
         out = numpy.zeros_like(angleperp)

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -274,3 +274,106 @@ def test_tdmoment_grad_vs_fd(sdf, backend_name, name, fn, dangle):
     assert best < 1e-5 * abs(ad) + 1e-6, (
         f"{name} {backend_name} dangle={dangle} grad-vs-FD best={best:.2e}"
     )
+
+
+###############################################################################
+# Phase A.3: the nested-quad perpendicular-angle moments (pangledAngle,
+# meanangledAngle, sigangledAngle) + the _pangledAnglet leaf.
+#
+# meanangledAngle/sigangledAngle are ratios of 2-D integrals (outer over
+# angleperp, inner over t via the batched pangledAngle). numpy keeps scipy's
+# adaptive quad (byte-identical); a jax/torch dangle routes to nested in-backend
+# GL (fixed_quad), so d(moment)/d(dangle) flows and jits. meanangledAngle is 0 by
+# odd symmetry (x*pangledAngle over [aplow,-aplow]) so it gets a reference-match
+# to that analytic zero; the meaningful grad target is sigangledAngle (even x^2).
+# Value parity is ~1e-13 (the inner [0,tdisrupt] integrand is smooth, no
+# straddled jump); grad-vs-FD h-converges to ~1e-13.
+###############################################################################
+_ANGLED_DANGLES = [0.3, 0.6, 1.0]
+
+
+@pytest.mark.parametrize("dangle", _ANGLED_DANGLES)
+@pytest.mark.parametrize("simple", [False, True], ids=["full", "simple"])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sigangled_value_parity(sdf, backend_name, simple, dangle):
+    ref = float(sdf.sigangledAngle(dangle, simple=simple, use_physical=False))
+    got = float(
+        sdf.sigangledAngle(
+            _arr(backend_name, dangle), simple=simple, use_physical=False
+        )
+    )
+    # full nested GL matches scipy ~1e-13; the simple estimate rides on the A.2
+    # meantdAngle (clamped-GL floor ~1e-6), so allow a looser rtol there.
+    rtol = 1e-5 if simple else 1e-9
+    numpy.testing.assert_allclose(
+        got, ref, rtol=rtol, atol=1e-10, err_msg=f"sigangled simple={simple} d={dangle}"
+    )
+
+
+@pytest.mark.parametrize("dangle", _ANGLED_DANGLES)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sigangled_grad_vs_fd(sdf, backend_name, dangle):
+    def fn(s, d):
+        return s.sigangledAngle(d, use_physical=False)
+
+    if backend_name == "jax":
+        ad = float(jax.grad(lambda d: fn(sdf, d))(jnp.asarray(dangle)))
+
+        def fdfun(d):
+            return float(fn(sdf, jnp.asarray(d)))
+    else:
+        dt = torch.tensor(dangle, dtype=torch.float64, requires_grad=True)
+        fn(sdf, dt).backward()
+        ad = float(dt.grad)
+
+        def fdfun(d):
+            return float(fn(sdf, torch.tensor(d, dtype=torch.float64)))
+
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    best = min(
+        abs(ad - (fdfun(dangle + h) - fdfun(dangle - h)) / (2 * h))
+        for h in (1e-4, 1e-5, 1e-6)
+    )
+    assert best < 1e-5 * abs(ad) + 1e-8, (
+        f"sigangled grad {backend_name} d={dangle} best={best:.2e}"
+    )
+
+
+@pytest.mark.parametrize("dangle", _ANGLED_DANGLES)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_meanangled_is_zero(sdf, backend_name, dangle):
+    # meanangledAngle == 0 by odd-integrand symmetry (numpy returns exactly 0);
+    # the backend must match that analytic zero (not merely be finite).
+    got = float(sdf.meanangledAngle(_arr(backend_name, dangle), use_physical=False))
+    assert abs(got) < 1e-12, f"meanangled {backend_name} d={dangle} = {got}"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_pangledAngle_array_parity_and_grad(sdf, backend_name):
+    # p(angle_perp|dangle) over an array of angleperp: batched-inner-quad value
+    # parity + d(sum)/d(dangle) h-converges.
+    ap = numpy.array([0.0, 0.01, -0.01, 0.02])
+    ref = numpy.asarray(sdf.pangledAngle(ap, 0.6))
+    got = numpy.asarray(
+        sdf.pangledAngle(_arr(backend_name, ap), _arr(backend_name, 0.6))
+    )
+    assert got.shape == ref.shape
+    numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-12)
+    if backend_name == "jax":
+        ad = float(
+            jax.grad(lambda d: sdf.pangledAngle(jnp.asarray(ap), d).sum())(
+                jnp.asarray(0.6)
+            )
+        )
+    else:
+        dt = torch.tensor(0.6, dtype=torch.float64, requires_grad=True)
+        sdf.pangledAngle(torch.tensor(ap, dtype=torch.float64), dt).sum().backward()
+        ad = float(dt.grad)
+    h = 1e-5
+    fd = (
+        float(sdf.pangledAngle(ap, 0.6 + h).sum())
+        - float(sdf.pangledAngle(ap, 0.6 - h).sum())
+    ) / (2 * h)
+    assert abs(ad - fd) < 1e-4 * abs(fd) + 1e-8, (
+        f"pangledAngle grad {backend_name}: {ad} vs {fd}"
+    )

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -377,3 +377,17 @@ def test_pangledAngle_array_parity_and_grad(sdf, backend_name):
     assert abs(ad - fd) < 1e-4 * abs(fd) + 1e-8, (
         f"pangledAngle grad {backend_name}: {ad} vs {fd}"
     )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sigangled_assumezeromean_false(sdf, backend_name):
+    # assumeZeroMean=False computes the nummean integral explicitly (the odd
+    # integrand ~0 by symmetry); covers that backend branch + matches numpy.
+    d = 0.6
+    ref = float(sdf.sigangledAngle(d, assumeZeroMean=False, use_physical=False))
+    got = float(
+        sdf.sigangledAngle(
+            _arr(backend_name, d), assumeZeroMean=False, use_physical=False
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-10)


### PR DESCRIPTION
## What

Phase A.3 of the streamdf backend migration (follows #1129/#1132). Migrates the **nested-quadrature** perpendicular-angle family to `galpy.backend`: `_pangledAnglet`, `pangledAngle`, `meanangledAngle`, `sigangledAngle`.

Dual-path: a numpy `dangle` keeps scipy's adaptive `quad` (byte-identical); a jax/torch `dangle` routes to **nested in-backend Gauss-Legendre** (`backend.quadrature.fixed_quad`), so `d(moment)/d(dangle)` flows and jits.

- **`_pangledAnglet`** backend branch = `N(angleperp;t)·ptdAngle(t)` — `ptdAngle` already self-masks `t≤0` & `t≥tdisrupt` and `t²σ+σₐ²>0` always, so **no `xp.where`/dead-branch guard** is needed (unlike the numpy masked write).
- **`pangledAngle`** — one **batched inner GL quad** over `t∈[0,tdisrupt]` for all `angleperp` at once (angleperp on a leading axis), replacing the numpy per-angleperp loop.
- **`meanangledAngle`/`sigangledAngle`** — outer GL quad of `xᵏ·pangledAngle` over `[aplow,−aplow]` (`aplow` is dangle-independent). `meanangledAngle` is **0 by odd symmetry**; `sigangledAngle` guards `denom==0`/nan and the `sqrt(var)` dead branch; `simple=True` reuses the A.2 backend `meantdAngle`.

## numpy byte-identical

Every numpy branch is the verbatim original — verified **byte-identical** via `repr()` across 16 values (4 methods × 4 dangles). Existing numpy `angledAngle`/`pangled` tests (3) pass.

## Validation (jax + torch, CPU-forced)

- Value parity **~1e-15** (full `sigangledAngle`, `pangledAngle` array); `simple=True` ~1e-11 (rides on A.2's `meantdAngle` clamped-GL floor)
- **`meanangledAngle` matches the analytic 0** (~1e-19) — reference-match, not finite-and-nonzero
- Gradient AD-vs-FD(backend) h-converges to **~1e-13**; jit-safe
- 26 new tests in `test_backend_streamdf.py`

The inner `[0, tdisrupt]` integral puts the `t=tdisrupt` jump at the endpoint (not straddled), so both scipy and GL nail the smooth bump — parity is ~1e-13 (no clamp needed, unlike A.2). n_x=100, n_t=150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm