### PR TITLE
ci: run the all-backend suite on feat/backends-develop + jit dispatch

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,6 +48,11 @@ on:
         type: boolean
         required: false
         default: false
+      jit:
+        description: 'Run the whole suite TRACED (jax.jit / torch.compile at every galpy entry point); burndown lists are keyed "<backend>-jit"'
+        type: boolean
+        required: false
+        default: false
 
 # The report job posts a sticky PR comment on pull_request runs.
 permissions:
@@ -278,6 +283,12 @@ jobs:
       env:
         TEST_FILES: ${{ matrix.TEST_FILES }}
         BACKEND: ${{ matrix.BACKEND }}
+        # workflow_dispatch(jit=true): trace every galpy entry point instead of
+        # running eager. Same shards, same ledger machinery -- conftest keys the
+        # burndown lists "<backend>-jit" so traced gaps stay separate from eager
+        # ones. Dispatch-only for now: tracing costs roughly what eager jax does
+        # again, and the eager jax matrix already sits near the session timeout.
+        JIT_FLAG: ${{ github.event.inputs.jit == 'true' && '--jit' || '' }}
       run: |
         # -rxX reports XFAIL/XPASS; junit xml drives the burndown summary and the
         # report job's per-file table. Do NOT pass -W error here: under a backend
@@ -313,7 +324,7 @@ jobs:
         # (xfail/xpass reporting via -rxX and pytest.warns are unaffected.)
         set -o pipefail
         eval "pytest -p no:cacheprovider -v $TEST_FILES \
-          --backend=$BACKEND \
+          --backend=$BACKEND ${JIT_FLAG} \
           --timeout=300 --timeout-method=signal --session-timeout=4500 \
           -rxX --junitxml=${JUNIT_PATH} \
           -p no:warnings" | tee backend-pytest.log || true

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -31,11 +31,18 @@ on:
   push:
     branches:
       - feat/backends
+      - feat/backends-develop
   pull_request:
-    # Only sub-PRs that TARGET the integration branch, so they get the full
+    # Only sub-PRs that TARGET an integration branch, so they get the full
     # per-file backend table before merge -- NOT every PR in the repo.
+    # feat/backends-develop is where the backend work now accumulates before
+    # being reviewed and rebased onto feat/backends; without it here a PR based
+    # there would run the numpy matrix and all-clear but NOT this suite, i.e.
+    # the jax/torch dimension would go unverified on exactly the branch whose
+    # whole purpose is that dimension.
     branches:
       - feat/backends
+      - feat/backends-develop
   schedule:
     - cron: '0 20 * * 2'
   # Manual trigger: run the full all-backend suite on demand and (optionally)
@@ -77,20 +84,28 @@ jobs:
   # GATED to run on push-to-feat/backends, the weekly schedule, a manual
   # workflow_dispatch, OR a pull_request whose BASE is feat/backends (so a sub-PR
   # into the integration branch gets the full per-file table before merge).
-  # Because the whole workflow only fires for feat/backends (push/PR branch
-  # filters above), it never runs on ordinary pushes/PRs elsewhere in the repo;
-  # the job-level `if` additionally pins the PR case to base==feat/backends.
+  # Because the whole workflow only fires for feat/backends and
+  # feat/backends-develop (push/PR branch filters above), it never runs on
+  # ordinary pushes/PRs elsewhere in the repo; the job-level `if` additionally
+  # pins the PR case to those two base branches.
   backend-suite:
     name: backend ${{ matrix.BACKEND }} ${{ matrix.TEST_FILES }}
     runs-on: ubuntu-latest
     # Backstop: even with the per-test --timeout below, cap the whole shard so a
     # pathological accumulation of slow tests can't keep the report job waiting.
-    timeout-minutes: 90
+    # 180, not 90, because a jit=true dispatch traces every entry point and costs
+    # roughly what eager jax does again; at 90 a traced shard is killed mid-run
+    # and reports as a red indistinguishable from a real failure.
+    timeout-minutes: 180
     if: |
       github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/feat/backends')
-      || (github.event_name == 'pull_request' && github.base_ref == 'feat/backends')
+      || (github.event_name == 'push'
+          && (github.ref == 'refs/heads/feat/backends'
+              || github.ref == 'refs/heads/feat/backends-develop'))
+      || (github.event_name == 'pull_request'
+          && (github.base_ref == 'feat/backends'
+              || github.base_ref == 'feat/backends-develop'))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Prerequisite for moving the backend work onto `feat/backends-develop`.

## Why

The backend work is moving to `feat/backends-develop`, which will accumulate
reviewed-later PRs before being rebased onto `feat/backends`. But this workflow
pinned `feat/backends` in **three** places, not one:

1. the `push` branch filter,
2. the `pull_request` branch filter,
3. the job-level `if` on `github.base_ref`.

Fixing only the trigger filters is a trap: the workflow would fire for a
develop PR, then skip every matrix job, so the PR goes **green having run zero
jax/torch jobs** — silently unverified on precisely the dimension that branch
exists to test. All three are updated together.

## Also here

- **`timeout-minutes` 90 → 180.** A `jit=true` dispatch traces every galpy entry
  point and costs roughly what eager jax costs again. At 90 a traced shard is
  killed mid-run and reports a red indistinguishable from a real failure.
- **`workflow_dispatch(jit=true)`** (cherry-picked from #1202, commit `90dbacaf`)
  — appends `--jit` so the whole suite runs under `jax.jit` / `torch.compile`,
  with burndown lists keyed `"<backend>-jit"`. Dispatch-only: tracing roughly
  doubles the eager cost and the eager jax matrix already sits near the session
  cap. #1202 drops this commit when it rebases.

## Verification

YAML parses; `push.branches` and `pull_request.branches` both list the two
branches; dispatch inputs are `['regen', 'jit']`; the `JIT_FLAG` env var and its
use in the pytest invocation both survived the cherry-pick; pre-commit
`check yaml` passes. No change to the numpy matrix, and no behaviour change for
`feat/backends` itself — every existing trigger and gate still matches exactly
as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
