### PR TITLE
backend: @backend_kernel decorator lifting coerce boilerplate across potentials (+ jit seam)

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -17,6 +17,7 @@ from ._coerce import (
     promote_scalars,
     zeros_like_backend,
 )
+from ._kernel import backend_kernel
 from ._namespaces import (
     as_numpy,
     asarray_on_device,
@@ -41,6 +42,7 @@ _seed_from_config()
 
 __all__ = [
     "autodiff_ops",
+    "backend_kernel",
     "get_namespace",
     "backend",
     "use",

--- a/galpy/backend/_kernel.py
+++ b/galpy/backend/_kernel.py
@@ -1,0 +1,104 @@
+###############################################################################
+#   galpy.backend._kernel: the @backend_kernel decorator.
+#
+#   Lifts the inline
+#
+#       xp = get_namespace(R, z)
+#       R, z = coerce_coords(xp, R, z)
+#
+#   boilerplate -- copy-pasted into every migrated method only because the
+#   backend migration was incremental -- into one decorator. The decorated
+#   function becomes the PURE kernel: it receives the coerced coordinate
+#   arguments plus an injected ``xp`` keyword and does nothing but the math.
+#
+#   This also defines the jit seam. jax.jit / torch.compile want exactly this
+#   split: outer Python glue (namespace resolution, coercion) separated from the
+#   inner traceable kernel. galpy itself never jits (see the no-internal-jit
+#   policy); the test suite's --backend jax-jit / torch-compile dimension wraps
+#   the decorated kernels.
+#
+#   The coordinate arguments are declared EXPLICITLY -- @backend_kernel("R","z")
+#   -- carrying exactly the information the old ``coerce_coords(xp, R, z)`` call
+#   already named, so there is no name-magic and no per-method whitelist to keep
+#   correct (a velocity list ``v`` must not be coerced like a scalar coord, for
+#   instance). The numpy path is a strict pass-through: ``get_namespace`` returns
+#   numpy and ``coerce_coords`` is object-identity, so the decorated method is
+#   byte-identical to the inline version.
+###############################################################################
+import functools
+import inspect
+
+from ._coerce import coerce_coords
+from ._resolver import get_namespace
+
+
+def backend_kernel(*coord_names):
+    """Resolve the array namespace from the named coordinate arguments, coerce
+    them onto the active backend, and inject the namespace as an ``xp`` keyword.
+
+    Usage::
+
+        @backend_kernel("R", "z")
+        def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp):
+            r2 = R**2.0 + z**2.0
+            return xp.log(r2) / 2.0
+
+    ``coord_names`` are the parameters holding coordinate arrays -- the same ones
+    the method used to pass to ``coerce_coords`` -- given by name. The decorated
+    kernel must accept a keyword-only ``xp`` (default ``None`` so it is bindable
+    without the decorator, e.g. under introspection); the wrapper always supplies
+    it. The numpy path is byte-identical: ``get_namespace`` -> numpy and
+    ``coerce_coords`` returns its inputs object-identically.
+    """
+
+    def deco(fn):
+        params = list(inspect.signature(fn).parameters.values())
+        names = [p.name for p in params]
+        if "xp" not in names:
+            raise TypeError(
+                f"@backend_kernel kernel {fn.__qualname__!r} must accept a "
+                "keyword-only 'xp' parameter"
+            )
+        # Precompute, once, each coordinate's positional index and default so the
+        # per-call path does no signature binding.
+        coord_info = []
+        for cn in coord_names:
+            try:
+                idx = names.index(cn)
+            except ValueError:
+                raise TypeError(
+                    f"@backend_kernel({cn!r}) names no parameter of {fn.__qualname__!r}"
+                )
+            coord_info.append((cn, idx, params[idx].default))
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            # Gather each coordinate value from wherever it was passed
+            # (positional / keyword / default), remembering where so the coerced
+            # value can be written back in place.
+            vals = []
+            locs = []
+            for cn, idx, default in coord_info:
+                if idx < len(args):
+                    vals.append(args[idx])
+                    locs.append((0, idx))  # positional
+                elif cn in kwargs:
+                    vals.append(kwargs[cn])
+                    locs.append((1, cn))  # keyword
+                else:
+                    vals.append(default)
+                    locs.append((2, cn))  # used its default
+            xp = get_namespace(*vals)
+            coerced = coerce_coords(xp, *vals)
+            args = list(args)
+            for (kind, key), cv in zip(locs, coerced):
+                if kind == 0:
+                    args[key] = cv
+                else:  # keyword, or a defaulted coord we now pass explicitly
+                    kwargs[key] = cv
+            kwargs["xp"] = xp
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return deco

--- a/galpy/potential/BurkertPotential.py
+++ b/galpy/potential/BurkertPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
 
@@ -58,9 +58,9 @@ class BurkertPotential(SphericalPotential):
         self.hasC_dens = True
         return None
 
-    def _revaluate(self, r, t=0.0):
+    @backend_kernel("r")
+    def _revaluate(self, r, t=0.0, *, xp=None):
         """Potential as a function of r and time"""
-        xp = get_namespace(r)
         x = r / self.a
         # special.xlogy(2/x, 1+x**2) == (2/x)*log(1+x**2), but with the convention
         # that it is 0 where the prefactor is 0 (i.e. as x -> infty, where the bare
@@ -90,8 +90,8 @@ class BurkertPotential(SphericalPotential):
     #                                +2.*(1.+x)*numpy.log(1.+x)
     #                                +(1.-x)*numpy.log(1.+x**2.))
 
-    def _rforce(self, r, t=0.0):
-        xp = get_namespace(r)
+    @backend_kernel("r")
+    def _rforce(self, r, t=0.0, *, xp=None):
         x = r / self.a
         return (
             self.a
@@ -116,8 +116,8 @@ class BurkertPotential(SphericalPotential):
         x = r / self.a
         return 1.0 / (1.0 + x) / (1.0 + x**2.0)
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         x = r / self.a
         Rpa = xp.sqrt(R**2.0 + self.a**2.0)

--- a/galpy/potential/CosmphiDiskPotential.py
+++ b/galpy/potential/CosmphiDiskPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -107,9 +107,8 @@ class CosmphiDiskPotential(planarPotential):
         self._backend_compatible = True
         self.hasC_dxdv = True
 
-    def _evaluate(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _evaluate(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         # Both branches contain a power of R that is singular at R=0 (the inside
         # rbp/R**p for p>0, the outside R**p for p<0). Under the eager xp.where
@@ -131,9 +130,8 @@ class CosmphiDiskPotential(planarPotential):
             )
         )
 
-    def _Rforce(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _Rforce(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         R_in = xp.where(inside, R, xp.ones_like(R * 1.0))
         R_out = xp.where(inside, xp.ones_like(R * 1.0), R)
@@ -150,9 +148,8 @@ class CosmphiDiskPotential(planarPotential):
             )
         )
 
-    def _phitorque(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _phitorque(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         R_in = xp.where(inside, R, xp.ones_like(R * 1.0))
         R_out = xp.where(inside, xp.ones_like(R * 1.0), R)
@@ -167,9 +164,8 @@ class CosmphiDiskPotential(planarPotential):
             )
         )
 
-    def _R2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _R2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         R_in = xp.where(inside, R, xp.ones_like(R * 1.0))
         R_out = xp.where(inside, xp.ones_like(R * 1.0), R)
@@ -185,9 +181,8 @@ class CosmphiDiskPotential(planarPotential):
             )
         )
 
-    def _phi2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _phi2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         R_in = xp.where(inside, R, xp.ones_like(R * 1.0))
         R_out = xp.where(inside, xp.ones_like(R * 1.0), R)
@@ -203,9 +198,8 @@ class CosmphiDiskPotential(planarPotential):
             )
         )
 
-    def _Rphideriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _Rphideriv(self, R, phi=0.0, t=0.0, *, xp=None):
         inside = R < self._rb
         R_in = xp.where(inside, R, xp.ones_like(R * 1.0))
         R_out = xp.where(inside, xp.ones_like(R * 1.0), R)

--- a/galpy/potential/CylindricallySeparablePotentialWrapper.py
+++ b/galpy/potential/CylindricallySeparablePotentialWrapper.py
@@ -12,7 +12,7 @@ import numpy
 
 from galpy.util import conversion
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -87,7 +87,8 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _evaluate
@@ -107,8 +108,6 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         # (byte-identical); on a non-numpy backend the reference coordinates are
         # anchored on the inputs so the wrapped potential sees backend arrays
         # (torch functions require Tensors) on the right device/dtype.
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return (
@@ -117,7 +116,8 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
             - self._refpot
         )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _Rforce
@@ -133,12 +133,11 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         return _evaluateRforces(self._pot, R, zero)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _zforce
@@ -154,12 +153,11 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return _evaluatezforces(self._pot, Rp, z)
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _R2deriv
@@ -175,12 +173,11 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
         zero = 0.0 if xp is numpy else xp.zeros_like(R)
         return evaluateR2derivs(self._pot, R, zero, use_physical=False)
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _z2deriv
@@ -196,8 +193,6 @@ class CylindricallySeparablePotentialWrapper(parentWrapperPotential):
         HISTORY:
            2026-01-14 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
         Rp = self._Rp if xp is numpy else self._Rp + xp.zeros_like(z)
         return evaluatez2derivs(self._pot, Rp, z, use_physical=False)
 

--- a/galpy/potential/DehnenBarPotential.py
+++ b/galpy/potential/DehnenBarPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, get_namespace
 from ..util import conversion
 from .Potential import Potential
 
@@ -160,10 +160,9 @@ class DehnenBarPotential(Potential):
         growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
         return xp.where(t < self._tform, 0.0, xp.where(t < self._tsteady, growth, 1.0))
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -191,10 +190,9 @@ class DehnenBarPotential(Potential):
             * R2_over_r2
         )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -218,10 +216,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _phitorque(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _phitorque(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -243,10 +240,9 @@ class DehnenBarPotential(Potential):
             * R2_over_r2
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -262,10 +258,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -289,10 +284,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -314,10 +308,9 @@ class DehnenBarPotential(Potential):
             * R2_over_r2
         )
 
-    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -336,10 +329,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -359,10 +351,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
@@ -385,10 +376,9 @@ class DehnenBarPotential(Potential):
             * xp.where(r <= self._rb, inner, outer)
         )
 
-    def _phizderiv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi", "t")
+    def _phizderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Calculate relevant time
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi, t = coerce_coords(xp, R, z, phi, t)
         smooth = self._smooth(t)
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)

--- a/galpy/potential/DoubleExponentialDiskPotential.py
+++ b/galpy/potential/DoubleExponentialDiskPotential.py
@@ -9,9 +9,8 @@ from scipy import special
 
 from ..backend import (
     asarray_on_device,
-    coerce_coords,
+    backend_kernel,
     device_of,
-    get_namespace,
     match_input_dtype,
 )
 from ..util import conversion
@@ -155,7 +154,8 @@ class DoubleExponentialDiskPotential(Potential):
         ):  # pragma: no cover
             self.normalize(normalize)
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0):
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0, *, xp=None):
         """
         Evaluate the potential at (R,z)
 
@@ -181,7 +181,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # the Ogata quadrature nodes/weights are deliberately float64
         # (precision); the result is cast to the input dtype at exit (no-op
         # for float64/scalar inputs), so keep the original inputs for that.
@@ -243,7 +242,8 @@ class DoubleExponentialDiskPotential(Potential):
             return match_input_dtype(xp.reshape(out, outShape), *in_coords)
 
     @check_potential_inputs_not_arrays
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate radial force K_R  (R,z)
 
@@ -269,7 +269,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # float64 Ogata tables anchored on the input's device (see _evaluate)
         dev = device_of(R, z)
         fun = lambda x: (
@@ -301,7 +300,8 @@ class DoubleExponentialDiskPotential(Potential):
         )
 
     @check_potential_inputs_not_arrays
-    def _zforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate vertical force K_z  (R,z)
 
@@ -327,7 +327,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - New method using Gaussian quadrature between zeros - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # float64 Ogata tables anchored on the input's device (see _evaluate)
         dev = device_of(R, z)
         fun = lambda x: (
@@ -357,7 +356,8 @@ class DoubleExponentialDiskPotential(Potential):
         return match_input_dtype(out * (2.0 * (z > 0.0) - 1.0), R, z, phi, t)
 
     @check_potential_inputs_not_arrays
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate radial force K_R (R,z) R2 derivative
 
@@ -382,7 +382,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-27 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # float64 Ogata tables anchored on the input's device (see _evaluate)
         dev = device_of(R, z)
         fun = lambda x: (
@@ -421,7 +420,8 @@ class DoubleExponentialDiskPotential(Potential):
         )
 
     @check_potential_inputs_not_arrays
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate vertical force K_Z (R,z) Z2 derivative
 
@@ -446,7 +446,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2012-12-26 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # float64 Ogata tables anchored on the input's device (see _evaluate)
         dev = device_of(R, z)
         fun = lambda x: (
@@ -480,7 +479,8 @@ class DoubleExponentialDiskPotential(Potential):
         )
 
     @check_potential_inputs_not_arrays
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate mixed R,z derivative d2phi/dR/dz.
 
@@ -505,7 +505,6 @@ class DoubleExponentialDiskPotential(Potential):
         - 2013-08-28 - Written - Bovy (IAS)
         - 2020-12-24 - New method using Ogata's Bessel integral formula - Bovy (UofT)
         """
-        xp = get_namespace(R, z)
         # float64 Ogata tables anchored on the input's device (see _evaluate)
         dev = device_of(R, z)
         fun = lambda x: (
@@ -532,14 +531,12 @@ class DoubleExponentialDiskPotential(Potential):
         # float64 quadrature interior, input-dtype exit cast (see _evaluate)
         return match_input_dtype(out * (2.0 * (z > 0.0) - 1.0), R, z, phi, t)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return xp.exp(-self._alpha * R - self._beta * xp.abs(z))
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return (
             2.0
             * xp.exp(-self._alpha * R)

--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -5,7 +5,7 @@ import numpy
 from scipy import special
 from scipy.optimize import fsolve
 
-from ..backend import get_namespace
+from ..backend import backend_kernel
 from ..backend.special import gamma as _gamma
 from ..backend.special import gammaincc as _gammaincc
 from ..util import conversion
@@ -98,9 +98,9 @@ class EinastoPotential(SphericalPotential):
         self.hasC_dens = True
         return None
 
-    def _revaluate(self, r, t=0.0):
+    @backend_kernel("r")
+    def _revaluate(self, r, t=0.0, *, xp=None):
         """Potential as a function of r and time"""
-        xp = get_namespace(r)
         s = r / self.h
         # r == 0 is handled by the separate `core` branch below; eager backends
         # evaluate BOTH xp.where branches, so the generic branch must stay

--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -16,7 +16,7 @@ from scipy import integrate
 
 from ..backend import (
     as_backend_constant,
-    coerce_coords,
+    backend_kernel,
     get_namespace,
     is_backend_array,
 )
@@ -190,9 +190,8 @@ class EllipsoidalPotential(Potential):
         Fz_ = rot[0, 2] * Fx + rot[1, 2] * Fy + rot[2, 2] * Fz
         return Fx_, Fy_, Fz_
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -261,8 +260,8 @@ class EllipsoidalPotential(Potential):
             self._force_hash = new_hash
         return Fx, Fy, Fz
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -270,8 +269,8 @@ class EllipsoidalPotential(Potential):
         Fx, Fy, _ = self._compute_forces(x, y, z, xp)
         return xp.cos(phi) * Fx + xp.sin(phi) * Fy
 
-    def _phitorque(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _phitorque(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -279,8 +278,8 @@ class EllipsoidalPotential(Potential):
         Fx, Fy, _ = self._compute_forces(x, y, z, xp)
         return R * (-xp.sin(phi) * Fx + xp.cos(phi) * Fy)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -336,8 +335,8 @@ class EllipsoidalPotential(Potential):
             self._2ndderiv_hash = new_hash
         return xx, xy, xz, yy, yz, zz
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -353,8 +352,8 @@ class EllipsoidalPotential(Potential):
             + 2.0 * xp.cos(phi) * xp.sin(phi) * phixy
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -366,8 +365,8 @@ class EllipsoidalPotential(Potential):
         _, _, phixz, _, phiyz, _ = self._compute_2ndderivs(x, y, z, xp)
         return xp.cos(phi) * phixz + xp.sin(phi) * phiyz
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -379,8 +378,8 @@ class EllipsoidalPotential(Potential):
         _, _, _, _, _, phizz = self._compute_2ndderivs(x, y, z, xp)
         return phizz
 
-    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -397,8 +396,8 @@ class EllipsoidalPotential(Potential):
             - 2.0 * xp.cos(phi) * xp.sin(phi) * phixy
         ) + R * (xp.cos(phi) * Fx + xp.sin(phi) * Fy)
 
-    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -416,8 +415,8 @@ class EllipsoidalPotential(Potential):
             - xp.cos(phi) * Fy
         )
 
-    def _phizderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _phizderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = 0.0
         phi = _anchor_phi(phi, R, xp)
@@ -429,8 +428,8 @@ class EllipsoidalPotential(Potential):
         _, _, phixz, _, phiyz, _ = self._compute_2ndderivs(x, y, z, xp)
         return R * (xp.cos(phi) * phiyz - xp.sin(phi) * phixz)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         phi = _anchor_phi(phi, R, xp)
         x, y = R * xp.cos(phi), R * xp.sin(phi)
         if self._aligned:

--- a/galpy/potential/EllipticalDiskPotential.py
+++ b/galpy/potential/EllipticalDiskPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -118,17 +118,15 @@ class EllipticalDiskPotential(planarPotential):
         growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
         return xp.where(t < self._tform, 0.0, xp.where(t < self._tsteady, growth, 1.0))
 
-    def _evaluate(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _evaluate(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             smooth * self._twophio / 2.0 * R**self._p * xp.cos(2.0 * (phi - self._phib))
         )
 
-    def _Rforce(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _Rforce(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             -smooth
@@ -139,15 +137,13 @@ class EllipticalDiskPotential(planarPotential):
             * xp.cos(2.0 * (phi - self._phib))
         )
 
-    def _phitorque(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _phitorque(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return smooth * self._twophio * R**self._p * xp.sin(2.0 * (phi - self._phib))
 
-    def _R2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _R2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             smooth
@@ -159,9 +155,8 @@ class EllipticalDiskPotential(planarPotential):
             * xp.cos(2.0 * (phi - self._phib))
         )
 
-    def _phi2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _phi2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             -2.0
@@ -171,9 +166,8 @@ class EllipticalDiskPotential(planarPotential):
             * xp.cos(2.0 * (phi - self._phib))
         )
 
-    def _Rphideriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _Rphideriv(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             -smooth

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -6,7 +6,7 @@ import warnings
 import numpy
 from scipy.special import exp1 as _scipy_exp1
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import backend_kernel, get_namespace, is_backend_array
 from ..backend._namespaces import namespace_from_arrays
 from ..backend.special import exp1
 from ..util import conversion, galpyWarning
@@ -239,23 +239,23 @@ class ExpTruncNFWPotential(SphericalPotential):
         out._voSet = nfw._voSet
         return out
 
-    def _F(self, r):
+    @backend_kernel("r")
+    def _F(self, r, *, xp=None):
         # F(r) = M(<r) / amp = int_0^r s e^{-s/rc} / (a+s)^2 ds, the
         # dimensionless enclosed-mass scale (so that _rforce = -F(r)/r^2 in
         # amp-units). For r << a, rc the two E1 terms cancel; use a Taylor
         # series in r there instead. Both branches are finite and smooth on the
         # whole domain (the split is for precision only), so the masked-out side
         # cannot NaN-poison AD -- a plain xp.where suffices.
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0
         small = r < self._small_r_thresh
         return xp.where(small, self._F_series(r), self._F_closed(r))
 
-    def _F_closed(self, r):
+    @backend_kernel("r")
+    def _F_closed(self, r, *, xp=None):
         # F(r) = exp(alpha)(1+alpha)[E1(alpha) - E1(beta)] - 1
         #        + a exp(-r/rc)/(a+r),
         # with alpha = a/rc and beta = (a+r)/rc.
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0  # so beta is a backend array (router/dtype match)
         a, rc = self.a, self.rc
         beta = (a + r) / rc
@@ -265,13 +265,13 @@ class ExpTruncNFWPotential(SphericalPotential):
             + a * xp.exp(-r / rc) / (a + r)
         )
 
-    def _F_series(self, r):
+    @backend_kernel("r")
+    def _F_series(self, r, *, xp=None):
         # Taylor expansion of F(r) about r=0 (through O(r^5)):
         # F(r) = (1/a^2) [ r^2/2 - (r^3/3)(1/rc + 2/a)
         #                + (r^4/4)(1/(2 rc^2) + 2/(rc a) + 3/a^2)
         #                - (r^5/5)(1/(6 rc^3) + 1/(rc^2 a)
         #                         + 3/(rc a^2) + 4/a^3) + ... ]
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0  # match _F_closed's namespace (direct-call parity)
         a, rc = self.a, self.rc
         c2 = 0.5
@@ -288,11 +288,11 @@ class ExpTruncNFWPotential(SphericalPotential):
         )
         return (r * r / (a * a)) * (c2 + r * (c3 + r * (c4 + r * c5)))
 
-    def _G(self, r):
+    @backend_kernel("r")
+    def _G(self, r, *, xp=None):
         # G(r) := 4 pi int_r^inf rho(s) s ds / amp
         #       = exp(-r/rc)/(a+r) - exp(alpha) E1(beta) / rc,
         # the outer-shell contribution to the potential.
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0  # so beta is a backend array (router/dtype match)
         a, rc = self.a, self.rc
         beta = (a + r) / rc
@@ -309,20 +309,20 @@ class ExpTruncNFWPotential(SphericalPotential):
         a = self.a
         return xp.exp(-r / self.rc) / (4.0 * numpy.pi * a * a * r * (1.0 + r / a) ** 2)
 
-    def _revaluate(self, r, t=0.0):
+    @backend_kernel("r")
+    def _revaluate(self, r, t=0.0, *, xp=None):
         # Phi(r)/amp = -[F(r)/r + G(r)]. F(r) ~ r^2/(2 a^2) near the origin, so
         # F/r has a finite (zero) limit there that we substitute by hand to
         # avoid a 0/0 NaN (e.g. eddingtondf seeds its rphi spline at r=0).
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0
         at0 = r == 0.0
         safe = xp.where(at0, xp.ones_like(r), r)  # avoid 0/0 at the origin
         FoverR = xp.where(at0, xp.zeros_like(r), self._F(safe) / safe)
         return -(FoverR + self._G(r))
 
-    def _rforce(self, r, t=0.0):
+    @backend_kernel("r")
+    def _rforce(self, r, t=0.0, *, xp=None):
         # -F(r)/r^2, with the finite r->0 limit -1/(2 a^2) substituted by hand.
-        xp = get_namespace(r)
         r = xp.asarray(r) * 1.0
         zero_limit = -0.5 / (self.a * self.a)
         at0 = r == 0.0

--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -15,6 +15,7 @@ from scipy import integrate
 from scipy.special import gamma
 
 from ..backend import (
+    backend_kernel,
     coerce_coords,
     get_namespace,
     is_backend_array,
@@ -253,8 +254,8 @@ class FerrersPotential(Potential):
             )
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
@@ -273,8 +274,8 @@ class FerrersPotential(Potential):
             + 2.0 * xp.cos(phi) * xp.sin(phi) * phixy
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
@@ -293,8 +294,8 @@ class FerrersPotential(Potential):
         x, y, z = self._compute_xyz(R, phi, z, t)
         return self._2ndderiv_xyz(x, y, z, 2, 2)
 
-    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
@@ -318,8 +319,8 @@ class FerrersPotential(Potential):
             - 2.0 * xp.cos(phi) * xp.sin(phi) * phixy
         ) + R * (xp.cos(phi) * Fx + xp.sin(phi) * Fy)
 
-    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
@@ -344,8 +345,8 @@ class FerrersPotential(Potential):
             - xp.cos(phi) * Fy
         )
 
-    def _phizderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _phizderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if not self.isNonAxi:
             phi = zeros_like_backend(xp, R)
         x, y, z = self._compute_xyz(R, phi, z, t)
@@ -381,8 +382,8 @@ class FerrersPotential(Potential):
             )
         )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         x, y, z = self._compute_xyz(R, phi, z, t)
         m2 = x**2 / self._a2 + y**2 / self._b2 + z**2 / self._c2
         if xp is numpy:

--- a/galpy/potential/HenonHeilesPotential.py
+++ b/galpy/potential/HenonHeilesPotential.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   HenonHeilesPotential: the Henon-Heiles (1964) potential
 ###############################################################################
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from .planarPotential import planarPotential
 
 
@@ -36,32 +36,26 @@ class HenonHeilesPotential(planarPotential):
         self._backend_compatible = True
         self.hasC_dxdv = True
 
-    def _evaluate(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _evaluate(self, R, phi=0.0, t=0.0, *, xp=None):
         return 0.5 * R * R * (1.0 + 2.0 / 3.0 * R * xp.sin(3.0 * phi))
 
-    def _Rforce(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _Rforce(self, R, phi=0.0, t=0.0, *, xp=None):
         return -R * (1.0 + R * xp.sin(3.0 * phi))
 
-    def _phitorque(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _phitorque(self, R, phi=0.0, t=0.0, *, xp=None):
         return -(R**3.0) * xp.cos(3.0 * phi)
 
-    def _R2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _R2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         return 1.0 + 2.0 * R * xp.sin(3.0 * phi)
 
-    def _phi2deriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _phi2deriv(self, R, phi=0.0, t=0.0, *, xp=None):
         return -3.0 * R**3.0 * xp.sin(3.0 * phi)
 
-    def _Rphideriv(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi")
+    def _Rphideriv(self, R, phi=0.0, t=0.0, *, xp=None):
         return 3.0 * R**2.0 * xp.cos(3.0 * phi)

--- a/galpy/potential/HomogeneousSpherePotential.py
+++ b/galpy/potential/HomogeneousSpherePotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential
 
@@ -57,9 +57,8 @@ class HomogeneousSpherePotential(Potential):
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         # safe denominator so the (dead) outside branch cannot produce a
@@ -67,25 +66,22 @@ class HomogeneousSpherePotential(Potential):
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
         return xp.where(inside, r2 - 3.0 * self._R2, -2.0 * self._R3 / xp.sqrt(safe))
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
         return xp.where(inside, -2.0 * R, -2.0 * self._R3 * R / safe**1.5)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
         return xp.where(inside, -2.0 * z, -2.0 * self._R3 * z / safe**1.5)
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -95,9 +91,8 @@ class HomogeneousSpherePotential(Potential):
             2.0 * self._R3 / safe**1.5 - 6.0 * self._R3 * R**2.0 / safe**2.5,
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -107,9 +102,8 @@ class HomogeneousSpherePotential(Potential):
             2.0 * self._R3 / safe**1.5 - 6.0 * self._R3 * z**2.0 / safe**2.5,
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         safe = xp.where(inside, xp.ones_like(r2 * 1.0), r2)
@@ -119,9 +113,8 @@ class HomogeneousSpherePotential(Potential):
             -6.0 * self._R3 * R * z / safe**2.5,
         )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         inside = r2 < self._R2
         return xp.where(

--- a/galpy/potential/IsochronePotential.py
+++ b/galpy/potential/IsochronePotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential
 
@@ -58,32 +58,28 @@ class IsochronePotential(Potential):
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return -1.0 / (self.b + rb)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         dPhidrr = -1.0 / rb / (self.b + rb) ** 2.0
         return dPhidrr * R
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         dPhidrr = -1.0 / rb / (self.b + rb) ** 2.0
         return dPhidrr * z
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -96,9 +92,8 @@ class IsochronePotential(Potential):
             / (self.b + rb) ** 3.0
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -111,16 +106,14 @@ class IsochronePotential(Potential):
             / (self.b + rb) ** 3.0
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return -R * z * (self.b + 3.0 * rb) / rb**3.0 / (self.b + rb) ** 3.0
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (
@@ -131,9 +124,8 @@ class IsochronePotential(Potential):
             / math.pi
         )
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         rb = xp.sqrt(r2 + self.b2)
         return (

--- a/galpy/potential/IsothermalDiskPotential.py
+++ b/galpy/potential/IsothermalDiskPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace, is_backend_array
+from ..backend import backend_kernel, get_namespace, is_backend_array
 from ..util import conversion
 from .linearPotential import linearPotential
 
@@ -55,20 +55,17 @@ class IsothermalDiskPotential(linearPotential):
         self.hasC_dxdv = True  # 1D variational (dxdv) second derivative in C
         self._backend_compatible = True
 
-    def _evaluate(self, x, t=0.0):
-        xp = get_namespace(x)
-        (x,) = coerce_coords(xp, x)
+    @backend_kernel("x")
+    def _evaluate(self, x, t=0.0, *, xp=None):
         return 2.0 * self._sigma2 * xp.log(xp.cosh(0.5 * x / self._H))
 
-    def _force(self, x, t=0.0):
-        xp = get_namespace(x)
-        (x,) = coerce_coords(xp, x)
+    @backend_kernel("x")
+    def _force(self, x, t=0.0, *, xp=None):
         return -self._sigma2 * xp.tanh(0.5 * x / self._H) / self._H
 
-    def _force2deriv(self, x, t=0.0):
+    @backend_kernel("x")
+    def _force2deriv(self, x, t=0.0, *, xp=None):
         # d^2 Phi / dx^2 = sigma^2 / (2 H^2) sech^2(x/2H)
-        xp = get_namespace(x)
-        (x,) = coerce_coords(xp, x)
         return (
             self._sigma2
             / (2.0 * self._H**2.0)

--- a/galpy/potential/KGPotential.py
+++ b/galpy/potential/KGPotential.py
@@ -1,6 +1,6 @@
 import numpy
 
-from ..backend import get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .linearPotential import linearPotential
@@ -70,12 +70,12 @@ class KGPotential(linearPotential):
         self.hasC_dxdv = True  # 1D variational (dxdv) second derivative in C
         self._backend_compatible = True
 
-    def _evaluate(self, x, t=0.0):
-        xp = get_namespace(x)
+    @backend_kernel("x")
+    def _evaluate(self, x, t=0.0, *, xp=None):
         return self._K * (xp.sqrt(x**2.0 + self._D2) - self._D) + self._F * x**2.0
 
-    def _force(self, x, t=0.0):
-        xp = get_namespace(x)
+    @backend_kernel("x")
+    def _force(self, x, t=0.0, *, xp=None):
         return -x * (self._K / xp.sqrt(x**2 + self._D2) + 2.0 * self._F)
 
     def _force2deriv(self, x, t=0.0):

--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -7,7 +7,7 @@ import copy
 import numpy
 from scipy import integrate
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..backend.special import logsumexp
 from .Potential import Potential
 
@@ -298,32 +298,26 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
 
         return (th, tH, tdH)
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Here and below: out-of-place accumulation (out = out + ...) instead of
         # += so torch autograd never sees an in-place op; identical numpy values.
-        xp = get_namespace(R, z)
-        # Coerce R/z onto the active backend so xp.sqrt and the Sigma/hz closures
-        # (xp.exp/xp.abs(...)) receive backend arrays, not numpy/python; numpy
-        # pass-through keeps this byte-identical.
-        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me(R, z, phi=phi, t=t, use_physical=False)
         for a, s, H in zip(self._Sigma_amp, self._Sigma, self._Hz):
             out = out + 4.0 * numpy.pi * a * s(r) * H(z)
         return out
 
-    def _Rforce(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0, t=0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rforce(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, H in zip(self._Sigma_amp, self._dSigmadR, self._Hz):
             out = out - 4.0 * numpy.pi * a * ds(r) * H(z) * R / r
         return out
 
-    def _zforce(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0, t=0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.zforce(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, H, dH in zip(
@@ -335,9 +329,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         return self._me.phitorque(R, z, phi=phi, t=t, use_physical=False)
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.R2deriv(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, d2s, H in zip(
@@ -353,9 +346,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             )
         return out
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.z2deriv(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(
@@ -379,9 +371,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             )
         return out
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.Rzderiv(R, z, phi=phi, t=t, use_physical=False)
         for a, ds, d2s, H, dH in zip(
@@ -398,9 +389,8 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
         return self._me.phi2deriv(R, z, phi=phi, t=t, use_physical=False)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         out = self._me.dens(R, z, phi=phi, t=t, use_physical=False)
         for a, s, ds, d2s, h, H, dH in zip(

--- a/galpy/potential/KuzminDiskPotential.py
+++ b/galpy/potential/KuzminDiskPotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential
 
@@ -63,37 +63,32 @@ class KuzminDiskPotential(Potential):
     def _Rforce(self, R, z, phi=0.0, t=0.0):
         return -(self._denom(R, z) ** -1.5) * R
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -xp.sign(z) * self._denom(R, z) ** -1.5 * (self._a + xp.abs(z))
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         return self._denom(R, z) ** -1.5 - 3.0 * R**2 * self._denom(R, z) ** -2.5
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         a = self._a
         return (
             self._denom(R, z) ** -1.5
             - 3.0 * (a + xp.abs(z)) ** 2.0 * self._denom(R, z) ** -2.5
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -3 * xp.sign(z) * R * (self._a + xp.abs(z)) * self._denom(R, z) ** -2.5
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         return self._a * (R**2 + self._a**2) ** -1.5 / 2.0 / math.pi
 
-    def _mass(self, R, z=None, t=0.0):
-        xp = get_namespace(R)
-        (R,) = coerce_coords(xp, R)
+    @backend_kernel("R")
+    def _mass(self, R, z=None, t=0.0, *, xp=None):
         return 1.0 - self._a / xp.sqrt(R**2.0 + self._a**2.0)
 
-    def _denom(self, R, z):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _denom(self, R, z, *, xp=None):
         return R**2.0 + (self._a + xp.abs(z)) ** 2.0

--- a/galpy/potential/KuzminKutuzovStaeckelPotential.py
+++ b/galpy/potential/KuzminKutuzovStaeckelPotential.py
@@ -8,7 +8,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion  # for prolate spherical coordinate transforms
 from ..util import coords
 from .Potential import Potential
@@ -63,33 +63,29 @@ class KuzminKutuzovStaeckelPotential(Potential):
         self.hasC_dxdv = True
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         return -1.0 / (xp.sqrt(l) + xp.sqrt(n))
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         dldR = xp.asarray(jac[0, 0])
         dndR = xp.asarray(jac[1, 0])
         return -(dldR * self._lderiv(l, n) + dndR * self._nderiv(l, n))
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         dldz = xp.asarray(jac[0, 1])
         dndz = xp.asarray(jac[1, 1])
         return -(dldz * self._lderiv(l, n) + dndz * self._nderiv(l, n))
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
@@ -105,9 +101,8 @@ class KuzminKutuzovStaeckelPotential(Potential):
             + 2.0 * dldR * dndR * self._lnderiv(l, n)
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
@@ -123,9 +118,8 @@ class KuzminKutuzovStaeckelPotential(Potential):
             + 2.0 * dldz * dndz * self._lnderiv(l, n)
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
         jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
         hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
@@ -143,7 +137,8 @@ class KuzminKutuzovStaeckelPotential(Potential):
             + (dldR * dndz + dldz * dndR) * self._lnderiv(l, n)
         )
 
-    def _lderiv(self, l, n):
+    @backend_kernel("l", "n")
+    def _lderiv(self, l, n, *, xp=None):
         """
         Evaluate the derivative w.r.t. lambda for this potential.
 
@@ -163,10 +158,10 @@ class KuzminKutuzovStaeckelPotential(Potential):
         -----
         - 2015-02-15 - Written - Trick (MPIA)
         """
-        xp = get_namespace(l, n)
         return 0.5 / xp.sqrt(l) / (xp.sqrt(l) + xp.sqrt(n)) ** 2
 
-    def _nderiv(self, l, n):
+    @backend_kernel("l", "n")
+    def _nderiv(self, l, n, *, xp=None):
         """
         Evaluate the derivative w.r.t. nu for this potential.
 
@@ -187,10 +182,10 @@ class KuzminKutuzovStaeckelPotential(Potential):
         - 2015-02-15 - Written - Trick (MPIA)
 
         """
-        xp = get_namespace(l, n)
         return 0.5 / xp.sqrt(n) / (xp.sqrt(l) + xp.sqrt(n)) ** 2
 
-    def _l2deriv(self, l, n):
+    @backend_kernel("l", "n")
+    def _l2deriv(self, l, n, *, xp=None):
         """
         Evaluate the second derivative w.r.t. lambda for this potential.
 
@@ -211,12 +206,12 @@ class KuzminKutuzovStaeckelPotential(Potential):
         - 2015-02-15 - Written - Trick (MPIA)
 
         """
-        xp = get_namespace(l, n)
         number = -3.0 * xp.sqrt(l) - xp.sqrt(n)
         denom = 4.0 * l**1.5 * (xp.sqrt(l) + xp.sqrt(n)) ** 3
         return number / denom
 
-    def _n2deriv(self, l, n):
+    @backend_kernel("l", "n")
+    def _n2deriv(self, l, n, *, xp=None):
         """
         Evaluate the second derivative w.r.t. nu for this potential.
 
@@ -237,12 +232,12 @@ class KuzminKutuzovStaeckelPotential(Potential):
         - 2015-02-15 - Written - Trick (MPIA)
 
         """
-        xp = get_namespace(l, n)
         number = -xp.sqrt(l) - 3.0 * xp.sqrt(n)
         denom = 4.0 * n**1.5 * (xp.sqrt(l) + xp.sqrt(n)) ** 3
         return number / denom
 
-    def _lnderiv(self, l, n):
+    @backend_kernel("l", "n")
+    def _lnderiv(self, l, n, *, xp=None):
         """
         Evaluate the mixed derivative w.r.t. lambda and nu for this potential.
 
@@ -263,5 +258,4 @@ class KuzminKutuzovStaeckelPotential(Potential):
         - 2015-02-13 - Written - Trick (MPIA)
 
         """
-        xp = get_namespace(l, n)
         return -0.5 / (xp.sqrt(l) * xp.sqrt(n) * (xp.sqrt(l) + xp.sqrt(n)) ** 3)

--- a/galpy/potential/KuzminLikeWrapperPotential.py
+++ b/galpy/potential/KuzminLikeWrapperPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace, zeros_like_backend
+from ..backend import backend_kernel, zeros_like_backend
 from ..util import conversion
 from .Potential import (
     _evaluatePotentials,
@@ -84,15 +84,15 @@ class KuzminLikeWrapperPotential(WrapperPotential):
         self.hasC_dxdv3d = True
         self.isNonAxi = False
 
-    def _xi(self, R, z):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _xi(self, R, z, *, xp=None):
         return xp.sqrt(R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0)
 
     def _dxidR(self, R, z):
         return R / self._xi(R, z)
 
-    def _dxidz(self, R, z):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _dxidz(self, R, z, *, xp=None):
         return (
             (self._a + xp.sqrt(z**2.0 + self._b2))
             * z
@@ -100,12 +100,12 @@ class KuzminLikeWrapperPotential(WrapperPotential):
             / xp.sqrt(z**2.0 + self._b2)
         )
 
-    def _d2xidR2(self, R, z):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _d2xidR2(self, R, z, *, xp=None):
         return ((self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) / self._xi(R, z) ** 3.0
 
-    def _d2xidz2(self, R, z):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _d2xidz2(self, R, z, *, xp=None):
         return (
             (
                 self._a**3.0 * self._b2
@@ -117,30 +117,27 @@ class KuzminLikeWrapperPotential(WrapperPotential):
             / self._xi(R, z) ** 3.0
         )
 
-    def _d2xidRdz(self, R, z):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _d2xidRdz(self, R, z, *, xp=None):
         return -(R * z * (self._a + xp.sqrt(self._b2 + z**2.0))) / (
             xp.sqrt(self._b2 + z**2.0)
             * ((self._a + xp.sqrt(self._b2 + z**2.0)) ** 2.0 + R**2.0) ** 1.5
         )
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return _evaluatePotentials(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return _evaluateRforces(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidR(R, z)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return _evaluateRforces(
             self._pot, self._xi(R, z), zeros_like_backend(xp, R), phi=phi, t=t
         ) * self._dxidz(R, z)
@@ -148,9 +145,8 @@ class KuzminLikeWrapperPotential(WrapperPotential):
     def _phitorque(self, R, z, phi=0.0, t=0.0):
         return 0.0
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
@@ -158,9 +154,8 @@ class KuzminLikeWrapperPotential(WrapperPotential):
             self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._d2xidR2(R, z)
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t
@@ -168,9 +163,8 @@ class KuzminLikeWrapperPotential(WrapperPotential):
             self._pot, self._xi(R, z), zero, phi=phi, t=t
         ) * self._d2xidz2(R, z)
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi, t)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         zero = zeros_like_backend(xp, R)
         return evaluateR2derivs(
             self._pot, self._xi(R, z), zero, phi=phi, t=t

--- a/galpy/potential/LogarithmicHaloPotential.py
+++ b/galpy/potential/LogarithmicHaloPotential.py
@@ -5,7 +5,7 @@
 import math
 import warnings
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..util import conversion, galpyWarning
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -94,27 +94,24 @@ class LogarithmicHaloPotential(Potential):
             R, z = coerce_coords(xp, R, z)
             return 1.0 / 2.0 * xp.log(R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return -Rt2 / R / (Rt2 + (z / self._q) ** 2.0 + self._core2)
         else:
             return -R / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return -z / self._q**2.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
         else:
             return -z / self._q**2.0 / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
 
-    def _phitorque(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phitorque(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return (
@@ -127,9 +124,8 @@ class LogarithmicHaloPotential(Potential):
         else:
             return 0
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             R2 = R**2.0
             Rt2 = R2 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
@@ -169,9 +165,8 @@ class LogarithmicHaloPotential(Potential):
                 / (R**2.0 + (z / self._q) ** 2.0 + self._core2) ** 2.0
             )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
@@ -180,9 +175,8 @@ class LogarithmicHaloPotential(Potential):
             denom = 1.0 / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
             return denom - 2.0 * R**2.0 * denom**2.0
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
@@ -191,9 +185,8 @@ class LogarithmicHaloPotential(Potential):
             denom = 1.0 / (R**2.0 + (z / self._q) ** 2.0 + self._core2)
             return denom / self._q**2.0 - 2.0 * z**2.0 * denom**2.0 / self._q**4.0
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             return (
@@ -213,9 +206,8 @@ class LogarithmicHaloPotential(Potential):
                 / (R**2.0 + (z / self._q) ** 2.0 + self._core2) ** 2.0
             )
 
-    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
@@ -226,9 +218,8 @@ class LogarithmicHaloPotential(Potential):
         else:
             return 0.0
 
-    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)
@@ -236,9 +227,8 @@ class LogarithmicHaloPotential(Potential):
         else:
             return 0.0
 
-    def _phizderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phizderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self.isNonAxi:
             Rt2 = R**2.0 * (1.0 - self._1m1overb2 * xp.sin(phi) ** 2.0)
             denom = 1.0 / (Rt2 + (z / self._q) ** 2.0 + self._core2)

--- a/galpy/potential/MiyamotoNagaiPotential.py
+++ b/galpy/potential/MiyamotoNagaiPotential.py
@@ -7,7 +7,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -67,21 +67,18 @@ class MiyamotoNagaiPotential(Potential):
         self.hasC_dens = True
         self._nemo_accname = "MiyamotoNagai"
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -1.0 / xp.sqrt(R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -R / (R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) ** (
             3.0 / 2.0
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -98,9 +95,8 @@ class MiyamotoNagaiPotential(Potential):
                 ** (3.0 / 2.0)
             )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -116,9 +112,8 @@ class MiyamotoNagaiPotential(Potential):
                 * self._b2
             )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return (
             1.0 / (R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) ** 1.5
             - 3.0
@@ -126,9 +121,8 @@ class MiyamotoNagaiPotential(Potential):
             / (R**2.0 + (self._a + xp.sqrt(z**2.0 + self._b2)) ** 2.0) ** 2.5
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:
@@ -147,9 +141,8 @@ class MiyamotoNagaiPotential(Potential):
                 * (3.0 * self._b2**2.0 - 4.0 * z**4.0 + self._b2 * (R**2.0 - z**2.0))
             ) / ((self._b2 + z**2.0) ** 1.5 * (R**2.0 + asqrtbz**2.0) ** 2.5)
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtbz = xp.sqrt(self._b2 + z**2.0)
         asqrtbz = self._a + sqrtbz
         if self._a == 0.0:

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -11,7 +11,7 @@ import numpy
 
 from galpy.util import conversion, coords
 
-from ..backend import coerce_coords, get_namespace, promote_scalars
+from ..backend import backend_kernel, get_namespace, promote_scalars
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -119,7 +119,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         return (self._U(u) - self._V(v)) / _staeckel_prefactor(u, v)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _Rforce
@@ -135,8 +136,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-12-15 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -155,7 +154,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             / prefac**2.0
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _zforce
@@ -171,8 +171,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-12-15 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -191,7 +189,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             / prefac**2.0
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _R2deriv
@@ -207,8 +206,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-21 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -255,7 +252,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             dprefacdu * xp.cosh(u) * xp.sin(v) + dprefacdv * xp.sinh(u) * xp.cos(v)
         ) / self._delta
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _z2deriv
@@ -271,8 +269,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-21 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -319,7 +315,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             -dprefacdu * xp.sinh(u) * xp.cos(v) + dprefacdv * xp.cosh(u) * xp.sin(v)
         ) / self._delta
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z", "phi")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         NAME:
            _Rzderiv
@@ -335,8 +332,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         HISTORY:
            2017-01-22 - Written - Bovy (UofT)
         """
-        xp = get_namespace(R, z, phi, t)
-        R, z, phi = coerce_coords(xp, R, z, phi)
         u, v = coords.Rz_to_uv(R, z, delta=self._delta)
         prefac = _staeckel_prefactor(u, v)
         dprefacdu, dprefacdv = _dstaeckel_prefactordudv(u, v)
@@ -385,16 +380,14 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             dprefacdu * xp.cosh(u) * xp.sin(v) + dprefacdv * xp.sinh(u) * xp.cos(v)
         ) / self._delta
 
-    def _U(self, u):
+    @backend_kernel("u")
+    def _U(self, u, *, xp=None):
         """Approximated U(u) = cosh^2(u) Phi(u,pi/2)"""
-        xp = get_namespace(u)
-        (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         return xp.cosh(u) ** 2.0 * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
 
-    def _dUdu(self, u):
-        xp = get_namespace(u)
-        (u,) = coerce_coords(xp, u)
+    @backend_kernel("u")
+    def _dUdu(self, u, *, xp=None):
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         # 1e-12 bc force should win the 0/0 battle
         return 2.0 * xp.cosh(u) * xp.sinh(u) * _evaluatePotentials(
@@ -404,9 +397,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             + _evaluatezforces(self._pot, Rz0[0], Rz0[1]) * Rz0[1] * xp.tanh(u)
         )
 
-    def _d2Udu2(self, u):
-        xp = get_namespace(u)
-        (u,) = coerce_coords(xp, u)
+    @backend_kernel("u")
+    def _d2Udu2(self, u, *, xp=None):
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, Rz0[0], Rz0[1])
         tzforce = _evaluatezforces(self._pot, Rz0[0], Rz0[1])
@@ -441,9 +433,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             self._pot, R0z[0], R0z[1]
         )
 
-    def _dVdv(self, v):
-        xp = get_namespace(v)
-        (v,) = coerce_coords(xp, v)
+    @backend_kernel("v")
+    def _dVdv(self, v, *, xp=None):
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         return -2.0 * xp.sin(v) * xp.cos(v) * _evaluatePotentials(
             self._pot, R0z[0], R0z[1]
@@ -452,9 +443,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             - _evaluatezforces(self._pot, R0z[0], R0z[1]) * R0z[1] * xp.tan(v)
         )
 
-    def _d2Vdv2(self, v):
-        xp = get_namespace(v)
-        (v,) = coerce_coords(xp, v)
+    @backend_kernel("v")
+    def _d2Vdv2(self, v, *, xp=None):
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, R0z[0], R0z[1])
         tzforce = _evaluatezforces(self._pot, R0z[0], R0z[1])

--- a/galpy/potential/PlummerPotential.py
+++ b/galpy/potential/PlummerPotential.py
@@ -6,7 +6,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..util import conversion
 from .Potential import Potential, kms_to_kpcGyrDecorator
 
@@ -57,31 +57,26 @@ class PlummerPotential(Potential):
         self.hasC_dens = True
         self._nemo_accname = "Plummer"
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -1.0 / xp.sqrt(R**2.0 + z**2.0 + self._b2)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         dPhidrr = -((R**2.0 + z**2.0 + self._b2) ** -1.5)
         return dPhidrr * R
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         dPhidrr = -((R**2.0 + z**2.0 + self._b2) ** -1.5)
         return dPhidrr * z
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return 3.0 / 4.0 / math.pi * self._b2 * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Rb = R**2.0 + self._b2
         return (
             self._b2
@@ -93,24 +88,20 @@ class PlummerPotential(Potential):
             / math.pi
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return (self._b2 - 2.0 * R**2.0 + z**2.0) * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return (self._b2 + R**2.0 - 2.0 * z**2.0) * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -3.0 * R * z * (R**2.0 + z**2.0 + self._b2) ** -2.5
 
-    def _ddensdr(self, r, t=0.0):
-        xp = get_namespace(r)
-        (r,) = coerce_coords(xp, r)
+    @backend_kernel("r")
+    def _ddensdr(self, r, t=0.0, *, xp=None):
         return (
             self._amp
             * (-15.0)
@@ -121,9 +112,8 @@ class PlummerPotential(Potential):
             * (r**2 + self._b2) ** -3.5
         )
 
-    def _d2densdr2(self, r, t=0.0):
-        xp = get_namespace(r)
-        (r,) = coerce_coords(xp, r)
+    @backend_kernel("r")
+    def _d2densdr2(self, r, t=0.0, *, xp=None):
         return (
             self._amp
             * (-15.0)
@@ -133,7 +123,8 @@ class PlummerPotential(Potential):
             * ((r**2.0 + self._b2) ** -3.5 - 7.0 * r**2.0 * (r**2 + self._b2) ** -4.5)
         )
 
-    def _ddenstwobetadr(self, r, beta=0):
+    @backend_kernel("r")
+    def _ddenstwobetadr(self, r, beta=0, *, xp=None):
         """
         Evaluate the radial density derivative x r^(2beta) for this potential.
 
@@ -154,8 +145,6 @@ class PlummerPotential(Potential):
         - 2021-03-15 - Written - Lane (UofT)
 
         """
-        xp = get_namespace(r)
-        (r,) = coerce_coords(xp, r)
         return (
             self._amp
             * 3.0

--- a/galpy/potential/PowerSphericalPotential.py
+++ b/galpy/potential/PowerSphericalPotential.py
@@ -11,7 +11,7 @@ import math
 import numpy
 from scipy import special
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential
 
@@ -66,7 +66,8 @@ class PowerSphericalPotential(Potential):
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
         self.hasC_dens = True
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate the potential at R,z
 
@@ -90,8 +91,6 @@ class PowerSphericalPotential(Potential):
         -----
         - Started: 2010-07-10 by Bovy (NYU)
         """
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
         r2 = R**2.0 + z**2.0
         if self.alpha == 2.0:
             return xp.log(r2) / 2.0
@@ -238,7 +237,8 @@ class PowerSphericalPotential(Potential):
         """
         return -self.alpha * R * z * (R**2.0 + z**2.0) ** (-1.0 - self.alpha / 2.0)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         """
         Evaluate the density for this potential.
 
@@ -262,8 +262,6 @@ class PowerSphericalPotential(Potential):
         -----
         - 2013-01-09 - Written - Bovy (IAS)
         """
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
         r = xp.sqrt(R**2.0 + z**2.0)
         return (3.0 - self.alpha) / 4.0 / math.pi / r**self.alpha
 

--- a/galpy/potential/PowerSphericalPotentialwCutoff.py
+++ b/galpy/potential/PowerSphericalPotentialwCutoff.py
@@ -8,7 +8,7 @@
 import numpy
 from scipy import special
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..backend._namespaces import namespace_from_arrays
 from ..backend.special import gamma as _gamma
 from ..backend.special import gammainc as _gammainc
@@ -72,9 +72,8 @@ class PowerSphericalPotentialwCutoff(Potential):
         self.hasC_dens = True
         self._nemo_accname = "PowSphwCut"
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         # guard r=0 in the dead branch (the 1/r term -> 0/0=NaN there) so the
         # xp.where stays finite under autodiff/jit; the value at r=0 is 0.
@@ -110,37 +109,32 @@ class PowerSphericalPotentialwCutoff(Potential):
             / r**2.0
         )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R * R + z * z)
         return self._rforce(r) * R / r
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R * R + z * z)
         return self._rforce(r) * z / r
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R * R + z * z)
         return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
         ) * R**2.0 + self._mass(r) / r**5.0 * (z**2.0 - 2.0 * R**2.0)
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R * R + z * z)
         return 4.0 * numpy.pi * r ** (-2.0 - self.alpha) * xp.exp(
             -((r / self.rc) ** 2.0)
         ) * z**2.0 + self._mass(r) / r**5.0 * (R**2.0 - 2.0 * z**2.0)
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R * R + z * z)
         return (
             R
@@ -166,8 +160,8 @@ class PowerSphericalPotentialwCutoff(Potential):
             * (2.0 * r**2.0 / self.rc**2.0 + self.alpha)
         )
 
-    def _d2densdr2(self, r, t=0.0):
-        xp = get_namespace(r)
+    @backend_kernel("r")
+    def _d2densdr2(self, r, t=0.0, *, xp=None):
         return (
             self._amp
             * r ** (-2.0 - self.alpha)
@@ -212,9 +206,8 @@ class PowerSphericalPotentialwCutoff(Potential):
             * ((self.alpha - 2.0 * beta) / r + 2.0 * r / self.rc**2.0)
         )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return 1.0 / r**self.alpha * xp.exp(-((r / self.rc) ** 2.0))
 

--- a/galpy/potential/PseudoIsothermalPotential.py
+++ b/galpy/potential/PseudoIsothermalPotential.py
@@ -6,7 +6,7 @@ import math
 
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .Potential import Potential
 
@@ -57,9 +57,8 @@ class PseudoIsothermalPotential(Potential):
             self.normalize(normalize)
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         if isinstance(r, (float, int)):  # numpy/python scalar fast path
@@ -76,16 +75,14 @@ class PseudoIsothermalPotential(Potential):
         ) / self._a
         return xp.where(r == 0, 1.0 / self._a, out)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return -(1.0 / r - self._a / r2 * xp.arctan(r / self._a)) / self._a * R / r
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return -(1.0 / r - self._a / r2 * xp.arctan(r / self._a)) / self._a * z / r
@@ -93,9 +90,8 @@ class PseudoIsothermalPotential(Potential):
     def _dens(self, R, z, phi=0.0, t=0.0):
         return 1.0 / (1.0 + (R**2.0 + z**2.0) / self._a2) / 4.0 / math.pi / self._a3
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (
@@ -105,9 +101,8 @@ class PseudoIsothermalPotential(Potential):
             + self._a / r2 / r * (3.0 * R**2.0 / r2 - 1.0) * xp.arctan(r / self._a)
         ) / self._a
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (
@@ -117,9 +112,8 @@ class PseudoIsothermalPotential(Potential):
             + self._a / r2 / r * (3.0 * z**2.0 / r2 - 1.0) * xp.arctan(r / self._a)
         ) / self._a
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r2 = R**2.0 + z**2.0
         r = xp.sqrt(r2)
         return (

--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -8,7 +8,7 @@ import math
 
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..backend import special as bspecial
 from ..util import conversion
 from .Potential import Potential
@@ -71,9 +71,8 @@ class RazorThinExponentialDiskPotential(Potential):
         ):  # pragma: no cover
             self.normalize(normalize)
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self._new:
             if xp.abs(z) < 10.0**-6.0:
                 y = 0.5 * self._alpha * R
@@ -104,9 +103,8 @@ class RazorThinExponentialDiskPotential(Potential):
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # move the numpy GL nodes/weights onto the backend first, so products
         # like R * glx are same-namespace (a torch tensor * a numpy array trips
         # numpy's __array_wrap__); xp.asarray is a no-op on numpy (byte-identical)
@@ -162,9 +160,8 @@ class RazorThinExponentialDiskPotential(Potential):
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         glx = xp.asarray(self._glx)
         glw = xp.asarray(self._glw)
         if self._new:
@@ -215,9 +212,8 @@ class RazorThinExponentialDiskPotential(Potential):
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         if self._new:
             if xp.abs(z) < 10.0**-6.0:
                 y = 0.5 * self._alpha * R
@@ -234,14 +230,12 @@ class RazorThinExponentialDiskPotential(Potential):
     def _z2deriv(self, R, z, phi=0.0, t=0.0):  # pragma: no cover
         return math.inf
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return xp.exp(-self._alpha * R)
 
-    def _mass(self, R, z=None, t=0.0):
-        xp = get_namespace(R)
-        (R,) = coerce_coords(xp, R)
+    @backend_kernel("R")
+    def _mass(self, R, z=None, t=0.0, *, xp=None):
         return (
             2.0
             * math.pi

--- a/galpy/potential/RingPotential.py
+++ b/galpy/potential/RingPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel
 from ..backend.special import ellipe, ellipk
 from ..util import conversion
 from .Potential import Potential
@@ -57,16 +57,14 @@ class RingPotential(Potential):
         self.hasC = False
         self.hasC_dxdv = False
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # Stable as r -> infty
         m = 4.0 * self.a / ((xp.sqrt(R) + self.a / xp.sqrt(R)) ** 2 + z**2 / R)
         return -4.0 * self.a / xp.sqrt((R + self.a) ** 2 + z**2) * ellipk(m)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         m = 4.0 * R * self.a / ((R + self.a) ** 2 + z**2)
         return (
             -2.0
@@ -90,9 +88,8 @@ class RingPotential(Potential):
             * ellipe(m)
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Raz2 = (R + self.a) ** 2 + z**2
         Raz = xp.sqrt(Raz2)
         m = 4.0 * R * self.a / Raz2

--- a/galpy/potential/SoftenedNeedleBarPotential.py
+++ b/galpy/potential/SoftenedNeedleBarPotential.py
@@ -7,7 +7,7 @@ import math
 
 import numpy
 
-from ..backend import coerce_coords, get_namespace, is_backend_array
+from ..backend import backend_kernel, get_namespace, is_backend_array
 from ..util import conversion
 from .Potential import Potential
 
@@ -94,71 +94,61 @@ class SoftenedNeedleBarPotential(Potential):
         self.isNonAxi = True
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         x, y, z = self._compute_xyz(R, phi, z, t)
         Tp, Tm = self._compute_TpTm(x, y, z)
         return xp.log((x - self._a + Tm) / (x + self._a + Tp)) / 2.0 / self._a
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
         return xp.cos(phi) * Fx + xp.sin(phi) * Fy
 
-    def _phitorque(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phitorque(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Fx, Fy, _ = self._cached_xyzforces(R, z, phi, t, xp)
         return R * (-xp.sin(phi) * Fx + xp.cos(phi) * Fy)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         _, _, Fz = self._cached_xyzforces(R, z, phi, t, xp)
         return Fz
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[0]
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[1]
 
-    def _phi2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phi2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[2]
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[3]
 
-    def _Rphideriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rphideriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[4]
 
-    def _phizderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phizderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._cached_cylhess(R, z, phi, t, xp)[5]
 
     def OmegaP(self):
         return self._omegab
 
-    def _compute_xyz(self, R, phi, z, t):
-        xp = get_namespace(R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _compute_xyz(self, R, phi, z, t, *, xp=None):
         ang = phi - self._pa - self._omegab * t
         return (R * xp.cos(ang), R * xp.sin(ang), z)
 
-    def _compute_TpTm(self, x, y, z):
-        xp = get_namespace(x, y, z)
+    @backend_kernel("x", "y", "z")
+    def _compute_TpTm(self, x, y, z, *, xp=None):
         secondpart = y**2.0 + (self._b + xp.sqrt(self._c2 + z**2.0)) ** 2.0
         return (
             xp.sqrt((self._a + x) ** 2.0 + secondpart),
@@ -262,8 +252,8 @@ class SoftenedNeedleBarPotential(Potential):
     def _xforce_xyz(self, x, y, z, Tp, Tm):
         return -2.0 * x / Tp / Tm / (Tp + Tm)
 
-    def _yforce_xyz(self, x, y, z, Tp, Tm):
-        xp = get_namespace(x, y, z)
+    @backend_kernel("x", "y", "z")
+    def _yforce_xyz(self, x, y, z, Tp, Tm, *, xp=None):
         return (
             -y
             / 2.0
@@ -273,8 +263,8 @@ class SoftenedNeedleBarPotential(Potential):
             / (y**2.0 + (self._b + xp.sqrt(z**2.0 + self._c2)) ** 2.0)
         )
 
-    def _zforce_xyz(self, x, y, z, Tp, Tm):
-        xp = get_namespace(x, y, z)
+    @backend_kernel("x", "y", "z")
+    def _zforce_xyz(self, x, y, z, Tp, Tm, *, xp=None):
         zc = xp.sqrt(z**2.0 + self._c2)
         return (
             -z
@@ -287,9 +277,8 @@ class SoftenedNeedleBarPotential(Potential):
             / zc
         )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         x, y, z = self._compute_xyz(R, phi, z, t)
         zc = xp.sqrt(z**2.0 + self._c2)
         bzc2 = (self._b + zc) ** 2.0

--- a/galpy/potential/SphericalPotential.py
+++ b/galpy/potential/SphericalPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import math
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, get_namespace
 from .Potential import Potential
 
 
@@ -49,54 +49,47 @@ class SphericalPotential(Potential):
         """Implement using the Poisson equation in case this isn't implemented"""
         return (self._r2deriv(r, t=t) - 2.0 * self._rforce(r, t=t) / r) / 4.0 / math.pi
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._revaluate(r, t=t)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * R / r
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rforce(r, t=t) * z / r
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R**2.0 / r**2.0
             - self._rforce(r, t=t) * z**2.0 / r**3.0
         )
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * z**2.0 / r**2.0
             - self._rforce(r, t=t) * R**2.0 / r**3.0
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             self._r2deriv(r, t=t) * R * z / r**2.0
             + self._rforce(r, t=t) * R * z / r**3.0
         )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return self._rdens(r, t=t)
 

--- a/galpy/potential/SphericalShellPotential.py
+++ b/galpy/potential/SphericalShellPotential.py
@@ -4,7 +4,7 @@
 ###############################################################################
 import math
 
-from ..backend import get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .SphericalPotential import SphericalPotential
 
@@ -58,37 +58,37 @@ class SphericalShellPotential(SphericalPotential):
         self.hasC = False
         self.hasC_dxdv = False
 
-    def _revaluate(self, r, t=0.0):
+    @backend_kernel("r")
+    def _revaluate(self, r, t=0.0, *, xp=None):
         """The potential as a function of r"""
-        xp = get_namespace(r)
         inside = r <= self.a
         # safe r so the (dead) outside branch cannot produce -1/0 at r == 0
         safe = xp.where(inside, xp.ones_like(r * 1.0), r)
         return xp.where(inside, -1.0 / self.a * xp.ones_like(r * 1.0), -1.0 / safe)
 
-    def _rforce(self, r, t=0.0):
+    @backend_kernel("r")
+    def _rforce(self, r, t=0.0, *, xp=None):
         """The force as a function of r"""
-        xp = get_namespace(r)
         inside = r <= self.a
         safe = xp.where(inside, xp.ones_like(r * 1.0), r)
         return xp.where(inside, xp.zeros_like(r * 1.0), -1 / safe**2.0)
 
-    def _r2deriv(self, r, t=0.0):
+    @backend_kernel("r")
+    def _r2deriv(self, r, t=0.0, *, xp=None):
         """The second radial derivative as a function of r"""
-        xp = get_namespace(r)
         inside = r <= self.a
         safe = xp.where(inside, xp.ones_like(r * 1.0), r)
         return xp.where(inside, xp.zeros_like(r * 1.0), -2.0 / safe**3.0)
 
-    def _rdens(self, r, t=0.0):
+    @backend_kernel("r")
+    def _rdens(self, r, t=0.0, *, xp=None):
         """The density as a function of r"""
-        xp = get_namespace(r)
         return xp.where(
             r != self.a, xp.zeros_like(r * 1.0), math.inf * xp.ones_like(r * 1.0)
         )
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         # h is real only where R <= a; use a safe argument so the dead
         # (R > a) branch cannot produce sqrt(negative) = NaN
         outside = R > self.a

--- a/galpy/potential/SpiralArmsPotential.py
+++ b/galpy/potential/SpiralArmsPotential.py
@@ -10,7 +10,7 @@ import math
 
 import numpy
 
-from ..backend import asarray_on_device, coerce_coords, device_of, get_namespace
+from ..backend import asarray_on_device, backend_kernel, device_of
 from ..util import conversion
 from .Potential import Potential
 
@@ -120,9 +120,8 @@ class SpiralArmsPotential(Potential):
         self.hasC_dxdv = True  # Potential has C implementation of second derivatives
         self.hasC_dxdv3d = True  # Full 3D Hessian (incl. zphideriv) now in C
 
-    def _evaluate(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _evaluate(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -142,9 +141,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _Rforce(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rforce(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         He = self._H * xp.exp(-(R - self._r_ref) / self._Rs)
@@ -186,9 +184,8 @@ class SpiralArmsPotential(Potential):
             axis=0,
         )
 
-    def _zforce(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _zforce(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -209,9 +206,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _phitorque(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phitorque(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -234,9 +230,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _R2deriv(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _R2deriv(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Rs = self._Rs
@@ -414,9 +409,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _z2deriv(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _z2deriv(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -440,9 +434,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _phi2deriv(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phi2deriv(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -465,9 +458,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Rs = self._Rs
@@ -523,9 +515,8 @@ class SpiralArmsPotential(Potential):
             axis=0,
         )
 
-    def _Rphideriv(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _Rphideriv(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         He = self._H * xp.exp(-(R - self._r_ref) / self._Rs)
@@ -571,9 +562,8 @@ class SpiralArmsPotential(Potential):
             axis=0,
         )
 
-    def _phizderiv(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _phizderiv(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         Ks = self._K(R, ns)
@@ -596,9 +586,8 @@ class SpiralArmsPotential(Potential):
             )
         )
 
-    def _dens(self, R, z, phi=0, t=0):
-        xp = get_namespace(R, z, phi)
-        R, z, phi = coerce_coords(xp, R, z, phi)
+    @backend_kernel("R", "z", "phi")
+    def _dens(self, R, z, phi=0, t=0, *, xp=None):
         Cs, ns, HNn = self._nvectors(R, z, xp)
 
         g = self._gamma(R, phi - self._omega * t)
@@ -682,10 +671,9 @@ class SpiralArmsPotential(Potential):
             )
         return Cs, ns, HNn
 
-    def _gamma(self, R, phi):
+    @backend_kernel("R", "phi")
+    def _gamma(self, R, phi, *, xp=None):
         """Return gamma. (eqn 3 in the paper)"""
-        xp = get_namespace(R, phi)
-        R, phi = coerce_coords(xp, R, phi)
         return self._N * (
             phi - self._phi_ref - xp.log(R / self._r_ref) / self._tan_alpha
         )

--- a/galpy/potential/SteadyLogSpiralPotential.py
+++ b/galpy/potential/SteadyLogSpiralPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -113,9 +113,8 @@ class SteadyLogSpiralPotential(planarPotential):
         growth = 3.0 / 16.0 * xi**5.0 - 5.0 / 8 * xi**3.0 + 15.0 / 16.0 * xi + 0.5
         return xp.where(t < self._tform, 0.0, xp.where(t < self._tsteady, growth, 1.0))
 
-    def _evaluate(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _evaluate(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             smooth
@@ -127,9 +126,8 @@ class SteadyLogSpiralPotential(planarPotential):
             )
         )
 
-    def _Rforce(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _Rforce(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             smooth
@@ -141,9 +139,8 @@ class SteadyLogSpiralPotential(planarPotential):
             )
         )
 
-    def _phitorque(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _phitorque(self, R, phi=0.0, t=0.0, *, xp=None):
         smooth = self._smooth(t)
         return (
             -smooth

--- a/galpy/potential/TransientLogSpiralPotential.py
+++ b/galpy/potential/TransientLogSpiralPotential.py
@@ -3,7 +3,7 @@
 ###############################################################################
 import numpy
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..util import conversion
 from .planarPotential import planarPotential
 
@@ -101,9 +101,8 @@ class TransientLogSpiralPotential(planarPotential):
         (t,) = coerce_coords(xpt, t)
         return xpt.exp(-((t - self._to) ** 2.0) / 2.0 / self._sigma2)
 
-    def _evaluate(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _evaluate(self, R, phi=0.0, t=0.0, *, xp=None):
         return (
             self._A
             * self._envelope(t)
@@ -114,9 +113,8 @@ class TransientLogSpiralPotential(planarPotential):
             )
         )
 
-    def _Rforce(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _Rforce(self, R, phi=0.0, t=0.0, *, xp=None):
         return (
             self._A
             * self._envelope(t)
@@ -127,9 +125,8 @@ class TransientLogSpiralPotential(planarPotential):
             )
         )
 
-    def _phitorque(self, R, phi=0.0, t=0.0):
-        xp = get_namespace(R, phi, t)
-        R, phi = coerce_coords(xp, R, phi)
+    @backend_kernel("R", "phi", "t")
+    def _phitorque(self, R, phi=0.0, t=0.0, *, xp=None):
         return (
             -self._A
             * self._envelope(t)

--- a/galpy/potential/TriaxialGaussianPotential.py
+++ b/galpy/potential/TriaxialGaussianPotential.py
@@ -10,7 +10,7 @@
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import backend_kernel
 from ..util import conversion
 from .EllipsoidalPotential import EllipsoidalPotential
 
@@ -102,19 +102,19 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 
-    def _psi(self, m):
+    @backend_kernel("m")
+    def _psi(self, m, *, xp=None):
         """\\psi(m) = -\\int_m^\\infty d m^2 \rho(m^2)"""
-        xp = get_namespace(m)
         return -self._twosigma2 * xp.exp(-(m**2.0) / self._twosigma2)
 
-    def _mdens(self, m):
+    @backend_kernel("m")
+    def _mdens(self, m, *, xp=None):
         """Density as a function of m"""
-        xp = get_namespace(m)
         return xp.exp(-(m**2) / self._twosigma2)
 
-    def _mdens_deriv(self, m):
+    @backend_kernel("m")
+    def _mdens_deriv(self, m, *, xp=None):
         """Derivative of the density as a function of m"""
-        xp = get_namespace(m)
         return -2.0 * m * xp.exp(-(m**2) / self._twosigma2) / self._twosigma2
 
     def _mass(self, R, z=None, t=0.0):

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -11,7 +11,7 @@ import math
 import numpy
 from scipy import optimize
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import backend_kernel, coerce_coords, get_namespace
 from ..backend.special import gamma as _gamma
 from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
@@ -179,9 +179,8 @@ class TwoPowerSphericalPotential(Potential):
                 )
             )
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
@@ -251,9 +250,8 @@ class TwoPowerSphericalPotential(Potential):
             * (self.a * (2.0 * beta - self.alpha) + r * (2.0 * beta - self.beta))
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         A = self.a ** (self.alpha - 3.0) / (3.0 - self.alpha)
         hyper = _hyp2f1(
@@ -276,9 +274,8 @@ class TwoPowerSphericalPotential(Potential):
         term3 = -A * R**2 * r ** (-self.alpha - 1.0) / self.a * hyper_deriv
         return term1 + term2 + term3
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         A = self.a ** (self.alpha - 3.0) / (3.0 - self.alpha)
         hyper = _hyp2f1(
@@ -300,9 +297,8 @@ class TwoPowerSphericalPotential(Potential):
         term2 = -A * R * r ** (-self.alpha - 1.0) * z / self.a * hyper_deriv
         return term1 + term2
 
-    def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _z2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return self._R2deriv(xp.abs(z), R)  # Spherical potential
 
     def _mass(self, R, z=None, t=0.0):
@@ -441,9 +437,8 @@ class DehnenSphericalPotential(TwoPowerSphericalPotential):
             R * z * r ** (-2.0 - alpha) * (a + r) ** (alpha - 4.0) * (3 * r + a * alpha)
         ) / (alpha - 3)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a / r) ** self.alpha
@@ -501,44 +496,38 @@ class DehnenCoreSphericalPotential(DehnenSphericalPotential):
         self.hasC_dens = True
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(1.0 - 1.0 / (1.0 + self.a / r) ** 2.0) / (6.0 * self.a)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -R / (xp.sqrt(R**2.0 + z**2.0) + self.a) ** 3.0 / 3.0
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(
             ((2.0 * R**2.0 - z**2.0) - self.a * r) / (3.0 * r * (r + self.a) ** 4.0)
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return -z / (self.a + r) ** 3.0 / 3.0
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         return self._R2deriv(z, R, phi=phi, t=t)
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         a = self.a
         r = xp.sqrt(R**2.0 + z**2.0)
         return -(R * z / r / (a + r) ** 4.0)
 
-    def _dens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _dens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         return 1.0 / (1.0 + r / self.a) ** 4.0 / 4.0 / math.pi / self.a**3.0
 
@@ -593,26 +582,22 @@ class HernquistPotential(DehnenSphericalPotential):
         self.hasC_dens = True
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -1.0 / (1.0 + xp.sqrt(R**2.0 + z**2.0) / self.a) / 2.0 / self.a
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / self.a / sqrtRz / (1.0 + sqrtRz / self.a) ** 2.0 / 2.0 / self.a
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * z**2.0 + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
@@ -621,9 +606,8 @@ class HernquistPotential(DehnenSphericalPotential):
             / 2.0
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
@@ -633,9 +617,8 @@ class HernquistPotential(DehnenSphericalPotential):
             / 2.0
         )
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # (a^2-R^2) -> 0, (r^2-a^2) -> 0): use the closed-form limit there. Both
@@ -768,26 +751,22 @@ class JaffePotential(DehnenSphericalPotential):
         self.hasC_dens = True
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         return -xp.log(1.0 + self.a / xp.sqrt(R**2.0 + z**2.0)) / self.a
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -R / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return -z / sqrtRz**3.0 / (1.0 + self.a / sqrtRz)
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             (self.a * (z**2.0 - R**2.0) + (z**2.0 - 2.0 * R**2.0) * sqrtRz)
@@ -795,9 +774,8 @@ class JaffePotential(DehnenSphericalPotential):
             / (self.a + sqrtRz) ** 2.0
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         sqrtRz = xp.sqrt(R**2.0 + z**2.0)
         return (
             -R
@@ -807,9 +785,8 @@ class JaffePotential(DehnenSphericalPotential):
             * (self.a + sqrtRz) ** -2.0
         )
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches
@@ -970,9 +947,8 @@ class NFWPotential(TwoPowerSphericalPotential):
         self._nemo_accname = "NFW"
         return None
 
-    def _evaluate(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         # -special.xlogy(1/r, 1+r/a) == -(1/r)*log(1+r/a), with xlogy's
         # convention that the result is 0 where the prefactor 1/r is 0 (i.e.
@@ -987,27 +963,24 @@ class NFWPotential(TwoPowerSphericalPotential):
         out = xp.where(atinf, xp.zeros_like(r * 1.0), bulk)
         return xp.where(at0, -1.0 / self.a * xp.ones_like(r * 1.0), out)
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return R * (
             1.0 / Rz / (self.a + sqrtRz) - xp.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
         )
 
-    def _zforce(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _zforce(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return z * (
             1.0 / Rz / (self.a + sqrtRz) - xp.log(1.0 + sqrtRz / self.a) / sqrtRz / Rz
         )
 
-    def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _R2deriv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return (
@@ -1023,9 +996,8 @@ class NFWPotential(TwoPowerSphericalPotential):
             / (self.a + sqrtRz) ** 2.0
         )
 
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0, *, xp=None):
         Rz = R**2.0 + z**2.0
         sqrtRz = xp.sqrt(Rz)
         return (
@@ -1042,9 +1014,8 @@ class NFWPotential(TwoPowerSphericalPotential):
             * (self.a + sqrtRz) ** -2.0
         )
 
-    def _surfdens(self, R, z, phi=0.0, t=0.0):
-        xp = get_namespace(R, z)
-        R, z = coerce_coords(xp, R, z)
+    @backend_kernel("R", "z")
+    def _surfdens(self, R, z, phi=0.0, t=0.0, *, xp=None):
         r = xp.sqrt(R**2.0 + z**2.0)
         # R == a is a removable singularity of the generic branch (Rma -> 0,
         # R^2-a^2 -> 0): use the closed-form limit there. Both xp.where branches

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -15,7 +15,7 @@ import math
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import backend_kernel, get_namespace
 from ..util import conversion
 from .EllipsoidalPotential import EllipsoidalPotential
 
@@ -410,9 +410,9 @@ class TriaxialJaffePotential(EllipsoidalPotential):
         self.hasC_dens = self.hasC  # works if mdens is defined, necessary for hasC
         return None
 
-    def _psi(self, m):
+    @backend_kernel("m")
+    def _psi(self, m, *, xp=None):
         """\\psi(m) = -\\int_m^\\infty d m^2 \rho(m^2)"""
-        xp = get_namespace(m)
         return (
             2.0
             * self.a2

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -7,7 +7,7 @@ import numpy
 from numpy.ctypeslib import ndpointer
 from scipy import interpolate
 
-from ..backend import get_namespace, is_backend_array, match_input_dtype
+from ..backend import backend_kernel, get_namespace, is_backend_array, match_input_dtype
 from ..backend.interpolate import (
     eval_ppoly,
     eval_rect_ppoly,
@@ -548,14 +548,14 @@ class interpRZPotential(Potential):
             setattr(self, attr, pp)
         return pp
 
-    def _eval_grid_backend(self, which, R, z, *, log_transform=False):
+    @backend_kernel("R", "z")
+    def _eval_grid_backend(self, which, R, z, *, log_transform=False, xp=None):
         """Backend (jax/torch) evaluation of an interpolated 2D quantity: the same
         frozen tensor-product spline as the numpy ``.ev`` path, evaluated through
         namespace-agnostic ``eval_rect_ppoly`` (searchsorted + 2D Horner), so the
         value is computed natively and is exactly autodifferentiable w.r.t. (R,z).
         Matches ``RectBivariateSpline.ev`` to ~1 ulp; like scipy's ``.ev`` it
         extrapolates the edge polynomial outside the grid (finite, NaN-free)."""
-        xp = get_namespace(R, z)
         xbr, ybr, c = self._grid_ppoly(which)
         Rq = xp.log(R) if self._logR else R
         out = eval_rect_ppoly(xp, xbr, ybr, c, Rq, z, extrapolate=True)
@@ -577,7 +577,8 @@ class interpRZPotential(Potential):
             setattr(self, attr, pp)
         return pp
 
-    def _eval_grid_backend_1d(self, which, R):
+    @backend_kernel("R")
+    def _eval_grid_backend_1d(self, which, R, *, xp=None):
         """Backend (jax/torch) evaluation of an interpolated 1D quantity: the same
         frozen spline as the numpy ``InterpolatedUnivariateSpline`` call, through
         namespace-agnostic ``eval_ppoly`` (searchsorted + Horner), so the value is
@@ -585,7 +586,6 @@ class interpRZPotential(Potential):
         to ~1 ulp; like scipy (ext=0) it extrapolates the edge polynomial outside
         the grid (finite, NaN-free) -- the backend path is on-grid interpolation
         only (the numpy off-grid fallback to the orig potential is numpy-only)."""
-        xp = get_namespace(R)
         x, c = self._grid_ppoly1d(which)
         Rq = xp.log(R) if self._logR else R
         out = eval_ppoly(xp, x, c, Rq, extrapolate=True)

--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -1,6 +1,6 @@
 import numpy
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import backend_kernel, get_namespace, is_backend_array
 from ..util import conversion
 from ._repr_utils import _build_physical_output_string, _strip_physical_output_info
 from .DissipativeForce import _isDissipative
@@ -196,17 +196,17 @@ class _BatchedVerticalPotential(verticalPotential):
         verticalPotential.__init__(self, Pot, R=R0, phi=phi, t0=t0)
         self._R = R
 
-    def _Rb(self, z):
+    @backend_kernel("z")
+    def _Rb(self, z, *, xp=None):
         # Reshape the batch R to broadcast against z (leading-axis aligned).
-        xp = get_namespace(z)
         R = self._R
         extra = z.ndim - R.ndim
         if extra > 0:
             R = xp.reshape(R, R.shape + (1,) * extra)
         return R
 
-    def _evaluate(self, z, t=0.0):
-        xp = get_namespace(z)
+    @backend_kernel("z")
+    def _evaluate(self, z, t=0.0, *, xp=None):
         Rb = self._Rb(z)
         tphi = self._phi * xp.ones_like(z)
         full = self._Pot(Rb, z, phi=tphi, t=t, use_physical=False)

--- a/tests/test_backend_kernel.py
+++ b/tests/test_backend_kernel.py
@@ -1,0 +1,72 @@
+import numpy
+import pytest
+
+from galpy.backend import backend_kernel
+
+
+class _Toy:
+    """Minimal carrier exercising the decorator's coord-coercion + xp injection."""
+
+    @backend_kernel("R", "z", "phi")
+    def ev(self, R, z, phi=0.0, t=0.0, *, xp=None):
+        return xp.sqrt(R**2 + z**2) + xp.sin(phi)
+
+    @backend_kernel("R")
+    def one(self, R, *, xp=None):
+        return xp.log(R)
+
+
+def _inline(R, z, phi=0.0):
+    return numpy.sqrt(R**2 + z**2) + numpy.sin(phi)
+
+
+def test_kernel_numpy_byte_identical():
+    # numpy path: get_namespace -> numpy, coerce_coords is identity, so the
+    # decorated kernel is bit-for-bit the hand-inlined equivalent.
+    t = _Toy()
+    for R, z, phi in [(1.3, 0.2, 0.0), (0.3, -0.9, 0.5), (5.0, 3.0, 2.1)]:
+        got = t.ev(R, z, phi=phi)
+        exp = _inline(R, z, phi)
+        assert repr(float(got)) == repr(float(exp))
+
+
+def test_kernel_arg_passing_positional_keyword_default():
+    t = _Toy()
+    base = t.ev(1.3, 0.2)
+    assert t.ev(R=1.3, z=0.2) == base  # keyword
+    assert t.ev(1.3, z=0.2) == base  # mixed
+    # phi defaulted (sin(0)=0) vs passed explicitly
+    assert t.ev(1.3, 0.2, phi=0.0) == base
+
+
+def test_kernel_requires_xp_param():
+    with pytest.raises(TypeError, match="must accept a keyword-only 'xp'"):
+
+        @backend_kernel("R")
+        def bad(self, R):
+            return R
+
+
+def test_kernel_unknown_coord_name():
+    with pytest.raises(TypeError, match="names no parameter"):
+
+        @backend_kernel("Q")
+        def bad(self, R, *, xp=None):
+            return R
+
+
+@pytest.mark.backend_managed
+@pytest.mark.parametrize("name", ["jax", "torch"])
+def test_kernel_coerces_under_forced_backend(name):
+    # Under a forced non-numpy backend the decorator must bring a numpy coord
+    # onto the backend so xp.<fn> (torch rejects numpy) succeeds and the result
+    # is a backend array -- the latent-torch-bug fix.
+    pytest.importorskip(name)
+    from galpy import backend
+    from galpy.backend import is_backend_array
+
+    t = _Toy()
+    with backend.use(name, force=True):
+        v = t.one(numpy.float64(2.0))
+        assert is_backend_array(v)
+        assert numpy.isclose(float(v), numpy.log(2.0))


### PR DESCRIPTION
## What

Introduce `galpy.backend.backend_kernel`, a decorator that lifts the inline

```python
xp = get_namespace(R, z)
R, z = coerce_coords(xp, R, z)
```

boilerplate — copy-pasted into every migrated potential method only because the
backend migration was incremental — into one decorator, and roll it out across
**~290 methods in ~40 potential files**. The decorated method becomes the pure
kernel: it declares its coordinate args explicitly (`@backend_kernel("R", "z")`,
the same information the old `coerce_coords` call carried) and receives them
coerced plus an injected `xp`:

```python
@backend_kernel("R", "z")
def _evaluate(self, R, z, phi=0.0, t=0.0, *, xp=None):
    r2 = R**2.0 + z**2.0
    return xp.log(r2) / 2.0
```

## Why

1. **Maintainability** — DRY; the coercion/namespace logic lives in one place.
2. **The jit seam** — the decorator separates outer Python glue (namespace
   resolution, coercion) from the inner traceable kernel, which is exactly the
   split `jax.jit` / `torch.compile` need. galpy itself never jits (no-internal-jit
   policy); the forthcoming `--backend jax-jit` / `torch-compile` test dimension
   wraps the decorated kernels. Prototyped and validated (jit==eager, grad flows,
   incl. the axisymmetric `phi=None` case).
3. **Torch-ledger burndown** — jax tolerates numpy inputs (`jnp.sin(numpy)`
   promotes) while torch rejects them (`torch.sin(numpy)` raises). So a method
   that resolved `xp` but didn't coerce ran green under `--backend jax` while
   being a latent torch crash. `@backend_kernel` always-coerces the declared
   coords, so every decorated entry point becomes torch-safe.

## Byte-identity

The numpy path is a strict pass-through — `get_namespace` returns numpy,
`coerce_coords` is object-identity, and the kernel body is textually unchanged —
so decorated methods are bit-for-bit identical to the inline version. This is
enforced by an audit (every changed line is one of {decorator, `*, xp=None`
signature, boilerplate/coerce deletion, import}) and confirmed empirically by
per-file stash-and-compare (hundreds of method outputs `array_equal` to
baseline). The full `test_potential.py` numpy suite passes.

## Scope / what's deferred

Applied to the primitive potential / force / density / derivative kernels. Left
inline (correctly): methods with instance-attr or no-arg `get_namespace`,
guard-first bodies (`_mass`), `if xp is numpy:` dual-path dispatchers
(MultipoleExpansion, SCFPotential, interpSpherical), `is_backend_array`
data-guards, and `promote_scalars`. Deferred to follow-ups:

- the base `Potential.py` and the derived-quantity accessors (`vcirc`/`omegac`/
  `epifreq`/`vesc`/`rforce`) — they interact with the unit-decorator stack;
- the `--backend jax-jit` / `torch-compile` test dimension + jit-xfail ledger.

One design nuance flagged in the commits: for the `get_namespace ⊃ coerce_coords`
mismatch (e.g. time-dependent potentials), whether to declare `t` as a coord is a
per-potential call (declaring it enables t-autodiff but makes `t` traced, which
breaks any Python `if t > tform` branch under jit) — the jit dimension will
surface these; byte-identity holds either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
