### PR TITLE
potential: fix scalar-under-forced-backend torch/jax coercion (HenonHeiles/IsothermalDisk/NonInertialFrame/AnySpherical)

### DIFF
--- a/galpy/potential/AnySphericalPotential.py
+++ b/galpy/potential/AnySphericalPotential.py
@@ -4,7 +4,7 @@
 import numpy
 from scipy import integrate
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import as_backend_constant, as_numpy, get_namespace, is_backend_array
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .SphericalPotential import SphericalPotential
@@ -55,6 +55,11 @@ class AnySphericalPotential(SphericalPotential):
         # A jax/torch coord routes _rawmass / the _revaluate tail to in-backend
         # Gauss-Legendre quadrature (see below); flag as backend-capable.
         self._backend_compatible = True
+        # A units-based density is numpy-only (astropy Quantity arithmetic
+        # strips a jax/torch node to numpy); on a backend node it is evaluated
+        # on numpy and the result anchored back on the backend (see
+        # _backend_dens). Set True below when the density involves units.
+        self._dens_needs_numpy = False
         # Parse density: does it have units? does it expect them?
         if _APY_LOADED:
             _dens_unit_input = False
@@ -87,6 +92,7 @@ class AnySphericalPotential(SphericalPotential):
                 self._rawdens = lambda R: conversion.parse_dens(
                     dens(R), ro=self._ro, vo=self._vo
                 )
+            self._dens_needs_numpy = _dens_unit_input or _dens_unit_output
         if not hasattr(self, "_rawdens"):  # unitless
             self._rawdens = dens
         # The potential at zero, try to figure out whether it's finite
@@ -116,6 +122,23 @@ class AnySphericalPotential(SphericalPotential):
             self.normalize(normalize)
         return None
 
+    def _backend_dens(self, a):
+        """Evaluate the density, keeping the backend-quadrature path type-clean.
+
+        A units-based ``dens`` runs through astropy Quantity arithmetic, which
+        strips a jax/torch node to numpy (emitting a numpy-2 ``__array__``
+        deprecation) and yields numpy -- and ``numpy * Tensor`` then raises. Such
+        a density is inherently non-differentiable, so on a backend node it is
+        evaluated on the numpy node and the result anchored back on the node's
+        backend/dtype/device. A backend-native (differentiable) density and the
+        numpy path both pass through untouched (``is_backend_array(a)`` is False
+        for numpy), so the numpy path stays byte-identical.
+        """
+        if is_backend_array(a) and self._dens_needs_numpy:
+            d = numpy.asarray(self._rawdens(as_numpy(a)))
+            return as_backend_constant(get_namespace(a), d, a)
+        return self._rawdens(a)
+
     def _rawmass(self, r):
         r"""Enclosed mass :math:`4\pi\int_0^r a^2\rho(a)\,da`.
 
@@ -128,7 +151,11 @@ class AnySphericalPotential(SphericalPotential):
         if is_backend_array(r):
             from ..backend.quadrature import quad as _bk_quad
 
-            return 4.0 * numpy.pi * _bk_quad(lambda a: a**2 * self._rawdens(a), 0.0, r)
+            return (
+                4.0
+                * numpy.pi
+                * _bk_quad(lambda a: a**2 * self._backend_dens(a), 0.0, r)
+            )
         return (
             4.0
             * numpy.pi
@@ -152,7 +179,7 @@ class AnySphericalPotential(SphericalPotential):
             edge = (r == 0) | xp.isinf(r)
             r_safe = xp.where(edge, xp.ones_like(r), r)
             tail = fixed_quad_semiinfinite(
-                xp, lambda a: self._rawdens(a) * a, r_safe, kind="recip"
+                xp, lambda a: self._backend_dens(a) * a, r_safe, kind="recip"
             )
             bulk = -self._rawmass(r_safe) / r_safe - 4.0 * numpy.pi * tail
             out = xp.where(r == 0, self._pot_zero, bulk)
@@ -177,7 +204,7 @@ class AnySphericalPotential(SphericalPotential):
         return -self._rawmass(r) / r**2
 
     def _r2deriv(self, r, t=0.0):
-        return -2 * self._rawmass(r) / r**3.0 + 4.0 * numpy.pi * self._rawdens(r)
+        return -2 * self._rawmass(r) / r**3.0 + 4.0 * numpy.pi * self._backend_dens(r)
 
     def _rdens(self, r, t=0.0):
-        return self._rawdens(r)
+        return self._backend_dens(r)

--- a/galpy/potential/HenonHeilesPotential.py
+++ b/galpy/potential/HenonHeilesPotential.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   HenonHeilesPotential: the Henon-Heiles (1964) potential
 ###############################################################################
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from .planarPotential import planarPotential
 
 
@@ -38,24 +38,30 @@ class HenonHeilesPotential(planarPotential):
 
     def _evaluate(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return 0.5 * R * R * (1.0 + 2.0 / 3.0 * R * xp.sin(3.0 * phi))
 
     def _Rforce(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return -R * (1.0 + R * xp.sin(3.0 * phi))
 
     def _phitorque(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return -(R**3.0) * xp.cos(3.0 * phi)
 
     def _R2deriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return 1.0 + 2.0 * R * xp.sin(3.0 * phi)
 
     def _phi2deriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return -3.0 * R**3.0 * xp.sin(3.0 * phi)
 
     def _Rphideriv(self, R, phi=0.0, t=0.0):
         xp = get_namespace(R, phi)
+        R, phi = coerce_coords(xp, R, phi)
         return 3.0 * R**2.0 * xp.cos(3.0 * phi)

--- a/galpy/potential/IsothermalDiskPotential.py
+++ b/galpy/potential/IsothermalDiskPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import coerce_coords, get_namespace, is_backend_array
 from ..util import conversion
 from .linearPotential import linearPotential
 
@@ -57,15 +57,18 @@ class IsothermalDiskPotential(linearPotential):
 
     def _evaluate(self, x, t=0.0):
         xp = get_namespace(x)
+        (x,) = coerce_coords(xp, x)
         return 2.0 * self._sigma2 * xp.log(xp.cosh(0.5 * x / self._H))
 
     def _force(self, x, t=0.0):
         xp = get_namespace(x)
+        (x,) = coerce_coords(xp, x)
         return -self._sigma2 * xp.tanh(0.5 * x / self._H) / self._H
 
     def _force2deriv(self, x, t=0.0):
         # d^2 Phi / dx^2 = sigma^2 / (2 H^2) sech^2(x/2H)
         xp = get_namespace(x)
+        (x,) = coerce_coords(xp, x)
         return (
             self._sigma2
             / (2.0 * self._H**2.0)

--- a/galpy/potential/NonInertialFrameForce.py
+++ b/galpy/potential/NonInertialFrameForce.py
@@ -319,7 +319,7 @@ class NonInertialFrameForce(DissipativeForce):
                 tOmega2 = self._Omega2
             elif self._Omega_as_func:
                 tOmega = (
-                    self._Omega_py(t)
+                    _anchor(self._Omega_py(t))
                     if self._omegaz_only
                     else _vec([self._Omega[0](t), self._Omega[1](t), self._Omega[2](t)])
                 )

--- a/tests/test_backend_anyspherical.py
+++ b/tests/test_backend_anyspherical.py
@@ -22,6 +22,7 @@ import pytest
 from galpy.backend import as_numpy
 from galpy.potential import (
     AnySphericalPotential,
+    evaluateDensities,
     evaluatePotentials,
     evaluater2derivs,
     evaluateRforces,
@@ -214,7 +215,12 @@ def test_units_density_backend_value_parity(backend_name):
     for R0, z0 in _RZ:
         R = _asarray(backend_name, R0)
         z = _asarray(backend_name, z0)
-        for fn in (evaluatePotentials, evaluateRforces, evaluater2derivs):
+        for fn in (
+            evaluatePotentials,
+            evaluateRforces,
+            evaluater2derivs,
+            evaluateDensities,
+        ):
             ref = fn(pot, R0, z0, use_physical=False)
             with warnings.catch_warnings():
                 warnings.simplefilter("error", DeprecationWarning)

--- a/tests/test_backend_anyspherical.py
+++ b/tests/test_backend_anyspherical.py
@@ -234,3 +234,26 @@ def test_units_density_backend_value_parity(backend_name):
                 atol=1e-9,
                 err_msg=f"{fn.__name__} R={R0} ({backend_name})",
             )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_backend_dens_numpy_fallback_and_mass(backend_name):
+    # Exercise the two internal branches that a units-based density drives on a
+    # backend node -- WITHOUT astropy (not installed in this shard). _dens_needs_numpy
+    # is only *set* via the astropy unit-detection in __init__, but the branch it
+    # gates is independent of astropy, so force it on a plain-numpy-density potential:
+    #   _backend_dens: evaluate the density on the numpy node, anchor back on the
+    #                  backend (the path a units density needs; numpy * Tensor raises).
+    #   _rawmass:      a backend r routes to in-backend Gauss-Legendre quadrature.
+    # Both must return a backend array whose value matches the numpy path.
+    pot = AnySphericalPotential(amp=1.3, dens=_dens)
+    assert not pot._dens_needs_numpy  # plain numpy density: normally False
+    pot._dens_needs_numpy = True  # force the numpy-eval-and-anchor branch
+    r0 = 1.7
+    r = _asarray(backend_name, r0)
+    d = pot._backend_dens(r)
+    assert backend_name in type(d).__module__
+    numpy.testing.assert_allclose(as_numpy(d), pot._rawdens(r0), rtol=1e-12)
+    m = pot._rawmass(r)
+    assert backend_name in type(m).__module__
+    numpy.testing.assert_allclose(as_numpy(m), pot._rawmass(r0), rtol=1e-5)

--- a/tests/test_backend_anyspherical.py
+++ b/tests/test_backend_anyspherical.py
@@ -14,6 +14,8 @@
 # finite-and-nonzero). Backends that are not installed self-skip, so this is
 # green on numpy alone.
 ###############################################################################
+import warnings
+
 import numpy
 import pytest
 
@@ -24,6 +26,7 @@ from galpy.potential import (
     evaluater2derivs,
     evaluateRforces,
 )
+from galpy.util._optional_deps import _APY_LOADED
 
 # This module manages backends explicitly (parametrizes over them), so it is
 # exempt from the global --backend force fixture.
@@ -176,3 +179,52 @@ def test_rforce_grad_vs_fd_amp(backend_name):
     fp = float(evaluateRforces(AnySphericalPotential(amp=amp0 + h, dens=_dens), R0, z0))
     fm = float(evaluateRforces(AnySphericalPotential(amp=amp0 - h, dens=_dens), R0, z0))
     numpy.testing.assert_allclose(ad, (fp - fm) / (2.0 * h), rtol=1e-6, atol=1e-8)
+
+
+# ==================== units-based density on the backend ================== #
+# A units-based density runs through astropy Quantity arithmetic, which strips a
+# jax/torch quadrature node to numpy (and emits a numpy-2 __array__ deprecation).
+# The backend integrands then did `numpy * Tensor`, which RAISES. Such a density
+# is inherently non-differentiable, so it is now evaluated on the numpy node and
+# the result anchored back on the backend (AnySphericalPotential._backend_dens).
+# Assert: no raise, a backend array, numpy value parity, and -- crucially, since
+# build.yml runs test_backend*.py under numpy with `-W error` -- NO Deprecation/
+# FutureWarning escapes the units evaluation.
+@pytest.mark.skipif(not _APY_LOADED, reason="astropy not installed")
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_units_density_backend_value_parity(backend_name):
+    from astropy import units
+
+    from galpy.util import conversion
+
+    ro, vo = 8.0, 220.0
+
+    def dens_units(r):
+        return (
+            0.64
+            / r
+            / (1.0 + r) ** 3
+            * conversion.dens_in_msolpc3(vo, ro)
+            * units.Msun
+            / units.pc**3
+        )
+
+    pot = AnySphericalPotential(dens=dens_units, ro=ro, vo=vo)
+    assert pot._dens_needs_numpy
+    for R0, z0 in _RZ:
+        R = _asarray(backend_name, R0)
+        z = _asarray(backend_name, z0)
+        for fn in (evaluatePotentials, evaluateRforces, evaluater2derivs):
+            ref = fn(pot, R0, z0, use_physical=False)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                warnings.simplefilter("error", FutureWarning)
+                got = fn(pot, R, z, use_physical=False)
+            assert backend_name in type(got).__module__, (fn.__name__, type(got))
+            numpy.testing.assert_allclose(
+                as_numpy(got),
+                ref,
+                rtol=1e-8,
+                atol=1e-9,
+                err_msg=f"{fn.__name__} R={R0} ({backend_name})",
+            )

--- a/tests/test_backend_linearpotential.py
+++ b/tests/test_backend_linearpotential.py
@@ -35,6 +35,7 @@
 import numpy
 import pytest
 
+from galpy.backend import use
 from galpy.potential import (
     IsothermalDiskPotential,
     KGPotential,
@@ -246,3 +247,31 @@ def test_torch_amp_grad_matches_fd():
     grad = float(at.grad)
     fd = _amp_fd(a0, x0)
     assert numpy.isclose(grad, fd, rtol=1e-4, atol=1e-6), (grad, fd)
+
+
+# ============ raw compute methods under a FORCED backend ================== #
+# Regression (scalar-under-forced-backend): the python orbit integrator calls
+# IsothermalDiskPotential._evaluate/_force/_force2deriv DIRECTLY with a
+# numpy-scalar x (the integrator RHS bypasses the @physical_input coercion gate,
+# unlike the p(x)/p.force(x)/evaluatelinear* public entries which coerce). Under
+# a forced backend get_namespace(x) then resolves to jax/torch while x stays a
+# numpy scalar, so xp.tanh/xp.cosh(x) raised (torch rejects numpy.float64).
+# Assert no raise, a backend array, and numpy value parity.
+@pytest.mark.parametrize("backend_name", ["jax", "torch"])
+def test_isodisk_raw_methods_numpy_scalar_forced_backend(backend_name):
+    if backend_name == "jax" and not _HAS_JAX:  # pragma: no cover
+        pytest.skip("jax not installed")
+    if backend_name == "torch" and not _HAS_TORCH:  # pragma: no cover
+        pytest.skip("torch not installed")
+    p = IsothermalDiskPotential(amp=1.0, sigma=1.0)
+    methods = ("_evaluate", "_force", "_force2deriv")
+    for x0 in (0.5, -0.3, 1.7):
+        x = numpy.float64(x0)
+        ref = {m: float(getattr(p, m)(x)) for m in methods}
+        with use(backend_name, force=True):
+            for m in methods:
+                got = getattr(p, m)(x)
+                assert backend_name in type(got).__module__, (m, type(got))
+                numpy.testing.assert_allclose(
+                    float(got), ref[m], rtol=1e-12, atol=1e-14, err_msg=f"{m} x={x0}"
+                )

--- a/tests/test_backend_noninertial.py
+++ b/tests/test_backend_noninertial.py
@@ -27,7 +27,7 @@
 import numpy
 import pytest
 
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, use
 from galpy.potential import (
     NonInertialFrameForce,
     evaluatephitorques,
@@ -169,6 +169,32 @@ def test_force_returns_backend_array(backend_name, name):
         assert backend_name in _module_of(f), (
             f"{name}: force left the {backend_name} namespace ({_module_of(f)})"
         )
+
+
+@pytest.mark.parametrize("name", _CONFIGS)
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_force_numpy_scalar_under_forced_backend(backend_name, name):
+    # Regression (scalar-under-forced-backend): the python orbit integrator
+    # feeds _force numpy-scalar coords/velocities under a FORCED backend -- the
+    # DissipativeForce RHS bypasses the @physical_input coercion gate. get_namespace
+    # then resolves to the backend while the coords stay numpy, so a strict-typed
+    # call raised: for the scalar-function config, tOmega = Omega(t) is a numpy
+    # scalar and torch.linalg.norm rejected it. Assert no raise, a backend array,
+    # and numpy value parity (a fresh pot each time so the md5 cache never leaks).
+    ref = numpy.asarray(_build(name)._force(_R0, _Z0, _PHI0, _T0, list(_V0)))
+    pot = _build(name)
+    R = numpy.float64(_R0)
+    z = numpy.float64(_Z0)
+    phi = numpy.float64(_PHI0)
+    t = numpy.float64(_T0)
+    v = [numpy.float64(vv) for vv in _V0]
+    with use(backend_name, force=True):
+        f = pot._force(R, z, phi, t, v)
+    assert backend_name in _module_of(f), (
+        f"{name}: forced-{backend_name} _force is {_module_of(f)}, expected a backend array"
+    )
+    got = numpy.asarray([float(as_numpy(fi)) for fi in f])
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14, err_msg=name)
 
 
 @pytest.mark.parametrize("name", _CONFIGS)

--- a/tests/test_backend_planarpotential.py
+++ b/tests/test_backend_planarpotential.py
@@ -37,7 +37,9 @@
 import numpy
 import pytest
 
+from galpy.backend import use
 from galpy.potential import (
+    HenonHeilesPotential,
     HernquistPotential,
     LogarithmicHaloPotential,
     MiyamotoNagaiPotential,
@@ -278,3 +280,43 @@ def test_phitorque_axi_jax_grad_zero(p):
         )
     )
     assert grad == 0.0, grad
+
+
+# ============ HenonHeiles raw methods under a FORCED backend =============== #
+# Regression (scalar-under-forced-backend): the python orbit integrator calls
+# HenonHeilesPotential._evaluate/_Rforce/_phitorque (and the 2nd derivatives)
+# DIRECTLY with numpy-scalar (R, phi) -- the integrator RHS bypasses the
+# @physical_input coercion gate. Under a forced backend get_namespace(R, phi)
+# resolves to jax/torch while phi stays a numpy scalar, so xp.sin/cos(3*phi)
+# raised (torch rejects numpy.float64). Assert no raise, a backend array, and
+# numpy value parity. (HenonHeiles is the potential behind test_lyapunov_*.)
+@pytest.mark.parametrize("backend_name", ["jax", "torch"])
+def test_henonheiles_raw_methods_numpy_scalar_forced_backend(backend_name):
+    if backend_name == "jax" and not _HAS_JAX:  # pragma: no cover
+        pytest.skip("jax not installed")
+    if backend_name == "torch" and not _HAS_TORCH:  # pragma: no cover
+        pytest.skip("torch not installed")
+    p = HenonHeilesPotential(amp=1.3)
+    methods = (
+        "_evaluate",
+        "_Rforce",
+        "_phitorque",
+        "_R2deriv",
+        "_phi2deriv",
+        "_Rphideriv",
+    )
+    for R0, phi0 in [(1.2, 0.7), (0.5, -2.1), (2.3, 3.14159)]:
+        R = numpy.float64(R0)
+        phi = numpy.float64(phi0)
+        ref = {m: float(getattr(p, m)(R, phi)) for m in methods}
+        with use(backend_name, force=True):
+            for m in methods:
+                got = getattr(p, m)(R, phi)
+                assert backend_name in type(got).__module__, (m, type(got))
+                numpy.testing.assert_allclose(
+                    float(got),
+                    ref[m],
+                    rtol=1e-12,
+                    atol=1e-14,
+                    err_msg=f"{m} R={R0} phi={phi0}",
+                )


### PR DESCRIPTION
Continues the coercion burndown (recipe proven in #1189). Under a **forced** backend, `get_namespace(numpy_scalar)` resolves to torch/jax while a coordinate stays numpy — torch then rejects `sin/cos/tanh(numpy.float64)`, `numpy.array([tensor,...])`, `numpy*Tensor`. Fixed at the public input boundary with the existing helpers (`coerce_coords` / `_anchor` / `as_backend_constant`), all **numpy pass-throughs**.

## Fixes (authoritative CI-regen tracebacks)
| potential | root cause | fix | tests fixed |
|---|---|---|---|
| **HenonHeilesPotential** | `xp.sin/cos(3*phi)` on numpy phi (6 compute methods) | `coerce_coords(xp, R, phi)` | `test_lyapunov_c_vs_python`, `test_lyapunov_spectrum_consistency` |
| **IsothermalDiskPotential** | `xp.tanh/cosh(x)` on numpy x (`_evaluate/_force/_force2deriv`) — the real `test_integrate_indiv_t` `tanh` source | `coerce_coords(xp, x)` | `test_integrate_indiv_t_1D/_python_paths` |
| **NonInertialFrameForce** | one residual config (`_omegaz_only` + `_Omega_as_func`): `xp.linalg.norm(Omega(t))` on a numpy scalar | wrap in the file's `_anchor(...)` (1 line) | `test_*linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz` |
| **AnySphericalPotential** | a **units-based** density routes through astropy Quantity arithmetic (strips a backend node to numpy + numpy-2 `__array__` deprecation) → `numpy*Tensor` in the backend quadrature | `_backend_dens`: units densities evaluated on the numpy node, result anchored back on the backend (non-differentiable by nature); backend-native densities + numpy path untouched | `test_potential_paramunits` |

## Validation (adversarially verified)
- **numpy byte-identical**: 40 numpy values across the four potentials — 0 differences vs `origin/feat/backends`; `coerce_coords`/`_anchor`/`as_backend_constant` confirmed numpy pass-throughs.
- **backend correctness**: AnySpherical units-density torch value matches numpy to **8.9e-15** across `_rdens/_rforce/_r2deriv/_revaluate`.
- **regression tests** (new, in the 4 `test_backend_*.py`): call the raw `_force/_evaluate` methods with **numpy-scalar coords under `use(backend, force=True)`** — the actual integrator path the old suites (which fed backend tensors) never exercised. Each was verified to **fail on pre-fix source**.
- **576 tests pass** across the four files, including under `-W error::DeprecationWarning -W error::FutureWarning` (the build.yml coverage-shard condition — the AnySpherical fix is deprecation-clean).
- **No ledger edits** (source + tests only → fixed tests become XPASS, pruned by the next regen). SoftenedNeedleBar left for a separate force/hessian-consistency migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm