### PR TITLE
sphericaldf burndown: +23 backend flips (osipkov/constantbeta/eddington root-cause fixes)

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -9,13 +9,14 @@ from scipy import integrate, interpolate, special
 from ..backend import (
     as_numpy,
     autodiff_ops,
+    device_of,
     get_namespace,
     is_backend_array,
     name_of_namespace,
     resolve_namespace,
     use,
 )
-from ..backend.quadrature import fixed_quad
+from ..backend.quadrature import fixed_quad, fixed_quad_semiinfinite
 from ..potential import evaluateRforces, interpSphericalPotential
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion, quadpack
@@ -272,20 +273,24 @@ class _constantbetadf(anisotropicsphericaldf):
         # and the vmax(r) integration limit; the node axis trails
         rb = xp.asarray(r) * 1.0  # coerce: torch potentials reject numpy coords
         Phir_b = (xp.asarray(_evaluatePotentials(self._pot, rb, 0)) * 1.0)[..., None]
+        integrand = lambda v: (
+            v ** (2.0 - 2.0 * self._beta + m + n) * self.fE(Phir_b + 0.5 * v**2.0)
+        )
+        if numpy.isinf(as_numpy(self._potInf)):
+            # divergent potential (Phi(inf)=inf): v_esc is infinite, so map the
+            # tail [0, inf) instead of integrating to an infinite limit (NaN)
+            integral = fixed_quad_semiinfinite(
+                xp, integrand, 0.0, n=_QUAD_N_VMOM, kind="recip", device=device_of(rb)
+            )
+        else:
+            integral = fixed_quad(
+                xp, integrand, 0.0, self._vmax_at_r(self._pot, rb), n=_QUAD_N_VMOM
+            )
         return (
             2.0
             * numpy.pi
             * rb ** (-2.0 * self._beta)
-            * fixed_quad(
-                xp,
-                lambda v: (
-                    v ** (2.0 - 2.0 * self._beta + m + n)
-                    * self.fE(Phir_b + 0.5 * v**2.0)
-                ),
-                0.0,
-                self._vmax_at_r(self._pot, rb),
-                n=_QUAD_N_VMOM,
-            )
+            * integral
             * special.gamma(m / 2.0 - self._beta + 1.0)
             * special.gamma((n + 1) / 2.0)
             / special.gamma(0.5 * (m + n - 2.0 * self._beta + 3.0))

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -69,12 +69,14 @@ class eddingtondf(isotropicsphericaldf):
         self._dnudr = (
             self._denspot._ddensdr
             if not isinstance(self._denspot, CompositePotential)
-            else lambda r: numpy.sum([p._ddensdr(r) for p in self._denspot])
+            # builtin sum keeps r's shape (numpy.sum collapses the vectorized
+            # backend node array); byte-identical for the scalar-r numpy path
+            else lambda r: sum(p._ddensdr(r) for p in self._denspot)
         )
         self._d2nudr2 = (
             self._denspot._d2densdr2
             if not isinstance(self._denspot, CompositePotential)
-            else lambda r: numpy.sum([p._d2densdr2(r) for p in self._denspot])
+            else lambda r: sum(p._d2densdr2(r) for p in self._denspot)
         )
         self._potInf = _evaluatePotentials(pot, self._rmax, 0)
         self._Emin = _evaluatePotentials(pot, self._rmin, 0)

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -2,7 +2,7 @@
 import numpy
 from scipy import integrate, interpolate, special
 
-from ..backend import as_numpy, resolve_namespace
+from ..backend import as_numpy, device_of, resolve_namespace
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..potential import evaluateDensities
 from ..potential.Potential import _evaluatePotentials
@@ -257,18 +257,31 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
                 / special.gamma(0.5 * (m + n + 3.0))
                 / (1 + r**2.0 / self._ra2) ** (m / 2 + 1)
             )
-        # jax/torch: fixed-order GL over v, differentiable in r; node axis trails
+        # jax/torch: GL after v = vmax sin(theta), which cancels the fQ endpoint
+        # singularity (power-law fQ ~ Q^{-1/2} as Q -> 0 at v = vmax); node axis trails
         rb = xp.asarray(r) * 1.0  # coerce: torch potentials reject numpy coords
         Phir_b = (xp.asarray(_evaluatePotentials(self._pot, rb, 0)) * 1.0)[..., None]
+        vmax = (xp.asarray(self._vmax_at_r(self._pot, rb)) * 1.0)[..., None]
+
+        def _integrand(theta):
+            v = vmax * xp.sin(theta)
+            return (
+                v ** (2.0 + m + n)
+                * self.fQ(-Phir_b - 0.5 * v**2.0)
+                * vmax
+                * xp.cos(theta)
+            )
+
         return (
             2.0
             * numpy.pi
             * fixed_quad(
                 xp,
-                lambda v: v ** (2.0 + m + n) * self.fQ(-Phir_b - 0.5 * v**2.0),
+                _integrand,
                 0.0,
-                self._vmax_at_r(self._pot, rb),
+                numpy.pi / 2.0,
                 n=_QUAD_N_VMOM,
+                device=device_of(rb),
             )
             * special.gamma(m / 2.0 + 1.0)
             * special.gamma((n + 1) / 2.0)

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -656,11 +656,19 @@ class sphericaldf(df):
         xis = numpy.arange(ximin, ximax, 1e-4)
         rs = _xiToR(xis, a=self._scale)
         # try/except necessary when mass doesn't take arrays, also need to
-        # switch to a more general mass method at some point...
+        # switch to a more general mass method at some point... (RuntimeError:
+        # a forced-backend integration-based mass can't broadcast the array rs
+        # against its quadrature nodes -- fall back to the per-r loop as numpy does)
         try:
             ms = mass(self._denspot, rs, use_physical=False)
-        except (ValueError, TypeError):
-            ms = numpy.array([mass(self._denspot, r, use_physical=False) for r in rs])
+        except (ValueError, TypeError, RuntimeError):
+            ms = numpy.array(
+                [as_numpy(mass(self._denspot, r, use_physical=False)) for r in rs]
+            )
+            # keep ms on the active backend so the mnorm/rmin arithmetic below
+            # stays same-namespace (as_numpy'd for the icdf table at the end)
+            if xp is not numpy:
+                ms = xp.asarray(ms)
         mnorm = mass(self._denspot, self._rmax, use_physical=False)
         if self._rmin_sampling > 0:
             ms -= mass(self._denspot, self._rmin_sampling, use_physical=False)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -127,18 +127,9 @@ jax tests/test_quantity.py::test_streamgapdf_setup_impactparamsAsQuantity
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dMdE_integral
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_dens_directint
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
-jax tests/test_sphericaldf.py::test_constantbeta_differentpotentials_dens_directint
 jax tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
-jax tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_dens_directint
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
 jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[0.5]
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[2.0]
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[5.0]
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_nonself_dens_directint
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[0.5]
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[2.0]
-jax tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[5.0]
 torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
 torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor_c
 torch tests/test_FDMdynamfric.py::test_dynamfric_c
@@ -286,23 +277,11 @@ torch tests/test_quantity.py::test_streamgapdf_sample
 torch tests/test_quantity.py::test_streamgapdf_setup_impactparamsAsQuantity
 torch tests/test_sphericaldf.py::test_anisotropic_hernquist_dMdE_integral
 torch tests/test_sphericaldf.py::test_anisotropic_hernquist_dens_directint
-torch tests/test_sphericaldf.py::test_anisotropic_hernquist_diffcalls
-torch tests/test_sphericaldf.py::test_constantbeta_differentpotentials_dens_directint
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_dens_directint
 torch tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
-torch tests/test_sphericaldf.py::test_eddington_powerspherical_divergent_auto_rmin
-torch tests/test_sphericaldf.py::test_eddington_powerspherical_massprofile
-torch tests/test_sphericaldf.py::test_isotropic_eddington_dehnencore_in_nfw_dens_directint
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[0.5]
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[2.0]
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_dens_directint[5.0]
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_nonself_dens_directint
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[0.5]
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[2.0]
-torch tests/test_sphericaldf.py::test_osipkovmerritt_powerlaw_sigmar_directint[5.0]
 torch tests/test_streamTrack.py::test_streamTrackPair_particles_property
 torch tests/test_streamTrack.py::test_streamTrack_cov_basis
 torch tests/test_streamTrack.py::test_streamTrack_cov_per_call_unit_overrides
@@ -375,7 +354,6 @@ jax tests/test_diskdf.py::test_dehnendf_sample_powerrise_returnROrbit
 # and two bespoke tests use numpy.all/scipy.quad/float32-FD on torch outputs.
 # (test_actionAngleStaeckel_wSpherical...c[jax] = pre-existing jax-eager flake,
 #  already ledgered for torch.) Removed as each Phase-2 PR lands.
-jax tests/test_sphericaldf.py::test_eddington_sample_negative_df_regions_no_crash
 # streamspraydf backend migration: the integrate=False sampling path is now
 # backend-native (returns a jax/torch array); these two integrate=True tests
 # assign into that array in place (RvR_noint[:,ii]=...), which jax's immutable
@@ -390,6 +368,5 @@ torch tests/test_scf.py::test_tdep_c_dynamical_friction_dens
 torch tests/test_scf.py::test_tdep_c_full_dxdv
 torch tests/test_scf.py::test_tdep_c_orbit_nonaxi
 torch tests/test_scf.py::test_tdep_c_orbit_spherical
-torch tests/test_sphericaldf.py::test_eddington_sample_negative_df_regions_no_crash
 torch tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
 torch tests/test_quantity.py::test_sphericaldf_sample_outputunits

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -180,6 +180,21 @@ def test_moments_parity(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_vmomentdensity_divergent_potential(backend):
+    # a divergent potential (alpha<2 -> Phi(inf)=inf -> v_esc=inf) drives the base
+    # _vmomentdensity onto the fixed_quad_semiinfinite branch (integrate the v_esc=inf
+    # tail via a reciprocal map instead of to an infinite fixed_quad limit -> NaN)
+    # (correctness of the divergent case is covered by test_sphericaldf's
+    # test_constantbeta_differentpotentials_dens_directint; here we just need the
+    # backend semiinfinite branch to run and return a finite, positive density.)
+    df = constantbetadf(pot=PowerSphericalPotential(amp=1.3, alpha=1.9), twobeta=-1)
+    got = df.vmomentdensity(_arr(backend, 1.3), 0, 0)
+    assert _is_backend_array(backend, got)
+    val = float(as_numpy(got))
+    assert numpy.isfinite(val) and val > 0.0
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_dMdE_parity(backend):
     # anisotropic constant-beta dM/dE (GL after the r = rphi - s^2 turning-point
     # substitution). rtol 1e-5 is the numpy adaptive-quad floor at the

--- a/tests/test_backend_eddingtondf.py
+++ b/tests/test_backend_eddingtondf.py
@@ -38,6 +38,7 @@ from galpy.potential import (
     DehnenCoreSphericalPotential,
     HernquistPotential,
     NFWPotential,
+    PowerSphericalPotential,
 )
 
 
@@ -237,3 +238,16 @@ def test_sample_forced_construction(backend):
     for g, r in zip(got, ref):
         assert isinstance(g, numpy.ndarray) and not _is_backend_array(backend, g)
         numpy.testing.assert_allclose(g, r, rtol=1e-7, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_powerspherical_mass_array_fallback(backend):
+    # PowerSpherical denspot: mass(denspot, array) raises under the backend in
+    # _make_cmf_interpolator, so the CMF construction falls back to the per-r
+    # backend loop (the except-RuntimeError branch). Samples stay numpy-side.
+    pot = PowerSphericalPotential(amp=1.3, alpha=1.4)
+    with galpy.backend.use(backend, force=True):
+        numpy.random.seed(654)
+        got = eddingtondf(pot=pot, rmax=5.0).sample(n=50, rmin=0.1, return_orbit=False)
+    assert not _is_backend_array(backend, got[0])
+    assert len(got[0]) == 50 and numpy.all(numpy.isfinite(got[0]))

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -13,7 +13,7 @@ import pytest
 from scipy import integrate, special
 
 from galpy import potential
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, get_namespace
 from galpy.df import (
     constantbetadf,
     constantbetaHernquistdf,
@@ -4016,21 +4016,29 @@ def test_eddington_sample_negative_df_regions_no_crash():
     rmax = 5.0
     dfe = eddingtondf(pot=pot, rmax=rmax)
     numpy.random.seed(1)
-    with pytest.warns(galpyWarning):
+    # numpy's scipy cubic spline overshoots the reconstructed DF slightly negative
+    # near the truncation (raising the negative-region galpyWarning); the backend
+    # Spline1D does not overshoot there, so no warning is raised on the backend path
+    if get_namespace() is numpy:
+        with pytest.warns(galpyWarning):
+            samp = dfe.sample(n=2000)
+    else:
         samp = dfe.sample(n=2000)
-    r = samp.r(use_physical=False)
+    r = as_numpy(samp.r(use_physical=False))
     assert numpy.all(numpy.isfinite(r)), "Sampled radii are not all finite"
     assert numpy.all(r <= rmax), "Sampled radii exceed rmax"
     assert numpy.all(r >= 0.0), "Sampled radii are negative"
     # Speeds must be finite and below the local escape speed of the cut-off DF
     v = numpy.sqrt(
-        samp.vR(use_physical=False) ** 2.0
-        + samp.vT(use_physical=False) ** 2.0
-        + samp.vz(use_physical=False) ** 2.0
+        as_numpy(samp.vR(use_physical=False)) ** 2.0
+        + as_numpy(samp.vT(use_physical=False)) ** 2.0
+        + as_numpy(samp.vz(use_physical=False)) ** 2.0
     )
     assert numpy.all(numpy.isfinite(v)), "Sampled velocities are not all finite"
-    vesc = numpy.sqrt(
-        2.0 * (pot(rmax, 0.0, use_physical=False) - pot(r, 0.0, use_physical=False))
+    vesc = as_numpy(
+        numpy.sqrt(
+            2.0 * (pot(rmax, 0.0, use_physical=False) - pot(r, 0.0, use_physical=False))
+        )
     )
     assert numpy.all(v <= vesc + 1e-7), (
         "Sampled speeds exceed the escape speed of the truncated DF"

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -578,13 +578,17 @@ def test_anisotropic_hernquist_diffcalls():
         # Calculate E directly and L from Orbit
         assert (
             numpy.fabs(
-                dfh(R, vR, vT, z, vz, phi)
-                - dfh(
-                    (
-                        pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
-                        numpy.sqrt(
-                            numpy.sum(Orbit([R, vR, vT, z, vz, phi]).L() ** 2.0)
-                        ),
+                as_numpy(dfh(R, vR, vT, z, vz, phi))
+                - as_numpy(
+                    dfh(
+                        (
+                            pot(R, z) + 0.5 * (vR**2.0 + vT**2.0 + vz**2.0),
+                            numpy.sqrt(
+                                numpy.sum(
+                                    as_numpy(Orbit([R, vR, vT, z, vz, phi]).L()) ** 2.0
+                                )
+                            ),
+                        )
                     )
                 )
             )
@@ -594,7 +598,10 @@ def test_anisotropic_hernquist_diffcalls():
         )
         # Also as orbit
         assert (
-            numpy.fabs(dfh(R, vR, vT, z, vz, phi) - dfh(Orbit([R, vR, vT, z, vz, phi])))
+            numpy.fabs(
+                as_numpy(dfh(R, vR, vT, z, vz, phi))
+                - as_numpy(dfh(Orbit([R, vR, vT, z, vz, phi])))
+            )
             < 1e-8
         ), (
             "Calling the anisotropic Hernquist DF with R,vR,... or E[R,vR,...] does not give the same answer"


### PR DESCRIPTION
Backend xfail-ledger burndown for the `test_sphericaldf` cluster — **+23 flips (13 torch + 10 jax)** via genuine root-cause fixes (not tolerance changes).

**Numerical (were ~0.7% AssertionErrors, NOT a GL-order floor):**
- **osipkovmerritt** dens/sigmar/nonself (6): power-law `fQ` has an integrable endpoint singularity at `v=vmax` (`Q^{-1/2}`); substitute `v=vmax·sinθ` so the `cosθ` Jacobian cancels it → 7.8e-3 → 2.5e-12 (numpy branch untouched; also improves osipkov-Hernquist).
- **constantbeta_differentpotentials** (1): `PowerSpherical(α=1.9)` has `Φ(∞)=∞` → `v_esc=∞` → backend `fixed_quad` to ∞ gives NaN; branch to `fixed_quad_semiinfinite(recip)`.
- **eddington_dehnencore_in_nfw** (1): composite denspot → `numpy.sum([...])` collapsed the backend node array; builtin `sum(gen)` (shape-preserving, byte-identical scalar-r).

**Bugs:**
- **eddington shape** (2): `mass(denspot, rs_array)` raised `RuntimeError` (uncaught) in `_make_cmf_interpolator`; add `RuntimeError` to the except + backend-native fallback.
- **eddington DID-NOT-WARN** (1): backend `Spline1D` doesn't overshoot negative near truncation → nothing to warn; require the warning only on numpy.
- **diffcalls** (1): as_numpy-cast the anisotropic assertion.

**Left ledgered** (precise out-of-scope reasons): hyp2f1 fallback `c-max(a,b)<1` (5); aniso-Hernquist β=-0.7 dens/dMdE (hyp2f1 ~1e-6 vs tol 1e-7 — would need backend-aware **torch tol, pending maintainer approval**); torch vmap of `eval_ppoly` searchsorted (2).

**Verified:** torch shard 223/0-fail, jax 223/0-fail (pruned ledger); numpy **byte-identical** (osipkov/eddington/constantbeta vmom `array_equal`); every flip stash-rerun proven. Ledger: 23 removals, 0 adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm