### PR TITLE
sphericaldf/kingdf: backend-native differentiable radial + angle sampling via interp_linear

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -271,14 +271,25 @@ def interp_linear(xp, x, y, r, *, nu=0, extrapolate=True):
     """Piecewise-linear interpolation of ``(x, y)`` at ``r``, built in ``xp``.
 
     ``searchsorted`` for the interval + a lerp; trivially differentiable w.r.t.
-    both ``r`` and ``y``. ``x`` must be increasing. ``extrapolate=True`` extends
+    ``r`` and ``y``, and (when ``x`` is a backend array) w.r.t. the knot
+    positions ``x`` too -- the differentiable-linear-inverse-CDF case. ``x`` must
+    be increasing. ``extrapolate=True`` extends
     the edge line beyond the ends (matching ``eval_ppoly``'s finite
     extrapolation); ``'clip'``/``'const'``/``3`` clamp ``r`` to the range first
     (edge value beyond the ends). ``nu=1`` returns the (per-interval constant)
     secant slope; ``nu>1`` returns zeros.
     """
     dev = device_of(r, y, x)
-    xb = asarray_on_device(xp, numpy.asarray(x), dev) * 1.0
+    # A backend (jax/torch) ``x`` is kept in the namespace so the knot positions
+    # are differentiable and jit-traceable (the inverse-CDF case, where
+    # ``x = cdf_grid`` is the parameter-dependent quantity -- mirrors
+    # ``sampling._natknot_coeffs``); a plain numpy/list grid (the frozen-Spline1D
+    # / structural-grid case) is materialized on ``r``'s device. The numpy path
+    # is byte-identical (``numpy.asarray`` of a numpy array is a no-op).
+    if is_backend_array(x):
+        xb = x * 1.0
+    else:
+        xb = asarray_on_device(xp, numpy.asarray(x), dev) * 1.0
     yb = y * 1.0
     if extrapolate is not True:
         if extrapolate not in ("clip", "const", 3):

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -13,9 +13,9 @@ from ..backend import (
     get_namespace,
     is_backend_array,
     name_of_namespace,
-    resolve_namespace,
-    use,
 )
+from ..backend import random as grandom
+from ..backend import resolve_namespace, use
 from ..backend.quadrature import fixed_quad, fixed_quad_semiinfinite
 from ..potential import evaluateRforces, interpSphericalPotential
 from ..potential.Potential import _evaluatePotentials
@@ -300,14 +300,33 @@ class _constantbetadf(anisotropicsphericaldf):
             / special.gamma(0.5 * (m + n - 2.0 * self._beta + 3.0))
         )
 
-    def sample(self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=0.0):
+    def sample(
+        self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=0.0, key=None
+    ):
         # No docstring so the superclass' is used. Sampling is a numpy-side
         # (stateful-RNG) operation drawn from the interpolated fE (built with
         # the backend's autodiff at construction); run it on numpy under torch
         # so the returned Orbit and its accessors are numpy (see _numpy_ctx).
+        # Backend-key velocity sampling for anisotropic DFs is deferred (the eta
+        # sampler needs a backend inverse-CDF); reject a jax/torch key clearly
+        # rather than silently returning numpy or a broken mixed result.
+        if grandom._backend_of_key(key) != "numpy":
+            raise NotImplementedError(
+                "backend-key (jax/torch) sampling is not yet supported for "
+                "anisotropic DFs (constantbetadf/osipkovmerrittdf); pass "
+                "key=None for numpy sampling. Backend anisotropic velocity "
+                "sampling is a planned follow-up."
+            )
         with _numpy_ctx(_active_backend_name()):
             return sphericaldf.sample(
-                self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin
+                self,
+                R=R,
+                z=z,
+                phi=phi,
+                n=n,
+                return_orbit=return_orbit,
+                rmin=rmin,
+                key=key,
             )
 
 
@@ -452,16 +471,19 @@ class constantbetadf(_constantbetadf):
                     Es, numpy.log10(startt) + 10.0 / 3.0 * (1.0 - self._alpha), k=3
                 )
 
-    def sample(self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None):
+    def sample(
+        self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None, key=None
+    ):
         # Slight over-write of superclass method to first build f(E) interp
         # No docstring so superclass' is used
         # Use self._rmin as default if rmin is not specified
         if rmin is None:
             rmin = self._rmin
         self._ensure_fE_interp()
-        # via _constantbetadf.sample so the torch->numpy sampling wrap applies
+        # via _constantbetadf.sample so the torch->numpy sampling wrap (and the
+        # backend-key guard) applies
         return super().sample(
-            R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin
+            R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )
 
     def _ensure_fE_interp(self):

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -213,8 +213,12 @@ class _constantbetadf(anisotropicsphericaldf):
         )
         return xp.where(pos, prefac * fE * integral, xp.zeros_like(fE))
 
-    def _sample_eta(self, r, n=1):
-        """Sample the angle eta which defines radial vs tangential velocities"""
+    def _sample_eta(self, r, n=1, key=None):
+        """Sample the angle eta which defines radial vs tangential velocities
+
+        ``key`` is accepted (threaded from ``_sample_velocity_angles``) but the
+        anisotropic eta sampler stays numpy-side for now (backend eta is a later
+        migration); ``key=None`` is byte-identical."""
         if not hasattr(self, "_coseta_icmf_interp"):
             # Cumulative dist for cos(eta) =
             # 0.5 + x 2F1(0.5,beta,1.5,x^2)/sqrt(pi)/Gamma(1-beta)*Gamma(1.5-beta)

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -95,14 +95,18 @@ class eddingtondf(isotropicsphericaldf):
             r_a_min=max(1e-6, self._rmin / self._scale)
         )
 
-    def sample(self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None):
+    def sample(
+        self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None, key=None
+    ):
         # Slight over-write of superclass method to first build f(E) interp
         # No docstring so superclass' is used
         if rmin is None:
             rmin = self._rmin
         self._ensure_fE_interp()
+        # isotropic: a backend key drives the general (no closed-form _icmf)
+        # interp_linear inverse-CDF radial sampler + isotropic angles
         return sphericaldf.sample(
-            self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin
+            self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )
 
     def _ensure_fE_interp(self):

--- a/galpy/df/kingdf.py
+++ b/galpy/df/kingdf.py
@@ -2,9 +2,14 @@
 import numpy
 from scipy import integrate, interpolate, special
 
-from ..backend import get_namespace, is_backend_array, resolve_namespace
+from ..backend import (
+    as_backend_constant,
+    get_namespace,
+    is_backend_array,
+    resolve_namespace,
+)
 from ..backend import special as _bspecial
-from ..backend.interpolate import Spline1D
+from ..backend.interpolate import Spline1D, interp_linear
 from ..util import conversion
 from .df import df
 from .sphericaldf import isotropicsphericaldf
@@ -80,17 +85,36 @@ class kingdf(isotropicsphericaldf):
             self, pot=pot, scale=self.r0, rmax=self.rt, ro=ro, vo=vo
         )
         self._potInf = self._pot(self.rt, 0.0, use_physical=False)
-        # Setup inverse cumulative mass function for radius sampling
-        self._icmf = interpolate.InterpolatedUnivariateSpline(
-            self._mass_scale * self._scalefree_kdf._cumul_mass / self.M,
-            self._radius_scale * self._scalefree_kdf._r,
-            k=1,
+        # Setup inverse cumulative mass function for radius sampling: store the
+        # (normalized cumulative-mass, radius) grids so a backend key can sample
+        # r via a differentiable interp_linear, plus the scipy k=1 spline for the
+        # byte-identical numpy path (see _icmf below).
+        self._icmf_cmf_grid = (
+            self._mass_scale * self._scalefree_kdf._cumul_mass / self.M
+        )
+        self._icmf_r_grid = self._radius_scale * self._scalefree_kdf._r
+        self._icmf_spline = interpolate.InterpolatedUnivariateSpline(
+            self._icmf_cmf_grid, self._icmf_r_grid, k=1
         )
         # Setup velocity DF interpolator for velocity sampling here
         self._rmin_sampling = 0.0
         self._v_vesc_pvr_interpolator = self._make_pvr_interpolator(
             r_a_end=numpy.log10(self.rt / self._scale)
         )
+
+    def _icmf(self, ms):
+        """Inverse cumulative mass function for radius sampling.
+
+        ``ms`` is the normalized mass fraction in [0, 1]. numpy queries hit the
+        byte-identical scipy k=1 spline; a backend ``ms`` (from a backend
+        ``sample(key=...)``) is sampled by a differentiable linear interp on the
+        stored (cumulative-mass, radius) grids."""
+        if not is_backend_array(ms):
+            return self._icmf_spline(ms)
+        xp = get_namespace(ms)
+        x = as_backend_constant(xp, self._icmf_cmf_grid, ms)
+        y = as_backend_constant(xp, self._icmf_r_grid, ms)
+        return interp_linear(xp, x, y, ms, extrapolate="clip")
 
     def dens(self, r):
         return self._scalefree_kdf.dens(r / self._radius_scale) * self._density_scale

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -187,8 +187,12 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
             )
         )
 
-    def _sample_eta(self, r, n=1):
-        """Sample the angle eta which defines radial vs tangential velocities"""
+    def _sample_eta(self, r, n=1, key=None):
+        """Sample the angle eta which defines radial vs tangential velocities
+
+        ``key`` is accepted (threaded from ``_sample_velocity_angles``) but the
+        anisotropic eta sampler stays numpy-side for now (backend eta is a later
+        migration); ``key=None`` is byte-identical."""
         # cumulative distribution of x = cos eta satisfies
         # x/(sqrt(A+1 -A* x^2)) = 2 b - 1 = c
         # where b \in [0,1] and A = (r/ra)^2

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -2,7 +2,9 @@
 import numpy
 from scipy import integrate, interpolate, special
 
-from ..backend import as_numpy, device_of, resolve_namespace
+from ..backend import as_numpy, device_of
+from ..backend import random as grandom
+from ..backend import resolve_namespace
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..potential import evaluateDensities
 from ..potential.Potential import _evaluatePotentials
@@ -403,14 +405,25 @@ class osipkovmerrittdf(_osipkovmerrittdf):
             )
         )
 
-    def sample(self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None):
+    def sample(
+        self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=None, key=None
+    ):
         # Slight over-write of superclass method to first build f(Q) interp
         # No docstring so superclass' is used
         if rmin is None:
             rmin = self._rmin
         self._ensure_fQ_interp()
+        # Backend-key velocity sampling for anisotropic DFs is deferred (the eta
+        # sampler needs a backend inverse-CDF); reject a jax/torch key clearly.
+        if grandom._backend_of_key(key) != "numpy":
+            raise NotImplementedError(
+                "backend-key (jax/torch) sampling is not yet supported for "
+                "anisotropic DFs (constantbetadf/osipkovmerrittdf); pass "
+                "key=None for numpy sampling. Backend anisotropic velocity "
+                "sampling is a planned follow-up."
+            )
         return sphericaldf.sample(
-            self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin
+            self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )
 
     def _ensure_fQ_interp(self):

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -24,13 +24,15 @@ import scipy.interpolate
 from scipy import integrate, special
 
 from ..backend import (
+    as_backend_constant,
     as_numpy,
     exit_cast,
     get_namespace,
     is_backend_array,
-    resolve_namespace,
 )
-from ..backend.interpolate import Spline1D
+from ..backend import random as grandom
+from ..backend import resolve_namespace
+from ..backend.interpolate import Spline1D, interp_linear
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..orbit import Orbit
 from ..potential import (
@@ -516,7 +518,9 @@ class sphericaldf(df):
         )
 
     ############################### SAMPLING THE DF################################
-    def sample(self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=0.0):
+    def sample(
+        self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=0.0, key=None
+    ):
         """
         Sample the DF
 
@@ -534,6 +538,14 @@ class sphericaldf(df):
             If True, return an orbit.Orbit instance. If False, return a tuple of (R,vR,vT,z,vz,phi). Default is True.
         rmin : float, Quantity, optional
             Minimum radius at which to sample. Default is 0.
+        key : optional
+            Backend random key from :func:`galpy.backend.random.key`. Default
+            ``None`` uses the global ``numpy.random`` draws (the numpy path,
+            byte-identical to galpy's historical behaviour). A jax/torch key
+            makes the radial + analytic-angle position sampling backend-native
+            (reproducible, differentiable in the CDF/potential, GPU/jit-able)
+            and returns backend-array coordinates (use ``return_orbit=False`` to
+            keep them; the Orbit constructor materializes numpy). Default None.
 
         Returns
         -------
@@ -544,20 +556,24 @@ class sphericaldf(df):
         -----
         - When specifying position, it is necessary to specify both R and z; if phi is not set in this case, it is sampled
         - 2020-07-22 - Written - Lane (UofT)
+        - 2026-07-21 - Added backend ``key`` for differentiable radial/angle sampling - Bovy (UofT)
         """
         rmin = conversion.parse_length(rmin, ro=self._ro)
         if hasattr(self, "_rmin_sampling") and rmin != self._rmin_sampling:
             # Build new grids, easiest
-            if hasattr(self, "_xi_cmf_interpolator"):
-                delattr(self, "_xi_cmf_interpolator")
-            if hasattr(self, "_v_vesc_pvr_interpolator"):
-                delattr(self, "_v_vesc_pvr_interpolator")
+            for attr in ("_xi_cmf_grids", "_xi_cmf_spline", "_v_vesc_pvr_interpolator"):
+                if hasattr(self, attr):
+                    delattr(self, attr)
         self._rmin_sampling = conversion.parse_length(rmin, ro=self._ro)
+        # dispatch the namespace on the key, NOT get_namespace(): key=None keeps
+        # the whole assembly numpy (byte-identical) even under a forced backend;
+        # a backend key follows its own draws into the active namespace.
         if R is None or z is None:  # Full 6D samples
-            r = self._sample_r(n=n)
-            phi, theta = self._sample_position_angles(n=n)
-            R = r * numpy.sin(theta)
-            z = r * numpy.cos(theta)
+            r = self._sample_r(n=n, key=key)
+            phi, theta = self._sample_position_angles(n=n, key=key)
+            xp = numpy if key is None else get_namespace(r)
+            R = r * xp.sin(theta)
+            z = r * xp.cos(theta)
         else:  # 3D velocity samples
             R = conversion.parse_length(R, ro=self._ro)
             z = conversion.parse_length(z, ro=self._ro)
@@ -578,6 +594,8 @@ class sphericaldf(df):
                 z = z * numpy.ones(n)
             r = numpy.sqrt(R**2.0 + z**2.0)
             theta = numpy.arctan2(R, z)
+            # the fixed-position branch stays numpy-side (R,z pulled in above)
+            xp = numpy
             if phi is None:  # Otherwise assume phi input type matches R,z
                 phi, _ = self._sample_position_angles(n=n)
             else:
@@ -589,13 +607,24 @@ class sphericaldf(df):
                     if not hasattr(phi, "__len__") or len(phi) < n
                     else phi
                 )
-        eta, psi = self._sample_velocity_angles(r, n=n)
+        # gate the key on xp: the full-6D branch follows the backend key; the
+        # fixed-position (R,z) branch stays numpy-side (xp is numpy there)
+        eta, psi = self._sample_velocity_angles(
+            r, n=n, key=None if xp is numpy else key
+        )
+        # velocity magnitude is still numpy-side (_sample_v is PR-2); coerce the
+        # numpy velocity pieces into xp so a backend key assembles backend
+        # velocities (numpy*tensor raises under torch). key=None -> xp is numpy
+        # -> as_backend_constant is a no-op (byte-identical).
         v = self._sample_v(r, eta, n=n)
-        vr = v * numpy.cos(eta)
-        vtheta = v * numpy.sin(eta) * numpy.cos(psi)
-        vT = v * numpy.sin(eta) * numpy.sin(psi)
-        vR = vr * numpy.sin(theta) + vtheta * numpy.cos(theta)
-        vz = vr * numpy.cos(theta) - vtheta * numpy.sin(theta)
+        v = v if is_backend_array(v) else as_backend_constant(xp, v, r)
+        eta = eta if is_backend_array(eta) else as_backend_constant(xp, eta, r)
+        psi = psi if is_backend_array(psi) else as_backend_constant(xp, psi, r)
+        vr = v * xp.cos(eta)
+        vtheta = v * xp.sin(eta) * xp.cos(psi)
+        vT = v * xp.sin(eta) * xp.sin(psi)
+        vR = vr * xp.sin(theta) + vtheta * xp.cos(theta)
+        vz = vr * xp.cos(theta) - vtheta * xp.sin(theta)
         if return_orbit:
             o = Orbit(vxvv=numpy.array([R, vR, vT, z, vz, phi]).T)
             if self._roSet and self._voSet:
@@ -611,7 +640,7 @@ class sphericaldf(df):
                 phi = units.Quantity(phi) * units.rad
             return (R, vR, vT, z, vz, phi)
 
-    def _sample_r(self, n=1):
+    def _sample_r(self, n=1, key=None):
         """Generate radial position samples from potential
         Note - the function interpolates the normalized CMF onto the variable
         xi defined as:
@@ -619,18 +648,50 @@ class sphericaldf(df):
         .. math:: \\xi = \\frac{r/a-1}{r/a+1}
 
         so that xi is in the range [-1,1], which corresponds to an r range of
-        [0,infinity)"""
-        rand_mass_frac = numpy.random.uniform(size=n)
+        [0,infinity)
+
+        ``key=None`` draws the mass fractions from the global ``numpy.random``
+        (byte-identical numpy path); a backend key draws backend uniforms and
+        returns a backend array, differentiable in the CDF/potential."""
+        rand_mass_frac = grandom.uniform(key, n)
         if hasattr(self, "_icmf"):
+            # closed-form / grid inverse-CMF; the analytic families and kingdf
+            # dispatch on the namespace of rand_mass_frac (backend -> backend)
             r_samples = self._icmf(rand_mass_frac)
+        elif is_backend_array(rand_mass_frac):
+            # backend inverse-CDF: differentiable in the CDF knots via a linear
+            # interp_linear on the (possibly backend, possibly frozen) mass grid
+            xp = get_namespace(rand_mass_frac)
+            cdf_grid, xi_grid = self._get_cmf_grids()
+            cg = (
+                cdf_grid
+                if is_backend_array(cdf_grid)
+                else as_backend_constant(xp, cdf_grid, rand_mass_frac)
+            )
+            xg = as_backend_constant(xp, as_numpy(xi_grid), rand_mass_frac)
+            xi_samples = interp_linear(xp, cg, xg, rand_mass_frac, extrapolate="clip")
+            # r = _xiToR inlined in-namespace (numpy.divide would drop the graph)
+            r_samples = self._scale * (1.0 + xi_samples) / (1.0 - xi_samples)
         else:
-            if not hasattr(self, "_xi_cmf_interpolator"):
-                self._xi_cmf_interpolator = self._make_cmf_interpolator()
-            xi_samples = self._xi_cmf_interpolator(rand_mass_frac)
+            # numpy path: byte-identical scipy k=1 inverse-CMF spline
+            if not hasattr(self, "_xi_cmf_spline"):
+                cdf_grid, xi_grid = self._get_cmf_grids()
+                self._xi_cmf_spline = Spline1D(
+                    as_numpy(cdf_grid), as_numpy(xi_grid), k=1
+                )
+            xi_samples = self._xi_cmf_spline(rand_mass_frac)
             r_samples = _xiToR(xi_samples, a=self._scale)
-        # a forced backend makes the deterministic icdf eval a backend array;
-        # samples are numpy-side by design
+        # numpy path (key=None) is numpy-side by design (a forced backend can make
+        # the deterministic icdf eval a backend array); a backend key keeps it
+        if is_backend_array(rand_mass_frac):
+            return r_samples
         return as_numpy(r_samples)
+
+    def _get_cmf_grids(self):
+        """Cache and return the (cdf_grid, xi_grid) inverse-CMF tables."""
+        if not hasattr(self, "_xi_cmf_grids"):
+            self._xi_cmf_grids = self._make_cmf_interpolator()
+        return self._xi_cmf_grids
 
     def _make_cmf_interpolator(self):
         """Create the interpolator object for calculating radii from the CMF
@@ -674,24 +735,34 @@ class sphericaldf(df):
             ms -= mass(self._denspot, self._rmin_sampling, use_physical=False)
             mnorm -= mass(self._denspot, self._rmin_sampling, use_physical=False)
         ms /= mnorm
-        # mass() may have evaluated on a (forced) backend; the icdf table is numpy
-        ms = as_numpy(ms)
-        # Add total mass point to avoid extrapolation beyond rmax
-        if numpy.isinf(self._rmax):
-            xis = numpy.append(xis, 1)
-            ms = numpy.append(ms, 1)
+        # Add the total-mass endpoint so the inverse-CMF never extrapolates
+        # beyond rmax. The xi grid is fixed geometry (numpy); ms is the CDF.
+        xis = numpy.append(xis, 1.0 if numpy.isinf(self._rmax) else ximax)
+        if is_backend_array(ms):
+            # backend context: KEEP ms a backend array so the inverse-CDF sample
+            # is differentiable in the CDF knots (interp_linear in _sample_r); the
+            # numpy path (key=None) as_numpy's it back for the byte-identical spline
+            end = as_backend_constant(xp, numpy.array([1.0]), ms)
+            concat = getattr(xp, "concat", None) or xp.concatenate
+            ms = concat([ms, end])
         else:
-            # For finite rmax, add the endpoint to ensure r <= rmax
-            xis = numpy.append(xis, ximax)
+            # numpy path: the icdf table is numpy (byte-identical scipy k=1 spline)
+            ms = as_numpy(ms)
             ms = numpy.append(ms, 1)
-        # backend-agnostic inverse-CDF: numpy queries hit the scipy spline
-        # (byte-identical); backend queries evaluate the frozen table natively
-        return Spline1D(ms, xis, k=1)
+        return ms, xis
 
-    def _sample_position_angles(self, n=1):
-        """Generate spherical angle samples"""
-        phi_samples = numpy.random.uniform(size=n) * 2 * numpy.pi
-        theta_samples = numpy.arccos(1.0 - 2 * numpy.random.uniform(size=n))
+    def _sample_position_angles(self, n=1, key=None):
+        """Generate spherical angle samples
+
+        ``key=None`` draws from the global ``numpy.random`` (byte-identical: phi
+        first, then theta); a backend key splits into two independent sub-keys and
+        returns backend arrays (analytic, differentiable in the draws)."""
+        kphi, ktheta = grandom.split(key, 2)
+        u_phi = grandom.uniform(kphi, n)
+        u_theta = grandom.uniform(ktheta, n)
+        xp = numpy if key is None else get_namespace(u_phi)
+        phi_samples = u_phi * 2.0 * numpy.pi
+        theta_samples = xp.arccos(1.0 - 2.0 * u_theta)
         return phi_samples, theta_samples
 
     def _sample_v(self, r, eta, n=1):
@@ -708,11 +779,15 @@ class sphericaldf(df):
             numpy.log10(r / self._scale), numpy.random.uniform(size=n), grid=False
         ) * as_numpy(self._vmax_at_r(self._pot, r))
 
-    def _sample_velocity_angles(self, r, n=1):
+    def _sample_velocity_angles(self, r, n=1, key=None):
         """Generate samples of angles that set radial vs tangential
-        velocities"""
-        eta_samples = self._sample_eta(r, n)
-        psi_samples = numpy.random.uniform(size=n) * 2 * numpy.pi
+        velocities
+
+        ``key=None`` draws from the global ``numpy.random`` (byte-identical: eta
+        first, then psi); a backend key splits into independent eta/psi sub-keys."""
+        keta, kpsi = grandom.split(key, 2)
+        eta_samples = self._sample_eta(r, n, key=keta)
+        psi_samples = grandom.uniform(kpsi, n) * 2.0 * numpy.pi
         return eta_samples, psi_samples
 
     def _vmax_at_r(self, pot, r, **kwargs):
@@ -1049,9 +1124,14 @@ class isotropicsphericaldf(sphericaldf):
             / special.gamma(m // 2 + n // 2 + 1.5)
         )
 
-    def _sample_eta(self, r, n=1):
-        """Sample the angle eta which defines radial vs tangential velocities"""
-        return numpy.arccos(1.0 - 2.0 * numpy.random.uniform(size=n))
+    def _sample_eta(self, r, n=1, key=None):
+        """Sample the angle eta which defines radial vs tangential velocities
+
+        Isotropic: eta is analytic (``arccos(1-2u)``). ``key=None`` is the
+        byte-identical numpy draw; a backend key returns a backend array."""
+        u = grandom.uniform(key, n)
+        xp = numpy if key is None else get_namespace(u)
+        return xp.arccos(1.0 - 2.0 * u)
 
     def _p_v_at_r(self, v, r):
         xp = resolve_namespace(v, r)

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -568,9 +568,16 @@ class sphericaldf(df):
         # dispatch the namespace on the key, NOT get_namespace(): key=None keeps
         # the whole assembly numpy (byte-identical) even under a forced backend;
         # a backend key follows its own draws into the active namespace.
+        # Split into INDEPENDENT sub-keys for the radial, position-angle, and
+        # velocity-angle draws: each angle helper re-splits its key internally, so
+        # handing the SAME key to both would make split() return identical sub-keys
+        # (velocity angles = deterministic fn of position angles -> biased joint
+        # distribution). key=None -> split returns (None, None, None) -> the global
+        # numpy generator draws sequentially -> byte-identical.
+        key_r, key_pos, key_vel = grandom.split(key, 3)
         if R is None or z is None:  # Full 6D samples
-            r = self._sample_r(n=n, key=key)
-            phi, theta = self._sample_position_angles(n=n, key=key)
+            r = self._sample_r(n=n, key=key_r)
+            phi, theta = self._sample_position_angles(n=n, key=key_pos)
             xp = numpy if key is None else get_namespace(r)
             R = r * xp.sin(theta)
             z = r * xp.cos(theta)
@@ -610,7 +617,7 @@ class sphericaldf(df):
         # gate the key on xp: the full-6D branch follows the backend key; the
         # fixed-position (R,z) branch stays numpy-side (xp is numpy there)
         eta, psi = self._sample_velocity_angles(
-            r, n=n, key=None if xp is numpy else key
+            r, n=n, key=None if xp is numpy else key_vel
         )
         # velocity magnitude is still numpy-side (_sample_v is PR-2); coerce the
         # numpy velocity pieces into xp so a backend key assembles backend
@@ -670,8 +677,9 @@ class sphericaldf(df):
             )
             xg = as_backend_constant(xp, as_numpy(xi_grid), rand_mass_frac)
             xi_samples = interp_linear(xp, cg, xg, rand_mass_frac, extrapolate="clip")
-            # r = _xiToR inlined in-namespace (numpy.divide would drop the graph)
-            r_samples = self._scale * (1.0 + xi_samples) / (1.0 - xi_samples)
+            # r = _xiToR inlined in-namespace (numpy.divide would drop the graph);
+            # parenthesized to match _xiToR's a*((1+xi)/(1-xi)) association exactly
+            r_samples = self._scale * ((1.0 + xi_samples) / (1.0 - xi_samples))
         else:
             # numpy path: byte-identical scipy k=1 inverse-CMF spline
             if not hasattr(self, "_xi_cmf_spline"):

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -782,7 +782,11 @@ class sphericaldf(df):
                 else 3
             )
             self._v_vesc_pvr_interpolator = self._make_pvr_interpolator(r_a_end=r_a_end)
-        # samples are numpy-side by design (_vmax_at_r follows a forced backend)
+        # samples are numpy-side by design (scipy interpolator; _vmax_at_r follows
+        # a forced backend); a backend-key r arrives as a backend array, so pull it
+        # numpy-side -- numpy.log10(<torch tensor>) trips the numpy-2.0
+        # __array_wrap__ deprecation (an error under the coverage shard's -W error)
+        r = as_numpy(r)
         return self._v_vesc_pvr_interpolator(
             numpy.log10(r / self._scale), numpy.random.uniform(size=n), grid=False
         ) * as_numpy(self._vmax_at_r(self._pot, r))

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -34,13 +34,18 @@ except ImportError:  # pragma: no cover
     torch = None
 
 import galpy.backend
-from galpy.df import isotropicHernquistdf
+from galpy.backend import random as grandom
+from galpy.backend.interpolate import interp_linear
+from galpy.df import eddingtondf, isotropicHernquistdf
 from galpy.df.sphericaldf import (
     anisotropicsphericaldf,
     isotropicsphericaldf,
     sphericaldf,
 )
 from galpy.potential import HernquistPotential
+
+if torch is not None:
+    import array_api_compat.torch as _TXP
 
 
 def _arr(backend, x):
@@ -357,3 +362,152 @@ def test_call_orbit_forced(backend):
     with galpy.backend.use(backend, force=True):
         got_a = ani(Orbit(ic))
     numpy.testing.assert_allclose(as_numpy(got_a), ref_a, rtol=1e-12)
+
+
+###############################################################################
+# Backend-native, differentiable radial + analytic-angle sampling via a backend
+# ``key`` (interp_linear inverse-CDF). The numpy path (key=None) is byte-
+# identical and covered by test_sphericaldf; here we exercise the backend key.
+###############################################################################
+def _key(backend, seed=7):
+    return grandom.key(seed, backend)
+
+
+def _ns(backend):
+    return jnp if backend == "jax" else _TXP
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_r_interp_linear_same_u_parity(backend):
+    # feed the SAME uniforms to interp_linear on the DF's (cdf, xi) grid under
+    # numpy vs the backend -> identical inverse-CDF samples (the whole radial
+    # sampler is a deterministic function of the uniforms)
+    xp = _ns(backend)
+    df = eddingtondf(pot=_HP)
+    df.sample(n=1, return_orbit=False)  # build the (cdf, xi) grids
+    ms, xis = df._get_cmf_grids()
+    u = numpy.random.uniform(size=400)
+    ref = interp_linear(numpy, ms, xis, u, extrapolate="clip")
+    got = interp_linear(
+        xp, _arr(backend, ms), _arr(backend, xis), _arr(backend, u), extrapolate="clip"
+    )
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-11, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_backend_key_coords_and_distribution(backend):
+    # a full sample() under a backend key returns backend-array coordinates and
+    # reproduces the analytic Hernquist mass profile + azimuthal symmetry
+    import tests.test_sphericaldf as T
+    from galpy.orbit import Orbit
+
+    df = isotropicHernquistdf(pot=_HP)
+    R, vR, vT, z, vz, phi = df.sample(n=4000, return_orbit=False, key=_key(backend))
+    for c in (R, z, phi, vR, vz, vT):
+        assert _is_backend_array(backend, c)
+    a = _HP.a
+    samp = Orbit(
+        vxvv=numpy.array(
+            [
+                as_numpy(R),
+                as_numpy(vR),
+                as_numpy(vT),
+                as_numpy(z),
+                as_numpy(vz),
+                as_numpy(phi),
+            ]
+        ).T
+    )
+    T.check_spherical_massprofile(
+        samp, lambda r: r**2.0 / (r + a) ** 2.0, 0.05, skip=1000
+    )
+    T.check_azimuthal_symmetry(samp, 1, 0.05)
+    # king also samples r backend-native via its grid _icmf
+    from galpy.df import kingdf
+
+    Rk, _, _, zk, _, _ = kingdf(W0=3.0, M=2.0, rt=1.5).sample(
+        n=1000, return_orbit=False, key=_key(backend)
+    )
+    assert _is_backend_array(backend, Rk) and _is_backend_array(backend, zk)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_r_grad_vs_fd_cdf_grid(backend):
+    # d(sample_r)/d(cdf_grid): the interp_linear inverse-CDF is differentiable in
+    # the CDF knots (the parameter-dependent quantity). Random directional AD
+    # must h-converge to a central FD of the numpy path.
+    df = eddingtondf(pot=_HP)
+    df.sample(n=1, return_orbit=False)
+    ms, xis = df._get_cmf_grids()
+    scale = _HP._scale
+    u = numpy.random.uniform(size=200)
+    rng = numpy.random.default_rng(0)
+    d = rng.standard_normal(ms.shape)
+    d /= numpy.linalg.norm(d)
+
+    def sumr_np(cdf):
+        xi = interp_linear(numpy, cdf, xis, u, extrapolate="clip")
+        return numpy.sum(scale * (1.0 + xi) / (1.0 - xi))
+
+    if backend == "jax":
+
+        def sumr(cdf):
+            xi = interp_linear(
+                jnp, cdf, jnp.asarray(xis), jnp.asarray(u), extrapolate="clip"
+            )
+            return jnp.sum(scale * (1.0 + xi) / (1.0 - xi))
+
+        g = numpy.asarray(jax.grad(sumr)(jnp.asarray(ms)))
+    else:
+        c = torch.tensor(ms, requires_grad=True)
+        xi = interp_linear(
+            _TXP, c, torch.tensor(xis), torch.tensor(u), extrapolate="clip"
+        )
+        (scale * (1.0 + xi) / (1.0 - xi)).sum().backward()
+        g = c.grad.numpy()
+    ad = float(numpy.dot(g, d))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    best = min(
+        abs(ad - (sumr_np(ms + h * d) - sumr_np(ms - h * d)) / (2 * h))
+        for h in (1e-4, 1e-5, 1e-6)
+    )
+    assert best < 1e-4 * abs(ad) + 1e-7, f"cdf-grad {backend} best={best:.2e}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_r_grad_vs_fd_scale(backend):
+    # d(sum sample_r)/d(a): Hernquist scale radius via the analytic (backend-
+    # native) _icmf, differentiated through _sample_r with a fixed backend key
+    # (CRN -> same uniforms). AD must h-converge to a central FD.
+    key = _key(backend, 3)
+
+    def make(aval):
+        d = isotropicHernquistdf(pot=HernquistPotential(amp=2.3, a=1.3))
+        d._pot.a = aval  # differentiable leaf on a fresh pot (no shared-obj leak)
+        return d
+
+    if backend == "jax":
+        g = float(
+            jax.grad(lambda a: jnp.sum(make(a)._sample_r(n=150, key=key)))(
+                jnp.asarray(1.3)
+            )
+        )
+        out = make(jnp.asarray(1.3))._sample_r(n=150, key=key)
+        u = numpy.asarray(grandom.uniform(key, 150))
+    else:
+        at = torch.tensor(1.3, requires_grad=True)
+        out = make(at)._sample_r(n=150, key=key)
+        out.sum().backward()
+        g = float(at.grad)
+        u = grandom.uniform(key, 150).numpy()
+    assert _is_backend_array(backend, out)
+    assert numpy.isfinite(g) and abs(g) > 0
+    sq = numpy.sqrt(u)
+
+    def sumr(a):
+        return numpy.sum(a * sq / (1.0 - sq))
+
+    best = min(
+        abs(g - (sumr(1.3 + h) - sumr(1.3 - h)) / (2 * h)) for h in (1e-3, 1e-4, 1e-5)
+    )
+    assert best < 1e-5 * abs(g) + 1e-7, f"scale-grad {backend} best={best:.2e}"

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -511,3 +511,48 @@ def test_sample_r_grad_vs_fd_scale(backend):
         abs(g - (sumr(1.3 + h) - sumr(1.3 - h)) / (2 * h)) for h in (1e-3, 1e-4, 1e-5)
     )
     assert best < 1e-5 * abs(g) + 1e-7, f"scale-grad {backend} best={best:.2e}"
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_backend_key_angles_independent(backend):
+    # regression: sample() must hand each angle sampler an INDEPENDENT sub-key.
+    # A prior bug passed the SAME parent key to the position- and velocity-angle
+    # samplers, which each re-split it identically -> the velocity polar angle
+    # became a deterministic function of the azimuthal position angle -> a biased
+    # joint (position, velocity) distribution. Isotropic -> E[vz] = 0, so the
+    # correlation showed up as a systematic mean(vz) offset (was ~ +0.033).
+    df = isotropicHernquistdf(pot=_HP)
+    vz = numpy.concatenate(
+        [
+            as_numpy(df.sample(n=6000, return_orbit=False, key=_key(backend, s))[4])
+            for s in (1, 2, 3)
+        ]
+    )
+    assert abs(numpy.mean(vz)) < 0.012, (
+        f"mean(vz)={numpy.mean(vz):.4f} -- correlated angle sub-keys?"
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_eddington_general_backend_reachable(backend):
+    # the general (no closed-form _icmf) interp_linear inverse-CDF branch is
+    # reachable via the public eddingtondf.sample(key=...) and returns backend
+    # coordinates -- isotropic velocity sampling is backend-native
+    coords = eddingtondf(pot=_HP).sample(n=300, return_orbit=False, key=_key(backend))
+    for c in coords:
+        assert _is_backend_array(backend, c)
+
+
+@pytest.mark.skipif(not BACKENDS, reason="no backend installed")
+def test_sample_anisotropic_backend_key_raises():
+    # anisotropic velocity-angle sampling on a backend key is deferred; a clear
+    # NotImplementedError beats a confusing TypeError / a silent numpy result.
+    # key=None (numpy) still works. Backend-independent (the guard keys off the
+    # key type), so run it once.
+    from galpy.df import constantbetadf, osipkovmerrittdf
+
+    backend = BACKENDS[0]
+    for df in (constantbetadf(pot=_HP, beta=-0.2), osipkovmerrittdf(pot=_HP, ra=1.5)):
+        with pytest.raises(NotImplementedError):
+            df.sample(n=10, return_orbit=False, key=_key(backend))
+        df.sample(n=10, return_orbit=False)  # numpy path still works


### PR DESCRIPTION
## What

Makes spherical-DF **sampling** backend-native and differentiable (jax/torch), while keeping the numpy path **byte-identical**. This is PR-1 of the df-sampling consolidation onto linear inverse-CDF (`interp_linear`).

The numpy samplers already used a **linear** inverse-CDF (`Spline1D(k=1)` / scipy `InterpolatedUnivariateSpline(k=1)`), but with *frozen* knots (not differentiable, and a numpy island). This routes the backend path through `interp_linear` on the same `(cdf, sample)` grid — same linear interpolation, now differentiable in the grid knots and the DF parameters, and jit/GPU-safe.

## Changes
- **`galpy/backend/interpolate.py`** — `interp_linear` now keeps a backend `x` (knots) *in-namespace* instead of freezing via `numpy.asarray(x)`, so it is differentiable in the knots and survives a jax trace of `x`. ⚠️ **Shared utility**: numpy/list `x` (frozen `Spline1D`, streamTrack structural grids) takes the unchanged old path → byte-identical; no existing caller passes a backend `x`.
- **`galpy/df/sphericaldf.py`** — threads a CRN `key` through `sample → _sample_r / _sample_position_angles / _sample_velocity_angles / _sample_eta`. `_sample_r` dual-paths: `key=None` → byte-identical scipy k=1 spline; a backend key → `interp_linear` on `(ms, xis)` with `r = a(1+xi)/(1-xi)` inlined in-namespace. Position/velocity assembly made namespace-aware.
- **`galpy/df/kingdf.py`** — `_icmf` scipy-spline island → dual-path (scipy for numpy byte-identity, `interp_linear` for a backend key).
- **`galpy/df/constantbetadf.py`, `osipkovmerrittdf.py`** — anisotropic `_sample_eta` accept-but-ignore `key` (kept numpy-side; deferred to a follow-up PR).
- **`tests/test_backend_sphericaldf.py`** — cross-backend `interp_linear` parity, backend-key full-sample (mass-profile + azimuthal-symmetry, incl. king), and grad-vs-FD for `d(sample_r)/d(cdf_grid)` and `d(sample_r)/d(a)`.

## Verification
- **numpy byte-identical** (`numpy.array_equal`, maxdiff 0.0) for isotropicHernquist/Plummer, eddington (general CMF), king, Hernquist+rmin — RNG stream/order unchanged.
- **cross-backend parity**: same `u` into `interp_linear` on the DF grid, numpy-vs-jax and numpy-vs-torch max rel diff 0.0.
- **grad-vs-FD**: `d(sample_r)/d(cdf_grid)` jax/torch |AD−FD| ≈ 2e-5; `d(Σsample_r)/d(a)` rel ~1e-13. Backend output confirmed.
- Backend suites green (jax+torch): sphericaldf 32/32, kingdf 22/22, eddingtondf 24/24, constantbetadf 31/31, osipkovmerritt 40/40, interpolate 117/117, streamTrack 62/62.

## Notes
- No `tests/backend_xfail.txt` edits — the win is a new capability + new passing tests, not an xfail flip.
- Deferred to follow-ups: anisotropic `_sample_eta` backend path; `constantbetadf`/`osipkovmerrittdf` full sampling; streamdf's cubic sampler → `interp_linear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm