### PR TITLE
actionAngle grids: cover the native backend-build paths (#1182 follow-up)

### DIFF
--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -2114,3 +2114,230 @@ def test_staeckelgrid_native_setup_differentiable(backend):
         fd = (_l(baseL_np + 1e-4 * V) - _l(baseL_np - 1e-4 * V)) / 2e-4
         assert _is_backend_array(backend, grad if backend == "jax" else bt.grad)
     numpy.testing.assert_allclose(dd, fd, rtol=1e-5, atol=1e-8)
+
+
+# The interpecc frozen tables (ecc/zmax/rperi/rap + their per-Lz maxima); all
+# stored under the same attribute names on the numpy and backend paths.
+_ECC_TABLES = ("_ecc", "_zmax", "_rperi", "_rap")
+_ECC_LZE_TABLES = ("_zmaxLzE", "_rperiLzE", "_rapLzE")
+
+
+def _staeckelgrid_numpy_ref_interpecc():
+    from galpy.potential import MWPotential2014
+
+    return actionAngleStaeckelGrid(
+        pot=MWPotential2014,
+        delta=0.45,
+        nE=12,
+        npsi=12,
+        nLz=14,
+        c=True,
+        interpecc=True,
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_native_setup_interpecc(backend):
+    # interpecc=True grid built inside a forced backend: the ecc/zmax/rperi/rap
+    # tables (+ their per-Lz maxima) are BACKEND arrays fit NATIVELY and match the
+    # numpy(interpecc) grid. This exercises the interpecc build block (the
+    # EccZmaxRperiRap solve, the _max_finite per-Lz reduction, the clamp/normalise,
+    # and the interpecc backend-interp wrappers) that interpecc=False never reaches.
+    from galpy import backend as galpy_backend
+    from galpy.potential import MWPotential2014
+
+    ref = _staeckelgrid_numpy_ref_interpecc()
+    ref_ecc = ref.EccZmaxRperiRap(*_NATIVE_S)
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleStaeckelGrid(
+            pot=MWPotential2014,
+            delta=0.45,
+            nE=12,
+            npsi=12,
+            nLz=14,
+            c=True,
+            interpecc=True,
+        )
+        for a in _ECC_TABLES + _ECC_LZE_TABLES:
+            assert _is_backend_array(backend, getattr(g, a)), a
+        # Tables match the numpy(interpecc) grid. The ecc-family tables derive from
+        # the same u0-sensitive orbit positions (see the differentiable/parity
+        # notes on the interpecc=False test), so they floor at the ~1e-4 _u0 band.
+        for a in _ECC_TABLES + _ECC_LZE_TABLES:
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg=a,
+            )
+        xp = galpy_backend.get_namespace()
+        got_ecc = g.EccZmaxRperiRap(*[xp.asarray(v) for v in _NATIVE_S])
+    for r, gg in zip(ref_ecc, got_ecc):
+        assert _is_backend_array(backend, gg)
+        numpy.testing.assert_allclose(
+            as_numpy(gg), numpy.asarray(r), rtol=1e-2, atol=1e-3
+        )
+
+
+def _interpRZ_pot():
+    from galpy.potential import MWPotential2014, interpRZPotential
+
+    return interpRZPotential(
+        RZPot=MWPotential2014,
+        rgrid=(numpy.log(0.01), numpy.log(20.0), 201),
+        logR=True,
+        zgrid=(0.0, 1.0, 101),
+        interpPot=True,
+        use_c=True,
+        enable_c=True,
+        zsym=True,
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_native_setup_interpRZ(backend):
+    # A grid built on an interpRZPotential under a forced backend: extreme grid
+    # orbits fall off the interpolated potential and are flagged 9999.99, so the
+    # build recomputes them with the ORIGINAL potential (the numpy-solver recompute
+    # block). Covers the interpRZ ``_origPot`` u0-solve branch AND the bad-orbit
+    # recompute (actions + interpecc) that a regular potential never triggers. The
+    # recomputed tables still land as backend arrays and match the numpy grid.
+    from galpy import backend as galpy_backend
+
+    rzpot = _interpRZ_pot()
+    ref = actionAngleStaeckelGrid(
+        pot=rzpot, delta=0.71, nE=8, npsi=8, nLz=8, c=True, interpecc=True
+    )
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleStaeckelGrid(
+            pot=rzpot, delta=0.71, nE=8, npsi=8, nLz=8, c=True, interpecc=True
+        )
+        for a in ("_jr", "_jz", "_u0") + _ECC_TABLES + _ECC_LZE_TABLES:
+            assert _is_backend_array(backend, getattr(g, a)), a
+        # jr/jz recompute the bad orbits with the ORIGINAL potential in both paths
+        # (tmpaA), so those tables match to grid parity (the ~1e-4 _u0 band).
+        # NOTE: the ecc/zmax/rperi/rap bad-orbit recompute does NOT match here --
+        # the numpy path recomputes them with self._aA (the interp potential),
+        # whereas the #1182 backend path uses tmpaA (the orig potential); the two
+        # therefore diverge on the flagged entries. We only pin the backend-array
+        # property for the ecc-family here (parity is covered by the regular-pot
+        # interpecc test, which has no bad orbits).
+        for a in ("_jr", "_jz"):
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg=a,
+            )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckelgrid_native_setup_noc(backend):
+    # c=False grid built inside a forced backend: the u0 solve takes the per-point
+    # calcu0 python loop (the non-c branch), which the c=True native tests skip.
+    # Keep the grid tiny (the non-c Staeckel action solve is a python quadrature).
+    from galpy import backend as galpy_backend
+    from galpy.potential import MWPotential2014
+
+    ref = actionAngleStaeckelGrid(
+        pot=MWPotential2014, delta=0.45, nE=6, npsi=6, nLz=6, c=False
+    )
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleStaeckelGrid(
+            pot=MWPotential2014, delta=0.45, nE=6, npsi=6, nLz=6, c=False
+        )
+        for a in ("_jr", "_jz", "_u0", "_jrLzE", "_jzLzE"):
+            assert _is_backend_array(backend, getattr(g, a)), a
+        for a in ("_jr", "_jz", "_jrLzE", "_jzLzE"):
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg=a,
+            )
+
+
+# AdiabaticGrid frozen tables (Ez + JR grids and their abscissae/maxima); same
+# attribute names on the numpy and backend paths.
+_ADIA_TABLES = ("_Rs", "_EzZmaxs", "_jz", "_Lzs", "_RL", "_ERRL", "_jr")
+
+
+# Jz() runs the shared _parse_eval_args, which computes the (unused-by-Jz) polar
+# angle via numpy.arctan2 -- benign on backend arrays but trips numpy's 2.0
+# __array_wrap__ deprecation under the -W error coverage shard; filter it here.
+@pytest.mark.filterwarnings(
+    "ignore:__array_wrap__ must accept context:DeprecationWarning"
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabaticgrid_native_setup_backend_arrays(backend):
+    # A c=True AdiabaticGrid built inside a forced backend stores its frozen tables
+    # as backend arrays (GPU-resident, no numpy island) fit NATIVELY, matching the
+    # numpy(scipy) grid. Exercises the backend build (Ez + JR grids) that the numpy
+    # xp-is-numpy path never reaches, plus the on-grid Jz() backend dispatch.
+    from galpy import backend as galpy_backend
+    from galpy.potential import MWPotential2014
+
+    kw = dict(pot=MWPotential2014, nR=8, nEz=8, nEr=10, nLz=10, c=True)
+    ref = actionAngleAdiabaticGrid(**kw)
+    ref_a = ref(*_NATIVE_S)
+    # numpy Jz() is scalar-only; build the reference point-by-point.
+    ref_jz = numpy.array(
+        [ref.Jz(*[float(v[i]) for v in _NATIVE_S]) for i in range(len(_NATIVE_S[0]))]
+    )
+    with galpy_backend.use(backend, force=True):
+        g = actionAngleAdiabaticGrid(**kw)
+        for a in _ADIA_TABLES:
+            assert _is_backend_array(backend, getattr(g, a)), a
+        for a in _ADIA_TABLES:
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-6,
+                atol=1e-8,
+                err_msg=a,
+            )
+        xp = galpy_backend.get_namespace()
+        args = [xp.asarray(v) for v in _NATIVE_S]
+        got_a = g(*args)
+        got_jz = g.Jz(*args)  # Jz() backend dispatch
+    assert _is_backend_array(backend, got_jz)
+    for r, gg in zip(ref_a, got_a):
+        numpy.testing.assert_allclose(
+            as_numpy(gg), numpy.asarray(r), rtol=1e-3, atol=1e-5
+        )
+    numpy.testing.assert_allclose(
+        as_numpy(got_jz), numpy.asarray(ref_jz), rtol=1e-3, atol=1e-5
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_adiabaticgrid_native_setup_noc(backend):
+    # c=False AdiabaticGrid built inside a forced backend: the jz/jr grids take the
+    # per-point actionAngleAdiabatic python loops (the non-c branch). Kept tiny (the
+    # non-c solve is a python quadrature per grid point); if the build is
+    # pathologically slow (>60s) it is skipped rather than shipping a timeout.
+    import time
+
+    from galpy import backend as galpy_backend
+    from galpy.potential import MWPotential2014
+
+    kw = dict(pot=MWPotential2014, nR=6, nEz=6, nEr=6, nLz=6, c=False)
+    ref = actionAngleAdiabaticGrid(**kw)
+    with galpy_backend.use(backend, force=True):
+        t0 = time.time()
+        g = actionAngleAdiabaticGrid(**kw)
+        if time.time() - t0 > 60.0:  # pragma: no cover
+            pytest.skip("non-c backend AdiabaticGrid build too slow on this backend")
+        for a in _ADIA_TABLES:
+            assert _is_backend_array(backend, getattr(g, a)), a
+        for a in ("_jz", "_jr"):
+            numpy.testing.assert_allclose(
+                as_numpy(getattr(g, a)),
+                numpy.asarray(getattr(ref, a)),
+                rtol=1e-6,
+                atol=1e-8,
+                err_msg=a,
+            )

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1072,3 +1072,46 @@ def test_native_rect_cubic_grad_vs_fd(backend):
 
     fd = (_l(z0 + 1e-4 * V) - _l(z0 - 1e-4 * V)) / 2e-4
     numpy.testing.assert_allclose(dd, fd, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline_filter_native_degenerate_axis(backend):
+    # A length<=1 axis takes the _spline_filter1d_native early-return (nothing to
+    # prefilter along it); the native prefilter still matches scipy (which leaves
+    # such an axis unchanged). Covers the L<=1 short-circuit.
+    for g in (numpy.array([3.7]), numpy.arange(6.0).reshape(1, 6)):
+        ref = sndi.spline_filter(g, order=3)
+        out = spline_filter(_asarray(backend, g))
+        assert _is_backend(backend, out)
+        numpy.testing.assert_allclose(as_numpy(out), ref, rtol=1e-11, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline2d_mode2_bad_k(backend):
+    # A backend z selects mode 2 (native fit); mode 2 only implements bicubic, so a
+    # non-cubic degree raises. Covers the kx/ky!=3 guard.
+    with pytest.raises(ValueError):
+        Spline2D(_NF_X, _NF_Y, _asarray(backend, _NF_Z_SMOOTH), kx=2)
+    with pytest.raises(ValueError):
+        Spline2D(_NF_X, _NF_Y, _asarray(backend, _NF_Z_SMOOTH), ky=2)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline2d_mode2_numpy_query(backend):
+    # A mode-2 (backend-native) Spline2D queried with NUMPY points materialises the
+    # native coeffs off the backend and evaluates through numpy -- both point-eval
+    # (grid=False) and outer-product (grid=True) -- matching scipy .ev / __call__.
+    spl = si.RectBivariateSpline(_NF_X, _NF_Y, _NF_Z_SMOOTH, kx=3, ky=3, s=0.0)
+    from galpy.backend import is_backend_array
+
+    s2 = Spline2D(_NF_X, _NF_Y, _asarray(backend, _NF_Z_SMOOTH))
+    assert s2._spl is None  # mode 2 (no scipy spline stored)
+    # grid=False: numpy points paired elementwise (like .ev), returns a numpy array
+    got = s2(_NF_XQ, _NF_YQ)
+    assert not is_backend_array(got)
+    numpy.testing.assert_allclose(got, spl.ev(_NF_XQ, _NF_YQ), rtol=1e-11, atol=1e-12)
+    # grid=True: outer product of numpy X,Y (like scipy __call__)
+    Xg = numpy.array([0.4, 1.1, 2.6])
+    Yg = numpy.array([-0.5, 0.3, 1.2, 1.8])
+    got_g = s2(Xg, Yg, grid=True)
+    numpy.testing.assert_allclose(got_g, spl(Xg, Yg, grid=True), rtol=1e-11, atol=1e-12)


### PR DESCRIPTION
## Why

PR #1182 (actionAngle native-grid backend spline fits) merged into `feat/backends` **without a codecov gate**, so **148 lines** of backend-build code shipped untested. This follow-up adds forced-backend tests that exercise those paths, restoring coverage. All tests are **additive** — the numpy path is byte-identical and unchanged.

## What

Measured the #1182-added lines as the diff of `ced6dd9c` vs its merge-parent `41fae0d6`, run under the coverage shard's `tests/test_backend*.py` + jax/torch. **148 uncovered → 0.**

**`tests/test_backend_actionAngle.py`**
- `test_staeckelgrid_native_setup_interpecc` — `interpecc=True` native build under a forced backend: asserts the ecc/zmax/rperi/rap tables (+ per-Lz maxima) are backend arrays and match the numpy(interpecc) grid. Covers the `EccZmaxRperiRap` grid solve, the `_max_finite` per-Lz reduction, the interpecc clamp/normalise, and the interpecc backend-interp wrappers (all skipped by the existing `interpecc=False` native test).
- `test_staeckelgrid_native_setup_interpRZ` — build on an `interpRZPotential`: extreme grid orbits are flagged `9999.99` and recomputed with the original potential. Covers the `_origPot` u0-solve branch and the bad-orbit numpy-solver recompute.
- `test_staeckelgrid_native_setup_noc` — `c=False` build: covers the per-point `calcu0` u0 python loop.
- `test_adiabaticgrid_native_setup_backend_arrays` — **the first forced-backend AdiabaticGrid setup test** (`c=True` Ez + JR grid build) + the on-grid `Jz()` backend dispatch.
- `test_adiabaticgrid_native_setup_noc` — small `c=False` build (non-c per-point loops), time-guarded.

**`tests/test_backend_interpolate.py`**
- `test_spline_filter_native_degenerate_axis` — the `_spline_filter1d_native` `L<=1` short-circuit.
- `test_spline2d_mode2_bad_k` — the mode-2 (backend-z) bad-degree guard.
- `test_spline2d_mode2_numpy_query` — a mode-2 block queried with numpy points (grid=False point-eval + grid=True outer product).

## Coverage (per file, #1182-added lines uncovered)

| file | before | after |
|---|---|---|
| `actionAngleStaeckelGrid.py` | 69 | 0 |
| `actionAngleAdiabaticGrid.py` | 69 | 0 |
| `backend/interpolate.py` | 10 | 0 |
| **total** | **148** | **0** |

Measured via `coverage run … -m pytest tests/test_backend_interpolate.py tests/test_backend_actionAngle.py` (numpy-default + jax x64 + torch float64), then `coverage json` intersected with the `41fae0d6…ced6dd9c` added-line set. Full run: **456 passed**. Also verified green under the coverage shard's `-W error::DeprecationWarning -W error::FutureWarning`.

## Notes for review

- **Behavioral divergence surfaced (not fixed here):** in the StaeckelGrid interpecc bad-orbit recompute, the numpy path recomputes ecc/zmax/rperi/rap with `self._aA` (the *interp* potential, line 238) whereas the #1182 backend path uses `tmpaA` (the *orig* potential, line 559). They therefore diverge on the flagged entries, so the interpRZ test only asserts jr/jz parity (both use `tmpaA`) + the backend-array property for the ecc-family; ecc-family parity is covered by the regular-potential interpecc test (which has no bad orbits). Flagging for a decision on which potential the backend recompute should use.
- One targeted `filterwarnings` on the AdiabaticGrid `Jz()` test: the shared `_parse_eval_args` computes a polar angle via `numpy.arctan2` on backend arrays (unused by `Jz`, benign), which trips numpy 2.0's `__array_wrap__` deprecation under `-W error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm