### PR TITLE
backend: trace mode -- run the ENTIRE test suite under jax.jit / torch.compile (--jit)

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -19,6 +19,7 @@ from ._coerce import (
 )
 from ._compat import is_backend_compatible
 from ._input import backend_input
+from ._jit import jit, jit_mode, set_jit
 from ._namespaces import (
     as_numpy,
     asarray_on_device,
@@ -44,6 +45,9 @@ _seed_from_config()
 __all__ = [
     "autodiff_ops",
     "backend_input",
+    "jit",
+    "jit_mode",
+    "set_jit",
     "get_namespace",
     "backend",
     "use",

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -40,6 +40,7 @@ import numpy
 
 from ._coerce import coerce_coords
 from ._compat import is_backend_compatible
+from ._jit import NOT_TRACED, traced_call
 from ._namespaces import is_backend_array
 from ._resolver import get_namespace
 
@@ -189,6 +190,12 @@ def backend_input(*coords):
                 for c, ii, dflt in defaults:
                     if ii >= nargs and c not in kwargs:
                         kwargs[c] = _coerce_one(xp, dflt)
+                # Under an opt-in trace mode this boundary is also where the
+                # jit/compile happens: the declared coordinates are the traced
+                # arguments and everything else is static. Off by default.
+                out = traced_call(method, args, kwargs, slots, nargs)
+                if out is not NOT_TRACED:
+                    return out
             return method(*args, **kwargs)
 
         return wrapper

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -69,12 +69,43 @@ def jit(mode):
         _JIT_CTX.reset(token)
 
 
+def _scalar_or_none(val):
+    """``val`` as a float if it is a scalar parameter, else None."""
+    if isinstance(val, bool) or isinstance(val, (int, float)):
+        return float(val)
+    if getattr(val, "ndim", None) == 0 and getattr(val, "dtype", None) is not None:
+        try:
+            return float(val)
+        except (TypeError, ValueError):  # pragma: no cover - exotic 0-d dtype
+            return None
+    return None
+
+
+def _object_key(obj):
+    """Identity PLUS the object's scalar parameters.
+
+    Identity alone is wrong. A traced function reads ``self._amp`` at trace time,
+    so its value is baked into the trace as a constant; ``pot.normalize(0.5)``
+    then mutates ``_amp`` without changing the cache key and the next call
+    silently returns the PREVIOUS normalization's numbers. Mixing the scalar
+    attributes into the key retraces when a parameter changes. Array-valued
+    attributes (coefficient tables) are left on identity: they are big, and
+    galpy replaces rather than mutates them.
+    """
+    scalars = []
+    for name, attr in vars(obj).items():
+        as_float = _scalar_or_none(attr)
+        if as_float is not None:
+            scalars.append((name, as_float))
+    scalars.sort()
+    return (id(obj), tuple(scalars))
+
+
 def _static_key(val):
     """A hashable key standing in for a static argument.
 
     Unhashable static arguments are ordinary here -- a list of potentials is the
-    standard
-    way to pass a composite potential -- so fall back to identity for those. jax
+    standard way to pass a composite -- so fall back to identity for those. jax
     keeps its static arguments alive in the trace cache, so an id kept as a key
     cannot be recycled onto a different object while the entry is live.
     """
@@ -82,6 +113,8 @@ def _static_key(val):
         return (tuple, tuple(_static_key(v) for v in val))
     if isinstance(val, dict):
         return (dict, tuple((k, _static_key(v)) for k, v in sorted(val.items())))
+    if hasattr(val, "__dict__"):  # a potential/df/orbit: parameters can change
+        return _object_key(val)
     try:
         hash(val)
     except TypeError:

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -1,0 +1,188 @@
+###############################################################################
+#   galpy.backend._jit: opt-in trace mode for the boundary.
+#
+#   galpy never jits itself (see the no-internal-jit rule): the library is
+#   written to be jit-COMPATIBLE and the user decides when to trace. This module
+#   is how a user -- or the test suite -- says "trace it", once, globally:
+#
+#       galpy.backend.set_jit("jax")      # jax.jit every boundary call
+#       with galpy.backend.jit("torch"):  # torch.compile every boundary call
+#           ...
+#
+#   Every public entry point already carries ``@backend_input(*coords)``, which
+#   names its COORDINATES explicitly. That declaration is exactly the split
+#   ``jax.jit`` needs: coordinates are traced, and everything else (derivative
+#   orders, ``forceint``, integrator names, the potential itself) is static. So
+#   trace mode is a few lines at the same boundary rather than a jit annotation
+#   scattered over the library, and turning it off restores the eager path
+#   exactly.
+#
+#   OFF by default and a hard no-op on the numpy path, so nothing about the
+#   numpy behaviour changes.
+###############################################################################
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# "off" | "jax" | "torch". Process-wide, like the backend selection itself.
+_JIT_CTX = ContextVar("galpy_jit_mode", default="off")
+# Set while a traced call is on the stack. Entry points call each other
+# (Potential.__call__ -> evaluatePotentials -> ...), and re-tracing at every
+# nested boundary multiplies compile time for no benefit -- the outermost trace
+# already inlines the inner calls.
+_TRACING = ContextVar("galpy_jit_tracing", default=False)
+
+_VALID = ("off", "jax", "torch")
+
+
+def set_jit(mode):
+    """Trace every boundary call under the named framework ("jax"/"torch"/"off").
+
+    Parameters
+    ----------
+    mode : str
+        ``"jax"`` wraps each entry point in ``jax.jit``, ``"torch"`` in
+        ``torch.compile``, ``"off"`` (default) leaves galpy eager.
+
+    Notes
+    -----
+    - 2026-07-25 - Written - Bovy (UofT)
+    """
+    if mode not in _VALID:
+        raise ValueError(f"jit mode must be one of {_VALID}, not {mode!r}")
+    _JIT_CTX.set(mode)
+
+
+def jit_mode():
+    """Return the active trace mode ("off" when galpy is running eager)."""
+    return _JIT_CTX.get()
+
+
+@contextmanager
+def jit(mode):
+    """Context manager form of :func:`set_jit`."""
+    if mode not in _VALID:
+        raise ValueError(f"jit mode must be one of {_VALID}, not {mode!r}")
+    token = _JIT_CTX.set(mode)
+    try:
+        yield
+    finally:
+        _JIT_CTX.reset(token)
+
+
+def _static_key(val):
+    """A hashable key standing in for a static argument.
+
+    Unhashable static arguments are ordinary here -- a list of potentials is the
+    standard
+    way to pass a composite potential -- so fall back to identity for those. jax
+    keeps its static arguments alive in the trace cache, so an id kept as a key
+    cannot be recycled onto a different object while the entry is live.
+    """
+    if isinstance(val, (list, tuple)):
+        return (tuple, tuple(_static_key(v) for v in val))
+    if isinstance(val, dict):
+        return (dict, tuple((k, _static_key(v)) for k, v in sorted(val.items())))
+    try:
+        hash(val)
+    except TypeError:
+        return (id, id(val))
+    return (type(val), val)
+
+
+class _StaticArgs:
+    """Carries the non-coordinate arguments through ``jax.jit`` as one static."""
+
+    __slots__ = ("value", "_key")
+
+    def __init__(self, value):
+        self.value = value
+        self._key = _static_key(value)
+
+    def __hash__(self):
+        return hash(self._key)
+
+    def __eq__(self, other):
+        return isinstance(other, _StaticArgs) and self._key == other._key
+
+
+_JITTED = {}
+
+
+def _jax_shim(method):
+    """``jax.jit``-ed shim taking (static bundle, *coords); built once per method."""
+    import jax
+
+    def shim(_static_args, *coord_vals):
+        args, kwargs, order = _static_args.value
+        args = list(args)
+        kwargs = dict(kwargs)
+        for (positional, key), val in zip(order, coord_vals):
+            if positional:
+                args[key] = val
+            else:
+                kwargs[key] = val
+        token = _TRACING.set(True)
+        try:
+            return method(*args, **kwargs)
+        finally:
+            _TRACING.reset(token)
+
+    return jax.jit(shim, static_argnums=(0,))
+
+
+def _torch_compiled(method):
+    """``torch.compile``-ed method. dynamo derives its own guards, so unlike jax
+    it needs no static/traced split -- the declaration is only used by jax."""
+    import torch
+
+    def call(*args, **kwargs):
+        token = _TRACING.set(True)
+        try:
+            return method(*args, **kwargs)
+        finally:
+            _TRACING.reset(token)
+
+    return torch.compile(call, fullgraph=False, dynamic=False)
+
+
+def traced_call(method, args, kwargs, slots, nargs):
+    """Run ``method`` under the active trace mode, or return ``NOT_TRACED``.
+
+    ``slots`` is ``@backend_input``'s precomputed (name, positional index) list:
+    those arguments are the traced coordinates and every other argument is
+    static.
+    """
+    mode = _JIT_CTX.get()
+    if mode == "off" or _TRACING.get():
+        return NOT_TRACED
+    if mode == "torch":
+        compiled = _JITTED.get((method, "torch"))
+        if compiled is None:
+            compiled = _JITTED[(method, "torch")] = _torch_compiled(method)
+        return compiled(*args, **kwargs)
+    # jax: split the call into traced coordinates and one static bundle.
+    args = list(args)
+    kwargs = dict(kwargs)
+    order, coord_vals = [], []
+    for name, index in slots:
+        if index is not None and index < nargs:
+            order.append((True, index))
+            coord_vals.append(args[index])
+            args[index] = None  # placeholder; the shim writes the tracer back
+        elif name in kwargs:
+            order.append((False, name))
+            coord_vals.append(kwargs.pop(name))
+    jitted = _JITTED.get((method, "jax"))
+    if jitted is None:
+        jitted = _JITTED[(method, "jax")] = _jax_shim(method)
+    return jitted(_StaticArgs((tuple(args), kwargs, tuple(order))), *coord_vals)
+
+
+class _NotTraced:
+    """Sentinel: trace mode is off (or we are already inside a trace)."""
+
+    __bool__ = staticmethod(lambda: False)
+    __repr__ = staticmethod(lambda: "NOT_TRACED")
+
+
+NOT_TRACED = _NotTraced()

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -276,3 +276,112 @@ jax tests/test_diskdf.py::test_dehnendf_sample_powerrise_returnROrbit
 # integrate). Already ledgered for torch.
 torch tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
 torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
+
+# --- jax-jit: the suite run TRACED (pytest --backend jax --jit) ---
+# Baseline for tests/test_potential.py, 2026-07-25: 100 of ~1300 tests fail
+# under jax.jit that pass eager, i.e. ~92% of the potential suite already runs
+# fully traced. They cluster by potential, not by test: RazorThinExponentialDisk
+# and TwoPowerTriaxial (data-dependent Python branch / numpy conversion of a
+# tracer -- the same two the boundary-jit file lists), and the
+# Multipole/SCF/interp families. Fixing those potentials clears most of this
+# list at once. Only reachable via workflow_dispatch(jit=true); shrink it.
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[SteadyLogSpiralPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[TransientLogSpiralPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[mockSteadyLogSpiralPotentialT1]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[mockSteadyLogSpiralPotentialTm1Omega0]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[mockSteadyLogSpiralPotentialTm1]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[mockSteadyLogSpiralPotentialTm5]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[mockTransientLogSpiralPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_2ndDeriv_potential[oblatenoGLNFWPotential]
+jax-jit tests/test_potential.py::test_Cautun20
+jax-jit tests/test_potential.py::test_DehnenBar_special
+jax-jit tests/test_potential.py::test_DehnenBinney98
+jax-jit tests/test_potential.py::test_DiskSCFPotential_againstDoubleExp
+jax-jit tests/test_potential.py::test_ExpDisk_special
+jax-jit tests/test_potential.py::test_ExpTruncNFW_smallr_series_c
+jax-jit tests/test_potential.py::test_InterpSnapshotRZPotential_pickling
+jax-jit tests/test_potential.py::test_McMillan17
+jax-jit tests/test_potential.py::test_TimeDependentAmplitudeWrapperPotential_against_DehnenSmooth_2d_dxdv
+jax-jit tests/test_potential.py::test_amp_mult_divide[HernquistTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[JaffeTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[NFWTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[fullyRotatednoGLTriaxialNFWPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[mockInterpSnapshotRZPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[mockTimeDependentMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[nonaxiDiskSCFPotential]
+jax-jit tests/test_potential.py::test_amp_mult_divide[oblatenoGLNFWPotential]
+jax-jit tests/test_potential.py::test_dehnen_bar_python_c_consistency
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[SteadyLogSpiralPotential]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[TransientLogSpiralPotential]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[mockSteadyLogSpiralPotentialT1]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[mockSteadyLogSpiralPotentialTm1Omega0]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[mockSteadyLogSpiralPotentialTm1]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[mockSteadyLogSpiralPotentialTm5]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[mockTransientLogSpiralPotential]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[nonaxiDiskSCFPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[HernquistTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[JaffeTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[NFWTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[fullyRotatednoGLTriaxialNFWPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[mockInterpSnapshotRZPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[nonaxiDiskSCFPotential]
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[oblatenoGLNFWPotential]
+jax-jit tests/test_potential.py::test_integration_RotateAndTiltWrapper
+jax-jit tests/test_potential.py::test_integration_RotateAndTiltWrapper_timedependent_forcecache
+jax-jit tests/test_potential.py::test_mass_spher_z
+jax-jit tests/test_potential.py::test_mass_spheroidal
+jax-jit tests/test_potential.py::test_normalize_potential[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_plotting
+jax-jit tests/test_potential.py::test_poisson_potential[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_poisson_potential[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[BurkertPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[FlattenedPowerPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[HernquistPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[IsochronePotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[JaffePotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[KeplerPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[KuzminDiskPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[NFWPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[PlummerPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[PowerSphericalPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[SphericalShellPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[testMWPotential]
+jax-jit tests/test_potential.py::test_potential_array_input[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_potential_at_infinity[AnyAxisymmetricRazorThinDiskPotential]
+jax-jit tests/test_potential.py::test_potential_at_infinity[mockMultipoleExpansionAxiPotential]
+jax-jit tests/test_potential.py::test_potential_at_infinity[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_potential_at_infinity[nonaxiDiskSCFPotential]
+jax-jit tests/test_potential.py::test_potential_at_infinity[oblatenoGLNFWPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[AnyAxisymmetricRazorThinDiskPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[HernquistTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[NFWTwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[fullyRotatednoGLTriaxialNFWPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[mockInterpSnapshotRZPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[nonaxiDiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[nonaxiDiskSCFPotential]
+jax-jit tests/test_potential.py::test_potential_at_zero[oblatenoGLNFWPotential]
+jax-jit tests/test_potential.py::test_rE_powervc
+jax-jit tests/test_potential.py::test_toVertical_array[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_toVertical_toPlanar[DiskMultipoleExpansionPotential]
+jax-jit tests/test_potential.py::test_toVertical_toPlanar[RazorThinExponentialDiskPotential]
+jax-jit tests/test_potential.py::test_toVertical_toPlanar[TwoPowerTriaxialPotential]
+jax-jit tests/test_potential.py::test_vtermnegl_issue314

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,6 +349,13 @@ def pytest_sessionfinish(session, exitstatus):
     # Force-exit after everything is written; gated to jax/torch so the numpy suite
     # -- including the coverage job, which never passes --backend -- is untouched.
     forced = session.config.getoption("--backend") in ("jax", "torch")
+    # ... but never from an xdist WORKER: os._exit there kills the worker before
+    # it reports back, and the controller records "node down: Not properly
+    # terminated" and writes no junit -- losing the whole run's results at 99%.
+    # The hang this guards against is a single-process shutdown problem; under
+    # xdist the controller reaps the workers.
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        forced = False
     if forced:
         # Backstop: arm a daemon timer BEFORE the yield so we still force-exit even
         # if an inner sessionfinish hook (junit/terminal/plugin teardown) itself

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,14 @@ def _load_backend_skip(backend_name):
     return _load_backend_nodeids(_backend_skip_path(), backend_name)
 
 
+def _run_backend(config):
+    """Name the burndown lists are keyed by: "jax", or "jax-jit" when traced."""
+    name = config.getoption("--backend")
+    if name != "numpy" and config.getoption("--jit"):
+        return f"{name}-jit"
+    return name
+
+
 def pytest_addoption(parser):
     # Force a single array backend for the whole run (numpy|jax|torch). With
     # numpy (default) this is a no-op, so the existing suite is unchanged.
@@ -162,6 +170,16 @@ def pytest_addoption(parser):
         action="store",
         default="numpy",
         help="Array backend to force for the test run: numpy|jax|torch",
+    )
+    # Run the WHOLE suite traced: every galpy entry point is wrapped in jax.jit
+    # or torch.compile at the @backend_input boundary. The burndown lists are
+    # keyed "<backend>-jit", so eager and traced gaps are tracked separately.
+    parser.addoption(
+        "--jit",
+        action="store_true",
+        default=False,
+        help="Trace every galpy entry point with the --backend framework "
+        "(jax.jit / torch.compile)",
     )
 
 
@@ -208,7 +226,7 @@ def pytest_collection_modifyitems(config, items):
     everything not slow-skipped runs and its real outcome is recorded in
     pytest_sessionfinish.
     """
-    backend_name = config.getoption("--backend")
+    backend_name = _run_backend(config)
     if backend_name == "numpy":
         return
     # Slow-skip applies in all modes (incl. regen) so the unrunnable tests never
@@ -309,7 +327,7 @@ def pytest_sessionfinish(session, exitstatus):
     terminal summary have been written."""
     # --- regen dump (before the wrapped hooks; unchanged behavior) ---
     if os.environ.get(_REGEN_ENV) == "1":
-        backend_name = session.config.getoption("--backend")
+        backend_name = _run_backend(session.config)
         if backend_name != "numpy":
             failed = sorted(_REGEN_STORE["failed"])
             outfile = _regen_outfile()
@@ -362,6 +380,10 @@ def _galpy_force_backend(request):
         import torch
 
         torch.set_default_dtype(torch.float64)
+    if request.config.getoption("--jit"):
+        with backend.use(backend_name, force=True), backend.jit(backend_name):
+            yield
+        return
     with backend.use(backend_name, force=True):
         yield
 

--- a/tests/test_backend_jit_mode.py
+++ b/tests/test_backend_jit_mode.py
@@ -84,16 +84,22 @@ def test_jax_traced_matches_eager(entry):
 
 @pytest.mark.skipif("jax is None")
 def test_jax_traces_with_an_unhashable_static():
-    """A list of potentials is the ordinary way to pass a composite; it is a
-    static argument and unhashable, which plain jax.jit would reject."""
-    pots = [
-        MiyamotoNagaiPotential(normalize=1.0),
-        LogarithmicHaloPotential(normalize=1.0),
-    ]
+    """A composite potential is a STATIC argument and is unhashable, which
+    plain jax.jit rejects -- traced_call keys it structurally instead.
+
+    Built with ``+`` rather than as a list: both are unhashable, so either
+    exercises the same path, but passing a list is deprecated and the coverage
+    shard runs with -W error::DeprecationWarning.
+    """
+    pot = MiyamotoNagaiPotential(normalize=1.0) + LogarithmicHaloPotential(
+        normalize=1.0
+    )
+    with pytest.raises(TypeError):  # the premise: plain jax.jit could not key it
+        hash(pot)
     R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
-    eager = float(evaluateRforces(pots, R, z))
+    eager = float(evaluateRforces(pot, R, z))
     with gb.jit("jax"):
-        traced = float(evaluateRforces(pots, R, z))
+        traced = float(evaluateRforces(pot, R, z))
     numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)
 
 

--- a/tests/test_backend_jit_mode.py
+++ b/tests/test_backend_jit_mode.py
@@ -1,0 +1,162 @@
+###############################################################################
+# test_backend_jit_mode.py: the opt-in trace mode.
+#
+# galpy.backend.jit("jax"|"torch") traces every boundary call, so the WHOLE test
+# suite can be run jitted (pytest --backend jax --jit). These tests cover the
+# mode itself: that it is off by default, that it leaves the numpy path alone,
+# that traced results match eager, that the coordinate/static split follows the
+# @backend_input declaration, and that the cache does not recompile per call.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = pytest.mark.backend_managed
+
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+except ImportError:  # pragma: no cover
+    torch = None
+
+import galpy.backend as gb
+from galpy.potential import (
+    LogarithmicHaloPotential,
+    MiyamotoNagaiPotential,
+    evaluateRforces,
+)
+
+_R0, _Z0 = 1.1, 0.2
+
+
+def test_jit_mode_is_off_by_default():
+    assert gb.jit_mode() == "off"
+
+
+def test_jit_mode_context_restores():
+    with gb.jit("jax"):
+        assert gb.jit_mode() == "jax"
+    assert gb.jit_mode() == "off"
+
+
+def test_jit_mode_rejects_unknown_framework():
+    with pytest.raises(ValueError):
+        gb.set_jit("tensorflow")
+    with pytest.raises(ValueError):
+        with gb.jit("tensorflow"):  # pragma: no cover - never entered
+            pass
+
+
+def test_numpy_path_ignores_jit_mode():
+    """Trace mode must not touch the numpy path: same object type, same value."""
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    eager = pot.Rforce(_R0, _Z0)
+    with gb.jit("jax"):
+        traced = pot.Rforce(_R0, _Z0)
+    assert type(traced) is type(eager)
+    assert traced == eager
+
+
+@pytest.mark.skipif("jax is None")
+@pytest.mark.parametrize("entry", ["__call__", "Rforce", "zforce", "dens"])
+def test_jax_traced_matches_eager(entry):
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    call = {
+        "__call__": lambda p, R, z: p(R, z),
+        "Rforce": lambda p, R, z: p.Rforce(R, z),
+        "zforce": lambda p, R, z: p.zforce(R, z),
+        "dens": lambda p, R, z: p.dens(R, z),
+    }[entry]
+    R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
+    eager = float(call(pot, R, z))
+    with gb.jit("jax"):
+        traced = float(call(pot, R, z))
+    # XLA is free to reassociate, so this is a numerical match, not bit-identity.
+    numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.skipif("jax is None")
+def test_jax_traces_with_an_unhashable_static():
+    """A list of potentials is the ordinary way to pass a composite; it is a
+    static argument and unhashable, which plain jax.jit would reject."""
+    pots = [
+        MiyamotoNagaiPotential(normalize=1.0),
+        LogarithmicHaloPotential(normalize=1.0),
+    ]
+    R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
+    eager = float(evaluateRforces(pots, R, z))
+    with gb.jit("jax"):
+        traced = float(evaluateRforces(pots, R, z))
+    numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.skipif("jax is None")
+def test_jax_control_parameters_stay_static():
+    """dR/dphi are derivative ORDERS, not coordinates: traced as a value they
+    would be a tracer where the body does `if dR == 0`."""
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
+    eager = float(pot(R, z, dR=1))
+    with gb.jit("jax"):
+        traced = float(pot(R, z, dR=1))
+    numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.skipif("jax is None")
+def test_jax_reuses_the_compiled_trace():
+    """A second call with the same static bundle must hit the cache. Without a
+    value-based key on the static bundle every call would recompile."""
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
+    with gb.jit("jax"):
+        pot.Rforce(R, z)
+        before = jax.jit._cache_size() if hasattr(jax.jit, "_cache_size") else None
+        for _ in range(5):
+            pot.Rforce(R, z)
+        after = jax.jit._cache_size() if hasattr(jax.jit, "_cache_size") else None
+    if before is not None:  # pragma: no cover - jax version dependent
+        assert after == before
+
+
+@pytest.mark.skipif("jax is None")
+def test_jax_nested_boundaries_do_not_retrace():
+    """Entry points call each other; only the outermost may trace."""
+    from galpy.backend._jit import _TRACING
+
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    seen = []
+
+    R, z = jnp.asarray(_R0), jnp.asarray(_Z0)
+    original = pot._evaluate
+
+    def spy(*args, **kwargs):
+        seen.append(_TRACING.get())
+        return original(*args, **kwargs)
+
+    pot._evaluate = spy
+    try:
+        with gb.jit("jax"):
+            pot(R, z)
+    finally:
+        pot._evaluate = original
+    assert seen and all(seen), "inner boundaries must run inside the outer trace"
+
+
+@pytest.mark.skipif("torch is None")
+def test_torch_compiled_matches_eager():
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    R, z = torch.tensor(_R0), torch.tensor(_Z0)
+    eager = float(pot.Rforce(R, z))
+    try:
+        with gb.jit("torch"):
+            traced = float(pot.Rforce(R, z))
+    except Exception as exc:  # pragma: no cover - torch.compile unsupported here
+        pytest.skip(f"torch.compile unavailable: {type(exc).__name__}")
+    numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)

--- a/tests/test_backend_jit_mode.py
+++ b/tests/test_backend_jit_mode.py
@@ -182,3 +182,34 @@ def test_torch_compiled_matches_eager():
     except Exception as exc:  # pragma: no cover - torch.compile unsupported here
         pytest.skip(f"torch.compile unavailable: {type(exc).__name__}")
     numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=1e-14)
+
+
+def test_set_jit_switches_mode_without_the_context_manager():
+    # set_jit is public API (galpy.backend.set_jit): turn tracing on and off
+    # without `with`. The jit() context manager is sugar over it, so every other
+    # test here goes through the manager and never exercises the setter itself.
+    assert gb.jit_mode() == "off"
+    try:
+        gb.set_jit("jax")
+        assert gb.jit_mode() == "jax"
+        gb.set_jit("torch")
+        assert gb.jit_mode() == "torch"
+    finally:
+        gb.set_jit("off")
+    assert gb.jit_mode() == "off"
+
+
+def test_static_key_falls_back_to_identity_for_an_unhashable_without_dict():
+    # _static_key's last resort. A set is unhashable AND has no __dict__, so it
+    # misses the list/tuple/dict branches and _object_key alike -- identity is
+    # its only route. The semantics that matter: keyed by IDENTITY, not value,
+    # so two equal-but-distinct objects must not collide in the trace cache.
+    from galpy.backend._jit import _static_key
+
+    a, b = {1, 2}, {1, 2}
+    assert a == b, "the two objects are equal but distinct"
+    assert _static_key(a) == _static_key(a), "must be stable for one object"
+    assert _static_key(a) != _static_key(b), (
+        "equal-but-distinct unhashables must key differently -- sharing a key "
+        "would hand one object's compiled trace to the other"
+    )

--- a/tests/test_backend_jit_mode.py
+++ b/tests/test_backend_jit_mode.py
@@ -126,6 +126,22 @@ def test_jax_reuses_the_compiled_trace():
 
 
 @pytest.mark.skipif("jax is None")
+def test_jax_retraces_after_a_parameter_changes():
+    """A trace bakes self._amp in as a constant, so a cache keyed on the
+    potential's IDENTITY alone would keep returning the previous
+    normalization's numbers after normalize() -- silently wrong, not an error.
+    """
+    pot = MiyamotoNagaiPotential(normalize=1.0)
+    R, z = jnp.asarray(1.0), jnp.asarray(0.0)
+    with gb.jit("jax"):
+        first = float(pot.Rforce(R, z))
+        pot.normalize(0.5)
+        second = float(pot.Rforce(R, z))
+    numpy.testing.assert_allclose(first, -1.0, rtol=1e-10)
+    numpy.testing.assert_allclose(second, -0.5, rtol=1e-10)
+
+
+@pytest.mark.skipif("jax is None")
 def test_jax_nested_boundaries_do_not_retrace():
     """Entry points call each other; only the outermost may trace."""
     from galpy.backend._jit import _TRACING


### PR DESCRIPTION
Makes **the existing test suite** the jit/compile test suite. Not a new test file that checks a few things under `jax.jit` — a mode in which `test_potential.py`, `test_orbit.py`, `test_actionAngle.py` and the df tests all run with every galpy entry point traced.

```console
$ pytest tests/test_potential.py --backend jax --jit      # the whole file, traced
$ pytest tests/test_orbit.py --backend torch --jit        # ... under torch.compile
```

and the same thing as a user-facing mode:

```python
galpy.backend.set_jit("jax")            # or: with galpy.backend.jit("torch"):
```

## Why this is cheap

galpy still never jits itself — the no-internal-jit rule stands; this is how the *caller* says "trace it". The mechanism is the boundary decorator from #1196: `@backend_input("R", "z", "phi", "t")` already names each entry point's **coordinates** explicitly, and that declaration is exactly the split `jax.jit` needs — coordinates traced, everything else (`dR`/`dphi` derivative orders, `forceint`, integrator names, the potential itself) **static**. So trace mode is one hook at one boundary instead of jit annotations spread through the library, and turning it off restores the eager path exactly.

torch needs no such split — dynamo derives its own guards — so the declaration is only used by the jax path.

**Off by default, and a hard no-op when the resolved namespace is numpy.** Nothing about the numpy path changes.

## Where it stands

`tests/test_potential.py --backend jax --jit`: **1053 passed, 142 failed, 101 skipped — 88% of run tests pass fully traced**, before any burndown. `--backend torch --jit` on the MiyamotoNagai subset: 20/20. The `<backend>-jit` burndown lists are keyed separately from the eager ones, so the traced ledger shrinking is the metric for "all of galpy is jittable".

## Two bugs it found immediately

**A silent wrong-answer in the trace cache (mine).** `test_normalize_potential` returned `-0.304` where it wanted `-0.5`, with no error. A traced function reads `self._amp` at *trace* time, so the value is baked into the compiled trace as a constant; keying the cache on `id(pot)` alone made `pot.normalize(0.5)` invisible to the cache and the next call returned the **previous** normalization's numbers. Any post-trace parameter change had the same failure mode. The key now mixes in the object's scalar attributes; array-valued tables stay on identity (big to hash, and galpy replaces rather than mutates them). Normalize tests went from failing to 54 passed / 1 failed, the one remaining being the already-known `RazorThinExponentialDisk` jax gap.

**xdist workers force-exiting.** The forced-backend `os._exit` (which dodges a native-thread shutdown hang) also fired inside xdist workers, where it kills the worker before it reports: the controller logs `node down: Not properly terminated` and writes **no junit**, so a run that reached 99% produced nothing. Guarded to the single-process case. This is what makes a parallel backend/jit run usable at all.

## Details worth a reviewer's eye

- The static bundle is keyed structurally with an identity fallback, because a **list of potentials** — the ordinary way to write a composite — is unhashable and plain `jax.jit` rejects it outright. jax keeps static arguments alive in its cache, so an id used as a key cannot be recycled while the entry is live.
- A `_TRACING` flag stops nested boundaries from re-tracing what the outermost trace already inlines (entry points call each other constantly).
- `tests/test_backend_jit_mode.py` (14 tests): off by default, numpy untouched, traced == eager for `__call__`/`Rforce`/`zforce`/`dens`, the unhashable-static case, control params staying static, cache reuse, the retrace-after-parameter-change regression, no nested re-tracing, and torch.

## CI

`workflow_dispatch(jit=true)` on the all-backend workflow appends `--jit` to every shard. Dispatch-only on purpose: tracing costs roughly what eager jax already costs, and the eager jax matrix is already near its limits (`test_potential.py` is split into 5 groups at ~44 min each to stay under the 75-min session cap), so a third always-on axis does not fit the current runners. Scheduled once traced shard times are measured.

Stacked on #1199 (which carries the `_backend_dtype` fix torch.compile needs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
