### PR TITLE
potentials/orbit: batch forced-backend scalar coercion + bruteSOS (+10 torch)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -6779,6 +6779,8 @@ class Orbit:
                 cross = self.y(self.t, use_physical=False, dontreshape=True)
             else:
                 cross = self.x(self.t, use_physical=False, dontreshape=True)
+        # numpy-based crossing detection below; forced-backend cross -> numpy
+        cross = as_numpy(cross)
         shifts = numpy.roll(cross, -1, axis=1)
         crossindx = (cross[:, :-1] < 0.0) * (shifts[:, :-1] > 0.0)
         anycrossindx = numpy.sum(crossindx, axis=0).astype("bool")

--- a/galpy/potential/CylindricallySeparablePotentialWrapper.py
+++ b/galpy/potential/CylindricallySeparablePotentialWrapper.py
@@ -108,6 +108,7 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         # anchored on the inputs so the wrapped potential sees backend arrays
         # (torch functions require Tensors) on the right device/dtype.
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return (
@@ -133,6 +134,7 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
            2026-01-14 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         return _evaluateRforces(self._pot, R, zero)
 
@@ -153,6 +155,7 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
            2026-01-14 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return _evaluatezforces(self._pot, Rp, z)
 
@@ -173,6 +176,7 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
            2026-01-14 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         return evaluateR2derivs(self._pot, R, zero, use_physical=False)
 
@@ -193,6 +197,7 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
            2026-01-14 - Written - Bovy (UofT)
         """
         xp = get_namespace(R, z, phi, t)
+        R, z = coerce_coords(xp, R, z)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return evaluatez2derivs(self._pot, Rp, z, use_physical=False)
 

--- a/galpy/potential/DehnenSmoothWrapperPotential.py
+++ b/galpy/potential/DehnenSmoothWrapperPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .WrapperPotential import parentWrapperPotential
 
@@ -99,6 +99,7 @@ class DehnenSmoothWrapperPotential(parentWrapperPotential):
             else:  # bar is fully on
                 smooth = 1.0
         else:
+            (t,) = coerce_coords(xp, t)
             deltat = t - self._tform
             xi = 2.0 * deltat / (self._tsteady - self._tform) - 1.0
             growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5

--- a/galpy/potential/GaussianAmplitudeWrapperPotential.py
+++ b/galpy/potential/GaussianAmplitudeWrapperPotential.py
@@ -6,7 +6,7 @@ import math
 
 import numpy
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..util import conversion
 from .WrapperPotential import parentWrapperPotential
 
@@ -68,6 +68,7 @@ class GaussianAmplitudeWrapperPotential(parentWrapperPotential):
             # forced-backend) Python/numpy-scalar t stays byte-identical and does
             # not feed a Python scalar to a backend's exp (torch rejects that).
             return math.exp(arg)
+        (arg,) = coerce_coords(xp, arg)
         return xp.exp(arg)
 
     def _wrap(self, attribute, *args, **kwargs):

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -685,6 +685,7 @@ class SpiralArmsPotential(Potential):
     def _gamma(self, R, phi):
         """Return gamma. (eqn 3 in the paper)"""
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return self._N * (
             phi - self._phi_ref - xp.log(R / self._r_ref) / self._tan_alpha
         )

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -5978,8 +5978,10 @@ def test_bruteSOS_2Dx():
             force_map="rk" in method,
             surface="x",
         )
-        xs = o.x(o.t)
-        vxs = o.vx(o.t)
+        from galpy.backend import as_numpy
+
+        xs = as_numpy(o.x(o.t))
+        vxs = as_numpy(o.vx(o.t))
         assert (numpy.fabs(xs) < 10.0**-3.0).all(), (
             f"x on SOS is not zero for bruteSOS for method={method}"
         )
@@ -6001,8 +6003,10 @@ def test_bruteSOS_2Dy():
             force_map="rk" in method,
             surface="y",
         )
-        ys = o.y(o.t)
-        vys = o.vy(o.t)
+        from galpy.backend import as_numpy
+
+        ys = as_numpy(o.y(o.t))
+        vys = as_numpy(o.vy(o.t))
         assert (numpy.fabs(ys) < 10.0**-3.0).all(), (
             f"y on SOS is not zero for bruteSOS for method={method}"
         )

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -2462,8 +2462,10 @@ def test_bruteSOS_2Dx():
             force_map="rk" in method,
             surface="x",
         )
-        xs = orbits.x(orbits.t)
-        vxs = orbits.vx(orbits.t)
+        from galpy.backend import as_numpy
+
+        xs = as_numpy(orbits.x(orbits.t))
+        vxs = as_numpy(orbits.vx(orbits.t))
         assert (numpy.fabs(xs[~numpy.isnan(xs)]) < 10.0**-3.0).all(), (
             f"x on SOS is not zero for bruteSOS for method={method}"
         )
@@ -2493,8 +2495,10 @@ def test_bruteSOS_2Dy():
             force_map="rk" in method,
             surface="y",
         )
-        ys = orbits.y(orbits.t)
-        vys = orbits.vy(orbits.t)
+        from galpy.backend import as_numpy
+
+        ys = as_numpy(orbits.y(orbits.t))
+        vys = as_numpy(orbits.vy(orbits.t))
         assert (numpy.fabs(ys[~numpy.isnan(ys)]) < 10.0**-3.0).all(), (
             f"y on SOS is not zero for bruteSOS for method={method}"
         )


### PR DESCRIPTION
## Summary

One consolidated PR (CI-efficient) applying the verified `coerce_coords` pattern (from #1175) across the remaining potentials/wrappers that crash under a **forced backend** — `get_namespace()` resolves torch/jax but the coord/time inputs stay numpy scalars, so `xp.log/where/abs(<numpy scalar>)` rejects them. `coerce_coords` is a strict pass-through when `xp is numpy` → **numpy byte-identical**. Plus a `bruteSOS` fix (SOS-crossing `cross` is a backend array → `as_numpy`).

## Flips (+10 torch, source-only → XPASS)
| test | fix |
|---|---|
| `test_SpiralArmsPotential::test_gamma` / `test_dgamma_dR` | `SpiralArmsPotential._gamma`: `coerce_coords(xp, R, phi)` |
| `test_orbit/test_orbits::test_dxdv_3d_c_vs_python[CylindricallySeparablePotentialWrapper]` (+`_tight`) | 5 methods: `coerce_coords(xp, R, z)` |
| `…[GaussianAmplitudeWrapperPotential]` | `coerce_coords(xp, arg)` in the backend branch |
| `…[DehnenSmoothWrapperPotential]` | `coerce_coords(xp, t)` in the `where` branch |
| `test_orbit/test_orbits::test_bruteSOS_2Dx` / `_2Dy` | `Orbits.py`: `cross = as_numpy(cross)` + test-side casts |

Each was verified failing under `--backend torch --runxfail` before the fix, passing after (with a stash-rerun confirming it fails without the change), and every touched source file re-verified byte-identical under `--backend numpy`.

Deferred (not this uniform pattern): actionAngle grid `_c` setup-path entries (backend-native SETUP migration), a couple that fix the crash but then need torch-tolerance approval.

**Note:** the `Orbits.py` edit is `bruteSOS` at line 6783 — disjoint from the E()/Jacobi() except-tuples (3307-3433) in the concurrent orbit-machinery PR (#1178); no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm