### PR TITLE
potential: make RazorThinExponentialDisk (Phi/Rforce/zforce) + TwoPowerTriaxial (Phi) jit-traceable

### DIFF
--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -75,16 +75,18 @@ class RazorThinExponentialDiskPotential(Potential):
         xp = get_namespace(R, z)
         R, z = coerce_coords(xp, R, z)
         if self._new:
-            if xp.abs(z) < 10.0**-6.0:
-                y = 0.5 * self._alpha * R
-                return (
-                    -math.pi
-                    * R
-                    * (
-                        bspecial.i0(y) * bspecial.k1(y)
-                        - bspecial.i1(y) * bspecial.k0(y)
-                    )
-                )
+            # In-plane closed form vs. the Gauss-Legendre integral: xp.where,
+            # not a python `if`, so this traces. Both branches run eagerly, so
+            # each gets a dead-side guard (Bessel at R=0, integrand at z=0).
+            inplane = xp.abs(z) < 10.0**-6.0
+            R_safe = xp.where(inplane, R, xp.ones_like(R * 1.0))
+            z_safe = xp.where(inplane, xp.ones_like(z * 1.0), z)
+            y = 0.5 * self._alpha * R_safe
+            inplane_val = (
+                -math.pi
+                * R_safe
+                * (bspecial.i0(y) * bspecial.k1(y) - bspecial.i1(y) * bspecial.k0(y))
+            )
             kalphamax = 10.0
             # ks/weights are built from the float64 Gauss-Legendre nodes; move
             # them onto the active backend/device anchored on the inputs so that
@@ -92,14 +94,16 @@ class RazorThinExponentialDiskPotential(Potential):
             # raises). xp.asarray on the numpy path is a no-op (byte-identical).
             ks = xp.asarray(kalphamax * 0.5 * (self._glx + 1.0))
             weights = xp.asarray(kalphamax * self._glw)
-            sqrtp = xp.sqrt(z**2.0 + (ks + R) ** 2.0)
-            sqrtm = xp.sqrt(z**2.0 + (ks - R) ** 2.0)
+            sqrtp = xp.sqrt(z_safe**2.0 + (ks + R) ** 2.0)
+            sqrtm = xp.sqrt(z_safe**2.0 + (ks - R) ** 2.0)
             evalInt = (
                 xp.arcsin(2.0 * ks / (sqrtp + sqrtm))
                 * ks
                 * bspecial.k0(self._alpha * ks)
             )
-            return -2.0 * self._alpha * xp.sum(weights * evalInt)
+            return xp.where(
+                inplane, inplane_val, -2.0 * self._alpha * xp.sum(weights * evalInt)
+            )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )
@@ -114,50 +118,53 @@ class RazorThinExponentialDiskPotential(Potential):
         glw = xp.asarray(self._glw)
         if self._new:
             # if R > 6.: return self._kp(R,z)
-            if xp.abs(z) < 10.0**-6.0:
-                y = 0.5 * self._alpha * R
-                return (
-                    -2.0
-                    * math.pi
-                    * y
-                    * (
-                        bspecial.i0(y) * bspecial.k0(y)
-                        - bspecial.i1(y) * bspecial.k1(y)
-                    )
-                )
+            # xp.where in place of the data-dependent `if`s: in-plane closed
+            # form (R_safe: Bessel diverges at R=0) vs the [0,R]+[R,10]
+            # quadrature (z_safe: its integrand is 0/0 at z=0 for k>R).
+            inplane = xp.abs(z) < 10.0**-6.0
+            R_safe = xp.where(inplane, R, xp.ones_like(R * 1.0))
+            z_safe = xp.where(inplane, xp.ones_like(z * 1.0), z)
+            y = 0.5 * self._alpha * R_safe
+            inplane_val = (
+                -2.0
+                * math.pi
+                * y
+                * (bspecial.i0(y) * bspecial.k0(y) - bspecial.i1(y) * bspecial.k1(y))
+            )
             kalphamax1 = R
             ks1 = kalphamax1 * 0.5 * (glx + 1.0)
             weights1 = kalphamax1 * glw
-            sqrtp = xp.sqrt(z**2.0 + (ks1 + R) ** 2.0)
-            sqrtm = xp.sqrt(z**2.0 + (ks1 - R) ** 2.0)
+            sqrtp = xp.sqrt(z_safe**2.0 + (ks1 + R) ** 2.0)
+            sqrtm = xp.sqrt(z_safe**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
                 ks1**2.0
                 * bspecial.k0(ks1 * self._alpha)
                 * ((ks1 + R) / sqrtp - (ks1 - R) / sqrtm)
-                / xp.sqrt(R**2.0 + z**2.0 - ks1**2.0 + sqrtp * sqrtm)
+                / xp.sqrt(R**2.0 + z_safe**2.0 - ks1**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
-            if R < 10.0:
-                kalphamax2 = 10.0
-                ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
-                weights2 = (kalphamax2 - kalphamax1) * glw
-                sqrtp = xp.sqrt(z**2.0 + (ks2 + R) ** 2.0)
-                sqrtm = xp.sqrt(z**2.0 + (ks2 - R) ** 2.0)
-                evalInt2 = (
-                    ks2**2.0
-                    * bspecial.k0(ks2 * self._alpha)
-                    * ((ks2 + R) / sqrtp - (ks2 - R) / sqrtm)
-                    / xp.sqrt(R**2.0 + z**2.0 - ks2**2.0 + sqrtp * sqrtm)
-                    / (sqrtp + sqrtm)
-                )
-                return (
-                    -2.0
-                    * math.sqrt(2.0)
-                    * self._alpha
-                    * xp.sum(weights1 * evalInt1 + weights2 * evalInt2)
-                )
-            else:
-                return -2.0 * math.sqrt(2.0) * self._alpha * xp.sum(weights1 * evalInt1)
+            # [R,10] panel: max(R,10) gives it zero width -- so exactly zero
+            # weights -- for R >= 10, replacing the old `if R < 10.`
+            kalphamax2 = xp.maximum(R, 10.0 * xp.ones_like(R * 1.0))
+            ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
+            weights2 = (kalphamax2 - kalphamax1) * glw
+            sqrtp = xp.sqrt(z_safe**2.0 + (ks2 + R) ** 2.0)
+            sqrtm = xp.sqrt(z_safe**2.0 + (ks2 - R) ** 2.0)
+            evalInt2 = (
+                ks2**2.0
+                * bspecial.k0(ks2 * self._alpha)
+                * ((ks2 + R) / sqrtp - (ks2 - R) / sqrtm)
+                / xp.sqrt(R**2.0 + z_safe**2.0 - ks2**2.0 + sqrtp * sqrtm)
+                / (sqrtp + sqrtm)
+            )
+            return xp.where(
+                inplane,
+                inplane_val,
+                -2.0
+                * math.sqrt(2.0)
+                * self._alpha
+                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2),
+            )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )
@@ -169,48 +176,44 @@ class RazorThinExponentialDiskPotential(Potential):
         glw = xp.asarray(self._glw)
         if self._new:
             # if R > 6.: return self._kp(R,z)
-            if xp.abs(z) < 10.0**-6.0:
-                return 0.0
+            # zforce = 0 in the plane, where the integrand has 1/|z| poles ->
+            # z_safe guards the eagerly-evaluated dead branch; max(R,10) empties
+            # the [R,10] panel for R >= 10 (the old `if R < 10.`).
+            inplane = xp.abs(z) < 10.0**-6.0
+            z_safe = xp.where(inplane, xp.ones_like(z * 1.0), z)
             kalphamax1 = R
             ks1 = kalphamax1 * 0.5 * (glx + 1.0)
             weights1 = kalphamax1 * glw
-            sqrtp = xp.sqrt(z**2.0 + (ks1 + R) ** 2.0)
-            sqrtm = xp.sqrt(z**2.0 + (ks1 - R) ** 2.0)
+            sqrtp = xp.sqrt(z_safe**2.0 + (ks1 + R) ** 2.0)
+            sqrtm = xp.sqrt(z_safe**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
                 ks1**2.0
                 * bspecial.k0(ks1 * self._alpha)
                 * (1.0 / sqrtp + 1.0 / sqrtm)
-                / xp.sqrt(R**2.0 + z**2.0 - ks1**2.0 + sqrtp * sqrtm)
+                / xp.sqrt(R**2.0 + z_safe**2.0 - ks1**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
-            if R < 10.0:
-                kalphamax2 = 10.0
-                ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
-                weights2 = (kalphamax2 - kalphamax1) * glw
-                sqrtp = xp.sqrt(z**2.0 + (ks2 + R) ** 2.0)
-                sqrtm = xp.sqrt(z**2.0 + (ks2 - R) ** 2.0)
-                evalInt2 = (
-                    ks2**2.0
-                    * bspecial.k0(ks2 * self._alpha)
-                    * (1.0 / sqrtp + 1.0 / sqrtm)
-                    / xp.sqrt(R**2.0 + z**2.0 - ks2**2.0 + sqrtp * sqrtm)
-                    / (sqrtp + sqrtm)
-                )
-                return (
-                    -z
-                    * 2.0
-                    * math.sqrt(2.0)
-                    * self._alpha
-                    * xp.sum(weights1 * evalInt1 + weights2 * evalInt2)
-                )
-            else:
-                return (
-                    -z
-                    * 2.0
-                    * math.sqrt(2.0)
-                    * self._alpha
-                    * xp.sum(weights1 * evalInt1)
-                )
+            kalphamax2 = xp.maximum(R, 10.0 * xp.ones_like(R * 1.0))
+            ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
+            weights2 = (kalphamax2 - kalphamax1) * glw
+            sqrtp = xp.sqrt(z_safe**2.0 + (ks2 + R) ** 2.0)
+            sqrtm = xp.sqrt(z_safe**2.0 + (ks2 - R) ** 2.0)
+            evalInt2 = (
+                ks2**2.0
+                * bspecial.k0(ks2 * self._alpha)
+                * (1.0 / sqrtp + 1.0 / sqrtm)
+                / xp.sqrt(R**2.0 + z_safe**2.0 - ks2**2.0 + sqrtp * sqrtm)
+                / (sqrtp + sqrtm)
+            )
+            return xp.where(
+                inplane,
+                xp.zeros_like(z * 1.0),
+                -z
+                * 2.0
+                * math.sqrt(2.0)
+                * self._alpha
+                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2),
+            )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
         )

--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -94,15 +94,25 @@ class RazorThinExponentialDiskPotential(Potential):
             # raises). xp.asarray on the numpy path is a no-op (byte-identical).
             ks = xp.asarray(kalphamax * 0.5 * (self._glx + 1.0))
             weights = xp.asarray(kalphamax * self._glw)
-            sqrtp = xp.sqrt(z_safe**2.0 + (ks + R) ** 2.0)
-            sqrtm = xp.sqrt(z_safe**2.0 + (ks - R) ** 2.0)
+            # The nodes broadcast on a NEW TRAILING axis and the quadrature
+            # reduces only that axis, so the coordinate shape is preserved.
+            # Reducing every axis instead collapses the DATA axis too and
+            # returns one Phi for every point -- silently, and galpy's Phi call
+            # IS vectorised (Orbit.E(ts) evaluates all times at once), so that
+            # is a wrong answer rather than an error.
+            Rb = xp.asarray(R)[..., None]
+            zb = xp.asarray(z_safe)[..., None]
+            sqrtp = xp.sqrt(zb**2.0 + (ks + Rb) ** 2.0)
+            sqrtm = xp.sqrt(zb**2.0 + (ks - Rb) ** 2.0)
             evalInt = (
                 xp.arcsin(2.0 * ks / (sqrtp + sqrtm))
                 * ks
                 * bspecial.k0(self._alpha * ks)
             )
             return xp.where(
-                inplane, inplane_val, -2.0 * self._alpha * xp.sum(weights * evalInt)
+                inplane,
+                inplane_val,
+                -2.0 * self._alpha * xp.sum(weights * evalInt, axis=-1),
             )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
@@ -131,30 +141,34 @@ class RazorThinExponentialDiskPotential(Potential):
                 * y
                 * (bspecial.i0(y) * bspecial.k0(y) - bspecial.i1(y) * bspecial.k1(y))
             )
-            kalphamax1 = R
+            # Nodes live on a NEW TRAILING axis and the quadrature reduces only
+            # that axis, so the coordinate shape is preserved (see _evaluate).
+            Rb = xp.asarray(R)[..., None]
+            zb = xp.asarray(z_safe)[..., None]
+            kalphamax1 = Rb
             ks1 = kalphamax1 * 0.5 * (glx + 1.0)
             weights1 = kalphamax1 * glw
-            sqrtp = xp.sqrt(z_safe**2.0 + (ks1 + R) ** 2.0)
-            sqrtm = xp.sqrt(z_safe**2.0 + (ks1 - R) ** 2.0)
+            sqrtp = xp.sqrt(zb**2.0 + (ks1 + Rb) ** 2.0)
+            sqrtm = xp.sqrt(zb**2.0 + (ks1 - Rb) ** 2.0)
             evalInt1 = (
                 ks1**2.0
                 * bspecial.k0(ks1 * self._alpha)
-                * ((ks1 + R) / sqrtp - (ks1 - R) / sqrtm)
-                / xp.sqrt(R**2.0 + z_safe**2.0 - ks1**2.0 + sqrtp * sqrtm)
+                * ((ks1 + Rb) / sqrtp - (ks1 - Rb) / sqrtm)
+                / xp.sqrt(Rb**2.0 + zb**2.0 - ks1**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
             # [R,10] panel: max(R,10) gives it zero width -- so exactly zero
             # weights -- for R >= 10, replacing the old `if R < 10.`
-            kalphamax2 = xp.maximum(R, 10.0 * xp.ones_like(R * 1.0))
+            kalphamax2 = xp.maximum(Rb, 10.0 * xp.ones_like(Rb * 1.0))
             ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
             weights2 = (kalphamax2 - kalphamax1) * glw
-            sqrtp = xp.sqrt(z_safe**2.0 + (ks2 + R) ** 2.0)
-            sqrtm = xp.sqrt(z_safe**2.0 + (ks2 - R) ** 2.0)
+            sqrtp = xp.sqrt(zb**2.0 + (ks2 + Rb) ** 2.0)
+            sqrtm = xp.sqrt(zb**2.0 + (ks2 - Rb) ** 2.0)
             evalInt2 = (
                 ks2**2.0
                 * bspecial.k0(ks2 * self._alpha)
-                * ((ks2 + R) / sqrtp - (ks2 - R) / sqrtm)
-                / xp.sqrt(R**2.0 + z_safe**2.0 - ks2**2.0 + sqrtp * sqrtm)
+                * ((ks2 + Rb) / sqrtp - (ks2 - Rb) / sqrtm)
+                / xp.sqrt(Rb**2.0 + zb**2.0 - ks2**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
             return xp.where(
@@ -163,7 +177,7 @@ class RazorThinExponentialDiskPotential(Potential):
                 -2.0
                 * math.sqrt(2.0)
                 * self._alpha
-                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2),
+                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2, axis=-1),
             )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"
@@ -181,28 +195,31 @@ class RazorThinExponentialDiskPotential(Potential):
             # the [R,10] panel for R >= 10 (the old `if R < 10.`).
             inplane = xp.abs(z) < 10.0**-6.0
             z_safe = xp.where(inplane, xp.ones_like(z * 1.0), z)
-            kalphamax1 = R
+            # Nodes on a NEW TRAILING axis, reduce only that axis (see _evaluate).
+            Rb = xp.asarray(R)[..., None]
+            zb = xp.asarray(z_safe)[..., None]
+            kalphamax1 = Rb
             ks1 = kalphamax1 * 0.5 * (glx + 1.0)
             weights1 = kalphamax1 * glw
-            sqrtp = xp.sqrt(z_safe**2.0 + (ks1 + R) ** 2.0)
-            sqrtm = xp.sqrt(z_safe**2.0 + (ks1 - R) ** 2.0)
+            sqrtp = xp.sqrt(zb**2.0 + (ks1 + Rb) ** 2.0)
+            sqrtm = xp.sqrt(zb**2.0 + (ks1 - Rb) ** 2.0)
             evalInt1 = (
                 ks1**2.0
                 * bspecial.k0(ks1 * self._alpha)
                 * (1.0 / sqrtp + 1.0 / sqrtm)
-                / xp.sqrt(R**2.0 + z_safe**2.0 - ks1**2.0 + sqrtp * sqrtm)
+                / xp.sqrt(Rb**2.0 + zb**2.0 - ks1**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
-            kalphamax2 = xp.maximum(R, 10.0 * xp.ones_like(R * 1.0))
+            kalphamax2 = xp.maximum(Rb, 10.0 * xp.ones_like(Rb * 1.0))
             ks2 = (kalphamax2 - kalphamax1) * 0.5 * (glx + 1.0) + kalphamax1
             weights2 = (kalphamax2 - kalphamax1) * glw
-            sqrtp = xp.sqrt(z_safe**2.0 + (ks2 + R) ** 2.0)
-            sqrtm = xp.sqrt(z_safe**2.0 + (ks2 - R) ** 2.0)
+            sqrtp = xp.sqrt(zb**2.0 + (ks2 + Rb) ** 2.0)
+            sqrtm = xp.sqrt(zb**2.0 + (ks2 - Rb) ** 2.0)
             evalInt2 = (
                 ks2**2.0
                 * bspecial.k0(ks2 * self._alpha)
                 * (1.0 / sqrtp + 1.0 / sqrtm)
-                / xp.sqrt(R**2.0 + z_safe**2.0 - ks2**2.0 + sqrtp * sqrtm)
+                / xp.sqrt(Rb**2.0 + zb**2.0 - ks2**2.0 + sqrtp * sqrtm)
                 / (sqrtp + sqrtm)
             )
             return xp.where(
@@ -212,7 +229,7 @@ class RazorThinExponentialDiskPotential(Potential):
                 * 2.0
                 * math.sqrt(2.0)
                 * self._alpha
-                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2),
+                * xp.sum(weights1 * evalInt1 + weights2 * evalInt2, axis=-1),
             )
         raise NotImplementedError(
             "Not new=True not implemented for RazorThinExponentialDiskPotential"

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -16,6 +16,7 @@ import numpy
 from scipy import special
 
 from ..backend import get_namespace
+from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
 from .EllipsoidalPotential import EllipsoidalPotential
 
@@ -137,13 +138,15 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
 
     def _psi(self, m):
         r"""\psi(m) = -\int_{m^2}^\infty d m'^2 \rho(m'^2)"""
+        # backend hyp2f1 (scipy on numpy, byte-identical): scipy.special.hyp2f1
+        # converts a traced/tensor m to numpy, which is not jit-traceable
         if self.twominusalpha == 0.0:
             return (
                 -2.0
                 * self.a**2
                 * (self.a / m) ** self.betaminusalpha
                 / self.betaminusalpha
-                * special.hyp2f1(
+                * _hyp2f1(
                     self.betaminusalpha,
                     self.betaminusalpha,
                     self.betaminusalpha + 1,
@@ -158,7 +161,7 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
                     self.psi_inf
                     - (m / self.a) ** self.twominusalpha
                     / self.twominusalpha
-                    * special.hyp2f1(
+                    * _hyp2f1(
                         self.twominusalpha,
                         self.betaminusalpha,
                         self.threeminusalpha,

--- a/tests/test_backend_disk.py
+++ b/tests/test_backend_disk.py
@@ -502,11 +502,13 @@ def test_doubleexp_grad_z_vs_finite_difference(backend_name):
 
 
 ###############################################################################
-# RazorThinExponentialDiskPotential: dedicated tests for the scalar-only
-# (the `if xp.abs(z) < 1e-6` / `if R < 10.` branches) Bessel-quadrature methods.
-# These exercise the jax/torch paths of the backend special router (i0/i1/k0/k1)
-# and, in _R2deriv at z==0, the I_2 = I_0 - (2/y) I_1 recurrence (_iv2) that
-# replaces scipy.special.iv on the traced backends.
+# RazorThinExponentialDiskPotential: dedicated tests for the scalar
+# Bessel-quadrature methods. The in-plane closed form vs. the two-panel
+# quadrature (was `if xp.abs(z) < 1e-6`) and the empty second panel at R >= 10
+# (was `if R < 10.`) are now xp.where / xp.maximum selections, so these methods
+# trace. The tests exercise the jax/torch paths of the backend special router
+# (i0/i1/k0/k1) and, in _R2deriv at z==0, the I_2 = I_0 - (2/y) I_1 recurrence
+# (_iv2) that replaces scipy.special.iv on the traced backends.
 ###############################################################################
 _RAZOR = RazorThinExponentialDiskPotential(amp=1.0, hr=0.4)
 # Points cover: z==0 (the closed-form Bessel branch), z!=0 with R<10 (the
@@ -554,6 +556,30 @@ def test_razorthin_R2deriv_iv2_recurrence(backend_name):
             rtol=1e-10,
             atol=1e-13,
             err_msg=f"RazorThin._R2deriv at R={R0} ({backend_name})",
+        )
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+@pytest.mark.parametrize("method", ["__call__", "Rforce", "zforce"])
+def test_razorthin_public_methods_jit_traceable(method):
+    # The public potential / Rforce / zforce entry points trace under jax.jit:
+    # they used to hit `if xp.abs(z) < 1e-6` (and `if R < 10.`) on a traced
+    # value -> TracerBoolConversionError. jit must reproduce the eager value at
+    # every point: both sides of the |z| < 1e-6 cut and R >= 10, where the
+    # [R, 10] quadrature panel collapses to zero width.
+    def call(R, z):
+        return _RAZOR(R, z) if method == "__call__" else getattr(_RAZOR, method)(R, z)
+
+    jitted = jax.jit(call)
+    for R0, z0 in _RAZOR_ZERO_POINTS + _RAZOR_ZNZ_POINTS + [(1.3, 1e-9), (12.0, 0.0)]:
+        got = float(jitted(jnp.asarray(R0), jnp.asarray(z0)))
+        ref = float(call(R0, z0))
+        numpy.testing.assert_allclose(
+            got,
+            ref,
+            rtol=1e-11,
+            atol=1e-14,
+            err_msg=f"jit RazorThin.{method} at (R,z)=({R0},{z0})",
         )
 
 

--- a/tests/test_backend_disk.py
+++ b/tests/test_backend_disk.py
@@ -598,3 +598,47 @@ def test_razorthin_evaluate_grad_identity(backend_name):
             rtol=1e-7,
             err_msg=f"RazorThin AD(_evaluate)==-_Rforce at R={R0} ({backend_name})",
         )
+
+
+@pytest.mark.parametrize("method", ["_evaluate", "_Rforce", "_zforce"])
+def test_razorthin_vectorised_equals_elementwise(method):
+    # RazorThin's quadrature broadcasts its Gauss-Legendre nodes against the
+    # coordinates, so the reduction MUST name the node axis: xp.sum(...) without
+    # axis=-1 also collapses the DATA axis and returns one value for every
+    # point. That is silent -- and galpy's Phi call IS vectorised (Orbit.E(ts)
+    # evaluates all times at once), so it corrupts energies rather than raising.
+    # Regression for the #1201 energy-conservation failure.
+    pot = RazorThinExponentialDiskPotential(amp=1.0, hr=0.4)
+    f = getattr(pot, method)
+    # spans both branch boundaries: |z|<1e-6 (in-plane closed form) and the
+    # R=10 quadrature-panel split.
+    pts = [
+        (0.8, 0.1),
+        (1.0, 0.3),
+        (1.5, -0.2),
+        (2.0, 0.05),
+        (5.0, 1.0),
+        (9.99, 0.2),
+        (10.5, 0.7),
+        (149.0, 0.4),
+        (1.0, 0.0),
+    ]
+    elementwise = numpy.array([float(f(R, z)) for R, z in pts])
+    # the (N,1) shape galpy itself passes when evaluating along an orbit
+    R2 = numpy.array([[p[0]] for p in pts])
+    z2 = numpy.array([[p[1]] for p in pts])
+    vec2 = numpy.asarray(f(R2, z2))
+    assert vec2.shape == (len(pts), 1), (
+        f"{method}: vectorised call collapsed the data axis -> {vec2.shape}"
+    )
+    numpy.testing.assert_array_equal(
+        numpy.ravel(vec2),
+        elementwise,
+        err_msg=f"{method}: (N,1) result differs from per-point evaluation",
+    )
+    # and plain 1-D
+    vec1 = numpy.asarray(
+        f(numpy.array([p[0] for p in pts]), numpy.array([p[1] for p in pts]))
+    )
+    assert vec1.shape == (len(pts),), f"{method}: 1-D shape {vec1.shape}"
+    numpy.testing.assert_array_equal(vec1, elementwise, err_msg=f"{method}: 1-D")

--- a/tests/test_backend_dtype_policy.py
+++ b/tests/test_backend_dtype_policy.py
@@ -194,14 +194,11 @@ def _make_registry():
         ),
         ("TriaxialJaffe", TriaxialJaffePotential(amp=1.3, a=1.5, b=0.9, c=0.7)),
         ("TriaxialNFW", TriaxialNFWPotential(amp=1.3, a=1.5, b=0.9, c=0.7)),
-        # _evaluate deferred (hyp2f1); the forces are migrated
         (
             "TwoPowerTriaxial-generic",
             TwoPowerTriaxialPotential(
                 amp=1.3, a=1.5, alpha=1.5, beta=3.5, b=0.9, c=0.7
             ),
-            "3d",
-            ("_Rforce",),
         ),
         # --- halo / bar / non-axisymmetric family -----------------------------
         ("LogarithmicHalo", LogarithmicHaloPotential(amp=1.3, q=0.8, core=0.1)),

--- a/tests/test_backend_ellipsoidal.py
+++ b/tests/test_backend_ellipsoidal.py
@@ -13,9 +13,9 @@
 # Scope notes (see the module docstrings / the PR's deferred list):
 #   * The Gauss-Legendre quadrature path (glorder set, the default) is migrated;
 #     the scipy.integrate fallback (glorder=None) is deferred (Pspecial PR).
-#   * TwoPowerTriaxialPotential._evaluate uses scipy.special.hyp2f1 in _psi and
-#     is therefore NOT migrated (its forces/2nd-derivs/dens, which only use the
-#     pure-arithmetic _mdens, ARE migrated).
+#   * TwoPowerTriaxialPotential._psi routes through the backend hyp2f1 (scipy on
+#     numpy, pure-backend fallback on jax/torch), so its _evaluate is migrated
+#     too; the fallback puts it ~1e-13 (not machine precision) from scipy.
 #   * The rotated (zvec/pa) compute path -- _rotate_to_aligned /
 #     _rotate_force_back applied to forces, density, and the potential -- is
 #     backend-agnostic and is exercised here with explicit rotated instances.
@@ -79,8 +79,8 @@ COMMON_METHODS = [
     "_phizderiv",
     "_dens",
 ]
-# _evaluate is migrated for every subclass whose _psi is namespace-clean; it is
-# deferred for TwoPowerTriaxialPotential (psi uses scipy.special.hyp2f1).
+# _evaluate is migrated for every subclass in this family (every _psi is either
+# namespace-clean or routes through the backend special router).
 EVAL = ["_evaluate"]
 
 # (name, instance, methods); aligned (default) instances exercise the migrated
@@ -92,11 +92,16 @@ _CASES = [
     ("Hernquist", TriaxialHernquistPotential(amp=1.3, a=1.5, b=0.9, c=0.7), EVAL),
     ("Jaffe", TriaxialJaffePotential(amp=1.3, a=1.5, b=0.9, c=0.7), EVAL),
     ("NFW", TriaxialNFWPotential(amp=1.3, a=1.5, b=0.9, c=0.7), EVAL),
-    # TwoPower: _evaluate deferred (hyp2f1), but forces/2nd-derivs/dens migrated.
     (
         "TwoPower",
         TwoPowerTriaxialPotential(amp=1.3, a=1.5, alpha=1.5, beta=3.5, b=0.9, c=0.7),
-        [],
+        EVAL,
+    ),
+    # alpha=2 takes _psi's other (twominusalpha == 0) hyp2f1 branch.
+    (
+        "TwoPower-alpha2",
+        TwoPowerTriaxialPotential(amp=1.3, a=1.5, alpha=2.0, beta=4.0, b=0.9, c=0.7),
+        EVAL,
     ),
 ]
 
@@ -104,7 +109,7 @@ _CASES = [
 # _rotate_force_back) is backend-agnostic; a prior review flagged it had no
 # coverage. Only the forces, density, and (where migrated) potential are defined
 # for rotated frames -- the 2nd derivatives raise NotImplementedError -- so the
-# rotated cases use a reduced method list. TwoPower's _evaluate stays deferred.
+# rotated cases use a reduced method list.
 _ROT_KW = dict(zvec=[0.0, 1.0, 1.0], pa=0.3)
 _ROT_METHODS = ["_Rforce", "_zforce", "_phitorque", "_dens"]
 _ROT_CASES = [
@@ -143,7 +148,7 @@ _ROT_CASES = [
         TwoPowerTriaxialPotential(
             amp=1.3, a=1.5, alpha=1.5, beta=3.5, b=0.9, c=0.7, **_ROT_KW
         ),
-        [],
+        EVAL,
     ),
 ]
 
@@ -204,7 +209,15 @@ def test_value_parity(backend_name, pot, method):
             _asarray(backend_name, _PHIS),
         )
     )
-    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-14)
+    # TwoPower's _evaluate goes through the hyp2f1 router -- scipy on numpy, the
+    # pure-backend fallback on jax/torch -- which agrees to ~1e-13, not to
+    # machine precision like the elementary-function _psi of the others.
+    rtol = (
+        1e-11
+        if method == "_evaluate" and isinstance(pot, TwoPowerTriaxialPotential)
+        else 1e-12
+    )
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-14)
 
 
 # --- exact analytic-identity gradient checks ----------------------------------
@@ -274,15 +287,14 @@ def _method_migrated(name, eval_migrated):
 
     Forces, 2nd derivatives, and density depend only on the pure-arithmetic
     _mdens/_mdens_deriv and are migrated for every potential here; _evaluate is
-    deferred for potentials whose _psi uses scipy.special (TwoPower)."""
+    migrated wherever the potential's _psi is (all of them, currently)."""
     if name == "_evaluate":
         return eval_migrated
     return name in COMMON_METHODS
 
 
 # Build (pot, lower, var, higher) params for every identity pair whose BOTH
-# methods are migrated for that (aligned) potential. TwoPower keeps the six
-# force/2nd-deriv pairs but drops the three _evaluate pairs (psi uses hyp2f1).
+# methods are migrated for that (aligned) potential.
 _IDENTITY_PARAMS = []
 for _name, _pot, _eval in _CASES:
     _eval_migrated = _eval == EVAL
@@ -311,6 +323,38 @@ def test_force_and_hessian_identities(backend_name, pot, lower, var, higher):
         )
     )
     numpy.testing.assert_allclose(ad, ref, rtol=1e-9)
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+@pytest.mark.parametrize(
+    "pot",
+    [
+        pytest.param(
+            TwoPowerTriaxialPotential(
+                amp=1.3, a=1.5, alpha=1.5, beta=3.5, b=0.9, c=0.7
+            ),
+            id="TwoPower",
+        ),
+        pytest.param(
+            TwoPowerTriaxialPotential(
+                amp=1.3, a=1.5, alpha=2.0, beta=4.0, b=0.9, c=0.7
+            ),
+            id="TwoPower-alpha2",
+        ),
+    ],
+)
+def test_twopower_public_call_jit_traceable(pot):
+    # The public potential evaluation traces under jax.jit now that _psi uses
+    # the backend hyp2f1 router: scipy.special.hyp2f1 called numpy.asarray() on
+    # the traced m -> TracerArrayConversionError. Both _psi branches are probed
+    # (alpha=2 is the twominusalpha == 0 one), and jit must match eager.
+    jitted = jax.jit(lambda R, z, phi: pot(R, z, phi))
+    for R0, z0, phi0 in [(1.3, 0.4, 0.5), (0.4, -0.7, 0.0), (3.0, 0.0, 1.2)]:
+        got = float(jitted(jnp.asarray(R0), jnp.asarray(z0), jnp.asarray(phi0)))
+        ref = float(pot(jnp.asarray(R0), jnp.asarray(z0), jnp.asarray(phi0)))
+        numpy.testing.assert_allclose(
+            got, ref, rtol=1e-13, err_msg=f"jit TwoPower at ({R0},{z0},{phi0})"
+        )
 
 
 @pytest.mark.parametrize("pot", _MASS_POTS)

--- a/tests/test_backend_potential_diff.py
+++ b/tests/test_backend_potential_diff.py
@@ -30,9 +30,12 @@
 # limitations (some potentials reject array inputs on numpy too) that are
 # orthogonal to backend trace-safety. It uses jax.jacfwd (not jax.jit) on the
 # jax side: jacfwd/torch-autograd operate on concrete primals, so a
-# differentiable-but-not-jit-compilable potential (data-dependent branch, e.g.
-# RazorThinExponentialDisk) is correctly NOT counted as a gap -- the target
-# class here is raw-numpy potentials that cannot be traced at all.
+# differentiable-but-not-jit-compilable potential (one whose python branch is
+# taken on a concrete value) is correctly NOT counted as a gap -- the target
+# class here is raw-numpy potentials that cannot be traced at all. Those
+# remaining `if <traced>` branches are fixed one family at a time (the
+# RazorThinExponentialDisk in-plane/panel selections became xp.where/xp.maximum;
+# the jax.jit coverage lives in that potential's own backend test module).
 #
 # Backends that are not installed self-skip, so this is green on numpy alone.
 ###############################################################################

--- a/tests/test_backend_potential_jit.py
+++ b/tests/test_backend_potential_jit.py
@@ -95,12 +95,14 @@ _ENTRY = {
 # (potential, entry, backend) that cannot be traced yet, with the failure mode.
 # Shrink this list; do not grow it without a stated reason.
 _NOT_TRACEABLE = {
-    # Data-dependent Python branch on a traced value (TracerBoolConversionError).
-    ("RazorThinExponentialDiskPotential", "__call__", "jax"),
-    ("RazorThinExponentialDiskPotential", "Rforce", "jax"),
-    ("RazorThinExponentialDiskPotential", "zforce", "jax"),
-    # numpy conversion of a traced array (TracerArrayConversionError).
-    ("TwoPowerTriaxialPotential", "__call__", "jax"),
+    # Same root cause as the TwoPowerSpherical entry below, and newly EXPOSED
+    # (not caused) by routing _psi through the backend hyp2f1: scipy's hyp2f1
+    # converts a traced value to numpy, so the backend router is required for
+    # jax -- and under inductor that router's own xp.where evaluates a singular
+    # dead side, giving inf where eager is finite. Fixing the router's
+    # dead-branch guards removes BOTH of these entries; tracked separately so
+    # this PR stays scoped to the two potentials.
+    ("TwoPowerTriaxialPotential", "__call__", "torch"),
     # Compiles, but returns inf where eager returns -0.1979: the compiled graph
     # evaluates the DEAD side of an xp.where (the alpha/beta special-case
     # branch), which is singular at these parameters. Same hazard as the


### PR DESCRIPTION
Four public potential entry points crashed the moment you traced them (they had only ever been exercised eagerly, which is the [documented blind spot](https://github.com/jobovy/galpy/blob/feat/backends/tests/test_backend_potential_diff.py) of the backend suite):

| entry point | error under `jax.jit` |
| --- | --- |
| `RazorThinExponentialDiskPotential.__call__` / `.Rforce` / `.zforce` | `TracerBoolConversionError` |
| `TwoPowerTriaxialPotential.__call__` | `TracerArrayConversionError` |

### Root cause

**RazorThin** — two python branches on traced values, in each of `_evaluate`, `_Rforce`, `_zforce`:

```python
if xp.abs(z) < 10.0**-6.0:      # in-plane closed form vs. the GL integral
...
if R < 10.0:                    # two quadrature panels [0,R]+[R,10] vs. one
```

**TwoPowerTriaxial** — `_psi` called `scipy.special.hyp2f1`, which runs `numpy.asarray()` on the traced `m` coming out of the `EllipsoidalPotential` GL integral (`_potInt`):

```python
* special.hyp2f1(self.twominusalpha, self.betaminusalpha, self.threeminusalpha, -m / self.a)
```

(`.dens` still raises `PotentialError` by design, and `_R2deriv` still raises for `z != 0`, so those keep their `if`.)

### Fix (backend-agnostic — no jax-specific paths)

* The in-plane selection becomes `xp.where`. The eager `xp.where` evaluates **both** branches, so each dead side is guarded: `R_safe` keeps the Bessel closed form finite at `R=0` (`k0(0)=inf`), and `z_safe` keeps the quadrature off the `z=0` plane, where its integrand is genuinely singular — `sqrt(R²+z²-k²+sqrtp·sqrtm) → 0` with a vanishing numerator in `_Rforce` (0/0), and `1/sqrtm = 1/|z| → inf` in `_zforce`. Without the guards the numpy path would start emitting NaNs/warnings for in-plane calls it previously never made, and reverse-mode gradients would be NaN-poisoned.
* The one-panel/two-panel split becomes `kalphamax2 = xp.maximum(R, 10.0)`: for `R >= 10` the `[R,10]` panel gets exactly zero width, hence exactly zero Gauss-Legendre weights, so `sum(w1*e1 + w2*e2)` reproduces the old `sum(w1*e1)` bit for bit (the integrand at the collapsed nodes stays finite thanks to `z_safe`).
* `TwoPowerTriaxialPotential._psi` uses `galpy.backend.special.hyp2f1`, exactly as `TwoPowerSphericalPotential` already does: `scipy.special.hyp2f1` on numpy (byte-identical), the pure-backend fallback on jax/torch (jax's native `hyp2f1` stays blocked by `_NATIVE_UNRELIABLE`). `_mass` keeps its scipy `hyp2f1` (unchanged, still numpy-only).

### numpy byte-identity

sha256 over float64 value dumps, pristine `origin/feat/backends` vs. this branch:

| grid | sha256 | n |
| --- | --- | --- |
| task grid (`{Razor,TwoPowerTriaxial}` × `__call__/Rforce/zforce` × R × z) | `4b5df5fe1be1d9745b3bad2368499092b8a5db85c318d27a84cdcb0ac9488b9c` | 96 |
| extended (2 Razor instances × R incl. 9.9999/10.0/10.0000001/12/50 × z incl. ±1e-5/±1e-6/±1e-7/0/1e-9 × `__call__/Rforce/zforce/R2deriv/surfdens/mass`; 4 TwoPowerTriaxial instances incl. `alpha=2` (the `twominusalpha == 0` `_psi` branch) and `glorder=None`, × `__call__/Rforce/zforce/dens/mass`) | `5db7f7e360e6fe18763d02f457050dd5e97ad079c65d3f4d643c1fbfebc7b80f` | 1410 |

Identical on both sides. The extended harness runs under `warnings.simplefilter("error")`, so the newly-always-evaluated dead branches provably emit no new numpy RuntimeWarning.

### Validation

* All four entry points now trace: `jax.jit` value == eager value to 0–7e-16, and == the numpy value to ≤1.4e-13 (TwoPowerTriaxial's residual is the hyp2f1 fallback vs. scipy, not the numpy path). Probed at `(1.1,0.2)`, `(0.4,-0.7)`, `(12,0.3)` (R≥10 panel), `(2,0)` and `(1.1,1e-9)` (in-plane).
* `jax.grad` through `jax.jit` matches central FD for all four (no NaNs — the dead-side guards hold); torch eager + `torch.autograd` likewise. `torch.compile` fails identically on this branch and on the pristine base (`InternalTorchDynamoError: Cannot interpret 'torch.float64' as a data type`, from `array_api_compat`), i.e. unchanged.
* `tests/test_potential.py -n 8`: numpy 1217 passed / 103 skipped; `--backend jax` 1201 passed / 119 skipped (pytest exit 0); `--backend torch` pytest exit 0. 0 failures each.
* `tests/test_backend*.py -n 8`: 0 failures.
* `tests/test_quantity.py`: unchanged vs. base (the same 4 pre-existing `streamgapdf` errors on both).
* Flip check: with the new/updated test files dropped onto a **pristine** `origin/feat/backends` checkout, the 5 new jit tests and the 14 newly-enabled TwoPowerTriaxial `_evaluate` params all fail (`TracerBoolConversionError` at `RazorThinExponentialDiskPotential.py:172`, `TracerArrayConversionError` for TwoPower) — so they really do guard this fix.

### Test changes

* `test_backend_ellipsoidal.py`: TwoPowerTriaxial's `_evaluate` is no longer deferred — it now gets the family value-parity check (aligned + rotated, plus a new `alpha=2` instance for `_psi`'s other branch) and the three `AD(_evaluate) == -force` identities (they hold to ~1e-14, well inside the module's 1e-9). Parity for that one method uses rtol 1e-11 because the jax/torch hyp2f1 fallback lands ~1e-13 from scipy rather than at machine precision.
* `test_backend_dtype_policy.py`: TwoPowerTriaxial's registry entry no longer restricts the gate methods to `_Rforce`.
* New `jax.jit`-vs-eager tests for all four entry points, in the potentials' own backend modules.
