### PR TITLE
tests: reclaim 9 torch test_potential backend xfails (as_numpy fixes + in-shard stale prune)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -446,23 +446,15 @@ jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot_nullpotential
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential
-torch tests/test_potential.py::test_2ndDeriv_potential[mockTimeDependentAmplitudeWrapperPotential]
 torch tests/test_potential.py::test_2ndDeriv_potential[specialSpiralArmsPotential]
-torch tests/test_potential.py::test_dehnen_bar_python_c_consistency
-torch tests/test_potential.py::test_evaluateAndDerivs_potential[mockTimeDependentAmplitudeWrapperPotential]
-torch tests/test_potential.py::test_forceAsDeriv_potential[mockTimeDependentAmplitudeWrapperPotential]
 torch tests/test_potential.py::test_forceAsDeriv_potential[specialSpiralArmsPotential]
 torch tests/test_potential.py::test_integration_RotateAndTiltWrapper_timedependent_forcecache
 torch tests/test_potential.py::test_mass_spher
 torch tests/test_potential.py::test_mass_spher_analytic
 torch tests/test_potential.py::test_mass_spher_z
 torch tests/test_potential.py::test_MWPotential2014
-torch tests/test_potential.py::test_OblateStaeckelWrapperPotential_againstKuzmin
-torch tests/test_potential.py::test_poisson_potential[mockTimeDependentAmplitudeWrapperPotential]
 torch tests/test_potential.py::test_rE_MWPotential2014
 torch tests/test_potential.py::test_rforce_dissipative
-torch tests/test_potential.py::test_vterm
-torch tests/test_potential.py::test_vtermnegl_issue314
 
 # --- jax single-orbit: action-angle accessors (Track E) ---
 # o.jr()/jz()/e()/zmax()/rperi()/rap() and physical/quantity/plotting paths that call
@@ -509,7 +501,6 @@ jax tests/test_sphericaldf.py::test_eddington_sample_negative_df_regions_no_cras
 # integrate). Already ledgered for torch.
 jax tests/test_streamspraydf.py::test_integrate
 jax tests/test_streamspraydf.py::test_integrate_rtnonarray
-torch tests/test_potential.py::test_ExpTruncNFW_smallr_series_c
 torch tests/test_scf.py::test_static_c_orbit_parity
 torch tests/test_scf.py::test_tdep_array_t_broadcast
 torch tests/test_scf.py::test_tdep_c_beyond_tgrid

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -5606,11 +5606,11 @@ def test_ExpTruncNFW_smallr_series_c():
         "ExpTruncNFW plunging orbit did not reach the small-r series regime"
     )
     # C and pure-Python orbits agree (C series branch == Python series branch)
-    assert numpy.amax(numpy.fabs(oc.r(ts) - op.r(ts))) < 1e-10, (
+    assert numpy.amax(numpy.fabs(as_numpy(oc.r(ts)) - as_numpy(op.r(ts)))) < 1e-10, (
         "ExpTruncNFWPotential C and Python plunging orbits disagree"
     )
     # energy is conserved across the plunge (series branch is accurate)
-    Ec = oc.E(ts)
+    Ec = as_numpy(oc.E(ts))
     assert numpy.amax(numpy.fabs(Ec - Ec[0])) < 1e-10, (
         "ExpTruncNFWPotential energy not conserved through the small-r plunge"
     )
@@ -7198,12 +7198,20 @@ def test_OblateStaeckelWrapperPotential_againstKuzmin():
     asp = potential.OblateStaeckelWrapperPotential(pot=kzp, delta=delta, u0=1.2)
     us = numpy.linspace(0.0, 3.0, 1001)
     assert (
-        numpy.amax(numpy.fabs(asp._U(us) + kzp._amp / delta * numpy.cosh(us))) < 1e-10
+        numpy.amax(
+            numpy.fabs(
+                as_numpy(asp._U(us)) + as_numpy(kzp._amp) / delta * numpy.cosh(us)
+            )
+        )
+        < 1e-10
     ), "OblateStaeckelWrapped KuzminDisk does not have the expected U(u)"
     vs = numpy.linspace(0.0, numpy.pi, 1001)
     assert (
         numpy.amax(
-            numpy.fabs(asp._V(vs) + kzp._amp / delta * numpy.fabs(numpy.cos(vs)))
+            numpy.fabs(
+                as_numpy(asp._V(vs))
+                + as_numpy(kzp._amp) / delta * numpy.fabs(numpy.cos(vs))
+            )
         )
         < 1e-10
     ), "OblateStaeckelWrapped KuzminDisk does not have the expected V(v)"
@@ -11133,9 +11141,9 @@ def test_dehnen_bar_python_c_consistency():
     orb_p.integrate(ts, pot=pot, method="dop853")
     orb_c.integrate(ts, pot=pot, method="dop853_c")
     # check equal
-    assert numpy.all(numpy.fabs(orb_p.E(ts) / orb_c.E(ts) - 1.0) < 10.0**-10), (
-        "C orbit integration in a Dehnen bar potential does not work as expected"
-    )
+    assert numpy.all(
+        numpy.fabs(as_numpy(orb_p.E(ts)) / as_numpy(orb_c.E(ts)) - 1.0) < 10.0**-10
+    ), "C orbit integration in a Dehnen bar potential does not work as expected"
 
 
 # Test the rm2 definition of EinastoPotential


### PR DESCRIPTION
Burns down torch backend xfail-ledger entries for `tests/test_potential.py`. **N = 9 reclaimed** (of 18): **3 as_numpy result-cast fixes + 6 in-shard stale-passing prunes**.

All decisions are justified by an in-shard run of the actual CI shard (`tests/test_potential.py` whole-file) under `GALPY_BACKEND_XFAIL_REGEN=1 --backend torch`. After the edits, a fresh regen re-run confirms **ledger == still-failing set** (0 XPASS, 0 un-ledgered FAIL).

### as_numpy fixes (3)
Wave-4 class: a numpy reduction / mixed-array arithmetic applied to a torch **output** (`numpy.amax`/`numpy.all` on a torch tensor, or `ndarray - Tensor`). Wrapped the galpy output in `galpy.backend.as_numpy(...)` at the assertion; the underlying values are well within tolerance.

| test | op that broke | value vs tol |
|---|---|---|
| `test_OblateStaeckelWrapperPotential_againstKuzmin` | `numpy.amax` on `asp._U/_V` torch arrays | ~1e-14 vs 1e-10 |
| `test_dehnen_bar_python_c_consistency` | `numpy.all` over `orb.E(ts)` tensors | ~1.4e-11 vs 1e-10 |
| `test_ExpTruncNFW_smallr_series_c` | `numpy.amax` over `oc.r/op.r`, `E(ts)` tensors | ~7e-12 vs 1e-10 |

Each was **stash-verified**: fails (TypeError) without the cast, passes with it, under `--backend torch`. numpy path is byte-identical (`as_numpy(numpy)` is a no-op) — the default-numpy run stays green.

### Stale-passing prune (6)
Already pass in-shard now (fixed by merged #1139/#1140/#1151), removed from the ledger:
- `test_2ndDeriv_potential[mockTimeDependentAmplitudeWrapperPotential]`
- `test_evaluateAndDerivs_potential[mockTimeDependentAmplitudeWrapperPotential]`
- `test_forceAsDeriv_potential[mockTimeDependentAmplitudeWrapperPotential]`
- `test_poisson_potential[mockTimeDependentAmplitudeWrapperPotential]`
- `test_vterm`
- `test_vtermnegl_issue314`

### Left ledgered (9) — genuine, not test-fixable
- `test_MWPotential2014` — bulge Rforce off 9.4e-10 vs a 1e-14 tol (torch round-off)
- `test_rE_MWPotential2014` — `rE` root-find 4.3e-8 vs 1e-8 tol; an as_numpy cast would only convert the TypeError into a silent numeric fail, so left ledgered per guardrail
- `test_mass_spher`, `test_mass_spher_analytic`, `test_mass_spher_z` — forceint / GL-quadrature mass, torch-vs-numpy 1.5e-9..3.5e-7 over a 1e-10 tol
- `test_rforce_dissipative` — Plummer `Rforce = rforce·R/r` relation off 6e-9 vs 1e-10
- `test_2ndDeriv_potential[specialSpiralArmsPotential]`, `test_forceAsDeriv_potential[specialSpiralArmsPotential]` — 1%..27% disagreement (genuine spiral-arms precision gap)
- `test_integration_RotateAndTiltWrapper_timedependent_forcecache` — **source gap**: `DehnenSmoothWrapperPotential._smooth` feeds numpy scalars into `torch.where` (needs a source coercion fix, out of scope for a test-only PR)

### Local verification
- 3 fixed tests pass under `--backend torch` (real run, un-ledgered) and under default numpy.
- Full-file regen re-run on this branch: exactly the 9 remaining ledgered entries fail; nothing un-ledgered fails; no XPASS.
- Ledger diff vs `origin/feat/backends` is exactly these 9 `torch tests/test_potential.py::` removals — no additions, no other files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm