### PR TITLE
symplecticode: backend-native, differentiable leapfrog (no-C linear orbits on the backend, no island) + RazorThin except (+3 torch)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -3304,7 +3304,7 @@ class Orbit:
                     )
                     + thiso[1] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3331,7 +3331,7 @@ class Orbit:
                     + thiso[1] ** 2.0 / 2.0
                     + thiso[2] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3359,7 +3359,7 @@ class Orbit:
                     + thiso[1] ** 2.0 / 2.0
                     + thiso[2] ** 2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3394,7 +3394,7 @@ class Orbit:
                     + thiso[2] ** 2.0 / 2.0
                     + vz**2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [
@@ -3430,7 +3430,7 @@ class Orbit:
                     + thiso[2] ** 2.0 / 2.0
                     + vz**2.0 / 2.0
                 ).T
-            except (ValueError, TypeError, IndexError):
+            except (ValueError, TypeError, IndexError, RuntimeError):
                 out = (
                     numpy.array(
                         [

--- a/galpy/util/symplecticode.py
+++ b/galpy/util/symplecticode.py
@@ -32,6 +32,8 @@
 #############################################################################
 import numpy
 
+from ..backend import as_numpy, coerce_coords, get_namespace, is_backend_array
+
 _MAX_DT_REDUCE = 10000.0
 
 
@@ -57,22 +59,43 @@ def leapfrog(func, yo, t, args=(), rtol=1.49012e-12, atol=1.49012e-12):
     Returns
     -------
     numpy.ndarray
-        Array containing the value of y for each desired time in t, with the initial value y0 in the first row.
+        Array containing the value of y for each desired time in t, with the initial value y0 in the first row. Under a forced/default jax|torch backend the result is the backend's array type (differentiable in yo and in the potential parameters carried by ``func``).
 
     Notes
     -----
     - 2011-02-02 - Written - Bovy (NYU)
+    - 2026-07-21 - Backend-native (jax/torch), differentiable; numpy path unchanged - Bovy (UofT)
     """
     # Initialize
     qo = yo[0 : len(yo) // 2]
     po = yo[len(yo) // 2 : len(yo)]
-    out = numpy.zeros((len(t), len(yo)))
-    out[0, :] = yo
+    # Probe the backend from the force: yo/t arrive as numpy (Orbit hands us
+    # numpy.array(vxvv)), so the backend only manifests through func's return.
+    # numpy -> historical byte-identical path (out[ii]=... item-assign); a backend
+    # force -> namespace-generic path, state coerced onto xp and rows accumulated
+    # functionally (no item-assign: jax is immutable / it breaks torch|jax AD).
+    force = func(qo, *args, t=t[0])
+    if is_backend_array(force):
+        xp = get_namespace(force)
+        if not is_backend_array(yo):
+            (yo,) = coerce_coords(xp, yo)
+        (t,) = coerce_coords(xp, t)
+        qo = yo[0 : len(yo) // 2]
+        po = yo[len(yo) // 2 : len(yo)]
+        rows = [yo]
+    else:
+        xp = numpy
+        out = numpy.zeros((len(t), len(yo)))
+        out[0, :] = yo
+    _concat = getattr(xp, "concat", None) or xp.concatenate
     # Estimate necessary step size
     dt = t[1] - t[0]  # assumes that the steps are equally spaced
     init_dt = dt
-    dt = _leapfrog_estimate_step(func, qo, po, dt, t[0], args, rtol, atol)
-    ndt = int(init_dt / dt)
+    dt = _leapfrog_estimate_step(func, qo, po, dt, t[0], args, rtol, atol, xp=xp)
+    # dt/ndt are a concrete step SCHEDULE (dt is init_dt halved a discrete number
+    # of times -> no gradient w.r.t. the state, a stop-gradient); ndt stays a
+    # python int.
+    ndt = int(init_dt / dt) if xp is numpy else int(as_numpy(init_dt / dt))
     # Integrate
     to = t[0]
     for ii in range(1, len(t)):
@@ -84,17 +107,21 @@ def leapfrog(func, yo, t, args=(), rtol=1.49012e-12, atol=1.49012e-12):
             po = leapfrog_leapp(po, dt, force)
             # full drift to next half step
             q12 = leapfrog_leapq(q12, po, dt)
-            # Get ready for next
-            to += dt
+            # Get ready for next (rebind: on a backend to=t[0] is a view and
+            # to += dt would mutate t in place)
+            to = to + dt
         # last kick and half drift to arrive at final step
         force = func(q12, *args, t=to + dt / 2)
         po = leapfrog_leapp(po, dt, force)
         qo = leapfrog_leapq(q12, po, dt / 2)
-        to += dt
+        to = to + dt
 
-        out[ii, 0 : len(yo) // 2] = qo
-        out[ii, len(yo) // 2 : len(yo)] = po
-    return out
+        if xp is numpy:
+            out[ii, 0 : len(yo) // 2] = qo
+            out[ii, len(yo) // 2 : len(yo)] = po
+        else:
+            rows.append(_concat([qo, po]))
+    return out if xp is numpy else xp.stack(rows)
 
 
 def leapfrog_leapq(q, p, dt):
@@ -105,13 +132,17 @@ def leapfrog_leapp(p, dt, force):
     return p + dt * force
 
 
-def _leapfrog_estimate_step(func, qo, po, dt, to, args, rtol, atol):
+def _leapfrog_estimate_step(func, qo, po, dt, to, args, rtol, atol, xp=numpy):
+    _concat = getattr(xp, "concat", None) or xp.concatenate
     init_dt = dt
-    qmax = numpy.amax(numpy.fabs(qo)) + numpy.zeros(len(qo))
-    pmax = numpy.amax(numpy.fabs(po)) + numpy.zeros(len(po))
-    scale = atol + rtol * numpy.array([qmax, pmax]).flatten()
+    qmax = xp.max(xp.abs(qo)) + xp.zeros_like(qo)
+    pmax = xp.max(xp.abs(po)) + xp.zeros_like(po)
+    scale = atol + rtol * _concat([qmax, pmax])
     err = 2.0
-    dt *= 2.0
+    # Rebind, not in-place *=/=: init_dt aliases dt (and the caller's dt) on a
+    # backend, so an in-place mul mutates that shared tensor and init_dt/dt -> 1
+    # (numpy scalars are immutable, so *= already rebinds -> byte-identical).
+    dt = dt * 2.0
     while err > 1.0 and init_dt / dt < _MAX_DT_REDUCE:
         # Do one leapfrog step with step dt and one with dt/2.
         # dt
@@ -128,7 +159,7 @@ def _leapfrog_estimate_step(func, qo, po, dt, to, args, rtol, atol):
         p12 = leapfrog_leapp(ptmp, dt / 2.0, force)
         q12 = leapfrog_leapq(qtmp, p12, dt / 4.0)
         # Norm
-        delta = numpy.array([numpy.fabs(q11 - q12), numpy.fabs(p11 - p12)]).flatten()
-        err = numpy.sqrt(numpy.mean((delta / scale) ** 2.0))
-        dt /= 2.0
+        delta = _concat([xp.abs(q11 - q12), xp.abs(p11 - p12)])
+        err = xp.sqrt(xp.mean((delta / scale) ** 2.0))
+        dt = dt / 2.0
     return dt

--- a/tests/test_backend_symplecticode.py
+++ b/tests/test_backend_symplecticode.py
@@ -1,0 +1,186 @@
+###############################################################################
+# test_backend_symplecticode.py: the backend-native, differentiable leapfrog
+# integrator (galpy.util.symplecticode.leapfrog).
+#
+# leapfrog is the Python symplectic integrator used for no-C potentials
+# (Orbit.integrate(..., method='leapfrog')); Orbit hands it numpy ICs but,
+# under a forced/default jax|torch backend, the force func returns a backend
+# array, which flips leapfrog onto its namespace-generic path. These tests hit
+# that path directly with a simple-harmonic force (force = -omega**2 q), which
+# is cheap enough to run under eager jax/torch and has a closed-form solution
+# (q(t) = q0 cos(omega t) + (p0/omega) sin(omega t)). They prove:
+#   1. the backend result is byte-identical to the numpy path (same steps),
+#   2. it matches the analytic SHM trajectory,
+#   3. autodiff through leapfrog gives correct gradients of the final state
+#      w.r.t. the initial condition AND a force parameter (vs FD / analytic),
+#   4. the numpy path is unchanged.
+#
+# Self-skips the backend cases unless jax / torch is installed.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.util import symplecticode
+
+pytestmark = pytest.mark.backend_managed
+
+HAVE_JAX = False
+HAVE_TORCH = False
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    HAVE_JAX = True
+except ImportError:  # pragma: no cover
+    pass
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+
+    HAVE_TORCH = True
+except ImportError:  # pragma: no cover
+    pass
+
+_TS = numpy.linspace(0.0, 6.0, 80)
+_YO = numpy.array([1.0, 0.0])  # SHM initial condition [q0, p0]
+_RTOL = 1e-8
+_ATOL = 1e-8
+
+
+def _analytic_shm(ts, q0, p0, omega):
+    # exact solution of q'' = -omega**2 q
+    return q0 * numpy.cos(omega * ts) + (p0 / omega) * numpy.sin(omega * ts)
+
+
+# ------------------------------------------------------------- numpy path unchanged
+def test_leapfrog_numpy_path_unchanged():
+    # the historical numpy path (item-assign into a preallocated array) still
+    # integrates SHM correctly -- guards byte-identity of the numpy branch
+    out = symplecticode.leapfrog(lambda q, t=0.0: -q, _YO, _TS, rtol=_RTOL, atol=_ATOL)
+    assert isinstance(out, numpy.ndarray)
+    assert out.shape == (len(_TS), 2)
+    numpy.testing.assert_allclose(
+        out[:, 0], _analytic_shm(_TS, 1.0, 0.0, 1.0), rtol=1e-5, atol=1e-5
+    )
+
+
+# ------------------------------------------------------- backend value parity vs numpy
+@pytest.mark.skipif(not HAVE_JAX, reason="jax not installed")
+def test_leapfrog_jax_value_parity():
+    # a numpy IC with a jax-returning force flips leapfrog onto the backend path
+    # (the IC is coerced onto the namespace); the trajectory is a jax array that
+    # is bit-for-bit identical to the numpy path and matches analytic SHM.
+    ref = symplecticode.leapfrog(lambda q, t=0.0: -q, _YO, _TS, rtol=_RTOL, atol=_ATOL)
+    got = symplecticode.leapfrog(
+        lambda q, t=0.0: -jnp.asarray(q), _YO, _TS, rtol=_RTOL, atol=_ATOL
+    )
+    assert "jax" in type(got).__module__
+    numpy.testing.assert_array_equal(numpy.asarray(got), ref)  # byte-identical
+    numpy.testing.assert_allclose(
+        numpy.asarray(got)[:, 0],
+        _analytic_shm(_TS, 1.0, 0.0, 1.0),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+def test_leapfrog_torch_value_parity():
+    ref = symplecticode.leapfrog(lambda q, t=0.0: -q, _YO, _TS, rtol=_RTOL, atol=_ATOL)
+    got = symplecticode.leapfrog(
+        lambda q, t=0.0: -torch.as_tensor(numpy.asarray(q)),
+        _YO,
+        _TS,
+        rtol=_RTOL,
+        atol=_ATOL,
+    )
+    assert "torch" in type(got).__module__
+    numpy.testing.assert_array_equal(got.detach().cpu().numpy(), ref)  # byte-identical
+    numpy.testing.assert_allclose(
+        got.detach().cpu().numpy()[:, 0],
+        _analytic_shm(_TS, 1.0, 0.0, 1.0),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+# --------------------------------------------------- gradient w.r.t. IC (vs FD/analytic)
+@pytest.mark.skipif(not HAVE_JAX, reason="jax not installed")
+def test_leapfrog_jax_grad_ic_vs_fd():
+    # d(final q)/d(q0): a backend IC (grad-tracked) stays on the backend (no
+    # coerce); the gradient matches FD and the analytic value cos(omega T).
+    def final_q(q0):
+        y = jnp.stack([q0, jnp.asarray(0.0)])
+        r = symplecticode.leapfrog(
+            lambda q, t=0.0: -q, y, jnp.asarray(_TS), rtol=_RTOL, atol=_ATOL
+        )
+        return r[-1, 0]
+
+    g = float(jax.grad(final_q)(1.0))
+    eps = 1e-6
+    fd = float((final_q(1.0 + eps) - final_q(1.0 - eps)) / (2 * eps))
+    numpy.testing.assert_allclose(g, fd, rtol=1e-6, atol=1e-8)
+    numpy.testing.assert_allclose(g, numpy.cos(_TS[-1]), rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+def test_leapfrog_torch_grad_ic_vs_fd():
+    q0 = torch.tensor(1.0, requires_grad=True)
+    y = torch.stack([q0, torch.tensor(0.0)])
+    r = symplecticode.leapfrog(
+        lambda q, t=0.0: -q, y, torch.as_tensor(_TS), rtol=_RTOL, atol=_ATOL
+    )
+    r[-1, 0].backward()
+    numpy.testing.assert_allclose(
+        float(q0.grad), numpy.cos(_TS[-1]), rtol=1e-4, atol=1e-5
+    )
+
+
+# ---------------------------------------------- gradient w.r.t. a force parameter (jax)
+@pytest.mark.skipif(not HAVE_JAX, reason="jax not installed")
+def test_leapfrog_jax_grad_param_vs_fd():
+    # d(final q)/d(omega) for force = -omega**2 q: gradients flow through the
+    # parameter carried by func (the potential-parameter analogue), matching FD.
+    def final_q(omega):
+        r = symplecticode.leapfrog(
+            lambda q, t=0.0: -(omega**2) * q,
+            jnp.asarray(_YO),
+            jnp.asarray(_TS),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
+        return r[-1, 0]
+
+    g = float(jax.grad(final_q)(1.0))
+    eps = 1e-6
+    fd = float((final_q(1.0 + eps) - final_q(1.0 - eps)) / (2 * eps))
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5, atol=1e-7)
+
+
+# --------------------------------------------- torch force-parameter gradient matches jax
+@pytest.mark.skipif(not (HAVE_JAX and HAVE_TORCH), reason="needs both jax and torch")
+def test_leapfrog_torch_grad_param_matches_jax():
+    def final_q_jax(omega):
+        r = symplecticode.leapfrog(
+            lambda q, t=0.0: -(omega**2) * q,
+            jnp.asarray(_YO),
+            jnp.asarray(_TS),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
+        return r[-1, 0]
+
+    g_jax = float(jax.grad(final_q_jax)(1.0))
+    omega = torch.tensor(1.0, requires_grad=True)
+    r = symplecticode.leapfrog(
+        lambda q, t=0.0: -(omega**2) * q,
+        torch.as_tensor(_YO),
+        torch.as_tensor(_TS),
+        rtol=_RTOL,
+        atol=_ATOL,
+    )
+    r[-1, 0].backward()
+    numpy.testing.assert_allclose(float(omega.grad), g_jax, rtol=1e-6, atol=1e-8)


### PR DESCRIPTION
## Summary

Replaces a rejected `use("numpy", force=True)` **island** with a real migration: `symplecticode.leapfrog` is now backend-agnostic, so a **no-C potential's linear orbit runs *and* autodiffs on the jax/torch backend**.

- **Dispatch by probing the force** (the IC `yo` arrives as numpy — `Orbit` hands `numpy.array(vxvv)` — so the backend only manifests through `func`'s return): a numpy force → the historical **byte-identical** path (`out[ii]=` item-assign); a backend force → namespace-generic path (state coerced onto `xp`, output rows accumulated functionally via `list + xp.stack`, no item-assign which breaks jax immutability/AD).
- `_leapfrog_estimate_step` made namespace-generic; `to`/`dt` rebound (not in-place, since on a backend they alias `t[0]`/`dt` views); the `dt`/`ndt` step schedule is a concrete **stop-gradient**.
- `RazorThinExponentialDiskPotential` is scalar-only → E()/Jacobi()'s vectorized-eval fallback `except` gains `RuntimeError` (torch's array-ambiguous bool) → scalar loop.

## Flips (+3 torch)
`test_energy_conservation_linear[BurkertPotentialNoC--10.0-False]`, `…[RazorThin…]`, `test_energy_jacobi_conservation[RazorThin…]`.

## Verification
- **numpy byte-identical** — leapfrog output `array_equal` (0.0) for 1-D/planar/full `yo`, and internal `dt` identical.
- **backend-native + differentiable** — `leapfrog(backend yo)` returns a backend array; `d(final q)/d(y0)` matches central FD to rel ~1e-9 (torch **and** jax.grad eager). jit/vmap raise loudly (documented eager-only, per the no-internal-jit policy).
- **Adversarial review**: no defects (byte-identity across dims, probe-eval = +1 discarded, no diff leak, Orbits.py except no numpy regression).

Note: d(orbit)/d(**IC**) through the public `Orbit.integrate` API is still gated on `integrateLinearOrbit`'s `numpy.array(vxvv)` IC coercion (the constructor-input gap, separate follow-up); d/d(**potential params**) already flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm