### PR TITLE
orbit: run forced-backend numerical accessors ON the backend (zmax/rperi/rap/ecc + radii warn)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -23,7 +23,7 @@ elif _SCIPY_VERSION < parse_version("0.19"):  # pragma: no cover
 else:
     from scipy.special import logsumexp
 
-from ..backend import as_numpy, get_namespace, is_backend_array
+from ..backend import as_numpy, coerce_coords, get_namespace, is_backend_array
 from ..potential import (
     _INF,
     CompositePotential,
@@ -2265,6 +2265,7 @@ class Orbit:
         interpolation range [rmin, rmax] of the potential potname"""
         rs = self.r(self.t, use_physical=False)
         xp = get_namespace(rs)
+        (rs,) = coerce_coords(xp, rs)
         outside = xp.any((rs < rmin) | (rs > rmax), axis=-1)
         if not xp.any(outside):
             return
@@ -4049,6 +4050,7 @@ class Orbit:
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
         xp = get_namespace(rs)
+        (rs,) = coerce_coords(xp, rs)
         return (xp.max(rs, axis=-1) - xp.min(rs, axis=-1)) / (
             xp.max(rs, axis=-1) + xp.min(rs, axis=-1)
         )
@@ -4099,6 +4101,7 @@ class Orbit:
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
         xp = get_namespace(rs)
+        (rs,) = coerce_coords(xp, rs)
         return xp.max(rs, axis=-1)
 
     @physical_conversion("position")
@@ -4147,6 +4150,7 @@ class Orbit:
             )
         rs = self.r(self.t, use_physical=False, dontreshape=True)
         xp = get_namespace(rs)
+        (rs,) = coerce_coords(xp, rs)
         return xp.min(rs, axis=-1)
 
     @physical_conversion("position")
@@ -4381,6 +4385,7 @@ class Orbit:
             )
         zs = self.z(self.t, use_physical=False, dontreshape=True)
         xp = get_namespace(zs)
+        (zs,) = coerce_coords(xp, zs)
         return xp.max(xp.abs(zs), axis=-1)
 
     @physical_conversion("action")

--- a/tests/test_backend_orbit_accessors.py
+++ b/tests/test_backend_orbit_accessors.py
@@ -19,6 +19,7 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy, is_backend_array, use
 from galpy.orbit import Orbit
 from galpy.potential import PlummerPotential
 
@@ -586,3 +587,36 @@ def test_analytic_char_numpy_path_unchanged():
         )
         assert isinstance(val, (float, numpy.floating, numpy.ndarray))
         assert numpy.isfinite(float(numpy.asarray(val)))
+
+
+# --- numerical-reduction accessors under a FORCED backend on a numpy orbit ------
+# zmax/rap/rperi/e reduce the integrated trajectory with xp.max/min/abs. Under a
+# forced backend get_namespace(numpy_zs) resolves to that backend, so
+# torch.abs(numpy)/torch.max(numpy) raised -- the exact crash that blocked the
+# streamdf progenitor setup (zmax on a numpy orbit) under forced torch. The
+# data-guard (is_backend_array(data) ? backend : numpy) keeps a numpy orbit numpy.
+_NUM_ACCESSORS = ["zmax", "rap", "rperi", "e"]
+_FORCE_BACKENDS = [b for b, h in [("jax", HAVE_JAX), ("torch", HAVE_TORCH)] if h]
+
+
+@pytest.mark.parametrize("acc", _NUM_ACCESSORS)
+@pytest.mark.parametrize("backend_name", _FORCE_BACKENDS)
+def test_numerical_accessor_forced_backend_on_numpy_orbit(acc, backend_name):
+    o = Orbit(list(_IC))
+    o.turn_physical_off()
+    o.integrate(_TS, _POT, method="dop853_c")  # numpy integration
+    ref = float(getattr(o, acc)())
+    with use(backend_name, force=True):
+        raw = getattr(o, acc)()
+        # the point of the forced backend is that the accessor RUNS on the
+        # backend (coerces the numpy trajectory onto it), not that it silently
+        # falls back to numpy -- lock that in.
+        assert is_backend_array(raw), f"{acc} forced-{backend_name} not on backend"
+        got = float(as_numpy(raw))
+    numpy.testing.assert_allclose(
+        got,
+        ref,
+        rtol=1e-12,
+        atol=1e-14,
+        err_msg=f"{acc} forced-{backend_name} numpy orbit",
+    )


### PR DESCRIPTION
## What

The numerical orbit accessors that reduce over the trajectory — `zmax`, `rap`, `rperi`, `e` (eccentricity), and the "r in interpolation range" warning — crashed under a **forced backend** on a numpy-integrated orbit: `xp = get_namespace(rs)` resolved to the forced backend while `rs` was still a numpy trajectory, so `xp.max`/`xp.abs`/`xp.any` raised (torch rejects numpy inputs).

## Fix

**Coerce** the trajectory onto the active backend (`coerce_coords`) and reduce there, so the accessor actually runs *on* the backend — the point of the forced-backend suite is to exercise the backend, not to data-guard back to numpy.

- **numpy path**: a strict `coerce_coords` pass-through (object-identical) → **byte-identical**.
- **genuine in-backend orbit**: a dtype-preserving no-op.

## Test

`test_numerical_accessor_forced_backend_on_numpy_orbit` asserts each accessor's forced-backend result *is* a backend array (runs on the backend) and matches the numpy value to 1e-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
