### PR TITLE
sphericaldf: backend-native anisotropic velocity-angle sampling (constantbeta/osipkovmerritt)

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -7,6 +7,7 @@ import numpy
 from scipy import integrate, interpolate, special
 
 from ..backend import (
+    as_backend_constant,
     as_numpy,
     autodiff_ops,
     device_of,
@@ -16,6 +17,7 @@ from ..backend import (
 )
 from ..backend import random as grandom
 from ..backend import resolve_namespace, use
+from ..backend.interpolate import interp_linear
 from ..backend.quadrature import fixed_quad, fixed_quad_semiinfinite
 from ..potential import evaluateRforces, interpSphericalPotential
 from ..potential.Potential import _evaluatePotentials
@@ -216,9 +218,13 @@ class _constantbetadf(anisotropicsphericaldf):
     def _sample_eta(self, r, n=1, key=None):
         """Sample the angle eta which defines radial vs tangential velocities
 
-        ``key`` is accepted (threaded from ``_sample_velocity_angles``) but the
-        anisotropic eta sampler stays numpy-side for now (backend eta is a later
-        migration); ``key=None`` is byte-identical."""
+        eta is drawn from the FIXED (r-independent) distribution
+        p(eta) ∝ sin(eta)^(1-2β) by inverting its cos(eta) CDF. ``key=None``
+        draws from the global ``numpy.random`` and inverts the CDF with the
+        scipy ``interp1d`` (byte-identical); a backend key draws a backend
+        uniform and inverts the SAME frozen (coseta_cmf, cosetas) inverse-CDF
+        grid natively via ``interp_linear`` -- so eta is a backend array
+        differentiable in the CDF grid (and hence, via the grid, in β)."""
         if not hasattr(self, "_coseta_icmf_interp"):
             # Cumulative dist for cos(eta) =
             # 0.5 + x 2F1(0.5,beta,1.5,x^2)/sqrt(pi)/Gamma(1-beta)*Gamma(1.5-beta)
@@ -231,10 +237,25 @@ class _constantbetadf(anisotropicsphericaldf):
                 * special.gamma(1.5 - self._beta)
                 + 0.5
             )
+            # cache the raw grids for the backend inverse-CDF (the numpy path
+            # keeps using the scipy interp1d below, byte-identically)
+            self._coseta_cmf_grid = coseta_cmf
+            self._cosetas_grid = cosetas
             self._coseta_icmf_interp = interpolate.interp1d(
                 coseta_cmf, cosetas, bounds_error=False, fill_value="extrapolate"
             )
-        return numpy.arccos(self._coseta_icmf_interp(numpy.random.uniform(size=n)))
+        if key is None:
+            # numpy path (byte-identical): global-numpy uniform + scipy interp1d
+            return numpy.arccos(self._coseta_icmf_interp(numpy.random.uniform(size=n)))
+        # backend key: native linear inverse-CDF on the frozen (coseta_cmf,
+        # cosetas) grid -- extrapolate=True matches interp1d(fill_value=
+        # "extrapolate"); eta is a backend array differentiable in the CDF grid
+        u = grandom.uniform(key, n)
+        xp = get_namespace(u)
+        cg = as_backend_constant(xp, self._coseta_cmf_grid, u)
+        vg = as_backend_constant(xp, self._cosetas_grid, u)
+        coseta = interp_linear(xp, cg, vg, u, extrapolate=True)
+        return xp.arccos(coseta)
 
     def _p_v_at_r(self, v, r):
         xp = resolve_namespace(v, r)
@@ -303,31 +324,37 @@ class _constantbetadf(anisotropicsphericaldf):
     def sample(
         self, R=None, z=None, phi=None, n=1, return_orbit=True, rmin=0.0, key=None
     ):
-        # No docstring so the superclass' is used. Sampling is a numpy-side
-        # (stateful-RNG) operation drawn from the interpolated fE (built with
-        # the backend's autodiff at construction); run it on numpy under torch
-        # so the returned Orbit and its accessors are numpy (see _numpy_ctx).
-        # Backend-key velocity sampling for anisotropic DFs is deferred (the eta
-        # sampler needs a backend inverse-CDF); reject a jax/torch key clearly
-        # rather than silently returning numpy or a broken mixed result.
-        if grandom._backend_of_key(key) != "numpy":
-            raise NotImplementedError(
-                "backend-key (jax/torch) sampling is not yet supported for "
-                "anisotropic DFs (constantbetadf/osipkovmerrittdf); pass "
-                "key=None for numpy sampling. Backend anisotropic velocity "
-                "sampling is a planned follow-up."
-            )
-        with _numpy_ctx(_active_backend_name()):
-            return sphericaldf.sample(
-                self,
-                R=R,
-                z=z,
-                phi=phi,
-                n=n,
-                return_orbit=return_orbit,
-                rmin=rmin,
-                key=key,
-            )
+        # No docstring so the superclass' is used.
+        # key=None (numpy sampling): a numpy-side (stateful-RNG) operation drawn
+        # from the interpolated fE (built with the backend's autodiff at
+        # construction); run it on numpy under torch so the scipy interpolators/
+        # quadrature don't see torch scalars and the returned Orbit is numpy
+        # (see _numpy_ctx -- byte-identical numpy pass-through). A backend key
+        # follows its OWN draws into jax/torch (the eta inverse-CDF and the
+        # velocity magnitude are backend-native, differentiable, GPU/jit-able),
+        # so it must NOT force numpy -- that would override the data dispatch.
+        if grandom._backend_of_key(key) == "numpy":
+            with _numpy_ctx(_active_backend_name()):
+                return sphericaldf.sample(
+                    self,
+                    R=R,
+                    z=z,
+                    phi=phi,
+                    n=n,
+                    return_orbit=return_orbit,
+                    rmin=rmin,
+                    key=key,
+                )
+        return sphericaldf.sample(
+            self,
+            R=R,
+            z=z,
+            phi=phi,
+            n=n,
+            return_orbit=return_orbit,
+            rmin=rmin,
+            key=key,
+        )
 
 
 class constantbetadf(_constantbetadf):

--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -2,7 +2,7 @@
 import numpy
 from scipy import integrate, interpolate, special
 
-from ..backend import as_numpy, device_of
+from ..backend import as_numpy, device_of, get_namespace
 from ..backend import random as grandom
 from ..backend import resolve_namespace
 from ..backend.quadrature import fixed_quad, nested_quad
@@ -192,23 +192,36 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
     def _sample_eta(self, r, n=1, key=None):
         """Sample the angle eta which defines radial vs tangential velocities
 
-        ``key`` is accepted (threaded from ``_sample_velocity_angles``) but the
-        anisotropic eta sampler stays numpy-side for now (backend eta is a later
-        migration); ``key=None`` is byte-identical."""
+        The cos(eta) inverse-CDF is CLOSED-FORM (r-dependent through
+        A = (r/ra)^2), so no grid is needed: ``key=None`` draws from the global
+        ``numpy.random`` (byte-identical); a backend key draws backend uniforms
+        (magnitude + symmetric sign) and evaluates the SAME analytic inversion
+        in-namespace -- so eta is a backend array differentiable in r."""
         # cumulative distribution of x = cos eta satisfies
         # x/(sqrt(A+1 -A* x^2)) = 2 b - 1 = c
         # where b \in [0,1] and A = (r/ra)^2
         # Solved by
         # x = c sqrt(1+[r/ra]^2) / sqrt( [r/ra]^2 c^2 + 1 ) for c > 0 [b > 0.5]
         # and symmetric wrt c
-        c = numpy.random.uniform(size=n)
-        x = (
-            c
-            * numpy.sqrt(1 + r**2.0 / self._ra2)
-            / numpy.sqrt(r**2.0 / self._ra2 * c**2.0 + 1)
-        )
-        x *= numpy.random.choice([1.0, -1.0], size=n)
-        return numpy.arccos(x)
+        if key is None:
+            # numpy path (byte-identical)
+            c = numpy.random.uniform(size=n)
+            x = (
+                c
+                * numpy.sqrt(1 + r**2.0 / self._ra2)
+                / numpy.sqrt(r**2.0 / self._ra2 * c**2.0 + 1)
+            )
+            x *= numpy.random.choice([1.0, -1.0], size=n)
+            return numpy.arccos(x)
+        # backend key: same analytic inversion, in-namespace and differentiable
+        # in r; independent sub-keys for the magnitude uniform and the sign
+        kc, ks = grandom.split(key, 2)
+        c = grandom.uniform(kc, n)
+        xp = get_namespace(c)
+        A = xp.asarray(r) ** 2.0 / self._ra2  # coerce: r is the backend sample r
+        x = c * xp.sqrt(1.0 + A) / xp.sqrt(A * c**2.0 + 1.0)
+        sign = grandom.choice(ks, xp.asarray([1.0, -1.0]), shape=n)
+        return xp.arccos(x * sign)
 
     def _p_v_at_r(self, v, r):
         """p( v*sqrt[1+r^2/ra^2*sin^2eta] | r) used in sampling"""
@@ -238,13 +251,17 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
     def _sample_v(self, r, eta, n=1, key=None):
         """Generate velocity samples
 
-        OM sampling is numpy-side (``osipkovmerrittdf.sample`` rejects a backend
-        key), so ``key`` is always ``None`` here and threaded through for
-        signature parity."""
+        ``key=None`` is the byte-identical numpy path; a backend key returns a
+        backend velocity (the base pvr sampler is native, so the r/eta transform
+        below runs in-namespace, differentiable in r and eta)."""
         # Use super-class method to obtain v*[1+r^2/ra^2*sin^2eta]
         out = super()._sample_v(r, eta, n=n, key=key)
         # Transform to v
-        return out / numpy.sqrt(1.0 + r**2.0 / self._ra2 * numpy.sin(eta) ** 2.0)
+        if key is None:
+            return out / numpy.sqrt(1.0 + r**2.0 / self._ra2 * numpy.sin(eta) ** 2.0)
+        xp = get_namespace(out, eta)
+        rb = xp.asarray(r) ** 2.0
+        return out / xp.sqrt(1.0 + rb / self._ra2 * xp.sin(eta) ** 2.0)
 
     def _vmomentdensity(self, r, n, m):
         if m % 2 == 1 or n % 2 == 1:
@@ -417,15 +434,9 @@ class osipkovmerrittdf(_osipkovmerrittdf):
         if rmin is None:
             rmin = self._rmin
         self._ensure_fQ_interp()
-        # Backend-key velocity sampling for anisotropic DFs is deferred (the eta
-        # sampler needs a backend inverse-CDF); reject a jax/torch key clearly.
-        if grandom._backend_of_key(key) != "numpy":
-            raise NotImplementedError(
-                "backend-key (jax/torch) sampling is not yet supported for "
-                "anisotropic DFs (constantbetadf/osipkovmerrittdf); pass "
-                "key=None for numpy sampling. Backend anisotropic velocity "
-                "sampling is a planned follow-up."
-            )
+        # key=None keeps the whole assembly numpy (byte-identical); a backend key
+        # makes the radial, angle (native analytic eta inverse-CDF), and velocity
+        # sampling backend-native (differentiable, GPU/jit-able).
         return sphericaldf.sample(
             self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -605,19 +605,55 @@ def test_sample_v_grad_vs_fd_r(backend):
     assert best < 1e-4 * abs(ad) + 1e-7, f"v-grad {backend} best={best:.2e}"
 
 
-@pytest.mark.skipif(not BACKENDS, reason="no backend installed")
-def test_sample_anisotropic_backend_key_raises():
-    # anisotropic velocity-angle sampling on a backend key is deferred; a clear
-    # NotImplementedError beats a confusing TypeError / a silent numpy result.
-    # key=None (numpy) still works. Backend-independent (the guard keys off the
-    # key type), so run it once.
+def _ellipsoid_beta(coords):
+    """Velocity-anisotropy beta (and the two tangential/radial dispersion ratios)
+    from a spherical-DF sample's cylindrical (R, vR, vT, z, vz)."""
+    R, vR, vT, z, vz = (as_numpy(c) for c in coords[:5])
+    r = numpy.sqrt(R**2.0 + z**2.0)
+    vr = (R * vR + z * vz) / r  # spherical radial
+    vtot2 = vR**2.0 + vT**2.0 + vz**2.0
+    vphi2 = vT**2.0  # azimuthal (spherical phi = cyl T)
+    vth2 = vtot2 - vr**2.0 - vphi2  # spherical polar
+    sr2, sth2, sph2 = numpy.mean(vr**2.0), numpy.mean(vth2), numpy.mean(vphi2)
+    return 1.0 - (sth2 + sph2) / (2.0 * sr2), sth2 / sr2, sph2 / sr2
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_anisotropic_backend_key_distribution(backend):
+    # constantbeta/osipkovmerritt sample() under a backend key now returns
+    # backend-array coordinates whose velocity ellipsoid reproduces the analytic
+    # anisotropy (the eta inverse-CDF is backend-native: constantbeta inverts a
+    # fixed 1-D cos-eta CDF via interp_linear, OM the closed-form r-dependent
+    # inversion). key=None stays byte-identical (test_sphericaldf).
     from galpy.df import constantbetadf, osipkovmerrittdf
 
-    backend = BACKENDS[0]
-    for df in (constantbetadf(pot=_HP, beta=-0.2), osipkovmerrittdf(pot=_HP, ra=1.5)):
-        with pytest.raises(NotImplementedError):
-            df.sample(n=10, return_orbit=False, key=_key(backend))
-        df.sample(n=10, return_orbit=False)  # numpy path still works
+    n = 40000
+    # constant-beta: beta is r-independent -> the ellipsoid beta equals the true
+    # beta and each tangential/radial dispersion ratio equals 1 - beta.
+    cbeta = -0.2
+    cb = constantbetadf(pot=_HP, beta=cbeta)
+    cb_coords = cb.sample(n=n, return_orbit=False, key=_key(backend))
+    for c in cb_coords:
+        assert _is_backend_array(backend, c)
+    b_est, rth, rph = _ellipsoid_beta(cb_coords)
+    assert numpy.isfinite(b_est), f"constantbeta beta_est not finite ({b_est})"
+    assert abs(b_est - cbeta) < 0.04, f"constantbeta beta_est={b_est:.3f} vs {cbeta}"
+    assert abs(rth - (1.0 - cbeta)) < 0.06 and abs(rph - (1.0 - cbeta)) < 0.06, (
+        f"constantbeta ratios vth2/vr2={rth:.3f} vph2/vr2={rph:.3f} vs {1.0 - cbeta}"
+    )
+    cb.sample(n=5, return_orbit=False)  # numpy (key=None) path still works
+
+    # Osipkov-Merritt: beta(r) varies with r, so the mixed-radius ellipsoid beta
+    # must match an independent numpy sample of the same size (both float64).
+    om = osipkovmerrittdf(pot=_HP, ra=1.5)
+    om_coords = om.sample(n=n, return_orbit=False, key=_key(backend))
+    for c in om_coords:
+        assert _is_backend_array(backend, c)
+    b_be = _ellipsoid_beta(om_coords)[0]
+    numpy.random.seed(4)
+    b_np = _ellipsoid_beta(om.sample(n=n, return_orbit=False))[0]
+    assert numpy.isfinite(b_be), f"OM beta_est not finite ({b_be})"
+    assert abs(b_be - b_np) < 0.03, f"OM beta backend={b_be:.3f} numpy={b_np:.3f}"
 
 
 def test_pvr_interpolator_getattr_delegation():
@@ -630,7 +666,7 @@ def test_pvr_interpolator_getattr_delegation():
     df = isotropicHernquistdf(pot=_HP)
     df.sample(n=1, return_orbit=False)  # builds the numpy pvr (has ._spl)
     pvr = df._v_vesc_pvr_interpolator
-    assert pvr.get_knots() is not None  # delegated to the scipy spline (line 196)
+    assert pvr.get_knots() is not None  # delegated to the scipy spline
     # a wrapper with no `_spl` raises AttributeError via the guard, not RecursionError
     bare = _PVRInterpolator.__new__(_PVRInterpolator)
     with pytest.raises(AttributeError):


### PR DESCRIPTION
## What

Completes **anisotropic** spherical-DF backend sampling: `_sample_eta` (the velocity-polar-angle sampler) is now backend-native for `constantbetadf` and `osipkovmerrittdf`, so their backend-key sampling works and the `NotImplementedError` guards are removed. numpy path stays **byte-identical**.

With #1181 (radial + angles), #1183 (velocity magnitude), and this, spherical-DF sampling is fully backend-native (jax/torch), differentiable, and GPU-capable — isotropic *and* anisotropic.

## Changes
- **`galpy/df/constantbetadf.py`** — `_sample_eta` dual-path: numpy (`key=None`) unchanged (scipy `interp1d`); a backend key inverts the fixed `p(η) ∝ sin(η)^(1−2β)` cos-η CDF natively via `interp_linear`. The `_constantbetadf`/`constantbetadf` `sample` backend-key `NotImplementedError` guards removed.
- **`galpy/df/osipkovmerrittdf.py`** — `_sample_eta` dual-path: backend branch evaluates the closed-form r-dependent OM inversion in-namespace (differentiable in r); `_sample_v` also dual-pathed (the `numpy.sqrt/sin` transform breaks on backend `r`/`eta`). Guard removed.
- **`tests/test_backend_sphericaldf.py`** — the former expect-raises guard test is now the positive `test_sample_anisotropic_backend_key_distribution` (backend coords + correct velocity ellipsoid), plus an `_ellipsoid_beta` helper.

## Verification
- **numpy byte-identical** (A/B vs base): constantbeta + osipkovmerritt `sample(return_orbit=False)` fixed-seed → `array_equal`, maxdiff **0.0**.
- **anisotropy recovery**: constantbeta β=−0.2 → backend β̂ ≈ −0.19/−0.21 (numpy −0.20), dispersion ratios ≈ 1−β; OM ra=1.5 → backend β̂ 0.548 vs numpy 0.544.
- **differentiable**: d(cos η)/d(CDF grid) (constantbeta) and d(cos η)/d(r) (OM) grad-vs-FD h-converged, jax + torch.
- `-W error` shard: full `test_backend_sphericaldf.py` passes (numpy-default + jax+torch). No `backend_xfail.txt` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm