### PR TITLE
sphericaldf: backend-native differentiable velocity-magnitude sampling (native 2D bilinear pvr)

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -52,6 +52,7 @@ __all__ = [
     "cubic_spline_coeffs",
     "eval_cubic",
     "interp_linear",
+    "interp_bilinear",
     "rect_bivariate_to_ppoly",
     "native_rect_cubic_coeffs",
     "eval_rect_ppoly",
@@ -313,6 +314,74 @@ def interp_linear(xp, x, y, r, *, nu=0, extrapolate=True):
     if nu == 1:
         return slope
     return slope * 0.0
+
+
+def interp_bilinear(xp, x, y, Z, X, Y, *, extrapolate=True):
+    """Bilinear interpolation of grid values ``Z(x, y)`` at points ``(X, Y)``.
+
+    The tensor-product degree-1 analogue of :func:`interp_linear`: two
+    ``searchsorted`` interval lookups (one per axis) and a bilinear blend of the
+    four surrounding grid corners, all through namespace ops -- so the value is
+    computed natively and is differentiable w.r.t. the query points ``X``/``Y``,
+    the grid VALUES ``Z``, and (when they are backend arrays) the knot positions
+    ``x``/``y``. Points are paired ELEMENTWISE (``X`` and ``Y`` broadcast
+    together, matching ``RectBivariateSpline.ev`` / ``grid=False``), not on an
+    outer product.
+
+    This reproduces ``scipy.interpolate.RectBivariateSpline(x, y, Z, kx=1, ky=1,
+    s=0).ev`` -- which IS exact bilinear interpolation on the grid -- to ~1e-13
+    in range. scipy CONSTANT-extrapolates a degree-1 ``RectBivariateSpline``
+    beyond the grid (the edge value), matched here by ``extrapolate='clip'`` /
+    ``'const'`` / ``3`` (clamp ``(X, Y)`` into the grid first). ``extrapolate=
+    True`` instead extends the edge cell linearly (finite extrapolation, matching
+    :func:`interp_linear`), keeping dead ``xp.where`` branches NaN-free.
+
+    ``x`` (length ``nx``) and ``y`` (length ``ny``) must be increasing; ``Z`` has
+    shape ``(nx, ny)``. A backend ``x``/``y``/``Z`` is kept in the namespace
+    (differentiable knots/values); a numpy grid is materialised onto the query's
+    device (the numpy path is byte-identical -- ``numpy.asarray`` of a numpy array
+    is a no-op).
+    """
+    dev = device_of(X, Y, Z, y, x)
+    xb = (
+        x * 1.0 if is_backend_array(x) else asarray_on_device(xp, numpy.asarray(x), dev)
+    )
+    yb = (
+        y * 1.0 if is_backend_array(y) else asarray_on_device(xp, numpy.asarray(y), dev)
+    )
+    Zb = (
+        Z * 1.0 if is_backend_array(Z) else asarray_on_device(xp, numpy.asarray(Z), dev)
+    )
+    if extrapolate is not True:
+        if extrapolate not in ("clip", "const", 3):
+            raise ValueError(
+                "interp_bilinear extrapolate must be True, 'clip', 'const', or 3; "
+                f"got {extrapolate!r}"
+            )
+        X = xp.clip(X, xb[0], xb[-1])
+        Y = xp.clip(Y, yb[0], yb[-1])
+    # per-axis interval index in [0, n-2]
+    ix = xp.clip(xp.searchsorted(xb, X, side="right") - 1, 0, xb.shape[0] - 2)
+    iy = xp.clip(xp.searchsorted(yb, Y, side="right") - 1, 0, yb.shape[0] - 2)
+    x0 = xb[ix]
+    x1 = xb[ix + 1]
+    y0 = yb[iy]
+    y1 = yb[iy + 1]
+    # (x1 - x0), (y1 - y0) are strictly positive geometry differences (grids
+    # increasing) -> no dead-branch guard needed (denominators never zero).
+    tx = (X - x0) / (x1 - x0)
+    ty = (Y - y0) / (y1 - y0)
+    # gather the 4 corner values (elementwise advanced indexing over the query)
+    z00 = Zb[ix, iy]
+    z01 = Zb[ix, iy + 1]
+    z10 = Zb[ix + 1, iy]
+    z11 = Zb[ix + 1, iy + 1]
+    return (
+        z00 * (1.0 - tx) * (1.0 - ty)
+        + z10 * tx * (1.0 - ty)
+        + z01 * (1.0 - tx) * ty
+        + z11 * tx * ty
+    )
 
 
 ###############################################################################

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -235,10 +235,14 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
         v, r = xp.asarray(v) * 1.0, xp.asarray(r) * 1.0
         return self.fQ(-_evaluatePotentials(self._pot, r, 0) - 0.5 * v**2.0) * v**2.0
 
-    def _sample_v(self, r, eta, n=1):
-        """Generate velocity samples"""
+    def _sample_v(self, r, eta, n=1, key=None):
+        """Generate velocity samples
+
+        OM sampling is numpy-side (``osipkovmerrittdf.sample`` rejects a backend
+        key), so ``key`` is always ``None`` here and threaded through for
+        signature parity."""
         # Use super-class method to obtain v*[1+r^2/ra^2*sin^2eta]
-        out = super()._sample_v(r, eta, n=n)
+        out = super()._sample_v(r, eta, n=n, key=key)
         # Transform to v
         return out / numpy.sqrt(1.0 + r**2.0 / self._ra2 * numpy.sin(eta) ** 2.0)
 

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -32,7 +32,7 @@ from ..backend import (
 )
 from ..backend import random as grandom
 from ..backend import resolve_namespace
-from ..backend.interpolate import Spline1D, interp_linear
+from ..backend.interpolate import Spline1D, interp_bilinear, interp_linear
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..orbit import Orbit
 from ..potential import (
@@ -144,6 +144,81 @@ def _handle_rmin(rmin, pot, denspot, scale, ro, df_name):
 
     # Non-divergent potential - use rmin = 0
     return 0.0
+
+
+class _PVRInterpolator:
+    """Dual-path inverse-CDF v/vesc interpolator for spherical-DF velocity
+    sampling.
+
+    Wraps the ``p(v|r)`` inverse cumulative-distribution table built by
+    :meth:`sphericaldf._make_pvr_interpolator`. A numpy query evaluates the
+    frozen scipy ``RectBivariateSpline`` (``kx=ky=1``, BYTE-IDENTICAL to galpy's
+    historical sampler); a backend (jax/torch) query evaluates the SAME bilinear
+    interpolation natively via :func:`galpy.backend.interpolate.interp_bilinear`,
+    so the sampled ``v/vesc`` is a backend array differentiable in the query
+    (``log10(r/scale)``) and GPU/jit-able. scipy CONSTANT-extrapolates a degree-1
+    ``RectBivariateSpline`` beyond the grid; the backend path matches with
+    ``extrapolate='clip'``. On a backend build the raw grids are held as backend
+    arrays (GPU-resident); a numpy build keeps them numpy and materialises them
+    onto the query's device if a backend query arrives.
+
+    Parameters
+    ----------
+    x_grid : numpy.ndarray
+        ``log10(r/a)`` grid (first axis), shape ``(n_r_a,)``.
+    y_grid : numpy.ndarray
+        Uniform CDF grid in ``[0, 1]`` (second axis), shape ``(n_pvr,)``.
+    z_grid : numpy.ndarray
+        ``v/vesc`` values, shape ``(n_r_a, n_pvr)``.
+    xp : module
+        The forced/context-default namespace at build time; a non-numpy ``xp``
+        stores the grids as backend arrays.
+    """
+
+    def __init__(self, x_grid, y_grid, z_grid, xp):
+        # scipy spline for the byte-identical numpy path
+        self._spl = scipy.interpolate.RectBivariateSpline(
+            x_grid, y_grid, z_grid, kx=1, ky=1
+        )
+        if xp is numpy:
+            self._x, self._y, self._z = x_grid, y_grid, z_grid
+        else:
+            self._x = xp.asarray(x_grid) * 1.0
+            self._y = xp.asarray(y_grid) * 1.0
+            self._z = xp.asarray(z_grid) * 1.0
+
+    def __getattr__(self, name):
+        # Delegate unknown attributes (e.g. get_knots, tck) to the scipy spline
+        # so the wrapper is a drop-in for the RectBivariateSpline it replaces.
+        # Guard _spl to avoid infinite recursion before it is assigned.
+        if name == "_spl":
+            raise AttributeError(name)
+        return getattr(self._spl, name)
+
+    def __call__(self, X, Y, grid=False):
+        """Evaluate ``v/vesc`` at query points ``(X, Y)`` (paired elementwise).
+
+        A numpy ``X`` delegates to the scipy spline (byte-identical); a backend
+        ``X`` runs the native bilinear interpolation."""
+        if not is_backend_array(X):
+            return self._spl(X, Y, grid=grid)
+        xp = get_namespace(X)
+        xg = (
+            self._x
+            if is_backend_array(self._x)
+            else as_backend_constant(xp, self._x, X)
+        )
+        yg = (
+            self._y
+            if is_backend_array(self._y)
+            else as_backend_constant(xp, self._y, X)
+        )
+        zg = (
+            self._z
+            if is_backend_array(self._z)
+            else as_backend_constant(xp, self._z, X)
+        )
+        return interp_bilinear(xp, xg, yg, zg, X, Y, extrapolate="clip")
 
 
 class sphericaldf(df):
@@ -568,13 +643,13 @@ class sphericaldf(df):
         # dispatch the namespace on the key, NOT get_namespace(): key=None keeps
         # the whole assembly numpy (byte-identical) even under a forced backend;
         # a backend key follows its own draws into the active namespace.
-        # Split into INDEPENDENT sub-keys for the radial, position-angle, and
-        # velocity-angle draws: each angle helper re-splits its key internally, so
-        # handing the SAME key to both would make split() return identical sub-keys
-        # (velocity angles = deterministic fn of position angles -> biased joint
-        # distribution). key=None -> split returns (None, None, None) -> the global
-        # numpy generator draws sequentially -> byte-identical.
-        key_r, key_pos, key_vel = grandom.split(key, 3)
+        # Split into INDEPENDENT sub-keys for the radial, position-angle,
+        # velocity-angle, and velocity-magnitude draws: each helper re-splits its
+        # key internally, so handing the SAME key to two would make split() return
+        # identical sub-keys (biased joint distribution). key=None -> split returns
+        # (None,)*4 -> the global numpy generator draws sequentially in the SAME
+        # order (r, position angles, velocity angles, velocity) -> byte-identical.
+        key_r, key_pos, key_vel, key_v = grandom.split(key, 4)
         if R is None or z is None:  # Full 6D samples
             r = self._sample_r(n=n, key=key_r)
             phi, theta = self._sample_position_angles(n=n, key=key_pos)
@@ -619,11 +694,12 @@ class sphericaldf(df):
         eta, psi = self._sample_velocity_angles(
             r, n=n, key=None if xp is numpy else key_vel
         )
-        # velocity magnitude is still numpy-side (_sample_v is PR-2); coerce the
-        # numpy velocity pieces into xp so a backend key assembles backend
-        # velocities (numpy*tensor raises under torch). key=None -> xp is numpy
-        # -> as_backend_constant is a no-op (byte-identical).
-        v = self._sample_v(r, eta, n=n)
+        # velocity magnitude: a backend key evaluates the inverse-CDF pvr natively
+        # at the backend r (differentiable); coerce any numpy pieces into xp so a
+        # backend key assembles backend velocities (numpy*tensor raises under
+        # torch). key=None -> xp is numpy -> as_backend_constant is a no-op
+        # (byte-identical).
+        v = self._sample_v(r, eta, n=n, key=None if xp is numpy else key_v)
         v = v if is_backend_array(v) else as_backend_constant(xp, v, r)
         eta = eta if is_backend_array(eta) else as_backend_constant(xp, eta, r)
         psi = psi if is_backend_array(psi) else as_backend_constant(xp, psi, r)
@@ -773,8 +849,15 @@ class sphericaldf(df):
         theta_samples = xp.arccos(1.0 - 2.0 * u_theta)
         return phi_samples, theta_samples
 
-    def _sample_v(self, r, eta, n=1):
-        """Generate velocity samples: typically the total velocity, but not for OM"""
+    def _sample_v(self, r, eta, n=1, key=None):
+        """Generate velocity samples: typically the total velocity, but not for OM.
+
+        ``key=None`` draws the velocity uniform from the global ``numpy.random``
+        and queries the scipy pvr interpolator numpy-side (byte-identical). A
+        backend key draws a backend uniform, evaluates the same inverse-CDF pvr
+        NATIVELY (bilinear) at the BACKEND ``r``, and multiplies by the backend
+        ``vmax`` -- so the sampled velocity is a backend array differentiable in
+        ``r`` (and hence, through the radial inverse-CDF, in the CDF/potential)."""
         if not hasattr(self, "_v_vesc_pvr_interpolator"):
             r_a_end = (
                 max(numpy.log10(self._rmax / self._scale), 3)
@@ -782,14 +865,24 @@ class sphericaldf(df):
                 else 3
             )
             self._v_vesc_pvr_interpolator = self._make_pvr_interpolator(r_a_end=r_a_end)
-        # samples are numpy-side by design (scipy interpolator; _vmax_at_r follows
-        # a forced backend); a backend-key r arrives as a backend array, so pull it
-        # numpy-side -- numpy.log10(<torch tensor>) trips the numpy-2.0
-        # __array_wrap__ deprecation (an error under the coverage shard's -W error)
-        r = as_numpy(r)
+        if key is None:
+            # numpy path: byte-identical scipy pvr + global-numpy uniform. A
+            # backend-key r may arrive as a backend array (forced backend); pull it
+            # numpy-side -- numpy.log10(<torch tensor>) trips the numpy-2.0
+            # __array_wrap__ deprecation (an error under the coverage shard's -W
+            # error).
+            r = as_numpy(r)
+            return self._v_vesc_pvr_interpolator(
+                numpy.log10(r / self._scale), numpy.random.uniform(size=n), grid=False
+            ) * as_numpy(self._vmax_at_r(self._pot, r))
+        # backend key: native bilinear inverse-CDF pvr at (log10(r/scale),
+        # backend-uniform), times the backend vmax -- r stays a backend array
+        # (differentiable, GPU/jit-able); no as_numpy / numpy-op-on-tensor here.
+        xp = get_namespace(r)
+        u = grandom.uniform(key, n)
         return self._v_vesc_pvr_interpolator(
-            numpy.log10(r / self._scale), numpy.random.uniform(size=n), grid=False
-        ) * as_numpy(self._vmax_at_r(self._pot, r))
+            xp.log10(r / self._scale), u, grid=False
+        ) * self._vmax_at_r(self._pot, r)
 
     def _sample_velocity_angles(self, r, n=1, key=None):
         """Generate samples of angles that set radial vs tangential
@@ -918,13 +1011,16 @@ class sphericaldf(df):
             v_vesc_samples_reg = cml_pvr_inv_interp(pvr_samples_reg)
             icdf_pvr_grid_reg[:, i] = pvr_samples_reg
             icdf_v_vesc_grid_reg[:, i] = v_vesc_samples_reg
-        # Create the interpolator
-        return scipy.interpolate.RectBivariateSpline(
+        # Create the dual-path inverse-CDF interpolator: a numpy query hits the
+        # scipy RectBivariateSpline (kx=ky=1, byte-identical); a backend query
+        # evaluates the same bilinear interpolation natively. On a backend build
+        # the raw grids are stored as backend arrays (GPU-resident); otherwise
+        # they stay numpy and a stray backend query materialises them per-call.
+        return _PVRInterpolator(
             numpy.log10(r_a_grid[0, :]),
             icdf_pvr_grid_reg[:, 0],
             icdf_v_vesc_grid_reg.T,
-            kx=1,
-            ky=1,
+            get_namespace(),  # forced/context default (numpy build -> numpy grids)
         )
 
     def _setup_rphi_interpolator(self, r_a_min=1e-6, r_a_max=1e6, nra=10001):

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -274,6 +274,126 @@ def test_interp_linear_bad_extrapolate():
         interp_linear(numpy, _XG, _YG, _RQ, extrapolate="nope")
 
 
+# --- interp_bilinear: degree-1 tensor-product interp (the spherical-DF pvr) ----
+# scipy RectBivariateSpline(kx=1, ky=1, s=0) IS exact bilinear interpolation, and
+# CONSTANT-extrapolates beyond the grid (edge value) -> matched by clip.
+_BX = numpy.linspace(-3.0, 3.0, 20)  # log10(r/a)-like abscissa
+_BY = numpy.linspace(0.0, 1.0, 15)  # uniform-CDF-like abscissa
+numpy.random.seed(4)
+_BZ_RAND = numpy.random.uniform(0.0, 1.0, (_BX.size, _BY.size))
+# a monotone-in-CDF, smooth-in-r "realistic" v/vesc-like grid
+_BZ_REAL = (
+    (numpy.tanh(_BX)[:, None] * 0.0 + 1.0)
+    * numpy.sqrt(_BY)[None, :]
+    * (1.0 - 0.3 / (1.0 + numpy.exp(-_BX))[:, None])
+)
+
+
+@pytest.mark.parametrize("Z", [_BZ_RAND, _BZ_REAL])
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_interp_bilinear_parity(backend, Z):
+    # native bilinear must reproduce RectBivariateSpline(kx=1, ky=1).ev to ~1e-13
+    # (in-range and clamped out-of-range), on a random and a realistic grid.
+    from galpy.backend.interpolate import interp_bilinear
+
+    spl = si.RectBivariateSpline(_BX, _BY, Z, kx=1, ky=1)
+    rng = numpy.random.default_rng(1)
+    X = rng.uniform(-4.0, 4.0, 60)  # includes out-of-range in X
+    Y = rng.uniform(0.0, 1.0, 60)  # in-range in Y (the CDF axis)
+    ref = spl.ev(X, Y)
+    xp = _xp(backend)
+    got = as_numpy(
+        interp_bilinear(
+            xp,
+            _asarray(backend, _BX),
+            _asarray(backend, _BY),
+            _asarray(backend, Z),
+            _asarray(backend, X),
+            _asarray(backend, Y),
+            extrapolate="clip",
+        )
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_interp_bilinear_grad_vs_fd(backend):
+    # d(value)/d(X), d/d(Y), and d/d(Z-values): random directional AD must
+    # h-converge to a central FD of the numpy bilinear (matches scipy).
+    from galpy.backend.interpolate import interp_bilinear
+
+    rng = numpy.random.default_rng(2)
+    X0 = rng.uniform(-2.5, 2.5, 12)
+    Y0 = rng.uniform(0.05, 0.95, 12)
+    Z0 = _BZ_RAND
+
+    def val_np(x, y, z):
+        return interp_bilinear(numpy, _BX, _BY, z, x, y, extrapolate="clip")
+
+    def loss_np(x, y, z):
+        return numpy.sum(val_np(x, y, z))
+
+    dX = rng.standard_normal(X0.shape)
+    dX /= numpy.linalg.norm(dX)
+    dY = rng.standard_normal(Y0.shape)
+    dY /= numpy.linalg.norm(dY)
+    dZ = rng.standard_normal(Z0.shape)
+    dZ /= numpy.linalg.norm(dZ)
+    if backend == "jax":
+
+        def loss(x, y, z):
+            return jnp.sum(interp_bilinear(jnp, _BX, _BY, z, x, y, extrapolate="clip"))
+
+        gx, gy, gz = jax.grad(loss, argnums=(0, 1, 2))(
+            jnp.asarray(X0), jnp.asarray(Y0), jnp.asarray(Z0)
+        )
+        gx, gy, gz = numpy.asarray(gx), numpy.asarray(gy), numpy.asarray(gz)
+    else:
+        xt = torch.tensor(X0, requires_grad=True)
+        yt = torch.tensor(Y0, requires_grad=True)
+        zt = torch.tensor(Z0, requires_grad=True)
+        interp_bilinear(
+            _xp("torch"), _BX, _BY, zt, xt, yt, extrapolate="clip"
+        ).sum().backward()
+        gx, gy, gz = xt.grad.numpy(), yt.grad.numpy(), zt.grad.numpy()
+    adX, adY, adZ = (
+        float(numpy.dot(gx, dX)),
+        float(numpy.dot(gy, dY)),
+        float(numpy.sum(gz * dZ)),
+    )
+    for ad, fn in (
+        (adX, lambda h: loss_np(X0 + h * dX, Y0, Z0)),
+        (adY, lambda h: loss_np(X0, Y0 + h * dY, Z0)),
+        (adZ, lambda h: loss_np(X0, Y0, Z0 + h * dZ)),
+    ):
+        best = min(abs(ad - (fn(h) - fn(-h)) / (2 * h)) for h in (1e-4, 1e-5, 1e-6))
+        assert best < 1e-5 * abs(ad) + 1e-8, f"{backend} bilinear grad best={best:.2e}"
+
+
+@pytest.mark.parametrize("backend", ["jax"] if "jax" in BACKENDS else [])
+def test_interp_bilinear_jit_equals_eager(backend):
+    # jit(interp_bilinear) == eager (pure namespace ops, jit-safe).
+    from galpy.backend.interpolate import interp_bilinear
+
+    X = jnp.asarray(numpy.linspace(-3.5, 3.5, 30))
+    Y = jnp.asarray(numpy.linspace(0.0, 1.0, 30))
+    bx, by, bz = jnp.asarray(_BX), jnp.asarray(_BY), jnp.asarray(_BZ_RAND)
+
+    def f(x, y):
+        return interp_bilinear(jnp, bx, by, bz, x, y, extrapolate="clip")
+
+    eager = numpy.asarray(f(X, Y))
+    jitted = numpy.asarray(jax.jit(f)(X, Y))
+    numpy.testing.assert_allclose(jitted, eager, rtol=0.0, atol=1e-14)
+
+
+def test_interp_bilinear_bad_extrapolate():
+    from galpy.backend.interpolate import interp_bilinear
+
+    with pytest.raises(ValueError):
+        interp_bilinear(numpy, _BX, _BY, _BZ_RAND, _BX[:3], _BY[:3], extrapolate="nope")
+
+
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_spline1d_mode2_linear(backend):
     # mode 2 with k=1: in-backend piecewise-linear; numpy AND backend queries of

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -543,6 +543,68 @@ def test_sample_eddington_general_backend_reachable(backend):
         assert _is_backend_array(backend, c)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_v_native_pvr_parity(backend):
+    # the native bilinear inverse-CDF pvr must reproduce the scipy
+    # RectBivariateSpline(kx=1, ky=1) it dual-paths, at the SAME (log10 r/a, u)
+    # query points, to ~1e-13 -- so a backend-key velocity equals the numpy one
+    # given the same uniforms.
+    df = isotropicHernquistdf(pot=_HP)
+    df.sample(n=1, return_orbit=False)  # build the pvr interpolator
+    pvr = df._v_vesc_pvr_interpolator
+    rng = numpy.random.default_rng(5)
+    X = rng.uniform(-2.0, 2.0, 300)  # log10(r/a)
+    Y = rng.uniform(0.0, 1.0, 300)  # velocity uniform
+    ref = pvr(X, Y, grid=False)  # scipy path
+    got = as_numpy(pvr(_arr(backend, X), _arr(backend, Y), grid=False))  # native
+    numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_v_grad_vs_fd_r(backend):
+    # d(sampled velocity)/d(r): the backend-key velocity magnitude is a
+    # differentiable function of the backend r (through both the pvr query
+    # log10(r/a) and vmax(r)). Random directional AD must h-converge to a central
+    # FD of the numpy path (fixed velocity uniforms = common random numbers).
+    xp = _ns(backend)
+    df = isotropicHernquistdf(pot=_HP)
+    df.sample(n=1, return_orbit=False)  # build the pvr interpolator
+    pvr = df._v_vesc_pvr_interpolator
+    scale = df._scale
+    rng = numpy.random.default_rng(6)
+    r0 = rng.uniform(0.3, 4.0, 20)
+    u_v = rng.uniform(0.05, 0.95, 20)  # fixed velocity uniforms (CRN)
+    d = rng.standard_normal(r0.shape)
+    d /= numpy.linalg.norm(d)
+
+    def sumv_np(r):
+        v = pvr(numpy.log10(r / scale), u_v, grid=False) * as_numpy(
+            df._vmax_at_r(df._pot, r)
+        )
+        return numpy.sum(v)
+
+    def loss_b(r_b):
+        v = pvr(xp.log10(r_b / scale), _arr(backend, u_v), grid=False) * df._vmax_at_r(
+            df._pot, r_b
+        )
+        return xp.sum(v)
+
+    with galpy.backend.use(backend, force=True):
+        if backend == "jax":
+            g = numpy.asarray(jax.grad(loss_b)(jnp.asarray(r0)))
+        else:
+            rt = torch.tensor(r0, requires_grad=True)
+            loss_b(rt).backward()
+            g = rt.grad.numpy()
+    ad = float(numpy.dot(g, d))
+    assert numpy.isfinite(ad) and abs(ad) > 0
+    best = min(
+        abs(ad - (sumv_np(r0 + h * d) - sumv_np(r0 - h * d)) / (2 * h))
+        for h in (1e-4, 1e-5, 1e-6)
+    )
+    assert best < 1e-4 * abs(ad) + 1e-7, f"v-grad {backend} best={best:.2e}"
+
+
 @pytest.mark.skipif(not BACKENDS, reason="no backend installed")
 def test_sample_anisotropic_backend_key_raises():
     # anisotropic velocity-angle sampling on a backend key is deferred; a clear

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -618,3 +618,20 @@ def test_sample_anisotropic_backend_key_raises():
         with pytest.raises(NotImplementedError):
             df.sample(n=10, return_orbit=False, key=_key(backend))
         df.sample(n=10, return_orbit=False)  # numpy path still works
+
+
+def test_pvr_interpolator_getattr_delegation():
+    # _PVRInterpolator delegates unknown attributes (e.g. get_knots) to the
+    # wrapped scipy spline so it is a drop-in for the RectBivariateSpline it
+    # replaces, and guards `_spl` to raise AttributeError (not recurse) before
+    # `_spl` is assigned.
+    from galpy.df.sphericaldf import _PVRInterpolator
+
+    df = isotropicHernquistdf(pot=_HP)
+    df.sample(n=1, return_orbit=False)  # builds the numpy pvr (has ._spl)
+    pvr = df._v_vesc_pvr_interpolator
+    assert pvr.get_knots() is not None  # delegated to the scipy spline (line 196)
+    # a wrapper with no `_spl` raises AttributeError via the guard, not RecursionError
+    bare = _PVRInterpolator.__new__(_PVRInterpolator)
+    with pytest.raises(AttributeError):
+        bare.some_missing_attr  # noqa: B018  (triggers __getattr__ -> _spl guard)


### PR DESCRIPTION
## What

Completes **isotropic** spherical-DF backend sampling: `_sample_v` (the velocity-magnitude sampler) is now backend-native, removing the last numpy island in the isotropic sample path (`as_numpy(r)`) and making sampled velocities differentiable. numpy path stays **byte-identical** (dual-path: numpy=scipy, backend=native).

Follows #1181 (backend-native radial + angle sampling): now `r`, the position/velocity angles, AND the velocity magnitude all run backend-native under a backend `key`.

## Changes
- **`galpy/backend/interpolate.py`** — new `interp_bilinear(xp, x, y, Z, X, Y, extrapolate=…)`: the degree-1 tensor-product analogue of `interp_linear` (two `searchsorted` lookups + a bilinear blend of the 4 corners), differentiable in X/Y/Z, jit-safe. Reproduces `RectBivariateSpline(kx=1, ky=1, s=0).ev` — including scipy's constant out-of-range extrapolation via `extrapolate='clip'`.
- **`galpy/df/sphericaldf.py`** — a `_PVRInterpolator` dual-path wrapper (numpy → the scipy `RectBivariateSpline`, byte-identical; backend → native `interp_bilinear` over the stored grids); `_sample_v` gains a `key` (backend key → native bilinear pvr × backend `vmax`, `r` stays backend); `sample()` splits the key **4-way** (r / position-angle / velocity-angle / velocity-magnitude).
- **`galpy/df/osipkovmerrittdf.py`** — threaded `key` through its `_sample_v` override (stays numpy-side).

## Verification
- **numpy byte-identical** (A/B vs origin, fixed seed): `array_equal`, maxdiff **0.0** for isotropicHernquist/Plummer, eddington, king, constantbeta. The velocity uniform keeps the same `numpy.random.uniform` draw order (`split(None,4)=(None,)*4`).
- **native == scipy**: `interp_bilinear` vs `RectBivariateSpline(kx=1,ky=1).ev` = **2.2e-16** (numpy/jax/torch, in-range + clamped out-of-range); native pvr = 2.2e-16.
- **differentiable**: `d(v)/d(r)` grad-vs-FD h-converges (3.9e-9 → 1.2e-10); the chain `d(v)/d(cdf-knots)` (v depends on the backend `r` from `interp_linear`) h-converges. jax + torch identical.
- **-W error coverage-shard** condition (numpy-default + jax+torch + `-W error::Deprecation/Future`): velocity + bilinear tests pass — no `numpy.op(<tensor>)`. Full `test_backend_interpolate` (144) + `test_backend_sphericaldf` (49) green. No `backend_xfail.txt` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm