### PR TITLE
potential: fix forced-backend gaps in the rotating bars (Ferrers/SoftenedNeedle: t-anchoring + array-coord quadrature + coord coercion)

### DIFF
--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -122,9 +122,10 @@ class FerrersPotential(Potential):
         x, y, z = coords.cyl_to_rect(R, phi, z)
         # rotation into the aligned frame: rot(t) @ [x, y] without array stacking
         # (numpy.array([x, y]) stacking is the torch-concat backend blocker). The
-        # rotation angle follows t (concrete t -> numpy coefficient; traced t ->
-        # that backend), like SoftenedNeedleBarPotential.
-        xpt = get_namespace(t)
+        # rotation angle follows t: a concrete scalar t -> numpy coefficient (broadcasts
+        # against backend coords under force; byte-identical for numpy), a traced backend
+        # t -> that backend (differentiable), like SoftenedNeedleBarPotential.
+        xpt = get_namespace(t) if is_backend_array(t) else numpy
         ang = self._pa + self._omegab * t
         ca, sa = xpt.cos(ang), xpt.sin(ang)
         x, y = ca * x + sa * y, -sa * x + ca * y
@@ -176,10 +177,10 @@ class FerrersPotential(Potential):
         Fx = self._xforce_xyz(x, y, z)
         Fy = self._yforce_xyz(x, y, z)
         Fz = self._zforce_xyz(x, y, z)
-        # de-rotation angle; follows t (concrete t -> numpy coefficient that
-        # broadcasts; traced t -> that backend's cos/sin), as in
-        # SoftenedNeedleBarPotential.
-        xpt = get_namespace(t)
+        # de-rotation angle; follows t (concrete scalar t -> numpy coefficient that
+        # broadcasts against backend coords; traced backend t -> that backend's cos/sin),
+        # as in SoftenedNeedleBarPotential.
+        xpt = get_namespace(t) if is_backend_array(t) else numpy
         tp = self._pa + self._omegab * t
         cp, sp = xpt.cos(tp), xpt.sin(tp)
         return (cp * Fx - sp * Fy, sp * Fx + cp * Fy, Fz)

--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -14,7 +14,12 @@ import numpy
 from scipy import integrate
 from scipy.special import gamma
 
-from ..backend import get_namespace, is_backend_array, zeros_like_backend
+from ..backend import (
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+    zeros_like_backend,
+)
 from ..backend.optimize import brentq
 from ..backend.quadrature import fixed_quad_semiinfinite
 from ..util import conversion, coords
@@ -117,8 +122,10 @@ class FerrersPotential(Potential):
         return None
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
+        xp = get_namespace(R, z)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if not self.isNonAxi:
-            phi = zeros_like_backend(get_namespace(R, z), R)
+            phi = zeros_like_backend(xp, R)
         x, y, z = coords.cyl_to_rect(R, phi, z)
         # rotation into the aligned frame: rot(t) @ [x, y] without array stacking
         # (numpy.array([x, y]) stacking is the torch-concat backend blocker). The
@@ -148,6 +155,7 @@ class FerrersPotential(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
@@ -155,6 +163,7 @@ class FerrersPotential(Potential):
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
@@ -162,6 +171,7 @@ class FerrersPotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z)
+        R, z, phi = coerce_coords(xp, R, z, phi)
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         _, _, Fz = self._cached_xyzforces(R, z, phi, t, xp)
@@ -411,9 +421,14 @@ def _potInt(x, y, z, a2, b2, c2, n):
         )[0]
     xp = get_namespace(x, y, z)
     ll = _lowerlim_backend(x**2, y**2, z**2, a2, b2, c2, xp)
+    # fixed_quad_semiinfinite appends a trailing quadrature-node axis to ll, so the
+    # integrand's tau carries that axis; give the coordinates the same trailing axis
+    # (no-op broadcast for a scalar point, correct for an ARRAY of points -- e.g. the
+    # per-time positions Orbit.E() evaluates at once).
+    xe, ye, ze = x[..., None], y[..., None], z[..., None]
 
     def integrand(tau):
-        return _FracInt(x, y, z, a2, b2, c2, tau, n + 1, xp)
+        return _FracInt(xe, ye, ze, a2, b2, c2, tau, n + 1, xp)
 
     return fixed_quad_semiinfinite(xp, integrand, ll, n=_GLORDER, kind="recip")
 
@@ -444,12 +459,15 @@ def _forceInt(x, y, z, a2, b2, c2, n, i):
         )[0]
     xp = get_namespace(x, y, z)
     ll = _lowerlim_backend(x**2, y**2, z**2, a2, b2, c2, xp)
+    # trailing quadrature-node axis on the coordinates (see _potInt): scalar-safe,
+    # and correct for an array of evaluation points.
+    xe, ye, ze = x[..., None], y[..., None], z[..., None]
 
     def integrand(tau):
         return (
-            (x * (i == 0) + y * (i == 1) + z * (i == 2))
+            (xe * (i == 0) + ye * (i == 1) + ze * (i == 2))
             / (a2 * (i == 0) + b2 * (i == 1) + c2 * (i == 2) + tau)
-            * _FracInt(x, y, z, a2, b2, c2, tau, n, xp)
+            * _FracInt(xe, ye, ze, a2, b2, c2, tau, n, xp)
         )
 
     return fixed_quad_semiinfinite(xp, integrand, ll, n=_GLORDER, kind="recip")
@@ -468,32 +486,35 @@ def _2ndDerivInt(x, y, z, a2, b2, c2, n, i, j):
     This is a second derivative of _potInt.
     """
 
-    def _integrand(tau, xp):
+    def _integrand(tau, xp, X, Y, Z):
         if i != j:
             return (
-                _FracInt(x, y, z, a2, b2, c2, tau, n - 1, xp)
+                _FracInt(X, Y, Z, a2, b2, c2, tau, n - 1, xp)
                 * n
-                * (1.0 + (-1.0 - 2.0 * x / (tau + a2)) * (i == 0 or j == 0))
-                * (1.0 + (-1.0 - 2.0 * y / (tau + b2)) * (i == 1 or j == 1))
-                * (1.0 + (-1.0 - 2.0 * z / (tau + c2)) * (i == 2 or j == 2))
+                * (1.0 + (-1.0 - 2.0 * X / (tau + a2)) * (i == 0 or j == 0))
+                * (1.0 + (-1.0 - 2.0 * Y / (tau + b2)) * (i == 1 or j == 1))
+                * (1.0 + (-1.0 - 2.0 * Z / (tau + c2)) * (i == 2 or j == 2))
             )
         else:
-            var2 = x**2 * (i == 0) + y**2 * (i == 1) + z**2 * (i == 2)
+            var2 = X**2 * (i == 0) + Y**2 * (i == 1) + Z**2 * (i == 2)
             coef2 = a2 * (i == 0) + b2 * (i == 1) + c2 * (i == 2)
-            return _FracInt(x, y, z, a2, b2, c2, tau, n - 1, xp) * n * (4.0 * var2) / (
+            return _FracInt(X, Y, Z, a2, b2, c2, tau, n - 1, xp) * n * (4.0 * var2) / (
                 tau + coef2
-            ) ** 2 + _FracInt(x, y, z, a2, b2, c2, tau, n, xp) * (-2.0 / (tau + coef2))
+            ) ** 2 + _FracInt(X, Y, Z, a2, b2, c2, tau, n, xp) * (-2.0 / (tau + coef2))
 
     if not (is_backend_array(x) or is_backend_array(y) or is_backend_array(z)):
         return integrate.quad(
-            lambda tau: _integrand(tau, numpy),
+            lambda tau: _integrand(tau, numpy, x, y, z),
             lowerlim(x**2, y**2, z**2, a2, b2, c2),
             numpy.inf,
         )[0]
     xp = get_namespace(x, y, z)
     ll = _lowerlim_backend(x**2, y**2, z**2, a2, b2, c2, xp)
+    # trailing quadrature-node axis on the coordinates (see _potInt): scalar-safe,
+    # correct for an array of evaluation points.
+    xe, ye, ze = x[..., None], y[..., None], z[..., None]
     return fixed_quad_semiinfinite(
-        xp, lambda tau: _integrand(tau, xp), ll, n=_GLORDER, kind="recip"
+        xp, lambda tau: _integrand(tau, xp, xe, ye, ze), ll, n=_GLORDER, kind="recip"
     )
 
 

--- a/galpy/potential/SoftenedNeedleBarPotential.py
+++ b/galpy/potential/SoftenedNeedleBarPotential.py
@@ -7,7 +7,7 @@ import math
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import get_namespace, is_backend_array
 from ..util import conversion
 from .Potential import Potential
 
@@ -166,10 +166,10 @@ class SoftenedNeedleBarPotential(Potential):
         # de-rotation angle; depends only on t, so its namespace follows t: a
         # concrete (Python/numpy) t -> numpy.cos/sin (a plain coefficient that
         # broadcasts into any backend's forces); a traced t (the in-backend
-        # integrator, or autodiff wrt time) -> that backend's cos/sin. (A bare
-        # math.cos/sin would break a tracer -- including a 0-d tracer, which has
-        # ndim 0 -- and torch's cos/sin reject a plain Python-float angle.)
-        xpt = get_namespace(t)
+        # integrator, or autodiff wrt time) -> that backend's cos/sin. Guard on
+        # is_backend_array(t): under a forced backend get_namespace(t) would return
+        # that backend and torch's cos/sin reject the plain Python-float angle.
+        xpt = get_namespace(t) if is_backend_array(t) else numpy
         tp = self._pa + self._omegab * t
         cp, sp = xpt.cos(tp), xpt.sin(tp)
         return (cp * Fx - sp * Fy, sp * Fx + cp * Fy, Fz)

--- a/tests/test_backend_ferrers.py
+++ b/tests/test_backend_ferrers.py
@@ -320,3 +320,44 @@ def test_rotating_scalar_t_under_forced_backend(backend_name):
         atol=1e-11,
         err_msg=f"Ferrers rotating scalar-t ({backend_name})",
     )
+
+
+@pytest.mark.parametrize("method", ["_evaluate", "_Rforce", "_zforce", "_phitorque"])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_array_coords_under_forced_backend(backend_name, method):
+    # Orbit.E() evaluates the potential/forces at an ARRAY of points in one call
+    # (all orbit times at once). The backend GL quadrature must broadcast the
+    # coordinate array against the quadrature nodes -- a scalar-only integrand
+    # produces wrong cross-terms (the energy-conservation gap). Checked against the
+    # numpy per-point reference under a FORCED backend (the orbit-integration
+    # context; a scalar float t also exercises the rotating de-rotation).
+    Rs = numpy.array([1.1, 0.8, 1.4, 0.6])
+    zs = numpy.array([0.1, -0.2, 0.05, 0.3])
+    ps = numpy.array([0.2, 0.5, -0.1, 0.4])
+    t0 = 0.1
+    ref = numpy.array(
+        [
+            float(
+                getattr(_FE, method)(
+                    numpy.asarray(R), numpy.asarray(z), numpy.asarray(p), t0
+                )
+            )
+            for R, z, p in zip(Rs, zs, ps)
+        ]
+    )
+    with use(backend_name, force=True):
+        got = as_numpy(
+            getattr(_FE, method)(
+                _asarray(backend_name, Rs),
+                _asarray(backend_name, zs),
+                _asarray(backend_name, ps),
+                t0,
+            )
+        )
+    numpy.testing.assert_allclose(
+        numpy.asarray(got).ravel(),
+        ref,
+        rtol=1e-9,
+        atol=1e-11,
+        err_msg=f"Ferrers.{method} array coords ({backend_name})",
+    )

--- a/tests/test_backend_ferrers.py
+++ b/tests/test_backend_ferrers.py
@@ -25,7 +25,7 @@
 import numpy
 import pytest
 
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, use
 from galpy.potential import (
     FerrersPotential,
     evaluateRforces,
@@ -275,3 +275,48 @@ def test_dens_grad_outside_is_finite(backend_name):
         ad = 0.0 if R.grad is None else float(R.grad)
     assert numpy.isfinite(ad), f"Ferrers _dens outside grad not finite ({backend_name})"
     assert ad == 0.0
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rotating_scalar_t_under_forced_backend(backend_name):
+    # The orbit integrator hands the force a scalar Python-float t while the
+    # coordinates are backend arrays. Under a FORCED backend get_namespace(t) would
+    # resolve to that backend and torch.cos(python_float) raises (the rotating-bar
+    # t-anchoring gap); the concrete-t rotation coefficient must fall back to numpy
+    # (byte-identical, broadcasts into the backend force). Checked at a scalar float
+    # t != 0 so the omegab*t de-rotation is actually exercised, against numpy.
+    R0, z0, phi0, t0 = 1.1, 0.15, 0.35, 0.7  # scalar Python-float t
+    methods = ("_Rforce", "_zforce", "_phitorque")
+    ref = numpy.array(
+        [
+            float(
+                getattr(_FE, m)(
+                    numpy.asarray(R0), numpy.asarray(z0), numpy.asarray(phi0), t0
+                )
+            )
+            for m in methods
+        ]
+    )
+    with use(backend_name, force=True):
+        got = numpy.array(
+            [
+                float(
+                    as_numpy(
+                        getattr(_FE, m)(
+                            _asarray(backend_name, R0),
+                            _asarray(backend_name, z0),
+                            _asarray(backend_name, phi0),
+                            t0,
+                        )
+                    )
+                )
+                for m in methods
+            ]
+        )
+    numpy.testing.assert_allclose(
+        got,
+        ref,
+        rtol=1e-9,
+        atol=1e-11,
+        err_msg=f"Ferrers rotating scalar-t ({backend_name})",
+    )

--- a/tests/test_backend_softenedneedlebar.py
+++ b/tests/test_backend_softenedneedlebar.py
@@ -1,0 +1,191 @@
+###############################################################################
+# test_backend_softenedneedlebar.py: backend tests for SoftenedNeedleBarPotential.
+#
+# The rotating "softened needle" bar evaluates a closed-form log potential in a
+# bar-aligned frame (phid = phi - pa - omegab t). numpy inputs are byte-identical
+# to before; jax/torch inputs route through the backend namespace so the whole
+# force chain is jit/grad-safe. This module checks:
+#   1. numpy / jax / torch value parity for the migrated first-order methods.
+#   2. the rotating-bar t-anchoring gap: a scalar Python-float t under a FORCED
+#      backend must not crash (torch.cos rejects a plain float) and must match
+#      numpy -- the concrete-t de-rotation coefficient falls back to numpy.
+#   3. the force gradient w.r.t. R h-converges to a central finite difference.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy, use
+from galpy.potential import (
+    SoftenedNeedleBarPotential,
+    evaluateRforces,
+    evaluatezforces,
+)
+
+# This module manages backends explicitly, so it is exempt from the global
+# --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+# Discover available backends
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+# Rotated (pa) and rotating (omegab) so the cos/sin de-rotation is exercised.
+_SN = SoftenedNeedleBarPotential(amp=1.2, a=1.0, c=0.5, pa=0.3, omegab=1.4)
+_METHODS = ["_evaluate", "_Rforce", "_zforce", "_phitorque", "_dens"]
+_R0, _Z0, _PHI0, _T0 = 1.2, 0.3, 0.4, 0.0
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    if backend_name == "torch":
+        return torch.tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("method", _METHODS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, method):
+    # numpy / jax / torch agree at a scalar (R, z, phi, t), all on the active
+    # backend; the numpy path is byte-identical.
+    ref = float(
+        getattr(_SN, method)(
+            numpy.asarray(_R0), numpy.asarray(_Z0), numpy.asarray(_PHI0), _T0
+        )
+    )
+    got = float(
+        as_numpy(
+            getattr(_SN, method)(
+                _asarray(backend_name, _R0),
+                _asarray(backend_name, _Z0),
+                _asarray(backend_name, _PHI0),
+                _asarray(backend_name, _T0),
+            )
+        )
+    )
+    rtol, atol = (0.0, 0.0) if backend_name == "numpy" else (1e-11, 1e-13)
+    numpy.testing.assert_allclose(
+        got,
+        ref,
+        rtol=rtol,
+        atol=atol,
+        err_msg=f"SoftenedNeedle.{method} ({backend_name})",
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_rotating_scalar_t_under_forced_backend(backend_name):
+    # The orbit integrator hands the force a scalar Python-float t while the
+    # coordinates are backend arrays. Under a FORCED backend get_namespace(t) would
+    # resolve to that backend and torch.cos(python_float) raises (the rotating-bar
+    # t-anchoring gap); the concrete-t de-rotation coefficient must fall back to
+    # numpy (byte-identical, broadcasts). Checked at a scalar float t != 0.
+    R0, z0, phi0, t0 = 1.1, 0.15, 0.35, 0.7  # scalar Python-float t
+    methods = ("_Rforce", "_zforce", "_phitorque")
+    ref = numpy.array(
+        [
+            float(
+                getattr(_SN, m)(
+                    numpy.asarray(R0), numpy.asarray(z0), numpy.asarray(phi0), t0
+                )
+            )
+            for m in methods
+        ]
+    )
+    with use(backend_name, force=True):
+        got = numpy.array(
+            [
+                float(
+                    as_numpy(
+                        getattr(_SN, m)(
+                            _asarray(backend_name, R0),
+                            _asarray(backend_name, z0),
+                            _asarray(backend_name, phi0),
+                            t0,
+                        )
+                    )
+                )
+                for m in methods
+            ]
+        )
+    numpy.testing.assert_allclose(
+        got,
+        ref,
+        rtol=1e-11,
+        atol=1e-13,
+        err_msg=f"SoftenedNeedle rotating scalar-t ({backend_name})",
+    )
+
+
+@pytest.mark.parametrize("force", ["R", "z"])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_grad_vs_finite_difference(backend_name, force):
+    # Stringent grad-vs-FD: the force gradient w.r.t. R h-converges to a central
+    # finite difference (central-FD error ~ h^2).
+    fn = {"R": evaluateRforces, "z": evaluatezforces}[force]
+    z0, phi0, t0 = 0.3, 0.4, 0.1
+    R0 = 1.3
+
+    def num_force(R):
+        return float(
+            fn(_SN, numpy.asarray(R), numpy.asarray(z0), phi=numpy.asarray(phi0), t=t0)
+        )
+
+    if backend_name == "jax":
+        ad = float(
+            jax.jacfwd(
+                lambda R: fn(
+                    _SN, R, jnp.asarray(z0), phi=jnp.asarray(phi0), t=jnp.asarray(t0)
+                )
+            )(jnp.asarray(R0))
+        )
+    else:
+        Rt = torch.tensor(R0, requires_grad=True)
+        fn(
+            _SN, Rt, torch.tensor(z0), phi=torch.tensor(phi0), t=torch.tensor(t0)
+        ).backward()
+        ad = float(Rt.grad)
+    prev = None
+    for h in (1e-3, 1e-4, 1e-5):
+        fd = (num_force(R0 + h) - num_force(R0 - h)) / (2 * h)
+        rel = abs(ad - fd) / (abs(fd) + 1e-30)
+        if prev is not None:
+            assert rel <= prev + 1e-12
+        prev = rel
+    assert rel < 1e-6, (
+        f"SoftenedNeedle {force}-force grad-vs-FD rel={rel:.2e} ({backend_name})"
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_eager_returns_backend_array(backend_name):
+    # A backend coordinate returns a backend array (the migrated path is taken).
+    from galpy.backend import is_backend_array
+
+    out = _SN._Rforce(
+        _asarray(backend_name, _R0),
+        _asarray(backend_name, _Z0),
+        _asarray(backend_name, _PHI0),
+        _asarray(backend_name, 0.1),
+    )
+    assert is_backend_array(out)


### PR DESCRIPTION
Fixes three forced-backend gaps in the rotating-bar potentials **FerrersPotential** and **SoftenedNeedleBarPotential**. All are numpy byte-identical and source-only (no ledger edit; a CI regen prunes the now-XPASS entries).

## 1. Rotating-bar `t`-anchoring (both potentials)

The bar de-rotation coefficient namespace was resolved with `get_namespace(t)`; under a **forced** backend that returns the active backend even for the scalar Python-float `t` the integrator passes, and `torch.cos(python_float)` raises. Guard on `is_backend_array(t)`: concrete `t` → numpy coefficient (byte-identical, broadcasts); traced `t` → that backend (time-differentiable).

## 2. Array-coordinate quadrature (Ferrers) — the energy-conservation gap

`Orbit.E()` evaluates the potential/forces at an **array** of points in one call (all orbit times at once). The backend Gauss-Legendre quadrature appends a trailing node axis to the lower limit (so the integrand's `tau` carries it), but the coordinates didn't — an array coord broadcast against the nodes as `(N, N, M)` cross-terms instead of `(N, 1, M)`, giving a silently wrong potential (**~5% energy drift**). Fix: give `x/y/z` the same trailing node axis in `_potInt` / `_forceInt` / `_2ndDerivInt` (no-op for a scalar point).

## 3. Forced-backend coord coercion (Ferrers)

Under force, `get_namespace` resolves to the backend even for the numpy-scalar coordinates the C-fallback integrator hands the force, and `xp.cos(numpy.float64)` raises. Coerce `R,z,phi` with `coerce_coords` at the `_evaluate`/`_Rforce`/`_phitorque`/`_zforce` leaves (strict pass-through on numpy).

## Verified (CPU)

- **`test_energy_conservation_linear[FerrersPotential]`** and **`test_energy_jacobi_conservation[FerrersPotential]`** now **pass under torch** (were xfail); numpy still passes.
- Forced-torch Ferrers/SoftenedNeedle force/potential match numpy to **3.7e-15 / 0.0**; grad-vs-FD h-converged (**5.4e-9 / 1.3e-9**).
- **numpy byte-identical** (git-stash sample equal).
- **81** ferrers + softenedneedle backend tests pass. New coverage: forced-backend scalar-`t` (both potentials) + array-coords (Ferrers), each verified to **fail without the fix**; plus a new `test_backend_softenedneedlebar.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm