### PR TITLE
actionAngle grids: backend-native GPU-resident spline fits (native cubic, no as_numpy)

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -14,9 +14,14 @@ import numpy
 from scipy import interpolate
 
 from .. import potential
-from ..backend import as_numpy, get_namespace
+from ..backend import (
+    as_numpy,
+    asarray_on_device,
+    device_of,
+    get_namespace,
+)
 from ..backend import interpolate as backend_interpolate
-from ..backend import promote_scalars
+from ..backend import promote_scalars, use
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -91,6 +96,15 @@ class actionAngleAdiabaticGrid(actionAngle):
         self._Rmin = 0.01
         # Set up the actionAngleAdiabatic object that we will use to interpolate
         self._aA = actionAngleAdiabatic(pot=self._pot, gamma=self._gamma, c=self._c)
+        xp = get_namespace()
+        if xp is not numpy:
+            # Forced/default backend: build the whole grid ON the backend so the
+            # frozen tables are backend arrays (GPU-resident) fit NATIVELY, and the
+            # build differentiates through to the query. numpy body below is left
+            # byte-identical (scipy).
+            self._build_grid_backend(xp, nR, nEz, nEr, nLz, numcores, **kwargs)
+            self._check_consistent_units()
+            return None
         # Build grid for Ez, first calculate Ez(zmax;R) function
         self._Rs = numpy.linspace(self._Rmin, self._Rmax, nR)
         self._EzZmaxs = _evaluatePotentials(
@@ -296,25 +310,181 @@ class actionAngleAdiabaticGrid(actionAngle):
         return None
 
     def _build_backend_interp(self, jzEzzmax, jrERRa):
-        """Wrap the fitted scipy interpolators for jax/torch evaluation."""
-        self._jzInterp_b = backend_interpolate.Spline2D(spl=self._jzInterp)
-        self._jrInterp_b = backend_interpolate.Spline2D(spl=self._jrInterp)
+        """Build the jax/torch eval wrappers from the RAW frozen tables (dual-path).
+
+        On the numpy path the tables are numpy, so the Spline1D/Spline2D wrappers
+        fit scipy internally (byte-identical to the scipy interpolators the numpy
+        ``_evaluate`` uses); on a forced backend the tables are backend arrays, so
+        the wrappers fit NATIVELY (Spline2D not-a-knot cubic) and stay backend
+        arrays, differentiable through to the query. ``bc='not-a-knot'`` matches
+        FITPACK's s=0 interpolating cubic on the mode-2 path (ignored on numpy).
+        """
+        xp = get_namespace(self._jz)
+        Rs = as_numpy(self._Rs)
+        Lzs = as_numpy(self._Lzs)
+        y_ez = numpy.linspace(0.0, 1.0, self._jz.shape[1])
+        y_er = numpy.linspace(0.0, 1.0, self._jr.shape[1])
+        # jz / jr tables are fit directly (NOT logged).
+        self._jzInterp_b = backend_interpolate.Spline2D(Rs, y_ez, self._jz)
+        self._jrInterp_b = backend_interpolate.Spline2D(Lzs, y_er, self._jr)
         self._EzZmaxsInterp_b = backend_interpolate.Spline1D(
-            self._Rs, numpy.log(self._EzZmaxs), k=3
+            Rs, xp.log(self._EzZmaxs), k=3, bc="not-a-knot"
         )
         self._jzEzmaxInterp_b = backend_interpolate.Spline1D(
-            self._Rs, numpy.log(jzEzzmax + 10.0**-5.0), k=3
+            Rs, xp.log(jzEzzmax + 10.0**-5.0), k=3, bc="not-a-knot"
         )
-        self._RLInterp_b = backend_interpolate.Spline1D(self._Lzs, self._RL, k=3)
+        self._RLInterp_b = backend_interpolate.Spline1D(
+            Lzs, self._RL, k=3, bc="not-a-knot"
+        )
         self._ERRLInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(-(self._ERRL - self._ERRLmax)), k=3
+            Lzs, xp.log(-(self._ERRL - self._ERRLmax)), k=3, bc="not-a-knot"
         )
         self._ERRaInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(-(self._ERRa - self._ERRamax)), k=3
+            Lzs, xp.log(-(self._ERRa - self._ERRamax)), k=3, bc="not-a-knot"
         )
         self._jrERRaInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(jrERRa + 10.0**-5.0), k=3
+            Lzs, xp.log(jrERRa + 10.0**-5.0), k=3, bc="not-a-knot"
         )
+        return None
+
+    def _build_grid_backend(self, xp, nR, nEz, nEr, nLz, numcores, **kwargs):
+        """Backend (jax/torch) counterpart of the numpy grid build.
+
+        Produces the SAME frozen-table attributes as the numpy path
+        (``_Rs, _EzZmaxs, _jz, _Lzs, _RL, _ERRL, _ERRa, _jr`` + the derived
+        maxima) as BACKEND arrays fit NATIVELY, so the tables are GPU-resident
+        and the build differentiates through to the query. The non-differentiable
+        per-orbit solvers (``rl``, the c=False ``actionAngleAdiabatic`` loop) run
+        as on numpy; the vectorised c=True action solve returns backend arrays
+        directly. Values match the numpy(scipy) grid to grid-parity tolerance.
+        """
+        # --- Ez grid ---
+        self._Rs = asarray_on_device(
+            xp, numpy.linspace(self._Rmin, self._Rmax, nR), None
+        )
+        self._EzZmaxs = _evaluatePotentials(
+            self._pot, self._Rs, self._zmax * xp.ones(nR)
+        ) - _evaluatePotentials(self._pot, self._Rs, xp.zeros(nR))
+        dev = device_of(self._EzZmaxs)
+        y = asarray_on_device(xp, numpy.linspace(0.0, 1.0, nEz), dev)
+        thisRs = _tileT_flat(xp, self._Rs, nEz)
+        thisEzZmaxs = _tileT_flat(xp, self._EzZmaxs, nEz)
+        this = xp.reshape(xp.tile(y, (nR, 1)), (-1,))
+        if self._c:
+            jz = self._aA(
+                thisRs,
+                xp.zeros(nR * nEz),
+                xp.ones(nR * nEz),  # these two r dummies
+                xp.zeros(nR * nEz),
+                xp.sqrt(2.0 * this * thisEzZmaxs),
+                **kwargs,
+            )[2]
+            jz = xp.reshape(jz, (nR, nEz))
+        else:
+            # c=False actionAngleAdiabatic per-point loop: run as numpy, bring back.
+            with use("numpy", force=True):
+                Rs_np = as_numpy(self._Rs)
+                Ez_np = as_numpy(self._EzZmaxs)
+                y_np = as_numpy(y)
+                jz_np = numpy.zeros((nR, nEz))
+                for ii in range(nR):
+                    for jj in range(nEz):
+                        jz_np[ii, jj] = self._aA(
+                            Rs_np[ii],
+                            0.0,
+                            1.0,
+                            0.0,
+                            numpy.sqrt(2.0 * y_np[jj] * Ez_np[ii]),
+                            _justjz=True,
+                            **kwargs,
+                        )[2][0]
+            jz = asarray_on_device(xp, jz_np, dev)
+        jzEzzmax = jz[:, nEz - 1]
+        jz = jz / jzEzzmax[:, None]
+        self._jz = jz
+        # --- JR grid ---
+        self._Lzmin = 0.01
+        vc = potential.vcirc(self._pot, self._Rmax)
+        frac = asarray_on_device(xp, numpy.linspace(0.0, 1.0, nLz), dev)
+        self._Lzs = self._Lzmin + frac * (self._Rmax * vc - self._Lzmin)
+        self._Lzmax = self._Lzs[-1]
+        with use("numpy", force=True):
+            RL_np = numpy.array(
+                [potential.rl(self._pot, as_numpy(l)) for l in self._Lzs]
+            )
+        self._RL = asarray_on_device(xp, RL_np, dev)
+        self._ERRL = (
+            _evaluatePotentials(self._pot, self._RL, xp.zeros(nLz))
+            + self._Lzs**2.0 / 2.0 / self._RL**2.0
+        )
+        self._ERRLmax = xp.max(self._ERRL) + 1.0
+        self._Ramax = 99.0
+        self._ERRa = (
+            _evaluatePotentials(self._pot, self._Ramax, 0.0)
+            + self._Lzs**2.0 / 2.0 / self._Ramax**2.0
+        )
+        self._ERRamax = xp.max(self._ERRa) + 1.0
+        y = asarray_on_device(xp, numpy.linspace(0.0, 1.0, nEr), dev)
+        thisRL = _tileT_flat(xp, self._RL, nEr - 1)
+        thisLzs = _tileT_flat(xp, self._Lzs, nEr - 1)
+        thisERRL = _tileT_flat(xp, self._ERRL, nEr - 1)
+        thisERRa = _tileT_flat(xp, self._ERRa, nEr - 1)
+        this = xp.reshape(xp.tile(y[0:-1], (nLz, 1)), (-1,))
+        if self._c:
+            mjr = self._aA(
+                thisRL,
+                xp.sqrt(
+                    2.0
+                    * (
+                        thisERRa
+                        + this * (thisERRL - thisERRa)
+                        - _evaluatePotentials(
+                            self._pot, thisRL, xp.zeros((nEr - 1) * nLz)
+                        )
+                    )
+                    - thisLzs**2.0 / thisRL**2.0
+                ),
+                thisLzs / thisRL,
+                xp.zeros((nEr - 1) * nLz),
+                xp.zeros((nEr - 1) * nLz),
+                **kwargs,
+            )[0]
+            mjr = xp.reshape(mjr, (nLz, nEr - 1))
+        else:
+            with use("numpy", force=True):
+                RL_np = as_numpy(self._RL)
+                Lzs_np = as_numpy(self._Lzs)
+                ERRL_np = as_numpy(self._ERRL)
+                ERRa_np = as_numpy(self._ERRa)
+                y_np = as_numpy(y)
+                mjr_np = numpy.zeros((nLz, nEr - 1))
+                for ii in range(nLz):
+                    for jj in range(nEr - 1):
+                        mjr_np[ii, jj] = self._aA(
+                            RL_np[ii],
+                            numpy.sqrt(
+                                2.0
+                                * (
+                                    ERRa_np[ii]
+                                    + y_np[jj] * (ERRL_np[ii] - ERRa_np[ii])
+                                    - _evaluatePotentials(self._pot, RL_np[ii], 0.0)
+                                )
+                                - Lzs_np[ii] ** 2.0 / RL_np[ii] ** 2.0
+                            ),
+                            Lzs_np[ii] / RL_np[ii],
+                            0.0,
+                            0.0,
+                            _justjr=True,
+                            **kwargs,
+                        )[0][0]
+            mjr = asarray_on_device(xp, mjr_np, dev)
+        # last Er column is zero by construction
+        jr = xp.concat([mjr, xp.zeros((nLz, 1))], axis=1)
+        jrERRa = jr[:, 0]
+        jr = jr / jrERRa[:, None]
+        self._jr = jr
+        # native fits + backend eval wrappers
+        self._build_backend_interp(jzEzzmax, jrERRa)
         return None
 
     def _evaluate(self, *args, **kwargs):
@@ -553,6 +723,19 @@ class actionAngleAdiabaticGrid(actionAngle):
 
         """
         self._parse_eval_args(*args)
+        xp = get_namespace(
+            self._eval_R, self._eval_vR, self._eval_vT, self._eval_z, self._eval_vz
+        )
+        if xp is not numpy:  # jax/torch: on-grid backend eval (no scipy fits built)
+            R, vR, vT, z, vz = promote_scalars(
+                xp,
+                self._eval_R,
+                self._eval_vR,
+                self._eval_vT,
+                self._eval_z,
+                self._eval_vz,
+            )
+            return self._evaluate_backend(R, vR, vT, z, vz)[2]
         Phi = _evaluatePotentials(self._pot, self._eval_R, self._eval_z)
         Phio = _evaluatePotentials(self._pot, self._eval_R, 0.0)
         Ez = Phi - Phio + self._eval_vz**2.0 / 2.0
@@ -580,3 +763,9 @@ class actionAngleAdiabaticGrid(actionAngle):
                 * (numpy.exp(self._jzEzmaxInterp(self._eval_R)) - 10.0**-5.0)
             )[0][0]
         return jz
+
+
+def _tileT_flat(xp, a, reps):
+    """``(tile(a, (reps, 1)).T).flatten()`` -- the numpy grid-tiling idiom, in xp.
+    ``a`` is 1-D (n,); returns (n*reps,) with ``a`` varying slowest."""
+    return xp.reshape(xp.matrix_transpose(xp.tile(a, (reps, 1))), (-1,))

--- a/galpy/actionAngle/actionAngleStaeckelGrid.py
+++ b/galpy/actionAngle/actionAngleStaeckelGrid.py
@@ -424,7 +424,11 @@ class actionAngleStaeckelGrid(actionAngle):
         C kernel, the ``actionAngleStaeckel`` action solve) run as they do on
         numpy; their outputs are brought onto the backend for the elementwise
         energy math and the native fits. The values match the numpy(scipy) grid
-        to grid-parity tolerance. Reductions/clips use ``xp.where``/``xp.max``
+        to grid-parity tolerance; the fit-produced tables agree to ~1e-13, while
+        the ``_u0``-derived tables agree to ~1e-7 because ``calcu0`` is
+        ill-conditioned (a 1-ULP-reorder difference in the energy handed to the
+        root-find amplifies ~1e8 -- a benign floating-point sensitivity, not a
+        native-fit error). Reductions/clips use ``xp.where``/``xp.max``
         (numpy's in-place boolean-index writes are jax-immutable).
         """
         vc = potential.vcirc(self._pot, self._Rmax)

--- a/galpy/actionAngle/actionAngleStaeckelGrid.py
+++ b/galpy/actionAngle/actionAngleStaeckelGrid.py
@@ -14,9 +14,14 @@ import numpy
 from scipy import interpolate, ndimage, optimize
 
 from .. import potential
-from ..backend import get_namespace
+from ..backend import (
+    as_numpy,
+    asarray_on_device,
+    device_of,
+    get_namespace,
+)
 from ..backend import interpolate as backend_interpolate
-from ..backend import is_backend_array, promote_scalars
+from ..backend import is_backend_array, promote_scalars, use
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -98,6 +103,15 @@ class actionAngleStaeckelGrid(actionAngle):
         )
         # Build grid
         self._Lzmin = 0.01
+        xp = get_namespace()
+        if xp is not numpy:
+            # Forced/default backend: build the whole grid ON the backend so the
+            # frozen tables are backend arrays (GPU-resident) fit NATIVELY, and the
+            # grid build differentiates through to the query. The numpy body below
+            # is left byte-identical (scipy).
+            self._build_grid_backend(xp, nE, npsi, nLz, numcores, interpecc)
+            self._check_consistent_units()
+            return None
         self._Lzs = numpy.linspace(
             self._Lzmin, self._Rmax * potential.vcirc(self._pot, self._Rmax), nLz
         )
@@ -339,52 +353,285 @@ class actionAngleStaeckelGrid(actionAngle):
         return None
 
     def _build_backend_interp(self, y, interpecc):
-        """Wrap the fitted scipy interpolators for jax/torch evaluation (numpy
-        path is byte-identical -- the wrappers delegate to scipy on numpy input).
+        """Build the jax/torch eval wrappers from the RAW frozen tables (dual-path).
+
+        On the numpy path the tables are numpy, so the Spline1D/Spline2D/
+        MapCoordinates wrappers fit scipy internally and are byte-identical to the
+        scipy interpolators used by the numpy ``_evaluate``; on a forced backend
+        the tables are backend arrays, so the wrappers fit NATIVELY (Spline2D
+        not-a-knot cubic, native spline_filter) and stay backend arrays,
+        differentiable through to the query. ``bc='not-a-knot'`` matches FITPACK's
+        s=0 interpolating cubic on the backend (mode-2) path; it is ignored on the
+        numpy (scipy) path.
         """
-        self._logu0Interp_b = backend_interpolate.Spline2D(spl=self._logu0Interp)
+        xp = get_namespace(self._u0)  # numpy or the forced/data backend
+        Lz_geom = as_numpy(self._Lzs)  # fit x-geometry (breakpoints) is numpy
+        self._logu0Interp_b = backend_interpolate.Spline2D(
+            Lz_geom, as_numpy(y), xp.log(self._u0)
+        )
         self._jrLzInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(self._jrLzE + 10.0**-5.0), k=3
+            Lz_geom, xp.log(self._jrLzE + 10.0**-5.0), k=3, bc="not-a-knot"
         )
         self._jzLzInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(self._jzLzE + 10.0**-5.0), k=3
+            Lz_geom, xp.log(self._jzLzE + 10.0**-5.0), k=3, bc="not-a-knot"
         )
         self._ERLInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(-(self._ERL - self._ERLmax)), k=3
+            Lz_geom, xp.log(-(self._ERL - self._ERLmax)), k=3, bc="not-a-knot"
         )
         self._ERaInterp_b = backend_interpolate.Spline1D(
-            self._Lzs, numpy.log(-(self._ERa - self._ERamax)), k=3
+            Lz_geom, xp.log(-(self._ERa - self._ERamax)), k=3, bc="not-a-knot"
         )
         # The filtered grids feed the backend cubic map_coordinates (mode/order
         # matching the scipy calls in _evaluate/_EccZmaxRperiRap).
         self._jrMap_b = backend_interpolate.MapCoordinates(
-            numpy.log(self._jr + 10.0**-10.0)
+            xp.log(self._jr + 10.0**-10.0)
         )
         self._jzMap_b = backend_interpolate.MapCoordinates(
-            numpy.log(self._jz + 10.0**-10.0)
+            xp.log(self._jz + 10.0**-10.0)
         )
         if interpecc:
             self._zmaxLzInterp_b = backend_interpolate.Spline1D(
-                self._Lzs, numpy.log(self._zmaxLzE + 10.0**-5.0), k=3
+                Lz_geom, xp.log(self._zmaxLzE + 10.0**-5.0), k=3, bc="not-a-knot"
             )
             self._rperiLzInterp_b = backend_interpolate.Spline1D(
-                self._Lzs, numpy.log(self._rperiLzE + 10.0**-5.0), k=3
+                Lz_geom, xp.log(self._rperiLzE + 10.0**-5.0), k=3, bc="not-a-knot"
             )
             self._rapLzInterp_b = backend_interpolate.Spline1D(
-                self._Lzs, numpy.log(self._rapLzE + 10.0**-5.0), k=3
+                Lz_geom, xp.log(self._rapLzE + 10.0**-5.0), k=3, bc="not-a-knot"
             )
             self._eccMap_b = backend_interpolate.MapCoordinates(
-                numpy.log(self._ecc + 10.0**-10.0)
+                xp.log(self._ecc + 10.0**-10.0)
             )
             self._zmaxMap_b = backend_interpolate.MapCoordinates(
-                numpy.log(self._zmax + 10.0**-10.0)
+                xp.log(self._zmax + 10.0**-10.0)
             )
             self._rperiMap_b = backend_interpolate.MapCoordinates(
-                numpy.log(self._rperi + 10.0**-10.0)
+                xp.log(self._rperi + 10.0**-10.0)
             )
             self._rapMap_b = backend_interpolate.MapCoordinates(
-                numpy.log(self._rap + 10.0**-10.0)
+                xp.log(self._rap + 10.0**-10.0)
             )
+        return None
+
+    def _build_grid_backend(self, xp, nE, npsi, nLz, numcores, interpecc):
+        """Backend (jax/torch) counterpart of the numpy grid build.
+
+        Produces the SAME frozen-table attributes as the numpy path
+        (``_Lzs, _RL, _ERL, _ERa, _u0, _jr, _jz, _jrLzE, _jzLzE`` + the interpecc
+        analogues), but as BACKEND arrays fit NATIVELY -- so the tables are
+        GPU-resident and the grid build differentiates through to the query. The
+        non-differentiable per-orbit solvers (``rl``, the ``calcu0`` root-find /
+        C kernel, the ``actionAngleStaeckel`` action solve) run as they do on
+        numpy; their outputs are brought onto the backend for the elementwise
+        energy math and the native fits. The values match the numpy(scipy) grid
+        to grid-parity tolerance. Reductions/clips use ``xp.where``/``xp.max``
+        (numpy's in-place boolean-index writes are jax-immutable).
+        """
+        vc = potential.vcirc(self._pot, self._Rmax)
+        dev = device_of(vc)
+        # --- Lz grid (differentiable in Lzmax = Rmax*vcirc) ---
+        frac = asarray_on_device(xp, numpy.linspace(0.0, 1.0, nLz), dev)
+        self._Lzs = self._Lzmin + frac * (self._Rmax * vc - self._Lzmin)
+        self._Lzmax = self._Lzs[-1]
+        self._nLz = nLz
+        # rl root-find (non-differentiable) -> RL, brought onto the backend
+        with use("numpy", force=True):
+            RL_np = numpy.array(
+                [potential.rl(self._pot, as_numpy(l)) for l in self._Lzs]
+            )
+        self._RL = asarray_on_device(xp, RL_np, dev)
+        self._ERL = (
+            _evaluatePotentials(self._pot, self._RL, xp.zeros(self._nLz))
+            + self._Lzs**2.0 / 2.0 / self._RL**2.0
+        )
+        self._ERLmax = xp.max(self._ERL) + 1.0
+        self._Ramax = 200.0 / 8.0
+        self._ERa = (
+            _evaluatePotentials(self._pot, self._Ramax, 0.0)
+            + self._Lzs**2.0 / 2.0 / self._Ramax**2.0
+        )
+        self._ERamax = xp.max(self._ERa) + 1.0
+        y = asarray_on_device(xp, numpy.linspace(0.0, 1.0, nE), dev)
+        self._nE = nE
+        psis = asarray_on_device(
+            xp, numpy.linspace(0.0, 1.0, npsi) * numpy.pi / 2.0, dev
+        )
+        self._npsi = npsi
+        # --- u0 grid (via the numpy calcu0 solver) ---
+        thisLzs = _tileT_flat(xp, self._Lzs, nE)
+        thisERL = _tileT_flat(xp, self._ERL, nE)
+        thisERa = _tileT_flat(xp, self._ERa, nE)
+        this = xp.reshape(xp.tile(y, (nLz, 1)), (-1,))
+        thisE = _invEfunc(
+            _Efunc(thisERa, thisERL)
+            + this * (_Efunc(thisERL, thisERL) - _Efunc(thisERa, thisERL)),
+            thisERL,
+        )
+        if isinstance(self._pot, potential.interpRZPotential) and hasattr(
+            self._pot, "_origPot"
+        ):
+            u0pot = self._pot._origPot
+        else:
+            u0pot = self._pot
+        with use("numpy", force=True):
+            thisE_np = as_numpy(thisE)
+            thisLzs_np = as_numpy(thisLzs)
+            if self._c:
+                mu0 = actionAngleStaeckel_c.actionAngleStaeckel_calcu0(
+                    thisE_np, thisLzs_np, u0pot, self._delta
+                )[0]
+            else:
+                mu0 = numpy.array(
+                    [self.calcu0(thisE_np[x], thisLzs_np[x]) for x in range(nE * nLz)]
+                )
+        u0 = asarray_on_device(xp, numpy.reshape(mu0, (nLz, nE)), dev)
+        thisR = self._delta * xp.sinh(u0)
+        thisv = xp.reshape(
+            self.vatu0(
+                xp.reshape(thisE, (-1,)),
+                xp.reshape(thisLzs, (-1,)),
+                xp.reshape(u0, (-1,)),
+                xp.reshape(thisR, (-1,)),
+            ),
+            (nLz, nE),
+        )
+        self.thisv = thisv
+        # tile over psi (mirrors the numpy layout exactly)
+        thisLzs = xp.reshape(thisLzs, (nLz, nE))
+        thispsi = xp.reshape(xp.tile(psis, (nLz, nE, 1)), (-1,))
+        thisLzs = xp.reshape(
+            _revT(xp, xp.tile(_revT(xp, thisLzs), (npsi, 1, 1))), (-1,)
+        )
+        thisR = xp.reshape(_revT(xp, xp.tile(_revT(xp, thisR), (npsi, 1, 1))), (-1,))
+        thisv = xp.reshape(_revT(xp, xp.tile(_revT(xp, thisv), (npsi, 1, 1))), (-1,))
+        mjr, mlz, mjz = self._aA(
+            thisR,
+            thisv * xp.cos(thispsi),
+            thisLzs / thisR,
+            xp.zeros(thisR.shape[0]),
+            thisv * xp.sin(thispsi),
+            fixed_quad=True,
+        )
+        if interpecc:
+            mecc, mzmax, mrperi, mrap = self._aA.EccZmaxRperiRap(
+                thisR,
+                thisv * xp.cos(thispsi),
+                thisLzs / thisR,
+                xp.zeros(thisR.shape[0]),
+                thisv * xp.sin(thispsi),
+            )
+        if isinstance(self._pot, potential.interpRZPotential) and hasattr(
+            self._pot, "_origPot"
+        ):
+            # Interpolated potentials have problems with extreme orbits: recompute
+            # the 9999.99 flags with the original potential (rare; numpy solver).
+            bad = (mjr == 9999.99) | (mjz == 9999.99)
+            if int(as_numpy(xp.sum(bad))) > 0:
+                bad_np = as_numpy(bad)
+                with use("numpy", force=True):
+                    tmpaA = actionAngleStaeckel.actionAngleStaeckel(
+                        pot=self._pot._origPot, delta=self._delta, c=self._c
+                    )
+                    R_np = as_numpy(thisR)
+                    v_np = as_numpy(thisv)
+                    psi_np = as_numpy(thispsi)
+                    Lz_np = as_numpy(thisLzs)
+                    rjr, _, rjz = tmpaA(
+                        R_np[bad_np],
+                        v_np[bad_np] * numpy.cos(psi_np[bad_np]),
+                        Lz_np[bad_np] / R_np[bad_np],
+                        numpy.zeros(int(bad_np.sum())),
+                        v_np[bad_np] * numpy.sin(psi_np[bad_np]),
+                        fixed_quad=True,
+                    )
+                    mjr_np = as_numpy(mjr).copy()
+                    mjz_np = as_numpy(mjz).copy()
+                    mjr_np[bad_np] = rjr
+                    mjz_np[bad_np] = rjz
+                mjr = asarray_on_device(xp, mjr_np, dev)
+                mjz = asarray_on_device(xp, mjz_np, dev)
+                if interpecc:
+                    with use("numpy", force=True):
+                        recc, rzmax, rrperi, rrap = tmpaA.EccZmaxRperiRap(
+                            R_np[bad_np],
+                            v_np[bad_np] * numpy.cos(psi_np[bad_np]),
+                            Lz_np[bad_np] / R_np[bad_np],
+                            numpy.zeros(int(bad_np.sum())),
+                            v_np[bad_np] * numpy.sin(psi_np[bad_np]),
+                        )
+                        mecc_np = as_numpy(mecc).copy()
+                        mzmax_np = as_numpy(mzmax).copy()
+                        mrperi_np = as_numpy(mrperi).copy()
+                        mrap_np = as_numpy(mrap).copy()
+                        mecc_np[bad_np] = recc
+                        mzmax_np[bad_np] = rzmax
+                        mrperi_np[bad_np] = rrperi
+                        mrap_np[bad_np] = rrap
+                    mecc = asarray_on_device(xp, mecc_np, dev)
+                    mzmax = asarray_on_device(xp, mzmax_np, dev)
+                    mrperi = asarray_on_device(xp, mrperi_np, dev)
+                    mrap = asarray_on_device(xp, mrap_np, dev)
+        jr = xp.reshape(mjr, (nLz, nE, npsi))
+        jz = xp.reshape(mjz, (nLz, nE, npsi))
+        if interpecc:
+            ecc = xp.reshape(mecc, (nLz, nE, npsi))
+            zmax = xp.reshape(mzmax, (nLz, nE, npsi))
+            rperi = xp.reshape(mrperi, (nLz, nE, npsi))
+            rap = xp.reshape(mrap, (nLz, nE, npsi))
+        # per-Lz maxima (nanmax over the non-9999.99 / finite entries)
+        jrLzE = xp.stack([_nanmax_ne(xp, jr[ii], 9999.99) for ii in range(nLz)])
+        jzLzE = xp.stack([_nanmax_ne(xp, jz[ii], 9999.99) for ii in range(nLz)])
+        jrLzE = _fill_zeros_minpos(xp, jrLzE)
+        jzLzE = _fill_zeros_minpos(xp, jzLzE)
+        if interpecc:
+            zmaxLzE = xp.stack([_max_finite(xp, zmax[ii]) for ii in range(nLz)])
+            rperiLzE = xp.stack([_max_finite(xp, rperi[ii]) for ii in range(nLz)])
+            rapLzE = xp.stack([_max_finite(xp, rap[ii]) for ii in range(nLz)])
+            zmaxLzE = _fill_zeros_minpos(xp, zmaxLzE)
+            rperiLzE = _fill_zeros_minpos(xp, rperiLzE)
+            rapLzE = _fill_zeros_minpos(xp, rapLzE)
+        # normalize + clamp (jr>1 -> 1; NaN -> 0)
+        jr = jr / jrLzE[:, None, None]
+        jz = jz / jzLzE[:, None, None]
+        jr = xp.where(jr > 1.0, 1.0, jr)
+        jz = xp.where(jz > 1.0, 1.0, jz)
+        jr = xp.where(xp.isnan(jr), 0.0, jr)
+        jz = xp.where(xp.isnan(jz), 0.0, jz)
+        if interpecc:
+            # ecc is NOT normalized by a per-Lz maximum (unlike zmax/rperi/rap).
+            zmax = zmax / zmaxLzE[:, None, None]
+            rperi = rperi / rperiLzE[:, None, None]
+            rap = rap / rapLzE[:, None, None]
+            ecc = xp.where(ecc < 0.0, 0.0, ecc)
+            ecc = xp.where(ecc > 1.0, 1.0, ecc)
+            ecc = xp.where(xp.isnan(ecc), 0.0, ecc)
+            ecc = xp.where(xp.isinf(ecc), 1.0, ecc)
+            zmax = xp.where(zmax > 1.0, 1.0, zmax)
+            zmax = xp.where(xp.isnan(zmax), 0.0, zmax)
+            zmax = xp.where(xp.isinf(zmax), 1.0, zmax)
+            rperi = xp.where(rperi > 1.0, 1.0, rperi)
+            rperi = xp.where(xp.isnan(rperi), 0.0, rperi)
+            rperi = xp.where(xp.isinf(rperi), 0.0, rperi)
+            rap = xp.where(rap > 1.0, 1.0, rap)
+            rap = xp.where(xp.isnan(rap), 0.0, rap)
+            rap = xp.where(xp.isinf(rap), 1.0, rap)
+        # store the frozen tables (backend arrays)
+        self._jr = jr
+        self._jz = jz
+        self._u0 = u0
+        self._jrLzE = jrLzE
+        self._jzLzE = jzLzE
+        if interpecc:
+            self._ecc = ecc
+            self._zmax = zmax
+            self._rperi = rperi
+            self._rap = rap
+            self._zmaxLzE = zmaxLzE
+            self._rperiLzE = rperiLzE
+            self._rapLzE = rapLzE
+        # native fits + backend eval wrappers (no scipy fits: numpy _evaluate is
+        # never reached under a forced backend)
+        self._build_backend_interp(y, interpecc)
         return None
 
     def _evaluate(self, *args, **kwargs):
@@ -1104,4 +1351,39 @@ def _Efunc(E, *args):
 def _invEfunc(Ef, *args):
     """Inverse of Efunc"""
     #    return Ef**2.+args[0]
-    return numpy.exp(Ef) + args[0] - 10.0**-10.0
+    xp = get_namespace(Ef) if is_backend_array(Ef) else numpy
+    return xp.exp(Ef) + args[0] - 10.0**-10.0
+
+
+def _revT(xp, a):
+    """Full-axis-reversing transpose (numpy ``.T`` for any ndim), namespace-generic."""
+    return xp.permute_dims(a, tuple(reversed(range(a.ndim))))
+
+
+def _tileT_flat(xp, a, reps):
+    """``(tile(a, (reps, 1)).T).flatten()`` -- the numpy grid-tiling idiom, in xp.
+    ``a`` is 1-D (n,); returns (n*reps,) with ``a`` varying slowest."""
+    return xp.reshape(xp.matrix_transpose(xp.tile(a, (reps, 1))), (-1,))
+
+
+def _nanmax_ne(xp, slc, exclude):
+    """``nanmax`` over the entries of ``slc`` that are neither NaN nor ``exclude``
+    (matches ``numpy.nanmax(slc[slc != exclude])`` on the physical grid, where at
+    least one valid entry remains)."""
+    neg_inf = asarray_on_device(xp, numpy.array(-numpy.inf), device_of(slc))
+    masked = xp.where((slc != exclude) & ~xp.isnan(slc), slc, neg_inf)
+    return xp.max(masked)
+
+
+def _max_finite(xp, slc):
+    """``numpy.amax(slc[numpy.isfinite(slc)])`` -- max over the finite entries."""
+    neg_inf = asarray_on_device(xp, numpy.array(-numpy.inf), device_of(slc))
+    return xp.max(xp.where(xp.isfinite(slc), slc, neg_inf))
+
+
+def _fill_zeros_minpos(xp, a):
+    """Replace zero entries with the minimum strictly-positive entry (mirrors
+    ``a[a == 0.0] = numpy.nanmin(a[a > 0.0])``)."""
+    pos_inf = asarray_on_device(xp, numpy.array(numpy.inf), device_of(a))
+    minpos = xp.min(xp.where(a > 0.0, a, pos_inf))
+    return xp.where(a == 0.0, minpos, a)

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -53,6 +53,7 @@ __all__ = [
     "eval_cubic",
     "interp_linear",
     "rect_bivariate_to_ppoly",
+    "native_rect_cubic_coeffs",
     "eval_rect_ppoly",
     "spline_filter",
     "map_coordinates",
@@ -376,6 +377,50 @@ def rect_bivariate_to_ppoly(spl):
     return xbr, ybr, out
 
 
+def native_rect_cubic_coeffs(xp, x, y, z):
+    """Native tensor-product not-a-knot cubic fit matching ``RectBivariateSpline``.
+
+    ``RectBivariateSpline(x, y, z, kx=3, ky=3, s=0)`` (FITPACK ``regrid_smth``) is
+    a tensor product of 1D interpolating cubic B-splines; for ``s=0`` FITPACK
+    places its interior knots at the data points ``x[2..n-3]``, which is exactly
+    NOT-A-KNOT placement -- so the fit is the tensor product of two not-a-knot 1D
+    cubics, separable on a full grid. This builds that block ENTIRELY in ``xp``
+    (two batched calls to :func:`cubic_spline_coeffs`), returning ``(xbr, ybr, c)``
+    in the :func:`eval_rect_ppoly` layout (``xbr`` ``(nx,)``, ``ybr`` ``(ny,)``,
+    ``c`` ``(4, 4, nx-1, ny-1)``). Matches ``RectBivariateSpline.ev`` to ~2e-15
+    and is differentiable w.r.t. the grid VALUES ``z`` (the point of going
+    native: the frozen scipy fit severs that gradient). The numpy path keeps
+    using scipy via :func:`rect_bivariate_to_ppoly` (byte-identical); this is the
+    jax/torch fit. ``x``/``y`` are grid geometry (numpy); ``z`` is ``(nx, ny)``.
+
+    Step 1 fits a not-a-knot cubic in X for every y-column at once -> x-power
+    coefficients ``cx`` ``(4, nx-1, ny)``. Step 2 fits, for each x-power, a
+    not-a-knot cubic in Y across the ``ny`` columns (again batched over the x
+    intervals): fixing the x-cell, each x-power coefficient is itself the unique
+    not-a-knot Y-interpolant of its grid values, so the tensor product is exact.
+    """
+    x = numpy.asarray(x, dtype=float)
+    y = numpy.asarray(y, dtype=float)
+    dev = device_of(z)
+    # step 1: not-a-knot cubic in X for all ny columns -> (4, nx-1, ny)
+    cx = cubic_spline_coeffs(xp, x, z, bc="not-a-knot")
+    # step 2: for each x-power px, not-a-knot cubic in Y across the columns. Feed
+    # cx[px] transposed to (ny, nx-1) so the batched (2-D y) solve fits one Y
+    # spline per x-interval -> (4, ny-1, nx-1); swap back to (4, nx-1, ny-1).
+    rows = [
+        xp.swapaxes(
+            cubic_spline_coeffs(xp, y, xp.swapaxes(cx[px], -1, -2), bc="not-a-knot"),
+            -1,
+            -2,
+        )
+        for px in range(4)
+    ]
+    c = xp.stack(rows, axis=0)  # (4, 4, nx-1, ny-1)
+    xbr = asarray_on_device(xp, x, dev)
+    ybr = asarray_on_device(xp, y, dev)
+    return xbr, ybr, c
+
+
 def eval_rect_ppoly(xp, xbr, ybr, c, X, Y, *, extrapolate=True):
     """Evaluate a tensor-product piecewise polynomial at points ``(X, Y)``.
 
@@ -426,23 +471,146 @@ def eval_rect_ppoly(xp, xbr, ybr, c, X, Y, *, extrapolate=True):
 #       scipy.ndimage.map_coordinates(filtered, coords, order=3, prefilter=False).
 #
 #   This is the StaeckelGrid jr/jz/ecc/zmax/rperi/rap evaluator. As in the
-#   design for the splines above, the EXPENSIVE part -- the spline PREFILTER --
-#   is done ONCE at setup in numpy via scipy.ndimage.spline_filter (so the
-#   stored coefficient grid is byte-identical to today's grid). Only the
-#   per-query interpolation off the prefiltered coefficients is reimplemented
-#   backend-agnostically, with the SAME centred cubic B-spline kernel scipy uses
-#   -- so the backend result matches scipy.ndimage.map_coordinates to ~1e-14 and
-#   the numpy path is a literal scipy passthrough (byte-identical).
+#   design for the splines above, the per-query interpolation off the
+#   prefiltered coefficients is reimplemented backend-agnostically, with the
+#   SAME centred cubic B-spline kernel scipy uses -- so the backend result
+#   matches scipy.ndimage.map_coordinates to ~1e-14 and the numpy path is a
+#   literal scipy passthrough (byte-identical).
+#
+#   The PREFILTER itself (:func:`spline_filter`) is dual-path: a numpy grid is a
+#   literal ``scipy.ndimage.spline_filter`` passthrough (byte-identical to the
+#   grids today); a backend (jax/torch) grid is prefiltered NATIVELY through
+#   namespace ops (:func:`_spline_filter_native`), so the coefficient grid stays
+#   a backend array (GPU-resident, differentiable w.r.t. the grid VALUES) and
+#   the whole grid-table build differentiates through to the query.
 ###############################################################################
-def spline_filter(grid, order=3):
-    """Prefilter ``grid`` for cubic ``map_coordinates`` (scipy passthrough).
+# Cubic (order-3) B-spline prefilter (recursive IIR B-spline filter (Thevenaz), mode=
+# 'mirror'): single pole z1 = sqrt(3) - 2, overall gain (1-z1)(1-1/z1).
+_SPLINE_Z1_ORDER3 = numpy.sqrt(3.0) - 2.0
+_SPLINE_GAIN_ORDER3 = (1.0 - _SPLINE_Z1_ORDER3) * (1.0 - 1.0 / _SPLINE_Z1_ORDER3)
 
-    Thin wrapper over ``scipy.ndimage.spline_filter`` run at SETUP in numpy, so
-    the stored coefficient grid is byte-identical to the grids today. The
-    coefficients then feed the backend-agnostic :func:`map_coordinates` below
-    (called with ``prefilter=False`` since the prefilter happened here).
+
+def _spline_causal_init_weights(n, z):
+    """Static weights ``w`` (length ``n``) so ``init_causal = sum_i w[i] c[i]`` for
+    the mode='mirror' cubic prefilter -- a whole-sample-symmetric boundary
+    (period ``2n-2``). The init is a fixed linear combination (geometry only), so
+    it is a plain dot product: differentiable and jit-safe."""
+    i = numpy.arange(n)
+    w = numpy.zeros(n, dtype=numpy.float64)
+    w[0] = 1.0
+    w[n - 1] += z ** (n - 1)
+    mid = (i >= 1) & (i <= n - 2)
+    im = i[mid]
+    w[mid] += z**im + z ** (2 * n - 2 - im)
+    w /= 1.0 - z ** (2 * n - 2)
+    return w
+
+
+def _spline_causal_scan(xp, gained, init0, z):
+    """Causal recursion ``c[k] = gained[k] + z c[k-1]`` along the last axis
+    (``c[0] = init0``). jax uses ``lax.scan`` (so the n embedded steps roll into a
+    single traced loop); numpy/torch use a static Python loop over the short grid
+    axis. Both are differentiable w.r.t. ``gained``."""
+    L = gained.shape[-1]
+    if name_of_namespace(xp) == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        xs = jnp.moveaxis(gained[..., 1:], -1, 0)  # (L-1, ...)
+
+        def step(carry, x_k):
+            new = x_k + z * carry
+            return new, new
+
+        _, ys = jax.lax.scan(step, init0, xs)
+        ys = jnp.moveaxis(ys, 0, -1)
+        return jnp.concatenate([init0[..., None], ys], axis=-1)
+    cols = [init0]
+    prev = init0
+    for k in range(1, L):
+        prev = gained[..., k] + z * prev
+        cols.append(prev)
+    return xp.stack(cols, axis=-1)
+
+
+def _spline_anticausal_scan(xp, c, z):
+    """Anticausal recursion ``c[k] = z (c[k+1] - c[k])`` along the last axis with
+    the mode='mirror' terminal init, applied to the post-causal coefficients."""
+    L = c.shape[-1]
+    init_last = (z / (z * z - 1.0)) * (z * c[..., L - 2] + c[..., L - 1])
+    if name_of_namespace(xp) == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        xs = jnp.moveaxis(c[..., : L - 1], -1, 0)[::-1]  # c[L-2], ..., c[0]
+
+        def step(carry, c_k):
+            new = z * (carry - c_k)
+            return new, new
+
+        _, ys = jax.lax.scan(step, init_last, xs)
+        ys = jnp.moveaxis(ys, 0, -1)[..., ::-1]  # -> k=0..L-2
+        return jnp.concatenate([ys, init_last[..., None]], axis=-1)
+    cols = [None] * L
+    cols[L - 1] = init_last
+    nxt = init_last
+    for k in range(L - 2, -1, -1):
+        nxt = z * (nxt - c[..., k])
+        cols[k] = nxt
+    return xp.stack(cols, axis=-1)
+
+
+def _spline_filter1d_native(
+    xp, arr, axis, z=_SPLINE_Z1_ORDER3, gain=_SPLINE_GAIN_ORDER3
+):
+    """Native cubic (order=3) spline prefilter of ``arr`` along ``axis``, mode=
+    'mirror' -- matching ``scipy.ndimage.spline_filter1d(order=3, mode='mirror')``
+    through namespace ops (so a backend array stays a differentiable backend
+    array). ``xp.swapaxes`` brings ``axis`` to the last position for the scans."""
+    moved = xp.swapaxes(arr, axis, -1)
+    L = moved.shape[-1]
+    if L <= 1:
+        return arr
+    gained = moved * gain
+    w = _spline_causal_init_weights(L, z)
+    wv = asarray_on_device(xp, w, device_of(gained))
+    init0 = xp.sum(gained * wv, axis=-1)  # static dot over the last axis
+    caus = _spline_causal_scan(xp, gained, init0, z)
+    out = _spline_anticausal_scan(xp, caus, z)
+    return xp.swapaxes(out, axis, -1)
+
+
+def _spline_filter_native(xp, arr, z=_SPLINE_Z1_ORDER3, gain=_SPLINE_GAIN_ORDER3):
+    """Native N-D cubic spline_filter (mode='mirror'): filter along every axis.
+
+    Matches ``scipy.ndimage.spline_filter(arr, order=3)`` (~1e-13 on grid data)
+    through namespace ops, so a backend ``arr`` stays a backend array
+    differentiable w.r.t. its VALUES. The numpy path never routes here (see
+    :func:`spline_filter`); this is the jax/torch prefilter."""
+    out = arr
+    for axis in range(arr.ndim):
+        out = _spline_filter1d_native(xp, out, axis, z=z, gain=gain)
+    return out
+
+
+def spline_filter(grid, order=3):
+    """Prefilter ``grid`` for cubic ``map_coordinates`` (dual-path).
+
+    A numpy ``grid`` is a literal ``scipy.ndimage.spline_filter`` passthrough
+    (byte-identical to the grids today). A backend (jax/torch) ``grid`` is
+    prefiltered NATIVELY via :func:`_spline_filter_native`, so the coefficient
+    grid stays a backend array (GPU-resident and differentiable w.r.t. the grid
+    values) -- this is what lets an action-angle grid table build entirely on the
+    backend and differentiate through to the query. The coefficients then feed
+    the backend-agnostic :func:`map_coordinates` below (with ``prefilter=False``,
+    since the prefilter happened here). Only order=3 is supported on the backend
+    path (galpy's only use); the numpy path forwards any order to scipy.
     """
-    return _scipy_ndimage.spline_filter(numpy.asarray(grid), order=order)
+    if not is_backend_array(grid):
+        return _scipy_ndimage.spline_filter(numpy.asarray(grid), order=order)
+    if order != 3:  # pragma: no cover - galpy only uses cubic on the backend path
+        raise NotImplementedError("backend spline_filter only implements order=3")
+    return _spline_filter_native(get_namespace(grid), grid)
 
 
 def _cubic_bspline_weights(xp, f):
@@ -545,8 +713,11 @@ def map_coordinates(filtered, coords, order=3, mode="nearest", prefilter=False):
     import array_api_compat
 
     xp = array_api_compat.array_namespace(coords)
-    dev = device_of(coords)
-    cb = asarray_on_device(xp, numpy.asarray(filtered), dev)
+    dev = device_of(coords, filtered)
+    # A backend ``filtered`` (native prefilter, GPU-resident/differentiable) stays
+    # on its backend; a numpy ``filtered`` is materialised onto the coords' device.
+    filt = filtered if is_backend_array(filtered) else numpy.asarray(filtered)
+    cb = asarray_on_device(xp, filt, dev)
     shape = cb.shape
     D = cb.ndim
     # coords is (D, M): split into per-dimension rows. base = floor index, frac =
@@ -777,12 +948,24 @@ class _Spline1DDerivative:
 class Spline2D:
     """Backend-agnostic 2D tensor-product spline over a rectangular grid.
 
-    Frozen (mode 1) only: built from a grid ``(x, y, z)`` or a pre-fitted scipy
-    ``RectBivariateSpline``, and frozen to a tensor-product power-basis block.
-    ``__call__(X, Y)`` on numpy input calls ``RectBivariateSpline.ev``
-    (BYTE-IDENTICAL to scipy); on backend arrays it evaluates the frozen block
-    through ``eval_rect_ppoly`` (differentiable w.r.t. the evaluation points).
-    Serves interpRZPotential and the DF ``RectBivariateSpline`` tables.
+    Two construction modes:
+
+    - **mode 1 (frozen, eval-point-differentiable)** -- built from numpy
+      ``(x, y, z)`` or a pre-fitted scipy ``RectBivariateSpline`` and frozen to a
+      tensor-product power-basis block. ``__call__(X, Y)`` on numpy input calls
+      ``RectBivariateSpline.ev`` (BYTE-IDENTICAL to scipy); on backend arrays it
+      evaluates the frozen block through ``eval_rect_ppoly`` (differentiable
+      w.r.t. the evaluation points).
+
+    - **mode 2 (in-backend, differentiable in z)** -- triggered when ``z`` is a
+      backend (jax/torch) array (and ``spl`` is not given). The tensor-product
+      not-a-knot cubic coefficients are built natively via
+      :func:`native_rect_cubic_coeffs` (matching ``RectBivariateSpline(s=0)``), so
+      the spline is differentiable w.r.t. the grid VALUES ``z`` -- the capability
+      the frozen scipy fit cannot provide (a parameter-dependent 2D table).
+
+    Serves interpRZPotential, the action-angle grids, and the DF
+    ``RectBivariateSpline`` tables.
 
     Parameters
     ----------
@@ -801,6 +984,19 @@ class Spline2D:
     """
 
     def __init__(self, x=None, y=None, z=None, kx=3, ky=3, spl=None, ext=0):
+        self._extrapolate = True if ext in (0, "extrapolate") else "const"
+        if spl is None and is_backend_array(z):
+            # mode 2 (in-backend, differentiable in z): a backend ``z`` builds the
+            # tensor-product not-a-knot cubic block NATIVELY (matching
+            # RectBivariateSpline(s=0)), so the fit stays a backend array and is
+            # differentiable w.r.t. the grid values. cubic only (galpy's use).
+            if kx != 3 or ky != 3:
+                raise ValueError("Spline2D mode-2 (backend z) supports only kx=ky=3")
+            self._spl = None
+            self._xbr, self._ybr, self._c = native_rect_cubic_coeffs(
+                get_namespace(z), x, y, z
+            )
+            return
         if spl is None:
             spl = _scipy_interpolate.RectBivariateSpline(
                 numpy.asarray(x, dtype=float),
@@ -810,7 +1006,6 @@ class Spline2D:
                 ky=ky,
             )
         self._spl = spl
-        self._extrapolate = True if ext in (0, "extrapolate") else "const"
         self._xbr, self._ybr, self._c = rect_bivariate_to_ppoly(spl)
 
     def __call__(self, X, Y, grid=False):
@@ -823,8 +1018,26 @@ class Spline2D:
         on the outer (tensor) product of ``X`` and ``Y``, matching scipy's
         default ``RectBivariateSpline.__call__``.
         """
-        if not (is_backend_array(X) or is_backend_array(Y)):
+        numpy_query = not (is_backend_array(X) or is_backend_array(Y))
+        if numpy_query and self._spl is not None:
             return self._spl(X, Y, grid=grid)
+        if numpy_query:
+            # mode-2 (backend-native) block queried with numpy points: evaluate
+            # the native coeffs through numpy (materialised off the backend).
+            xp = numpy
+            Xa = numpy.asarray(X, dtype=float)
+            Ya = numpy.asarray(Y, dtype=float)
+            xbr, ybr, c = (
+                numpy.asarray(self._xbr),
+                numpy.asarray(self._ybr),
+                numpy.asarray(self._c),
+            )
+            if grid:
+                Xa = Xa[:, None]
+                Ya = Ya[None, :]
+            return eval_rect_ppoly(
+                xp, xbr, ybr, c, Xa, Ya, extrapolate=self._extrapolate
+            )
         import array_api_compat
 
         ref = X if is_backend_array(X) else Y

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -2029,24 +2029,33 @@ def test_staeckelgrid_native_setup_backend_arrays(backend):
         g = actionAngleStaeckelGrid(
             pot=MWPotential2014, delta=0.45, nE=12, npsi=12, nLz=14, c=True
         )
-        for a in (
-            "_Lzs",
-            "_RL",
-            "_ERL",
-            "_ERa",
-            "_jr",
-            "_jz",
-            "_u0",
-            "_jrLzE",
-            "_jzLzE",
-        ):
+        # every frozen table is a backend array (GPU-resident, no numpy island)
+        _tight = ("_Lzs", "_RL", "_ERL", "_ERa", "_jr", "_jz", "_jrLzE", "_jzLzE")
+        for a in _tight + ("_u0",):
             assert _is_backend_array(backend, getattr(g, a)), a
+        # ... AND the tables match the numpy(scipy) grid: the solver-lifted /
+        # native-fit tables to ~1e-13, and the C-solver-sensitive _u0 to ~1e-7 (a
+        # 1-ULP-reorder E fed to the ill-conditioned calcu0 amplifies ~1e8; see
+        # _build_grid_backend). This is the load-bearing native-setup parity check
+        # (the single-orbit query below only floors at ~1e-3 on the shared,
+        # pre-existing query path, so it can't pin the tables this PR produces).
+        for a in _tight:
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-6,
+                atol=1e-8,
+                err_msg=a,
+            )
+        numpy.testing.assert_allclose(
+            as_numpy(g._u0), numpy.asarray(ref._u0), rtol=1e-4, atol=1e-6
+        )
         xp = galpy_backend.get_namespace()
         got_a = g(*[xp.asarray(v) for v in _NATIVE_S])
-    # Sanity parity vs the numpy(scipy) grid (a coarse c=True grid: the exact
-    # native-fit parity is pinned by the flip tests + the numpy-shard
-    # test_staeckelgrid_parity; here the query-path/solver backend parity floors
-    # the agreement at ~1e-5 rel).
+    # coarse query sanity: the shared query-path/solver backend parity floors this
+    # well-conditioned orbit at ~1e-3 rel (near-circular edge orbits diverge more,
+    # a pre-existing _grid_common_backend floor unrelated to the native fits); the
+    # native-fit parity is pinned by the table checks above + the flip tests.
     for r, gg in zip(ref_a, got_a):
         numpy.testing.assert_allclose(
             as_numpy(gg), numpy.asarray(r), rtol=1e-3, atol=1e-5

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -1989,3 +1989,119 @@ def test_staeckelgrid_vatu0_backend(backend):
     )  # backend -> xp.where branch
     assert _is_backend_array(backend, vb)
     numpy.testing.assert_allclose(as_numpy(vb), vn, rtol=1e-10, atol=1e-12)
+
+
+###############################################################################
+# NATIVE grid SETUP under a forced backend: the grid built inside a forced
+# jax/torch context stores its frozen tables as BACKEND arrays (GPU-resident, no
+# numpy island) fit NATIVELY, matches the numpy(scipy) grid to grid-parity, and
+# the build differentiates through to the query (the capability the frozen scipy
+# fit severs). These build their own grid under a forced backend, so they are
+# backend_managed and skip cleanly when the backend is absent.
+###############################################################################
+_NATIVE_S = (
+    numpy.array([1.1, 0.8, 1.3]),
+    numpy.array([0.1, -0.2, 0.05]),
+    numpy.array([0.9, 0.6, 1.0]),
+    numpy.array([0.1, -0.15, 0.08]),
+    numpy.array([0.08, 0.1, -0.05]),
+)
+
+
+def _staeckelgrid_numpy_ref():
+    from galpy.potential import MWPotential2014
+
+    return actionAngleStaeckelGrid(
+        pot=MWPotential2014, delta=0.45, nE=12, npsi=12, nLz=14, c=True
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_native_setup_backend_arrays(backend):
+    # A grid built inside a forced backend stores its frozen tables as backend
+    # arrays (GPU-resident, no numpy island) and matches the numpy(scipy) grid.
+    from galpy import backend as galpy_backend
+    from galpy.potential import MWPotential2014
+
+    ref = _staeckelgrid_numpy_ref()
+    ref_a = ref(*_NATIVE_S)
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleStaeckelGrid(
+            pot=MWPotential2014, delta=0.45, nE=12, npsi=12, nLz=14, c=True
+        )
+        for a in (
+            "_Lzs",
+            "_RL",
+            "_ERL",
+            "_ERa",
+            "_jr",
+            "_jz",
+            "_u0",
+            "_jrLzE",
+            "_jzLzE",
+        ):
+            assert _is_backend_array(backend, getattr(g, a)), a
+        xp = galpy_backend.get_namespace()
+        got_a = g(*[xp.asarray(v) for v in _NATIVE_S])
+    # Sanity parity vs the numpy(scipy) grid (a coarse c=True grid: the exact
+    # native-fit parity is pinned by the flip tests + the numpy-shard
+    # test_staeckelgrid_parity; here the query-path/solver backend parity floors
+    # the agreement at ~1e-5 rel).
+    for r, gg in zip(ref_a, got_a):
+        numpy.testing.assert_allclose(
+            as_numpy(gg), numpy.asarray(r), rtol=1e-3, atol=1e-5
+        )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_native_setup_differentiable(backend):
+    # d(sum Jz^2 / 2)/d(the log-jz grid table) flows through the NATIVE
+    # spline_filter fit + native map_coordinates query -- directional, central-FD
+    # converged. This is differentiability THROUGH the grid-table build, which the
+    # frozen scipy prefilter cannot provide.
+    from galpy import backend as galpy_backend
+    from galpy.backend._namespaces import stop_gradient as sg
+    from galpy.backend.interpolate import MapCoordinates
+    from galpy.potential import MWPotential2014
+
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleStaeckelGrid(
+            pot=MWPotential2014, delta=0.45, nE=12, npsi=12, nLz=14, c=True
+        )
+        xp = galpy_backend.get_namespace()
+        args = [xp.asarray(v) for v in _NATIVE_S]
+        Lz, _, cz = g._grid_common_backend(xp, *args)
+        cz, Lz = sg(cz), sg(Lz)
+        baseL = sg(xp.log(g._jz + 1e-10))
+        fac = sg(xp.exp(g._jzLzInterp_b(Lz)) - 1e-5)
+        rng = numpy.random.default_rng(3)
+        V = rng.standard_normal(as_numpy(baseL).shape)
+        V /= numpy.linalg.norm(V)
+
+        def loss(L):
+            jz = (xp.exp(MapCoordinates(L)(cz)) - 1e-10) * fac
+            return 0.5 * xp.sum(jz**2)
+
+        if backend == "jax":
+            grad = jax.grad(loss)(baseL)
+            dd = float(jnp.sum(grad * jnp.asarray(V)))
+            # jit-safe: jax.jit == eager
+            numpy.testing.assert_allclose(
+                float(jax.jit(loss)(baseL)), float(loss(baseL)), rtol=1e-11, atol=1e-11
+            )
+
+            def _l(a):
+                return float(loss(jnp.asarray(a)))
+        else:
+            bt = baseL.clone().detach().requires_grad_(True)
+            loss(bt).backward()
+            dd = float(torch.sum(bt.grad * torch.as_tensor(V)))
+
+            def _l(a):
+                with torch.no_grad():
+                    return float(loss(torch.as_tensor(a)))
+
+        baseL_np = as_numpy(baseL)
+        fd = (_l(baseL_np + 1e-4 * V) - _l(baseL_np - 1e-4 * V)) / 2e-4
+        assert _is_backend_array(backend, grad if backend == "jax" else bt.grad)
+    numpy.testing.assert_allclose(dd, fd, rtol=1e-5, atol=1e-8)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -17,9 +17,11 @@ from galpy.backend.interpolate import (
     Spline2D,
     cubic_spline_coeffs,
     eval_cubic,
+    eval_rect_ppoly,
     interp_linear,
     make_smoothing_spline,
     map_coordinates,
+    native_rect_cubic_coeffs,
     smoothing_spline,
     spline_filter,
 )
@@ -56,6 +58,12 @@ def _xp(backend):
         "jax": jnp if jax else None,
         "torch": txp if torch else None,
     }[backend]
+
+
+def _is_backend(backend, x):
+    from galpy.backend import is_backend_array
+
+    return is_backend_array(x) if backend != "numpy" else not is_backend_array(x)
 
 
 def _asarray(backend, x, requires_grad=False):
@@ -772,3 +780,175 @@ def test_smoothing_spline_default_weight(backend):
     refu = si.UnivariateSpline(_SMX, _SMY, s=5.0, k=3)(_SMG)
     gotu = as_numpy(smoothing_spline(_SMX, _asarray(backend, _SMY), s=5.0)(_SMG))
     numpy.testing.assert_allclose(gotu, refu, rtol=1e-9, atol=1e-12)
+
+
+###############################################################################
+# NATIVE FITS (backend-native, GPU-resident, differentiable) -- the dual-path
+# spline_filter (backend grid -> native recursive prefilter) and the tensor-product
+# not-a-knot cubic fit native_rect_cubic_coeffs (backend z -> RectBivariateSpline
+# s=0 match). These back the actionAngleStaeckelGrid/AdiabaticGrid setup on the
+# backend so the frozen tables stay backend arrays and the build differentiates
+# through to the query. All run under the numpy-default shard (jax+torch
+# installed) so numpy.op(<tensor>) deprecation traps surface.
+###############################################################################
+_NF_RNG = numpy.random.default_rng(20240722)
+_NF_G1D = _NF_RNG.standard_normal(21)
+_NF_G2D = _NF_RNG.standard_normal((15, 18))
+_NF_G3D = _NF_RNG.standard_normal((7, 8, 6))
+# a realistic (strictly-positive, log-transformed) StaeckelGrid-like table
+_NF_GRID_REAL = numpy.log(_NF_RNG.uniform(0.05, 3.0, (9, 11, 7)))
+_MC3 = numpy.vstack(
+    [_NF_RNG.uniform(0.0, _NF_GRID_REAL.shape[d] - 1.0, 25) for d in range(3)]
+)
+
+
+def test_spline_filter_numpy_byte_identical():
+    # numpy grid -> literal scipy.ndimage.spline_filter passthrough.
+    for g in (_NF_G1D, _NF_G2D, _NF_G3D):
+        numpy.testing.assert_array_equal(
+            spline_filter(g), sndi.spline_filter(g, order=3)
+        )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline_filter_native_vs_scipy(backend):
+    # a backend grid takes the NATIVE recursive prefilter and matches scipy to ~1e-13,
+    # while staying a backend array (GPU-resident, no numpy island).
+    for g in (_NF_G1D, _NF_G2D, _NF_G3D, _NF_GRID_REAL):
+        ref = sndi.spline_filter(g, order=3)
+        out = spline_filter(_asarray(backend, g))
+        assert _is_backend(backend, out)
+        numpy.testing.assert_allclose(as_numpy(out), ref, rtol=1e-11, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_mapcoordinates_native_filtered_vs_scipy(backend):
+    # MapCoordinates built from a BACKEND grid prefilters natively (backend-array
+    # coefficients) yet reproduces the full scipy pipeline at ~1e-12.
+    mc = MapCoordinates(_asarray(backend, _NF_GRID_REAL), order=3)
+    assert _is_backend(backend, mc.filtered)
+    ref = sndi.map_coordinates(
+        sndi.spline_filter(_NF_GRID_REAL, order=3),
+        _MC3,
+        order=3,
+        prefilter=False,
+        mode="nearest",
+    )
+    got = as_numpy(mc(_asarray(backend, _MC3)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline_filter_grad_vs_fd(backend):
+    # d(0.5||spline_filter(g)||^2)/dg through the native prefilter, directional
+    # (random unit direction), central-FD-converged. This is the differentiability
+    # the grid-table build needs (scipy's prefilter severs it).
+    g0 = _NF_GRID_REAL
+    V = _NF_RNG.standard_normal(g0.shape)
+    V /= numpy.linalg.norm(V)
+
+    def loss(xp, arr):
+        return 0.5 * xp.sum(spline_filter(arr) ** 2)
+
+    if backend == "jax":
+        gb = jnp.asarray(g0)
+        grad = jax.grad(lambda a: loss(jnp, a))(gb)
+        dd = float(jnp.sum(grad * jnp.asarray(V)))
+
+        def _l(a):
+            return float(loss(jnp, jnp.asarray(a)))
+
+        # jit-safe: jax.jit == eager
+        numpy.testing.assert_allclose(
+            float(jax.jit(lambda a: loss(jnp, a))(gb)), _l(g0), rtol=1e-12, atol=1e-12
+        )
+    else:
+        gt = torch.tensor(g0, requires_grad=True)
+        loss(txp, gt).backward()
+        dd = float(torch.sum(gt.grad * torch.as_tensor(V)))
+
+        def _l(a):
+            return float(loss(txp, torch.as_tensor(a)))
+
+    fd = (_l(g0 + 1e-4 * V) - _l(g0 - 1e-4 * V)) / 2e-4
+    numpy.testing.assert_allclose(dd, fd, rtol=1e-6, atol=1e-9)
+
+
+# --- native tensor-product not-a-knot cubic fit (RectBivariateSpline s=0) ---
+_NF_X = numpy.linspace(0.0, 3.0, 16)
+_NF_Y = numpy.linspace(-1.0, 2.0, 19)
+_NFXX, _NFYY = numpy.meshgrid(_NF_X, _NF_Y, indexing="ij")
+_NF_Z_SMOOTH = numpy.sin(1.3 * _NFXX) * numpy.cos(0.7 * _NFYY) + 0.2 * _NFXX * _NFYY
+_NF_Z_RAND = _NF_RNG.standard_normal((16, 19))
+_NF_XQ = _NF_RNG.uniform(0.05, 2.95, 400)
+_NF_YQ = _NF_RNG.uniform(-0.95, 1.95, 400)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("z", [_NF_Z_SMOOTH, _NF_Z_RAND])
+def test_native_rect_cubic_coeffs_vs_scipy(backend, z):
+    # native tensor-product not-a-knot cubic == RectBivariateSpline(s=0).ev to
+    # ~2e-13 on smooth + random data; the coeffs stay a backend array.
+    xp = _xp(backend)
+    spl = si.RectBivariateSpline(_NF_X, _NF_Y, z, kx=3, ky=3, s=0.0)
+    ref = spl.ev(_NF_XQ, _NF_YQ)
+    xbr, ybr, c = native_rect_cubic_coeffs(xp, _NF_X, _NF_Y, _asarray(backend, z))
+    assert _is_backend(backend, c)
+    got = as_numpy(
+        eval_rect_ppoly(
+            xp, xbr, ybr, c, _asarray(backend, _NF_XQ), _asarray(backend, _NF_YQ)
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline2d_mode2_native_vs_scipy(backend):
+    # Spline2D with a BACKEND z builds the native fit (mode 2) and matches scipy's
+    # RectBivariateSpline.ev; the block stays a backend array.
+    spl = si.RectBivariateSpline(_NF_X, _NF_Y, _NF_Z_SMOOTH, kx=3, ky=3, s=0.0)
+    ref = spl.ev(_NF_XQ, _NF_YQ)
+    s2 = Spline2D(_NF_X, _NF_Y, _asarray(backend, _NF_Z_SMOOTH))
+    assert s2._spl is None and _is_backend(backend, s2._c)
+    got = as_numpy(s2(_asarray(backend, _NF_XQ), _asarray(backend, _NF_YQ)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_native_rect_cubic_grad_vs_fd(backend):
+    # d(0.5||fit(z).ev(Xq,Yq)||^2)/dz through the native 2D fit, directional,
+    # central-FD-converged + jit-safe (jax) -- the y-value differentiability the
+    # frozen scipy fit cannot provide.
+    z0 = _NF_Z_RAND
+    V = _NF_RNG.standard_normal(z0.shape)
+    V /= numpy.linalg.norm(V)
+
+    def loss(xp, cast, zz):
+        xbr, ybr, c = native_rect_cubic_coeffs(xp, _NF_X, _NF_Y, zz)
+        return 0.5 * xp.sum(
+            eval_rect_ppoly(xp, xbr, ybr, c, cast(_NF_XQ), cast(_NF_YQ)) ** 2
+        )
+
+    if backend == "jax":
+        zb = jnp.asarray(z0)
+        grad = jax.grad(lambda zz: loss(jnp, jnp.asarray, zz))(zb)
+        dd = float(jnp.sum(grad * jnp.asarray(V)))
+        numpy.testing.assert_allclose(
+            float(jax.jit(lambda zz: loss(jnp, jnp.asarray, zz))(zb)),
+            float(loss(jnp, jnp.asarray, zb)),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+        def _l(a):
+            return float(loss(jnp, jnp.asarray, jnp.asarray(a)))
+    else:
+        zt = torch.tensor(z0, requires_grad=True)
+        loss(txp, torch.as_tensor, zt).backward()
+        dd = float(torch.sum(zt.grad * torch.as_tensor(V)))
+
+        def _l(a):
+            return float(loss(txp, torch.as_tensor, torch.as_tensor(a)))
+
+    fd = (_l(z0 + 1e-4 * V) - _l(z0 - 1e-4 * V)) / 2e-4
+    numpy.testing.assert_allclose(dd, fd, rtol=1e-6, atol=1e-9)


### PR DESCRIPTION
## What

Replaces the `as_numpy`/scipy-at-setup **spline fits** in the actionAngle grids with backend-native (jax/torch), differentiable, GPU-resident fits — so a grid built under a forced backend keeps its frozen tables as backend arrays instead of round-tripping through numpy. The numpy path is unchanged (keeps calling scipy) and byte-identical.

Two reusable native primitives land in `galpy/backend/interpolate.py`:
- **native `spline_filter`** — the cubic B-spline prefilter (`ndimage.spline_filter`) as an Unser recursive filter (`lax.scan`), dual-path: scipy for numpy input (byte-identical), native for backend input. Matches scipy to ~1e-13.
- **native 2D cubic fit** (`native_rect_cubic_coeffs`) — `RectBivariateSpline(s=0)` reproduced natively (its interior knots at `x[2:-2]` **are** the not-a-knot placement, so it's a tensor product of two not-a-knot 1D cubics). Matches scipy to ~2e-15.

The 1D cubic (`Spline1D`) already fit natively. Grid setup (`actionAngleStaeckelGrid`, `actionAngleAdiabaticGrid`) forks on the namespace: numpy `__init__` unchanged; a backend build assembles every frozen table as a backend array via `xp`-generic energy math + native fits.

## Verification
- **numpy byte-identical**: every frozen-table attr + action/EccZmax query, A/B maxdiff **0.0** (both grids).
- **backend native == scipy**: tables ~3e-14, on-grid actions ~3e-11 (forced jax/torch); table attrs asserted `is_backend_array` (GPU-resident, no numpy island in the fits).
- **value-differentiable**: `d(query action)/d(grid-table values)` through the native fit, grad-vs-FD h-converged ~1e-10 (jax/torch), jit-safe.
- **flips**: StaeckelGrid + AdiabaticGrid `_c`/Isochrone/EccZmax entries pass, 9/9 torch + 9/9 jax (stash-verified fails-without-fix). No `backend_xfail.txt` edits.
- New `test_backend_interpolate` / `test_backend_actionAngle` tests pass under the `-W error` coverage-shard condition.

## Scope note
The **fit/interpolation** machinery is fully native. The grid's **solvers** (`rl` root-find, the Stäckel action solve, `EccZmaxRperiRap`) still run under a narrowed `use("numpy", force=True)` at setup. This is a deliberate, informed choice: `d(action)/d(potential-parameter)` through the grid is architecturally blocked anyway — the grid's `map_coordinates` query is a grid-*index* interpolation over a geometry that shifts with the parameter, so it cannot propagate a potential-parameter gradient regardless of solver nativeness (verified: a fully-native `c=False` variant gives wrong-sign end-to-end grads, plus interpRZ breakage and a jax setup timeout). Parameter-differentiable actions are the job of — and already provided by — the **non-grid** backend `actionAngleStaeckel`. This PR delivers what the grid *can* structurally give: native, GPU-resident, value-differentiable interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm