### PR TITLE
backend: match_input_dtype robust to mixed numpy+backend coord dtypes (time-dep SCF/Multipole)

### DIFF
--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -194,16 +194,24 @@ def match_input_dtype(out, *coords):
         if target is not None and target != numpy.float64:
             return numpy.asarray(out, dtype=target)[()]
         return out
+    xp = namespace_from_arrays((out,))
+    # Normalise every coord dtype to ``out``'s namespace: an unmigrated potential
+    # (or the Python integrator) can hand mixed numpy+backend coords, so ``dtypes``
+    # carries a numpy dtype object alongside a torch dtype -- torch's ``result_type``
+    # (and ``astype``) reject a numpy dtype. ``_backend_dtype`` is a strict
+    # pass-through when ``xp is numpy`` (numpy path byte-identical) and maps a numpy
+    # dtype to the backend's same-named dtype otherwise.
+    dtypes = [_backend_dtype(xp, dtype) for dtype in dtypes]
     if all(dtype == dtypes[0] for dtype in dtypes):
         target = dtypes[0]
     else:
-        target = namespace_from_arrays((out,)).result_type(*dtypes)
+        target = xp.result_type(*dtypes)
     if target == out_dtype:
         return out
     if isinstance(out, (numpy.ndarray, numpy.generic)):
         # plain numpy: ndarray.astype works on every supported numpy version
         return out.astype(target)
-    return namespace_from_arrays((out,)).astype(out, target)
+    return xp.astype(out, target)
 
 
 def device_of(*coords):

--- a/tests/test_MultipoleExpansionPotential.py
+++ b/tests/test_MultipoleExpansionPotential.py
@@ -4,7 +4,7 @@
 import numpy
 import pytest
 
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, is_backend_array
 from galpy.potential import (
     HernquistPotential,
     MiyamotoNagaiPotential,
@@ -1244,8 +1244,12 @@ def test_time_dependent_density_at_multiple_times():
     cached_after_t1 = mp._cached_t
     d2 = evaluateDensities(mp, 1.0, 0.0, t=t2)
     cached_after_t2 = mp._cached_t
-    assert cached_after_t1 == t1
-    assert cached_after_t2 == t2
+    if not is_backend_array(d1):
+        # _cached_t is a numpy-path implementation detail: the backend density
+        # path (_backend_dens) computes functionally and never populates it.
+        assert cached_after_t1 == t1
+        assert cached_after_t2 == t2
+    d1, d2 = as_numpy(d1), as_numpy(d2)
     assert d1 != d2, "Density should differ at different times"
     # Density should increase with time since factor is (1 + 0.1*t)
     assert d2 > d1, "Density at t=4 should be larger than at t=1"
@@ -1581,12 +1585,14 @@ def test_time_dependent_nonaxi_c_orbit():
     ts = numpy.linspace(0, 2, 51)
     o.integrate(ts, mp, method="dop853_c")
     # For a time-dependent potential energy is not conserved, but should be bounded
-    E = o.E(ts)
+    # as_numpy: forced-backend accessors return backend arrays (numpy no-op)
+    E = as_numpy(o.E(ts))
     assert numpy.all(numpy.isfinite(E)), "Orbit energy not finite"
     # Compare C orbit to Python orbit for consistency
     o_py = Orbit([1.0, 0.1, 1.1, 0.1, 0.05, 0.3])
     o_py.integrate(ts, mp, method="odeint")
-    assert numpy.max(numpy.abs(o.R(ts) - o_py.R(ts))) / numpy.mean(o.R(ts)) < 0.01, (
+    oR, opyR = as_numpy(o.R(ts)), as_numpy(o_py.R(ts))
+    assert numpy.max(numpy.abs(oR - opyR)) / numpy.mean(oR) < 0.01, (
         "C and Python orbits disagree"
     )
 

--- a/tests/test_backend_dtype_policy.py
+++ b/tests/test_backend_dtype_policy.py
@@ -669,3 +669,44 @@ def test_backend_dtype_passes_through_nongeneric_numpy_dtype(backend):
     )
     # numpy stays a strict pass-through on the same input (xp is numpy guard).
     assert _backend_dtype(numpy, _NONGENERIC_NPDTYPE) is _NONGENERIC_NPDTYPE
+
+
+@pytest.mark.parametrize(
+    "backend", [b for b in ("jax", "torch") if globals()[b] is not None]
+)
+def test_match_input_dtype_mixed_framework_coords(backend):
+    # An unmigrated potential (or the Python integrator) can hand a backend
+    # ``out`` alongside MIXED numpy+backend coord dtypes -- a raw numpy dtype
+    # object sitting next to a torch dtype. torch's result_type/astype reject a
+    # numpy dtype, so match_input_dtype must normalise every coord dtype to
+    # ``out``'s namespace first. (Regression: SCF/Multipole time-dependent C
+    # orbits under a forced torch backend.)
+    from galpy.backend import get_namespace
+
+    if backend == "jax":
+        out = jnp.asarray([1.0, 2.0])
+    else:
+        out = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    # a numpy scalar whose dtype matches ``out``'s precision
+    np_same = numpy.zeros((), dtype=str(out.dtype).split(".")[-1])
+    # mixed numpy-dtype + backend-dtype coords, matching precision -> no cast,
+    # same object back (normalise-to-namespace, all-equal branch)
+    assert match_input_dtype(out, np_same, out[0]) is out
+    # all-numpy same-precision coords with a backend ``out``: the all-equal
+    # branch that previously handed a numpy dtype straight to astype -> no cast
+    assert match_input_dtype(out, np_same, np_same) is out
+    if backend == "torch":
+        # mixed numpy-float32 + torch-float64 -> result_type else-branch -> f64,
+        # equals ``out`` dtype so a no-op
+        assert (
+            match_input_dtype(
+                out,
+                numpy.array([0.5], dtype=numpy.float32),
+                torch.tensor(0.3, dtype=torch.float64),
+            )
+            is out
+        )
+        # genuine narrowing: all numpy-float32 coords -> torch.float32 astype cast
+        cast = match_input_dtype(out, numpy.array([0.5], dtype=numpy.float32))
+        assert cast.dtype == torch.float32
+        assert get_namespace(cast) is not numpy

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -1545,8 +1545,11 @@ def test_tdep_c_dynamical_friction_dens():
     op = Orbit(init)
     oc.integrate(ts, sp + cdf, method="dop853_c")
     op.integrate(ts, sp + cdf, method="dop853")
-    assert numpy.all(numpy.isfinite(oc.r(ts)))
-    assert numpy.max(numpy.fabs(oc.r(ts) - op.r(ts))) < 1e-4
+    # as_numpy: under a forced backend the accessors return backend arrays and
+    # numpy.isfinite/fabs reject them (numpy path passes through unchanged)
+    oc_r, op_r = as_numpy(oc.r(ts)), as_numpy(op.r(ts))
+    assert numpy.all(numpy.isfinite(oc_r))
+    assert numpy.max(numpy.fabs(oc_r - op_r)) < 1e-4
 
 
 # ---------------------- from_density time dependence ----------------------


### PR DESCRIPTION
## Summary

`match_input_dtype` (the backend dtype-reconciliation helper that casts a table-backed potential's float64-interior result to the input-coordinate precision) resolved the target dtype via the out-namespace `result_type`/`astype` over the **raw** coordinate dtypes. Under a **forced torch backend**, an unmigrated potential (time-dependent SCF / Multipole density) or the Python orbit integrator can hand a **numpy dtype object alongside a torch dtype** — and torch's `result_type`/`astype` reject a numpy dtype:

```
AttributeError: 'numpy.dtypes.Float64DType' object has no attribute 'dtype'
```

**Fix:** normalise every coordinate dtype to the `out` namespace via the existing `_backend_dtype` helper *before* the all-equal check / `result_type` / `astype`. `_backend_dtype` is a strict pass-through when `xp is numpy`, so **the numpy path is byte-identical by construction**. This also fixes a latent second crash: the all-equal branch could hand a numpy `target` straight to `torch.astype`.

## Verification
- **numpy byte-identical:** full `test_scf.py` + `test_MultipoleExpansionPotential.py` under numpy → **201/201 pass, 0 changes**.
- **torch no regression:** same files under torch → **201/201 pass**.
- New source lines (normalise / `result_type` else / `astype`) covered by a new backend-shard test (`test_match_input_dtype_mixed_framework_coords`), verified HIT under torch+jax.

## Flips (ledger untouched — source-only policy; these become XPASS, `strict=False`)
**Source fix (torch):** `test_scf` `static_c_orbit_parity`, `tdep_c_beyond_tgrid`, `tdep_c_full_dxdv`, `tdep_c_orbit_nonaxi`, `tdep_c_orbit_spherical`; `test_MultipoleExpansionPotential::test_time_dependent_nonaxi_c_orbit`.

**Test-side, enabled by the fix:**
- `as_numpy` casts on forced-backend accessor tensors (`numpy.isfinite`/`fabs` reject them) → flip `test_scf::test_tdep_c_dynamical_friction_dens` and the Multipole nonaxi C-orbit.
- backend-aware guard on the `_cached_t` assertions (numpy-path caching is an impl detail — the backend density path computes functionally) → flip `test_time_dependent_density_at_multiple_times` (**torch AND jax**).

Net: **+8 torch, +1 jax**. Files disjoint from all other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm