### PR TITLE
streamgapdf: backend-native, differentiable gap-kick track _determine_deltaOmegaTheta_kick (Phase 2b)

### DIFF
--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -8,13 +8,16 @@ import numpy
 from scipy import integrate, interpolate, special
 
 from ..backend import (
+    as_backend_constant,
+    as_numpy,
     coerce_coords,
     device_of,
     get_namespace,
     is_backend_array,
     use,
 )
-from ..backend._namespaces import namespace_from_arrays
+from ..backend._namespaces import namespace_from_arrays, under_jax_trace
+from ..backend.interpolate import Spline1D
 from ..backend.quadrature import fixed_quad, simpson
 from ..orbit import Orbit
 from ..potential import MovingObjectPotential, PlummerPotential, evaluateRforces
@@ -31,6 +34,14 @@ def impact_check_range(func):
 
     @wraps(func)
     def impact_wrapper(*args, **kwargs):
+        if is_backend_array(args[1]):
+            # backend da: evaluate the (extrapolating, finite) raw spline on the
+            # full array and zero out-of-range entries with xp.where (item-assign
+            # would break autodiff/vmap); mirrors the numpy mask below.
+            da = args[1]
+            xp = get_namespace(da)
+            good = (da < args[0]._deltaAngleTrackImpact) & (da > 0.0)
+            return xp.where(good, func(args[0], da), 0.0)
         if isinstance(args[1], numpy.ndarray):
             out = numpy.zeros(len(args[1]))
             goodIndx = (args[1] < args[0]._deltaAngleTrackImpact) * (args[1] > 0.0)
@@ -699,6 +710,8 @@ class streamgapdf(streamdf.streamdf):
 
     def _determine_deltaOmegaTheta_kick(self, spline_order):
         # Propagate deltav(angle) -> delta (Omega,theta) [angle]
+        if is_backend_array(self._kick_deltav):
+            return self._determine_deltaOmegaTheta_kick_backend(spline_order)
         # Cylindrical coordinates of the perturbed points
         vXp = self._kick_interpolatedObsTrackXY[:, 3] + self._kick_deltav[:, 0]
         vYp = self._kick_interpolatedObsTrackXY[:, 4] + self._kick_deltav[:, 1]
@@ -801,6 +814,130 @@ class streamgapdf(streamdf.streamdf):
         self._kick_interpdOpar_poly = interpolate.PPoly(
             ppoly.c[:, nzIndx[0][:-1]], ppoly.x[nzIndx[0]]
         )
+        return None
+
+    def _determine_deltaOmegaTheta_kick_backend(self, spline_order):
+        # Backend (jax/torch) twin of _determine_deltaOmegaTheta_kick: propagate
+        # the differentiable velocity kick deltav(angle) -> delta(Omega,theta)
+        # along the near-impact track. The frozen numpy track/AA tables are
+        # coerced into the kick's namespace via as_backend_constant; the six
+        # dO/da(angle) interpolants become differentiable-in-y Spline1D's. The
+        # per-angle closest-point/Jacobian selection inside _approxaA is a
+        # stop-gradient integer gather (see _approxaA_backend) -- the gradient
+        # flows through deltav and the gathered continuous rows.
+        kv = self._kick_deltav
+        xp = get_namespace(kv)
+        trkXY = as_backend_constant(xp, self._kick_interpolatedObsTrackXY, kv)
+        trk = as_backend_constant(xp, self._kick_interpolatedObsTrack, kv)
+        vXp = trkXY[:, 3] + kv[:, 0]
+        vYp = trkXY[:, 4] + kv[:, 1]
+        vZp = trkXY[:, 5] + kv[:, 2]
+        vRp, vTp, vZp = coords.rect_to_cyl_vec(
+            vXp, vYp, vZp, trk[:, 0], trk[:, 5], trk[:, 3], cyl=True
+        )
+        # Abuse streamdf functions for the (O,a) -> (R,vR) transform (as numpy);
+        # pass a backend R so _approxaA dispatches to its backend twin (its guard
+        # tests R/_track, not vR).
+        self._interpolatedObsTrack = self._kick_interpolatedObsTrack
+        self._ObsTrack = self._gap_ObsTrack
+        self._interpolatedObsTrackXY = self._kick_interpolatedObsTrackXY
+        self._ObsTrackXY = self._gap_ObsTrackXY
+        self._alljacsTrack = self._gap_alljacsTrack
+        self._interpolatedObsTrackAA = self._kick_interpolatedObsTrackAA
+        self._ObsTrackAA = self._gap_ObsTrackAA
+        self._nTrackChunks = self._nTrackChunksImpact
+        Oap = self._approxaA(
+            trk[:, 0],
+            vRp,
+            vTp,
+            trk[:, 3],
+            vZp,
+            trk[:, 5],
+            interp=True,
+            cindx=range(len(self._kick_interpolatedObsTrackAA)),
+        )
+        delattr(self, "_interpolatedObsTrack")
+        delattr(self, "_ObsTrack")
+        delattr(self, "_interpolatedObsTrackXY")
+        delattr(self, "_ObsTrackXY")
+        delattr(self, "_alljacsTrack")
+        delattr(self, "_interpolatedObsTrackAA")
+        delattr(self, "_ObsTrackAA")
+        delattr(self, "_nTrackChunks")
+        aa = as_backend_constant(xp, self._kick_interpolatedObsTrackAA, Oap)
+        self._kick_dOap = Oap.T - aa
+        thetas = self._kick_interpolatedThetasTrack
+        self._kick_interpdOr_raw = Spline1D(
+            thetas, self._kick_dOap[:, 0], k=spline_order
+        )
+        self._kick_interpdOp_raw = Spline1D(
+            thetas, self._kick_dOap[:, 1], k=spline_order
+        )
+        self._kick_interpdOz_raw = Spline1D(
+            thetas, self._kick_dOap[:, 2], k=spline_order
+        )
+        self._kick_interpdar_raw = Spline1D(
+            thetas, self._kick_dOap[:, 3], k=spline_order
+        )
+        self._kick_interpdap_raw = Spline1D(
+            thetas, self._kick_dOap[:, 4], k=spline_order
+        )
+        self._kick_interpdaz_raw = Spline1D(
+            thetas, self._kick_dOap[:, 5], k=spline_order
+        )
+        # Parallel/perpendicular frequencies
+        eigvecs = as_backend_constant(
+            xp, self._sigomatrixEig[1][:, self._sigomatrixEigsortIndx], Oap
+        )
+        dOaparperp = self._kick_dOap[:, :3] @ eigvecs
+        # numpy does an in-place _kick_dOaparperp[:,2] *= sign; rebuild
+        # functionally (backend arrays are immutable/AD-unfriendly in place)
+        self._kick_dOaparperp = xp.stack(
+            [
+                dOaparperp[:, 0],
+                dOaparperp[:, 1],
+                dOaparperp[:, 2] * self._sigMeanSign,
+            ],
+            axis=-1,
+        )
+        progdir = as_backend_constant(xp, self._dsigomeanProgDirection, Oap)
+        self._kick_interpdOpar_raw = Spline1D(
+            thetas,
+            (self._kick_dOap[:, :3] @ progdir) * self._sigMeanSign,
+            k=spline_order,
+        )
+        self._kick_interpdOperp0_raw = Spline1D(
+            thetas, self._kick_dOaparperp[:, 0], k=spline_order
+        )
+        self._kick_interpdOperp1_raw = Spline1D(
+            thetas, self._kick_dOaparperp[:, 1], k=spline_order
+        )
+        # Derivative of dOpar (Spline1D.derivative supports the mode-2 backend
+        # spline and stays differentiable in the y values)
+        self._kick_interpdOpar_dapar = self._kick_interpdOpar_raw.derivative(1)
+        # Piecewise-polynomial representation of dOpar. Phase-3 island: the gap
+        # DF-evaluation layer that reads _kick_interpdOpar_poly (_density_par/
+        # meanOmega/minOpar) is still numpy, and the breakpoints depend only on
+        # the numpy angle grid, so build it from a numpy fit; a differentiable
+        # .c is deferred to the DF-eval (Phase 3) migration. Skip it under a jax
+        # trace: as_numpy on a tracer raises, and the (numpy-only) PPoly is not
+        # consumed while differentiating the backend kick interpolants (the
+        # concrete build already populated it).
+        if not under_jax_trace(self._kick_dOap):
+            dOpar_y = as_numpy((self._kick_dOap[:, :3] @ progdir) * self._sigMeanSign)
+            _np_dOpar_spl = interpolate.InterpolatedUnivariateSpline(
+                thetas, dOpar_y, k=spline_order
+            )
+            ppoly = interpolate.PPoly.from_spline(_np_dOpar_spl._eval_args)
+            nzIndx = numpy.nonzero(
+                (numpy.roll(ppoly.x, -1) - ppoly.x > 0)
+                * (numpy.arange(len(ppoly.x)) < len(ppoly.x) // 2)
+                + (ppoly.x - numpy.roll(ppoly.x, 1) > 0)
+                * (numpy.arange(len(ppoly.x)) >= len(ppoly.x) // 2)
+            )
+            self._kick_interpdOpar_poly = interpolate.PPoly(
+                ppoly.c[:, nzIndx[0][:-1]], ppoly.x[nzIndx[0]]
+            )
         return None
 
     # Functions that evaluate the interpolated kicks, but also check the range

--- a/tests/test_backend_streamgapdf.py
+++ b/tests/test_backend_streamgapdf.py
@@ -292,3 +292,135 @@ def test_hernquistX_grad_vs_fd(backend, s0):
         HernquistX(st).backward()
         g = float(st.grad)
     numpy.testing.assert_allclose(g, gfd, rtol=1e-5, atol=1e-7)
+
+
+# --------------------------------------------------------------------------
+# Gap-track Phase 2b: the backend twin of _determine_deltaOmegaTheta_kick --
+# propagate the velocity kick deltav(angle) -> delta(Omega,theta)(angle) along
+# the near-impact track and build the differentiable dO/da(angle) interpolants.
+# --------------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def _gapdf_kick():
+    # A real (numpy) Sanders15 trailing gap DF; capture the numpy reference of
+    # the kick track, then each test swaps _kick_deltav to a backend array and
+    # re-runs the (fast) kick propagation, restoring numpy state afterwards.
+    from galpy.actionAngle import actionAngleIsochroneApprox
+    from galpy.df import streamgapdf
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+    from galpy.util import conversion
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    aAI = actionAngleIsochroneApprox(pot=lp, b=0.8)
+    prog = Orbit(
+        [
+            2.6556151742081835,
+            0.2183747276300308,
+            0.67876510797240575,
+            -2.0143395648974671,
+            -0.3273737682604374,
+            0.24218273922966019,
+        ]
+    )
+    V0, R0 = 220.0, 8.0
+    sigv = 0.365 * (10.0 / 2.0) ** (1.0 / 3.0)
+    sdf = streamgapdf(
+        sigv / V0,
+        progenitor=prog,
+        pot=lp,
+        aA=aAI,
+        leading=False,
+        nTrackChunks=26,
+        nTrackIterations=1,
+        sigMeanOffset=4.5,
+        tdisrupt=10.88 / conversion.time_in_Gyr(V0, R0),
+        vo=V0,
+        ro=R0,
+        impactb=0.0,
+        subhalovel=numpy.array([6.82200571, 132.7700529, 149.4174464]) / V0,
+        timpact=0.88 / conversion.time_in_Gyr(V0, R0),
+        impact_angle=-2.34,
+        GM=10.0**-2.0 / conversion.mass_in_1010msol(V0, R0),
+        rs=0.625 / R0,
+    )
+    deltav_np = numpy.asarray(sdf._kick_deltav).copy()
+    theta = numpy.linspace(1e-4, sdf._deltaAngleTrackImpact * 0.999, 40)
+    evals = (
+        "_kick_interpdOr",
+        "_kick_interpdOp",
+        "_kick_interpdOz",
+        "_kick_interpdar",
+        "_kick_interpdap",
+        "_kick_interpdaz",
+        "_kick_interpdOpar",
+        "_kick_interpdOperp0",
+        "_kick_interpdOperp1",
+    )
+    ref = {
+        "dOap": sdf._kick_dOap.copy(),
+        "evals": {e: getattr(sdf, e)(theta).copy() for e in evals},
+    }
+    return sdf, ref, deltav_np, theta, evals
+
+
+def _reset_kick_numpy(sdf, deltav_np):
+    sdf._kick_deltav = deltav_np
+    sdf._determine_deltaOmegaTheta_kick(3)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_kick_track_value_parity(_gapdf_kick, backend):
+    # The backend twin reproduces the numpy kick track to the Spline1D-vs-scipy
+    # floor, and dispatch actually fires (the outputs are backend arrays).
+    sdf, ref, deltav_np, theta, evals = _gapdf_kick
+    try:
+        sdf._kick_deltav = _to_backend(backend, deltav_np)
+        sdf._determine_deltaOmegaTheta_kick(3)
+        assert is_backend_array(sdf._kick_dOap)
+        numpy.testing.assert_allclose(
+            as_numpy(sdf._kick_dOap), ref["dOap"], rtol=1e-9, atol=1e-11
+        )
+        thb = _to_backend(backend, theta)
+        for name in evals:
+            bv = as_numpy(getattr(sdf, name)(thb))
+            numpy.testing.assert_allclose(
+                bv, ref["evals"][name], rtol=1e-7, atol=1e-9, err_msg=name
+            )
+    finally:
+        _reset_kick_numpy(sdf, deltav_np)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_kick_track_grad_vs_fd(_gapdf_kick, backend):
+    # d(sum w * _kick_interpdOpar(theta)) / d(deltav) is exact vs central FD --
+    # the frequency/angle kick is differentiable in the velocity kick (composes
+    # with the #1167 impulse's d(deltav)/d(perturber)).
+    sdf, ref, deltav_np, theta, evals = _gapdf_kick
+    rng = numpy.random.RandomState(3)
+    w = rng.randn(len(theta))
+
+    def loss(dv_backend, th_backend, w_backend):
+        sdf._kick_deltav = dv_backend
+        sdf._determine_deltaOmegaTheta_kick(3)
+        return (w_backend * sdf._kick_interpdOpar(th_backend)).sum()
+
+    try:
+        thb = _to_backend(backend, theta)
+        wb = _to_backend(backend, w)
+        # direction for the FD check
+        d = rng.randn(*deltav_np.shape)
+        d /= numpy.linalg.norm(d)
+        if backend == "jax":
+            g = jax.grad(lambda dv: loss(dv, thb, wb))(jnp.asarray(deltav_np))
+            ad_dir = float(numpy.sum(as_numpy(g) * d))
+        else:
+            dv = torch.tensor(deltav_np, requires_grad=True)
+            loss(dv, thb, wb).backward()
+            ad_dir = float(numpy.sum(as_numpy(dv.grad) * d))
+        h = 1e-3
+        lp = float(as_numpy(loss(_to_backend(backend, deltav_np + h * d), thb, wb)))
+        lm = float(as_numpy(loss(_to_backend(backend, deltav_np - h * d), thb, wb)))
+        fd = (lp - lm) / (2.0 * h)
+        numpy.testing.assert_allclose(ad_dir, fd, rtol=1e-6, atol=1e-9)
+    finally:
+        _reset_kick_numpy(sdf, deltav_np)


### PR DESCRIPTION
## Summary

Backend (jax/torch) twin of `streamgapdf._determine_deltaOmegaTheta_kick` — the machinery that propagates the impulse velocity kick `deltav(angle)` into the near-impact frequency/angle kick `Δ(Ω,θ)(angle)` and builds the interpolants the gap DF reads. Consumes #1168's `_approxaA_backend` (forward (O,a) map) + #1167's differentiable impulse. Dispatches on `is_backend_array(self._kick_deltav)`.

**What becomes differentiable:** the frequency/angle kick is now differentiable w.r.t. the velocity kick, which composes with #1167's `d(deltav)/d(GM,rs,subhalovel)` to give the full `d(kick)/d(perturber)` chain. This is the prerequisite for Phase 3 (the DF-evaluation layer that flips the ledger).

## Design
- Frozen numpy track/AA tables coerced into the kick namespace via `as_backend_constant`.
- Six `dO/da(angle)` interpolants become mode-2 (differentiable-in-`y`) `Spline1D`s; `.derivative(1)` supplies `dOpar'`.
- Parallel/perp rotation rebuilt functionally (no in-place mutation).
- A backend `R` is passed into `_approxaA` so its backend twin dispatches (its guard tests `R`/`_track`, not `vR`).
- `impact_check_range` gains an `is_backend_array` branch (`xp.where` over the finite extrapolating spline — no NaN poisoning).
- **`_kick_interpdOpar_poly` PPoly stays a numpy island** (Phase-3 DF-eval that reads it is still numpy; its breakpoints depend only on the numpy angle grid). The build is **skipped under a jax trace** (`under_jax_trace`) — `as_numpy` on a tracer raises, and the numpy-only poly isn't consumed while differentiating the kick splines.
- `_interpolate_stream_track_kick*` stay numpy (perturber-independent setup).

## Verification
- **Value parity** (real Sanders15 gap DF, swap `_kick_deltav`→backend, re-run): `_kick_dOap` **2.2e-16**, nine kick-spline evals ~1e-11 (Spline1D-vs-scipy floor), `poly.x` exact.
- **grad-vs-FD** `d(_kick_interpdOpar)/d(_kick_deltav)`: exact (torch rel 2.6e-12; jax passes).
- **numpy byte-identical**: `test_streamgapdf.py` **30/30** (numpy body changed only by a 2-line dispatch guard).
- New `test_backend_streamgapdf` tests: `test_kick_track_value_parity` + `test_kick_track_grad_vs_fd`, both backends.
- **Adversarial review** (subagent): logic correct, byte-identity preserved; the jax-trace `as_numpy` crash it would have flagged is fixed by the `under_jax_trace` guard (confirmed passing).

## Known Phase-3 boundaries (documented, not blocking)
- A backend-kick DF is **construction-only** until Phase 3: the public density/`pOparapar`/`meanOmega` methods read `_kick_interpdOpar_raw._eval_args[2]` (a scipy attr a mode-2 `Spline1D` lacks) — Phase 3 will store the spline order as an int and migrate those methods.
- The backend kick spline supports `spline_order ∈ {1, 3}` (`Spline1D` mode-2); the numpy default is 3.

Flips no ledger entry alone (the kick track is internal machinery); Phase 3 flips the `test_quantity` streamgapdf entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm