### PR TITLE
tests: reclaim 4 torch test_sphericaldf backend xfails (as_numpy fixes + in-shard stale prune)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -368,16 +368,13 @@ torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_dens_directint
 torch tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_dMdE_integral
 torch tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
-torch tests/test_sphericaldf.py::test_eddington_hernquist_dMdE
 torch tests/test_sphericaldf.py::test_eddington_powerspherical_divergent_auto_rmin
 torch tests/test_sphericaldf.py::test_eddington_powerspherical_massprofile
 torch tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_dens_directint
 torch tests/test_sphericaldf.py::test_isotropic_hernquist_dMdE_integral
-torch tests/test_sphericaldf.py::test_isotropic_hernquist_diffcalls
 torch tests/test_sphericaldf.py::test_isotropic_plummer_dMdE_integral
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
-torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_diffcalls
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[0.5]
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[2.0]
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[5.0]
@@ -385,7 +382,6 @@ torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_nonself_dens_direc
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[0.5]
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[2.0]
 torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[5.0]
-torch tests/test_sphericaldf.py::test_pvr_interpolator_large_rmax_sampling
 torch tests/test_streamTrack.py::test_streamTrackPair_particles_property
 torch tests/test_streamTrack.py::test_streamTrack_cov_basis
 torch tests/test_streamTrack.py::test_streamTrack_cov_per_call_unit_overrides

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -321,8 +321,8 @@ def test_isotropic_hernquist_diffcalls():
     # Calculate E directly
     assert (
         numpy.fabs(
-            dfh(R, vR, vT, z, vz, phi)
-            - dfh((pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),))
+            as_numpy(dfh(R, vR, vT, z, vz, phi))
+            - as_numpy(dfh((pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),)))
         )
         < 1e-8
     ), (
@@ -331,11 +331,17 @@ def test_isotropic_hernquist_diffcalls():
     # Also L
     assert (
         numpy.fabs(
-            dfh(R, vR, vT, z, vz, phi)
-            - dfh(
-                (
-                    pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
-                    numpy.sqrt(numpy.sum(Orbit([R, vR, vT, z, vz, phi]).L() ** 2.0)),
+            as_numpy(dfh(R, vR, vT, z, vz, phi))
+            - as_numpy(
+                dfh(
+                    (
+                        pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
+                        numpy.sqrt(
+                            numpy.sum(
+                                as_numpy(Orbit([R, vR, vT, z, vz, phi]).L() ** 2.0)
+                            )
+                        ),
+                    )
                 )
             )
         )
@@ -345,7 +351,10 @@ def test_isotropic_hernquist_diffcalls():
     )
     # Also as orbit
     assert (
-        numpy.fabs(dfh(R, vR, vT, z, vz, phi) - dfh(Orbit([R, vR, vT, z, vz, phi])))
+        numpy.fabs(
+            as_numpy(dfh(R, vR, vT, z, vz, phi))
+            - as_numpy(dfh(Orbit([R, vR, vT, z, vz, phi])))
+        )
         < 1e-8
     ), (
         "Calling the isotropic Hernquist DF with R,vR,... or E[R,vR,...] does not give the same answer"
@@ -828,13 +837,17 @@ def test_osipkovmerritt_hernquist_diffcalls():
         # Calculate E directly and L from Orbit
         assert (
             numpy.fabs(
-                dfh(R, vR, vT, z, vz, phi)
-                - dfh(
-                    (
-                        pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
-                        numpy.sqrt(
-                            numpy.sum(Orbit([R, vR, vT, z, vz, phi]).L() ** 2.0)
-                        ),
+                as_numpy(dfh(R, vR, vT, z, vz, phi))
+                - as_numpy(
+                    dfh(
+                        (
+                            pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
+                            numpy.sqrt(
+                                numpy.sum(
+                                    as_numpy(Orbit([R, vR, vT, z, vz, phi]).L() ** 2.0)
+                                )
+                            ),
+                        )
                     )
                 )
             )
@@ -844,7 +857,10 @@ def test_osipkovmerritt_hernquist_diffcalls():
         )
         # Also as orbit
         assert (
-            numpy.fabs(dfh(R, vR, vT, z, vz, phi) - dfh(Orbit([R, vR, vT, z, vz, phi])))
+            numpy.fabs(
+                as_numpy(dfh(R, vR, vT, z, vz, phi))
+                - as_numpy(dfh(Orbit([R, vR, vT, z, vz, phi])))
+            )
             < 1e-8
         ), (
             "Calling the Osipkov-Merritt isotropic Hernquist DF with R,vR,... or E[R,vR,...] does not give the same answer"
@@ -1596,9 +1612,9 @@ def test_eddington_hernquist_dMdE():
     Emin = pot(0.0, 0.0)
     Emax = pot(numpy.inf, 0.0)
     E = numpy.linspace(0.99 * Emin, Emax - 0.001, 1001)
-    assert numpy.all(numpy.fabs(dfe.dMdE(E) / dfi.dMdE(E) - 1.0) < 1e-4), (
-        "dMdE for isotropic Hernquist DF does not agree with exact solution"
-    )
+    assert numpy.all(
+        numpy.fabs(as_numpy(dfe.dMdE(E)) / as_numpy(dfi.dMdE(E)) - 1.0) < 1e-4
+    ), "dMdE for isotropic Hernquist DF does not agree with exact solution"
     return None
 
 
@@ -3218,14 +3234,16 @@ def test_pvr_interpolator_large_rmax_sampling():
     dfh = eddingtondf(pot=pot, rmax=rmax)
     numpy.random.seed(42)
     samp = dfh.sample(n=10000)
-    rs = samp.r()
-    vs = numpy.sqrt(samp.vR() ** 2 + samp.vz() ** 2 + samp.vT() ** 2)
+    rs = as_numpy(samp.r())
+    vs = as_numpy(numpy.sqrt(samp.vR() ** 2 + samp.vz() ** 2 + samp.vT() ** 2))
     # All velocities should be <= escape velocity at their radius
-    vescs = numpy.sqrt(
-        2.0
-        * (
-            potential.evaluatePotentials(pot, rmax, 0.0)
-            - potential.evaluatePotentials(pot, rs, numpy.zeros_like(rs))
+    vescs = as_numpy(
+        numpy.sqrt(
+            2.0
+            * (
+                potential.evaluatePotentials(pot, rmax, 0.0)
+                - potential.evaluatePotentials(pot, rs, numpy.zeros_like(rs))
+            )
         )
     )
     assert numpy.all(vs <= vescs * 1.01), (


### PR DESCRIPTION
Burns down torch backend xfail-ledger entries for `tests/test_sphericaldf.py` (CI shard = that one file). **N = 4** = 4 as_numpy fixes + 0 in-shard stale prune.

## Part A — in-shard stale prune (0)
The regen-mode run (`GALPY_BACKEND_XFAIL_REGEN=1`, `--backend torch`, the exact CI-shard context) failing set is **identical** to the origin ledger's 27 `torch test_sphericaldf` entries — nothing has started passing in-shard since the last regen, so there are no stale entries to reclaim.

## Part B — as_numpy fixes (4)
Wave-4 pattern: a numpy op runs on a torch DF output at the assertion (`numpy.ndarray - Tensor`, `numpy.sum/all(Tensor)`, `numpy <= Tensor`). Fix = wrap the galpy **output** in `galpy.backend.as_numpy(...)` at the assertion (import already present). `as_numpy(numpy)` is a no-op → default-numpy path byte-identical. Each stash-verified (fails without, passes with, under `--backend torch`):

- `test_isotropic_hernquist_diffcalls` — `numpy.ndarray - Tensor`
- `test_osipkovmerritt_hernquist_diffcalls` — `numpy.sum(Tensor, axis=)`
- `test_eddington_hernquist_dMdE` — `numpy.all(Tensor)` (tol 1e-4, real match)
- `test_pvr_interpolator_large_rmax_sampling` — `numpy.ndarray <= Tensor`

## Left ledgered (23 — genuinely unfixable at the assertion)
- **Numeric torch-vs-numpy mismatches** (over tolerance): `*_dens_directint`, `*_sigmar_directint`, `*_dMdE_integral` (Hernquist/Plummer/DehnenCore), `*_nonself_dens_directint`.
- **float32-vs-float64**: `test_anisotropic_hernquist_diffcalls` — the `constantbetaHernquistdf` scalar-args path returns float32 vs the E,L path float64 → 1.69e-8 > 1e-8 tol (as_numpy converts the type error into a real numeric fail; edit reverted).
- **Source gaps** (note for separate source PRs, not test-level): hyp2f1 fallback `NotImplementedError` in torch's regime (`test_osipkovmerritt_hernquist_dMdE_limits[_generalimplementation]`, `test_constantbetadf_against_hernquist`); torch `vmap`/`.item()` in interpolated-potential path (`test_constantbeta_interpolatedpotentials_dens_directint`, `_beta`); tensor-size-mismatch in eddington powerspherical (`test_eddington_powerspherical_massprofile`, `_divergent_auto_rmin`); NaN dens (`test_constantbeta_differentpotentials_dens_directint`); `DID NOT WARN` behavior diff (`test_eddington_sample_negative_df_regions_no_crash`).

## Ledger diff vs origin (only torch test_sphericaldf removals, no adds, no other files)
```
371d370
< torch tests/test_sphericaldf.py::test_eddington_hernquist_dMdE
376d374
< torch tests/test_sphericaldf.py::test_isotropic_hernquist_diffcalls
380d377
< torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_diffcalls
388d384
< torch tests/test_sphericaldf.py::test_pvr_interpolator_large_rmax_sampling
```

## Local verify (PYTHONPATH=worktree, `CUDA_VISIBLE_DEVICES=""`)
- **torch** shard: 223 tests, **0 real failures**, 23 xfailed.
- **regen** re-run: failing set == the 23 remaining ledger entries → **0 XPASS, 0 un-ledgered FAIL**.
- **default numpy** shard: **223 passed, 0 failures** (byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm