### PR TITLE
streamdf Phase E: backend-native, differentiable stream-track interpolation

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -734,6 +734,34 @@ class Spline1D:
             extrapolate=self._extrapolate,
         )
 
+    def derivative(self, n=1):
+        """Return a callable for the ``n``-th derivative.
+
+        Mirrors ``scipy.interpolate.InterpolatedUnivariateSpline.derivative()``:
+        ``self.derivative(n)(r) == self(r, nu=n)``. On the numpy (mode-1) path
+        this delegates to the fitted scipy spline's own ``.derivative()``
+        (BYTE-IDENTICAL to using scipy directly); on a backend spline it returns
+        a lightweight callable that evaluates the SAME power-basis polynomial
+        with ``nu=n`` (the analytic derivative, agreeing with scipy to ~1 ulp),
+        so the derivative stays differentiable in both the evaluation point and
+        -- for a mode-2 in-backend spline -- the ``y`` values.
+        """
+        if self._spl is not None:
+            return self._spl.derivative(n=n)
+        return _Spline1DDerivative(self, n)
+
+
+class _Spline1DDerivative:
+    """The ``n``-th derivative of a backend :class:`Spline1D`, callable at ``r``
+    (``== spl(r, nu=n)``); returned by :meth:`Spline1D.derivative`."""
+
+    def __init__(self, spl, n):
+        self._spl = spl
+        self._n = n
+
+    def __call__(self, r):
+        return self._spl(r, nu=self._n)
+
 
 class Spline2D:
     """Backend-agnostic 2D tensor-product spline over a rectangular grid.

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -19,7 +19,7 @@ else:
 from ..actionAngle.actionAngleIsochroneApprox import dePeriod
 from ..backend import as_backend_constant, as_numpy, get_namespace, is_backend_array
 from ..backend import special as _bspecial
-from ..backend.interpolate import cubic_spline_coeffs, eval_ppoly
+from ..backend.interpolate import Spline1D, cubic_spline_coeffs, eval_ppoly
 from ..backend.quadrature import fixed_quad as _backend_fixed_quad
 from ..backend.quadrature import quad as _backend_quad
 from ..orbit import Orbit
@@ -2099,6 +2099,8 @@ class streamdf(df):
         """Build interpolations of the stream track"""
         if hasattr(self, "_interpolatedThetasTrack"):
             return None  # Already did this
+        if is_backend_array(self._ObsTrack):
+            return self._interpolate_stream_track_backend()
         TrackX = self._ObsTrack[:, 0] * numpy.cos(self._ObsTrack[:, 5])
         TrackY = self._ObsTrack[:, 0] * numpy.sin(self._ObsTrack[:, 5])
         TrackZ = self._ObsTrack[:, 3]
@@ -2178,6 +2180,58 @@ class streamdf(df):
         self._interpolatedObsTrack[:, 5] = tphi
         return None
 
+    def _interpolate_stream_track_backend(self):
+        """Backend (jax/torch) twin of :meth:`_interpolate_stream_track`.
+
+        Dispatched when the assembled track ``_ObsTrack`` is a backend array.
+        Functional throughout (numpy item-assignment -> ``xp.stack``). The six
+        coordinate splines (``_interpTrackX/Y/Z/vX/vY/vZ``) are built in-backend
+        via :class:`galpy.backend.interpolate.Spline1D` (mode 2:
+        ``cubic_spline_coeffs`` with ``bc='not-a-knot'``, matching scipy's
+        ``InterpolatedUnivariateSpline(k=3)`` to ~1e-13), so the interpolated
+        track is backend-native and DIFFERENTIABLE w.r.t. the track
+        (``_ObsTrack``). The knots/fine grid are geometry (numpy host
+        bookkeeping); the fine grid is coerced onto the backend to evaluate so
+        the gradient flows. The numpy path is untouched (still scipy,
+        byte-identical).
+        """
+        xp = get_namespace(self._ObsTrack)
+        ObsTrack = self._ObsTrack
+        thetas_np = as_numpy(self._thetasTrack)  # spline knots are geometry (concrete)
+        phi = ObsTrack[:, 5]
+        TrackX = ObsTrack[:, 0] * xp.cos(phi)
+        TrackY = ObsTrack[:, 0] * xp.sin(phi)
+        TrackZ = ObsTrack[:, 3]
+        TrackvX, TrackvY, TrackvZ = coords.cyl_to_rect_vec(
+            ObsTrack[:, 1], ObsTrack[:, 2], ObsTrack[:, 4], phi
+        )
+        # In-backend cubic splines (differentiable in the track y-values); the
+        # scipy IUS(k=3) not-a-knot boundary condition is reproduced natively.
+        self._interpTrackX = Spline1D(thetas_np, TrackX, k=3, ext=0, bc="not-a-knot")
+        self._interpTrackY = Spline1D(thetas_np, TrackY, k=3, ext=0, bc="not-a-knot")
+        self._interpTrackZ = Spline1D(thetas_np, TrackZ, k=3, ext=0, bc="not-a-knot")
+        self._interpTrackvX = Spline1D(thetas_np, TrackvX, k=3, ext=0, bc="not-a-knot")
+        self._interpTrackvY = Spline1D(thetas_np, TrackvY, k=3, ext=0, bc="not-a-knot")
+        self._interpTrackvZ = Spline1D(thetas_np, TrackvZ, k=3, ext=0, bc="not-a-knot")
+        # Fine grid: geometry (numpy host bookkeeping, matching the numpy path);
+        # coerce onto the backend to evaluate so d(track)/d(_ObsTrack) flows.
+        self._interpolatedThetasTrack = numpy.linspace(
+            0.0, float(self._deltaAngleTrack), self.nInterpolatedTrackChunks
+        )
+        interpThetas = as_backend_constant(xp, self._interpolatedThetasTrack, ObsTrack)
+        iX = self._interpTrackX(interpThetas)
+        iY = self._interpTrackY(interpThetas)
+        iZ = self._interpTrackZ(interpThetas)
+        ivX = self._interpTrackvX(interpThetas)
+        ivY = self._interpTrackvY(interpThetas)
+        ivZ = self._interpTrackvZ(interpThetas)
+        self._interpolatedObsTrackXY = xp.stack([iX, iY, iZ, ivX, ivY, ivZ], axis=1)
+        # Also in cylindrical coordinates (backend-aware coords helpers).
+        tR, tphi, tZ = coords.rect_to_cyl(iX, iY, iZ)
+        tvR, tvT, tvZ = coords.rect_to_cyl_vec(ivX, ivY, ivZ, tR, tphi, tZ, cyl=True)
+        self._interpolatedObsTrack = xp.stack([tR, tvR, tvT, tZ, tvZ, tphi], axis=1)
+        return None
+
     def _interpolate_stream_track_aA(self):
         """Build interpolations of the stream track in action-angle coordinates"""
         if hasattr(self, "_interpolatedObsTrackAA"):
@@ -2185,6 +2239,8 @@ class streamdf(df):
         # Calculate 1D meanOmega on a fine grid in angle and interpolate
         if not hasattr(self, "_interpolatedThetasTrack"):
             self._interpolate_stream_track()
+        if is_backend_array(self._ObsTrack):
+            return self._interpolate_stream_track_aA_backend()
         dmOs = numpy.array(
             [
                 self.meanOmega(da, oned=True, use_physical=False)
@@ -2212,6 +2268,45 @@ class streamdf(df):
             self._interpolatedObsTrackAA[ii, 3:] = numpy.mod(
                 self._interpolatedObsTrackAA[ii, 3:], 2.0 * numpy.pi
             )
+        return None
+
+    def _interpolate_stream_track_aA_backend(self):
+        """Backend (jax/torch) twin of :meth:`_interpolate_stream_track_aA`.
+
+        Dispatched when the track is a backend array. ``dmOs`` (the 1D mean
+        frequency offset on the fine angle grid) routes through the backend
+        :meth:`meanOmega`, and the frequency/angle blocks are assembled
+        functionally, so ``_interpolatedObsTrackAA`` is backend-native and
+        differentiable w.r.t. the frequency-covariance scalars / progenitor AA.
+        ``_interpTrackAAdmeanOmegaOneD`` is rebuilt in-backend for API parity
+        (it is not read downstream). The numpy path is untouched (byte-identical).
+        """
+        xp = get_namespace(self._ObsTrack)
+        interpThetas_np = self._interpolatedThetasTrack  # host bookkeeping (numpy)
+        interpThetas = as_backend_constant(xp, interpThetas_np, self._ObsTrack)
+        dmOs = xp.stack(
+            [
+                self.meanOmega(interpThetas[ii], oned=True, use_physical=False)
+                for ii in range(interpThetas.shape[0])
+            ]
+        )  # (nInterp,)
+        # Vestigial spline (rebuilt for API parity; not read downstream).
+        self._interpTrackAAdmeanOmegaOneD = Spline1D(
+            interpThetas_np, dmOs, k=3, ext=0, bc="not-a-knot"
+        )
+        progOmega = as_backend_constant(xp, self._progenitor_Omega, self._ObsTrack)
+        progAngle = as_backend_constant(xp, self._progenitor_angle, self._ObsTrack)
+        dsig = as_backend_constant(
+            xp, self._dsigomeanProgDirection, self._ObsTrack
+        )  # (3,)
+        sign = self._sigMeanSign
+        Omega_block = progOmega[None, :] + dmOs[:, None] * dsig[None, :] * sign
+        angle_block = xp.remainder(
+            progAngle[None, :] + interpThetas[:, None] * dsig[None, :] * sign,
+            2.0 * numpy.pi,
+        )
+        concat = getattr(xp, "concat", None) or xp.concatenate
+        self._interpolatedObsTrackAA = concat([Omega_block, angle_block], axis=1)
         return None
 
     def calc_stream_lb(self, vo=None, ro=None, R0=None, Zsun=None, vsun=None):

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -597,6 +597,32 @@ def test_spline1d_mode2_k1_deriv(backend):
     numpy.testing.assert_allclose(dval, slope, atol=1e-12)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline1d_derivative_method(backend):
+    # Spline1D.derivative()(r) == self(r, nu=1), mirroring scipy IUS.derivative().
+    # mode-1 (numpy y) delegates to the fitted scipy spline's own .derivative()
+    # (byte-identical to scipy); mode-2 (backend y) returns a callable evaluating
+    # the analytic derivative of the same power-basis cubic.
+    ref = si.InterpolatedUnivariateSpline(_XG, _YG, k=3).derivative()(_RQ)
+    # mode 1: numpy-fitted spline, evaluated under each backend
+    s1 = Spline1D(_XG, _YG, k=3)
+    got1 = as_numpy(s1.derivative()(_asarray(backend, _RQ)))
+    numpy.testing.assert_allclose(got1, ref, rtol=1e-9, atol=1e-12)
+    if backend == "numpy":
+        # mode-1 numpy path is scipy's own derivative spline (byte-identical)
+        numpy.testing.assert_array_equal(s1.derivative()(_RQ), ref)
+        return
+    # mode 2: in-backend cubic (natural bc) -> match scipy CubicSpline derivative
+    ref2 = si.CubicSpline(_XG, _YG, bc_type="natural").derivative()(_RQ)
+    s2 = Spline1D(_XG, _asarray(backend, _YG), k=3, bc="natural")
+    got2 = as_numpy(s2.derivative()(_asarray(backend, _RQ)))
+    numpy.testing.assert_allclose(got2, ref2, rtol=1e-9, atol=1e-12)
+    # derivative() agrees with the nu=1 call on the same instance
+    numpy.testing.assert_allclose(
+        got2, as_numpy(s2(_asarray(backend, _RQ), nu=1)), rtol=1e-12, atol=1e-12
+    )
+
+
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_eval_ppoly_nu_past_degree_zero(backend):
     # The backend eval_ppoly returns zeros for a derivative order past the

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -1510,3 +1510,248 @@ def test_sample_t_numpy_byte_identical(sdf):
     numpy.random.seed(77)
     ref = numpy.random.uniform(size=2000) * sdf._tdisrupt
     numpy.testing.assert_array_equal(got, ref)
+
+
+###############################################################################
+# Phase E: _interpolate_stream_track / _interpolate_stream_track_aA -- the
+# stream-track interpolation splines.
+#
+# numpy path byte-identical (scipy InterpolatedUnivariateSpline(k=3), the
+# else-branch is the verbatim original -- verified by a git-stash A/B: the
+# interpTrackX/Y/Z/vX/vY/vZ evaluations, _interpolatedObsTrackXY and
+# _interpolatedObsTrack are bit-unchanged). Backend twins
+# (_interpolate_stream_track_backend / _interpolate_stream_track_aA_backend),
+# dispatched when the assembled track _ObsTrack is a backend array, build the six
+# coordinate splines in-backend via Spline1D (cubic_spline_coeffs, bc='not-a-knot'
+# == scipy IUS(k=3) to ~1e-13) and assemble the fine-grid track functionally, so
+# the interpolated track (and the AA track) is backend-native and DIFFERENTIABLE
+# w.r.t. the track (_ObsTrack) / the frequency-covariance scalars.
+###############################################################################
+def _mock_track_sdf(nC, nInterp, mk):
+    # Minimal object exposing what _interpolate_stream_track reads: a backend
+    # ObsTrack + a monotone theta grid. R (col 0) kept positive so rect<->cyl is
+    # well-defined.
+    from galpy.df.streamdf import streamdf as _cls
+
+    rng = numpy.random.default_rng(11)
+    dtheta = 1.3
+    obs = rng.standard_normal((nC, 6)) * 0.15 + numpy.array(
+        [1.1, 0.05, 1.0, 0.1, 0.02, 0.3]
+    )
+
+    class _M:
+        pass
+
+    m = _M()
+    m._nTrackChunks = nC
+    m._ObsTrack = mk(obs)
+    m._thetasTrack = numpy.linspace(0.0, dtheta, nC)
+    m._deltaAngleTrack = dtheta
+    m.nInterpolatedTrackChunks = nInterp
+    m._interpolate_stream_track = _cls._interpolate_stream_track.__get__(m)
+    m._interpolate_stream_track_backend = (
+        _cls._interpolate_stream_track_backend.__get__(m)
+    )
+    return m, obs
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_interpolate_stream_track_value_parity(backend_name):
+    nC, nI = 8, 301
+    m_np, _ = _mock_track_sdf(nC, nI, numpy.asarray)
+    m_np._interpolate_stream_track()
+    m_b, _ = _mock_track_sdf(nC, nI, lambda a: _arr(backend_name, a))
+    m_b._interpolate_stream_track()
+    assert is_backend_array(m_b._interpolatedObsTrackXY)
+    assert is_backend_array(m_b._interpolatedObsTrack)
+    q = numpy.linspace(-0.1, 1.4, 53)  # incl. out-of-range (ext=0 extrapolation)
+    qb = _arr(backend_name, q)
+    for n in ("X", "Y", "Z", "vX", "vY", "vZ"):
+        numpy.testing.assert_allclose(
+            as_numpy(getattr(m_b, "_interpTrack" + n)(qb)),
+            getattr(m_np, "_interpTrack" + n)(q),
+            rtol=1e-11,
+            atol=1e-12,
+            err_msg=f"interpTrack{n} ({backend_name})",
+        )
+    numpy.testing.assert_allclose(
+        as_numpy(m_b._interpolatedObsTrackXY),
+        m_np._interpolatedObsTrackXY,
+        rtol=1e-11,
+        atol=1e-12,
+    )
+    numpy.testing.assert_allclose(
+        as_numpy(m_b._interpolatedObsTrack),
+        m_np._interpolatedObsTrack,
+        rtol=1e-11,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_interpolate_stream_track_derivative_parity(backend_name):
+    # Spline1D.derivative() on the backend spline == scipy IUS.derivative() on the
+    # numpy path (used by streamdf.length(phys=True)).
+    nC, nI = 8, 51
+    m_np, _ = _mock_track_sdf(nC, nI, numpy.asarray)
+    m_np._interpolate_stream_track()
+    m_b, _ = _mock_track_sdf(nC, nI, lambda a: _arr(backend_name, a))
+    m_b._interpolate_stream_track()
+    q = numpy.linspace(0.0, 1.3, 37)
+    qb = _arr(backend_name, q)
+    numpy.testing.assert_allclose(
+        as_numpy(m_b._interpTrackX.derivative()(qb)),
+        m_np._interpTrackX.derivative()(q),
+        rtol=1e-9,
+        atol=1e-9,
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_interpolate_stream_track_grad_vs_fd(backend_name):
+    # d(sum interpTrackX(q))/d(_ObsTrack[0,0]) AD h-converges to a central FD of
+    # the numpy path (stringent, not finite-and-nonzero).
+    nC, nI = 8, 101
+    q = numpy.linspace(0.0, 1.3, 41)
+
+    def loss_np(o):
+        m, _ = _mock_track_sdf(nC, nI, numpy.asarray)
+        m._ObsTrack = o
+        m._interpolate_stream_track()
+        return float(numpy.sum(m._interpTrackX(q)))
+
+    _, obs = _mock_track_sdf(nC, nI, numpy.asarray)
+    if backend_name == "jax":
+
+        def loss(o):
+            m, _ = _mock_track_sdf(nC, nI, jnp.asarray)
+            m._ObsTrack = o
+            m._interpolate_stream_track()
+            return jnp.sum(m._interpTrackX(jnp.asarray(q)))
+
+        ad = float(jax.grad(loss)(jnp.asarray(obs))[0, 0])
+    else:
+        obs_t = torch.tensor(obs, requires_grad=True)
+        m, _ = _mock_track_sdf(nC, nI, lambda a: a)
+        m._ObsTrack = obs_t
+        m._interpolate_stream_track()
+        torch.sum(m._interpTrackX(torch.tensor(q))).backward()
+        ad = float(obs_t.grad[0, 0])
+    best = float("inf")
+    for h in (1e-4, 1e-5, 1e-6):
+        op, om = obs.copy(), obs.copy()
+        op[0, 0] += h
+        om[0, 0] -= h
+        best = min(best, abs(ad - (loss_np(op) - loss_np(om)) / (2 * h)))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    assert best < 1e-5 * abs(ad) + 1e-6, f"track grad {backend_name} {best:.2e}"
+
+
+def _backendify_track(sdf, mk):
+    # A shallow copy of a real (numpy) streamdf with the assembled track and the
+    # AA scalars promoted to a backend array, and the cached interpolation
+    # dropped, so _interpolate_stream_track[_aA] dispatch to their backend twins.
+    s = _copy.copy(sdf)
+    for a in (
+        "_ObsTrack",
+        "_progenitor_Omega",
+        "_progenitor_angle",
+        "_dsigomeanProgDirection",
+        "_meandO",
+        "_sortedSigOEig",
+    ):
+        setattr(s, a, mk(numpy.asarray(getattr(sdf, a))))
+    for a in (
+        "_interpolatedThetasTrack",
+        "_interpolatedObsTrackXY",
+        "_interpolatedObsTrack",
+        "_interpolatedObsTrackAA",
+    ):
+        if hasattr(s, a):
+            delattr(s, a)
+    return s
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_interpolate_stream_track_real_sdf_parity(sdf, backend_name):
+    # The real Bovy(2014) track promoted to the backend, rebuilt INSIDE a forced-
+    # backend context (mirrors the --backend shard's namespace/coercion). Both the
+    # physical track (_interpolatedObsTrackXY/_interpolatedObsTrack) and the AA
+    # track (_interpolatedObsTrackAA) match the numpy setup to ~1e-11.
+    from galpy import backend as _bk
+
+    ref_XY = numpy.asarray(sdf._interpolatedObsTrackXY)
+    ref_Track = numpy.asarray(sdf._interpolatedObsTrack)
+    ref_AA = numpy.asarray(sdf._interpolatedObsTrackAA)
+    mk = lambda a: _arr(backend_name, a)
+    with _bk.use(backend_name, force=True):
+        s = _backendify_track(sdf, mk)
+        s._interpolate_stream_track()
+        s._interpolate_stream_track_aA()
+        assert is_backend_array(s._interpolatedObsTrackXY)
+        assert is_backend_array(s._interpolatedObsTrack)
+        assert is_backend_array(s._interpolatedObsTrackAA)
+        got_XY = as_numpy(s._interpolatedObsTrackXY)
+        got_Track = as_numpy(s._interpolatedObsTrack)
+        got_AA = as_numpy(s._interpolatedObsTrackAA)
+    numpy.testing.assert_allclose(got_XY, ref_XY, rtol=1e-11, atol=1e-12)
+    numpy.testing.assert_allclose(got_Track, ref_Track, rtol=1e-11, atol=1e-12)
+    numpy.testing.assert_allclose(got_AA, ref_AA, rtol=1e-11, atol=1e-12)
+
+
+def _mock_aa_sdf(mk, meandO, nInterp=121):
+    from galpy.df.streamdf import streamdf as _cls
+
+    dsig = numpy.array([0.3, 0.8, 0.5])
+    dsig = dsig / numpy.linalg.norm(dsig)
+
+    class _M:
+        pass
+
+    m = _M()
+    m._ObsTrack = mk(numpy.zeros((5, 6)))  # dispatch + namespace only
+    m._interpolatedThetasTrack = numpy.linspace(0.0, 1.4, nInterp)
+    m._meandO = meandO
+    m._sortedSigOEig = mk(numpy.array([0.0, 0.0, 3.1e-4]))
+    m._tdisrupt = 12.0
+    m._sigMeanSign = 1.0
+    m._progenitor_Omega = mk(numpy.array([0.31, 0.55, -0.42]))
+    m._progenitor_angle = mk(numpy.array([1.1, 2.2, 0.7]))
+    m._dsigomeanProgDirection = mk(dsig)
+    m._interpolate_stream_track_aA_backend = (
+        _cls._interpolate_stream_track_aA_backend.__get__(m)
+    )
+    m.meanOmega = _cls.meanOmega.__get__(m)
+    return m
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_interpolate_stream_track_aA_grad_vs_fd(backend_name):
+    # d(sum _interpolatedObsTrackAA)/d(_meandO) AD h-converges to a central FD of
+    # the numpy build (the AA track is differentiable via meanOmega's dmOs).
+    md0 = 0.021
+
+    def loss_np(md):
+        m = _mock_aa_sdf(numpy.asarray, float(md))
+        m._interpolate_stream_track_aA_backend()
+        return float(numpy.sum(m._interpolatedObsTrackAA))
+
+    if backend_name == "jax":
+
+        def loss(md):
+            m = _mock_aa_sdf(jnp.asarray, md)
+            m._interpolate_stream_track_aA_backend()
+            return jnp.sum(m._interpolatedObsTrackAA)
+
+        ad = float(jax.grad(loss)(jnp.asarray(md0)))
+    else:
+        mdt = torch.tensor(md0, requires_grad=True)
+        m = _mock_aa_sdf(lambda a: torch.tensor(a), mdt)
+        m._interpolate_stream_track_aA_backend()
+        torch.sum(m._interpolatedObsTrackAA).backward()
+        ad = float(mdt.grad)
+    best = float("inf")
+    for h in (1e-5, 1e-6, 1e-7):
+        best = min(best, abs(ad - (loss_np(md0 + h) - loss_np(md0 - h)) / (2 * h)))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    assert best < 1e-4 * abs(ad) + 1e-6, f"aA grad {backend_name} {best:.2e}"


### PR DESCRIPTION
Phase E (interpolation) of the streamdf backend migration — makes the interpolated stream track backend-native and differentiable. **Feature**, no ledger burndown (under a forced `--backend` the streamdf `_ObsTrack` stays numpy by Phase-B design, so this code is inert there; it activates via a backend progenitor + diffrax AA).

- `_interpolate_stream_track` + `_interpolate_stream_track_aA` → dual-path: one-line `is_backend_array(self._ObsTrack)` guard, numpy body **untouched**; backend twins build the 6 coord splines + AA meanOmega spline via `galpy.backend.interpolate.Spline1D(k=3, not-a-knot)` and assemble `_interpolatedObsTrack(XY/AA)` functionally (xp.stack/concat/remainder + backend coords) — mirrors Phase C.2.
- `Spline1D.derivative()` added (mode-1 delegates to scipy byte-identical; mode-2 analytic nu=1) so the backend track is a drop-in for `length(phys=True)`.

**Verified:** numpy **BYTE-IDENTICAL** (maxdiff 0.0 on interpTrackX/derivative/ObsTrackXY/ObsTrackAA); backend parity ~1e-15..1e-16 (real Bovy2014 sdf); grad-vs-FD h-converged (2e-12 track, 1.4e-5 AA); torch 13/13 + jax 13/13 new Phase-E tests. streamdf is now A–D + E-interp; `_approxaAInv` (sample() propagation) is the last remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm