### PR TITLE
EllipsoidalPotential: fix _anchor_phi numpy-R dtype coercion (torch dxdv_3d_c[Triaxial*])

### DIFF
--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -33,18 +33,20 @@ def _anchor_phi(phi, R, xp):
     passed a backend array. torch's ``cos``/``sin`` only accept tensors, so
     such scalars are anchored as ``xp.asarray(phi, dtype=R.dtype)`` (input-
     dtype anchoring, so float32 inputs are not promoted through the backend's
-    default dtype). When ``R`` carries no dtype (a plain python scalar -- e.g.
-    the un-coerced ``Rforce(1.,0.)`` that ``normalize()`` issues from within
-    ``__init__``, before the backend-compat flag is set so the input boundary
-    does not lift the coordinates), ``phi`` is anchored to ``xp.float64``
-    (galpy's interior precision) rather than the backend default (torch's
-    float32), so the resulting amplitude does not silently drop to float32. The
-    numpy path returns ``phi`` untouched (byte-identical), as do already-backend
-    ``phi`` arrays (no silent cast/detach of user tensors, which would break
-    autodiff w.r.t. ``phi``)."""
+    default dtype). ``R.dtype`` is only trusted when ``R`` is itself a backend
+    array (its dtype is then a valid ``xp`` dtype); when ``R`` is a plain python
+    scalar (no dtype -- e.g. the un-coerced ``Rforce(1.,0.)`` that ``normalize()``
+    issues from within ``__init__``, before the backend-compat flag is set so
+    the input boundary does not lift the coordinates) OR a numpy array (whose
+    numpy dtype ``torch.asarray``/``jax`` would reject), ``phi`` is anchored to
+    ``xp.float64`` (galpy's interior precision) rather than the backend default
+    (torch's float32), so the resulting amplitude does not silently drop to
+    float32. The numpy path returns ``phi`` untouched (byte-identical), as do
+    already-backend ``phi`` arrays (no silent cast/detach of user tensors, which
+    would break autodiff w.r.t. ``phi``)."""
     if xp is numpy or is_backend_array(phi):
         return phi
-    dtype = getattr(R, "dtype", None)
+    dtype = R.dtype if is_backend_array(R) else None
     if dtype is None:
         dtype = xp.float64
     return xp.asarray(phi, dtype=dtype)

--- a/tests/test_backend_ellipsoidal.py
+++ b/tests/test_backend_ellipsoidal.py
@@ -549,6 +549,43 @@ def test_anchor_phi_dtypeless_scalar_R_anchors_float64(backend_name):
     assert _anchor_phi(0.5, 1.0, numpy) == 0.5  # numpy short-circuit, untouched
 
 
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_anchor_phi_numpy_R_anchors_float64(backend_name):
+    # Regression: under a forced backend R can arrive as a numpy array/scalar (an
+    # un-coerced coordinate in the dxdv/variational path). R.dtype is then a numpy
+    # dtype that torch.asarray / jax reject -- _anchor_phi must trust R.dtype only
+    # for backend-array R and otherwise anchor phi to xp.float64. Fixes the
+    # test_orbit dxdv_3d_c[Triaxial*/PerfectEllipsoid*] TypeError "asarray():
+    # argument 'dtype' must be torch.dtype, not numpy.dtypes.Float64DType".
+    import galpy.backend
+    from galpy.potential.EllipsoidalPotential import _anchor_phi
+
+    with galpy.backend.use(backend_name, force=True):
+        xp = galpy.backend.get_namespace()
+        for R in (numpy.array([1.0, 2.0]), numpy.float64(1.0)):
+            out = _anchor_phi(0.5, R, xp)  # must NOT raise on the numpy dtype
+            assert galpy.backend.is_backend_array(out)
+            assert "float64" in str(out.dtype)
+            assert as_numpy(out) == 0.5
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_anchor_phi_preserves_backend_float32_R(backend_name):
+    # A backend float32 R still anchors phi to float32 (input-dtype anchoring);
+    # only numpy / dtype-less R falls back to float64. Guards against a naive
+    # "just force float64" fix that would silently promote genuine float32 inputs.
+    import galpy.backend
+    from galpy.potential.EllipsoidalPotential import _anchor_phi
+
+    with galpy.backend.use(backend_name, force=True):
+        xp = galpy.backend.get_namespace()
+        R32 = xp.asarray([1.0, 2.0], dtype=xp.float32)
+        out = _anchor_phi(0.5, R32, xp)
+    assert "float32" in str(out.dtype), (
+        f"{backend_name}: backend float32 R should anchor phi to float32, got {out.dtype}"
+    )
+
+
 def test_evaluate_xyz_namespace_fallback():
     # _evaluate_xyz infers the backend from its (x,y,z) arguments when called
     # without an explicit ``xp`` (the public _evaluate always passes one, so this


### PR DESCRIPTION
## Problem
Under a forced backend, `R` can reach `_anchor_phi(phi, R, xp)` as a **numpy** array/scalar (an un-coerced coordinate in the dxdv / variational path). `getattr(R, "dtype")` is then a numpy dtype, so `xp.asarray(phi, dtype=<numpy dtype>)` with `xp=torch`/`jax` raises:

```
TypeError: asarray(): argument 'dtype' must be torch.dtype, not numpy.dtypes.Float64DType
```

This is the exact failure the authoritative CI regen (run 29979778304) records for **`test_orbit::test_dxdv_3d_c_vs_python[Triaxial*/PerfectEllipsoid*]`** under torch (7–8 entries), and the same root cause underlies the `sin/cos(numpy)` variants elsewhere in that cluster.

## Fix
Trust `R.dtype` **only when `R` is itself a backend array** (its dtype is then a valid `xp` dtype). For numpy or dtype-less `R`, anchor `phi` to `xp.float64` — galpy's interior precision — exactly like the existing dtype-less-scalar branch.

```python
dtype = R.dtype if is_backend_array(R) else None
if dtype is None:
    dtype = xp.float64
return xp.asarray(phi, dtype=dtype)
```

Semantics preserved:
- **numpy path** untouched (byte-identical — early `if xp is numpy: return phi`).
- **backend float32 `R`** still anchors `phi` to float32 (input-dtype anchoring — a regression test guards against a naive "force float64" fix that would promote genuine float32 inputs).
- **already-backend `phi`** returned as-is (no cast/detach → autodiff w.r.t. `phi` preserved).

## Validation
- Unit-level: reproduced the exact `TypeError` (numpy array **and** scalar `R`), fix resolves it; 7 edge cases checked.
- Full `test_backend_ellipsoidal.py` stays green (**693 tests, 0 failures**) with 6 new regression cases.
- The `dxdv_3d_c[Triaxial*]` integration tests are ordering-dependent (whole-shard forced-backend state) + need the C extension, so they can't be reproduced in a local subset — **CI confirms** them. They stay XPASS-ledgered; the next regen prunes them.

**No ledger edit** → no conflict with the milestone regen PR #1188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm