### PR TITLE
potential: coerce scalar coords at migrated leaves (forced-backend torch/jax fix)

### DIFF
--- a/galpy/potential/LogarithmicHaloPotential.py
+++ b/galpy/potential/LogarithmicHaloPotential.py
@@ -5,7 +5,7 @@
 import math
 import warnings
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion, galpyWarning
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -79,6 +79,7 @@ class LogarithmicHaloPotential(Potential):
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         if self.isNonAxi:
             xp = get_namespace(R, z, phi)
+            R, z, phi = coerce_coords(xp, R, z, phi)
             return (
                 1.0
                 / 2.0
@@ -90,27 +91,31 @@ class LogarithmicHaloPotential(Potential):
             )
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             return 1.0 / 2.0 * xp.log(R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return -Rt2 / R / (Rt2 + (z / self._q) ** 2.0 + self._core2)
         else:
             return -R / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return -z / self._q**2.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
         else:
             return -z / self._q**2.0 / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return (
                 R**2.0
@@ -123,8 +128,9 @@ class LogarithmicHaloPotential(Potential):
             return 0
 
     def _dens(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             R2 = R**2.0
             Rt2 = R2 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
@@ -164,8 +170,9 @@ class LogarithmicHaloPotential(Potential):
             )
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
             return (denom - 2.0 * Rt2 * denom**2.0) * Rt2 / R**2.0
@@ -174,8 +181,9 @@ class LogarithmicHaloPotential(Potential):
             return denom - 2.0 * R**2.0 * denom**2.0
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
             return denom / self._q**2.0 - 2.0 * z**2.0 * denom**2.0 / self._q**4.0
@@ -184,8 +192,9 @@ class LogarithmicHaloPotential(Potential):
             return denom / self._q**2.0 - 2.0 * z**2.0 * denom**2.0 / self._q**4.0
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return (
                 -2.0
@@ -205,8 +214,9 @@ class LogarithmicHaloPotential(Potential):
             )
 
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
             return -self._1m1overb2 * (
@@ -217,8 +227,9 @@ class LogarithmicHaloPotential(Potential):
             return 0.0
 
     def _Rphideriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
             return -(denom - Rt2 * denom**2.0) * R * xp.sin(2.0 * phi) * self._1m1overb2
@@ -226,8 +237,9 @@ class LogarithmicHaloPotential(Potential):
             return 0.0
 
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z, phi)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if self.isNonAxi:
-            xp = get_namespace(R, z, phi)
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
             return (

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -11,7 +11,7 @@ import numpy
 
 from galpy.util import conversion, coords
 
-from ..backend import get_namespace, promote_scalars
+from ..backend import coerce_coords, get_namespace, promote_scalars
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -136,6 +136,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
            2017-12-15 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -171,6 +172,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
            2017-12-15 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -206,6 +208,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
            2017-01-21 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -269,6 +272,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
            2017-01-21 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -332,6 +336,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
            2017-01-22 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -383,11 +388,13 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
     def _U(self, u):
         """Approximated U(u) = cosh^2(u) Phi(u,pi/2)"""
         xp = get_namespace(u)
+        (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         return xp.cosh(u) ** 2.0 * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
 
     def _dUdu(self, u):
         xp = get_namespace(u)
+        (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         # 1e-12 bc force should win the 0/0 battle
         return 2.0 * xp.cosh(u) * xp.sinh(u) * _evaluatePotentials(
@@ -399,6 +406,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _d2Udu2(self, u):
         xp = get_namespace(u)
+        (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, Rz0[0], Rz0[1])
         tzforce = _evaluatezforces(self._pot, Rz0[0], Rz0[1])
@@ -435,6 +443,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _dVdv(self, v):
         xp = get_namespace(v)
+        (v,) = coerce_coords(xp, v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         return -2.0 * xp.sin(v) * xp.cos(v) * _evaluatePotentials(
             self._pot, R0z[0], R0z[1]
@@ -445,6 +454,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _d2Vdv2(self, v):
         xp = get_namespace(v)
+        (v,) = coerce_coords(xp, v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, R0z[0], R0z[1])
         tzforce = _evaluatezforces(self._pot, R0z[0], R0z[1])

--- a/galpy/potential/PlummerPotential.py
+++ b/galpy/potential/PlummerPotential.py
@@ -6,7 +6,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -59,20 +59,29 @@ class PlummerPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -1.0 / xp.sqrt(R**2.0 + z**2.0 + self._b2)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         dPhidrr = -((R**2.0 + z**2.0 + self._b2) ** -1.5)
         return dPhidrr * R
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         dPhidrr = -((R**2.0 + z**2.0 + self._b2) ** -1.5)
         return dPhidrr * z
 
     def _dens(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return 3.0 / 4.0 / math.pi * self._b2 * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Rb = R**2.0 + self._b2
         return (
             self._b2
@@ -85,15 +94,23 @@ class PlummerPotential(Potential):
         )
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return (self._b2 - 2.0 * R**2.0 + z**2.0) * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return (self._b2 + R**2.0 - 2.0 * z**2.0) * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -3.0 * R * z * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
     def _ddensdr(self, r, t=0.0):
+        xp = get_namespace(r)
+        (r,) = coerce_coords(xp, r)
         return (
             self._amp
             * (-15.0)
@@ -105,6 +122,8 @@ class PlummerPotential(Potential):
         )
 
     def _d2densdr2(self, r, t=0.0):
+        xp = get_namespace(r)
+        (r,) = coerce_coords(xp, r)
         return (
             self._amp
             * (-15.0)
@@ -135,6 +154,8 @@ class PlummerPotential(Potential):
         - 2021-03-15 - Written - Lane (UofT)
 
         """
+        xp = get_namespace(r)
+        (r,) = coerce_coords(xp, r)
         return (
             self._amp
             * 3.0
@@ -151,6 +172,8 @@ class PlummerPotential(Potential):
     def _mass(self, R, z=None, t=0.0):
         if z is not None:
             raise AttributeError  # use general implementation
+        xp = get_namespace(R)
+        (R,) = coerce_coords(xp, R)
         r2 = R**2.0
         return (1.0 + self._b2 / r2) ** -1.5  # written so it works for r=inf
 

--- a/galpy/potential/SphericalPotential.py
+++ b/galpy/potential/SphericalPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from .Potential import Potential
 
 
@@ -51,21 +51,25 @@ class SphericalPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._revaluate(r, t=t)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * R / r
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * z / r
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R**2.0 / r**2.0
@@ -74,6 +78,7 @@ class SphericalPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * z**2.0 / r**2.0
@@ -82,6 +87,7 @@ class SphericalPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R * z / r**2.0
@@ -90,6 +96,7 @@ class SphericalPotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rdens(r, t=t)
 

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -11,7 +11,7 @@ import math
 import numpy
 from scipy import optimize
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend.special import gamma as _gamma
 from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
@@ -100,6 +100,7 @@ class TwoPowerSphericalPotential(Potential):
             return self._specialSelf._evaluate(R, z, phi=phi, t=t)
         elif self.beta == 3.0:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 (1.0 / self.a)
@@ -118,6 +119,7 @@ class TwoPowerSphericalPotential(Potential):
             )
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = (
                 xp.sqrt(R**2.0 + z**2.0) + 1e-11
             )  # avoid division by zero and numerical instability of the hyp2f1 function
@@ -142,6 +144,7 @@ class TwoPowerSphericalPotential(Potential):
             return self._specialSelf._Rforce(R, z, phi=phi, t=t)
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -R
@@ -161,6 +164,7 @@ class TwoPowerSphericalPotential(Potential):
             return self._specialSelf._zforce(R, z, phi=phi, t=t)
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -z
@@ -177,6 +181,7 @@ class TwoPowerSphericalPotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
@@ -248,6 +253,7 @@ class TwoPowerSphericalPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         A = self.a ** (self.alpha - 3.0) / (3.0 - self.alpha)
         hyper = _hyp2f1(
@@ -272,6 +278,7 @@ class TwoPowerSphericalPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         A = self.a ** (self.alpha - 3.0) / (3.0 - self.alpha)
         hyper = _hyp2f1(
@@ -295,6 +302,7 @@ class TwoPowerSphericalPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return self._R2deriv(xp.abs(z), R)  # Spherical potential
 
     def _mass(self, R, z=None, t=0.0):
@@ -370,6 +378,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
             return self._specialSelf._evaluate(R, z, phi=phi, t=t)
         else:  # valid for alpha != 2, 3
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return -(1.0 - 1.0 / (1.0 + self.a / r) ** (2.0 - self.alpha)) / (
                 self.a * (2.0 - self.alpha) * (3.0 - self.alpha)
@@ -380,6 +389,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
             return self._specialSelf._Rforce(R, z, phi=phi, t=t)
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -R
@@ -392,6 +402,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
         if self._specialSelf is not None:
             return self._specialSelf._R2deriv(R, z, phi=phi, t=t)
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         a, alpha = self.a, self.alpha
         r = xp.sqrt(R**2.0 + z**2.0)
         # formula not valid for alpha=2,3, (integers?)
@@ -407,6 +418,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
             return self._specialSelf._zforce(R, z, phi=phi, t=t)
         else:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             r = xp.sqrt(R**2.0 + z**2.0)
             return (
                 -z
@@ -422,6 +434,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
         if self._specialSelf is not None:
             return self._specialSelf._Rzderiv(R, z, phi=phi, t=t)
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         a, alpha = self.a, self.alpha
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
@@ -430,6 +443,7 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
@@ -489,15 +503,18 @@ class DehnenCoreSphericalPotential(DehnenSphericalPotential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(1.0 - 1.0 / (1.0 + self.a / r) ** 2.0) / (6.0 * self.a)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -R / (xp.sqrt(R**2.0 + z**2.0) + self.a) ** 3.0 / 3.0
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(
             ((2.0 * R**2.0 - z**2.0) - self.a * r) / (3.0 * r * (r + self.a) ** 4.0)
@@ -505,6 +522,7 @@ class DehnenCoreSphericalPotential(DehnenSphericalPotential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return -z / (self.a + r) ** 3.0 / 3.0
 
@@ -513,12 +531,14 @@ class DehnenCoreSphericalPotential(DehnenSphericalPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         a = self.a
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(R * z / r / (a + r) ** 4.0)
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return 1.0 / (1.0 + r / self.a) ** 4.0 / 4.0 / math.pi / self.a**3.0
 
@@ -575,20 +595,24 @@ class HernquistPotential(DehnenSphericalPotential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -1.0 / (1.0 + xp.sqrt(R**2.0 + z**2.0) / self.a) / 2.0 / self.a
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * z**2.0 + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
@@ -599,6 +623,7 @@ class HernquistPotential(DehnenSphericalPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
@@ -610,6 +635,7 @@ class HernquistPotential(DehnenSphericalPotential):
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # (a^2-R^2) -> 0, (r^2-a^2) -> 0): use the closed-form limit there. Both
@@ -744,20 +770,24 @@ class JaffePotential(DehnenSphericalPotential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -xp.log(1.0 + self.a / xp.sqrt(R**2.0 + z**2.0)) / self.a
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * (z**2.0 - R**2.0) + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
@@ -767,6 +797,7 @@ class JaffePotential(DehnenSphericalPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
@@ -778,6 +809,7 @@ class JaffePotential(DehnenSphericalPotential):
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches
@@ -940,6 +972,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         # -special.xlogy(1/r, 1+r/a) == -(1/r)*log(1+r/a), with xlogy's
         # convention that the result is 0 where the prefactor 1/r is 0 (i.e.
@@ -956,6 +989,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return R * (
@@ -964,6 +998,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return z * (
@@ -972,6 +1007,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return (
@@ -989,6 +1025,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return (
@@ -1007,6 +1044,7 @@ class NFWPotential(TwoPowerSphericalPotential):
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches
@@ -1046,6 +1084,7 @@ class NFWPotential(TwoPowerSphericalPotential):
         if z is not None:
             raise AttributeError  # use general implementation
         xp = get_namespace(R)
+        (R,) = coerce_coords(xp, R)
         return xp.log(1 + R / self.a) - R / self.a / (1.0 + R / self.a)
 
     @conversion.physical_conversion("position", pop=False)


### PR DESCRIPTION
## What

Under the forced-backend test harness (`backend.use(name, force=True)` / `--backend=torch`), `get_namespace()` resolves to jax/torch regardless of input type. But the scalar root-finders (`rE`/`zvc`/`vcirc`/`vterm`) and `eddingtondf.__init__` (potential eval at `rmax`) call the **migrated** potential leaves with raw Python floats, so `xp.sqrt/log/sin/cosh(float)` raised `TypeError` under torch — a whole class of ledgered forced-backend xfails.

Fix: coerce the coordinate inputs onto the backend at each migrated leaf via `galpy.backend.coerce_coords`, so the leaf **genuinely computes on the backend** (no numpy island). `coerce_coords` is a strict **object-identical pass-through when `xp is numpy`** (numpy path stays byte-identical) and lifts python/int scalars to the backend float64 (device-anchored, grad-safe) otherwise.

The fix is at the **migrated leaves only**, never the universal `_call_nodecorator`/`_evaluatePotentials` funnel — that funnel also serves *unmigrated* numpy/scipy/C leaves, which torch tensors would break.

## Files (80 `coerce_coords` insertions)

- `SphericalPotential` (base → all spherical subclasses: Burkert/Einasto/ExpTruncNFW/King/PowerSpherical/…)
- `LogarithmicHaloPotential`
- `PlummerPotential`
- `TwoPowerSphericalPotential` (+ Dehnen/DehnenCore/Hernquist/Jaffe/NFW subclasses)
- `OblateStaeckelWrapperPotential`

## Verification

- **numpy byte-identical**: git-stash before/after diff + object-identity of the `coerce_coords` numpy pass-through; numpy regression slice on affected potentials passes.
- **numpy ≡ torch** to machine eps: Plummer/LogHalo/Spherical exactly `0.0`, TwoPower family `<1.3e-15`. (The generic TwoPower β≠3,4 branch's `7.6e-9` is a **pre-existing** hyp2f1 special-fn floor — identical on the public-API path, not introduced by coercion.)
- **grad-vs-FD** (torch autodiff vs central-FD numpy Φ, and vs `-Rforce`): `3e-12 … 7e-11`; jax x64 matching.

## Ledger

Ledger xfails are `strict=False`, so newly-passing (XPASS) tests stay green. The ledger prune of the now-flipped entries is done separately via a CI regen (authoritative across all Python versions; some tests also need an as_numpy assertion cast before they flip end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm