### PR TITLE
streamdf Phase C: backend-native, differentiable stream spread (C.1+C.2+C.4)

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -17,8 +17,9 @@ else:
     from scipy.special import logsumexp
 
 from ..actionAngle.actionAngleIsochroneApprox import dePeriod
-from ..backend import as_backend_constant, get_namespace, is_backend_array
+from ..backend import as_backend_constant, as_numpy, get_namespace, is_backend_array
 from ..backend import special as _bspecial
+from ..backend.interpolate import cubic_spline_coeffs, eval_ppoly
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..backend.quadrature import quad as _backend_quad
 from ..orbit import Orbit
@@ -1734,6 +1735,8 @@ class streamdf(df):
         then eigen-slerp interpolate it onto ``_interpolatedThetasTrack``.
         Returns ``(allErrCovsXY, interpolatedAllErrCovsXY)``.
         """
+        if is_backend_array(chunk_covs) or is_backend_array(self._ObsTrack):
+            return self._cart_and_interp_cov_backend(chunk_covs)
         nC = self._nTrackChunks
         allErrCovsXY = numpy.empty_like(chunk_covs)
         eigvals = numpy.empty((nC, 6))
@@ -1790,6 +1793,130 @@ class streamdf(df):
                     numpy.diag(interpolatedEigval[:, ii]), interpolatedEigvec[ii].T
                 ),
             )
+        return allErrCovsXY, interpolated
+
+    def _cart_and_interp_cov_backend(self, chunk_covs):
+        """Backend (jax/torch) twin of :meth:`_cart_and_interp_cov`.
+
+        Functional throughout (numpy item-assignment -> ``xp.stack``/``xp.where``).
+
+        The per-chunk Cartesian covariance ``allErrCovsXY`` = ``tjac @ cov @
+        tjac.T`` is backend-native and DIFFERENTIABLE w.r.t. ``chunk_covs`` and
+        ``_ObsTrack`` -- the priority output.
+
+        The fine-grid ``interpolated`` covariance is reconstructed from
+        eigenvalue-splined + eigenvector-slerped chunks:
+          * symmetric covariance -> ``xp.linalg.eigh`` (real, ascending-sorted,
+            stable), matching the numpy ``argsort`` order; eigenvector sign
+            differences vs ``numpy.linalg.eig`` are removed by the sign-alignment
+            and are invariant in the reconstructed covariance;
+          * eigenvalues are cubic-splined natively in ``xp`` (see the inline note
+            below): a scipy spline on a jax tracer would break tracing of the
+            whole function, so the backend uses ``cubic_spline_coeffs`` (matching
+            scipy to ~1e-15) -- ``interpolated`` is thus fully backend-native and
+            differentiable w.r.t. both the eigenvalues and the eigenvectors;
+          * the slerp ``/ sin(Omega)`` is a 0/0 trap as ``Omega -> 0``: it is
+            guarded (arccos fed a value bounded away from +-1 where degenerate,
+            with a linear-interpolation fallback) so both value and gradient stay
+            finite (both ``xp.where`` branches are finite). NOTE the numpy path
+            has a latent 0/0 -> NaN here (unguarded ``/ numpy.sin(Omega)``); the
+            backend produces the correct finite linear-interpolation limit.
+
+        The backend ``interpolated`` therefore intentionally diverges from the
+        numpy path at TWO degeneracies, and is the more accurate party at both:
+        (a) the slerp Omega -> 0 NaN above; and (b) eigenvalue NEAR-degeneracy --
+        the numpy path reconstructs with ``V diag(lambda) V.T`` from
+        ``numpy.linalg.eig``, whose eigenvectors go NON-orthonormal as two
+        eigenvalues approach each other (its own node reconstruction then drifts
+        by O(eps / eigenvalue_gap)), whereas ``eigh`` stays orthonormal so the
+        backend reconstruction is exact. Elsewhere the two agree to ~1e-14.
+        """
+        xp = get_namespace(chunk_covs, self._ObsTrack)
+        nC = self._nTrackChunks
+        if nC < 4:  # not-a-knot cubic spline needs >= 4 knots (numpy IUS(k=3) too)
+            raise ValueError("backend _cart_and_interp_cov requires nTrackChunks >= 4")
+        # Coerce onto the backend; a backend array passes through untouched so its
+        # gradient is preserved (do NOT round-trip _ObsTrack/chunk_covs via numpy).
+        if not is_backend_array(chunk_covs):
+            chunk_covs = as_backend_constant(xp, chunk_covs, self._ObsTrack)
+        ref = chunk_covs
+        ObsTrack = self._ObsTrack
+        if not is_backend_array(ObsTrack):
+            ObsTrack = as_backend_constant(xp, ObsTrack, ref)
+        thetas = self._thetasTrack
+        if not is_backend_array(thetas):
+            thetas = as_backend_constant(xp, thetas, ref)
+        # allErrCovsXY = tjac @ cov @ tjac.T per chunk (the differentiable output).
+        covsxy = []
+        for ii in range(nC):
+            tjac = coords.cyl_to_rect_jac(*ObsTrack[ii])
+            covsxy.append(tjac @ (chunk_covs[ii] @ xp.matrix_transpose(tjac)))
+        allErrCovsXY = xp.stack(covsxy)  # (nC, 6, 6)
+        # Eigendecompose (symmetric -> eigh: real, ascending) + sign-align the
+        # eigenvectors chunk-to-chunk (numpy carries eigDir[jj]; start from e_0).
+        e0 = as_backend_constant(xp, numpy.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]), ref)
+        prev = [e0] * 6
+        eigvals_list, eigvecs_list = [], []
+        for ii in range(nC):
+            w, v = xp.linalg.eigh(allErrCovsXY[ii])  # ascending eigvals, columns
+            cols = []
+            for jj in range(6):
+                vj = v[:, jj]
+                vj = xp.where(xp.sum(prev[jj] * vj) < 0.0, -vj, vj)
+                cols.append(vj)
+                prev[jj] = vj
+            eigvecs_list.append(xp.stack(cols, axis=1))  # (6, 6) columns
+            eigvals_list.append(w)
+        eigvecs = xp.stack(eigvecs_list)  # (nC, 6, 6)
+        eigvals = xp.stack(eigvals_list)  # (nC, 6)
+        # Eigenvalue spline: the numpy path uses a scipy cubic
+        # InterpolatedUnivariateSpline, but scipy on a jax TRACER breaks tracing
+        # (`as_numpy` of a tracer raises), which would make the WHOLE function --
+        # allErrCovsXY included -- non-jittable/non-differentiable under jax. So
+        # the backend spline is built natively (galpy.backend.interpolate mode 2:
+        # cubic_spline_coeffs, a tridiagonal solve in xp); bc='not-a-knot' matches
+        # scipy's InterpolatedUnivariateSpline(k=3) to ~1e-15, and it is
+        # jax-traceable AND differentiable w.r.t. the eigenvalues (so the fine
+        # grid is differentiable too -- exceeding the Phase-E deferral). The numpy
+        # path is untouched (still scipy, byte-identical).
+        thetas_np = as_numpy(thetas)  # spline knots are geometry (concrete)
+        interpThetas_np = self._interpolatedThetasTrack  # host bookkeeping (numpy)
+        nInterp = len(interpThetas_np)
+        interpThetas = as_backend_constant(xp, interpThetas_np, ref)
+        coeffs = cubic_spline_coeffs(xp, thetas_np, eigvals, bc="not-a-knot")
+        interpolatedEigval = eval_ppoly(
+            xp, thetas_np, coeffs, interpThetas
+        )  # (nInterp, 6)
+        # Eigenvector slerp (backend-native, differentiable), 0/0-guarded.
+        interpolatedEigvec = as_backend_constant(xp, numpy.zeros((nInterp, 6, 6)), ref)
+        for ii in range(nC - 1):
+            v0, v1 = eigvecs[ii], eigvecs[ii + 1]  # (6, 6) each, cols = eigvecs
+            dots = xp.sum(v0 * v1, axis=0)  # (6,)
+            c = xp.clip(dots, -1.0, 1.0)
+            sin2 = 1.0 - c * c  # sin^2(Omega) >= 0
+            degenerate = sin2 < 1e-14  # Omega -> 0 (or pi): slerp is 0/0
+            # feed arccos a value with a FINITE derivative where degenerate (0,
+            # not +-1 where arccos' = inf) so no inf*0 = NaN under AD.
+            c_safe = xp.where(degenerate, xp.zeros_like(c), c)
+            Om = xp.arccos(c_safe)  # (6,) finite value + grad
+            sinOm = xp.sin(Om)  # nonzero (== 1 where degenerate)
+            t = (interpThetas - thetas[ii]) / (thetas[ii + 1] - thetas[ii])  # (nI,)
+            mask = (t >= 0.0) & (t <= 1.0)  # (nInterp,)
+            A = xp.sin((1.0 - t)[:, None] * Om[None, :])  # (nInterp, 6)
+            B = xp.sin(t[:, None] * Om[None, :])  # (nInterp, 6)
+            slerp = (
+                A[:, None, :] * v0[None, :, :] + B[:, None, :] * v1[None, :, :]
+            ) / sinOm[None, None, :]
+            linear = (1.0 - t)[:, None, None] * v0[None, :, :] + t[:, None, None] * v1[
+                None, :, :
+            ]
+            val = xp.where(degenerate[None, None, :], linear, slerp)  # (nI, 6, 6)
+            interpolatedEigvec = xp.where(mask[:, None, None], val, interpolatedEigvec)
+        # Reconstruct V @ diag(lambda) @ V.T on the fine grid.
+        Vt = xp.matrix_transpose(interpolatedEigvec)  # (nInterp, 6, 6)
+        interpolated = xp.matmul(
+            interpolatedEigvec, interpolatedEigval[:, :, None] * Vt
+        )
         return allErrCovsXY, interpolated
 
     def _determine_stream_spreadLB(

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -1682,12 +1682,45 @@ class streamdf(df):
         :meth:`streamTrack` so ``track.cov`` matches the streamspraydf
         convention.
         """
-        allErrCovs = numpy.empty((self._nTrackChunks, 6, 6))
-        allErrCovsLocal = numpy.empty((self._nTrackChunks, 6, 6))
         sigOmega_fn = lambda x: self.sigOmega(x, use_physical=False)
         sigAngle_fn = lambda y: self.sigangledAngle(
             y, simple=simple, use_physical=False
         )
+        if is_backend_array(self._allinvjacsTrack):
+            # Backend (jax/torch) track: assemble the per-chunk covariances
+            # functionally (xp.stack, no numpy.empty item-assignment) so the spread
+            # is backend-native/jit/GPU and differentiable through the track. The
+            # frozen (numpy) sigomatrixEig is coerced onto the backend as a constant
+            # (its own differentiability w.r.t. the progenitor freq-covariance is a
+            # later step); the deprecated LB pipeline stays numpy and is skipped.
+            xp = get_namespace(self._allinvjacsTrack)
+            sigEig = (
+                as_backend_constant(xp, self._sigomatrixEig[0], self._allinvjacsTrack),
+                as_backend_constant(xp, self._sigomatrixEig[1], self._allinvjacsTrack),
+            )
+            thetas = as_backend_constant(xp, self._thetasTrack, self._allinvjacsTrack)
+            fulls, locals_ = [], []
+            for ii in range(self._nTrackChunks):
+                f, l = _determine_stream_spread_single(
+                    sigEig,
+                    thetas[ii],
+                    sigOmega_fn,
+                    sigAngle_fn,
+                    self._allinvjacsTrack[ii],
+                )
+                fulls.append(f)
+                locals_.append(l)
+            self._allErrCovs = xp.stack(fulls)
+            allErrCovsLocal = xp.stack(locals_)
+            self._allErrCovsXY, self._interpolatedAllErrCovsXY = (
+                self._cart_and_interp_cov(self._allErrCovs)
+            )
+            self._allErrCovsLocalXY, self._interpolatedAllErrCovsLocalXY = (
+                self._cart_and_interp_cov(allErrCovsLocal)
+            )
+            return None
+        allErrCovs = numpy.empty((self._nTrackChunks, 6, 6))
+        allErrCovsLocal = numpy.empty((self._nTrackChunks, 6, 6))
         if self._multi is None:
             for ii in range(self._nTrackChunks):
                 allErrCovs[ii], allErrCovsLocal[ii] = _determine_stream_spread_single(

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -4515,6 +4515,10 @@ def _determine_stream_spread_single(
       matching the streamspraydf-streamTrack convention. Used by
       :meth:`streamdf.streamTrack` to populate the StreamTrack's ``cov``.
     """
+    if is_backend_array(allinvjacsTrack) or is_backend_array(sigomatrixEig[1]):
+        return _determine_stream_spread_single_backend(
+            sigomatrixEig, thetasTrack, sigOmega, sigAngle, allinvjacsTrack
+        )
     inv_eigvecs = numpy.linalg.inv(sigomatrixEig[1])
     sigObig2 = sigOmega(thetasTrack) ** 2.0
     tsigOdiag = copy.copy(sigomatrixEig[0])
@@ -4549,6 +4553,56 @@ def _determine_stream_spread_single(
     local_diag = numpy.ones(3) * sigangle2
     local_cov = _assemble(local_diag, parallel_corr_zero=False)
 
+    return full_cov, local_cov
+
+
+def _determine_stream_spread_single_backend(
+    sigomatrixEig, thetasTrack, sigOmega, sigAngle, allinvjacsTrack
+):
+    """Backend (jax/torch) twin of :func:`_determine_stream_spread_single`.
+
+    Pure/functional: the numpy item-assignments (``tsigOdiag[argmax]=``,
+    ``full_diag[parallel_idx]=``, ``correlations[p,p]=0``, the 4 block writes into
+    ``fullMatrix``) become ``xp.where`` / ``xp.concat`` so the covariance
+    differentiates w.r.t. the frequency covariance (``sigomatrixEig``), the
+    dispersions (``sigOmega``/``sigAngle``) and the track Jacobian
+    (``allinvjacsTrack``). Reproduces the numpy assembly exactly.
+    """
+    xp = get_namespace(allinvjacsTrack)
+    eigvals, eigvecs = sigomatrixEig[0], sigomatrixEig[1]
+    inv_eigvecs = xp.linalg.inv(eigvecs)
+    ar = xp.arange(eigvals.shape[0])  # (3,)
+    sigObig2 = sigOmega(thetasTrack) ** 2.0
+    # replace the largest frequency eigenvalue with the along-stream dispersion
+    tsigOdiag = xp.where(ar == xp.argmax(eigvals), sigObig2, eigvals)
+    tsigO = eigvecs @ (xp.diag(tsigOdiag) @ inv_eigvecs)
+    sigangle2 = (
+        sigAngle(thetasTrack) ** 2.0 if hasattr(sigAngle, "__call__") else sigAngle**2.0
+    )
+    parallel_idx = xp.argmax(tsigOdiag)
+
+    def _assemble(tsigadiag, parallel_corr_zero):
+        tsiga = eigvecs @ (xp.diag(tsigadiag) @ inv_eigvecs)
+        # numpy.diag(0.5*ones(3)) * sqrt(tsigOdiag*tsigadiag) == diag(0.5*sqrt(...))
+        corr_diag = 0.5 * xp.sqrt(tsigOdiag * tsigadiag)
+        if parallel_corr_zero:
+            corr_diag = xp.where(
+                ar == parallel_idx, xp.zeros_like(corr_diag), corr_diag
+            )
+        correlations = eigvecs @ (xp.diag(corr_diag) @ inv_eigvecs)
+        fullMatrix = xp.concat(
+            [
+                xp.concat([tsigO, correlations.T], axis=1),  # [:3,:3], [:3,3:]
+                xp.concat([correlations, tsiga], axis=1),  # [3:,:3], [3:,3:]
+            ],
+            axis=0,
+        )
+        return allinvjacsTrack @ (fullMatrix @ allinvjacsTrack.T)
+
+    full_diag = xp.where(ar == parallel_idx, xp.ones_like(ar * 1.0), sigangle2)
+    full_cov = _assemble(full_diag, parallel_corr_zero=True)
+    local_diag = sigangle2 * xp.ones_like(ar * 1.0)
+    local_cov = _assemble(local_diag, parallel_corr_zero=False)
     return full_cov, local_cov
 
 

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -1864,7 +1864,12 @@ class streamdf(df):
         by O(eps / eigenvalue_gap)), whereas ``eigh`` stays orthonormal so the
         backend reconstruction is exact. Elsewhere the two agree to ~1e-14.
         """
-        xp = get_namespace(chunk_covs, self._ObsTrack)
+        # Derive the backend from whichever input is already a backend array (the
+        # dispatcher enters here if EITHER chunk_covs or _ObsTrack is backend), so a
+        # mixed dispatch does not trip array-api's "multiple namespaces"; the numpy
+        # one is then coerced onto that backend below.
+        ref0 = chunk_covs if is_backend_array(chunk_covs) else self._ObsTrack
+        xp = get_namespace(ref0)
         nC = self._nTrackChunks
         if nC < 4:  # not-a-knot cubic spline needs >= 4 knots (numpy IUS(k=3) too)
             raise ValueError("backend _cart_and_interp_cov requires nTrackChunks >= 4")

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -80,7 +80,12 @@ from functools import wraps
 
 import numpy
 
-from ..backend import get_namespace, is_backend_array, promote_scalars
+from ..backend import (
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+    promote_scalars,
+)
 from ..util import _rotate_to_arbitrary_vector
 from ..util._optional_deps import _APY_LOADED
 from ..util.config import __config__
@@ -1690,6 +1695,8 @@ def cyl_to_rect_jac(*args):
     -----
     - 2013-12-09 - Written - Bovy (IAS)
     """
+    if any(is_backend_array(a) for a in args):
+        return _cyl_to_rect_jac_backend(*args)
     out = numpy.zeros((6, 6))
     if len(args) == 3:
         R, phi, Z = args
@@ -1716,6 +1723,44 @@ def cyl_to_rect_jac(*args):
         out = out[:3, outIndx]
         out[:, [1, 2]] = out[:, [2, 1]]
     return out
+
+
+def _cyl_to_rect_jac_backend(*args):
+    """Backend (jax/torch) twin of :func:`cyl_to_rect_jac`.
+
+    Builds the Jacobian FUNCTIONALLY (rows assembled with ``xp.stack``, no
+    numpy item-assignment) so it is traceable/differentiable w.r.t. the
+    cylindrical coordinates. Reproduces both the 3-arg spatial and 6-arg
+    phase-space branches exactly; the 3-arg column-swap is baked into the
+    stacked column order.
+    """
+    xp = get_namespace(*args)
+    args = coerce_coords(xp, *args)
+    if len(args) == 3:
+        R, phi, Z = args
+        cp, sp = xp.cos(phi), xp.sin(phi)
+        zero, one = xp.zeros_like(R), xp.ones_like(R)
+        # columns already in the post-swap order [d/dR, d/dphi, d/dZ]
+        return xp.stack(
+            [
+                xp.stack([cp, -R * sp, zero]),
+                xp.stack([sp, R * cp, zero]),
+                xp.stack([zero, zero, one]),
+            ]
+        )
+    R, vR, vT, Z, vZ, phi = args
+    cp, sp = xp.cos(phi), xp.sin(phi)
+    zero, one = xp.zeros_like(R), xp.ones_like(R)
+    return xp.stack(
+        [
+            xp.stack([cp, zero, zero, zero, zero, -R * sp]),
+            xp.stack([sp, zero, zero, zero, zero, R * cp]),
+            xp.stack([zero, zero, zero, one, zero, zero]),
+            xp.stack([zero, cp, -sp, zero, zero, -vT * cp - vR * sp]),
+            xp.stack([zero, sp, cp, zero, zero, -vT * sp + vR * cp]),
+            xp.stack([zero, zero, zero, zero, one, zero]),
+        ]
+    )
 
 
 def galcenrect_to_XYZ_jac(*args, **kwargs):

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -44,7 +44,9 @@ from galpy.actionAngle import actionAngleIsochroneApprox
 from galpy.backend import as_numpy, get_namespace
 from galpy.backend.jacobian import jacobian
 from galpy.df.streamdf import (
+    _determine_stream_spread_single,
     _determine_stream_track_single,
+    _real_eig,
     _vmap_track_chunks,
     calcaAJac,
 )
@@ -978,3 +980,76 @@ def test_vmap_track_chunks_torch_stack():
         assert tuple(out[k].shape) == (3,)
         expected = numpy.array([float(xv0[i].sum() + thetas[i] + k) for i in range(3)])
         numpy.testing.assert_allclose(as_numpy(out[k]), expected, atol=1e-12)
+
+
+###############################################################################
+# Phase C: _determine_stream_spread_single -- the per-chunk covariance assembly.
+# numpy path is byte-identical; a backend sigomatrixEig / invjac routes to a
+# PURE/functional twin (item-assignment -> xp.where/xp.concat) so the 6x6 stream
+# covariance differentiates w.r.t. the frequency covariance, the dispersions and
+# the track Jacobian.
+###############################################################################
+def _spread_inputs():
+    rng = numpy.random.default_rng(3)
+    A = rng.standard_normal((3, 3))
+    sigo = A @ A.T + 3.0 * numpy.eye(3)  # SPD frequency covariance
+    eig = _real_eig(sigo)  # (eigvals(3,), eigvecs(3,3))
+    invjac = rng.standard_normal((6, 6))
+    return eig, invjac
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_determine_stream_spread_single_value_parity(backend_name):
+    eig, invjac = _spread_inputs()
+    theta = 0.7
+    sigOm = lambda t: 0.5 + 0.0 * t
+    sigAn = lambda t: 0.3 + 0.0 * t
+    f_np, l_np = _determine_stream_spread_single(
+        eig, numpy.asarray(theta), sigOm, sigAn, invjac
+    )
+    eb = (_arr(backend_name, eig[0]), _arr(backend_name, eig[1]))
+    f_b, l_b = _determine_stream_spread_single(
+        eb, _arr(backend_name, theta), sigOm, sigAn, _arr(backend_name, invjac)
+    )
+    numpy.testing.assert_allclose(as_numpy(f_b), f_np, rtol=1e-11, atol=1e-13)
+    numpy.testing.assert_allclose(as_numpy(l_b), l_np, rtol=1e-11, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_determine_stream_spread_single_grad_vs_fd(backend_name):
+    # d(sum full_cov + sum local_cov)/d(invjac[0,0]) AD h-converges to a central FD
+    # of the numpy path (the covariance is now differentiable through the assembly).
+    eig, invjac = _spread_inputs()
+    theta = 0.7
+    sigOm = lambda t: 0.5 + 0.0 * t
+    sigAn = lambda t: 0.3 + 0.0 * t
+
+    def loss_np(J):
+        f, l = _determine_stream_spread_single(eig, theta, sigOm, sigAn, J)
+        return float(f.sum() + l.sum())
+
+    if backend_name == "jax":
+        eb = (jnp.asarray(eig[0]), jnp.asarray(eig[1]))
+
+        def loss(J):
+            f, l = _determine_stream_spread_single(eb, theta, sigOm, sigAn, J)
+            return f.sum() + l.sum()
+
+        ad = float(jax.grad(loss)(jnp.asarray(invjac))[0, 0])
+    else:
+        Jt = torch.tensor(invjac, requires_grad=True)
+        eb = (torch.tensor(eig[0]), torch.tensor(eig[1]))
+        f, l = _determine_stream_spread_single(eb, theta, sigOm, sigAn, Jt)
+        (f.sum() + l.sum()).backward()
+        ad = float(Jt.grad[0, 0])
+    best = float("inf")
+    for h in (1e-4, 1e-5, 1e-6):
+        Jp, Jm = invjac.copy(), invjac.copy()
+        Jp[0, 0] += h
+        Jm[0, 0] -= h
+        fd = (loss_np(Jp) - loss_np(Jm)) / (2 * h)
+        best = min(best, abs(ad - fd))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    assert best < 1e-5 * abs(ad) + 1e-6, (
+        f"spread grad-vs-FD {backend_name} best={best:.2e}"
+    )

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -1165,3 +1165,49 @@ def test_cyl_to_rect_jac_backend(backend_name, nargs):
     ref = _coords.cyl_to_rect_jac(*[numpy.asarray(a) for a in args])
     got = as_numpy(_coords.cyl_to_rect_jac(*[_arr(backend_name, a) for a in args]))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+###############################################################################
+# Phase C.4: _determine_stream_spread pipeline dispatches to the backend when the
+# track (_allinvjacsTrack) is a backend array -- assembles the per-chunk covs
+# functionally + reuses the C.2 eigen-slerp interpolation.
+###############################################################################
+@pytest.mark.slow
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_determine_stream_spread_backend_pipeline(backend_name):
+    import copy
+
+    from galpy.df import streamdf as _cls
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    aA = actionAngleIsochroneApprox(pot=lp, b=0.8, tintJ=15)
+    obs = Orbit(numpy.array(_STREAM_IC))
+    sdf = _cls(
+        0.365 / 220.0,
+        progenitor=obs,
+        pot=lp,
+        aA=aA,
+        leading=True,
+        nTrackChunks=5,
+        nTrackIterations=0,
+        tdisrupt=_tdisrupt(),
+    )
+    # Same invjacs/ObsTrack on the backend -> isolates the pipeline from the track
+    # FD-vs-AD floor; the backend spread must match the numpy spread to ~machine.
+    s = copy.copy(sdf)
+    s._allinvjacsTrack = _arr(backend_name, numpy.array(sdf._allinvjacsTrack))
+    s._ObsTrack = _arr(backend_name, numpy.array(sdf._ObsTrack))
+    s._determine_stream_spread()
+    for attr in (
+        "_allErrCovsXY",
+        "_interpolatedAllErrCovsXY",
+        "_allErrCovsLocalXY",
+        "_interpolatedAllErrCovsLocalXY",
+    ):
+        numpy.testing.assert_allclose(
+            as_numpy(getattr(s, attr)),
+            numpy.array(getattr(sdf, attr)),
+            rtol=1e-10,
+            atol=1e-12,
+            err_msg=f"{attr} ({backend_name})",
+        )

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -1053,3 +1053,115 @@ def test_determine_stream_spread_single_grad_vs_fd(backend_name):
     assert best < 1e-5 * abs(ad) + 1e-6, (
         f"spread grad-vs-FD {backend_name} best={best:.2e}"
     )
+
+
+###############################################################################
+# Phase C.2: _cart_and_interp_cov -- eigen-slerp interpolation of the 6x6 covs.
+# numpy path byte-identical; backend twin: eigh (not eig) + functional sign-align
+# + backend-native eigenvalue cubic spline + guarded slerp + reconstruction.
+###############################################################################
+from galpy.util import coords as _coords
+
+
+def _mock_spread_sdf(nC, xp_mk):
+    # Minimal object exposing the attributes _cart_and_interp_cov reads. Random
+    # but reproducible ObsTrack + SPD chunk covariances + monotone theta grids.
+    from galpy.df.streamdf import streamdf as _cls
+
+    rng = numpy.random.default_rng(7)
+    dtheta = 1.3
+    thetas = numpy.linspace(0.0, dtheta, nC)
+    interp = numpy.linspace(0.0, dtheta, 6 * nC)
+    obs = rng.standard_normal((nC, 6)) * 0.3 + numpy.array(
+        [1.1, 0.05, 1.0, 0.1, 0.02, 0.3]
+    )
+    covs = numpy.empty((nC, 6, 6))
+    for ii in range(nC):
+        A = rng.standard_normal((6, 6))
+        covs[ii] = A @ A.T + 3.0 * numpy.eye(6)  # SPD
+
+    class _M:
+        pass
+
+    m = _M()
+    m._nTrackChunks = nC
+    m._ObsTrack = xp_mk(obs)
+    m._thetasTrack = thetas
+    m._interpolatedThetasTrack = interp
+    m._cart_and_interp_cov = _cls._cart_and_interp_cov.__get__(m)
+    m._cart_and_interp_cov_backend = _cls._cart_and_interp_cov_backend.__get__(m)
+    return m, covs
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_cart_and_interp_cov_value_parity(backend_name):
+    m_np, covs = _mock_spread_sdf(5, numpy.asarray)
+    xy_np, interp_np = m_np._cart_and_interp_cov(covs)
+    m_b, _ = _mock_spread_sdf(5, lambda a: _arr(backend_name, a))
+    xy_b, interp_b = m_b._cart_and_interp_cov(_arr(backend_name, covs))
+    # chunk-level Cartesian covariance == numpy to machine precision;
+    # interpolated matches to the eigh-vs-eig + spline floor.
+    numpy.testing.assert_allclose(as_numpy(xy_b), xy_np, rtol=1e-11, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(interp_b), interp_np, rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_cart_and_interp_cov_grad_vs_fd(backend_name):
+    # d(sum allErrCovsXY)/d(chunk_covs[0,0,0]) AD h-converges to a central FD of numpy.
+    m_np, covs = _mock_spread_sdf(5, numpy.asarray)
+
+    def loss_np(c):
+        return float(m_np._cart_and_interp_cov(c)[0].sum())
+
+    if backend_name == "jax":
+        m_b, _ = _mock_spread_sdf(5, jnp.asarray)
+
+        def loss(c):
+            return m_b._cart_and_interp_cov(c)[0].sum()
+
+        ad = float(jax.grad(loss)(jnp.asarray(covs))[0, 0, 0])
+    else:
+        m_b, _ = _mock_spread_sdf(5, lambda a: torch.tensor(a))
+        ct = torch.tensor(covs, requires_grad=True)
+        m_b._cart_and_interp_cov(ct)[0].sum().backward()
+        ad = float(ct.grad[0, 0, 0])
+    best = float("inf")
+    for h in (1e-4, 1e-5, 1e-6):
+        cp, cm = covs.copy(), covs.copy()
+        cp[0, 0, 0] += h
+        cm[0, 0, 0] -= h
+        best = min(best, abs(ad - (loss_np(cp) - loss_np(cm)) / (2 * h)))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    assert best < 1e-5 * abs(ad) + 1e-6, (
+        f"cart_and_interp grad {backend_name} {best:.2e}"
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_cart_and_interp_cov_slerp_degeneracy_finite(backend_name):
+    # Near-identical adjacent chunks drive the slerp Omega->0 (numpy NaNs there,
+    # unguarded / sin(Omega)); the backend must stay finite in value AND gradient.
+    m_b, covs = _mock_spread_sdf(5, lambda a: _arr(backend_name, a))
+    covs[1] = covs[0]  # identical adjacent covariance -> parallel eigenvectors
+    if backend_name == "jax":
+        cb = jnp.asarray(covs)
+        out = m_b._cart_and_interp_cov(cb)
+        g = jax.grad(lambda c: m_b._cart_and_interp_cov(c)[1].sum())(cb)
+        assert bool(jnp.all(jnp.isfinite(out[1]))) and bool(jnp.all(jnp.isfinite(g)))
+    else:
+        cb = torch.tensor(covs, requires_grad=True)
+        out = m_b._cart_and_interp_cov(cb)
+        out[1].sum().backward()
+        assert bool(torch.all(torch.isfinite(out[1]))) and bool(
+            torch.all(torch.isfinite(cb.grad))
+        )
+
+
+@pytest.mark.parametrize("nargs", [3, 6])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_cyl_to_rect_jac_backend(backend_name, nargs):
+    rng = numpy.random.default_rng(1)
+    args = rng.standard_normal(nargs)
+    ref = _coords.cyl_to_rect_jac(*[numpy.asarray(a) for a in args])
+    got = as_numpy(_coords.cyl_to_rect_jac(*[_arr(backend_name, a) for a in args]))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -41,7 +41,7 @@ except ImportError:  # pragma: no cover
 AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
 
 from galpy.actionAngle import actionAngleIsochroneApprox
-from galpy.backend import as_numpy, get_namespace
+from galpy.backend import as_numpy, get_namespace, is_backend_array
 from galpy.backend.jacobian import jacobian
 from galpy.df.streamdf import (
     _determine_stream_spread_single,
@@ -1165,6 +1165,32 @@ def test_cyl_to_rect_jac_backend(backend_name, nargs):
     ref = _coords.cyl_to_rect_jac(*[numpy.asarray(a) for a in args])
     got = as_numpy(_coords.cyl_to_rect_jac(*[_arr(backend_name, a) for a in args]))
     numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_cart_and_interp_cov_backend_coerce_and_guard(backend_name):
+    # The backend twin's defensive branches: the nC<4 guard (cubic spline needs
+    # >=4 knots) and the numpy-input coercion that fires when it is reached via a
+    # MIXED dispatch (one of chunk_covs/_ObsTrack backend, the other numpy). The
+    # coercion must be value-preserving, so each mixed call matches the all-backend
+    # reference (same seed -> same data).
+    mk = lambda a: _arr(backend_name, a)
+    # (a) nC < 4 -> ValueError
+    m3, covs3 = _mock_spread_sdf(3, mk)
+    with pytest.raises(ValueError, match="nTrackChunks"):
+        m3._cart_and_interp_cov_backend(mk(covs3))
+    # reference: fully-backend inputs
+    m_all, covs = _mock_spread_sdf(5, mk)
+    xy_ref = as_numpy(m_all._cart_and_interp_cov_backend(mk(covs))[0])
+    # (b) numpy chunk_covs + backend _ObsTrack -> coerce chunk_covs
+    xy_b = m_all._cart_and_interp_cov_backend(covs)[0]
+    assert is_backend_array(xy_b)
+    numpy.testing.assert_allclose(as_numpy(xy_b), xy_ref, rtol=1e-11, atol=1e-12)
+    # (c) backend chunk_covs + numpy _ObsTrack/_thetasTrack -> coerce those
+    m_nobs, covs2 = _mock_spread_sdf(5, numpy.asarray)
+    xy_n = m_nobs._cart_and_interp_cov_backend(mk(covs2))[0]
+    assert is_backend_array(xy_n)
+    numpy.testing.assert_allclose(as_numpy(xy_n), xy_ref, rtol=1e-11, atol=1e-12)
 
 
 ###############################################################################


### PR DESCRIPTION
## Phase C: backend-native, differentiable stream spread

Makes the streamdf stream **spread** (the position covariances along the track) backend-native (jax/torch, jit/GPU) and **differentiable through the track**, keeping the numpy path byte-identical. This is the spread analogue of Phase B (#1145), which did the track. It activates on a backend **track** (Phase B's `_ic_backend` → diffrax `calcaAJac` on the track points → backend `_allinvjacsTrack`), so the whole track→spread pipeline is now differentiable end-to-end w.r.t. the progenitor phase-space.

### What's in this PR

- **C.1 — `_determine_stream_spread_single`**: per-chunk full+local covariance assembly as a functional dual-path (numpy item-assignment → `xp.where`/`xp.concat`), differentiable w.r.t. the frequency eigenbasis and the inverse Jacobian.
- **C.2 — `_cart_and_interp_cov`** (+ `coords.cyl_to_rect_jac`): propagate the cov to galcen-Cartesian and interpolate onto the fine grid via a backend-native **eigen-slerp** — `xp.linalg.eigh`, functional sign-alignment, the in-backend cubic spline (`galpy.backend.interpolate`, no scipy so jax tracers survive), and a 0/0-guarded slerp. Adversarially reviewed; the backend path is actually *more* accurate than numpy at eigenvalue near-degeneracy (numpy `eig`+VᵀV drifts non-orthonormal there).
- **C.4 — `_determine_stream_spread`**: dispatch the pipeline to the backend when the track is a backend array; assemble the per-chunk covs functionally (`xp.stack`, no `numpy.empty`) and reuse C.2. The deprecated LB pipeline stays numpy and is skipped on the backend.

### numpy byte-identity

Every method is a strict dual-path: `is_backend_array`-gated backend branch, numpy branch verbatim. Verified the backend spread == numpy to **~3e-15** (jax + torch) with the same track inputs (isolating the pipeline from the track's FD-vs-AD floor). New per-method value-parity + grad-vs-FD tests, plus a whole-pipeline `@slow` test.

### Deferred follow-up (not in this PR)

Making the **frozen frequency covariance** (`_offset_setup`: `_sigomatrixEig`/`_meandO`/`_sigomatrixinv`) differentiable w.r.t. the progenitor is a separate step. It's currently coerced onto the backend as a constant (same convention as Phase B's track). It only activates once the **progenitor's** actionAngle (`calcaAJac`/`actionAngleIsochroneApprox`) is backend-migrated so `_dOdJp` genuinely becomes a backend array — a Track-E-level effort. A byte-identical, torch-grad-verified backend `_offset_setup` twin exists but is dead code without that activation, so it's held back rather than shipped as an unreachable branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
