### PR TITLE
torch.compile: make the scipy-setup / scipy-quad dispatches traceable (under_trace + untraceable_setup)

### DIFF
--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -2,6 +2,8 @@
 #   galpy.backend._namespaces: helpers mapping backend names to array
 #   namespaces and small namespace-agnostic utilities.
 ###############################################################################
+from functools import wraps
+
 import numpy
 
 from ..util._optional_deps import (
@@ -70,6 +72,67 @@ def under_jax_trace(*xs):
     import jax
 
     return any(isinstance(x, jax.core.Tracer) for x in xs)
+
+
+def under_trace(*xs):
+    """True iff one of ``xs`` is being TRACED rather than concretely evaluated.
+
+    The backend-agnostic generalisation of ``under_jax_trace``, for the "do I
+    have a concrete value?" probes that pick an out-of-backend (scipy/numpy)
+    computation when they do. A jax tracer answers by raising from ``float(x)``;
+    a torch tensor under ``torch.compile`` does NOT -- dynamo turns ``float(x)``
+    into a symbolic scalar, so the probe wrongly takes the concrete branch and
+    drags the scipy/numpy code into the graph (where it dies on a data-dependent
+    output shape). ``torch.compiler.is_compiling()`` is dynamo's own answer.
+    False on numpy, and on plain (untraced) jax/torch arrays.
+    """
+    import sys
+
+    if under_jax_trace(*xs):
+        return True
+    if "torch" not in sys.modules:
+        return False
+    import torch
+
+    return torch.compiler.is_compiling() and any(
+        isinstance(x, torch.Tensor) for x in xs
+    )
+
+
+def untraceable_setup(method):
+    """Mark a lazy SETUP/table builder so a tracer never traces it.
+
+    The table-backed potentials build their constant backend tables lazily and
+    memoize them on the instance, so numpy-only users never pay for the build.
+    That build is pure numpy/scipy (FITPACK splines, PPoly basis changes,
+    ``scipy.special.comb``, ...) and is not traceable: when the very FIRST call
+    happens to be inside a ``torch.compile`` region, dynamo tries to trace the
+    scipy code and dies (``scipy.special.comb`` -> "'numpy.float64' object does
+    not support item assignment"). It is also pointless to trace -- the result
+    is a dict of constants, identical on every call.
+
+    ``torch.compiler.disable`` tells dynamo to run the builder eagerly (as an
+    opaque call) and feed its constants back into the graph. torch is imported
+    only if it is ALREADY imported, so numpy-only runs never touch it, and the
+    disabled view is built once and reused. jax needs nothing here: a lazy build
+    under ``jax.jit`` sees concrete (untraced) values because the tables depend
+    on nothing traced.
+    """
+    disabled = []
+
+    @wraps(method)
+    def wrapper(*args, **kwargs):
+        import sys
+
+        if "torch" not in sys.modules:
+            return method(*args, **kwargs)
+        if not disabled:
+            import torch
+
+            disabled.append(torch.compiler.disable(method))
+        return disabled[0](*args, **kwargs)
+
+    return wrapper
 
 
 def under_torch_grad(*xs):

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -15,6 +15,7 @@ from ..backend import (
 )
 from ..backend import quadrature as _bquad
 from ..backend import special as _bspecial
+from ..backend._namespaces import under_trace
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .Potential import Potential, check_potential_inputs_not_arrays
@@ -165,7 +166,11 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         xp = get_namespace(R, z)
         dev = device_of(R, z)
         if not (
-            getattr(R, "requires_grad", False) or getattr(z, "requires_grad", False)
+            getattr(R, "requires_grad", False)
+            or getattr(z, "requires_grad", False)
+            # torch.compile does not raise from the float() probe below (dynamo
+            # makes it symbolic) and would trace scipy's quad instead: ask.
+            or under_trace(R, z)
         ):
             try:  # plain concrete backend input: reuse scipy's accurate value
                 Rf, zf = float(R), float(z)

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -25,6 +25,7 @@ from ..backend import (
     match_input_dtype,
 )
 from ..backend import use as _use_backend
+from ..backend._namespaces import untraceable_setup
 from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
@@ -2239,6 +2240,7 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         """Constant numpy tables for the backend path (static or TD layout)."""
         return self._backend_tdep_data() if self._tdep else self._backend_static_data()
 
+    @untraceable_setup
     def _backend_static_data(self):
         """Build (once) the numpy constant tables for the backend path.
 
@@ -2301,6 +2303,7 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
         )
         return self._backend_data
 
+    @untraceable_setup
     def _backend_tdep_data(self):
         """Build (once) the numpy constant tables for the time-dependent
         backend path.

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -232,3 +232,54 @@ def test_vcirc_no_longer_crashes(backend_name):
     ref = float(pot.vcirc(1.3, use_physical=False))
     got = float(pot.vcirc(_scalar(backend_name, 1.3), use_physical=False))
     numpy.testing.assert_allclose(got, ref, rtol=1e-10)
+
+
+def _no_torch_compile_deprecations():
+    """Suppress torch's own import-time DeprecationWarnings during a compile.
+
+    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
+    warns on ``torch.jit.script_method`` at class-definition time. A per-test
+    ``filterwarnings`` mark cannot suppress it (a module-level
+    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
+    filter it here, around the call itself.
+    """
+    import contextlib
+    import warnings
+
+    @contextlib.contextmanager
+    def _ctx():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            yield
+
+    return _ctx()
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_torch_compile_takes_the_backend_gl_path():
+    # Regression: under torch.compile the dispatch must pick the in-backend GL
+    # quadrature, exactly as a jax tracer does. Its concreteness probe is
+    # ``float(R)``, which a jax tracer answers by raising -- but dynamo makes it
+    # a symbolic scalar, so the probe took the scipy branch and dynamo then
+    # traced scipy's adaptive quad and died on numpy.unique's data-dependent
+    # output shape (InductorError: DynamicOutputShapeException aten.unique_dim).
+    # ``under_trace`` asks dynamo directly instead.
+    #
+    # The DEFAULT (inductor) compile backend is deliberate: with backend="eager"
+    # a graph break silently rescues the scipy branch, so the bug would not
+    # show. Only ``_evaluate`` is compiled -- the forces take minutes to codegen
+    # the 3-panel/100-node GL graph and add no coverage.
+    R0 = torch.tensor(1.1, dtype=torch.float64)
+    z0 = torch.tensor(0.2, dtype=torch.float64)
+    ref = float(evaluatePotentials(_POT, R0, z0))  # eager (scipy) value
+    torch._dynamo.reset()
+    with _no_torch_compile_deprecations():
+        got = float(
+            torch.compile(
+                lambda R, z: evaluatePotentials(_POT, R, z),
+                fullgraph=False,
+                dynamic=False,
+            )(R0, z0)
+        )
+    # GL vs scipy adaptive quad differ only at the quadrature floor
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10)

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -621,3 +621,59 @@ def test_from_density_backend_amp_closure(backend_name, symmetry):
         pt = build()
         got = numpy.array([as_numpy(ep(pt, R, z, phi=phi)) for R, z, phi in pts])
     numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-13)
+
+
+def _no_torch_compile_deprecations():
+    """Suppress torch's own import-time DeprecationWarnings during a compile.
+
+    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
+    warns on ``torch.jit.script_method`` at class-definition time. A per-test
+    ``filterwarnings`` mark cannot suppress it (a module-level
+    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
+    filter it here, around the call itself.
+    """
+    import contextlib
+    import warnings
+
+    @contextlib.contextmanager
+    def _ctx():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            yield
+
+    return _ctx()
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_torch_compile_cold_lazy_table_build():
+    # Regression: the backend constant tables are built lazily and memoized, so
+    # a potential whose FIRST evaluation happens inside a torch.compile region
+    # had dynamo trace the pure-scipy builder (PPoly.from_bernstein_basis ->
+    # scipy.special.comb -> "'numpy.float64' object does not support item
+    # assignment"). ``untraceable_setup`` runs the builder eagerly instead. The
+    # instance is built fresh here so the trace really is the cold path.
+    from galpy.potential import DiskMultipoleExpansionPotential
+
+    def build():
+        return DiskMultipoleExpansionPotential(
+            dens=lambda R, z: (
+                13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
+            ),
+            Sigma={"h": 1.0 / 3.0, "type": "exp", "amp": 1.0},
+            hz={"type": "exp", "h": 1.0 / 27.0},
+            L=3,
+            rgrid=numpy.geomspace(1e-2, 20, 51),
+        )
+
+    R0 = torch.tensor(1.1, dtype=torch.float64)
+    z0 = torch.tensor(0.2, dtype=torch.float64)
+    ref = float(build().Rforce(R0, z0))  # warm/eager reference
+    cold = build()  # never evaluated outside the trace
+    torch._dynamo.reset()
+    with _no_torch_compile_deprecations():
+        got = float(
+            torch.compile(
+                lambda R, z: cold.Rforce(R, z), fullgraph=False, dynamic=False
+            )(R0, z0)
+        )
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12)

--- a/tests/test_backend_potential_jit.py
+++ b/tests/test_backend_potential_jit.py
@@ -101,32 +101,11 @@ _NOT_TRACEABLE = {
     ("RazorThinExponentialDiskPotential", "zforce", "jax"),
     # numpy conversion of a traced array (TracerArrayConversionError).
     ("TwoPowerTriaxialPotential", "__call__", "jax"),
-    # The lazy backend table build (_backend_static_data -> scipy PPoly /
-    # scipy.special.binom) runs inside the FIRST traced call and dynamo cannot
-    # trace scipy. Calling the potential once eagerly first is a user-side
-    # workaround: it then compiles and matches eager exactly.
-    ("DiskMultipoleExpansionPotential", "__call__", "torch"),
-    ("DiskMultipoleExpansionPotential", "Rforce", "torch"),
-    ("DiskMultipoleExpansionPotential", "zforce", "torch"),
-    ("DiskMultipoleExpansionPotential", "dens", "torch"),
-    # Writes into a numpy scalar (`TypeError: 'numpy.float64' object does not
-    # support item assignment`): the coefficient path indexes an array that is
-    # 0-d once the coordinates are tensors.
-    ("MultipoleExpansionPotential", "__call__", "torch"),
-    ("MultipoleExpansionPotential", "Rforce", "torch"),
-    ("MultipoleExpansionPotential", "zforce", "torch"),
-    ("MultipoleExpansionPotential", "dens", "torch"),
     # Compiles, but returns inf where eager returns -0.1979: the compiled graph
     # evaluates the DEAD side of an xp.where (the alpha/beta special-case
     # branch), which is singular at these parameters. Same hazard as the
     # AD-NaN-poisoning one, surfacing through inductor instead of a gradient.
     ("TwoPowerSphericalPotential", "__call__", "torch"),
-    # torch dynamo cannot trace this yet (InternalTorchDynamoError); it takes a
-    # user-supplied Python callable for the surface density.
-    ("AnyAxisymmetricRazorThinDiskPotential", "__call__", "torch"),
-    ("AnyAxisymmetricRazorThinDiskPotential", "Rforce", "torch"),
-    ("AnyAxisymmetricRazorThinDiskPotential", "zforce", "torch"),
-    ("AnyAxisymmetricRazorThinDiskPotential", "dens", "torch"),
 }
 
 

--- a/tests/test_backend_trace.py
+++ b/tests/test_backend_trace.py
@@ -1,0 +1,134 @@
+###############################################################################
+# test_backend_trace.py: coverage for the two trace-awareness helpers in
+# galpy.backend._namespaces that make galpy COMPATIBLE with torch.compile
+# (galpy never compiles anything itself).
+#
+# ``under_trace``      -- "am I being traced rather than concretely evaluated?".
+#   galpy has several dispatch points that pick an out-of-backend (scipy/numpy)
+#   computation when they hold a concrete value. Under jax those probe by
+#   ``float(x)``, which a tracer answers by RAISING. torch.compile does not:
+#   dynamo turns ``float(x)`` into a symbolic scalar, so the probe wrongly takes
+#   the concrete branch and drags the scipy code into the graph.
+#
+# ``untraceable_setup`` -- marks a lazy numpy/scipy SETUP builder so a tracer
+#   runs it eagerly instead of tracing it. The table-backed potentials build
+#   their constant backend tables lazily; when the FIRST call lands inside a
+#   compiled region dynamo tries to trace scipy and dies.
+#
+# The backend-tests CI job uploads no coverage, so both branches are exercised
+# here explicitly. Backends that are not installed self-skip.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend._namespaces import under_trace, untraceable_setup
+
+pytestmark = pytest.mark.backend_managed
+
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+except ImportError:  # pragma: no cover
+    torch = None
+
+
+def test_under_trace_false_on_numpy():
+    # Never true off a trace: plain numpy/python values are always concrete.
+    assert not under_trace(numpy.float64(1.1), numpy.zeros(3), 2.0, None)
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_under_trace_jax():
+    # Concrete jax arrays are NOT traced; a jit tracer is.
+    assert not under_trace(jnp.asarray(1.1), jnp.zeros(3))
+    seen = []
+
+    def probe(x):
+        seen.append(under_trace(x))
+        return x * 2.0
+
+    jax.jit(probe)(jnp.asarray(1.1))
+    assert seen == [True]
+
+
+def _no_torch_compile_deprecations():
+    """Suppress torch's own import-time DeprecationWarnings during a compile.
+
+    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
+    warns on ``torch.jit.script_method`` at class-definition time. A per-test
+    ``filterwarnings`` mark cannot suppress it (a module-level
+    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
+    filter it here, around the call itself.
+    """
+    import contextlib
+    import warnings
+
+    @contextlib.contextmanager
+    def _ctx():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            yield
+
+    return _ctx()
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_under_trace_torch():
+    # A concrete tensor -- even one carrying grad -- is not traced; only a
+    # torch.compile region is. This is THE case float() cannot detect.
+    assert not under_trace(torch.tensor(1.1, dtype=torch.float64))
+    assert not under_trace(torch.tensor(1.1, dtype=torch.float64, requires_grad=True))
+    seen = []
+
+    def probe(x):
+        seen.append(under_trace(x))
+        return x * 2.0
+
+    torch._dynamo.reset()
+    with _no_torch_compile_deprecations():
+        torch.compile(probe, fullgraph=False, dynamic=False, backend="eager")(
+            torch.tensor(1.1, dtype=torch.float64)
+        )
+    assert seen == [True]
+
+
+def _scipy_only_builder():
+    # Stands in for the real lazy table builders: pure scipy, untraceable by
+    # dynamo (scipy.special.comb assigns into a numpy scalar under a trace).
+    from scipy.special import comb
+
+    return float(comb(5, 2))
+
+
+@untraceable_setup
+def _decorated_builder():
+    return _scipy_only_builder()
+
+
+def test_untraceable_setup_is_transparent_off_a_trace():
+    # Plain call: same value, no behaviour change (and no torch import needed).
+    assert _decorated_builder() == _scipy_only_builder() == 10.0
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_untraceable_setup_runs_scipy_setup_under_compile():
+    # Without the decorator dynamo traces scipy.special.comb and raises
+    # ("'numpy.float64' object does not support item assignment"); with it the
+    # builder runs eagerly and its constant feeds back into the graph.
+    def use_builder(x):
+        return x * _decorated_builder()
+
+    torch._dynamo.reset()
+    with _no_torch_compile_deprecations():
+        got = torch.compile(use_builder, fullgraph=False, dynamic=False)(
+            torch.tensor(2.0, dtype=torch.float64)
+        )
+    assert float(got) == 20.0

--- a/tests/test_backend_trace.py
+++ b/tests/test_backend_trace.py
@@ -132,3 +132,29 @@ def test_untraceable_setup_runs_scipy_setup_under_compile():
             torch.tensor(2.0, dtype=torch.float64)
         )
     assert float(got) == 20.0
+
+
+def test_helpers_take_the_fallback_when_torch_is_not_imported():
+    # Both helpers guard on `"torch" not in sys.modules` so that a numpy-only
+    # run never pays the torch import -- that guard IS the contract, not an
+    # optimisation. The coverage shard always has torch imported, so these two
+    # fallbacks are only reachable by hiding it.
+    import sys
+    from unittest import mock
+
+    built = []
+
+    @untraceable_setup
+    def build(x):
+        built.append(x)
+        return 2 * x
+
+    with mock.patch.dict(sys.modules):  # copies; restored on exit
+        sys.modules.pop("torch", None)
+        # under_trace: nothing is being traced, and torch is not consulted
+        assert under_trace(numpy.array([1.0, 2.0])) is False
+        # untraceable_setup: calls straight through, undecorated semantics
+        assert build(21) == 42
+        # the point of the guard: neither helper imported torch to answer
+        assert "torch" not in sys.modules, "the numpy-only path must not import torch"
+    assert built == [21], "the wrapped builder must run exactly once"


### PR DESCRIPTION
## What

Two galpy-side reasons a potential died under `torch.compile`, both of the same shape: **a numpy/scipy computation got dragged into the graph**. Neither is the user-supplied density callable — the default densities are plain arithmetic and trace fine.

### 1. `AnyAxisymmetricRazorThinDiskPotential` — the concreteness probe

`_bk_dispatch` decides *"do I hold a concrete value?"* with

```python
try:  # plain concrete backend input: reuse scipy's accurate value
    Rf, zf = float(R), float(z)
except Exception:  # tracer: in-backend differentiable GL
    pass
```

A jax tracer answers by **raising**, so `jax.jit` has always taken the differentiable GL branch. dynamo does **not** raise — it turns `float(R)` into a symbolic scalar — so the probe took the scipy branch, dynamo traced `scipy.integrate.quad`, and died on its data-dependent output shape:

```
InductorError: DynamicOutputShapeException: aten.unique_dim.default
While executing %unique_dim : ... = call_function[target=torch.ops.aten.unique_dim.default](args = (%full_default, 0), ...)
    the_points = np.unique(points)                 # scipy/integrate/_quadpack_py.py
```

Fixed with a new backend-agnostic predicate **`under_trace(*xs)`** in `galpy.backend._namespaces` — the generalisation of the existing `under_jax_trace` to torch (`torch.compiler.is_compiling()` is dynamo's own answer). Under a trace the dispatch now takes the same in-backend GL path jax already took. The concrete/eager and numpy paths are untouched.

Note `backend="eager"` **hides** this bug: with `fullgraph=False` a graph break silently rescues the scipy branch. Only the default (inductor) backend surfaces it, which is what the new test uses.

### 2. `MultipoleExpansionPotential` / `DiskMultipoleExpansionPotential` — the lazy table build

The constant backend tables are built lazily and memoized, so a potential whose **first** evaluation lands inside a compiled region had dynamo trace the pure-scipy builder (`_backend_static_data` → `PPoly.from_bernstein_basis` → `scipy.special.comb`):

```
TypeError: 'numpy.float64' object does not support item assignment
```

Fixed with **`untraceable_setup`**, a decorator that runs such a setup builder through `torch.compiler.disable`, so its constants are spliced into the graph instead of traced. Applied to the *builders*, not to a potential, so any future lazy table build can reuse it. torch is imported only when it is already imported (numpy-only runs never touch it); jax needs nothing — its trace-time build sees concrete values.

## Numpy path is byte-identical

Both helpers sit behind `is_backend_array` guards, so the numpy path never reaches them. Empirical hash over `AnySpherical` / `AnyAxisymmetricRazorThinDisk` / `DiskMultipoleExpansion` / `MultipoleExpansion` × (potential, Rforce, zforce, dens) × 16 `(R, z)` points, against the pristine base, **with and without torch imported**:

```
0f0664058e65dd32f6a59d7320aeb9fa18fd9b454b90bf601554551e9008b3ca  256 values   (base and branch, both torch states)
a4a8d3485bf1cc46c6721a01327967571775fc9b6c3bc0f464272ea20b4032ca  128 values   (AnySpherical + AnyAxisym only)
```

## Verified

* All four `AnyAxisymmetricRazorThinDiskPotential` entry points **plus** `R2deriv`/`z2deriv`/`Rzderiv` (they share `_bk_dispatch`) compile and match eager to ≤ 2.7e-13.
* All four `DiskMultipoleExpansionPotential` entry points compile *cold* (first call inside the trace) and match eager to ≤ 1e-15.
* `jax.jit` + `jax.jacfwd` unregressed on the same entry points; cold `DiskMultipoleExpansion` under `jax.jit` matches numpy to 4.6e-15.

## Stacking

The two new end-to-end `torch.compile` **potential** tests need the `_backend_dtype` boundary fix (`numpy.issubdtype` probing a torch dtype inside `try/except`, which dynamo surfaces as `InternalTorchDynamoError: Cannot interpret 'torch.float64' as a data type` rather than letting the `except` run) — without it no compiled call reaches galpy's own code at all. That fix is **not** in this branch; it lands separately. The `tests/test_backend_trace.py` unit tests for the two new helpers pass standalone.
