### PR TITLE
interpRZPotential: forced-backend zsym sign correction + as_numpy casts (+2 torch)

### DIFF
--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -67,9 +67,12 @@ def zsymDecorator(odd):
             else:
                 out = func(*args, **kwargs)
             if odd and args[0]._zsym:
-                if backend:
-                    xp = get_namespace(R, z)
-                    return xp.where(z < 0.0, -1.0, 1.0) * out
+                # out can be a backend array even for numpy R,z under a forced
+                # backend (the interpolated force resolves the forced namespace),
+                # so key the sign correction off the output, not the inputs
+                if is_backend_array(out):
+                    xp = get_namespace(out)
+                    return xp.where(xp.asarray(z) < 0.0, -1.0, 1.0) * out
                 return sign(z) * out
             else:
                 return out

--- a/tests/test_interp_potential.py
+++ b/tests/test_interp_potential.py
@@ -1016,10 +1016,10 @@ def test_interpolation_potential_force_c_vdiffgridsizes():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.Rforce(mr, mz)
-                - potential.evaluateRforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.Rforce(mr, mz))
+                - as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluateRforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluateRforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), (
@@ -1028,10 +1028,10 @@ def test_interpolation_potential_force_c_vdiffgridsizes():
     assert numpy.all(
         numpy.fabs(
             (
-                rzpot.zforce(mr, mz)
-                - potential.evaluatezforces(potential.MWPotential, mr, mz)
+                as_numpy(rzpot.zforce(mr, mz))
+                - as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
             )
-            / potential.evaluatezforces(potential.MWPotential, mr, mz)
+            / as_numpy(potential.evaluatezforces(potential.MWPotential, mr, mz))
         )
         < 10.0**-6.0
     ), (


### PR DESCRIPTION
## Summary

`interpRZPotential`'s `zsymDecorator` keyed its odd-function (`zforce`) sign correction off `is_backend_array(R/z)` — the **inputs** — but under a forced backend the interpolated force `out` is a backend array even for numpy `R,z`, so `numpy.sign(z) * out` crashed (`numpy.ndarray * Tensor`). Fix: key the correction off **`out`** and coerce `z` into `out`'s namespace. numpy path byte-identical (numpy `out` → unchanged `sign(z) * out`).

Also `as_numpy`-cast the two `numpy.all(...)` force-comparison assertions in `test_interpolation_potential_force_c_vdiffgridsizes` (the force accessors return backend arrays under a forced backend — same pattern already used elsewhere in the file).

## Flips
- **+2 torch** (confirmed): `test_interpolation_potential_force_notinterpolated`, `test_interpolation_potential_force_c_vdiffgridsizes`.
- The 2 jax entries (`force_c` via the same decorator; `secondderivs`) may also flip but time out under jax eager-XLA locally, so not asserted here — source-only (ledger untouched) so they XPASS in CI if fixed, stay green-xfail otherwise.

Verified: torch 2/2 pass, numpy 40/40 unchanged (byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm