### PR TITLE
planar time-dependent potentials: coerce coords/t under forced backend (+4 torch)

### DIFF
--- a/galpy/potential/EllipticalDiskPotential.py
+++ b/galpy/potential/EllipticalDiskPotential.py
@@ -112,6 +112,7 @@ class EllipticalDiskPotential(planarPotential):
         if self._tform is None:
             return 1.0
         xp = get_namespace(t)
+        (t,) = coerce_coords(xp, t)
         deltat = t - self._tform
         xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
         growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5

--- a/galpy/potential/SteadyLogSpiralPotential.py
+++ b/galpy/potential/SteadyLogSpiralPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -107,6 +107,7 @@ class SteadyLogSpiralPotential(planarPotential):
         if self._tform is None:
             return 1.0
         xp = get_namespace(t)
+        (t,) = coerce_coords(xp, t)
         deltat = t - self._tform
         xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
         growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
@@ -114,6 +115,7 @@ class SteadyLogSpiralPotential(planarPotential):
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             smooth
@@ -127,6 +129,7 @@ class SteadyLogSpiralPotential(planarPotential):
 
     def _Rforce(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             smooth
@@ -140,6 +143,7 @@ class SteadyLogSpiralPotential(planarPotential):
 
     def _phitorque(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         smooth = self._smooth(t)
         return (
             -smooth

--- a/galpy/potential/TransientLogSpiralPotential.py
+++ b/galpy/potential/TransientLogSpiralPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -98,10 +98,12 @@ class TransientLogSpiralPotential(planarPotential):
         # spatial arrays); a traced t (the in-backend diffrax/torchdiffeq
         # integrator, or autodiff wrt time) -> that backend's exp.
         xpt = get_namespace(t)
+        (t,) = coerce_coords(xpt, t)
         return xpt.exp(-((t - self._to) ** 2.0) / 2.0 / self._sigma2)
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         return (
             self._A
             * self._envelope(t)
@@ -114,6 +116,7 @@ class TransientLogSpiralPotential(planarPotential):
 
     def _Rforce(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         return (
             self._A
             * self._envelope(t)
@@ -126,6 +129,7 @@ class TransientLogSpiralPotential(planarPotential):
 
     def _phitorque(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi, t)
+        R, phi = coerce_coords(xp, R, phi)
         return (
             -self._A
             * self._envelope(t)


### PR DESCRIPTION
## Summary

`SteadyLogSpiralPotential` / `TransientLogSpiralPotential` / `EllipticalDiskPotential` resolve their namespace from the (numpy-scalar) coordinate/time inputs, but under a **forced** backend `get_namespace()` returns torch/jax while the scalars stay numpy → `xp.log(R)` / `xp.exp(t)` / `xp.where(t < tform, ...)` reject the numpy scalar and crash.

Fix: coerce `R,phi` (and `t` in `_smooth`/`_envelope`) via `coerce_coords`, which is a **strict pass-through when `xp is numpy`** → the numpy path is byte-identical.

## Flips (+4 torch, source-only → XPASS)
`test_orbit.py::test_energy_jacobi_conservation` for `mockFlatSteadyLogSpiralPotential`, `mockSlowFlatSteadyLogSpiralPotential`, `mockFlatTransientLogSpiralPotential`, `mockSlowFlatEllipticalDiskPotential`.

Verified: 4 torch flips pass, numpy 22/22 unchanged (byte-identical).

(Part of the "scalar under forced backend" cluster; the RazorThin/Burkert orbit-machinery cases are a separate PR — different files + a timeout consideration.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm