### PR TITLE
tests: burn down 36 torch + 11 jax backend xfails via as_numpy result-casts (wave 4)

### DIFF
--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -6005,32 +6005,41 @@ def test_orbit_interface_unbound_complexshape_adiabatic():
         obs.rperi(pot=MWPotential2014, type="adiabatic", analytic=True),
         obs.rap(pot=MWPotential2014, type="adiabatic", analytic=True),
     )
-    assert numpy.all(numpy.fabs(jr[:, 0] - aAA(obs[:, 0])[0]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(numpy.fabs(jp[:, 0] - aAA(obs[:, 0])[1]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(numpy.fabs(jz[:, 0] - aAA(obs[:, 0])[2]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
     assert numpy.all(
-        numpy.fabs(e[:, 0] - aAA.EccZmaxRperiRap(obs[:, 0])[0]) < 10.0**-10.0
+        numpy.fabs(jr[:, 0] - as_numpy(aAA(obs[:, 0])[0])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(zmax[:, 0] - aAA.EccZmaxRperiRap(obs[:, 0])[1]) < 10.0**-10.0
+        numpy.fabs(jp[:, 0] - as_numpy(aAA(obs[:, 0])[1])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(rperi[:, 0] - aAA.EccZmaxRperiRap(obs[:, 0])[2]) < 10.0**-10.0
+        numpy.fabs(jz[:, 0] - as_numpy(aAA(obs[:, 0])[2])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(rap[:, 0] - aAA.EccZmaxRperiRap(obs[:, 0])[3]) < 10.0**-10.0
+        numpy.fabs(e[:, 0] - as_numpy(aAA.EccZmaxRperiRap(obs[:, 0])[0])) < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(zmax[:, 0] - as_numpy(aAA.EccZmaxRperiRap(obs[:, 0])[1]))
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(rperi[:, 0] - as_numpy(aAA.EccZmaxRperiRap(obs[:, 0])[2]))
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(rap[:, 0] - as_numpy(aAA.EccZmaxRperiRap(obs[:, 0])[3]))
+        < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleAdiabatic does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
@@ -6098,62 +6107,74 @@ def test_orbit_interface_unbound_complexshape_staeckel():
         obs.rperi(pot=MWPotential2014, type="staeckel", delta=0.71, analytic=True),
         obs.rap(pot=MWPotential2014, type="staeckel", delta=0.71, analytic=True),
     )
-    assert numpy.all(numpy.fabs(jr[:, 0] - aAS(obs[:, 0])[0]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(numpy.fabs(jp[:, 0] - aAS(obs[:, 0])[1]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(numpy.fabs(jz[:, 0] - aAS(obs[:, 0])[2]) < 10.0**-10.0), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
     assert numpy.all(
-        numpy.fabs(omr[:, 0] - aAS.actionsFreqs(obs[:, 0])[3]) < 10.0**-10.0
+        numpy.fabs(jr[:, 0] - as_numpy(aAS(obs[:, 0])[0])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(omp[:, 0] - aAS.actionsFreqs(obs[:, 0])[4]) < 10.0**-10.0
+        numpy.fabs(jp[:, 0] - as_numpy(aAS(obs[:, 0])[1])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(omz[:, 0] - aAS.actionsFreqs(obs[:, 0])[5]) < 10.0**-10.0
+        numpy.fabs(jz[:, 0] - as_numpy(aAS(obs[:, 0])[2])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(wr[:, 0] - aAS.actionsFreqsAngles(obs[:, 0])[6]) < 10.0**-10.0
+        numpy.fabs(omr[:, 0] - as_numpy(aAS.actionsFreqs(obs[:, 0])[3])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(wp[:, 0] - aAS.actionsFreqsAngles(obs[:, 0])[7]) < 10.0**-10.0
+        numpy.fabs(omp[:, 0] - as_numpy(aAS.actionsFreqs(obs[:, 0])[4])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(wz[:, 0] - aAS.actionsFreqsAngles(obs[:, 0])[8]) < 10.0**-10.0
+        numpy.fabs(omz[:, 0] - as_numpy(aAS.actionsFreqs(obs[:, 0])[5])) < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(e[:, 0] - aAS.EccZmaxRperiRap(obs[:, 0])[0]) < 10.0**-10.0
+        numpy.fabs(wr[:, 0] - as_numpy(aAS.actionsFreqsAngles(obs[:, 0])[6]))
+        < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(zmax[:, 0] - aAS.EccZmaxRperiRap(obs[:, 0])[1]) < 10.0**-10.0
+        numpy.fabs(wp[:, 0] - as_numpy(aAS.actionsFreqsAngles(obs[:, 0])[7]))
+        < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(rperi[:, 0] - aAS.EccZmaxRperiRap(obs[:, 0])[2]) < 10.0**-10.0
+        numpy.fabs(wz[:, 0] - as_numpy(aAS.actionsFreqsAngles(obs[:, 0])[8]))
+        < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
     assert numpy.all(
-        numpy.fabs(rap[:, 0] - aAS.EccZmaxRperiRap(obs[:, 0])[3]) < 10.0**-10.0
+        numpy.fabs(e[:, 0] - as_numpy(aAS.EccZmaxRperiRap(obs[:, 0])[0])) < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(zmax[:, 0] - as_numpy(aAS.EccZmaxRperiRap(obs[:, 0])[1]))
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(rperi[:, 0] - as_numpy(aAS.EccZmaxRperiRap(obs[:, 0])[2]))
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(rap[:, 0] - as_numpy(aAS.EccZmaxRperiRap(obs[:, 0])[3]))
+        < 10.0**-10.0
     ), (
         "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
     )
@@ -6214,26 +6235,8 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     aAS = actionAngleStaeckel(pot=MWPotential2014, delta=0.71)  # just a dummy delta
     bound_indx = numpy.array([True, False, True, False, True, False])
     assert numpy.all(
-        numpy.fabs(jr[:, 0] - aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[0])
-        < 10.0**-10.0
-    ), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(
-        numpy.fabs(jp[:, 0] - aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[1])
-        < 10.0**-10.0
-    ), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(
-        numpy.fabs(jz[:, 0] - aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[2])
-        < 10.0**-10.0
-    ), (
-        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
-    )
-    assert numpy.all(
         numpy.fabs(
-            omr[:, 0] - aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[3]
+            jr[:, 0] - as_numpy(aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[0])
         )
         < 10.0**-10.0
     ), (
@@ -6241,7 +6244,7 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     )
     assert numpy.all(
         numpy.fabs(
-            omp[:, 0] - aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[4]
+            jp[:, 0] - as_numpy(aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[1])
         )
         < 10.0**-10.0
     ), (
@@ -6249,7 +6252,34 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     )
     assert numpy.all(
         numpy.fabs(
-            omz[:, 0] - aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[5]
+            jz[:, 0] - as_numpy(aAS(obs[:, 0], delta=obs._aA._delta[bound_indx])[2])
+        )
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(
+            omr[:, 0]
+            - as_numpy(aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[3])
+        )
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(
+            omp[:, 0]
+            - as_numpy(aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[4])
+        )
+        < 10.0**-10.0
+    ), (
+        "Orbit interface for actionAngleStaeckel does not return the same as actionAngle interface for bound orbit in a collection with an unbound orbit"
+    )
+    assert numpy.all(
+        numpy.fabs(
+            omz[:, 0]
+            - as_numpy(aAS.actionsFreqs(obs[:, 0], delta=obs._aA._delta[bound_indx])[5])
         )
         < 10.0**-10.0
     ), (
@@ -6258,7 +6288,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             wr[:, 0]
-            - aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[6]
+            - as_numpy(
+                aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[6]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6267,7 +6299,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             wp[:, 0]
-            - aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[7]
+            - as_numpy(
+                aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[7]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6276,7 +6310,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             wz[:, 0]
-            - aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[8]
+            - as_numpy(
+                aAS.actionsFreqsAngles(obs[:, 0], delta=obs._aA._delta[bound_indx])[8]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6285,7 +6321,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             e[:, 0]
-            - aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[0]
+            - as_numpy(
+                aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[0]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6294,7 +6332,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             zmax[:, 0]
-            - aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[1]
+            - as_numpy(
+                aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[1]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6303,7 +6343,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             rperi[:, 0]
-            - aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[2]
+            - as_numpy(
+                aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[2]
+            )
         )
         < 10.0**-10.0
     ), (
@@ -6312,7 +6354,9 @@ def test_orbit_interface_unbound_staeckeldelta_handling():
     assert numpy.all(
         numpy.fabs(
             rap[:, 0]
-            - aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[3]
+            - as_numpy(
+                aAS.EccZmaxRperiRap(obs[:, 0], delta=obs._aA._delta[bound_indx])[3]
+            )
         )
         < 10.0**-10.0
     ), (

--- a/tests/test_noninertial.py
+++ b/tests/test_noninertial.py
@@ -3,6 +3,7 @@ import numpy
 import pytest
 
 from galpy import potential
+from galpy.backend import as_numpy
 from galpy.orbit import Orbit
 from galpy.util import coords
 
@@ -11,7 +12,7 @@ def test_lsrframe_scalaromegaz():
     # Test that integrating an orbit in the LSR frame is equivalent to
     # normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     dp = potential.DehnenBarPotential(omegab=1.8, rb=0.5, Af=0.03)
     diskpot = lp + dp
     framepot = potential.NonInertialFrameForce(cinterp=False, Omega=omega)
@@ -29,10 +30,10 @@ def test_lsrframe_scalaromegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(as_numpy(o.phi(ts)) - omega * ts)
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(as_numpy(o.phi(ts)) - omega * ts)
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the rotating LSR frame does not agree with the equivalent orbit in the inertial frame for integration method {method}"
         )
@@ -49,7 +50,7 @@ def test_lsrframe_scalaromegaz_2d():
     # Test that integrating an orbit in the LSR frame is equivalent to
     # normal orbit integration in 2D
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     dp = potential.DehnenBarPotential(omegab=1.8, rb=0.5, Af=0.03)
     diskpot = lp + dp
     framepot = potential.NonInertialFrameForce(cinterp=False, Omega=omega)
@@ -67,10 +68,10 @@ def test_lsrframe_scalaromegaz_2d():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(as_numpy(o.phi(ts)) - omega * ts)
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(as_numpy(o.phi(ts)) - omega * ts)
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the rotating LSR frame does not agree with the equivalent orbit in the inertial frame for integration method {method}"
         )
@@ -87,7 +88,7 @@ def test_lsrframe_vecomegaz():
     # Test that integrating an orbit in the LSR frame is equivalent to
     # normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     dp = potential.DehnenBarPotential(omegab=1.8, rb=0.5, Af=0.03)
     diskpot = lp + dp
     framepot = potential.NonInertialFrameForce(
@@ -107,10 +108,10 @@ def test_lsrframe_vecomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(as_numpy(o.phi(ts)) - omega * ts)
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(as_numpy(o.phi(ts)) - omega * ts)
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -127,7 +128,7 @@ def test_lsrframe_vecomegaz_2d():
     # Test that integrating an orbit in the LSR frame is equivalent to
     # normal orbit integration in 2D
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     dp = potential.DehnenBarPotential(omegab=1.8, rb=0.5, Af=0.03)
     diskpot = lp + dp
     framepot = potential.NonInertialFrameForce(
@@ -147,10 +148,10 @@ def test_lsrframe_vecomegaz_2d():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(as_numpy(o.phi(ts)) - omega * ts)
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(as_numpy(o.phi(ts)) - omega * ts)
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -167,7 +168,7 @@ def test_accellsrframe_scalaromegaz():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     diskpot = lp
     framepot = potential.NonInertialFrameForce(
@@ -186,10 +187,14 @@ def test_accellsrframe_scalaromegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -206,7 +211,7 @@ def test_accellsrframe_scalaromegaz_2d():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration in 2D
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     diskpot = lp
     framepot = potential.NonInertialFrameForce(
@@ -225,10 +230,14 @@ def test_accellsrframe_scalaromegaz_2d():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -245,7 +254,7 @@ def test_accellsrframe_vecomegaz():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     diskpot = lp
     framepot = potential.NonInertialFrameForce(
@@ -266,10 +275,14 @@ def test_accellsrframe_vecomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -286,7 +299,7 @@ def test_accellsrframe_vecomegaz_2d():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration in 2D
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     diskpot = lp
     framepot = potential.NonInertialFrameForce(
@@ -307,10 +320,14 @@ def test_accellsrframe_vecomegaz_2d():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -327,7 +344,7 @@ def test_accellsrframe_funcomegaz():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     omega_func = lambda t: lp.omegac(1.0) + 0.02 * t
     omegadot_func = lambda t: 0.02
@@ -348,10 +365,14 @@ def test_accellsrframe_funcomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -368,7 +389,7 @@ def test_accellsrframe_funcomegaz_2d():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     omega_func = lambda t: lp.omegac(1.0) + 0.02 * t
     omegadot_func = lambda t: 0.02
@@ -389,10 +410,14 @@ def test_accellsrframe_funcomegaz_2d():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -409,7 +434,7 @@ def test_accellsrframe_vecfuncomegaz():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     omega_func = [lambda t: 0.0, lambda t: 0.0, lambda t: lp.omegac(1.0) + 0.02 * t]
     omegadot_func = [lambda t: 0.0, lambda t: 0.0, lambda t: 0.02]
@@ -430,10 +455,14 @@ def test_accellsrframe_vecfuncomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -450,7 +479,7 @@ def test_accellsrframe_vecfuncomegaz_2D():
     # Test that integrating an orbit in an LSR frame that is accelerating
     # is equivalent to normal orbit integration
     lp = potential.LogarithmicHaloPotential(normalize=1.0)
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     omega_func = [lambda t: 0.0, lambda t: 0.0, lambda t: lp.omegac(1.0) + 0.02 * t]
     omegadot_func = [lambda t: 0.0, lambda t: 0.0, lambda t: 0.02]
@@ -471,10 +500,14 @@ def test_accellsrframe_vecfuncomegaz_2D():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.R(ts) * numpy.cos(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        o_ys = o.R(ts) * numpy.sin(o.phi(ts) - omega * ts - omegadot * ts**2.0 / 2.0)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.R(ts)) * numpy.cos(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        o_ys = as_numpy(o.R(ts)) * numpy.sin(
+            as_numpy(o.phi(ts)) - omega * ts - omegadot * ts**2.0 / 2.0
+        )
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in the acceleratingly-rotating LSR frame does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -532,29 +565,35 @@ def test_arbitraryaxisrotation_nullpotential():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t), op.y(t), phi=op.z(t), t=t, rot=rot, omega=omega, rect=True
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
+                t=t,
+                rot=rot,
+                omega=omega,
+                rect=True,
             )
             op_xs.append(xyz[0])
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -634,29 +673,35 @@ def test_arbitraryaxisrotation():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t), op.y(t), phi=op.z(t), t=t, rot=rot, omega=omega, rect=True
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
+                t=t,
+                rot=rot,
+                omega=omega,
+                rect=True,
             )
             op_xs.append(xyz[0])
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -745,20 +790,20 @@ def test_arbitraryaxisrotation_omegadot_nullpotential():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t),
-                op.y(t),
-                phi=op.z(t),
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -769,12 +814,12 @@ def test_arbitraryaxisrotation_omegadot_nullpotential():
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -866,20 +911,20 @@ def test_arbitraryaxisrotation_omegadot():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t),
-                op.y(t),
-                phi=op.z(t),
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -890,12 +935,12 @@ def test_arbitraryaxisrotation_omegadot():
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -1003,20 +1048,20 @@ def test_arbitraryaxisrotation_omegafunc_nullpotential():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t),
-                op.y(t),
-                phi=op.z(t),
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -1028,12 +1073,12 @@ def test_arbitraryaxisrotation_omegafunc_nullpotential():
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -1150,20 +1195,20 @@ def test_arbitraryaxisrotation_omegafunc():
         )
         # Compare
         # Orbit in the inertial frame
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vRs = o.vR(ts)
-        o_vTs = o.vT(ts)
-        o_vzs = o.vz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vRs = as_numpy(o.vR(ts))
+        o_vTs = as_numpy(o.vT(ts))
+        o_vzs = as_numpy(o.vz(ts))
         # and that computed in the non-inertial frame converted back to inertial
         op_xs, op_ys, op_zs = [], [], []
         op_vRs, op_vTs, op_vzs = [], [], []
         for ii, t in enumerate(ts):
             xyz = rotate_and_omega(
-                op.x(t),
-                op.y(t),
-                phi=op.z(t),
+                as_numpy(op.x(t)),
+                as_numpy(op.y(t)),
+                phi=as_numpy(op.z(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -1175,12 +1220,12 @@ def test_arbitraryaxisrotation_omegafunc():
             op_ys.append(xyz[1])
             op_zs.append(xyz[2])
             vRTz = rotate_and_omega_vec(
-                op.vR(t),
-                op.vT(t),
-                op.vz(t),
-                op.R(t),
-                op.z(t),
-                phi=op.phi(t),
+                as_numpy(op.vR(t)),
+                as_numpy(op.vT(t)),
+                as_numpy(op.vz(t)),
+                as_numpy(op.R(t)),
+                as_numpy(op.z(t)),
+                phi=as_numpy(op.phi(t)),
                 t=t,
                 rot=rot,
                 omega=omega,
@@ -1246,12 +1291,12 @@ def test_linacc_constantacc_z():
         op = o()
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
-        op_zs = op.z(ts) + intaz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
+        op_zs = as_numpy(op.z(ts)) + intaz(ts)
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1296,10 +1341,10 @@ def test_linacc_constantacc_x_2d():
         op = o()
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        op_xs = op.x(ts) + intax(ts)
-        op_ys = op.y(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        op_xs = as_numpy(op.x(ts)) + intax(ts)
+        op_ys = as_numpy(op.y(ts))
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1342,12 +1387,12 @@ def test_linacc_constantacc_xyz():
         op = o()
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        op_xs = op.x(ts) + inta[0](ts)
-        op_ys = op.y(ts) + inta[1](ts)
-        op_zs = op.z(ts) + inta[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        op_xs = as_numpy(op.x(ts)) + inta[0](ts)
+        op_ys = as_numpy(op.y(ts)) + inta[1](ts)
+        op_zs = as_numpy(op.z(ts)) + inta[2](ts)
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1394,12 +1439,12 @@ def test_linacc_changingacc_z():
         op = o()
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        op_xs = op.x(ts)
-        op_ys = op.y(ts)
-        op_zs = op.z(ts) + intaz(ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        op_xs = as_numpy(op.x(ts))
+        op_ys = as_numpy(op.y(ts))
+        op_zs = as_numpy(op.z(ts)) + intaz(ts)
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1449,12 +1494,12 @@ def test_linacc_changingacc_xyz():
         op = o()
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        op_xs = op.x(ts) + inta[0](ts)
-        op_ys = op.y(ts) + inta[1](ts)
-        op_zs = op.z(ts) + inta[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        op_xs = as_numpy(op.x(ts)) + inta[0](ts)
+        op_ys = as_numpy(op.y(ts)) + inta[1](ts)
+        op_zs = as_numpy(op.z(ts)) + inta[2](ts)
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1495,7 +1540,7 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     framepot = potential.NonInertialFrameForce(
         cinterp=False, x0=x0, v0=v0, a0=a0, Omega=omega, Omegadot=omegadot
@@ -1517,28 +1562,28 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vxs = o.vx(ts)
-        o_vys = o.vy(ts)
-        o_vzs = o.vz(ts)
-        op_xs = op.x(ts) + x0[0](ts)
-        op_ys = op.y(ts) + x0[1](ts)
-        op_zs = op.z(ts) + x0[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vxs = as_numpy(o.vx(ts))
+        o_vys = as_numpy(o.vy(ts))
+        o_vzs = as_numpy(o.vz(ts))
+        op_xs = as_numpy(op.x(ts)) + x0[0](ts)
+        op_ys = as_numpy(op.y(ts)) + x0[1](ts)
+        op_zs = as_numpy(op.z(ts)) + x0[2](ts)
         Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
         phip += omega * ts + omegadot * ts**2.0 / 2.0
         op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
-        op_vxs = op.vx(ts) + v0[0](ts)
-        op_vys = op.vy(ts) + v0[1](ts)
-        op_vzs = op.vz(ts) + v0[2](ts)
+        op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
+        op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
+        op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
         vRp, vTp, _ = coords.rect_to_cyl_vec(
             op_vxs,
             op_vys,
             op_vzs,
-            op.x(ts) + x0[0](ts),
-            op.y(ts) + x0[1](ts),
-            op.z(ts) + x0[2](ts),
+            as_numpy(op.x(ts)) + x0[0](ts),
+            as_numpy(op.y(ts)) + x0[1](ts),
+            as_numpy(op.z(ts)) + x0[2](ts),
         )
         vTp += omega * Rp + omegadot * ts * Rp
         op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
@@ -1591,7 +1636,7 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     framepot = potential.NonInertialFrameForce(
         cinterp=False,
@@ -1618,28 +1663,28 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vxs = o.vx(ts)
-        o_vys = o.vy(ts)
-        o_vzs = o.vz(ts)
-        op_xs = op.x(ts) + x0[0](ts)
-        op_ys = op.y(ts) + x0[1](ts)
-        op_zs = op.z(ts) + x0[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vxs = as_numpy(o.vx(ts))
+        o_vys = as_numpy(o.vy(ts))
+        o_vzs = as_numpy(o.vz(ts))
+        op_xs = as_numpy(op.x(ts)) + x0[0](ts)
+        op_ys = as_numpy(op.y(ts)) + x0[1](ts)
+        op_zs = as_numpy(op.z(ts)) + x0[2](ts)
         Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
         phip += omega * ts + omegadot * ts**2.0 / 2.0
         op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
-        op_vxs = op.vx(ts) + v0[0](ts)
-        op_vys = op.vy(ts) + v0[1](ts)
-        op_vzs = op.vz(ts) + v0[2](ts)
+        op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
+        op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
+        op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
         vRp, vTp, _ = coords.rect_to_cyl_vec(
             op_vxs,
             op_vys,
             op_vzs,
-            op.x(ts) + x0[0](ts),
-            op.y(ts) + x0[1](ts),
-            op.z(ts) + x0[2](ts),
+            as_numpy(op.x(ts)) + x0[0](ts),
+            as_numpy(op.y(ts)) + x0[1](ts),
+            as_numpy(op.z(ts)) + x0[2](ts),
         )
         vTp += omega * Rp + omegadot * ts * Rp
         op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
@@ -1692,7 +1737,7 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.1
     omegadotdot = 0.01
     omega_func = lambda t: omega + omegadot * t + omegadotdot * t**2.0 / 2.0
@@ -1721,28 +1766,28 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vxs = o.vx(ts)
-        o_vys = o.vy(ts)
-        o_vzs = o.vz(ts)
-        op_xs = op.x(ts) + x0[0](ts)
-        op_ys = op.y(ts) + x0[1](ts)
-        op_zs = op.z(ts) + x0[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vxs = as_numpy(o.vx(ts))
+        o_vys = as_numpy(o.vy(ts))
+        o_vzs = as_numpy(o.vz(ts))
+        op_xs = as_numpy(op.x(ts)) + x0[0](ts)
+        op_ys = as_numpy(op.y(ts)) + x0[1](ts)
+        op_zs = as_numpy(op.z(ts)) + x0[2](ts)
         Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
         op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
-        op_vxs = op.vx(ts) + v0[0](ts)
-        op_vys = op.vy(ts) + v0[1](ts)
-        op_vzs = op.vz(ts) + v0[2](ts)
+        op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
+        op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
+        op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
         vRp, vTp, _ = coords.rect_to_cyl_vec(
             op_vxs,
             op_vys,
             op_vzs,
-            op.x(ts) + x0[0](ts),
-            op.y(ts) + x0[1](ts),
-            op.z(ts) + x0[2](ts),
+            as_numpy(op.x(ts)) + x0[0](ts),
+            as_numpy(op.y(ts)) + x0[1](ts),
+            as_numpy(op.z(ts)) + x0[2](ts),
         )
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
         op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
@@ -1795,7 +1840,7 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.1
     omegadotdot = 0.01
     omega_func = [
@@ -1828,28 +1873,28 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
         op = Orbit([o.R(), o.vR(), o.vT() - omega * o.R(), o.z(), o.vz(), o.phi()])
         op.integrate(ts, diskframepot, method=method)
         # Compare
-        o_xs = o.x(ts)
-        o_ys = o.y(ts)
-        o_zs = o.z(ts)
-        o_vxs = o.vx(ts)
-        o_vys = o.vy(ts)
-        o_vzs = o.vz(ts)
-        op_xs = op.x(ts) + x0[0](ts)
-        op_ys = op.y(ts) + x0[1](ts)
-        op_zs = op.z(ts) + x0[2](ts)
+        o_xs = as_numpy(o.x(ts))
+        o_ys = as_numpy(o.y(ts))
+        o_zs = as_numpy(o.z(ts))
+        o_vxs = as_numpy(o.vx(ts))
+        o_vys = as_numpy(o.vy(ts))
+        o_vzs = as_numpy(o.vz(ts))
+        op_xs = as_numpy(op.x(ts)) + x0[0](ts)
+        op_ys = as_numpy(op.y(ts)) + x0[1](ts)
+        op_zs = as_numpy(op.z(ts)) + x0[2](ts)
         Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
         op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
-        op_vxs = op.vx(ts) + v0[0](ts)
-        op_vys = op.vy(ts) + v0[1](ts)
-        op_vzs = op.vz(ts) + v0[2](ts)
+        op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
+        op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
+        op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
         vRp, vTp, _ = coords.rect_to_cyl_vec(
             op_vxs,
             op_vys,
             op_vzs,
-            op.x(ts) + x0[0](ts),
-            op.y(ts) + x0[1](ts),
-            op.z(ts) + x0[2](ts),
+            as_numpy(op.x(ts)) + x0[0](ts),
+            as_numpy(op.y(ts)) + x0[1](ts),
+            as_numpy(op.z(ts)) + x0[2](ts),
         )
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
         op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
@@ -1920,22 +1965,22 @@ def test_python_vs_c_arbitraryaxisrotation():
             ),
             method=c_method,
         )
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -1994,22 +2039,22 @@ def test_python_vs_c_arbitraryaxisrotation_omegadot():
             method=c_method,
         )
         # Compare
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2098,22 +2143,22 @@ def test_python_vs_c_arbitraryaxisrotation_funcomega():
             method=c_method,
         )
         # Compare
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2150,22 +2195,22 @@ def test_python_vs_c_linacc_changingacc_xyz():
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
         # Compare
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2195,7 +2240,7 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     framepot = potential.NonInertialFrameForce(
         cinterp=False, x0=x0, v0=v0, a0=a0, Omega=omega, Omegadot=omegadot
@@ -2211,22 +2256,22 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         # In C
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2256,7 +2301,7 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalaromegaz_2d():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     framepot = potential.NonInertialFrameForce(
         cinterp=False, x0=x0, v0=v0, a0=a0, Omega=omega, Omegadot=omegadot
@@ -2272,16 +2317,16 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalaromegaz_2d():
         # In C
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2311,7 +2356,7 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.02
     framepot = potential.NonInertialFrameForce(
         cinterp=False,
@@ -2332,22 +2377,22 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         # In C
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2377,7 +2422,7 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.1
     omegadotdot = 0.01
     omega_func = lambda t: omega + omegadot * t + omegadotdot * t**2.0 / 2.0
@@ -2396,22 +2441,22 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         # In C
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2441,7 +2486,7 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         lambda t: 0.04 + 0.08 * t / 20.0,
         lambda t: 0.02 + 0.03 * t / 20.0,
     ]
-    omega = lp.omegac(1.0)
+    omega = as_numpy(lp.omegac(1.0))
     omegadot = 0.1
     omegadotdot = 0.01
     omega_func = [
@@ -2464,22 +2509,22 @@ def test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         # In C
         op = o()
         op.integrate(ts, diskpot + framepot, method=c_method)
-        assert numpy.amax(numpy.fabs(o.x(ts) - op.x(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.x(ts)) - as_numpy(op.x(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.y(ts) - op.y(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.y(ts)) - as_numpy(op.y(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.z(ts) - op.z(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.z(ts)) - as_numpy(op.z(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vx(ts) - op.vx(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vx(ts)) - as_numpy(op.vx(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vy(ts) - op.vy(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vy(ts)) - as_numpy(op.vy(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
-        assert numpy.amax(numpy.fabs(o.vz(ts) - op.vz(ts))) < tol, (
+        assert numpy.amax(numpy.fabs(as_numpy(o.vz(ts)) - as_numpy(op.vz(ts)))) < tol, (
             f"Integrating an orbit in a rotating frame in Python does not agree with integrating the same orbit in C; using methods {py_method} and {c_method}"
         )
         return None
@@ -2803,7 +2848,11 @@ def _cinterp_TvsF_maxdiff(pot_builder, ic, ts, fns, method="dop853_c"):
     o_true.turn_physical_off()
     o_true.integrate(ts, pot_builder(True), method=method)
     return max(
-        numpy.amax(numpy.fabs(getattr(o_false, f)(ts) - getattr(o_true, f)(ts)))
+        numpy.amax(
+            numpy.fabs(
+                as_numpy(getattr(o_false, f)(ts)) - as_numpy(getattr(o_true, f)(ts))
+            )
+        )
         for f in fns
     )
 

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1483,15 +1483,15 @@ def test_orbit_method_value():
     ), "Orbit method Jacobi does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.L(pot=MWPotential2014).to(units.km / units.s * units.kpc).value
-            - oc.L(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.L(pot=MWPotential2014).to(units.km / units.s * units.kpc).value)
+            - as_numpy(oc.L(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Lz(pot=MWPotential2014).to(units.km / units.s * units.kpc).value
-            - oc.Lz(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.Lz(pot=MWPotential2014).to(units.km / units.s * units.kpc).value)
+            - as_numpy(oc.Lz(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value as Quantity"
@@ -1811,15 +1811,15 @@ def test_orbit_method_value_turnquantityoff():
     ), "Orbit method Jacobi does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.L(pot=MWPotential2014, quantity=False)
-            - oc.L(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.L(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.L(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Lz(pot=MWPotential2014, quantity=False)
-            - oc.Lz(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.Lz(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.Lz(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value when Quantity turned off"
@@ -3125,310 +3125,451 @@ def test_orbits_method_value():
     oc.turn_physical_off()
     assert numpy.all(
         numpy.fabs(
-            o.E(pot=MWPotential2014).to(units.km**2 / units.s**2).value
-            - oc.E(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.E(pot=MWPotential2014).to(units.km**2 / units.s**2).value)
+            - as_numpy(oc.E(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method E does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.ER(pot=MWPotential2014).to(units.km**2 / units.s**2).value
-            - oc.ER(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.ER(pot=MWPotential2014).to(units.km**2 / units.s**2).value)
+            - as_numpy(oc.ER(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method ER does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Ez(pot=MWPotential2014).to(units.km**2 / units.s**2).value
-            - oc.Ez(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.Ez(pot=MWPotential2014).to(units.km**2 / units.s**2).value)
+            - as_numpy(oc.Ez(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method Ez does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Jacobi(pot=MWPotential2014).to(units.km**2 / units.s**2).value
-            - oc.Jacobi(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.Jacobi(pot=MWPotential2014).to(units.km**2 / units.s**2).value)
+            - as_numpy(oc.Jacobi(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method Jacobi does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.L(pot=MWPotential2014).to(units.km / units.s * units.kpc).value
-            - oc.L(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.L(pot=MWPotential2014).to(units.km / units.s * units.kpc).value)
+            - as_numpy(oc.L(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Lz(pot=MWPotential2014).to(units.km / units.s * units.kpc).value
-            - oc.Lz(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.Lz(pot=MWPotential2014).to(units.km / units.s * units.kpc).value)
+            - as_numpy(oc.Lz(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.rap(pot=MWPotential2014, analytic=True).to(units.kpc).value
-            - oc.rap(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.rap(pot=MWPotential2014, analytic=True).to(units.kpc).value)
+            - as_numpy(oc.rap(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rap does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.rperi(pot=MWPotential2014, analytic=True).to(units.kpc).value
-            - oc.rperi(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.rperi(pot=MWPotential2014, analytic=True).to(units.kpc).value)
+            - as_numpy(oc.rperi(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rperi does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.rguiding(pot=MWPotential2014).to(units.kpc).value
-            - oc.rguiding(pot=MWPotential2014) * o._ro
+            as_numpy(o.rguiding(pot=MWPotential2014).to(units.kpc).value)
+            - as_numpy(oc.rguiding(pot=MWPotential2014) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rguiding does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.rE(pot=MWPotential2014).to(units.kpc).value
-            - oc.rE(pot=MWPotential2014) * o._ro
+            as_numpy(o.rE(pot=MWPotential2014).to(units.kpc).value)
+            - as_numpy(oc.rE(pot=MWPotential2014) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rE does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.LcE(pot=MWPotential2014).to(units.kpc * units.km / units.s).value
-            - oc.LcE(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(
+                o.LcE(pot=MWPotential2014).to(units.kpc * units.km / units.s).value
+            )
+            - as_numpy(oc.LcE(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method LcE does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.zmax(pot=MWPotential2014, analytic=True).to(units.kpc).value
-            - oc.zmax(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.zmax(pot=MWPotential2014, analytic=True).to(units.kpc).value)
+            - as_numpy(oc.zmax(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method zmax does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.jr(pot=MWPotential2014, type="staeckel", delta=0.5)
-            .to(units.km / units.s * units.kpc)
-            .value
-            - oc.jr(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            as_numpy(
+                o.jr(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.km / units.s * units.kpc)
+                .value
+            )
+            - as_numpy(
+                oc.jr(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jr does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.jp(pot=MWPotential2014, type="staeckel", delta=4.0 * units.kpc)
-            .to(units.km / units.s * units.kpc)
-            .value
-            - oc.jp(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            as_numpy(
+                o.jp(pot=MWPotential2014, type="staeckel", delta=4.0 * units.kpc)
+                .to(units.km / units.s * units.kpc)
+                .value
+            )
+            - as_numpy(
+                oc.jp(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jp does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.jz(pot=MWPotential2014, type="isochroneapprox", b=0.8 * 8.0 * units.kpc)
-            .to(units.km / units.s * units.kpc)
-            .value
-            - oc.jz(pot=MWPotential2014, type="isochroneapprox", b=0.8) * o._ro * o._vo
+            as_numpy(
+                o.jz(
+                    pot=MWPotential2014, type="isochroneapprox", b=0.8 * 8.0 * units.kpc
+                )
+                .to(units.km / units.s * units.kpc)
+                .value
+            )
+            - as_numpy(
+                oc.jz(pot=MWPotential2014, type="isochroneapprox", b=0.8)
+                * o._ro
+                * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jz does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.wr(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.rad).value
-            - oc.wr(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wr(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.rad)
+                .value
+            )
+            - as_numpy(oc.wr(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wr does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.wp(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.rad).value
-            - oc.wp(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wp(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.rad)
+                .value
+            )
+            - as_numpy(oc.wp(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wp does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.wz(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.rad).value
-            - oc.wz(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.rad)
+                .value
+            )
+            - as_numpy(oc.wz(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wz does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Tr(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.Gyr).value
-            - oc.Tr(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tr(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Tr(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tr does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Tp(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.Gyr).value
-            - oc.Tp(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tp(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Tp(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tp does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Tz(pot=MWPotential2014, type="staeckel", delta=0.5).to(units.Gyr).value
-            - oc.Tz(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Tz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tz does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
-            .to(1 / units.Gyr)
-            .value
-            - oc.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(1 / units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Or does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
-            .to(1 / units.Gyr)
-            .value
-            - oc.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(1 / units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Opbit method Or does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
-            .to(1 / units.Gyr)
-            .value
-            - oc.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                .to(1 / units.Gyr)
+                .value
+            )
+            - as_numpy(
+                oc.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Ozbit method Or does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.time().to(units.Gyr).value
-            - oc.time() * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(o.time().to(units.Gyr).value)
+            - as_numpy(oc.time() * conversion.time_in_Gyr(o._vo, o._ro))
         )
         < 10.0**-8.0
     ), "Orbit method time does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.R().to(units.kpc).value - oc.R() * o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.R().to(units.kpc).value) - as_numpy(oc.R() * o._ro))
+        < 10.0**-8.0
     ), "Orbit method R does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.r().to(units.kpc).value - oc.r() * o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.r().to(units.kpc).value) - as_numpy(oc.r() * o._ro))
+        < 10.0**-8.0
     ), "Orbit method r does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vR().to(units.km / units.s).value - oc.vR() * o._vo) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.vR().to(units.km / units.s).value) - as_numpy(oc.vR() * o._vo)
+        )
+        < 10.0**-8.0
     ), "Orbit method vR does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vT().to(units.km / units.s).value - oc.vT() * o._vo) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.vT().to(units.km / units.s).value) - as_numpy(oc.vT() * o._vo)
+        )
+        < 10.0**-8.0
     ), "Orbit method vT does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.z().to(units.kpc).value - oc.z() * o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.z().to(units.kpc).value) - as_numpy(oc.z() * o._ro))
+        < 10.0**-8.0
     ), "Orbit method z does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vz().to(units.km / units.s).value - oc.vz() * o._vo) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.vz().to(units.km / units.s).value) - as_numpy(oc.vz() * o._vo)
+        )
+        < 10.0**-8.0
     ), "Orbit method vz does not return the correct value as Quantity"
-    assert numpy.all(numpy.fabs(o.phi().to(units.rad).value - oc.phi()) < 10.0**-8.0), (
-        "Orbit method phi does not return the correct value as Quantity"
-    )
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.phi().to(units.rad).value) - as_numpy(oc.phi()))
+        < 10.0**-8.0
+    ), "Orbit method phi does not return the correct value as Quantity"
     assert numpy.all(
         numpy.fabs(
-            o.vphi().to(units.km / units.s / units.kpc).value
-            - oc.vphi() * o._vo / o._ro
+            as_numpy(o.vphi().to(units.km / units.s / units.kpc).value)
+            - as_numpy(oc.vphi() * o._vo / o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method vphi does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.x().to(units.kpc).value - oc.x() * o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.x().to(units.kpc).value) - as_numpy(oc.x() * o._ro))
+        < 10.0**-8.0
     ), "Orbit method x does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.y().to(units.kpc).value - oc.y() * o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.y().to(units.kpc).value) - as_numpy(oc.y() * o._ro))
+        < 10.0**-8.0
     ), "Orbit method y does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vx().to(units.km / units.s).value - oc.vx() * o._vo) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.vx().to(units.km / units.s).value) - as_numpy(oc.vx() * o._vo)
+        )
+        < 10.0**-8.0
     ), "Orbit method vx does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vy().to(units.km / units.s).value - oc.vy() * o._vo) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.vy().to(units.km / units.s).value) - as_numpy(oc.vy() * o._vo)
+        )
+        < 10.0**-8.0
     ), "Orbit method vy does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.ra().to(units.deg).value - oc.ra(quantity=False)) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.ra().to(units.deg).value) - as_numpy(oc.ra(quantity=False))
+        )
+        < 10.0**-8.0
     ), "Orbit method ra does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.dec().to(units.deg).value - oc.dec(quantity=False)) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.dec().to(units.deg).value) - as_numpy(oc.dec(quantity=False))
+        )
+        < 10.0**-8.0
     ), "Orbit method dec does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.ll().to(units.deg).value - oc.ll(quantity=False)) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.ll().to(units.deg).value) - as_numpy(oc.ll(quantity=False))
+        )
+        < 10.0**-8.0
     ), "Orbit method ll does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.bb().to(units.deg).value - oc.bb(quantity=False)) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.bb().to(units.deg).value) - as_numpy(oc.bb(quantity=False))
+        )
+        < 10.0**-8.0
     ), "Orbit method bb does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.dist().to(units.kpc).value - oc.dist(quantity=False)) < 10.0**-8.0
+        numpy.fabs(
+            as_numpy(o.dist().to(units.kpc).value) - as_numpy(oc.dist(quantity=False))
+        )
+        < 10.0**-8.0
     ), "Orbit method dist does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.pmra().to(units.mas / units.yr).value - oc.pmra(quantity=False))
+        numpy.fabs(
+            as_numpy(o.pmra().to(units.mas / units.yr).value)
+            - as_numpy(oc.pmra(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method pmra does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.pmdec().to(units.mas / units.yr).value - oc.pmdec(quantity=False))
+        numpy.fabs(
+            as_numpy(o.pmdec().to(units.mas / units.yr).value)
+            - as_numpy(oc.pmdec(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method pmdec does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.pmll().to(units.mas / units.yr).value - oc.pmll(quantity=False))
+        numpy.fabs(
+            as_numpy(o.pmll().to(units.mas / units.yr).value)
+            - as_numpy(oc.pmll(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method pmll does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.pmbb().to(units.mas / units.yr).value - oc.pmbb(quantity=False))
+        numpy.fabs(
+            as_numpy(o.pmbb().to(units.mas / units.yr).value)
+            - as_numpy(oc.pmbb(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method pmbb does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vlos().to(units.km / units.s).value - oc.vlos(quantity=False))
+        numpy.fabs(
+            as_numpy(o.vlos().to(units.km / units.s).value)
+            - as_numpy(oc.vlos(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method vlos does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vra().to(units.km / units.s).value - oc.vra(quantity=False))
+        numpy.fabs(
+            as_numpy(o.vra().to(units.km / units.s).value)
+            - as_numpy(oc.vra(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method vra does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vdec().to(units.km / units.s).value - oc.vdec(quantity=False))
+        numpy.fabs(
+            as_numpy(o.vdec().to(units.km / units.s).value)
+            - as_numpy(oc.vdec(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method vdec does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vll().to(units.km / units.s).value - oc.vll(quantity=False))
+        numpy.fabs(
+            as_numpy(o.vll().to(units.km / units.s).value)
+            - as_numpy(oc.vll(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method vll does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.vbb().to(units.km / units.s).value - oc.vbb(quantity=False))
+        numpy.fabs(
+            as_numpy(o.vbb().to(units.km / units.s).value)
+            - as_numpy(oc.vbb(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method vbb does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.helioX().to(units.kpc).value - oc.helioX(quantity=False))
+        numpy.fabs(
+            as_numpy(o.helioX().to(units.kpc).value)
+            - as_numpy(oc.helioX(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method helioX does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.helioY().to(units.kpc).value - oc.helioY(quantity=False))
+        numpy.fabs(
+            as_numpy(o.helioY().to(units.kpc).value)
+            - as_numpy(oc.helioY(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method helioY does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.helioZ().to(units.kpc).value - oc.helioZ(quantity=False))
+        numpy.fabs(
+            as_numpy(o.helioZ().to(units.kpc).value)
+            - as_numpy(oc.helioZ(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method helioZ does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.U().to(units.km / units.s).value - oc.U(quantity=False))
+        numpy.fabs(
+            as_numpy(o.U().to(units.km / units.s).value)
+            - as_numpy(oc.U(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method U does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.V().to(units.km / units.s).value - oc.V(quantity=False))
+        numpy.fabs(
+            as_numpy(o.V().to(units.km / units.s).value)
+            - as_numpy(oc.V(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method V does not return the correct value as Quantity"
     assert numpy.all(
-        numpy.fabs(o.W().to(units.km / units.s).value - oc.W(quantity=False))
+        numpy.fabs(
+            as_numpy(o.W().to(units.km / units.s).value)
+            - as_numpy(oc.W(quantity=False))
+        )
         < 10.0**-8.0
     ), "Orbit method W does not return the correct value as Quantity"
     return None
@@ -3463,64 +3604,64 @@ def test_orbits_method_value_turnquantityoff():
     oc.turn_physical_off()
     assert numpy.all(
         numpy.fabs(
-            o.E(pot=MWPotential2014, quantity=False)
-            - oc.E(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.E(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.E(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method E does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.ER(pot=MWPotential2014, quantity=False)
-            - oc.ER(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.ER(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.ER(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method ER does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Ez(pot=MWPotential2014, quantity=False)
-            - oc.Ez(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.Ez(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.Ez(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method Ez does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Jacobi(pot=MWPotential2014, quantity=False)
-            - oc.Jacobi(pot=MWPotential2014) * o._vo**2.0
+            as_numpy(o.Jacobi(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.Jacobi(pot=MWPotential2014) * o._vo**2.0)
         )
         < 10.0**-8.0
     ), "Orbit method Jacobi does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.L(pot=MWPotential2014, quantity=False)
-            - oc.L(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.L(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.L(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Lz(pot=MWPotential2014, quantity=False)
-            - oc.Lz(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.Lz(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.Lz(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method L does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.rap(pot=MWPotential2014, analytic=True, quantity=False)
-            - oc.rap(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.rap(pot=MWPotential2014, analytic=True, quantity=False))
+            - as_numpy(oc.rap(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rap does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.rperi(pot=MWPotential2014, analytic=True, quantity=False)
-            - oc.rperi(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.rperi(pot=MWPotential2014, analytic=True, quantity=False))
+            - as_numpy(oc.rperi(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rperi does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.rguiding(pot=MWPotential2014, quantity=False)
-            - oc.rguiding(pot=MWPotential2014) * o._ro
+            as_numpy(o.rguiding(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.rguiding(pot=MWPotential2014) * o._ro)
         )
         < 10.0**-8.0
     ), (
@@ -3528,167 +3669,225 @@ def test_orbits_method_value_turnquantityoff():
     )
     assert numpy.all(
         numpy.fabs(
-            o.rE(pot=MWPotential2014, quantity=False)
-            - oc.rE(pot=MWPotential2014) * o._ro
+            as_numpy(o.rE(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.rE(pot=MWPotential2014) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method rE does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.LcE(pot=MWPotential2014, quantity=False)
-            - oc.LcE(pot=MWPotential2014) * o._ro * o._vo
+            as_numpy(o.LcE(pot=MWPotential2014, quantity=False))
+            - as_numpy(oc.LcE(pot=MWPotential2014) * o._ro * o._vo)
         )
         < 10.0**-8.0
     ), "Orbit method LcE does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.zmax(pot=MWPotential2014, analytic=True, quantity=False)
-            - oc.zmax(pot=MWPotential2014, analytic=True) * o._ro
+            as_numpy(o.zmax(pot=MWPotential2014, analytic=True, quantity=False))
+            - as_numpy(oc.zmax(pot=MWPotential2014, analytic=True) * o._ro)
         )
         < 10.0**-8.0
     ), "Orbit method zmax does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.jr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.jr(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            as_numpy(
+                o.jr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.jr(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jr does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.jp(
-                pot=MWPotential2014,
-                type="staeckel",
-                delta=4.0 * units.kpc,
-                quantity=False,
+            as_numpy(
+                o.jp(
+                    pot=MWPotential2014,
+                    type="staeckel",
+                    delta=4.0 * units.kpc,
+                    quantity=False,
+                )
             )
-            - oc.jp(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            - as_numpy(
+                oc.jp(pot=MWPotential2014, type="staeckel", delta=0.5) * o._ro * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jp does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.jz(
-                pot=MWPotential2014,
-                type="isochroneapprox",
-                b=0.8 * 8.0 * units.kpc,
-                quantity=False,
+            as_numpy(
+                o.jz(
+                    pot=MWPotential2014,
+                    type="isochroneapprox",
+                    b=0.8 * 8.0 * units.kpc,
+                    quantity=False,
+                )
             )
-            - oc.jz(pot=MWPotential2014, type="isochroneapprox", b=0.8) * o._ro * o._vo
+            - as_numpy(
+                oc.jz(pot=MWPotential2014, type="isochroneapprox", b=0.8)
+                * o._ro
+                * o._vo
+            )
         )
         < 10.0**-8.0
     ), "Orbit method jz does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.wr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.wr(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(oc.wr(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wr does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.wp(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.wp(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wp(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(oc.wp(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wp does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.wz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.wz(pot=MWPotential2014, type="staeckel", delta=0.5)
+            as_numpy(
+                o.wz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(oc.wz(pot=MWPotential2014, type="staeckel", delta=0.5))
         )
         < 10.0**-8.0
     ), "Orbit method wz does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Tr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Tr(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tr(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Tr(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tr does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Tp(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Tp(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tp(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Tp(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tp does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Tz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Tz(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Tz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Tz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.time_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Tz does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Or(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Or(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Or(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Orbit method Or does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Op(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Op(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Op(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Opbit method Or does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.Oz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
-            - oc.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
-            * conversion.freq_in_Gyr(o._vo, o._ro)
+            as_numpy(
+                o.Oz(pot=MWPotential2014, type="staeckel", delta=0.5, quantity=False)
+            )
+            - as_numpy(
+                oc.Oz(pot=MWPotential2014, type="staeckel", delta=0.5)
+                * conversion.freq_in_Gyr(o._vo, o._ro)
+            )
         )
         < 10.0**-8.0
     ), "Ozbit method Or does not return the correct value when Quantity turned off"
     assert numpy.all(
         numpy.fabs(
-            o.time(quantity=False) - oc.time() * conversion.time_in_Gyr(o._vo, o._ro)
+            as_numpy(o.time(quantity=False))
+            - as_numpy(oc.time() * conversion.time_in_Gyr(o._vo, o._ro))
         )
         < 10.0**-8.0
     ), "Orbit method time does not return the correct value when Quantity turned off"
-    assert numpy.all(numpy.fabs(o.R(quantity=False) - oc.R() * o._ro) < 10.0**-8.0), (
-        "Orbit method R does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.r(quantity=False) - oc.r() * o._ro) < 10.0**-8.0), (
-        "Orbit method r does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.vR(quantity=False) - oc.vR() * o._vo) < 10.0**-8.0), (
-        "Orbit method vR does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.vT(quantity=False) - oc.vT() * o._vo) < 10.0**-8.0), (
-        "Orbit method vT does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.z(quantity=False) - oc.z() * o._ro) < 10.0**-8.0), (
-        "Orbit method z does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.vz(quantity=False) - oc.vz() * o._vo) < 10.0**-8.0), (
-        "Orbit method vz does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.phi(quantity=False) - oc.phi()) < 10.0**-8.0), (
-        "Orbit method phi does not return the correct value when Quantity turned off"
-    )
     assert numpy.all(
-        numpy.fabs(o.vphi(quantity=False) - oc.vphi() * o._vo / o._ro) < 10.0**-8.0
+        numpy.fabs(as_numpy(o.R(quantity=False)) - as_numpy(oc.R() * o._ro))
+        < 10.0**-8.0
+    ), "Orbit method R does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.r(quantity=False)) - as_numpy(oc.r() * o._ro))
+        < 10.0**-8.0
+    ), "Orbit method r does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.vR(quantity=False)) - as_numpy(oc.vR() * o._vo))
+        < 10.0**-8.0
+    ), "Orbit method vR does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.vT(quantity=False)) - as_numpy(oc.vT() * o._vo))
+        < 10.0**-8.0
+    ), "Orbit method vT does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.z(quantity=False)) - as_numpy(oc.z() * o._ro))
+        < 10.0**-8.0
+    ), "Orbit method z does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.vz(quantity=False)) - as_numpy(oc.vz() * o._vo))
+        < 10.0**-8.0
+    ), "Orbit method vz does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.phi(quantity=False)) - as_numpy(oc.phi())) < 10.0**-8.0
+    ), "Orbit method phi does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(
+            as_numpy(o.vphi(quantity=False)) - as_numpy(oc.vphi() * o._vo / o._ro)
+        )
+        < 10.0**-8.0
     ), "Orbit method vphi does not return the correct value when Quantity turned off"
-    assert numpy.all(numpy.fabs(o.x(quantity=False) - oc.x() * o._ro) < 10.0**-8.0), (
-        "Orbit method x does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.y(quantity=False) - oc.y() * o._ro) < 10.0**-8.0), (
-        "Orbit method y does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.vx(quantity=False) - oc.vx() * o._vo) < 10.0**-8.0), (
-        "Orbit method vx does not return the correct value when Quantity turned off"
-    )
-    assert numpy.all(numpy.fabs(o.vy(quantity=False) - oc.vy() * o._vo) < 10.0**-8.0), (
-        "Orbit method vy does not return the correct value when Quantity turned off"
-    )
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.x(quantity=False)) - as_numpy(oc.x() * o._ro))
+        < 10.0**-8.0
+    ), "Orbit method x does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.y(quantity=False)) - as_numpy(oc.y() * o._ro))
+        < 10.0**-8.0
+    ), "Orbit method y does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.vx(quantity=False)) - as_numpy(oc.vx() * o._vo))
+        < 10.0**-8.0
+    ), "Orbit method vx does not return the correct value when Quantity turned off"
+    assert numpy.all(
+        numpy.fabs(as_numpy(o.vy(quantity=False)) - as_numpy(oc.vy() * o._vo))
+        < 10.0**-8.0
+    ), "Orbit method vy does not return the correct value when Quantity turned off"
     return None
 
 
@@ -6514,8 +6713,8 @@ def test_potential_method_inputAsQuantity_Rzaskwargs():
     ), "Potential method rtide does not return the correct value when input is Quantity"
     assert numpy.all(
         numpy.fabs(
-            pot.ttensor(R=1.1 * ro, z=0.1 * ro, use_physical=False)
-            - potu.ttensor(1.1, 0.1)
+            as_numpy(pot.ttensor(R=1.1 * ro, z=0.1 * ro, use_physical=False))
+            - as_numpy(potu.ttensor(1.1, 0.1))
         )
         < 10.0**-8.0
     ), (
@@ -6523,8 +6722,10 @@ def test_potential_method_inputAsQuantity_Rzaskwargs():
     )
     assert numpy.all(
         numpy.fabs(
-            pot.ttensor(R=1.1 * ro, z=0.1 * ro, eigenval=True, use_physical=False)
-            - potu.ttensor(1.1, 0.1, eigenval=True)
+            as_numpy(
+                pot.ttensor(R=1.1 * ro, z=0.1 * ro, eigenval=True, use_physical=False)
+            )
+            - as_numpy(potu.ttensor(1.1, 0.1, eigenval=True))
         )
         < 10.0**-8.0
     ), (
@@ -7522,8 +7723,8 @@ def test_potential_function_inputAsQuantity_Rzaskwargs():
     )
     assert numpy.all(
         numpy.fabs(
-            potential.ttensor(pot, R=1.1 * ro, z=0.1 * ro, use_physical=False)
-            - potential.ttensor(potu, 1.1, 0.1)
+            as_numpy(potential.ttensor(pot, R=1.1 * ro, z=0.1 * ro, use_physical=False))
+            - as_numpy(potential.ttensor(potu, 1.1, 0.1))
         )
         < 10.0**-8.0
     ), (
@@ -7531,10 +7732,12 @@ def test_potential_function_inputAsQuantity_Rzaskwargs():
     )
     assert numpy.all(
         numpy.fabs(
-            potential.ttensor(
-                pot, R=1.1 * ro, z=0.1 * ro, eigenval=True, use_physical=False
+            as_numpy(
+                potential.ttensor(
+                    pot, R=1.1 * ro, z=0.1 * ro, eigenval=True, use_physical=False
+                )
             )
-            - potential.ttensor(potu, 1.1, 0.1, eigenval=True)
+            - as_numpy(potential.ttensor(potu, 1.1, 0.1, eigenval=True))
         )
         < 10.0**-8.0
     ), (


### PR DESCRIPTION
## What

Combined **test-only** `as_numpy` burndown across three disjoint test files — **36 torch + 11 jax** ledgered xfails now pass.

Each cast wraps a galpy-computed **result** (orbit accessor / aA output / method `.value`) at a numpy-reduction assertion site so the torch/jax **values** validate. `as_numpy` is a no-op on numpy inputs → the numpy path is **byte-identical**, and galpy still computes in the backend (**no numpy islands**).

| file | flips | pattern |
|---|---|---|
| `test_noninertial.py` | 27 torch + 11 jax | `o.R(ts)`/`op.x(ts)` tensors mixed with numpy in each `check_orbit` reference trajectory (354+ casts) |
| `test_quantity.py` | 6 torch | `test_orbit(s)_method_value(_turnquantityoff)` + `test_potential_*_inputAsQuantity_Rzaskwargs` array assertions (102 casts) |
| `test_actionAngle.py` | 3 torch | `test_orbit_interface_unbound_complexshape_*` — `jr[:,0] - aAS()[k]` = ndarray−Tensor (33 casts) |

## Verification

Each flip was verified **fail-without / pass-with** under `--backend=torch/jax --runxfail`, and all pass on **numpy** (byte-identity). 0 non-target regressions.

## Scope

**No source changes, no ledger edit.** Flipped entries become XPASS → stay green under `strict=False`; a CI regen prunes them (avoids conflict with the open ledger-prune #1147).

The remaining ledgered entries in these files are **genuine source gaps** (catalogued for a future source-fix PR): `DehnenBarPotential._smooth` `xp.where(bool)`, `actionAngleIsochroneApprox` `ts`/`maxn` kwarg collision, `Orbits.py:4384` `abs(numpy)` in the streamdf zmax setup, `vterm` `xp.sin(float)`, grid-setup `numpy.amax`-on-tensor, the 1-D physical-conversion decorator returning a tuple, and the Staeckel unbound-angle sentinel — plus a few float32 precision / `isinstance(float)` asserts that aren't test-castable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm