### PR TITLE
backend: @backend_input boundary decorator with explicitly declared coordinates

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -1196,11 +1196,7 @@ def _backend_dePeriod(xp, arr):
     return arr + _TWOPI * addto
 
 
-# coerce_backend=False: the migrated body resolves its own namespace from the
-# coordinate data (get_namespace) and routes backend arrays through the
-# backend-agnostic brentq, so coordinate coercion is unnecessary and the
-# byte-identical numpy/Quantity path is preserved.
-@potential_physical_input(coerce_backend=False)
+@potential_physical_input
 @physical_conversion("position", pop=True)
 def estimateBIsochrone(pot, R, z, phi=None):
     """

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -2548,12 +2548,7 @@ def calcu0(E, Lz, pot, delta):
     return out
 
 
-# coerce_backend=False: the migrated body resolves its own namespace from the
-# coordinate data (get_namespace) and never feeds numpy/Python coords into a
-# backend evaluator, so coordinate coercion is unnecessary; keeping it off also
-# preserves the byte-identical numpy/Quantity path (the decorator's get_namespace
-# probe is skipped) regardless of any ambient backend default.
-@potential_physical_input(coerce_backend=False)
+@potential_physical_input
 @physical_conversion("position", pop=True)
 def estimateDeltaStaeckel(pot, R, z, no_median=False, delta0=1e-6):
     """

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -17,6 +17,7 @@ from ._coerce import (
     promote_scalars,
     zeros_like_backend,
 )
+from ._input import backend_input
 from ._namespaces import (
     as_numpy,
     asarray_on_device,
@@ -41,6 +42,7 @@ _seed_from_config()
 
 __all__ = [
     "autodiff_ops",
+    "backend_input",
     "get_namespace",
     "backend",
     "use",

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -1,0 +1,188 @@
+###############################################################################
+#   galpy.backend._input: the @backend_input boundary decorator.
+#
+#   Coerces a potential/df evaluator's DECLARED coordinate inputs onto the
+#   active array backend, so torch's strict scalar handling
+#   (torch.sqrt(numpy.float64) etc.) does not reject them. This is the backend
+#   counterpart to the legacy ``potential_physical_input`` unit decorator --
+#   kept as its OWN decorator in galpy.backend rather than bolted onto the unit
+#   decorator, so the backend concern is cleanly separated from the pre-backend
+#   galpy machinery.
+#
+#   The coordinates are named EXPLICITLY, never guessed. These entry points mix
+#   coordinates with control/option parameters (``dR``/``dphi`` derivative
+#   orders, ``forceint``, ``M``, ``nsigma``, ``integrate_method``, grid objects,
+#   ...), and only the coordinates may be coerced -- turning a derivative order
+#   into a float tensor, or an option string into an array, is either silently
+#   wrong or an outright error. Declaring them per site also documents at each
+#   entry point exactly what crosses onto the backend.
+#
+#   Stack it just INSIDE ``@potential_physical_input`` (which parses units to
+#   plain floats first) and outside ``@physical_conversion``:
+#
+#       @potential_physical_input        # units -> floats (outer)
+#       @backend_input("R", "z", "phi", "t")   # floats -> active backend (this)
+#       @physical_conversion("energy", pop=True)
+#       def __call__(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0): ...
+#
+#   Declared names are checked against the signature at DECORATION time, so a
+#   typo raises at import instead of silently skipping a coordinate.
+#
+#   No-op on the numpy path (xp is numpy), so the numpy/Quantity path stays
+#   byte-identical, and -- for now -- on targets that are not backend-ready
+#   (see ``_backend_ready``, a temporary guard for the few unmigrated potentials
+#   that break when their coordinates arrive as jax/torch arrays).
+###############################################################################
+import inspect
+from functools import wraps
+
+import numpy
+
+from ._coerce import coerce_coords
+from ._namespaces import is_backend_array
+from ._resolver import get_namespace
+
+_EMPTY = inspect.Parameter.empty
+
+
+def _backend_ready(target):
+    """True if ``target``'s compute methods can take backend arrays.
+
+    TEMPORARY compatibility guard, not part of the decorator's design: an entry
+    point that carries ``@backend_input`` should simply coerce. It is still here
+    because a handful of potentials are not migrated and break when their
+    coordinates arrive as jax/torch arrays -- measured, not assumed:
+
+      * ``interpRZPotential`` (scipy interpolation) diverges from the numpy path
+        at the grid edge -- at (R,z)=(0.5,0.0) the force is off by 3.3% and the
+        second derivative by 32%, in float64;
+      * ``MovingObjectPotential`` interpolates the perturber's trajectory with
+        ``self._orb.R(t)``, so a coerced ``t`` reaches a numpy lookup as a jax
+        tracer under jit (``TracerArrayConversionError``).
+
+    Drop this guard -- and this function -- once those are backend-native; the
+    lists in tests/test_backend_input.py track what is left.
+    """
+    # Deferred (galpy.backend loads before galpy.potential); reached only off the
+    # numpy path, so the numpy hot path pays neither the import nor the flatten.
+    from ..potential import _check_backend_compatible
+    from ..potential import flatten as flatten_potential
+
+    return _check_backend_compatible(flatten_potential(target))
+
+
+def _coerce_one(xp, val):
+    """Coerce a single declared coordinate, preserving a sequence as a sequence.
+
+    A coordinate may be a sequence -- the ``[vR,vT,vz]`` velocity of the
+    dissipative forces, whose elements can be grad-carrying tensors. Coercing it
+    element-wise and rebuilding the container keeps each element's autograd
+    graph; stacking it into one array with a single ``asarray`` detaches them.
+    """
+    if isinstance(val, (list, tuple)):
+        return type(val)(coerce_coords(xp, *val))
+    (out,) = coerce_coords(xp, val)
+    return out
+
+
+def backend_input(*coords):
+    """Coerce the named coordinate inputs of an entry point onto the active backend.
+
+    Parameters
+    ----------
+    *coords : str
+        Names of the parameters that are coordinates, e.g.
+        ``@backend_input("R", "z", "phi", "t")``. Only these are coerced,
+        whether passed positionally or by keyword; every other parameter
+        (derivative orders, flags, masses, grids, option strings) is left
+        untouched. Names must exist in the decorated signature.
+
+    Notes
+    -----
+    See the module docstring for placement in the decorator stack. The numpy
+    path is a strict pass-through (byte-identical).
+    """
+    if not coords or callable(coords[0]):
+        raise TypeError(
+            "@backend_input must be called with the coordinate names to coerce, "
+            'e.g. @backend_input("R", "z")'
+        )
+
+    def decorator(method):
+        params = list(inspect.signature(method).parameters.values())
+        index_of = {
+            p.name: ii
+            for ii, p in enumerate(params)
+            if p.kind is not inspect.Parameter.VAR_KEYWORD
+        }
+        # A coordinate may be reachable only through **kwargs (Force.rforce takes
+        # (R, z, **kwargs) and forwards phi/t): declarable, but keyword-only.
+        takes_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params)
+        unknown = [c for c in coords if c not in index_of]
+        if unknown and not takes_var_kw:
+            raise ValueError(
+                f"@backend_input on {method.__qualname__}: declared coordinate(s) "
+                f"{unknown} are not parameters of the decorated function"
+            )
+        # Precomputed at decoration time so the per-call path does no signature
+        # introspection: (name, positional index) for each declared coordinate,
+        # plus the defaults worth injecting when the caller omits them.
+        # index None => the coordinate can only arrive by keyword (via **kwargs).
+        slots = tuple((c, index_of.get(c)) for c in coords)
+        # A coordinate left at a non-None signature default (phi=0.0, t=0.0) never
+        # appears in args or kwargs, so it would reach the backend as a raw Python
+        # float (torch.sin(0.0) raises); inject it coerced instead. None defaults
+        # (v=None, z=None) are passed through by coerce_coords, so skip them.
+        defaults = tuple(
+            (c, ii, params[ii].default)
+            for c, ii in slots
+            if ii is not None
+            and params[ii].default is not _EMPTY
+            and params[ii].default is not None
+        )
+
+        @wraps(method)
+        def wrapper(*args, **kwargs):
+            nargs = len(args)
+            probe = []
+            for c, ii in slots:
+                if ii is not None and ii < nargs:
+                    val = args[ii]
+                elif c in kwargs:
+                    val = kwargs[c]
+                else:
+                    continue
+                # A coordinate may be a sequence -- the [vR,vT,vz] velocity of
+                # the dissipative forces. get_namespace dispatches on arrays and
+                # rejects a bare list, so probe the components instead.
+                if isinstance(val, (list, tuple)):
+                    probe.extend(val)
+                else:
+                    probe.append(val)
+            # Namespace follows the coordinates only. When some coordinates are
+            # backend arrays and others are numpy (Orbits.E passes a numpy t=
+            # alongside torch R/z), resolve from the backend ones -- the numpy
+            # coordinates are weak and coerce_coords brings them across below,
+            # whereas probing the mix raises "Multiple namespaces". Everything
+            # below is skipped on the numpy path, so numpy pays just this probe.
+            on_backend = [val for val in probe if is_backend_array(val)]
+            xp = get_namespace(*(on_backend or probe))
+            if xp is not numpy and _backend_ready(args[0]):
+                newargs = None
+                for c, ii in slots:
+                    if ii is not None and ii < nargs:
+                        if newargs is None:
+                            newargs = list(args)
+                        newargs[ii] = _coerce_one(xp, newargs[ii])
+                    elif c in kwargs:
+                        kwargs[c] = _coerce_one(xp, kwargs[c])
+                if newargs is not None:
+                    args = tuple(newargs)
+                for c, ii, dflt in defaults:
+                    if ii >= nargs and c not in kwargs:
+                        kwargs[c] = _coerce_one(xp, dflt)
+            return method(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -17,7 +17,7 @@ import warnings
 import numpy
 from scipy import integrate
 
-from ..backend import device_of, get_namespace, is_backend_array
+from ..backend import backend_input, device_of, get_namespace, is_backend_array
 from ..orbit import Orbit
 from ..potential import calcRotcurve, planarCompositePotential, planarForce
 from ..potential.Potential import _check_c, _check_potential_list_and_deprecate, _dim

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -15,7 +15,7 @@ from ..util.conversion import physical_conversion, potential_physical_input
 _INVSQRTTWO = 1.0 / numpy.sqrt(2.0)
 
 
-@potential_physical_input(coerce_backend=False)
+@potential_physical_input
 @physical_conversion("velocity", pop=True)
 def sigmar(Pot, r, dens=None, beta=0.0):
     """
@@ -105,7 +105,7 @@ def sigmar(Pot, r, dens=None, beta=0.0):
     )
 
 
-@potential_physical_input(coerce_backend=False)
+@potential_physical_input
 @physical_conversion("velocity", pop=True)
 def sigmalos(Pot, R, dens=None, surfdens=None, beta=0.0, sigma_r=None):
     """

--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -8,6 +8,7 @@ from scipy import integrate, interpolate, optimize
 from .. import actionAngle, potential
 from ..actionAngle import actionAngleIsochrone
 from ..backend import (
+    backend_input,
     coerce_coords,
     get_namespace,
     is_backend_array,

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -26,6 +26,7 @@ from scipy import integrate, special
 from ..backend import (
     as_backend_constant,
     as_numpy,
+    backend_input,
     exit_cast,
     get_namespace,
     is_backend_array,

--- a/galpy/potential/DissipativeForce.py
+++ b/galpy/potential/DissipativeForce.py
@@ -3,6 +3,7 @@
 ###############################################################################
 import numpy
 
+from ..backend import backend_input
 from ..util.conversion import physical_conversion, potential_physical_input
 from .Force import Force
 
@@ -52,6 +53,7 @@ class DissipativeForce(Force):
         self.hasC_planar = True
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("force", pop=True)
     def Rforce(self, R, z, phi=0.0, t=0.0, v=None):
         """
@@ -83,6 +85,7 @@ class DissipativeForce(Force):
         return self._Rforce_nodecorator(R, z, phi=phi, t=t, v=v)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("force", pop=True)
     def zforce(self, R, z, phi=0.0, t=0.0, v=None):
         """
@@ -114,6 +117,7 @@ class DissipativeForce(Force):
         return self._zforce_nodecorator(R, z, phi=phi, t=t, v=v)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("energy", pop=True)
     def phitorque(self, R, z, phi=0.0, t=0.0, v=None):
         """

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -5,7 +5,7 @@
 ###############################################################################
 import copy
 
-from ..backend import get_namespace
+from ..backend import backend_input, get_namespace
 from ..util import config, conversion
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -317,6 +317,7 @@ class Force:
             return 0.0
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
     def rforce(self, R, z, **kwargs):
         """

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -23,7 +23,7 @@ import numpy
 from packaging.version import Version
 from scipy import integrate, optimize
 
-from ..backend import coerce_coords, get_namespace, is_backend_array
+from ..backend import backend_input, coerce_coords, get_namespace, is_backend_array
 from ..util import conversion, coords, galpyWarning, plot
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -236,6 +236,7 @@ class Potential(Force):
         return None
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
     def __call__(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0):
         """
@@ -293,6 +294,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
     def Rforce(self, R, z, phi=0.0, t=0.0):
         """
@@ -322,6 +324,7 @@ class Potential(Force):
         return self._Rforce_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
     def zforce(self, R, z, phi=0.0, t=0.0):
         """
@@ -351,6 +354,7 @@ class Potential(Force):
         return self._zforce_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
     def phitorque(self, R, z, phi=0.0, t=0.0):
         """
@@ -379,6 +383,7 @@ class Potential(Force):
         return self._phitorque_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def R2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -413,6 +418,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def z2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -447,6 +453,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
     def phi2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -482,6 +489,7 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def Rzderiv(self, R, z, phi=0.0, t=0.0):
         """
@@ -516,6 +524,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
     def Rphideriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -551,6 +560,7 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
     def phizderiv(self, R, z, phi=0.0, t=0.0):
         """
@@ -587,6 +597,7 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def r2deriv(self, R, z, phi=0.0, t=0.0):
         """
@@ -625,6 +636,7 @@ class Potential(Force):
         ) * z / r
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("density", pop=True)
     def dens(self, R, z, phi=0.0, t=0.0, forcepoisson=False):
         """
@@ -672,6 +684,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("surfacedensity", pop=True)
     def surfdens(self, R, z, phi=0.0, t=0.0, forcepoisson=False):
         """
@@ -757,6 +770,7 @@ class Potential(Force):
         )[0]
 
     @potential_physical_input
+    @backend_input("R", "z", "t")
     @physical_conversion("mass", pop=True)
     def mass(self, R, z=None, t=0.0, forceint=False):
         """
@@ -870,6 +884,7 @@ class Potential(Force):
         return rhalf(self, t=t, INF=INF, use_physical=False)
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("time", pop=True)
     def tdyn(self, R, t=0.0):
         """
@@ -1271,6 +1286,7 @@ class Potential(Force):
         )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("velocity", pop=True)
     def vcirc(self, R, phi=None, t=0.0):
         """
@@ -1303,6 +1319,7 @@ class Potential(Force):
         )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("frequency", pop=True)
     def dvcircdR(self, R, phi=None, t=0.0):
         """
@@ -1338,6 +1355,7 @@ class Potential(Force):
         )
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
     def omegac(self, R, t=0.0):
         """
@@ -1364,6 +1382,7 @@ class Potential(Force):
         return xp.sqrt(-self.Rforce(R, 0.0, t=t, use_physical=False) / R)
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
     def epifreq(self, R, t=0.0):
         """
@@ -1393,6 +1412,7 @@ class Potential(Force):
         )
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
     def verticalfreq(self, R, t=0.0):
         """
@@ -1450,6 +1470,7 @@ class Potential(Force):
         return lindbladR(self, OmegaP, m=m, t=t, use_physical=False, **kwargs)
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("velocity", pop=True)
     def vesc(self, R, t=0.0):
         """
@@ -1565,6 +1586,7 @@ class Potential(Force):
         return LcE(self, E, t=t, use_physical=False)
 
     @potential_physical_input
+    @backend_input("R", "z", "t")
     @physical_conversion("dimensionless", pop=True)
     def flattening(self, R, z, t=0.0):
         """
@@ -1797,6 +1819,7 @@ class Potential(Force):
             )
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("position", pop=True)
     def rtide(self, R, z, phi=0.0, t=0.0, M=None):
         """
@@ -1844,6 +1867,7 @@ class Potential(Force):
         return (M / (omegac2 - d2phidr2)) ** (1.0 / 3.0)
 
     @potential_physical_input
+    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def ttensor(self, R, z, phi=0.0, t=0.0, eigenval=False):
         """
@@ -2007,6 +2031,7 @@ class PotentialError(Exception):  # pragma: no cover
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("energy", pop=True)
 @potential_list_of_potentials_input
 def evaluatePotentials(Pot, R, z, phi=None, t=0.0, dR=0, dphi=0):
@@ -2055,6 +2080,7 @@ def _evaluatePotentials(Pot, R, z, phi=None, t=0.0, dR=0, dphi=0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("density", pop=True)
 @potential_list_of_potentials_input
 def evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
@@ -2097,6 +2123,7 @@ def evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("surfacedensity", pop=True)
 @potential_list_of_potentials_input
 def evaluateSurfaceDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
@@ -2140,6 +2167,7 @@ def evaluateSurfaceDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "t")
 @physical_conversion("mass", pop=True)
 @potential_list_of_potentials_input
 def mass(Pot, R, z=None, t=0.0, forceint=False):
@@ -2180,6 +2208,7 @@ def mass(Pot, R, z=None, t=0.0, forceint=False):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluateRforces(Pot, R, z, phi=None, t=0.0, v=None):
@@ -2235,6 +2264,7 @@ def _evaluateRforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("energy", pop=True)
 @potential_list_of_potentials_input
 def evaluatephitorques(Pot, R, z, phi=None, t=0.0, v=None):
@@ -2290,6 +2320,7 @@ def _evaluatephitorques(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluatezforces(Pot, R, z, phi=None, t=0.0, v=None):
@@ -2345,6 +2376,7 @@ def _evaluatezforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluaterforces(Pot, R, z, phi=None, t=0.0, v=None):
@@ -2394,6 +2426,7 @@ def evaluaterforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 @potential_list_of_potentials_input
 def evaluateR2derivs(Pot, R, z, phi=None, t=0.0):
@@ -2433,6 +2466,7 @@ def evaluateR2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 @potential_list_of_potentials_input
 def evaluatez2derivs(Pot, R, z, phi=None, t=0.0):
@@ -2472,6 +2506,7 @@ def evaluatez2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 @potential_list_of_potentials_input
 def evaluateRzderivs(Pot, R, z, phi=None, t=0.0):
@@ -2511,6 +2546,7 @@ def evaluateRzderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("energy", pop=True)
 @potential_list_of_potentials_input
 def evaluatephi2derivs(Pot, R, z, phi=None, t=0.0):
@@ -2550,6 +2586,7 @@ def evaluatephi2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluateRphiderivs(Pot, R, z, phi=None, t=0.0):
@@ -2589,6 +2626,7 @@ def evaluateRphiderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluatephizderivs(Pot, R, z, phi=None, t=0.0):
@@ -2628,6 +2666,7 @@ def evaluatephizderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 @potential_list_of_potentials_input
 def evaluater2derivs(Pot, R, z, phi=None, t=0.0):
@@ -3131,6 +3170,7 @@ def plotSurfaceDensities(
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
 @potential_list_of_potentials_input
 def epifreq(Pot, R, t=0.0):
@@ -3161,6 +3201,7 @@ def epifreq(Pot, R, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
 @potential_list_of_potentials_input
 def verticalfreq(Pot, R, t=0.0):
@@ -3191,6 +3232,7 @@ def verticalfreq(Pot, R, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "t")
 @physical_conversion("dimensionless", pop=True)
 @potential_list_of_potentials_input
 def flattening(Pot, R, z, t=0.0):
@@ -3553,6 +3595,7 @@ def _lindbladR_eq(R, Pot, OmegaP, m, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
 @potential_list_of_potentials_input
 def omegac(Pot, R, t=0.0):
@@ -3592,6 +3635,7 @@ def omegac(Pot, R, t=0.0):
 
 
 @potential_physical_input
+@backend_input("R", "phi", "t")
 @physical_conversion("velocity", pop=True)
 @potential_list_of_potentials_input
 def vcirc(Pot, R, phi=None, t=0.0):
@@ -3637,6 +3681,7 @@ def vcirc(Pot, R, phi=None, t=0.0):
 
 
 @potential_physical_input
+@backend_input("R", "phi", "t")
 @physical_conversion("frequency", pop=True)
 @potential_list_of_potentials_input
 def dvcircdR(Pot, R, phi=None, t=0.0):
@@ -3696,6 +3741,7 @@ def dvcircdR(Pot, R, phi=None, t=0.0):
 
 
 @potential_physical_input
+@backend_input("R", "t")
 @physical_conversion("velocity", pop=True)
 @potential_list_of_potentials_input
 def vesc(Pot, R, t=0.0):
@@ -4448,6 +4494,7 @@ def kms_to_kpcGyrDecorator(func):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("position", pop=True)
 def rtide(Pot, R, z, phi=0.0, t=0.0, M=None):
     """
@@ -4500,6 +4547,7 @@ def rtide(Pot, R, z, phi=0.0, t=0.0, M=None):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 def ttensor(Pot, R, z, phi=0.0, t=0.0, eigenval=False):
     """
@@ -4828,6 +4876,7 @@ def _rhalfFindStart(rh, pot, tot_mass, t=0.0, lower=False):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "t")
 @physical_conversion("time", pop=True)
 def tdyn(Pot, R, t=0.0):
     """

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -5,6 +5,7 @@ import pickle
 
 import numpy
 
+from ..backend import backend_input
 from ..util import config, conversion, plot
 from ..util.conversion import (
     physical_compatible,
@@ -230,6 +231,7 @@ class linearPotential:
         return None
 
     @potential_physical_input
+    @backend_input("x", "t")
     @physical_conversion("energy", pop=True)
     def __call__(self, x, t=0.0):
         """
@@ -264,6 +266,7 @@ class linearPotential:
             )
 
     @potential_physical_input
+    @backend_input("x", "t")
     @physical_conversion("force", pop=True)
     def force(self, x, t=0.0):
         """
@@ -358,6 +361,7 @@ class linearPotential:
 @potential_positional_arg
 @potential_list_of_potentials_input
 @potential_physical_input
+@backend_input("x", "t")
 @physical_conversion("energy", pop=True)
 def evaluatelinearPotentials(Pot, x, t=0.0):
     """
@@ -398,6 +402,7 @@ def _evaluatelinearPotentials(Pot, x, t=0.0):
 @potential_positional_arg
 @potential_list_of_potentials_input
 @potential_physical_input
+@backend_input("x", "t")
 @physical_conversion("force", pop=True)
 def evaluatelinearForces(Pot, x, t=0.0):
     """

--- a/galpy/potential/planarDissipativeForce.py
+++ b/galpy/potential/planarDissipativeForce.py
@@ -3,6 +3,7 @@
 ###############################################################################
 import numpy
 
+from ..backend import backend_input
 from ..util.conversion import physical_conversion, potential_physical_input
 from .planarForce import planarForce
 
@@ -33,6 +34,7 @@ class planarDissipativeForce(planarForce):
         self.isDissipative = True
 
     @potential_physical_input
+    @backend_input("R", "phi", "t", "v")
     @physical_conversion("force", pop=True)
     def Rforce(self, R, phi=0.0, t=0.0, v=None):
         """
@@ -62,6 +64,7 @@ class planarDissipativeForce(planarForce):
         return self._Rforce_nodecorator(R, phi=phi, t=t, v=v)
 
     @potential_physical_input
+    @backend_input("R", "phi", "t", "v")
     @physical_conversion("energy", pop=True)
     def phitorque(self, R, phi=0.0, t=0.0, v=None):
         """

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -4,7 +4,7 @@ import pickle
 import numpy
 from scipy import integrate
 
-from ..backend import get_namespace
+from ..backend import backend_input, get_namespace
 from ..util import config, conversion, plot
 from ..util.conversion import (
     physical_compatible,
@@ -36,6 +36,7 @@ class planarPotential(planarForce):
         self.isDissipative = False
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
     def __call__(self, R, phi=0.0, t=0.0, dR=0, dphi=0):
         """
@@ -91,6 +92,7 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("force", pop=True)
     def Rforce(self, R, phi=0.0, t=0.0):
         r"""
@@ -118,6 +120,7 @@ class planarPotential(planarForce):
         return self._Rforce_nodecorator(R, phi=phi, t=t)
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
     def phitorque(self, R, phi=0.0, t=0.0):
         """
@@ -145,6 +148,7 @@ class planarPotential(planarForce):
         return self._phitorque_nodecorator(R, phi=phi, t=t)
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
     def R2deriv(self, R, phi=0.0, t=0.0):
         """
@@ -176,6 +180,7 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
     def phi2deriv(self, R, phi=0.0, t=0.0):
         """
@@ -208,6 +213,7 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("force", pop=True)
     def Rphideriv(self, R, phi=0.0, t=0.0):
         """
@@ -240,6 +246,7 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
     def epifreq(self, R, t=0.0):
         """
@@ -269,6 +276,7 @@ class planarPotential(planarForce):
         )
 
     @potential_physical_input
+    @backend_input("R", "phi", "t")
     @physical_conversion("velocity", pop=True)
     def vcirc(self, R, phi=None, t=0.0):
         """
@@ -298,6 +306,7 @@ class planarPotential(planarForce):
         return xp.sqrt(R * -self.Rforce(R, phi=phi, t=t, use_physical=False))
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
     def omegac(self, R, t=0.0):
         """
@@ -443,6 +452,7 @@ class planarAxiPotential(planarPotential):
         return lindbladR(self, OmegaP, m=m, t=t, use_physical=False, **kwargs)
 
     @potential_physical_input
+    @backend_input("R", "t")
     @physical_conversion("velocity", pop=True)
     def vesc(self, R, t=0.0):
         """
@@ -985,6 +995,7 @@ def toPlanarPotential(Pot):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "phi", "t")
 @physical_conversion("energy", pop=True)
 @potential_list_of_potentials_input
 def evaluateplanarPotentials(Pot, R, phi=None, t=0.0, dR=0, dphi=0):
@@ -1038,6 +1049,7 @@ def _evaluateplanarPotentials(Pot, R, phi=None, t=0.0, dR=0, dphi=0):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "phi", "t", "v")
 @physical_conversion("force", pop=True)
 @potential_list_of_potentials_input
 def evaluateplanarRforces(Pot, R, phi=None, t=0.0, v=None):
@@ -1101,6 +1113,7 @@ def _evaluateplanarRforces(Pot, R, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "phi", "t", "v")
 @physical_conversion("energy", pop=True)
 @potential_list_of_potentials_input
 def evaluateplanarphitorques(Pot, R, phi=None, t=0.0, v=None):
@@ -1163,6 +1176,7 @@ def _evaluateplanarphitorques(Pot, R, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
+@backend_input("R", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
 @potential_list_of_potentials_input
 def evaluateplanarR2derivs(Pot, R, phi=None, t=0.0):

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -5,11 +5,10 @@
 #
 ###############################################################################
 import copy
-import inspect
 import math as m
 import numbers
 import warnings
-from functools import partial, wraps
+from functools import wraps
 from typing import Any, Tuple
 
 import numpy
@@ -1057,23 +1056,15 @@ def physical_conversion_tuple(quantities, pop=False):
     return wrapper
 
 
-def potential_physical_input(method=None, *, coerce_backend=True):
+def potential_physical_input(method):
     """Decorator to convert inputs to Potential functions from physical
     to internal coordinates.
 
-    Parameters
-    ----------
-    coerce_backend : bool, optional
-        When True (default), coordinate inputs are coerced onto the active array
-        backend for backend-migrated targets (the torch-scalar fix; see below).
-        Set False on Potential-taking utility functions that consume a potential's
-        evaluator output but do their own numpy-only computation on the
-        coordinates (estimateDeltaStaeckel, estimateBIsochrone, jeans.sigmar/
-        sigmalos), so those coordinates stay numpy even when the potential itself
-        is backend-migrated.
+    Backend coercion of the coordinate inputs is NOT done here -- it is owned by
+    the backend-specific ``@backend_input`` boundary decorator (galpy.backend),
+    stacked just inside this one on the potential/df entry points, keeping the
+    backend concern separate from this legacy unit-handling decorator.
     """
-    if method is None:
-        return partial(potential_physical_input, coerce_backend=coerce_backend)
 
     @wraps(method)
     def wrapper(*args, **kwargs):
@@ -1139,36 +1130,6 @@ def potential_physical_input(method=None, *, coerce_backend=True):
             and isinstance(kwargs["zmax"], units.Quantity)
         ):
             kwargs["zmax"] = kwargs["zmax"].to(units.kpc).value / ro
-        # Coerce coordinate inputs onto the active backend so torch's strict
-        # scalar handling (torch.sqrt(numpy.float64) etc.) does not reject them.
-        # Gated so it is a no-op on the numpy path (xp is numpy) and on unmigrated
-        # targets (_check_backend_compatible); only the coordinate args/kwargs are
-        # coerced, not control kwargs (dR/dphi/dz/zmax/M).
-        if coerce_backend:
-            from ..backend import coerce_coords, get_namespace
-            from ..potential import _check_backend_compatible
-
-            xp = get_namespace(*args[1:])
-            if xp is not numpy and _check_backend_compatible(Pot):
-                args = (args[0],) + coerce_coords(xp, *args[1:])
-                for _key in ("phi", "t", "R", "z", "x", "v"):
-                    if _key in kwargs:
-                        (kwargs[_key],) = coerce_coords(xp, kwargs[_key])
-                # Default kwargs (B): when phi/t fall back to their SIGNATURE
-                # default (a Python float the caller never passed, so neither
-                # args nor kwargs holds it), inject the coerced default so the
-                # backend never sees a raw float (torch.sin(0.0) raises). Stays
-                # strictly inside the non-numpy + backend-compatible guard so the
-                # numpy path never rebinds/injects kwargs (byte-identical).
-                params = list(inspect.signature(method).parameters.values())
-                for _idx, _p in enumerate(params):
-                    if (
-                        _p.name in ("phi", "t")
-                        and _p.default is not inspect.Parameter.empty
-                        and _idx >= len(args)
-                        and _p.name not in kwargs
-                    ):
-                        (kwargs[_p.name],) = coerce_coords(xp, _p.default)
         return method(*args, **kwargs)
 
     return wrapper

--- a/tests/test_backend_input.py
+++ b/tests/test_backend_input.py
@@ -1,0 +1,379 @@
+###############################################################################
+# test_backend_input.py: the @backend_input boundary decorator
+# (galpy.backend._input).
+#
+# @backend_input coerces a potential/df evaluator's DECLARED coordinate inputs
+# onto the active backend so torch's strict scalar handling accepts them. It is
+# the backend counterpart to the legacy units-only potential_physical_input,
+# stacked just inside it on the public entry points. Contract:
+#   * numpy path (xp is numpy) -> object-identical pass-through (byte-identical);
+#   * forced non-numpy backend on a migrated target -> the DECLARED coordinates
+#     are coerced whether passed positionally or by keyword, and a coordinate
+#     left at a non-None signature default is injected coerced;
+#   * everything NOT declared (dR/dphi derivative orders, forceint, M, nsigma,
+#     option strings, grid objects) is passed through untouched -- these entry
+#     points mix coordinates with control parameters, and coercing a control
+#     parameter is either silently wrong or an outright error;
+#   * a declared name that is not a parameter raises at DECORATION time, so a
+#     typo cannot silently skip a coordinate.
+###############################################################################
+import numpy
+import pytest
+
+from galpy import backend
+from galpy.backend import backend_input, is_backend_array
+
+# This module manages backends explicitly, so it is exempt from the global force.
+pytestmark = pytest.mark.backend_managed
+
+_NS = {"numpy": numpy}
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+
+    _NS["jax"] = jax
+except ImportError:  # pragma: no cover
+    pass
+try:
+    import torch
+
+    _NS["torch"] = torch
+except ImportError:  # pragma: no cover
+    pass
+
+AD_BACKENDS = [b for b in _NS if b != "numpy"]
+
+
+def _pot():
+    from galpy.potential import MiyamotoNagaiPotential
+
+    return MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.05)
+
+
+def test_numpy_path_is_byte_identical_passthrough():
+    # numpy backend: the decorator's non-numpy branch is skipped entirely; the
+    # evaluator runs exactly as it would undecorated (byte-identical numpy path).
+    mp = _pot()
+    assert not is_backend_array(mp.Rforce(1.0, 0.1))
+    assert mp.Rforce(1.0, 0.1) == mp.Rforce(1.0, 0.1)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_positional_coords_coerced_under_forced_backend(backend_name):
+    # numpy/python positional coords fed under a forced backend must be coerced
+    # so the migrated evaluator returns a backend array matching numpy. This also
+    # exercises the signature-default injection: Rforce(R, z) leaves phi=0.0 and
+    # t=0.0 at their defaults, which the decorator coerces before the call (torch
+    # would reject a raw python 0.0).
+    mp = _pot()
+    ref = mp.Rforce(1.1, 0.2)
+    with backend.use(backend_name, force=True):
+        got = mp.Rforce(1.1, 0.2)
+    assert is_backend_array(got), f"{backend_name}: coords not coerced"
+    numpy.testing.assert_allclose(float(got), float(ref), rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_coordinate_kwargs_coerced_under_forced_backend(backend_name):
+    # The phi/t/R/z/x/v kwarg loop: coords passed by keyword must be coerced too.
+    mp = _pot()
+    ref = mp.Rforce(R=1.1, z=0.2, phi=0.3)
+    with backend.use(backend_name, force=True):
+        got = mp.Rforce(R=1.1, z=0.2, phi=0.3)
+    assert is_backend_array(got), f"{backend_name}: coord kwargs not coerced"
+    numpy.testing.assert_allclose(float(got), float(ref), rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_explicitly_passed_phi_t_coerced_under_forced_backend(backend_name):
+    # phi/t supplied positionally (so they do NOT hit the signature-default
+    # branch) are coerced by the positional loop; result still a backend array.
+    mp = _pot()
+    ref = mp.Rforce(1.1, 0.2, 0.3, 0.0)
+    with backend.use(backend_name, force=True):
+        got = mp.Rforce(1.1, 0.2, 0.3, 0.0)
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(float(got), float(ref), rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_undeclared_control_params_are_not_coerced(backend_name):
+    # The point of declaring coordinates explicitly: these entry points mix
+    # coordinates with control parameters, and only the coordinates may cross
+    # onto the backend. A derivative order turned into a float tensor, or an
+    # option string fed to asarray, is silently wrong / an outright error.
+    seen = {}
+
+    @backend_input("R", "z")
+    def probe(pot, R, z, dR=0, forceint=False, method="rk4"):
+        seen.update(R=R, z=z, dR=dR, forceint=forceint, method=method)
+
+    with backend.use(backend_name, force=True):
+        probe(_pot(), 1.1, 0.2, 3, True, "rk4_c")  # control params POSITIONAL
+    assert is_backend_array(seen["R"]) and is_backend_array(seen["z"])
+    assert seen["dR"] == 3 and isinstance(seen["dR"], int)
+    assert seen["forceint"] is True
+    assert seen["method"] == "rk4_c"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_control_params_untouched_through_a_real_entry_point(backend_name):
+    # Integration: Potential.mass declares ("R", "z", "t") and leaves the
+    # trailing forceint flag alone, so passing it positionally still selects the
+    # analytic branch (a coerced flag would be an array, not a bool).
+    mp = _pot()
+    ref = mp.mass(1.1, 0.2, 0.0, False)
+    with backend.use(backend_name, force=True):
+        got = mp.mass(1.1, 0.2, 0.0, False)
+    assert is_backend_array(got)
+    numpy.testing.assert_allclose(float(got), float(ref), rtol=1e-12, atol=1e-14)
+
+
+def test_unknown_declared_coordinate_raises_at_decoration():
+    # A typo'd coordinate name must fail loudly at import, not silently skip
+    # coercing that coordinate.
+    with pytest.raises(ValueError, match="not parameters"):
+
+        @backend_input("R", "notaparameter")
+        def _bad(pot, R, z):  # pragma: no cover - never called
+            return R
+
+
+def test_bare_usage_without_coordinates_raises():
+    # @backend_input must be called with names; bare usage would coerce nothing.
+    with pytest.raises(TypeError, match="coordinate names"):
+
+        @backend_input
+        def _bad(pot, R, z):  # pragma: no cover - never called
+            return R
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS + ["numpy"])
+def test_sequence_valued_coordinate_as_kwarg(backend_name):
+    # The dissipative forces take v=[vR,vT,vz] as a LIST. get_namespace
+    # dispatches on arrays and rejects a bare list, so the decorator must probe
+    # the components -- otherwise passing v by keyword raises
+    # "list is not a supported array type" even on the numpy path.
+    from galpy.potential import ChandrasekharDynamicalFrictionForce
+
+    cdf = ChandrasekharDynamicalFrictionForce(GMs=0.01, rhm=0.1)
+    ref = cdf.Rforce(1.1, 0.2, phi=0.0, t=0.0, v=[0.1, 1.0, 0.05])
+    if backend_name == "numpy":
+        assert not is_backend_array(ref)
+        return
+    with backend.use(backend_name, force=True):
+        got = cdf.Rforce(1.1, 0.2, phi=0.0, t=0.0, v=[0.1, 1.0, 0.05])
+    numpy.testing.assert_allclose(float(got), float(ref), rtol=1e-10, atol=1e-14)
+
+
+def _asarray(backend_name, x):
+    if backend_name == "jax":
+        import jax.numpy
+
+        return jax.numpy.asarray(x, dtype=jax.numpy.float64)
+    import torch
+
+    return torch.as_tensor(x, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_mixed_backend_and_numpy_coordinates(backend_name):
+    # Data-driven dispatch (NO forced backend -- forcing short-circuits the
+    # namespace probe): Orbits.E calls evaluatePotentials with backend R/z but a
+    # NUMPY t=. Probing that mix raises "Multiple namespaces for array inputs",
+    # so the namespace must come from the backend coordinates while the numpy
+    # ones are coerced across.
+    mp = _pot()
+    R = _asarray(backend_name, [1.1, 1.2])
+    z = _asarray(backend_name, [0.2, 0.1])
+    got = mp.Rforce(R, z, t=numpy.zeros(2))
+    assert is_backend_array(got), (
+        f"{backend_name}: mixed coords did not stay on backend"
+    )
+    ref = [float(mp.Rforce(1.1, 0.2)), float(mp.Rforce(1.2, 0.1))]
+    numpy.testing.assert_allclose(numpy.asarray(got, dtype=float), ref, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sequence_coordinate_is_coerced_element_wise(backend_name):
+    # A sequence coordinate keeps its container and is coerced ELEMENT-WISE.
+    # Stacking it into a single array with one asarray detaches grad-carrying
+    # elements from the autograd graph -- that is what broke the
+    # NonInertialFrameForce grad-vs-finite-difference tests.
+    seen = {}
+
+    @backend_input("R", "v")
+    def probe(pot, R, v=None):
+        seen.update(R=R, v=v)
+
+    with backend.use(backend_name, force=True):
+        probe(_pot(), 1.1, v=[0.1, 1.0, 0.05])
+    assert is_backend_array(seen["R"])
+    assert isinstance(seen["v"], list), "sequence coordinate must stay a sequence"
+    assert len(seen["v"]) == 3
+    assert all(is_backend_array(c) for c in seen["v"])
+
+
+# Coordinate parameter names used across galpy's entry points. A decorated entry
+# point must declare every one of these that it takes -- an undeclared
+# coordinate is silently NOT coerced, which the decoration-time check (which only
+# sees the names that WERE declared) structurally cannot catch.
+_COORD_NAMES = frozenset(("R", "z", "phi", "t", "x", "r", "v", "vR", "vT", "vz"))
+
+
+def _decorated_entry_points():
+    """Every @backend_input site in the installed galpy, via a static AST walk."""
+    import ast
+    import pathlib
+
+    import galpy
+
+    for path in sorted(pathlib.Path(galpy.__file__).parent.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - galpy always parses
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for dec in node.decorator_list:
+                if (
+                    isinstance(dec, ast.Call)
+                    and isinstance(dec.func, ast.Name)
+                    and dec.func.id == "backend_input"
+                ):
+                    declared = [
+                        a.value for a in dec.args if isinstance(a, ast.Constant)
+                    ]
+                    named = [a.arg for a in node.args.posonlyargs + node.args.args][1:]
+                    yield path.name, node.name, declared, named, node.args.kwarg
+
+
+def test_every_declared_coordinate_exists_in_the_signature():
+    # Typos: a declared name that is not a parameter would coerce nothing. Only
+    # legal when the entry point takes **kwargs (Force.rforce forwards phi/t).
+    bad = [
+        f"{f}::{fn} declares {sorted(set(dec) - set(named))}"
+        for f, fn, dec, named, kwarg in _decorated_entry_points()
+        if not set(dec) <= set(named) and kwarg is None
+    ]
+    assert not bad, "declared coordinates that are not parameters:\n  " + "\n  ".join(
+        bad
+    )
+
+
+def test_no_coordinate_parameter_is_left_undeclared():
+    # Wrong application: a coordinate the entry point takes but does not declare
+    # is silently left on numpy while its siblings move to the backend.
+    bad = [
+        f"{f}::{fn} takes {sorted(set(named) & _COORD_NAMES - set(dec))} but declares {dec}"
+        for f, fn, dec, named, _ in _decorated_entry_points()
+        if (set(named) & _COORD_NAMES) - set(dec)
+    ]
+    assert not bad, "undeclared coordinate parameters:\n  " + "\n  ".join(bad)
+
+
+def test_decorated_entry_points_are_registered():
+    # Guard against the audit silently finding nothing (a refactor renaming the
+    # decorator would make both checks above vacuously pass).
+    assert len(list(_decorated_entry_points())) > 50
+
+
+# Whole modules whose public entry points deliberately do NOT coerce yet, with
+# the blocker for each. These are the burndown list: decorate them as the blocker
+# clears. (Under the old coerce_backend gate these modules could carry the
+# decorator harmlessly because _check_backend_compatible returned False for every
+# df, so it never fired; with the gate gone, decorating them would route real
+# calls onto an incomplete backend path.)
+_UNDECORATED_MODULES = {
+    # evolveddiskdf raises NotImplementedError for grid deriv= on jax/torch;
+    # quasiisothermaldf's sampling and adiabatic action-Jacobian path take 0-d
+    # backend arrays through a C callback that expects sized numpy input;
+    # sphericaldf.sigmar returns NaN for a coerced radius (kingdf).
+    "diskdf.py": "backend evaluation path incomplete",
+    "evolveddiskdf.py": "grid deriv= unsupported on jax/torch",
+    "quasiisothermaldf.py": "sampling + adiabatic action-Jacobian C callback",
+    "sphericaldf.py": "sigmar/sigmat return NaN for a coerced radius",
+    "kingdf.py": "inherits sphericaldf.sigmar",
+    "streamdf.py": "not yet migrated to the coercion boundary",
+    "streamgapdf.py": "not yet migrated to the coercion boundary",
+    "streamspraydf.py": "not yet migrated to the coercion boundary",
+}
+
+# Individual public coordinate-taking entry points that deliberately do NOT
+# coerce, with the reason each one is exempt. Everything else that takes a
+# coordinate must carry @backend_input -- these two lists are what keep the
+# footprint auditable instead of historical, so adding to them should be a
+# deliberate, reviewed act.
+_UNDECORATED_BY_DESIGN = {
+    # Numpy-only computation ON the coordinates: they consume a potential's
+    # evaluator output and do their own numpy/scipy work, so coercing their
+    # inputs would only force a round trip (the old coerce_backend=False opt-outs).
+    ("jeans.py", "sigmar"),
+    ("jeans.py", "sigmalos"),
+    ("actionAngleStaeckel.py", "estimateDeltaStaeckel"),
+    ("actionAngleIsochroneApprox.py", "estimateBIsochrone"),
+    # scipy-interpolation island; migrating it is tracked separately.
+    ("interpRZPotential.py", "vcirc"),
+    ("interpRZPotential.py", "dvcircdR"),
+    ("interpRZPotential.py", "epifreq"),
+    ("interpRZPotential.py", "verticalfreq"),
+    # scipy root-finders / quadrature over E, Lz, OmegaP, l: the coordinate-named
+    # parameter is an evaluation time, and the solve itself is numpy.
+    ("Potential.py", "rl"),
+    ("Potential.py", "rE"),
+    ("Potential.py", "LcE"),
+    ("Potential.py", "lindbladR"),
+    ("Potential.py", "vterm"),
+    ("Potential.py", "rhalf"),
+    ("Potential.py", "mvir"),
+    ("Potential.py", "zvc"),
+    ("Potential.py", "zvc_range"),
+    ("planarPotential.py", "lindbladR"),
+}
+
+
+def test_coordinate_entry_points_are_decorated_or_listed():
+    """Every public coordinate-taking entry point is decorated or exempt-by-name.
+
+    Keeps the decorated footprint principled rather than historical: a new public
+    method that takes R/z/phi/t must either coerce or be added to
+    _UNDECORATED_BY_DESIGN with a reason.
+    """
+    import ast
+    import pathlib
+
+    import galpy
+
+    stray = []
+    for path in sorted(pathlib.Path(galpy.__file__).parent.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - galpy always parses
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            names = {
+                (
+                    d.func.id
+                    if isinstance(d, ast.Call) and isinstance(d.func, ast.Name)
+                    else getattr(d, "id", None)
+                )
+                for d in node.decorator_list
+            }
+            if "physical_conversion" not in names or "backend_input" in names:
+                continue
+            named = [a.arg for a in node.args.posonlyargs + node.args.args][1:]
+            if (
+                set(named) & _COORD_NAMES
+                and (path.name, node.name) not in _UNDECORATED_BY_DESIGN
+                and path.name not in _UNDECORATED_MODULES
+            ):
+                stray.append(f"{path.name}::{node.name}({', '.join(named)})")
+    assert not stray, (
+        "public coordinate-taking entry points that neither coerce nor are listed "
+        "in _UNDECORATED_BY_DESIGN / _UNDECORATED_MODULES:\n  "
+        + "\n  ".join(sorted(set(stray)))
+    )


### PR DESCRIPTION
## Summary

Extracts backend coordinate coercion out of the legacy `potential_physical_input`
unit decorator into a dedicated `@backend_input` decorator in `galpy.backend`,
where each entry point **declares the coordinates it coerces**.

```python
@potential_physical_input                 # units -> floats (outer)
@backend_input("R", "z", "phi", "t")      # floats -> active backend (this)
@physical_conversion("energy", pop=True)
def __call__(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0): ...
```

- **`@backend_input`** (new, `galpy/backend/_input.py`) owns coordinate coercion.
- `potential_physical_input` is **units-only** again (matches `main`).
- The four `coerce_backend=False` opt-outs drop their flags.

Supersedes #1194, which lifted coercion into a per-method `@backend_kernel`
decorator.

## Why the coordinates are declared

The old block coerced *every* positional argument after the first, while its
kwarg path was whitelisted to coordinates — so the same parameter was
**protected as a keyword and coerced as a positional**:

| Site | Previously coerced by position |
|---|---|
| `evaluatePotentials`, `__call__` | `dR`, `dphi` — derivative **orders** |
| `mass`, `dens`, `surfdens` | `forceint`, `forcepoisson` flags |
| `rtide`, `ttensor` | `M`, `eigenval` |
| `evolveddiskdf.*` | `integrate_method` (**string**), `grid` objects |

Coercing those is silently wrong (a derivative order becomes a float tensor) or
an outright error (`asarray` of an option string). Declaring the coordinates
closes it, and declared names are validated against the signature at
**decoration time**, so a typo raises at import.

## The migration guard, and why it is still here

The old block only coerced when `_check_backend_compatible(flatten(args[0]))`
passed. That assumed `args[0]` is a Potential and returned `False` for **every
df**, so the df sites never coerced at all — those 48 decorations were dead.

Removing it was tried and measured. It is still load-bearing, so it survives as
`_backend_ready`, marked `TEMPORARY` with the evidence in its docstring:

| Removing the guard broke | Cause |
|---|---|
| `evolveddiskdf` `deriv=`, `qdf.sample()` | df backend paths incomplete — *working* calls began raising |
| `interpRZPotential` | scipy interpolation diverges at the grid edge (3.3% force, 32% 2nd derivative, float64) |
| `MovingObjectPotential` under jit | the perturber's `_orb.R(t)` is a numpy lookup; a coerced `t` arrives as a `DynamicJaxprTracer` (baseline gets a plain `float`) |

Deleting the guard is follow-up #1; its docstring names exactly what must be
migrated first.

## Scope — auditable, not historical

Applied at **73 potential-side entry points**. Every other public
coordinate-taking entry point is listed in `_UNDECORATED_MODULES` /
`_UNDECORATED_BY_DESIGN` in `tests/test_backend_input.py` **with its blocker**,
and a test fails if a new one appears in neither list. Those two lists are the
burndown list.

The df modules are deliberately not decorated rather than decorated-but-dead:
their decorations never fired under the guard, and their backend paths are not
ready (`evolveddiskdf` grid `deriv=`; `quasiisothermaldf` sampling + adiabatic
action-Jacobian C callback on 0-d arrays; `sphericaldf.sigmar` returning `NaN`
for a coerced radius, which breaks `kingdf`). Leaving them undecorated
reproduces `feat/backends` behaviour exactly and states the gap honestly.

## What is still outside the boundary

Only the potential-side entry points coerce at a boundary. Everything else keeps
handling backends internally, unchanged by this PR:

- **actionAngle** — 80 `get_namespace` + 38 `promote_scalars` call sites and
  **zero** `coerce_coords`: it resolves the namespace from the data and promotes
  scalars in place rather than coercing at an entry point.
- **orbit / streamdf / streamgapdf / streamspraydf / util.coords** — the same
  data-driven pattern.
- **df** — see above.

One limitation of the footprint audit worth knowing: it inspects *named*
parameters, so it cannot see varargs entry points. actionAngle's public API is
`actionsFreqs(*args)` / `actionsFreqsAngles(*args)` / `EccZmaxRperiRap(*args)` /
`__call__(*args)` — no named coordinates to declare, so those can never be flagged
by the test, and `@backend_input` as written cannot describe them. Giving varargs
entry points a boundary needs a different mechanism (positional-slot declaration),
deliberately out of scope here.

## Byte-identity and the numpy path

Numpy is untouched — `@backend_input` returns before doing anything when
`xp is numpy`, verified by a hash over forces/potentials/densities/masses
(single + list potentials, including the `dR=1` control-kwarg path). The numpy
path also gets slightly **faster**: the old block ran two deferred imports on
every numpy call (`Rforce` ~9.4 → ~7.4 µs).

## Testing

- `test_potential.py` green under **numpy**, forced **torch**, forced **jax**
  (1320 tests each).
- `test_quantity.py` + `test_coords.py` green under forced jax (332 passed).
- The unforced `tests/test_backend*.py` shard: 6251 tests, **0 failures** (this
  is the only mode that exercises data-driven namespace resolution — a forced
  `--backend` short-circuits the probe, which is why it caught what the forced
  runs could not).
- New `tests/test_backend_input.py` (22 tests): coercion positional/keyword/
  signature-default, numpy pass-through, **control parameters left untouched**,
  a sequence-valued coordinate (`v=[vR,vT,vz]`), mixed backend+numpy coordinates,
  typo rejection, and the two static footprint audits.
- **No new ledger entries.**

### Two real bugs found and fixed while building this

- **Sequence coordinates are coerced element-wise.** `v=[vR,vT,vz]` was being
  stacked into a single array by `asarray`, which **detaches grad-carrying
  elements from the autograd graph** — it broke the `NonInertialFrameForce`
  grad-vs-finite-difference tests.
- **Mixed backend/numpy coordinates.** `Orbits.E` passes a numpy `t=` alongside
  torch `R`/`z`; probing the mix raises `Multiple namespaces for array inputs`,
  which surfaced as a failure **on the numpy path**. The namespace now follows
  the backend coordinates and the numpy ones are coerced across.

## Follow-ups, in order

1. **Make the df boundary live.** Blockers found while building this PR:
   `evolveddiskdf` grid `deriv=`; `quasiisothermaldf` sampling + adiabatic
   action-Jacobian C callback; `sphericaldf.sigmar`/`sigmat` NaN on a coerced
   radius. As each clears, delete the module from `_UNDECORATED_MODULES` — the
   test then *requires* the decoration.
2. **`interpRZPotential` and `MovingObjectPotential`** — the two potentials that
   currently keep `_backend_ready` alive. Migrating them (plus the df modules in
   1.) lets the guard be deleted outright.
3. **scipy root-finders** — `rl`/`rE`/`LcE`/`lindbladR`/`vterm`/`rhalf`/`mvir`/
   `zvc` still solve in numpy over `E`/`Lz`/`OmegaP`; port them onto the existing
   backend root-find helpers, then decorate.
4. **Audit the 266 inline `coerce_coords` sites** against the boundary. They are
   almost entirely in `galpy/potential/*` leaf classes (`TwoPowerSpherical` 39,
   `KuijkenDubinski` 20, `SpiralArms` 12, …) inside `_evaluate`/`_Rforce`, which
   are reachable *without* passing a decorated entry point (the Python
   integrator, wrappers, `_nodecorator` paths) — so most are **not** redundant.
   The task is to find the ones the boundary genuinely shadows, not to delete
   them wholesale.
5. **Boundary-jit test dimension** (replaces the per-method seam abandoned with
   #1195): jit the whole public method and the decorators trace away. Cheap now
   that coercion is a single boundary decorator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
