### PR TITLE
tests: burn down 28 torch xfails via as_numpy result-casts (wave 3)

### DIFF
--- a/tests/test_interp_potential.py
+++ b/tests/test_interp_potential.py
@@ -1,6 +1,7 @@
 import numpy
 
 from galpy import potential
+from galpy.backend import as_numpy
 
 
 def test_errors():
@@ -81,10 +82,10 @@ def test_interpolation_potential():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), "RZPot interpolation w/ interpRZPotential fails for vector input"
@@ -104,10 +105,10 @@ def test_interpolation_potential():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), "RZPot interpolation w/ interpRZPotential fails for vector input, w/ logR"
@@ -128,10 +129,10 @@ def test_interpolation_potential():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-6.0
     ), "RZPot interpolation w/ interpRZPotential fails for vector input, w/o zsym"
@@ -152,10 +153,10 @@ def test_interpolation_potential():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-6.0
     ), (
@@ -181,13 +182,17 @@ def test_interpolation_potential_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(rs, zs[10])
-                - potential.evaluatePotentials(
-                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                as_numpy(rzpot(rs, zs[10]))
+                - as_numpy(
+                    potential.evaluatePotentials(
+                        potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                    )
                 )
             )
-            / potential.evaluatePotentials(
-                potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+            / as_numpy(
+                potential.evaluatePotentials(
+                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                )
             )
         )
         < 10.0**-6.0
@@ -196,13 +201,17 @@ def test_interpolation_potential_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(rs[10], zs)
-                - potential.evaluatePotentials(
-                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                as_numpy(rzpot(rs[10], zs))
+                - as_numpy(
+                    potential.evaluatePotentials(
+                        potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                    )
                 )
             )
-            / potential.evaluatePotentials(
-                potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+            / as_numpy(
+                potential.evaluatePotentials(
+                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                )
             )
         )
         < 10.0**-6.0
@@ -230,10 +239,10 @@ def test_interpolation_potential_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), "RZPot interpolation w/ interpRZPotential fails for vector input, using C"
@@ -250,10 +259,10 @@ def test_interpolation_potential_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-6.0
     ), (
@@ -277,10 +286,10 @@ def test_interpolation_potential_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), (
@@ -304,10 +313,10 @@ def test_interpolation_potential_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-6.0
     ), (
@@ -334,15 +343,19 @@ def test_interpolation_potential_diffinputs_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(rs, zs[10])
-                - potential.evaluatePotentials(
-                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                as_numpy(rzpot(rs, zs[10]))
+                - as_numpy(
+                    potential.evaluatePotentials(
+                        potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                    )
                 )
             )
-            / potential.evaluatePotentials(
-                potential.MWPotential,
-                rs,
-                zs[10] * numpy.ones(len(rs)),
+            / as_numpy(
+                potential.evaluatePotentials(
+                    potential.MWPotential,
+                    rs,
+                    zs[10] * numpy.ones(len(rs)),
+                )
             )
         )
         < 10.0**-6.0
@@ -351,13 +364,17 @@ def test_interpolation_potential_diffinputs_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(rs[10], zs)
-                - potential.evaluatePotentials(
-                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                as_numpy(rzpot(rs[10], zs))
+                - as_numpy(
+                    potential.evaluatePotentials(
+                        potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                    )
                 )
             )
-            / potential.evaluatePotentials(
-                potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+            / as_numpy(
+                potential.evaluatePotentials(
+                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                )
             )
         )
         < 10.0**-6.0
@@ -385,10 +402,10 @@ def test_interpolation_potential_c_vdiffgridsizes():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot(mr, mz)
-                - potential.evaluatePotentials(potential.MWPotential, mr, mz)
+                as_numpy(rzpot(mr, mz))
+                - as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatePotentials(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatePotentials(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), "RZPot interpolation w/ interpRZPotential fails for vector input, using C"
@@ -581,20 +598,20 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of Rforce w/ interpRZPotential fails for vector input"
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of zforce w/ interpRZPotential fails for vector input"
@@ -615,10 +632,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), (
@@ -627,10 +644,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), (
@@ -654,10 +671,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-5.0
     ), (
@@ -666,10 +683,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-5.0
     ), (
@@ -693,10 +710,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -705,10 +722,10 @@ def test_interpolation_potential_force():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -735,13 +752,17 @@ def test_interpolation_potential_force_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(rs, zs[10])
-                - potential.evaluateRforces(
-                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                as_numpy(rzpot.Rforce(rs, zs[10]))
+                - as_numpy(
+                    potential.evaluateRforces(
+                        potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                    )
                 )
             )
-            / potential.evaluateRforces(
-                potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+            / as_numpy(
+                potential.evaluateRforces(
+                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                )
             )
         )
         < 10.0**-5.0
@@ -751,13 +772,17 @@ def test_interpolation_potential_force_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(rs, zs[10])
-                - potential.evaluatezforces(
-                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                as_numpy(rzpot.zforce(rs, zs[10]))
+                - as_numpy(
+                    potential.evaluatezforces(
+                        potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                    )
                 )
             )
-            / potential.evaluatezforces(
-                potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+            / as_numpy(
+                potential.evaluatezforces(
+                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                )
             )
         )
         < 10.0**-5.0
@@ -768,13 +793,17 @@ def test_interpolation_potential_force_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(rs[10], zs)
-                - potential.evaluateRforces(
-                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                as_numpy(rzpot.Rforce(rs[10], zs))
+                - as_numpy(
+                    potential.evaluateRforces(
+                        potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                    )
                 )
             )
-            / potential.evaluateRforces(
-                potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+            / as_numpy(
+                potential.evaluateRforces(
+                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                )
             )
         )
         < 10.0**-6.0
@@ -782,13 +811,17 @@ def test_interpolation_potential_force_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(rs[10], zs)
-                - potential.evaluatezforces(
-                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                as_numpy(rzpot.zforce(rs[10], zs))
+                - as_numpy(
+                    potential.evaluatezforces(
+                        potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                    )
                 )
             )
-            / potential.evaluatezforces(
-                potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+            / as_numpy(
+                potential.evaluatezforces(
+                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                )
             )
         )
         < 10.0**-6.0
@@ -818,10 +851,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), (
@@ -830,10 +863,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -853,14 +886,16 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(
-                    potential.MWPotential,
-                    mr,
-                    mz,
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(
+                    potential.evaluateRforces(
+                        potential.MWPotential,
+                        mr,
+                        mz,
+                    )
                 )
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -869,10 +904,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -897,10 +932,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), (
@@ -909,10 +944,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-5.0
     ), (
@@ -937,10 +972,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -949,10 +984,10 @@ def test_interpolation_potential_force_c():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 2.0 * 10.0**-5.0
     ), (
@@ -1184,10 +1219,10 @@ def test_interpolation_potential_rzderiv():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rzderiv(mr, mz)
-                - potential.evaluateRzderivs(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rzderiv(mr, mz))
+                - as_numpy(potential.evaluateRzderivs(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRzderivs(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRzderivs(potential.MWPotential, mr, mz))
         )
         < 10.0**-10.0
     ), (
@@ -1227,7 +1262,8 @@ def test_interpolation_potential_secondderivs():
         vdirect = fdirect(potential.MWPotential, mr, mz)
         # Rzderiv crosses zero (odd in z), so guard the relative error
         relerr = numpy.amax(
-            numpy.fabs(vinterp - vdirect) / (numpy.fabs(vdirect) + 1e-8)
+            numpy.fabs(as_numpy(vinterp) - as_numpy(vdirect))
+            / (numpy.fabs(as_numpy(vdirect)) + 1e-8)
         )
         assert relerr < 10.0**-3.0, (
             f"RZPot interpolation of {name} w/ interpRZPotential fails for vector input by {relerr:g}"
@@ -1255,7 +1291,8 @@ def test_interpolation_potential_secondderivs():
         vinterp = finterp(mr, mz)
         vdirect = fdirect(potential.MWPotential, mr, mz)
         relerr = numpy.amax(
-            numpy.fabs(vinterp - vdirect) / (numpy.fabs(vdirect) + 1e-8)
+            numpy.fabs(as_numpy(vinterp) - as_numpy(vdirect))
+            / (numpy.fabs(as_numpy(vdirect)) + 1e-8)
         )
         assert relerr < 10.0**-5.0, (
             f"RZPot interpolation of {name} w/ interpRZPotential fails for vector input, w/ logR by {relerr:g}"
@@ -1282,7 +1319,8 @@ def test_interpolation_potential_secondderivs():
         vinterp = finterp(mr, mz)
         vdirect = fdirect(potential.MWPotential, mr, mz)
         relerr = numpy.amax(
-            numpy.fabs(vinterp - vdirect) / (numpy.fabs(vdirect) + 1e-8)
+            numpy.fabs(as_numpy(vinterp) - as_numpy(vdirect))
+            / (numpy.fabs(as_numpy(vdirect)) + 1e-8)
         )
         # coarser z grid (same number of points over twice the range) ->
         # interpolation-limited at the few-x-1e-3 level near the sharp
@@ -1327,7 +1365,8 @@ def test_interpolation_potential_secondderivs_c():
         vinterp = finterp(mr, mz)
         vdirect = fdirect(potential.MWPotential, mr, mz)
         relerr = numpy.amax(
-            numpy.fabs(vinterp - vdirect) / (numpy.fabs(vdirect) + 1e-8)
+            numpy.fabs(as_numpy(vinterp) - as_numpy(vdirect))
+            / (numpy.fabs(as_numpy(vdirect)) + 1e-8)
         )
         # the C cubic B-spline uses mirror boundary conditions, which add an
         # O(h^2) boundary layer at the grid edges (and, for the odd-in-z
@@ -1392,7 +1431,8 @@ def test_interpolation_potential_secondderivs_c():
         vinterp = finterp(mr, mz)
         vdirect = fdirect(potential.MWPotential, mr, mz)
         relerr = numpy.amax(
-            numpy.fabs(vinterp - vdirect) / (numpy.fabs(vdirect) + 1e-8)
+            numpy.fabs(as_numpy(vinterp) - as_numpy(vdirect))
+            / (numpy.fabs(as_numpy(vdirect)) + 1e-8)
         )
         assert relerr < 10.0**-2.0, (
             f"RZPot interpolation of {name} w/ interpRZPotential fails for vector input, w/o logR, in C by {relerr:g}"
@@ -1520,10 +1560,10 @@ def test_interpolation_potential_dens():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(mr, mz)
-                - potential.evaluateDensities(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.dens(mr, mz))
+                - as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateDensities(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-6.0
     ), "RZPot interpolation of density w/ interpRZPotential fails for vector input"
@@ -1543,10 +1583,10 @@ def test_interpolation_potential_dens():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(mr, mz)
-                - potential.evaluateDensities(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.dens(mr, mz))
+                - as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateDensities(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-6.0
     ), (
@@ -1569,10 +1609,10 @@ def test_interpolation_potential_dens():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(mr, mz)
-                - potential.evaluateDensities(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.dens(mr, mz))
+                - as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateDensities(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-6.0
     ), (
@@ -1595,10 +1635,10 @@ def test_interpolation_potential_dens():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(mr, mz)
-                - potential.evaluateDensities(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.dens(mr, mz))
+                - as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateDensities(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateDensities(potential.MWPotential, mr, mz))
         )
         < 4.0 * 10.0**-6.0
     ), (
@@ -1624,13 +1664,17 @@ def test_interpolation_potential_dens_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(rs, zs[10])
-                - potential.evaluateDensities(
-                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                as_numpy(rzpot.dens(rs, zs[10]))
+                - as_numpy(
+                    potential.evaluateDensities(
+                        potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                    )
                 )
             )
-            / potential.evaluateDensities(
-                potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+            / as_numpy(
+                potential.evaluateDensities(
+                    potential.MWPotential, rs, zs[10] * numpy.ones(len(rs))
+                )
             )
         )
         < 4.0 * 10.0**-6.0
@@ -1641,13 +1685,17 @@ def test_interpolation_potential_dens_diffinputs():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.dens(rs[10], zs)
-                - potential.evaluateDensities(
-                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                as_numpy(rzpot.dens(rs[10], zs))
+                - as_numpy(
+                    potential.evaluateDensities(
+                        potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                    )
                 )
             )
-            / potential.evaluateDensities(
-                potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+            / as_numpy(
+                potential.evaluateDensities(
+                    potential.MWPotential, rs[10] * numpy.ones(len(zs)), zs
+                )
             )
         )
         < 4.0 * 10.0**-6.0
@@ -1747,8 +1795,11 @@ def test_interpolation_potential_vcirc():
     # Test all at the same time to use vector evaluation
     assert numpy.all(
         numpy.fabs(
-            (rzpot.vcirc(rs) - potential.vcirc(potential.MWPotential, rs))
-            / potential.vcirc(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.vcirc(rs))
+                - as_numpy(potential.vcirc(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.vcirc(potential.MWPotential, rs))
         )
         < 10.0**-6.0
     ), "RZPot interpolation of vcirc w/ interpRZPotential fails for vector input"
@@ -1763,8 +1814,11 @@ def test_interpolation_potential_vcirc():
     rs = numpy.linspace(0.01, 20.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.vcirc(rs) - potential.vcirc(potential.MWPotential, rs))
-            / potential.vcirc(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.vcirc(rs))
+                - as_numpy(potential.vcirc(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.vcirc(potential.MWPotential, rs))
         )
         < 10.0**-6.0
     ), (
@@ -1782,8 +1836,11 @@ def test_interpolation_potential_vcirc():
     rs = numpy.linspace(0.01, 2.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.vcirc(rs) - potential.vcirc(potential.MWPotential, rs))
-            / potential.vcirc(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.vcirc(rs))
+                - as_numpy(potential.vcirc(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.vcirc(potential.MWPotential, rs))
         )
         < 10.0**-6.0
     ), "RZPot interpolation of vcirc w/ interpRZPotential fails for vector input"
@@ -1864,8 +1921,11 @@ def test_interpolation_potential_dvcircdR():
     # Test all at the same time to use vector evaluation
     assert numpy.all(
         numpy.fabs(
-            (rzpot.dvcircdR(rs) - potential.dvcircdR(potential.MWPotential, rs))
-            / potential.dvcircdR(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.dvcircdR(rs))
+                - as_numpy(potential.dvcircdR(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.dvcircdR(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of dvcircdR w/ interpRZPotential fails for vector input"
@@ -1880,8 +1940,11 @@ def test_interpolation_potential_dvcircdR():
     rs = numpy.linspace(0.01, 20.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.dvcircdR(rs) - potential.dvcircdR(potential.MWPotential, rs))
-            / potential.dvcircdR(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.dvcircdR(rs))
+                - as_numpy(potential.dvcircdR(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.dvcircdR(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), (
@@ -1899,8 +1962,11 @@ def test_interpolation_potential_dvcircdR():
     rs = numpy.linspace(0.01, 2.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.dvcircdR(rs) - potential.dvcircdR(potential.MWPotential, rs))
-            / potential.dvcircdR(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.dvcircdR(rs))
+                - as_numpy(potential.dvcircdR(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.dvcircdR(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of dvcircdR w/ interpRZPotential fails for vector input"
@@ -1981,8 +2047,11 @@ def test_interpolation_potential_epifreq():
     # Test all at the same time to use vector evaluation
     assert numpy.all(
         numpy.fabs(
-            (rzpot.epifreq(rs) - potential.epifreq(potential.MWPotential, rs))
-            / potential.epifreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.epifreq(rs))
+                - as_numpy(potential.epifreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.epifreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of epifreq w/ interpRZPotential fails for vector input"
@@ -1997,8 +2066,11 @@ def test_interpolation_potential_epifreq():
     rs = numpy.linspace(0.01, 20.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.epifreq(rs) - potential.epifreq(potential.MWPotential, rs))
-            / potential.epifreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.epifreq(rs))
+                - as_numpy(potential.epifreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.epifreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), (
@@ -2016,8 +2088,11 @@ def test_interpolation_potential_epifreq():
     rs = numpy.linspace(0.01, 2.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.epifreq(rs) - potential.epifreq(potential.MWPotential, rs))
-            / potential.epifreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.epifreq(rs))
+                - as_numpy(potential.epifreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.epifreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of epifreq w/ interpRZPotential fails for vector input"
@@ -2036,8 +2111,11 @@ def test_interpolation_potential_epifreq_smalln():
     rs = numpy.linspace(1.1, 1.2, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.epifreq(rs) - potential.epifreq(potential.MWPotential, rs))
-            / potential.epifreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.epifreq(rs))
+                - as_numpy(potential.epifreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.epifreq(potential.MWPotential, rs))
         )
         < 10.0**-2.0
     ), (
@@ -2053,8 +2131,11 @@ def test_interpolation_potential_epifreq_smalln():
     rs = numpy.linspace(1.1, 1.2, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.epifreq(rs) - potential.epifreq(potential.MWPotential, rs))
-            / potential.epifreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.epifreq(rs))
+                - as_numpy(potential.epifreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.epifreq(potential.MWPotential, rs))
         )
         < 10.0**-2.0
     ), (
@@ -2143,8 +2224,11 @@ def test_interpolation_potential_verticalfreq():
     # Test all at the same time to use vector evaluation
     assert numpy.all(
         numpy.fabs(
-            (rzpot.verticalfreq(rs) - potential.verticalfreq(potential.MWPotential, rs))
-            / potential.verticalfreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.verticalfreq(rs))
+                - as_numpy(potential.verticalfreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.verticalfreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of verticalfreq w/ interpRZPotential fails for vector input"
@@ -2159,8 +2243,11 @@ def test_interpolation_potential_verticalfreq():
     rs = numpy.linspace(0.01, 20.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.verticalfreq(rs) - potential.verticalfreq(potential.MWPotential, rs))
-            / potential.verticalfreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.verticalfreq(rs))
+                - as_numpy(potential.verticalfreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.verticalfreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), (
@@ -2178,8 +2265,11 @@ def test_interpolation_potential_verticalfreq():
     rs = numpy.linspace(0.01, 2.0, 20)
     assert numpy.all(
         numpy.fabs(
-            (rzpot.verticalfreq(rs) - potential.verticalfreq(potential.MWPotential, rs))
-            / potential.verticalfreq(potential.MWPotential, rs)
+            (
+                as_numpy(rzpot.verticalfreq(rs))
+                - as_numpy(potential.verticalfreq(potential.MWPotential, rs))
+            )
+            / as_numpy(potential.verticalfreq(potential.MWPotential, rs))
         )
         < 10.0**-5.0
     ), "RZPot interpolation of verticalfreq w/ interpRZPotential fails for vector input"

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -8630,7 +8630,7 @@ def test_scf_analytic_2ndderiv():
     # pole so the angular derivatives stay finite.
     axi, nonaxi = pots
     N, L, _ = axi._Acos.shape
-    assert numpy.all(axi._d2phiTilde(0.0, N, L) == 0.0), (
+    assert numpy.all(as_numpy(axi._d2phiTilde(0.0, N, L)) == 0.0), (
         "SCF _d2phiTilde should vanish at r=0"
     )
     assert axi._compute_spher_2nd_derivs_at_point(0.0, 0.0, 0.0) == (

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -15,6 +15,8 @@ _NUMPY_1_22 = (_NUMPY_VERSION > parse_version("1.21")) * (
 )  # For testing 1.22/1.24 precision issues
 from astropy import constants, units
 
+from galpy.backend import as_numpy  # noqa: E402
+
 sdf_sanders15 = None  # so we can set this up and then use in other tests
 sdf_sanders15_nou = None  # so we can set this up and then use in other tests
 
@@ -11472,7 +11474,8 @@ def test_SCFPotential_from_density():
     assert numpy.all(
         numpy.fabs(
             1.0
-            - sp.dens(rs, rs, use_physical=False) / hp.dens(rs, rs, use_physical=False)
+            - as_numpy(sp.dens(rs, rs, use_physical=False))
+            / as_numpy(hp.dens(rs, rs, use_physical=False))
         )
         < 1e-10
     ), "SCF density does not agree when initialized with density with units"
@@ -11491,7 +11494,8 @@ def test_SCFPotential_from_density():
     assert numpy.all(
         numpy.fabs(
             1.0
-            - sp.dens(rs, rs, use_physical=False) / hp.dens(rs, rs, use_physical=False)
+            - as_numpy(sp.dens(rs, rs, use_physical=False))
+            / as_numpy(hp.dens(rs, rs, use_physical=False))
         )
         < 1e-10
     ), "SCF density does not agree when initialized with density with units"
@@ -11507,7 +11511,8 @@ def test_SCFPotential_from_density():
     assert numpy.all(
         numpy.fabs(
             1.0
-            - sp.dens(rs, rs, use_physical=False) / hp.dens(rs, rs, use_physical=False)
+            - as_numpy(sp.dens(rs, rs, use_physical=False))
+            / as_numpy(hp.dens(rs, rs, use_physical=False))
         )
         < 1e-10
     ), "SCF density does not agree when initialized with density with units"
@@ -14178,7 +14183,10 @@ def test_estimateDeltaStaeckel_method_value():
             estimateDeltaStaeckel(pot, 1.1 * numpy.ones(3), 0.1 * numpy.ones(3))
             .to(units.kpc)
             .value
-            - estimateDeltaStaeckel(potu, 1.1 * numpy.ones(3), 0.1 * numpy.ones(3)) * ro
+            - as_numpy(
+                estimateDeltaStaeckel(potu, 1.1 * numpy.ones(3), 0.1 * numpy.ones(3))
+            )
+            * ro
         )
         < 10.0**-8.0
     ), "estimateDeltaStaeckel function does not return Quantity with the right value"
@@ -17469,12 +17477,20 @@ def test_sphericaldf_sample():
     numpy.random.seed(10)
     sam_nou = dfh.sample(R=1.0 / ro, z=0.0 / ro, phi=10.0 / 180.0 * numpy.pi, n=2)
     assert numpy.all(
-        numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+        numpy.fabs(
+            as_numpy(sam.r(use_physical=False))
+            - as_numpy(sam_nou.r(use_physical=False))
+        )
+        < 1e-8
     ), (
         "Sample returned by sphericaldf.sample with input R,z,phi with units does not agree with that returned by sampline with input R,z,phi without units"
     )
     assert numpy.all(
-        numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False)) < 1e-8
+        numpy.fabs(
+            as_numpy(sam.vr(use_physical=False))
+            - as_numpy(sam_nou.vr(use_physical=False))
+        )
+        < 1e-8
     ), (
         "Sample returned by sphericaldf.sample with input R,z,phi with units does not agree with that returned by sampline with input R,z,phi without units"
     )
@@ -17492,12 +17508,20 @@ def test_sphericaldf_sample():
         R=arr / ro, z=arr * 0.0 / ro, phi=arr * 10.0 / 180.0 * numpy.pi, n=len(arr)
     )
     assert numpy.all(
-        numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+        numpy.fabs(
+            as_numpy(sam.r(use_physical=False))
+            - as_numpy(sam_nou.r(use_physical=False))
+        )
+        < 1e-8
     ), (
         "Sample returned by sphericaldf.sample with input R,z,phi with units does not agree with that returned by sampline with input R,z,phi without units"
     )
     assert numpy.all(
-        numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False)) < 1e-8
+        numpy.fabs(
+            as_numpy(sam.vr(use_physical=False))
+            - as_numpy(sam_nou.vr(use_physical=False))
+        )
+        < 1e-8
     ), (
         "Sample returned by sphericaldf.sample with input R,z,phi with units does not agree with that returned by sampline with input R,z,phi without units"
     )
@@ -17507,7 +17531,11 @@ def test_sphericaldf_sample():
     numpy.random.seed(10)
     sam_nou = dfh.sample(n=2, rmin=1.1 / ro)
     assert numpy.all(
-        numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+        numpy.fabs(
+            as_numpy(sam.r(use_physical=False))
+            - as_numpy(sam_nou.r(use_physical=False))
+        )
+        < 1e-8
     ), (
         "Sample returned by sphericaldf.sample with input rmin with units does not agree with that returned by sampline with input rmin without units"
     )
@@ -18682,12 +18710,19 @@ def test_streamspraydf_setup_paramsAsQuantity():
         numpy.random.seed(10)
         sam_nou = spdf_bovy14_nou.sample(n=2)
         assert numpy.all(
-            numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+            numpy.fabs(
+                as_numpy(sam.r(use_physical=False))
+                - as_numpy(sam_nou.r(use_physical=False))
+            )
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False))
+            numpy.fabs(
+                as_numpy(sam.vr(use_physical=False))
+                - as_numpy(sam_nou.vr(use_physical=False))
+            )
             < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
@@ -18728,12 +18763,19 @@ def test_streamspraydf_sample_orbit():
         numpy.random.seed(10)
         sam_nou = spdf_bovy14_nou.sample(n=2)
         assert numpy.all(
-            numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+            numpy.fabs(
+                as_numpy(sam.r(use_physical=False))
+                - as_numpy(sam_nou.r(use_physical=False))
+            )
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False))
+            numpy.fabs(
+                as_numpy(sam.vr(use_physical=False))
+                - as_numpy(sam_nou.vr(use_physical=False))
+            )
             < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
@@ -18774,35 +18816,43 @@ def test_streamspraydf_sample_RvR():
         numpy.random.seed(10)
         sam_nou, dt_nou = spdf_bovy14_nou.sample(n=2, return_orbit=False, returndt=True)
         assert numpy.all(
-            numpy.fabs(sam[0].to_value(units.kpc) / ro - sam_nou[0]) < 1e-8
+            numpy.fabs(sam[0].to_value(units.kpc) / ro - as_numpy(sam_nou[0])) < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam[1].to_value(units.km / units.s) / vo - sam_nou[1]) < 1e-8
+            numpy.fabs(sam[1].to_value(units.km / units.s) / vo - as_numpy(sam_nou[1]))
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam[2].to_value(units.km / units.s) / vo - sam_nou[2]) < 1e-8
+            numpy.fabs(sam[2].to_value(units.km / units.s) / vo - as_numpy(sam_nou[2]))
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam[3].to_value(units.kpc) / ro - sam_nou[3]) < 1e-8
+            numpy.fabs(sam[3].to_value(units.kpc) / ro - as_numpy(sam_nou[3])) < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(sam[4].to_value(units.km / units.s) / vo - sam_nou[4]) < 1e-8
+            numpy.fabs(sam[4].to_value(units.km / units.s) / vo - as_numpy(sam_nou[4]))
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
-        assert numpy.all(numpy.fabs(sam[5].to_value(units.rad) - sam_nou[5]) < 1e-8), (
+        assert numpy.all(
+            numpy.fabs(sam[5].to_value(units.rad) - as_numpy(sam_nou[5])) < 1e-8
+        ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
         )
         assert numpy.all(
-            numpy.fabs(dt.to_value(units.Gyr) / conversion.time_in_Gyr(vo, ro) - dt_nou)
+            numpy.fabs(
+                dt.to_value(units.Gyr) / conversion.time_in_Gyr(vo, ro)
+                - as_numpy(dt_nou)
+            )
             < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with with unit output is inconsistenty with the same sample sampled without unit output"
@@ -18851,12 +18901,19 @@ def test_streamspraydf_progmass_callable_unitfulin_unitfulout():
         numpy.random.seed(10)
         sam_nou = spdf_nou.sample(n=4)
         assert numpy.all(
-            numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+            numpy.fabs(
+                as_numpy(sam.r(use_physical=False))
+                - as_numpy(sam_nou.r(use_physical=False))
+            )
+            < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with Quantity-in/out callable progenitor_mass is inconsistent with the internal-units twin"
         )
         assert numpy.all(
-            numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False))
+            numpy.fabs(
+                as_numpy(sam.vr(use_physical=False))
+                - as_numpy(sam_nou.vr(use_physical=False))
+            )
             < 1e-8
         ), (
             "Sample returned by streamspraydf.sample with Quantity-in/out callable progenitor_mass is inconsistent with the internal-units twin"
@@ -18902,10 +18959,17 @@ def test_streamspraydf_progmass_callable_unitlessin_unitfulout():
         numpy.random.seed(11)
         sam_nou = spdf_nou.sample(n=4)
         assert numpy.all(
-            numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+            numpy.fabs(
+                as_numpy(sam.r(use_physical=False))
+                - as_numpy(sam_nou.r(use_physical=False))
+            )
+            < 1e-8
         )
         assert numpy.all(
-            numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False))
+            numpy.fabs(
+                as_numpy(sam.vr(use_physical=False))
+                - as_numpy(sam_nou.vr(use_physical=False))
+            )
             < 1e-8
         )
 
@@ -18948,10 +19012,17 @@ def test_streamspraydf_progmass_callable_unitfulin_unitlessout():
         numpy.random.seed(12)
         sam_nou = spdf_nou.sample(n=4)
         assert numpy.all(
-            numpy.fabs(sam.r(use_physical=False) - sam_nou.r(use_physical=False)) < 1e-8
+            numpy.fabs(
+                as_numpy(sam.r(use_physical=False))
+                - as_numpy(sam_nou.r(use_physical=False))
+            )
+            < 1e-8
         )
         assert numpy.all(
-            numpy.fabs(sam.vr(use_physical=False) - sam_nou.vr(use_physical=False))
+            numpy.fabs(
+                as_numpy(sam.vr(use_physical=False))
+                - as_numpy(sam_nou.vr(use_physical=False))
+            )
             < 1e-8
         )
 


### PR DESCRIPTION
## What

Follow-on to #1138: wrap galpy-computed RESULTS with `galpy.backend.as_numpy(...)` at numpy-reduction assertion sites so forced-backend (torch) tests validate the torch **values** instead of crashing (`numpy.all/amax` and `numpy_array - torch_tensor` reject a tensor). `as_numpy` is a no-op on numpy → numpy path **byte-identical**; only galpy OUTPUTS are cast (in `test_interp_potential`, both the interp-side and direct-side values are galpy-computed), never inputs — **no islands**.

## Flips (28 verified fail→pass un-xfailed)

- **test_interp_potential.py — 18**: `test_interpolation_potential`(+`_diffinputs`/`_c`/`_c_vdiffgridsizes`), `_force`(+variants), `_dens`(+`_diffinputs`), `_rzderiv`, `_secondderivs`(+`_c`), `_vcirc`, `_dvcircdR`, `_epifreq`(+`_smalln`), `_verticalfreq`.
- **test_quantity.py — 9**: `test_SCFPotential_from_density`, `test_estimateDeltaStaeckel_method_value`, `test_sphericaldf_sample`, `test_streamspraydf_setup_paramsAsQuantity`, `test_streamspraydf_sample_orbit`, `test_streamspraydf_sample_RvR`, 3× `test_streamspraydf_progmass_callable_*`.
- **test_potential.py — 1**: `test_scf_analytic_2ndderiv` degenerate assertion — flips once **#1142** (SCFPotential._RToxi fix) merges (the test crashes in galpy before the assertion on the current base; verified against #1142's branch).

## Verification

Every flip verified fail→pass by running it un-xfailed under `--backend=torch`. numpy path byte-identical: `test_interp_potential.py` 40/40 pass on numpy + touched quantity/potential tests pass. Ledger untouched (XPASS stays green, `strict=False`; pruned by a milestone regen).

Catalogued (not fixed here) a set of genuine galpy-source gaps for follow-up (interpRZPotential `ndarray*Tensor`, several Orbits.py/Potential.py numpy-op-on-tensor sites — some already addressed by the Orbit-accessor / rotating-bar waves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm