### PR TITLE
DehnenBarPotential: fix forced-backend gap (coerce_coords at the force leaves)

### DIFF
--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -162,8 +162,9 @@ class DehnenBarPotential(Potential):
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -192,8 +193,9 @@ class DehnenBarPotential(Potential):
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -218,8 +220,9 @@ class DehnenBarPotential(Potential):
 
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -242,8 +245,9 @@ class DehnenBarPotential(Potential):
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -260,8 +264,9 @@ class DehnenBarPotential(Potential):
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -286,8 +291,9 @@ class DehnenBarPotential(Potential):
 
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -310,8 +316,9 @@ class DehnenBarPotential(Potential):
 
     def _Rphideriv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -331,8 +338,9 @@ class DehnenBarPotential(Potential):
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -353,8 +361,9 @@ class DehnenBarPotential(Potential):
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0
@@ -378,8 +387,9 @@ class DehnenBarPotential(Potential):
 
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         # Calculate relevant time
-        smooth = self._smooth(t)
         xp = get_namespace(R, z, phi, t)
+        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
+        smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         bad = r2 == 0.0

--- a/tests/test_backend_dehnenbar.py
+++ b/tests/test_backend_dehnenbar.py
@@ -1,0 +1,152 @@
+###############################################################################
+# test_backend_dehnenbar.py: backend tests for DehnenBarPotential.
+#
+# The rotating Dehnen bar has a time-smoothing factor _smooth(t) (xp.where over
+# t < tform / t < tsteady) and a cos(phi - omegab t) rotation. Under a FORCED
+# backend the pure-Python integrator hands the force numpy coordinates + a scalar
+# Python-float t; get_namespace then resolves to the backend, so xp.sqrt(numpy)
+# and array_api_compat torch.where(python-bool) raised. coerce_coords at each leaf
+# (before _smooth) brings R,z,phi,t onto the backend so the whole force chain runs
+# and differentiates, while the numpy path stays byte-identical.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import as_numpy, use
+from galpy.potential import DehnenBarPotential, evaluateRforces, evaluatezforces
+
+pytestmark = pytest.mark.backend_managed
+
+BACKENDS = ["numpy"]
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    BACKENDS.append("jax")
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+    BACKENDS.append("torch")
+except ImportError:  # pragma: no cover
+    torch = None
+
+AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+
+_DB = DehnenBarPotential()  # default rotating bar
+# mid-growth t so _smooth's interior (growth) branch is exercised, not just 0/1
+_TG = 0.5 * (_DB._tform + _DB._tsteady)
+_METHODS = [
+    "_evaluate",
+    "_Rforce",
+    "_zforce",
+    "_phitorque",
+    "_R2deriv",
+    "_z2deriv",
+    "_phi2deriv",
+    "_Rzderiv",
+    "_Rphideriv",
+]
+_R0, _Z0, _PHI0 = 1.1, 0.15, 0.35
+
+
+def _asarray(backend_name, x):
+    if backend_name == "numpy":
+        return numpy.asarray(x, dtype=float)
+    if backend_name == "jax":
+        return jnp.asarray(x, dtype=jnp.float64)
+    return torch.tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("method", _METHODS)
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_value_parity(backend_name, method):
+    ref = float(
+        getattr(_DB, method)(
+            numpy.asarray(_R0), numpy.asarray(_Z0), numpy.asarray(_PHI0), _TG
+        )
+    )
+    got = float(
+        as_numpy(
+            getattr(_DB, method)(
+                _asarray(backend_name, _R0),
+                _asarray(backend_name, _Z0),
+                _asarray(backend_name, _PHI0),
+                _asarray(backend_name, _TG),
+            )
+        )
+    )
+    rtol, atol = (0.0, 0.0) if backend_name == "numpy" else (1e-12, 1e-14)
+    numpy.testing.assert_allclose(
+        got, ref, rtol=rtol, atol=atol, err_msg=f"DehnenBar.{method} ({backend_name})"
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_numpy_coords_scalar_t_under_forced_backend(backend_name):
+    # The orbit-integrator scenario: the pure-Python integrator hands the force
+    # numpy-scalar coordinates + a scalar Python-float t while a FORCED backend is
+    # active. get_namespace resolves to the backend and xp.sqrt(numpy) / _smooth's
+    # torch.where(python-bool) raised; coerce_coords fixes it. Checked at a t inside
+    # the growth window (so _smooth's interior branch runs) against numpy.
+    methods = ("_evaluate", "_Rforce", "_zforce", "_phitorque")
+    ref = numpy.array([float(getattr(_DB, m)(_R0, _Z0, _PHI0, _TG)) for m in methods])
+    with use(backend_name, force=True):
+        got = numpy.array(
+            [float(as_numpy(getattr(_DB, m)(_R0, _Z0, _PHI0, _TG))) for m in methods]
+        )
+    numpy.testing.assert_allclose(
+        got,
+        ref,
+        rtol=1e-11,
+        atol=1e-13,
+        err_msg=f"DehnenBar forced scalar-t ({backend_name})",
+    )
+
+
+@pytest.mark.parametrize("force", ["R", "z"])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_grad_vs_finite_difference(backend_name, force):
+    # Stringent grad-vs-FD through the smoothing + rotation + softened-needle force.
+    fn = {"R": evaluateRforces, "z": evaluatezforces}[force]
+    R0 = 1.3
+
+    def num_force(R):
+        return float(
+            fn(
+                _DB,
+                numpy.asarray(R),
+                numpy.asarray(_Z0),
+                phi=numpy.asarray(_PHI0),
+                t=_TG,
+            )
+        )
+
+    if backend_name == "jax":
+        ad = float(
+            jax.jacfwd(
+                lambda R: fn(
+                    _DB, R, jnp.asarray(_Z0), phi=jnp.asarray(_PHI0), t=jnp.asarray(_TG)
+                )
+            )(jnp.asarray(R0))
+        )
+    else:
+        Rt = torch.tensor(R0, requires_grad=True)
+        fn(
+            _DB, Rt, torch.tensor(_Z0), phi=torch.tensor(_PHI0), t=torch.tensor(_TG)
+        ).backward()
+        ad = float(Rt.grad)
+    prev = None
+    for h in (1e-3, 1e-4, 1e-5):
+        fd = (num_force(R0 + h) - num_force(R0 - h)) / (2 * h)
+        rel = abs(ad - fd) / (abs(fd) + 1e-30)
+        if prev is not None:
+            assert rel <= prev + 1e-12
+        prev = rel
+    assert rel < 1e-6, (
+        f"DehnenBar {force}-force grad-vs-FD rel={rel:.2e} ({backend_name})"
+    )


### PR DESCRIPTION
## What

Fixes a forced-backend crash in **DehnenBarPotential** — the reason every noninertial test that integrates a Dehnen bar via a Python integrator failed under torch.

Under a forced backend, the pure-Python orbit integrator (`odeint`/`dop853`) hands the force **numpy-scalar coordinates + a scalar Python-float `t`**. `get_namespace(R,z,phi,t)` then resolves to the backend, so:
- `xp.sqrt(numpy)` → `torch.sqrt(numpy.float64)` raises;
- `_smooth`'s `xp.where(t < self._tform, …)` gets a python/numpy **bool** condition, which `array_api_compat` `torch.where` rejects.

## Fix

Coerce `R,z,phi,t` with `coerce_coords` (before `_smooth`) at each of the **10 leaves** (`_evaluate`/`_Rforce`/`_zforce`/`_phitorque` + the 5 second derivatives). The coerced `t` makes `_smooth`'s `t < tform` a backend tensor, so its `where` runs; numpy is a strict object-identical pass-through (byte-identical).

## Verified

- forced-torch force / potential / 2nd-derivatives **== numpy to 0.0** (byte-identical, all 10 methods);
- grad-vs-FD h-converged (**3.9e-13**);
- new `test_backend_dehnenbar.py`: value parity + the **numpy-coords/scalar-`t`-under-forced-backend** integrator case (verified to **fail without the fix**) + stringent grad-vs-FD. 33 tests pass.

Source-only, no ledger edit. The 21 ledgered noninertial torch entries (`test_arbitraryaxisrotation*`, `test_python_vs_c_*`, the DehnenBar-integrating `linacc`/`lsrframe` variants) flip once **this** and the as_numpy wave (**#1148**) both land — confirmed locally by combining the two (`test_arbitraryaxisrotation` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm