### PR TITLE
df: open the coercion boundary for sphericaldf (+ Quantity passthrough)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,12 @@ jobs:
             REQUIRES_ASTROPY: true
             REQUIRES_ASTROQUERY: false
             REQUIRES_NUMBA: false
-            REQUIRES_JAX: false
+            # units-through-a-backend: the only shard here with astropy that can
+            # also force a backend (tests/test_backend*.py is deliberately
+            # astropy-free), so it is where a Quantity-on-a-backend test can
+            # run. jax alone is enough -- the boundary's Quantity passthrough
+            # returns before any backend call, so it is backend-independent.
+            REQUIRES_JAX: true
           - os: ubuntu-latest
             python-version: "3.14"
             TEST_FILES: tests/test_orbit.py -k 'test_energy_jacobi_conservation or from_name'

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -17,6 +17,7 @@ from ._coerce import (
     promote_scalars,
     zeros_like_backend,
 )
+from ._compat import is_backend_compatible
 from ._input import backend_input
 from ._namespaces import (
     as_numpy,
@@ -48,6 +49,7 @@ __all__ = [
     "use",
     "set_default_backend",
     "is_backend_array",
+    "is_backend_compatible",
     "match_input_dtype",
     "name_of_namespace",
     "device_of",

--- a/galpy/backend/_compat.py
+++ b/galpy/backend/_compat.py
@@ -1,0 +1,83 @@
+###############################################################################
+#   galpy.backend._compat: object-level backend compatibility.
+#
+#   ONE question, asked the same way of every kind of galpy object: are this
+#   object's compute methods backend-aware (jax/torch), or do they only handle
+#   numpy? Potentials, forces, wrappers, composites and lists thereof answer it
+#   recursively (a container is only as backend-aware as its members); every
+#   other galpy object -- a df, and in the future an actionAngle or an Orbit --
+#   answers it with the same ``_backend_compatible`` flag its ``__init__`` sets,
+#   exactly as ``hasC`` is set for the C layer.
+#
+#   Lives here rather than in galpy.potential because it is not a potential
+#   question: the coercion boundary in ``_input`` asks it of dfs too, and the
+#   potential-specific recursion is just how potentials happen to answer it.
+###############################################################################
+
+
+def is_backend_compatible(obj):
+    """
+    Check whether a galpy object's compute methods are backend-aware (jax/torch).
+
+    Gates the coordinate coercion at galpy's backend entry points (see
+    ``galpy.backend.backend_input``): only an object that can do arithmetic on
+    backend arrays may be handed them.
+
+    Answered recursively for potentials, mirroring ``_check_c``: a list iff every
+    member is; a composite through its component list; a wrapper iff it is itself
+    backend-aware AND the potential it wraps is. Any other galpy object (a df, an
+    actionAngle, an Orbit) reads its own ``_backend_compatible`` flag, which
+    defaults to False and is set in ``__init__`` by whatever has been migrated.
+
+    Parameters
+    ----------
+    obj : object
+        Any galpy object: a Potential/Force/planarForce/linearPotential, a list
+        of them (possibly nested), a combined potential formed using addition
+        (pot1+pot2+…), a wrapper, a df instance, ...
+
+    Returns
+    -------
+    bool
+        True iff the object's compute methods are backend-aware.
+
+    Notes
+    -----
+    - 2026-06-15 - Written as potential._check_backend_compatible - Bovy (UofT)
+    - 2026-07-24 - Generalized to all galpy objects and moved to galpy.backend - Bovy (UofT)
+
+    """
+    # Deferred: galpy.backend is imported before galpy.potential, so this cannot
+    # be a module-level import. Reached only off the numpy path, so the numpy hot
+    # path pays neither the import nor the flatten.
+    from ..potential import flatten
+    from ..potential.baseCompositePotential import baseCompositePotential
+    from ..potential.WrapperPotential import (
+        WrapperPotential,
+        parentWrapperPotential,
+        planarWrapperPotential,
+    )
+
+    obj = flatten(obj)
+    if isinstance(obj, list):
+        return all(is_backend_compatible(o) for o in obj)
+    elif isinstance(obj, baseCompositePotential):
+        # A (planar/linear)CompositePotential delegates to its members through
+        # the no-decorator internal path (no per-member coercion), so coercion
+        # must fire at the OUTER boundary; it is backend-compatible iff every
+        # component is (mirrors the list branch). flatten leaves a composite
+        # as-is, so this must precede the generic Force branch (a composite IS
+        # a Force).
+        return is_backend_compatible(obj._potlist)
+    elif isinstance(
+        obj, (parentWrapperPotential, WrapperPotential, planarWrapperPotential)
+    ):
+        # A wrapper modulates what it wraps, so both must be backend-aware.
+        return bool(
+            getattr(obj, "_backend_compatible", False)
+            and is_backend_compatible(obj._pot)
+        )
+    # Leaf: a Force/planarForce/linearPotential, or any other galpy object that
+    # opts in with the same flag (galpy.df.sphericaldf does). Anything without
+    # the flag -- a plain object, an unmigrated class -- is False.
+    return bool(getattr(obj, "_backend_compatible", False))

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -60,6 +60,10 @@ def _backend_ready(target):
         ``self._orb.R(t)``, so a coerced ``t`` reaches a numpy lookup as a jax
         tracer under jit (``TracerArrayConversionError``).
 
+    df classes are not Forces, so ``_check_backend_compatible`` reports False for
+    every one of them; a backend-ready df opts in by setting
+    ``_backend_compatible = True`` itself.
+
     Drop this guard -- and this function -- once those are backend-native; the
     lists in tests/test_backend_input.py track what is left.
     """
@@ -68,7 +72,12 @@ def _backend_ready(target):
     from ..potential import _check_backend_compatible
     from ..potential import flatten as flatten_potential
 
-    return _check_backend_compatible(flatten_potential(target))
+    if _check_backend_compatible(flatten_potential(target)):
+        return True
+    # A df is not a Force, so _check_backend_compatible always says False for one.
+    # Backend-ready dfs opt in with the same ``_backend_compatible`` flag the
+    # potentials use, so the boundary can fire for them too.
+    return bool(getattr(target, "_backend_compatible", False))
 
 
 def _coerce_one(xp, val):
@@ -79,6 +88,14 @@ def _coerce_one(xp, val):
     element-wise and rebuilding the container keeps each element's autograd
     graph; stacking it into one array with a single ``asarray`` detaches them.
     """
+    # A Quantity is not a coordinate value yet -- it still carries units. Some
+    # entry points strip units INSIDE the body (sphericaldf.sigmar does
+    # `r = conversion.parse_length(r, ro=self._ro)`) rather than through an outer
+    # units decorator, so the boundary can be handed one; asarray() of a Quantity
+    # yields garbage that the later parse turns into NaN. Pass it through and let
+    # the body parse it. Detected by duck-typing so this stays astropy-free.
+    if hasattr(val, "unit"):
+        return val
     if isinstance(val, (list, tuple)):
         return type(val)(coerce_coords(xp, *val))
     (out,) = coerce_coords(xp, val)

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -39,6 +39,7 @@ from functools import wraps
 import numpy
 
 from ._coerce import coerce_coords
+from ._compat import is_backend_compatible
 from ._namespaces import is_backend_array
 from ._resolver import get_namespace
 
@@ -48,10 +49,14 @@ _EMPTY = inspect.Parameter.empty
 def _backend_ready(target):
     """True if ``target``'s compute methods can take backend arrays.
 
-    TEMPORARY compatibility guard, not part of the decorator's design: an entry
-    point that carries ``@backend_input`` should simply coerce. It is still here
-    because a handful of potentials are not migrated and break when their
-    coordinates arrive as jax/torch arrays -- measured, not assumed:
+    Thin alias of ``is_backend_compatible`` (the general galpy-object check),
+    named for what the decorator uses it for and kept as the place to document
+    WHY the decorator asks at all.
+
+    The question is a TEMPORARY compatibility guard, not part of the decorator's
+    design: an entry point that carries ``@backend_input`` should simply coerce.
+    It is still asked because a handful of potentials are not migrated and break
+    when their coordinates arrive as jax/torch arrays -- measured, not assumed:
 
       * ``interpRZPotential`` (scipy interpolation) diverges from the numpy path
         at the grid edge -- at (R,z)=(0.5,0.0) the force is off by 3.3% and the
@@ -60,24 +65,10 @@ def _backend_ready(target):
         ``self._orb.R(t)``, so a coerced ``t`` reaches a numpy lookup as a jax
         tracer under jit (``TracerArrayConversionError``).
 
-    df classes are not Forces, so ``_check_backend_compatible`` reports False for
-    every one of them; a backend-ready df opts in by setting
-    ``_backend_compatible = True`` itself.
-
     Drop this guard -- and this function -- once those are backend-native; the
     lists in tests/test_backend_input.py track what is left.
     """
-    # Deferred (galpy.backend loads before galpy.potential); reached only off the
-    # numpy path, so the numpy hot path pays neither the import nor the flatten.
-    from ..potential import _check_backend_compatible
-    from ..potential import flatten as flatten_potential
-
-    if _check_backend_compatible(flatten_potential(target)):
-        return True
-    # A df is not a Force, so _check_backend_compatible always says False for one.
-    # Backend-ready dfs opt in with the same ``_backend_compatible`` flag the
-    # potentials use, so the boundary can fire for them too.
-    return bool(getattr(target, "_backend_compatible", False))
+    return is_backend_compatible(target)
 
 
 def _coerce_one(xp, val):

--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -17,7 +17,7 @@ import warnings
 import numpy
 from scipy import integrate
 
-from ..backend import backend_input, device_of, get_namespace, is_backend_array
+from ..backend import device_of, get_namespace, is_backend_array
 from ..orbit import Orbit
 from ..potential import calcRotcurve, planarCompositePotential, planarForce
 from ..potential.Potential import _check_c, _check_potential_list_and_deprecate, _dim

--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -8,7 +8,6 @@ from scipy import integrate, interpolate, optimize
 from .. import actionAngle, potential
 from ..actionAngle import actionAngleIsochrone
 from ..backend import (
-    backend_input,
     coerce_coords,
     get_namespace,
     is_backend_array,

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -225,6 +225,11 @@ class _PVRInterpolator:
 class sphericaldf(df):
     """Superclass for spherical distribution functions"""
 
+    # The radius-based evaluators below are backend-native (they resolve their
+    # namespace from the data and exit-cast), so the @backend_input boundary may
+    # coerce their coordinates. Mirrors the potentials' opt-in flag.
+    _backend_compatible = True
+
     def __init__(self, pot=None, denspot=None, rmax=None, scale=None, ro=None, vo=None):
         """
         Initializes a spherical DF
@@ -418,6 +423,7 @@ class sphericaldf(df):
             Ei,
         )
 
+    @backend_input("r")
     def vmomentdensity(self, r, n, m, **kwargs):
         """
         Calculate an arbitrary moment of the velocity distribution at r times the density.
@@ -518,6 +524,7 @@ class sphericaldf(df):
             )
         )
 
+    @backend_input("r")
     @physical_conversion("velocity", pop=True)
     def sigmar(self, r):
         """
@@ -543,6 +550,7 @@ class sphericaldf(df):
             xp.sqrt(self._vmomentdensity(r, 2, 0) / self._vmomentdensity(r, 0, 0)), r
         )
 
+    @backend_input("r")
     @physical_conversion("velocity", pop=True)
     def sigmat(self, r):
         """
@@ -569,6 +577,7 @@ class sphericaldf(df):
             xp.sqrt(self._vmomentdensity(r, 0, 2) / self._vmomentdensity(r, 0, 0)), r
         )
 
+    @backend_input("r")
     def beta(self, r):
         """
         Calculate the anisotropy at radius r.

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -23,7 +23,13 @@ import numpy
 from packaging.version import Version
 from scipy import integrate, optimize
 
-from ..backend import backend_input, coerce_coords, get_namespace, is_backend_array
+from ..backend import (
+    backend_input,
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+    is_backend_compatible,
+)
 from ..util import conversion, coords, galpyWarning, plot
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -4368,10 +4374,11 @@ def _check_c(Pot, dxdv=False, dxdv3d=False, dens=False):
 def _check_backend_compatible(Pot):
     """
     Check whether a potential (or combined/wrapped potential) has backend-aware
-    compute methods (jax/torch). Gates the coordinate coercion in
-    potential_physical_input. Mirrors ``_check_c``: a list iff every member is; a
-    wrapper iff it is itself backend-aware AND the wrapped potential is; a leaf
-    reads its ``_backend_compatible`` flag (default False, set in __init__).
+    compute methods (jax/torch).
+
+    Potential-facing alias of ``galpy.backend.is_backend_compatible``, the
+    general check that answers the same question for any galpy object; see there
+    for the recursion (list, composite, wrapper, leaf flag).
 
     Parameters
     ----------
@@ -4386,45 +4393,10 @@ def _check_backend_compatible(Pot):
     Notes
     -----
     - 2026-06-15 - Written - Bovy (UofT)
+    - 2026-07-24 - Generalized to all galpy objects in galpy.backend - Bovy (UofT)
 
     """
-    Pot = flatten(Pot)
-    from ..potential import linearPotential, planarForce
-    from .baseCompositePotential import baseCompositePotential
-    from .WrapperPotential import (
-        WrapperPotential,
-        parentWrapperPotential,
-        planarWrapperPotential,
-    )
-
-    if isinstance(Pot, list):
-        return bool(
-            numpy.all(
-                numpy.array([_check_backend_compatible(p) for p in Pot], dtype="bool")
-            )
-        )
-    elif isinstance(Pot, baseCompositePotential):
-        # A (planar/linear)CompositePotential delegates to its members through
-        # the no-decorator internal path (no per-member coercion), so coercion
-        # must fire at the OUTER boundary; it is backend-compatible iff every
-        # component is (mirrors the list branch). flatten leaves a composite
-        # as-is, so this must precede the generic Force branch (a composite IS
-        # a Force).
-        return _check_backend_compatible(Pot._potlist)
-    elif isinstance(
-        Pot, (parentWrapperPotential, WrapperPotential, planarWrapperPotential)
-    ):
-        return bool(
-            getattr(Pot, "_backend_compatible", False)
-            * _check_backend_compatible(Pot._pot)
-        )
-    elif (
-        isinstance(Pot, Force)
-        or isinstance(Pot, planarForce)
-        or isinstance(Pot, linearPotential)
-    ):
-        return getattr(Pot, "_backend_compatible", False)
-    return False
+    return is_backend_compatible(Pot)
 
 
 def _dim(Pot):

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -386,3 +386,15 @@ jax tests/test_streamTrack.py
 # FAILED. torch runs it fine (also dropped). Un-skip when the Python Staeckel path
 # is jit-fast under jax.
 jax tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles
+# jax-eager dynamical friction: these two spend the full 300 s per-test timeout,
+# which pytest-timeout delivers as a SIGNAL. Landing mid-jax-operation it leaves
+# jax's thread-local trace state as None, and then EVERY later test in the shard
+# dies at its first jax op with `AttributeError: 'NoneType' object has no
+# attribute 'process_primitive'` -- including at potential construction
+# (normalize() -> Rforce -> asarray). So a slow ledgered-xfail here does not
+# merely fail itself, it poisons the process; whether the damage lands is pure
+# timing, which is why the shard was green until an unrelated change shifted it.
+# Skipping means the timeout is never spent. torch runs both fine (107 s worst).
+# Un-skip when the jax dynamical-friction path is vectorized.
+jax tests/test_dynamfric.py::test_dynamfric_c
+jax tests/test_FDMdynamfric.py::test_dynamfric_c

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -87,7 +87,6 @@
 # format: <backend> <nodeid>   (conftest applies xfail(strict=False) per backend;
 # tests unrunnable-until-vectorized go in backend_slow_skip.txt instead, not here)
 
-jax tests/test_FDMdynamfric.py::test_dynamfric_c
 jax tests/test_SpiralArmsPotential.py::TestSpiralArmsPotential::test_Rzderiv
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
@@ -119,7 +118,6 @@ jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_point
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform_bisect
 jax tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
 jax tests/test_actionAngle.py::test_physical_vertical
-jax tests/test_dynamfric.py::test_dynamfric_c
 jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -171,6 +171,10 @@ def test_check_backend_compatible_semantics():
     # combined potential: all members must be compatible
     assert cbc([mn, potential.NFWPotential(normalize=1.0)]) is True
     assert cbc([mn, unmig]) is False
+    # composite potential (pot1+pot2): delegates to its components, so it is
+    # compatible iff every component is (mirrors the list branch)
+    assert cbc(mn + potential.NFWPotential(normalize=1.0)) is True
+    assert cbc(mn + unmig) is False
     # wrapper: own flag AND wrapped potential
     assert cbc(potential.OblateStaeckelWrapperPotential(pot=mn)) is True
     assert (

--- a/tests/test_backend_input.py
+++ b/tests/test_backend_input.py
@@ -215,6 +215,31 @@ def test_sequence_coordinate_is_coerced_element_wise(backend_name):
     assert all(is_backend_array(c) for c in seen["v"])
 
 
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_quantity_coordinate_passes_through(backend_name):
+    # @backend_input is only correct INSIDE something that has already stripped
+    # units. Some entry points strip them in the body instead -- sphericaldf.sigmar
+    # does `r = conversion.parse_length(r, ro=self._ro)` -- so the boundary can be
+    # handed a Quantity. asarray() of a Quantity yields garbage that the later
+    # parse turns into NaN, so it must pass through untouched. Uses a stub rather
+    # than astropy: the coverage shard runs without it.
+    class _Quantityish:
+        unit = "kpc"
+        value = 1.1
+
+    q = _Quantityish()
+    seen = {}
+
+    @backend_input("R", "z")
+    def probe(pot, R, z):
+        seen.update(R=R, z=z)
+
+    with backend.use(backend_name, force=True):
+        probe(_pot(), q, 0.2)
+    assert seen["R"] is q, "a Quantity-like coordinate must not be coerced"
+    assert is_backend_array(seen["z"]), "plain coordinates alongside it still coerce"
+
+
 # Coordinate parameter names used across galpy's entry points. A decorated entry
 # point must declare every one of these that it takes -- an undeclared
 # coordinate is silently NOT coerced, which the decoration-time check (which only
@@ -282,7 +307,8 @@ def test_decorated_entry_points_are_registered():
 
 # Whole modules whose public entry points deliberately do NOT coerce yet, with
 # the blocker for each. These are the burndown list: decorate them as the blocker
-# clears. (Under the old coerce_backend gate these modules could carry the
+# clears -- sphericaldf/kingdf came off it once sphericaldf opted in
+# (``_backend_compatible``) and its radius entry points declared their coordinate. (Under the old coerce_backend gate these modules could carry the
 # decorator harmlessly because _check_backend_compatible returned False for every
 # df, so it never fired; with the gate gone, decorating them would route real
 # calls onto an incomplete backend path.)
@@ -294,8 +320,6 @@ _UNDECORATED_MODULES = {
     "diskdf.py": "backend evaluation path incomplete",
     "evolveddiskdf.py": "grid deriv= unsupported on jax/torch",
     "quasiisothermaldf.py": "sampling + adiabatic action-Jacobian C callback",
-    "sphericaldf.py": "sigmar/sigmat return NaN for a coerced radius",
-    "kingdf.py": "inherits sphericaldf.sigmar",
     "streamdf.py": "not yet migrated to the coercion boundary",
     "streamgapdf.py": "not yet migrated to the coercion boundary",
     "streamspraydf.py": "not yet migrated to the coercion boundary",

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -705,23 +705,9 @@ def test_coercion_boundary_fires_for_sphericaldf(backend_name):
         )
 
 
-@pytest.mark.parametrize("backend_name", BACKENDS)
-def test_quantity_radius_is_not_coerced(backend_name):
-    # sigmar strips units INSIDE the body (conversion.parse_length), so the
-    # boundary is handed a Quantity; coercing it produced NaN. It must pass
-    # through and let the body parse it.
-    #
-    # End-to-end with a REAL Quantity, so it needs astropy AND a backend -- no
-    # CI job has both (this shard is the only one running test_backend*.py and
-    # it is astropy-free), so this runs locally and skips in CI. The boundary
-    # branch itself is covered there without astropy, by the duck-typed stub in
-    # test_backend_input.py::test_quantity_coordinate_passes_through; importing
-    # astropy unconditionally here is a hard ERROR on this shard, not a skip.
-    units = pytest.importorskip("astropy.units")
-
-    df = isotropicHernquistdf(pot=_HP, ro=8.0, vo=220.0)
-    ref = float(df.sigmar(100.0 * units.pc, use_physical=False))
-    with galpy.backend.use(backend_name, force=True):
-        got = float(as_numpy(df.sigmar(100.0 * units.pc, use_physical=False)))
-    assert numpy.isfinite(got), "Quantity radius produced a non-finite result"
-    numpy.testing.assert_allclose(got, ref, rtol=1e-7)
+# The Quantity-radius regression (a Quantity handed to the @backend_input
+# boundary must pass through, not be coerced into NaN) lives in
+# tests/test_quantity.py: it needs a REAL Quantity, and this shard is
+# deliberately astropy-free, so an astropy import here is a hard error rather
+# than a skip. The boundary branch itself is covered without astropy by
+# test_backend_input.py::test_quantity_coordinate_passes_through.

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -710,7 +710,14 @@ def test_quantity_radius_is_not_coerced(backend_name):
     # sigmar strips units INSIDE the body (conversion.parse_length), so the
     # boundary is handed a Quantity; coercing it produced NaN. It must pass
     # through and let the body parse it.
-    from astropy import units
+    #
+    # End-to-end with a REAL Quantity, so it needs astropy AND a backend -- no
+    # CI job has both (this shard is the only one running test_backend*.py and
+    # it is astropy-free), so this runs locally and skips in CI. The boundary
+    # branch itself is covered there without astropy, by the duck-typed stub in
+    # test_backend_input.py::test_quantity_coordinate_passes_through; importing
+    # astropy unconditionally here is a hard ERROR on this shard, not a skip.
+    units = pytest.importorskip("astropy.units")
 
     df = isotropicHernquistdf(pot=_HP, ro=8.0, vo=220.0)
     ref = float(df.sigmar(100.0 * units.pc, use_physical=False))

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -671,3 +671,50 @@ def test_pvr_interpolator_getattr_delegation():
     bare = _PVRInterpolator.__new__(_PVRInterpolator)
     with pytest.raises(AttributeError):
         bare.some_missing_attr  # noqa: B018  (triggers __getattr__ -> _spl guard)
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_coercion_boundary_fires_for_sphericaldf(backend_name):
+    # sphericaldf opts into the @backend_input boundary (_backend_compatible), so
+    # its radius entry points COERCE: under a forced backend they must return a
+    # backend array rather than silently computing on numpy, and must agree with
+    # the numpy path. Before the opt-in the guard reported False for every df
+    # (a df is not a Force), so the decoration could never fire.
+    df = isotropicHernquistdf(pot=_HP)
+    ref = {
+        "sigmar": float(df.sigmar(1.3, use_physical=False)),
+        "sigmat": float(df.sigmat(1.3, use_physical=False)),
+        "beta": float(df.beta(1.3)),
+        "vmomentdensity": float(df.vmomentdensity(1.3, 0, 0)),
+    }
+    with galpy.backend.use(backend_name, force=True):
+        got = {
+            "sigmar": df.sigmar(1.3, use_physical=False),
+            "sigmat": df.sigmat(1.3, use_physical=False),
+            "beta": df.beta(1.3),
+            "vmomentdensity": df.vmomentdensity(1.3, 0, 0),
+        }
+    for name, val in got.items():
+        assert galpy.backend.is_backend_array(val), (
+            f"{name} did not stay on the {backend_name} backend"
+        )
+        # ~1e-9: the backend quadrature sums in a different order than numpy's,
+        # so this checks agreement, not bit-parity.
+        numpy.testing.assert_allclose(
+            float(as_numpy(val)), ref[name], rtol=1e-7, err_msg=name
+        )
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_quantity_radius_is_not_coerced(backend_name):
+    # sigmar strips units INSIDE the body (conversion.parse_length), so the
+    # boundary is handed a Quantity; coercing it produced NaN. It must pass
+    # through and let the body parse it.
+    from astropy import units
+
+    df = isotropicHernquistdf(pot=_HP, ro=8.0, vo=220.0)
+    ref = float(df.sigmar(100.0 * units.pc, use_physical=False))
+    with galpy.backend.use(backend_name, force=True):
+        got = float(as_numpy(df.sigmar(100.0 * units.pc, use_physical=False)))
+    assert numpy.isfinite(got), "Quantity radius produced a non-finite result"
+    numpy.testing.assert_allclose(got, ref, rtol=1e-7)

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1,4 +1,6 @@
 # Make sure to set configuration, needs to be before any galpy imports
+import importlib.util
+
 import pytest
 from packaging.version import parse as parse_version
 
@@ -16,6 +18,11 @@ _NUMPY_1_22 = (_NUMPY_VERSION > parse_version("1.21")) * (
 from astropy import constants, units
 
 from galpy.backend import as_numpy  # noqa: E402
+
+# Backends installed here, for the units-through-a-backend regressions. Probed
+# rather than imported: importing torch/jax costs seconds and most of this file
+# does not need them.
+_BACKENDS = [b for b in ("jax", "torch") if importlib.util.find_spec(b) is not None]  # noqa: E402
 
 sdf_sanders15 = None  # so we can set this up and then use in other tests
 sdf_sanders15_nou = None  # so we can set this up and then use in other tests
@@ -17734,6 +17741,37 @@ def test_sphericaldf_method_returnunit():
             "sphericaldf method sigmar does not return Quantity with the right units"
         )
     return None
+
+
+@pytest.mark.parametrize("backend_name", _BACKENDS)
+def test_sphericaldf_quantity_radius_is_not_coerced_on_a_backend(backend_name):
+    # sigmar strips units INSIDE the body (conversion.parse_length), so the
+    # @backend_input boundary is handed a Quantity; coercing it produced NaN.
+    # It must pass through and let the body parse it.
+    #
+    # This lives here rather than in tests/test_backend_sphericaldf.py because
+    # it needs a REAL Quantity AND a forced backend: tests/test_backend*.py runs
+    # in a single CI job that is deliberately astropy-free, so an astropy import
+    # there is a hard error. This shard has astropy in both workflows.
+    import galpy.backend
+    from galpy import potential
+    from galpy.df import isotropicHernquistdf
+
+    if backend_name == "jax":
+        # Every tests/test_backend_*.py enables x64 at import; this file does
+        # not, and jax defaults to float32, which lands ~3e-6 from the numpy
+        # reference. Set it here (no jax array exists yet, so it takes effect)
+        # so the comparison is float64-vs-float64.
+        import jax
+
+        jax.config.update("jax_enable_x64", True)
+    pot = potential.HernquistPotential(amp=2.0, a=1.3)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    ref = float(dfh.sigmar(100.0 * units.pc, use_physical=False))
+    with galpy.backend.use(backend_name, force=True):
+        got = float(as_numpy(dfh.sigmar(100.0 * units.pc, use_physical=False)))
+    assert numpy.isfinite(got), "Quantity radius produced a non-finite result"
+    numpy.testing.assert_allclose(got, ref, rtol=1e-7)
 
 
 def test_sphericaldf_method_value():


### PR DESCRIPTION
## Summary

First module of the df follow-up to #1196: **the coercion boundary now actually
fires for a df**. Three pieces, all of which were required before a single df
entry point could coerce at all.

### 1. A Quantity is not a coordinate value yet

`@backend_input` is only correct stacked **inside** something that has already
stripped units. Some entry points strip them in the **body** instead —
`sphericaldf.sigmar` does `r = conversion.parse_length(r, ro=self._ro)` — so the
boundary can be handed a `Quantity`, and `asarray()` of one yields garbage that
the later parse turns into `NaN`:

| | numpy | forced jax (before) |
|---|---|---|
| `sigmar(0.001)` | 0.9163035 | 0.9163035 |
| `sigmar(1.0*u.pc)` | 0.9163069 | **nan** |

`_coerce_one` now passes a Quantity through untouched and lets the body parse it,
duck-typed on `.unit` so `galpy.backend` stays astropy-free (the coverage shard
runs without astropy).

### 2. The guard was structurally blind to dfs

`_backend_ready` consulted `_check_backend_compatible`, which returns `False` for
anything that is not a `Force` — so it returned `False` for **every** df and the
boundary could never fire for one. That is why the df decorations in #1196 were
dead. A backend-ready df now opts in with the same `_backend_compatible` flag the
potentials use.

### 3. sphericaldf opts in

`sigmar`, `sigmat`, `beta`, `vmomentdensity` declare their coordinate. Under a
forced backend these now return backend arrays instead of silently computing on
numpy. Flip-tested: the new tests fail if the opt-in flag is set back to `False`.

`sphericaldf.py` and `kingdf.py` come off the `_UNDECORATED_MODULES` burndown
list, which is now diskdf / evolveddiskdf / quasiisothermaldf + the three stream
modules.

## Deliberately NOT done: hoisting the unit parsing

Hoisting with `potential_physical_input` changes what `ro=` means. `sphericaldf`
parses the input radius with `self._ro` and uses `ro=` for **output** only (with
`use_physical=False` it previously had no effect at all); `potential_physical_input`
consumes `ro=` for **input** conversion. That moved 3 of 48 sampled values, one by
**9.1 %**:

```
hern.sigmar(1 pc, use_physical=False, ro=10.)   0.029383409 -> 0.026701396
```

so it is left out and the numpy path stays byte-identical.

Worth flagging separately: `diskdf` and `quasiisothermaldf` **do** already use
`potential_physical_input`, so the two conventions currently disagree across df
modules. Unifying them is a public-API decision that deserves its own change.

## Drive-by

#1196 left three `backend_input` imports unused in
`evolveddiskdf`/`quasiisothermaldf`/`sphericaldf` — the revert there dropped the
standalone import lines, but isort had already merged the names into existing
blocks so they survived and pycln did not flag them. Removed. The other F401s in
those files are pre-existing and untouched.

## Testing

- **numpy byte-identical**: 48/48 sampled values across kingdf / Hernquist /
  Plummer (`sigmar`/`sigmat`/`beta`/`vmomentdensity`, float + Quantity + the `ro=`
  form) match `origin/feat/backends` exactly.
- `test_sphericaldf.py` **223/223 numpy**, 218 pass/5 skip torch, 191 pass/32 skip
  jax — **0 failures** (run serially: it has lazily-initialised module state,
  `_fE_interp`, that xdist workers cannot share).
- The unforced `tests/test_backend*.py` shard: 6255 tests, **0 failures**.
- New tests: the boundary fires for sphericaldf (backend arrays + agreement),
  the Quantity radius stays finite and matches numpy, and a Quantity coordinate
  is not coerced at the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
