### PR TITLE
potential: coerce scalar coords at more migrated leaves (forced-backend fix, wave 2)

### DIFF
--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -9,6 +9,7 @@ from scipy import special
 
 from ..backend import (
     asarray_on_device,
+    coerce_coords,
     device_of,
     get_namespace,
     match_input_dtype,
@@ -533,10 +534,12 @@ class DoubleExponentialDiskPotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return xp.exp(-self._alpha * R - self._beta * xp.abs(z))
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return (
             2.0
             * xp.exp(-self._alpha * R)

--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -14,7 +14,12 @@ import math
 import numpy
 from scipy import integrate
 
-from ..backend import as_backend_constant, get_namespace, is_backend_array
+from ..backend import (
+    as_backend_constant,
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+)
 from ..util import _rotate_to_arbitrary_vector, conversion
 from .Potential import Potential
 
@@ -185,6 +190,7 @@ class EllipsoidalPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)

--- a/galpy/potential/FlattenedPowerPotential.py
+++ b/galpy/potential/FlattenedPowerPotential.py
@@ -8,7 +8,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -86,6 +86,7 @@ class FlattenedPowerPotential(Potential):
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         if self.alpha == 0.0:
             xp = get_namespace(R, z)
+            R, z = coerce_coords(xp, R, z)
             return 1.0 / 2.0 * xp.log(R**2.0 + z**2.0 / self.q2 + self.core2)
         else:
             m2 = self.core2 + R**2.0 + z**2.0 / self.q2

--- a/galpy/potential/HomogeneousSpherePotential.py
+++ b/galpy/potential/HomogeneousSpherePotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -59,6 +59,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         # safe denominator so the (dead) outside branch cannot produce a
@@ -68,6 +69,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -75,6 +77,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -82,6 +85,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -93,6 +97,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -104,6 +109,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -115,6 +121,7 @@ class HomogeneousSpherePotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         return xp.where(

--- a/galpy/potential/IsochronePotential.py
+++ b/galpy/potential/IsochronePotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -60,12 +60,14 @@ class IsochronePotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return -1.0 / (self.b + rb)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         dPhidrr = -1.0 / rb / (self.b + rb) ** 2.0
@@ -73,6 +75,7 @@ class IsochronePotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         dPhidrr = -1.0 / rb / (self.b + rb) ** 2.0
@@ -80,6 +83,7 @@ class IsochronePotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -94,6 +98,7 @@ class IsochronePotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -108,12 +113,14 @@ class IsochronePotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return -R * z * (self.b + 3.0 * rb) / rb**3.0 / (self.b + rb) ** 3.0
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -126,6 +133,7 @@ class IsochronePotential(Potential):
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (

--- a/galpy/potential/KuzminDiskPotential.py
+++ b/galpy/potential/KuzminDiskPotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -65,6 +65,7 @@ class KuzminDiskPotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -xp.sign(z) * self._denom(R, z) ** -1.5 * (self._a + xp.abs(z))
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
@@ -72,6 +73,7 @@ class KuzminDiskPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         a = self._a
         return (
             self._denom(R, z) ** -1.5
@@ -80,6 +82,7 @@ class KuzminDiskPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -3 * xp.sign(z) * R * (self._a + xp.abs(z)) * self._denom(R, z) ** -2.5
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
@@ -87,8 +90,10 @@ class KuzminDiskPotential(Potential):
 
     def _mass(self, R, z=None, t=0.0):
         xp = get_namespace(R)
+        (R,) = coerce_coords(xp, R)
         return 1.0 - self._a / xp.sqrt(R**2.0 + self._a**2.0)
 
     def _denom(self, R, z):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return R**2.0 + (self._a + xp.abs(z)) ** 2.0

--- a/galpy/potential/KuzminKutuzovStaeckelPotential.py
+++ b/galpy/potential/KuzminKutuzovStaeckelPotential.py
@@ -8,7 +8,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion  # for prolate spherical coordinate transforms
 from ..util import coords
 from .Potential import Potential
@@ -65,11 +65,13 @@ class KuzminKutuzovStaeckelPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         return -1.0 / (xp.sqrt(l) + xp.sqrt(n))
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         dldR = xp.asarray(jac[0, 0])
@@ -78,6 +80,7 @@ class KuzminKutuzovStaeckelPotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         dldz = xp.asarray(jac[0, 1])
@@ -86,6 +89,7 @@ class KuzminKutuzovStaeckelPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
@@ -103,6 +107,7 @@ class KuzminKutuzovStaeckelPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
@@ -120,6 +125,7 @@ class KuzminKutuzovStaeckelPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)

--- a/galpy/potential/KuzminLikeWrapperPotential.py
+++ b/galpy/potential/KuzminLikeWrapperPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace, zeros_like_backend
+from ..backend import coerce_coords, get_namespace, zeros_like_backend
 from ..util import conversion
 from .Potential import (
     _evaluatePotentials,
@@ -126,18 +126,21 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         return _evaluatePotentials(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         )
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         return _evaluateRforces(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidR(R, z)
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         return _evaluateRforces(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidz(R, z)
@@ -147,6 +150,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
@@ -156,6 +160,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
@@ -165,6 +170,7 @@ class KuzminLikeWrapperPotential(WrapperPotential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t

--- a/galpy/potential/MiyamotoNagaiPotential.py
+++ b/galpy/potential/MiyamotoNagaiPotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -69,16 +69,19 @@ class MiyamotoNagaiPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -1.0 / xp.sqrt(R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return -R / (R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) ** (
             3.0 / 2.0
         )
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -97,6 +100,7 @@ class MiyamotoNagaiPotential(Potential):
 
     def _dens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -114,6 +118,7 @@ class MiyamotoNagaiPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return (
             1.0 / (R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) ** 1.5
             - 3.0
@@ -123,6 +128,7 @@ class MiyamotoNagaiPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -143,6 +149,7 @@ class MiyamotoNagaiPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:

--- a/galpy/potential/PseudoIsothermalPotential.py
+++ b/galpy/potential/PseudoIsothermalPotential.py
@@ -6,7 +6,7 @@ import math
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -59,6 +59,7 @@ class PseudoIsothermalPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         if isinstance(r, (float, int)):  # numpy/python scalar fast path
@@ -77,12 +78,14 @@ class PseudoIsothermalPotential(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return -(1.0 / r - self._a / r2 * xp.arctan(r / self._a)) / self._a * R / r
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return -(1.0 / r - self._a / r2 * xp.arctan(r / self._a)) / self._a * z / r
@@ -92,6 +95,7 @@ class PseudoIsothermalPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (
@@ -103,6 +107,7 @@ class PseudoIsothermalPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (
@@ -114,6 +119,7 @@ class PseudoIsothermalPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (

--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -8,7 +8,7 @@ import math
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend import special as bspecial
 from ..util import conversion
 from .Potential import Potential
@@ -73,6 +73,7 @@ class RazorThinExponentialDiskPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         if self._new:
             if xp.abs(z) < 10.0**-6.0:
                 y = 0.5 * self._alpha * R
@@ -105,6 +106,7 @@ class RazorThinExponentialDiskPotential(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         # move the numpy GL nodes/weights onto the backend first, so products
         # like R * glx are same-namespace (a torch tensor * a numpy array trips
         # numpy's __array_wrap__); xp.asarray is a no-op on numpy (byte-identical)
@@ -162,6 +164,7 @@ class RazorThinExponentialDiskPotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         glx = xp.asarray(self._glx)
         glw = xp.asarray(self._glw)
         if self._new:
@@ -214,6 +217,7 @@ class RazorThinExponentialDiskPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         if self._new:
             if xp.abs(z) < 10.0**-6.0:
                 y = 0.5 * self._alpha * R
@@ -232,10 +236,12 @@ class RazorThinExponentialDiskPotential(Potential):
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         return xp.exp(-self._alpha * R)
 
     def _mass(self, R, z=None, t=0.0):
         xp = get_namespace(R)
+        (R,) = coerce_coords(xp, R)
         return (
             2.0
             * math.pi

--- a/galpy/potential/RingPotential.py
+++ b/galpy/potential/RingPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend.special import ellipe, ellipk
 from ..util import conversion
 from .Potential import Potential
@@ -59,12 +59,14 @@ class RingPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         # Stable as r -> infty
         m = 4.0 * self.a / ((xp.sqrt(R) + self.a / xp.sqrt(R)) ** 2 + z**2 / R)
         return -4.0 * self.a / xp.sqrt((R + self.a) ** 2 + z**2) * ellipk(m)
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         m = 4.0 * R * self.a / ((R + self.a) ** 2 + z**2)
         return (
             -2.0
@@ -90,6 +92,7 @@ class RingPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z = coerce_coords(xp, R, z)
         Raz2 = (R + self.a) ** 2 + z**2
         Raz = xp.sqrt(Raz2)
         m = 4.0 * R * self.a / Raz2


### PR DESCRIPTION
## What

Follow-up to #1139. Under the forced-backend harness (`--backend=torch`), a scalar root-finder (`rE`/`vcirc`) or `__init__` (e.g. `eddingtondf` at `rmax`) passes a raw Python float into a **migrated** potential leaf, so `xp.sqrt/log/isinf(float)` raises `TypeError`. Fix: coerce coords onto the backend at each migrated leaf via `galpy.backend.coerce_coords` — a strict **object-identical pass-through when `xp is numpy`** (numpy path byte-identical), lifting python scalars to the backend float64 otherwise, so the leaf **genuinely computes on the backend** (no numpy island). Migrated leaves only, never the universal funnel.

## Files (12; 70 `coerce_coords` insertions)

MiyamotoNagai, Isochrone, DoubleExponentialDisk (`_dens`/`_surfdens`), HomogeneousSphere, KuzminDisk, PseudoIsothermal, RazorThinExponentialDisk, Ring, KuzminKutuzovStaeckel, KuzminLikeWrapper, **EllipsoidalPotential** (base `_evaluate` `isinf` → covers PerfectEllipsoid/TriaxialGaussian/TriaxialNFW/…), FlattenedPower (`alpha==0` branch).

**Skipped (correctly):** `AnyAxisymmetricRazorThinDisk` (no gap — #1127 already made it backend-agnostic); `Ferrers` (a **different-class** rotating-bar `t`-anchoring gap — `xp.cos(self._pa + self._omegab*t)` on a raw scalar `t`, not fixable by coord coercion; shared with DehnenBar/SoftenedNeedleBar — deferred to a separate PR).

## Verification

Against the **real** `_rEfunc` root-finder trigger (not just the public interface, which arrays-ifies scalars and hides the gap):
- **numpy ≡ torch** global `max = 7.1e-15` (most methods exactly 0.0); jax smoke `max = 4.4e-16`.
- **grad-vs-FD**: torch autodiff `dΦ/dR` ≈ `−Rforce` to ~machine precision, and central-FD to the h=1e-6 floor; kink potentials (KuzminDisk/RazorThin) tested at non-crossing ICs (z≠0).
- **numpy byte-identical**: git-stash A/B over 59 values across all 12 files — 0 differ (repr-exact).

## Ledger

`strict=False` xfails, so newly-passing (XPASS) tests stay green; the ledger prune happens via a milestone CI regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm