### PR TITLE
streamTrack burndown: torch accessor/plot flips (+6 torch)

### DIFF
--- a/galpy/df/streamTrack.py
+++ b/galpy/df/streamTrack.py
@@ -2618,12 +2618,14 @@ class StreamTrack:
         line = pyplot.plot(v1, v2, **kwargs)
         if spread > 0 and self._cov_xyz is not None and d2 in self._COORD_BASIS:
             basis, idx = self._COORD_BASIS[d2]
-            cov = self.cov(
-                tp,
-                basis=basis,
-                ro=ro,
-                vo=vo,
-                use_physical=use_physical,
+            cov = as_numpy(  # plot spread band feeds matplotlib -> numpy
+                self.cov(
+                    tp,
+                    basis=basis,
+                    ro=ro,
+                    vo=vo,
+                    use_physical=use_physical,
+                )
             )
             s2 = numpy.sqrt(numpy.maximum(cov[:, idx, idx], 0.0))
             color = line[0].get_color() if line else None

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -274,17 +274,11 @@ torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_dens_d
 torch tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
 torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
-torch tests/test_streamTrack.py::test_streamTrackPair_particles_property
 torch tests/test_streamTrack.py::test_streamTrack_cov_basis
 torch tests/test_streamTrack.py::test_streamTrack_cov_per_call_unit_overrides
-torch tests/test_streamTrack.py::test_streamTrack_iteration_changes_track
 torch tests/test_streamTrack.py::test_streamTrack_out_of_range_returns_nan
-torch tests/test_streamTrack.py::test_streamTrack_physical_accessors_all
-torch tests/test_streamTrack.py::test_streamTrack_physical_length_spread
 torch tests/test_streamTrack.py::test_streamTrack_plot_smoke
 torch tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian
-torch tests/test_streamTrack.py::test_streamTrack_smoothing_factor
-torch tests/test_streamTrack.py::test_streamTrack_smoothing_variants
 torch tests/test_streamdf.py::test_bovy14_callMargXZ
 torch tests/test_streamdf.py::test_fardalwmwpot_trackaa
 torch tests/test_streamdf.py::test_plotting

--- a/tests/test_streamTrack.py
+++ b/tests/test_streamTrack.py
@@ -11,6 +11,7 @@ import pytest
 
 matplotlib.use("Agg")
 
+from galpy.backend import as_numpy
 from galpy.df import chen24spraydf, fardal15spraydf
 from galpy.df.streamTrack import (
     StreamTrack,
@@ -202,8 +203,9 @@ def test_streamTrack_iteration_changes_track(_simple_spdf):
     hi = min(tr0.tp_grid()[-1], tr1.tp_grid()[-1])
     tps = numpy.linspace(lo, hi, 101)
     # Track-to-track difference should be small compared to the stream size
-    ampl = numpy.ptp(tr0.x(tps))
-    dmax = numpy.max(numpy.abs(tr0.x(tps) - tr1.x(tps)))
+    x0, x1 = as_numpy(tr0.x(tps)), as_numpy(tr1.x(tps))
+    ampl = numpy.ptp(x0)
+    dmax = numpy.max(numpy.abs(x0 - x1))
     assert dmax < 0.5 * max(ampl, 0.1), (
         "Iteration changed the track by more than half the stream amplitude"
     )
@@ -477,10 +479,20 @@ def test_streamTrackPair_particles_property(_simple_spdf):
     tps_l = numpy.linspace(max(g_l[0], g_l2[0]), min(g_l[-1], g_l2[-1]), 21)
     tps_t = numpy.linspace(max(g_t[0], g_t2[0]), min(g_t[-1], g_t2[-1]), 21)
     assert (
-        numpy.max(numpy.abs(pair.leading.x(tps_l) - pair_reuse.leading.x(tps_l))) < 1e-3
+        numpy.max(
+            numpy.abs(
+                as_numpy(pair.leading.x(tps_l)) - as_numpy(pair_reuse.leading.x(tps_l))
+            )
+        )
+        < 1e-3
     )
     assert (
-        numpy.max(numpy.abs(pair.trailing.x(tps_t) - pair_reuse.trailing.x(tps_t)))
+        numpy.max(
+            numpy.abs(
+                as_numpy(pair.trailing.x(tps_t))
+                - as_numpy(pair_reuse.trailing.x(tps_t))
+            )
+        )
         < 1e-3
     )
 
@@ -594,7 +606,9 @@ def test_streamTrack_smoothing_variants(_simple_spdf):
     # tp grids (modulo small FITPACK iteration noise).
     g_a, g_b = tr_gcv.tp_grid(), tr_reuse.tp_grid()
     tps = numpy.linspace(max(g_a[0], g_b[0]), min(g_a[-1], g_b[-1]), 21)
-    assert numpy.max(numpy.abs(tr_gcv.x(tps) - tr_reuse.x(tps))) < 5e-3
+    assert (
+        numpy.max(numpy.abs(as_numpy(tr_gcv.x(tps)) - as_numpy(tr_reuse.x(tps)))) < 5e-3
+    )
     # order=1 returns only 6 s values
     numpy.random.seed(18)
     tr_o1 = _simple_spdf.streamTrack(n=800, tail="leading", order=1)
@@ -661,7 +675,10 @@ def test_streamTrack_smoothing_factor(_simple_spdf):
         velocity_weight=1.0,
     )
     tps = tr_default.tp_grid()
-    assert numpy.max(numpy.abs(tr_default.x(tps) - tr_unity.x(tps))) < 1e-3
+    assert (
+        numpy.max(numpy.abs(as_numpy(tr_default.x(tps)) - as_numpy(tr_unity.x(tps))))
+        < 1e-3
+    )
     # The saved smoothing_s round-trips through ``smoothing=`` with
     # smoothing_factor=1.0 — passing both the smoothed s values and
     # factor=1 should reproduce the smoother track (FITPACK iteration
@@ -674,7 +691,10 @@ def test_streamTrack_smoothing_factor(_simple_spdf):
         smoothing_factor=1.0,
         velocity_weight=1.0,
     )
-    assert numpy.max(numpy.abs(tr_smoother.x(tps) - tr_reuse.x(tps))) < 1e-3
+    assert (
+        numpy.max(numpy.abs(as_numpy(tr_smoother.x(tps)) - as_numpy(tr_reuse.x(tps))))
+        < 1e-3
+    )
 
 
 def test_smooth_series_too_few_valid_bins():


### PR DESCRIPTION
Backend xfail-ledger burndown for the `test_streamTrack` cluster — **+6 torch flips**. The StreamTrack object is already backend-native; every failure was numpy/Tensor mixing at a numpy boundary, not a compute gap.

- **Source (byte-identical):** `plot()` wraps `self.cov(...)` in `as_numpy(...)` before the matplotlib `fill_between` (the spread band feeds matplotlib -> numpy; only galcenrect bases reach it). numpy path unchanged (`as_numpy(numpy)` is identity). Flips physical_accessors_all, physical_length_spread.
- **Test-cast (result only, inputs untouched):** as_numpy the `track.x(...)` accessor results before `numpy.max`/`numpy.ptp`. Flips iteration_changes_track, smoothing_factor, smoothing_variants, StreamTrackPair_particles_property.

**Left ledgered (5):** all require `cov()` in a non-galcenrect basis (sky/cyl/customsky) on a backend track, which the source explicitly defers (`streamTrack.py:2367` NotImplementedError = the parked #861 work).

**Verified:** all 6 flips stash-rerun-proven (6/6 fail on base files, 6/6 pass with fix); full `test_streamTrack.py` torch = 45 pass / 0 fail / 5 xfail; numpy byte-identical (plot band + cov + accessor `array_equal`). Ledger: 6 removals, 0 adds. No new backend branch (unconditional as_numpy) so no test_backend coverage needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm