### PR TITLE
qdf burndown: backend-coerce quasiisothermaldf leaves (+8 torch flips)

### DIFF
--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -7,7 +7,12 @@ from scipy import integrate, interpolate, optimize
 
 from .. import actionAngle, potential
 from ..actionAngle import actionAngleIsochrone
-from ..backend import get_namespace, is_backend_array, promote_scalars
+from ..backend import (
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+    promote_scalars,
+)
 from ..backend.interpolate import Spline1D
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..orbit import Orbit
@@ -242,6 +247,7 @@ class quasiisothermaldf(df):
             # if isinstance(jr,(list,numpy.ndarray)) and len(jr) > 1: jr= jr[0]
             # if isinstance(jz,(list,numpy.ndarray)) and len(jz) > 1: jz= jz[0]
         xp = get_namespace(jr, lz, jz)
+        jr, lz, jz = coerce_coords(xp, jr, lz, jz)  # torch rejects python-float xp.abs
         if (
             not isinstance(lz, numpy.ndarray)
             and not is_backend_array(lz)
@@ -1035,10 +1041,13 @@ class quasiisothermaldf(df):
         **kwargs,
     ):
         """Non-physical version of jmomentdensity, otherwise the same"""
+        xp = get_namespace(R, z)
         if nsigma == None:
             nsigma = _NSIGMA
-        sigmaR1 = self._sr * numpy.exp((self._refr - R) / self._hsr)
-        sigmaz1 = self._sz * numpy.exp((self._refr - R) / self._hsz)
+        if xp is not numpy:  # promote scalar (R,z) so xp.exp etc. run on backend
+            R, z = promote_scalars(xp, R, z)
+        sigmaR1 = self._sr * xp.exp((self._refr - R) / self._hsr)
+        sigmaz1 = self._sz * xp.exp((self._refr - R) / self._hsz)
         thisvc = potential.vcirc(self._pot, R, use_physical=False)
         # Use the asymmetric drift equation to estimate va
         gamma = numpy.sqrt(0.5)
@@ -1052,7 +1061,9 @@ class quasiisothermaldf(df):
                 + R * (1.0 / self._hr + 2.0 / self._hsr)
             )
         )
-        if numpy.fabs(va) > sigmaR1:
+        if is_backend_array(va):
+            va = xp.where(xp.abs(va) > sigmaR1, 0.0, va)  # avoid craziness near center
+        elif numpy.fabs(va) > sigmaR1:
             va = 0.0  # To avoid craziness near the center
         if mc:
             mvT = (thisvc - va) / gamma / sigmaR1
@@ -1060,20 +1071,26 @@ class quasiisothermaldf(df):
                 vrs = numpy.random.normal(size=nmc)
             else:
                 vrs = _vrs
+            # defer the mvT add so the numpy.random draw order is byte-identical
+            add_mvT_to_vts = _vts is None
             if _vts is None:
-                vts = numpy.random.normal(size=nmc) + mvT
+                vts = numpy.random.normal(size=nmc)
             else:
                 vts = _vts
             if _vzs is None:
                 vzs = numpy.random.normal(size=nmc)
             else:
                 vzs = _vzs
+            if xp is not numpy:  # promote the (numpy) draws to combine with backend
+                vrs, vts, vzs = promote_scalars(xp, vrs, vts, vzs)
+            if add_mvT_to_vts:
+                vts = vts + mvT
             Is = _jmomentsurfaceMCIntegrand(
                 vzs,
                 vrs,
                 vts,
-                numpy.ones(nmc) * R,
-                numpy.ones(nmc) * z,
+                xp.ones(nmc) * R,
+                xp.ones(nmc) * z,
                 self,
                 sigmaR1,
                 gamma,
@@ -1085,13 +1102,13 @@ class quasiisothermaldf(df):
             )
             if _returnmc:
                 return (
-                    numpy.mean(Is) * sigmaR1**2.0 * gamma * sigmaz1,
+                    xp.mean(Is) * sigmaR1**2.0 * gamma * sigmaz1,
                     vrs,
                     vts,
                     vzs,
                 )
             else:
-                return numpy.mean(Is) * sigmaR1**2.0 * gamma * sigmaz1
+                return xp.mean(Is) * sigmaR1**2.0 * gamma * sigmaz1
         else:  # pragma: no cover because this is too slow; a warning is shown
             warnings.warn(
                 "Calculations using direct numerical integration using tplquad is not recommended and extremely slow; it has also not been carefully tested",
@@ -3199,6 +3216,7 @@ def _jmomentsurfaceMCIntegrand(
     vz, vR, vT, R, z, df, sigmaR1, gamma, sigmaz1, mvT, n, m, o
 ):
     """Internal function that is the integrand for the vmomentsurface mass integration"""
+    xp = get_namespace(vz, vR, vT, R, z)
     return df(
         R,
         vR * sigmaR1,
@@ -3207,4 +3225,4 @@ def _jmomentsurfaceMCIntegrand(
         vz * sigmaz1,
         use_physical=False,
         func=(lambda x, y, z: x**n * y**m * z**o),
-    ) * numpy.exp(vR**2.0 / 2.0 + (vT - mvT) ** 2.0 / 2.0 + vz**2.0 / 2.0)
+    ) * xp.exp(vR**2.0 / 2.0 + (vT - mvT) ** 2.0 / 2.0 + vz**2.0 / 2.0)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -251,14 +251,6 @@ torch tests/test_orbits.py::test_bruteSOS_2Dy
 torch tests/test_orbits.py::test_plotBruteSOS
 torch tests/test_pv2qdf.py::test_pvRvz_staeckel_arrayin
 torch tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_qdf.py::test_jmomentdensity_diffinoutputs
-torch tests/test_qdf.py::test_jmomentdensity_physical
-torch tests/test_qdf.py::test_meanjr
-torch tests/test_qdf.py::test_meanjr_center
-torch tests/test_qdf.py::test_meanjz
-torch tests/test_qdf.py::test_meanjz_noaac_issue300
-torch tests/test_qdf.py::test_meanlz
-torch tests/test_qdf.py::test_pvz_staeckel_arrayin
 torch tests/test_qdf.py::test_sampleV
 torch tests/test_qdf.py::test_sampleV_interpolate
 torch tests/test_qdf.py::test_sampleV_physical

--- a/tests/test_backend_qdf.py
+++ b/tests/test_backend_qdf.py
@@ -260,6 +260,20 @@ def test_vmomentdensity_mc_parity(backend):
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-9)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_jmomentdensity_mc_parity(backend):
+    # Monte-Carlo _jmomentdensity path: promote_scalars on (R,z) and on the numpy
+    # draws, the xp.where va-clamp, xp.mean reduction -- the backend-only branches
+    # (the numpy result is byte-identical). Re-seed both sides for a tight MC match.
+    numpy.random.seed(2)
+    ref = as_numpy(_qdf._jmomentdensity(0.9, 0.05, 0, 0, 0, mc=True, nmc=10000))
+    with galpy.backend.use(backend, force=True):
+        numpy.random.seed(2)
+        got = _qdf._jmomentdensity(0.9, 0.05, 0, 0, 0, mc=True, nmc=10000)
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-9)
+
+
 # --- moment-wrapper backend parity: the gl moment engine via the public API ---
 _R0, _Z0 = 0.9, 0.08
 

--- a/tests/test_qdf.py
+++ b/tests/test_qdf.py
@@ -2,6 +2,7 @@
 import numpy
 
 from galpy.actionAngle import actionAngleAdiabatic, actionAngleStaeckel
+from galpy.backend import as_numpy
 from galpy.df import quasiisothermaldf
 
 # fiducial setup uses these
@@ -1215,9 +1216,10 @@ def test_pvz_staeckel_arrayin():
         1.0 / 4.0, 0.2, 0.1, 1.0, 1.0, pot=MWPotential, aA=aAS, cutcounter=True
     )
     R, z = 0.8, 0.1
-    pvz = qdf.pvz(0.05 * numpy.ones(2), R * numpy.ones(2), z * numpy.ones(2))
+    pvz = as_numpy(qdf.pvz(0.05 * numpy.ones(2), R * numpy.ones(2), z * numpy.ones(2)))
     assert numpy.all(
-        numpy.fabs(numpy.log(pvz) - numpy.log(qdf.pvz(0.05, R, z))) < 10.0**-10.0
+        numpy.fabs(numpy.log(pvz) - numpy.log(as_numpy(qdf.pvz(0.05, R, z))))
+        < 10.0**-10.0
     ), (
         "pvz calculated with R and z array input does not equal to calculated with scalar input"
     )


### PR DESCRIPTION
Backend-coerce the migrated `quasiisothermaldf` leaves so they run on the forced backend instead of raising on python-float/numpy scalars.

- `_call_internal`: `coerce_coords(xp, jr, lz, jz)`
- `_jmomentdensity` (MC path): `get_namespace` + `promote_scalars`, `xp.exp/mean/ones`, `xp.where` for the near-center va clamp; **defers the `+mvT` add so `numpy.random` draw order stays byte-identical**
- `test_qdf.py`: as_numpy-cast two assertion sites

**+8 torch `test_qdf` flips** (all verified fail-without/pass-with): jmomentdensity_diffinoutputs/_physical, meanjr[_center], meanjz[_noaac_issue300], meanlz, pvz_staeckel_arrayin.

- numpy **BYTE-IDENTICAL** (jmomentdensity MC `array_equal` across R,z grid)
- jax + torch green on the 8
- ledger: 8 removals, 0 adds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm