### PR TITLE
df: fix forced-backend gaps in sphericaldf / eddingtondf / osipkovmerrittdf

### DIFF
--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -112,7 +112,12 @@ class eddingtondf(isotropicsphericaldf):
                     sorted(1.0 - numpy.geomspace(1e-4, 0.5, 101)),
                 )
             )
-            Es4interp = (Es4interp * (self._Emin - self._potInf) + self._potInf)[::-1]
+            # scipy/backend spline table is built on a numpy grid; under a
+            # forced backend the potential bounds are backend scalars, so pull
+            # them numpy-side (no-op on the numpy path)
+            Emin = as_numpy(self._Emin)
+            potInf = as_numpy(self._potInf)
+            Es4interp = (Es4interp * (Emin - potInf) + potInf)[::-1]
             xp = get_namespace()  # context/forced default only (grid is numpy)
             if xp is numpy:
                 fE4interp = self.fE(Es4interp)

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -209,11 +209,13 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
         xp = resolve_namespace(v, r)
         if hasattr(self, "_logfQ_interp"):
             # scipy interpolator (general OM df) is numpy-only; sampling numpy-side
+            # (the potential eval stays on the active backend, so pull it numpy-side
+            # before the scipy spline; no-op on the numpy path)
             v, r = as_numpy(v), as_numpy(r)
             return (
                 numpy.exp(
                     self._logfQ_interp(
-                        -_evaluatePotentials(self._pot, r, 0) - 0.5 * v**2.0
+                        -as_numpy(_evaluatePotentials(self._pot, r, 0)) - 0.5 * v**2.0
                     )
                 )
                 * v**2.0
@@ -403,10 +405,13 @@ class osipkovmerrittdf(_osipkovmerrittdf):
                     sorted(1.0 - numpy.geomspace(1e-8, 0.5, 101)),
                 )
             )
-            Qs4interp = -(
-                Qs4interp * (self._edf._Emin - self._edf._potInf) + self._edf._potInf
-            )
-            fQ4interp = numpy.log(self.fQ(Qs4interp))
+            # scipy spline table is inherently numpy (no backend spline here);
+            # under a forced backend the potential bounds and fQ come back as
+            # backend scalars, so pull them numpy-side (no-op on the numpy path)
+            Emin = as_numpy(self._edf._Emin)
+            potInf = as_numpy(self._edf._potInf)
+            Qs4interp = -(Qs4interp * (Emin - potInf) + potInf)
+            fQ4interp = numpy.log(as_numpy(self.fQ(Qs4interp)))
             iindx = numpy.isfinite(fQ4interp)
             self._logfQ_interp = interpolate.InterpolatedUnivariateSpline(
                 Qs4interp[iindx], fQ4interp[iindx], k=3, ext=3

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -243,7 +243,12 @@ class sphericaldf(df):
                 E, L, Lz = (args[0] + (None, None))[:3]
             else:  # Orbit
                 E = args[0].E(pot=self._pot, use_physical=False)
-                L = numpy.sqrt(numpy.sum(args[0].L(use_physical=False) ** 2.0))
+                Lval = args[0].L(use_physical=False)
+                if is_backend_array(Lval):  # forced backend: |L| in-namespace
+                    xp = get_namespace(Lval)
+                    L = xp.sqrt(xp.sum(Lval**2.0))
+                else:
+                    L = numpy.sqrt(numpy.sum(Lval**2.0))
                 Lz = args[0].Lz(use_physical=False)
             E = conversion.parse_energy(E, vo=self._vo)
             L = conversion.parse_angmom(L, ro=self._ro, vo=self._vo)

--- a/tests/test_backend_eddingtondf.py
+++ b/tests/test_backend_eddingtondf.py
@@ -204,3 +204,36 @@ def test_ensure_fE_interp_forced(backend):
     gb = dfb._fE_interp(_arr(backend, Es))
     assert _is_backend_array(backend, gb)
     numpy.testing.assert_allclose(as_numpy(gb), ref_df._fE_interp(Es), rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ensure_fE_interp_forced_construction(backend):
+    # DF CONSTRUCTED under a forced backend (the real harness case): _Emin/_potInf
+    # are backend scalars, so the numpy interpolation-grid bounds must be pulled
+    # numpy-side (else numpy_grid * tensor raises). Construction-outside (the test
+    # above) leaves them numpy and misses this. The f(E) interp still matches
+    # pure numpy.
+    ref_df = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3))
+    ref_df._ensure_fE_interp()
+    with galpy.backend.use(backend, force=True):
+        dfb = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3))
+        dfb._ensure_fE_interp()
+    Es = _egrid(ref_df)
+    numpy.testing.assert_allclose(dfb._fE_interp(Es), ref_df._fE_interp(Es), rtol=1e-6)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_forced_construction(backend):
+    # end-to-end sample() with the DF built under a forced backend: exercises the
+    # _ensure_fE_interp grid-bound coercion through the public sampling entry.
+    ref_df = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3))
+    numpy.random.seed(321)
+    ref = ref_df.sample(n=100, return_orbit=False)
+    numpy.random.seed(321)
+    with galpy.backend.use(backend, force=True):
+        got = eddingtondf(pot=HernquistPotential(amp=2.3, a=1.3)).sample(
+            n=100, return_orbit=False
+        )
+    for g, r in zip(got, ref):
+        assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(g, r, rtol=1e-7, atol=1e-8)

--- a/tests/test_backend_osipkovmerrittdf.py
+++ b/tests/test_backend_osipkovmerrittdf.py
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover
 import galpy.backend
 from galpy.backend import as_numpy
 from galpy.df import (
+    osipkovmerrittdf,
     osipkovmerrittHernquistdf,
     osipkovmerrittNFWdf,
     osipkovmerrittPowerLawdf,
@@ -285,3 +286,44 @@ def test_sample_numpy_side_forced(backend, tag):
                 <= 1e-8 * numpy.median(numpy.fabs(numpy.asarray(r))) + 1e-10
             ), "plaw sample bulk not bit-identical -> real backend divergence"
             numpy.testing.assert_allclose(g, r, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_general_fQ_interp_forced_construction(backend):
+    # the GENERAL (numeric) osipkovmerrittdf built under a forced backend: its
+    # helper eddingtondf's _Emin/_potInf are backend scalars, so _ensure_fQ_interp
+    # (a scipy InterpolatedUnivariateSpline on a numpy grid, queried numpy-side in
+    # _p_v_at_r) pulls the grid bounds + fQ numpy-side (else numpy_grid * tensor
+    # raises). The frozen numpy table matches pure numpy; numpy path byte-identical.
+    ref_df = osipkovmerrittdf(pot=_HP, ra=2.3)
+    ref_df._ensure_fQ_interp()
+    with galpy.backend.use(backend, force=True):
+        dfb = osipkovmerrittdf(pot=_HP, ra=2.3)
+        dfb._ensure_fQ_interp()
+    knots = ref_df._logfQ_interp.get_knots()
+    Qs = 0.5 * (knots[:-1] + knots[1:])
+    got = as_numpy(dfb._logfQ_interp(Qs))
+    exp = ref_df._logfQ_interp(Qs)
+    reldiff = numpy.fabs(got - exp) / numpy.fabs(exp)
+    # the bulk of the numpy-side table matches pure numpy to fp noise; a few
+    # deep-tail knots differ (the migrated eddington fE is finite there where the
+    # scipy-adaptive fE hits a turning-point NaN that numpy filters out), but they
+    # are physically negligible and do not affect sampling (next test). A real
+    # regression shifts the WHOLE table, not a near-tail handful (cf. plaw sample).
+    assert numpy.median(reldiff) < 1e-7, "fQ table bulk diverges -> real backend bug"
+    assert numpy.max(numpy.fabs(got - exp)) < 0.05
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_general_sample_forced_construction(backend):
+    # end-to-end sample() of the general OM df built under a forced backend:
+    # sampling is numpy-side (numpy RNG draws unchanged), so draws match pure numpy
+    # to the numpy-side fQ-table's fp noise.
+    numpy.random.seed(24)
+    ref = osipkovmerrittdf(pot=_HP, ra=2.3).sample(n=80, return_orbit=False)
+    numpy.random.seed(24)
+    with galpy.backend.use(backend, force=True):
+        got = osipkovmerrittdf(pot=_HP, ra=2.3).sample(n=80, return_orbit=False)
+    for g, r in zip(got, ref):
+        assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
+        numpy.testing.assert_allclose(g, r, rtol=1e-6, atol=1e-8)

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -331,3 +331,29 @@ def test_setup_rphi_interpolator_forced(backend):
     gb = got(_arr(backend, Es))
     assert _is_backend_array(backend, gb)
     numpy.testing.assert_allclose(as_numpy(gb), ref(Es), rtol=1e-10)
+
+
+# Orbit.E()/L() accessors trip a pre-existing numpy __array_wrap__ deprecation on
+# torch tensors (Orbits.py, outside the df scope); ignore just that one here.
+@pytest.mark.filterwarnings(
+    "ignore:__array_wrap__ must accept context:DeprecationWarning"
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_call_orbit_forced(backend):
+    # __call__'s Orbit branch builds |L| = sqrt(sum L^2); under a forced backend
+    # Orbit.L() is a backend array, so the reduction runs in the active namespace
+    # (numpy.sum(tensor) would raise TypeError). numpy path stays byte-identical.
+    from galpy.orbit import Orbit
+
+    ic = [0.6, 0.05, 0.2, 0.02, 0.03, 1.0]  # bound -> nonzero f
+    ref = as_numpy(_DF(Orbit(ic)))
+    assert numpy.all(ref > 0.0)
+    with galpy.backend.use(backend, force=True):
+        got = _DF(Orbit(ic))
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12)
+    # the anisotropic base actually consumes |L| in _call_internal
+    ani = _IsoAsAniso(pot=_HP)
+    ref_a = as_numpy(ani(Orbit(ic)))
+    with galpy.backend.use(backend, force=True):
+        got_a = ani(Orbit(ic))
+    numpy.testing.assert_allclose(as_numpy(got_a), ref_a, rtol=1e-12)


### PR DESCRIPTION
## What

Three genuine df-module gaps that surface when a DF is **constructed inside a forced backend** (its stored bounds/tables become backend tensors). Existing forced tests build the DF *outside* the forced context, so the bounds stay numpy and the gap is missed — these tests construct *inside* it (the real harness case).

- **`sphericaldf.__call__`** (Orbit branch): `numpy.sum` on `Orbit.L()` (a tensor under forced torch) → dispatch on `is_backend_array` so the backend computes `xp.sqrt(xp.sum(...))` **in-namespace**, numpy stays `numpy.sqrt(numpy.sum(...))` (byte-identical). This flips the `*_diffcalls` tests.
- **`eddingtondf._ensure_fE_interp`**: `Es4interp(numpy grid) * (self._Emin - self._potInf)` (tensor scalars) → `as_numpy` the scalar bounds. The fE interpolation grid is an inherently numpy scipy spline → dual-path numpy=scipy, **not an island**.
- **`osipkovmerrittdf._ensure_fQ_interp` / `_p_v_at_r`**: same numpy-scipy-spline boundary (`InterpolatedUnivariateSpline` is numpy-only) → `as_numpy` the grid bounds, the `fQ` result, and the `_evaluatePotentials` query feeding the numpy sampling spline.

## Verification

- **Reproduce-then-fixed** under forced torch for each.
- **numpy ≡ torch**: DF values `0.0`; fE-interp `6.6e-10`; fQ median rel `1.3e-9`; **sampling statistically identical** (KS p=1.0, Hernquist & NFW).
- **numpy BYTE-IDENTICAL**: git-stash A/B on DF values + spline knots/coeffs.
- Per-module backend tests (`test_backend_{sphericaldf,eddingtondf,osipkovmerrittdf}.py`), 10 new (5 × jax/torch), all pass; broader df backend suite 193 pass; touched-module numpy suites 95 pass.

Noticed (out of scope, future Orbits.py wave): `Orbits.py:3420` — `Orbit.E()`/`.L()` accessors run a numpy op on a torch tensor (numpy-2.0 `__array_wrap__` DeprecationWarning under `-W error`).

## Ledger

`strict=False` xfails stay green; pruned by a milestone CI regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm