### PR TITLE
orbit machinery: forced-backend numpy integrator (no-C) + RazorThin scalar-fallback except (+3 torch)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -3304,7 +3304,7 @@ class Orbit:
                     )
                     + thiso[1] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3331,7 +3331,7 @@ class Orbit:
                     + thiso[1] ** 2.0 / 2.0
                     + thiso[2] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3359,7 +3359,7 @@ class Orbit:
                     + thiso[1] ** 2.0 / 2.0
                     + thiso[2] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3394,7 +3394,7 @@ class Orbit:
                     + thiso[2] ** 2.0 / 2.0
                     + vz**2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3430,7 +3430,7 @@ class Orbit:
                     + thiso[2] ** 2.0 / 2.0
                     + vz**2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -6,6 +6,7 @@ from numpy.ctypeslib import ndpointer
 from scipy import integrate
 
 from .. import potential
+from ..backend import as_numpy, use
 from ..potential.linearPotential import (
     _evaluatelinearForce2derivs,
     _evaluatelinearForces,
@@ -315,7 +316,7 @@ def integrateLinearOrbit(
         def integrate_for_map(idx):
             vxvv = yo[idx]
             return symplecticode.leapfrog(
-                lambda x, t=0.0: _evaluatelinearForces(pot, x, t=t),
+                lambda x, t=0.0: as_numpy(_evaluatelinearForces(pot, x, t=t)),
                 numpy.array(vxvv),
                 _t_for(idx),
                 rtol=rtol,
@@ -358,20 +359,24 @@ def integrateLinearOrbit(
                 atol=atol,
             )[0]
 
-    if len(yo) == 1:  # Can't map a single value...
-        return numpy.atleast_3d(integrate_for_map(0).T).T, 0
-    else:
-        return (
-            numpy.array(
-                parallel_map(
-                    integrate_for_map,
-                    numpy.arange(len(yo)),
-                    numcores=numcores,
-                    progressbar=progressbar,
-                )
-            ),
-            numpy.zeros(len(yo)),
-        )
+    # The Python symplectic/ODE integrators are numpy-only; force numpy so a
+    # migrated potential's force eval returns numpy (byte-identical: no-op under
+    # numpy) rather than a backend tensor the numpy integrator can't combine with.
+    with use("numpy", force=True):
+        if len(yo) == 1:  # Can't map a single value...
+            return numpy.atleast_3d(integrate_for_map(0).T).T, 0
+        else:
+            return (
+                numpy.array(
+                    parallel_map(
+                        integrate_for_map,
+                        numpy.arange(len(yo)),
+                        numcores=numcores,
+                        progressbar=progressbar,
+                    )
+                ),
+                numpy.zeros(len(yo)),
+            )
 
 
 def _linearEOM(y, t, pot):
@@ -397,7 +402,7 @@ def _linearEOM(y, t, pot):
     - 2010-07-13 - Bovy (NYU)
 
     """
-    return [y[1], _evaluatelinearForces(pot, y[0], t=t)]
+    return [y[1], as_numpy(_evaluatelinearForces(pot, y[0], t=t))]
 
 
 def integrateLinearOrbit_dxdv_c(


### PR DESCRIPTION
## Summary

Two orbit-machinery fixes for the "scalar under forced backend" cluster (numpy byte-identical):

**Family C — no-C potential python integrator** (`integrateLinearOrbit.py`). `BurkertPotentialNoC` has no C, so the linear integrator falls back to the python leapfrog (`symplecticode`), where a numpy integrator-state array meets a torch force → `TypeError: Concatenation ... NumPy`. Fix: keep the per-step integrator internals in numpy (`with use("numpy", force=True):`, fast) **and** `as_numpy` the force output — needed because the potential's `_amp` is coerced to a torch tensor during `normalize()` under the forced backend and persists on the instance (`_amp(torch) * _force(numpy)` = torch even inside forced-numpy). Both no-ops on numpy → byte-identical.

**Family B — RazorThin scalar-only potential** (`Orbits.py` E()/Jacobi() fallback). `RazorThinExponentialDiskPotential` is scalar-only; `E()`/`Jacobi()` try a vectorized eval then fall back to a scalar loop on `except (ValueError, TypeError, IndexError)`. numpy raises `ValueError` (caught); torch raises `RuntimeError: Boolean value of Tensor ... ambiguous` (not caught) → crash. Fix: add `RuntimeError` to the 5 except tuples. numpy byte-identical (RuntimeError never fires on numpy).

## Flips (+3 torch)
`test_energy_conservation_linear[BurkertPotentialNoC--10.0-False]`, `test_energy_conservation_linear[RazorThinExponentialDiskPotential--10.0-False]`, `test_energy_jacobi_conservation[RazorThinExponentialDiskPotential--10.0--9.0-False]`.

**Timeout gate (RazorThin scalar-loop):** verified 13.5s / 40–56s under torch, and *faster* on fewer cores (the user-time was thread-thrash on scalar ops) → CI-safe. Verified: 3 torch PASS + numpy PASS; numpy regression on other energy/jacobi params unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm