### PR TITLE
potential: fix forced-backend gaps in the expansion/density-probe family (SCF/Multipole/AnySpherical)

### DIFF
--- a/galpy/potential/AnySphericalPotential.py
+++ b/galpy/potential/AnySphericalPotential.py
@@ -66,14 +66,14 @@ class AnySphericalPotential(SphericalPotential):
             if _dens_unit_input:
                 try:
                     dens(1.0 * units.kpc).to(units.Msun / units.pc**3)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, units.UnitConversionError, TypeError):
                     pass
                 else:
                     _dens_unit_output = True
             else:
                 try:
                     dens(1.0).to(units.Msun / units.pc**3)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, units.UnitConversionError, TypeError):
                     pass
                 else:
                     _dens_unit_output = True

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -17,9 +17,11 @@ from scipy.interpolate import (
 )
 
 from ..backend import (
+    as_numpy,
     asarray_on_device,
     device_of,
     get_namespace,
+    is_backend_array,
     match_input_dtype,
 )
 from ..backend import use as _use_backend
@@ -773,6 +775,16 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         -----
         - 2026-02-13 - Written - Bovy (UofT)
         """
+        # Under a forced backend a user density that closes over a backend-amp
+        # potential returns a backend array even in this numpy-force setup; cast
+        # to numpy so the numpy quadrature/tables work (byte-identical no-op for
+        # numpy/Quantity, which are not backend arrays).
+        _raw_dens_func = dens_func
+
+        def dens_func(R, z, phi):
+            val = _raw_dens_func(R, z, phi)
+            return as_numpy(val) if is_backend_array(val) else val
+
         Nr = len(rgrid)
         rho_cos = numpy.zeros((Nr, L, M))
         rho_sin = numpy.zeros((Nr, L, M))

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -16,7 +16,9 @@ else:
     from scipy.special import assoc_legendre_p_all
 
 from ..backend import (
+    as_numpy,
     asarray_on_device,
+    coerce_coords,
     device_of,
     get_namespace,
     is_backend_array,
@@ -473,9 +475,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
                 param = [1] * numOfParam
                 try:
                     dens(*param).to(units.kg / units.m**3)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, units.UnitConversionError, TypeError):
                     # We'll just assume that unit conversion means density
-                    # is scalar Quantity
+                    # is scalar Quantity. TypeError: a backend (torch) tensor
+                    # has a .to() that rejects a unit -> treat as non-physical.
                     pass
                 else:
                     ro = internal_ro
@@ -857,12 +860,15 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         xp = get_namespace(r)
         if xp is numpy:
             return _rhoTilde_basis(r, N, L, self._a)
-        # backend path: same expression, functional (no in-place writes); the
-        # constant (n,l) grids are built in numpy and converted once, on the
-        # input's device (CUDA support). For a scalar r this returns (N, L); for
-        # an array r of shape (P,) (the vectorized eval path) K gains a trailing
-        # point axis (N, L, 1) and l moves to (L, 1) so the r-prefactor is (L, P)
+        # backend path: coerce r first (a direct call may pass a python/numpy
+        # scalar) so _RToxi/xp ops below see a backend array. Same expression,
+        # functional (no in-place writes); the constant (n,l) grids are built in
+        # numpy and converted once, on the input's device (CUDA support). For a
+        # scalar r this returns (N, L); for an array r of shape (P,) (the
+        # vectorized eval path) K gains a trailing point axis (N, L, 1) and l
+        # moves to (L, 1) so the r-prefactor is (L, P)
         # and the result is (N, L, P) -- one batched call, no per-point loop.
+        (r,) = coerce_coords(xp, r)
         xi = _RToxi(r, self._a)
         CC = _C(xi, N, L)
         a = self._a
@@ -917,6 +923,8 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # array r of shape (P,) (the vectorized eval path) it sits on axis 0 so
         # the r-dependent prefactor broadcasts to (L, P) and, against CC (N, L, P),
         # gives (N, L, P) -- one batched call instead of a per-point Python loop.
+        # Coerce r: a direct call may pass a python/numpy scalar that xp.where rejects.
+        (r,) = coerce_coords(xp, r)
         xi = _RToxi(r, self._a)
         CC = _C(xi, N, L)
         a = self._a
@@ -1126,6 +1134,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
 
     def _dphiTilde(self, r, N, L):
         xp = get_namespace(r)
+        # Coerce r first (a direct call may pass a python scalar; 0.0 ** -1 would
+        # raise, and _RToxi must see a backend array to route to its backend
+        # path); numpy pass-through keeps the numpy branch byte-identical.
+        (r,) = coerce_coords(xp, r)
         a = self._a
         xi = _RToxi(r, self._a)
         dC = _dC(xi, N, L)
@@ -1167,6 +1179,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # factors are already folded into the algebra below. (r=0 -- the centre
         # -- is a removable singularity never hit along an orbit; guarded.)
         xp = get_namespace(r)
+        # Coerce r first (a direct call may pass a python/numpy scalar the xp.where
+        # guards below reject, and _RToxi must see a backend array to route to its
+        # backend path); numpy pass-through keeps the numpy branch byte-identical.
+        (r,) = coerce_coords(xp, r)
         a = self._a
         xi = _RToxi(r, a)
         CC = _C(xi, N, L)
@@ -1442,6 +1458,9 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
         # branches stay finite under tracing/eager AD. The coefficient tables
         # come from _coeffs_at_time (fixed if static, interpolated-at-t and
         # differentiable in t if time-dependent), on the input's device.
+        # Coerce inputs: a direct call may pass python/numpy scalars that the
+        # xp.isfinite / xp.where degenerate-point guards below reject.
+        R, z, phi = coerce_coords(xp, R, z, phi)
         dev = device_of(R, z, phi)
         Acos, Asin = self._coeffs_at_time(t, xp, dev)
         r, theta, phi = coords.cyl_to_spher(R, z, phi)
@@ -1627,8 +1646,11 @@ def _xiToR(xi, a=1):
 
 
 def _RToxi(r, a=1):
-    xp = get_namespace(r)
-    if xp is numpy:
+    # Leaf helper consumed by both the numpy coefficient setup and the backend
+    # evaluation: dispatch on the DATA, not the (possibly forced) namespace, so a
+    # numpy/scalar r stays numpy (byte-identical, keeps numpy parents working)
+    # while a backend array routes to the differentiable backend path.
+    if not is_backend_array(r):
         out = numpy.divide((r / a - 1.0), (r / a + 1.0), where=True ^ numpy.isinf(r))
         if numpy.any(numpy.isinf(r)):
             if hasattr(r, "__len__"):
@@ -1639,8 +1661,20 @@ def _RToxi(r, a=1):
     # backend path: functional version of the above. The division is computed
     # at a guarded radius (inf/inf = NaN would poison tracing/eager AD) and the
     # r = inf entries are set to the xi = 1 limit with xp.where.
+    xp = get_namespace(r)
     rsafe = xp.where(xp.isinf(r), 0.0, r)
     return xp.where(xp.isinf(r), 1.0, (rsafe / a - 1.0) / (rsafe / a + 1.0))
+
+
+def _coeff_dens_numpy(val):
+    """Cast a coefficient-quadrature density value to numpy.
+
+    The coefficient setup runs under a forced-numpy context, but a user density
+    that closes over a backend-amp potential still returns a backend array; cast
+    it to numpy so the numpy quadrature works. No-op (byte-identical) for
+    numpy/Quantity outputs, which are not backend arrays.
+    """
+    return as_numpy(val) if is_backend_array(val) else val
 
 
 def _C(xi, N, L, alpha=lambda x: 2 * x + 3.0 / 2, singleL=False):
@@ -1856,7 +1890,7 @@ def scf_compute_coeffs_spherical(dens, N, a=1.0, radial_order=None):
             param[0] = R
             return (
                 a**3.0
-                * dens(*param, **dens_kw)
+                * _coeff_dens_numpy(dens(*param, **dens_kw))
                 * (1 + xi) ** 2.0
                 * (1 - xi) ** -3.0
                 * _C(xi, N, 1)[:, 0]
@@ -2008,7 +2042,7 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
             )
             param[0] = R
             param[1] = z
-            return phi_nl * dV * dens(*param, **dens_kw)
+            return phi_nl * dV * _coeff_dens_numpy(dens(*param, **dens_kw))
 
         Acos = numpy.zeros((N, L, 1), float)
         Asin = None
@@ -2339,7 +2373,7 @@ def scf_compute_coeffs(
             )
 
             return (
-                dens(R, z, phi, **dens_kw)
+                _coeff_dens_numpy(dens(R, z, phi, **dens_kw))
                 * phi_nl[numpy.newaxis, :, :, :]
                 * numpy.array([numpy.cos(m * phi), numpy.sin(m * phi)])
                 * dV

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -589,3 +589,35 @@ def test_tdep_diskmep_composite_jax():
         numpy.testing.assert_allclose(
             got, ref, rtol=1e-12, atol=1e-12, err_msg=f"composite TD DiskMEP {meth}"
         )
+
+
+###############################################################################
+# Forced-backend coercion regression test (burndown wave: expansion family).
+# Under a forced backend the expwhole* DiskMultipole catalogue potentials used
+# to crash in from_density: _compute_rho_lm multiplied numpy Legendre/weight
+# arrays by a backend-array density (a user density closing over a backend-amp
+# potential returns backend arrays even in the numpy-force setup). This asserts
+# the density-value cast keeps the coefficient tables (hence the potential)
+# identical to the numpy build.
+###############################################################################
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("symmetry", ["spherical", "axisymmetric"])
+def test_from_density_backend_amp_closure(backend_name, symmetry):
+    from galpy import backend as _b
+    from galpy.potential import HernquistPotential
+    from galpy.potential import evaluatePotentials as ep
+
+    def build():
+        hp = HernquistPotential(amp=2.0, a=1.3)
+        return MultipoleExpansionPotential.from_density(
+            lambda R, z: hp.dens(R, z), L=4, symmetry=symmetry
+        )
+
+    pts = [(0.75, 0.2, 0.4), (1.5, -0.3, 1.1)]
+    ref = numpy.array([ep(build(), R, z, phi=phi) for R, z, phi in pts])
+    with _b.use(backend_name, force=True):
+        pt = build()
+        got = numpy.array([as_numpy(ep(pt, R, z, phi=phi)) for R, z, phi in pts])
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-13)

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -508,3 +508,65 @@ def test_mass_backend_parity(backend_name, name, pot, ts):
             atol=1e-13,
             err_msg=f"SCF[{name}]._mass backend parity ({backend_name}, t={t})",
         )
+
+
+###############################################################################
+# Forced-backend coercion regression tests (burndown wave: expansion family).
+# Under a forced backend (use(..., force=True)) the expwhole* DiskSCF catalogue
+# potentials used to crash: _RToxi hit xp.isinf on a python/numpy scalar, and
+# the from_density coefficient quadrature multiplied numpy basis arrays by a
+# backend-array density (a user density closing over a backend-amp potential
+# returns backend arrays even in the numpy-force setup). These assert the fixes.
+###############################################################################
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_RToxi_parity(backend_name):
+    # _RToxi on a backend array (incl. the r = inf -> xi = 1 limit, handled by
+    # the xp.where(isinf) branch) matches the numpy transform.
+    from galpy.potential.SCFPotential import _RToxi
+
+    rr = numpy.array([0.05, 0.5, 1.3, 5.0, numpy.inf])
+    numpy.testing.assert_allclose(
+        as_numpy(_RToxi(_asarray(backend_name, rr), a=numpy.pi)),
+        _RToxi(rr, a=numpy.pi),
+        rtol=1e-13,
+        atol=1e-14,
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_RToxi_data_dispatch(backend_name):
+    # Leaf data-guard: under a forced backend a numpy/scalar r stays numpy (so
+    # the numpy coefficient setup / numpy parents keep working), while a genuine
+    # backend array routes to the backend path.
+    from galpy import backend as _b
+    from galpy.backend import is_backend_array
+    from galpy.potential.SCFPotential import _RToxi
+
+    with _b.use(backend_name, force=True):
+        assert not is_backend_array(_RToxi(1.4, a=1.3))
+        assert not is_backend_array(_RToxi(numpy.linspace(0.1, 5.0, 5), a=1.3))
+        assert is_backend_array(_RToxi(_asarray(backend_name, 2.0), a=1.3))
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("symmetry", ["spherical", "axisymmetric"])
+def test_from_density_backend_amp_closure(backend_name, symmetry):
+    # from_density's coefficient quadrature runs on numpy, but a user density
+    # closing over a backend-amp potential returns backend arrays even there; the
+    # setup must cast them to numpy (and the .to() units probe must treat a
+    # backend array as non-physical) so the coefficients match the numpy build.
+    from galpy import backend as _b
+    from galpy.potential import HernquistPotential
+
+    def build():
+        hp = HernquistPotential(amp=2.0, a=1.3)
+        return SCFPotential.from_density(
+            lambda R, z: hp.dens(R, z), 6, 2, a=1.3, symmetry=symmetry
+        )
+
+    ref = numpy.asarray(build()._Acos)
+    with _b.use(backend_name, force=True):
+        got = as_numpy(build()._Acos)
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-13)


### PR DESCRIPTION
## What

Genuine forced-backend gaps in the expansion-potential + density-probe family (numpy path **byte-identical** throughout, 30-entry git-stash verified):

- **`SCFPotential._RToxi`**: `numpy.isinf`/`divide`/item-assign on a backend `r` → dispatch on `is_backend_array` so a backend array routes to a differentiable `xp.where(isinf)` branch; numpy/scalar stays numpy. Fixes `test_scf_xiToR` at the code level.
- **SCF `from_density` coefficient quadrature** (`numpy.ndarray * Tensor`): a user density closing over a **backend-`_amp`** potential returns tensors even inside the `use("numpy")` coefficient setup → module helper `_coeff_dens_numpy = as_numpy(val) if is_backend_array(val) else val`, wrapped at the three static integrands (the quadrature grid is inherently numpy → dual-path, not an island; byte-identical no-op on numpy/Quantity).
- **SCF / AnySpherical density units-probe**: `dens(1.0).to(units…)` on a tensor raises `TypeError` → add `TypeError` to the caught exceptions (matches Multipole's `_density_has_units`). Unlocks `test_mass_spher*`.
- **`Multipole._compute_rho_lm`** (`numpy.ndarray * Tensor`): same density-closure issue → cast the backend-array density output at the integrand.
- **SCF degenerate-point methods** (`_phiTilde`/`_dphiTilde`/`_d2phiTilde`/`_rhoTilde`/`_compute_spher_2nd_derivs_at_point`): `coerce_coords` so `xp.where`/`xp.isfinite` don't reject a raw scalar (numpy pass-through → byte-identical).

## Verification

- **Reproduce-then-fixed** under forced torch for every gap.
- **numpy ≡ torch**: `2e-16 … 9e-11` (pot/forces/dens/2nd-derivs); SCF coefficients bit-identical; **grad-vs-FD ~1e-12**.
- **numpy BYTE-IDENTICAL**: 30-entry git-stash A/B (coefficients, transforms, all three families).
- **291** existing backend expansion tests pass + **14** new per-module tests (`test_backend_scf.py`, `test_backend_multipole.py`) under numpy/jax/torch incl. `-W error::DeprecationWarning`.

Deferred (test-side, standard as_numpy cast): 3 degenerate assertions in `test_scf_analytic_2ndderiv`. Noticed as pre-existing (not backend): `test_energy_conservation` for expwholeDiskSCF fails identically on numpy.

## Ledger
`strict=False` xfails stay green; pruned by a milestone CI regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm