### PR TITLE
backend orbit interp: batch the off-grid cubic solve ACROSS orbits (shared grid, ~8.7x eager)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -7264,18 +7264,51 @@ class Orbit:
         descending = self_t.shape[0] > 1 and self_t[1] < self_t[0]
         grid = numpy.array(self_t[::-1]) if descending else self_t
 
-        def _interp_one(orb):  # (nt_grid, phasedim) -> (phasedim, nt_query)
-            # backward integration -> flip orb to match the ascending grid
-            o = xp.flip(orb, axis=0) if descending else orb
-            return self._backend_spline_orbit(o, grid, tq)
+        size = self.orbit.shape[0]
+        pd = self.phasedim()
+        if grid.shape[0] > 3 and size > 1:
+            # Cross-orbit batching: all orbits share ONE grid, so every one of the
+            # size*pd spline columns shares the SAME tridiagonal matrix -> a single
+            # multi-RHS cubic solve for the whole batch (vs one per-orbit
+            # _backend_spline_orbit -- itself one solve -- looped size times). Falls
+            # back below for a <=3-point (k=1) grid or a single orbit.
+            from ..backend.interpolate import cubic_spline_coeffs, eval_ppoly
 
-        # self.orbit is (size, nt_grid, phasedim); spline each orbit on the shared
-        # grid and stack on the trailing (orbit) axis -> (phasedim, nt_query, size).
-        # size == 1 (single orbit) reproduces the prior (phasedim, nt, 1) layout.
-        out = xp.stack(
-            [_interp_one(self.orbit[ii]) for ii in range(self.orbit.shape[0])],
-            axis=-1,
-        )
+            orb = xp.flip(self.orbit, axis=1) if descending else self.orbit
+            if pd == 4 or pd == 6:  # spline x=Rcos(phi), y=Rsin(phi) (not R, phi)
+                rr = orb[:, :, 0]
+                ph = orb[:, :, -1]
+                cols = [rr * xp.cos(ph), rr * xp.sin(ph)]
+                cols += [orb[:, :, ii] for ii in range(1, pd - 1)]
+            else:
+                cols = [orb[:, :, ii] for ii in range(pd)]
+            # (size, nt_grid, pd) -> (nt_grid, size*pd): one RHS matrix.
+            Ycols = xp.reshape(
+                xp.permute_dims(xp.stack(cols, axis=-1), (1, 0, 2)),
+                (grid.shape[0], size * pd),
+            )
+            coeffs = cubic_spline_coeffs(xp, grid, Ycols, bc="not-a-knot")
+            vals = xp.reshape(
+                eval_ppoly(xp, grid, coeffs, tq), (tq.shape[0], size, pd)
+            )  # (nt_query, size, pd)
+            if pd == 4 or pd == 6:  # recover R, phi from the splined x, y
+                xv, yv = vals[..., 0], vals[..., 1]
+                rec = [xp.sqrt(xv * xv + yv * yv)]
+                rec += [vals[..., j] for j in range(2, pd)]
+                rec.append(xp.arctan2(yv, xv))
+                out = xp.stack(rec, axis=0)  # (phasedim, nt_query, size)
+            else:
+                out = xp.permute_dims(vals, (2, 0, 1))  # (phasedim, nt_query, size)
+        else:
+
+            def _interp_one(orb):  # (nt_grid, phasedim) -> (phasedim, nt_query)
+                # backward integration -> flip orb to match the ascending grid
+                o = xp.flip(orb, axis=0) if descending else orb
+                return self._backend_spline_orbit(o, grid, tq)
+
+            # spline each orbit on the shared grid and stack on the trailing
+            # (orbit) axis; size == 1 reproduces the prior (phasedim, nt, 1) layout.
+            out = xp.stack([_interp_one(self.orbit[ii]) for ii in range(size)], axis=-1)
         if scalar:
             return out[:, 0]  # (phasedim, size)
         return out  # (phasedim, nt_query, size)

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -520,6 +520,28 @@ def test_integrate_inbackend_offgrid_phasedim5_no_phi():
         )
 
 
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_integrate_multiorbit_inbackend_offgrid_phasedim5():
+    # A MULTI-orbit phasedim-5 (no phi) batch exercises the cross-orbit batched
+    # interp's non-(4/6) branch (all size*pd columns spliced into one solve, with
+    # the permute-dims output layout); each orbit's off-grid eval must match its
+    # single-orbit reference.
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    ic = numpy.array([[1.0, 0.1, 1.1, 0.05, 0.02], [0.9, 0.0, 1.0, 0.1, -0.03]])
+    o = Orbit(jnp.asarray(ic))
+    o.integrate(jnp.asarray(_TS), pot, method="diffrax")
+    assert o.phasedim() == 5 and o.shape == (2,)
+    toff = jnp.asarray([0.37, 2.15, 4.9])
+    got = numpy.asarray(o.R(toff))  # (size, nt_query)
+    assert got.shape == (2, len(toff))
+    for kk in range(2):
+        ok = Orbit(jnp.asarray(ic[kk]))
+        ok.integrate(jnp.asarray(_TS), pot, method="diffrax")
+        numpy.testing.assert_allclose(
+            got[kk], numpy.asarray(ok.R(toff)), rtol=1e-6, atol=1e-7
+        )
+
+
 # ----------------------------------------- all phase-space dimensions (not just 6)
 @pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Follow-up to #1133. `_call_internal_backend_interp` still **looped** the (per-orbit multi-RHS) `_backend_spline_orbit` once per orbit → `size` separate cubic solves for a multi-orbit off-grid eval (up to 6 orbits × 6 columns via `L()`).

But an in-backend / C-STM multi-orbit batch shares **one integration grid**, so every one of the `size × pd` spline columns shares the **same** tridiagonal matrix → spline them all in a **single multi-RHS solve**. Assemble `(size, nt_grid, pd) → (nt_grid, size·pd)` (x,y instead of R,phi for phasedim 4/6), one `cubic_spline_coeffs` + `eval_ppoly`, reshape back and reconstruct R,phi per orbit.

A single orbit or a ≤3-point (k=1) grid keeps the per-orbit path unchanged. This is a **backend-only** path (`is_backend_array`-guarded); the numpy off-grid interpolator is a separate scipy route, untouched.

## Validation (jax + torch, CPU-forced)

- Existing `test_backend_orbit_integrate.py` (**83**) pass — including the multi-orbit off-grid-matches-per-orbit parity test + scalar-t
- New multi-orbit **phasedim-5** test covers the non-(4/6) batched branch; all new lines covered
- Measured (24-orbit, 120-pt grid, off-grid `o.R` eager): **396 → 45 ms/call (~8.7×)** — scales with N_orbits (one solve vs N)

The jaxpr of a *concrete*-orbit value eval is unchanged (the solve is baked at trace time); the win is **eager multi-orbit evals** and **differentiating a multi-orbit interp w.r.t. ICs/params** (N solves → 1 in the graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm