### PR TITLE
tests: slow-skip the jax scalarfuncomegaz noninertial timeout flake

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -354,6 +354,7 @@ jax tests/test_noninertial.py::test_accellsrframe_vecomegaz
 jax tests/test_noninertial.py::test_accellsrframe_vecomegaz_2d
 jax tests/test_noninertial.py::test_cinterp_funcomegaz
 jax tests/test_noninertial.py::test_cinterp_vecfuncomega
+jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz
 jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_vecomegaz
 jax tests/test_noninertial.py::test_lsrframe_vecomegaz
 jax tests/test_noninertial.py::test_lsrframe_vecomegaz_2d


### PR DESCRIPTION
## What

`tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz` under **jax** is an eager-XLA **timeout flake**: it runs right at the 300s per-test timeout, and when it tips over, `pytest-timeout` records it as a plain `FAILED` (not xfail) — which reds the `backend jax` shard (`test_qdf` / `test_pv2qdf` / `test_streamgapdf_impulse` / `test_noninertial`) intermittently.

Observed on two **unrelated** PRs this week (#1150 orbit accessors, #1151 vterm) that don't touch these tests — confirming it's a base flake, not their code. The shard was green on #1148/#1149 (same tests finished under 300s that time).

## Fix

Its sibling variants are **already** jax-slow-skipped — `...accellsrframe_funcomegaz` and `...accellsrframe_vecomegaz` — so `scalarfuncomegaz` was simply missed. Add it to `tests/backend_slow_skip.txt` (jax) so it's deferred like its variants and stops flaking the shard.

- **torch** keeps it in the xfail-ledger (there it's a fast value-failure, not a timeout).
- Pure test-infra; **no source change**.

Once merged, the open backend PRs (#1150/#1151/#1152) pick this up on rebase and their jax shards stop flaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
