### PR TITLE
hyp2f1 fallback: guard expm1 against inductor's fused-kernel cancellation (empties _NOT_TRACEABLE)

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -87,7 +87,15 @@ def hyp2f1_fallback(xp, a, b, c, z):
     L = xp.log1p(w_for_int)[..., None]  # (..., 1)
     wb = w_for_int[..., None]
     XL = X * L  # (..., N)
-    T = xp.expm1(XL) / wb
+    # T = expm1(XL)/|z|, but X = xi^k puts the first node at XL ~ 1e-49, where
+    # inductor's FUSED expm1 (its standalone one is exact) degenerates to
+    # exp(x)-1 and returns 0; T**(B-1) with B < 1 is then inf and poisons the
+    # quadrature at EVERY z. Factor out expm1(u)/u -> 1 and series it below the
+    # crossover instead, so nothing tiny ever reaches expm1.
+    small = XL < 1e-8
+    u_safe = xp.where(small, xp.ones_like(XL), XL)
+    ratio = xp.where(small, 1.0 + XL / 2.0 + XL**2.0 / 6.0, xp.expm1(u_safe) / u_safe)
+    T = XL * ratio / wb
     dt = xp.exp(XL) * L / wb
     integ = T ** (B - 1.0) * (1.0 - T) ** (q - 1.0) * (1.0 + wb * T) ** (-A) * dt * dX
     val_int = pref * xp.sum(integ * wg, axis=-1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,47 @@
+import atexit
 import os
+import shutil
 import signal
 import sys
+import tempfile
 import threading
 import time
 
 import numpy
 import pytest
+
+# torch.compile caches generated kernels on DISK, and that cache changes the
+# verdict of every test that compiles: with it warm, code that fails a cold
+# compile can pass, so consecutive runs disagree. Concurrent xdist workers also
+# collide in the shared directory, which surfaces as an InductorError wrapping
+# an ImportError on a half-written .so. Give every process -- and so every
+# worker, which imports this file itself -- a private, empty cache, so what is
+# measured is always the cold compile a user actually hits. Set here rather than
+# per test module because it must land before torch is imported ANYWHERE, and it
+# applies equally to the always-on jit shard and to `--backend torch --jit`.
+_inductor_cache = tempfile.mkdtemp(prefix="torchinductor_galpy_")
+os.environ["TORCHINDUCTOR_CACHE_DIR"] = _inductor_cache
+atexit.register(shutil.rmtree, _inductor_cache, True)
+
+
+def torch_compiles():
+    """Whether torch.compile actually WORKS on this interpreter.
+
+    dynamo trails the Python release and refuses to run on one it does not
+    support yet, so `import torch` succeeding does not imply that compiling
+    works, and CI runs the backend shards on 3.10 through 3.14. Probing is only
+    reliable this way. Deliberately a function, not a module-level constant, so
+    importing this conftest never drags torch into a numpy-only session.
+    """
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - torch not installed
+        return False
+    try:
+        torch.compile(lambda x: x + 1.0, fullgraph=True)(torch.tensor(1.0))
+        return True
+    except Exception:  # pragma: no cover - interpreter-dependent
+        return False
 
 
 def _to_numpy(x):

--- a/tests/test_backend_potential_jit.py
+++ b/tests/test_backend_potential_jit.py
@@ -21,26 +21,13 @@
 # Expect siblings here only if some other object type needs a comparable
 # fast always-on check of its own (test_backend_orbit_jit.py, ...).
 ###############################################################################
-import atexit
-import os
-import shutil
-import tempfile
-
 import numpy
 import pytest
 
 pytestmark = pytest.mark.backend_managed
 
-# torch.compile caches generated kernels on DISK, and that cache decides the
-# verdict here: with it warm, potentials that fail a cold compile can pass, so
-# the same code gives different burndown lists on consecutive runs. Concurrent
-# xdist workers additionally collide in the shared directory, which surfaces as
-# an InductorError wrapping an ImportError on a half-written .so. Give every run
-# -- and every worker -- a private, empty cache, so what is measured is always
-# the cold compile a user actually hits. Must be set before torch is imported.
-_cache_dir = tempfile.mkdtemp(prefix="torchinductor_galpy_")
-os.environ["TORCHINDUCTOR_CACHE_DIR"] = _cache_dir
-atexit.register(shutil.rmtree, _cache_dir, True)
+# NB: the private TORCHINDUCTOR_CACHE_DIR that makes every compile below a COLD
+# one is set in conftest.py, which pytest imports before this module.
 
 try:
     import jax
@@ -66,17 +53,9 @@ if torch is not None:
     torch._dynamo.config.cache_size_limit = 4096
     torch._dynamo.config.accumulated_cache_size_limit = 8192
 
-if torch is not None:  # pragma: no cover - depends on the interpreter version
-    # torch.compile trails the Python release (dynamo refuses to run on a Python
-    # it does not support yet), so probe the capability rather than assuming that
-    # `import torch` implies it. CI runs this shard on 3.10 through 3.14.
-    try:
-        torch.compile(lambda x: x + 1.0, fullgraph=True)(torch.tensor(1.0))
-        _TORCH_COMPILES = True
-    except Exception:
-        _TORCH_COMPILES = False
-else:  # pragma: no cover
-    _TORCH_COMPILES = False
+from conftest import torch_compiles
+
+_TORCH_COMPILES = torch_compiles()
 
 import galpy.potential as gp
 from galpy.potential import Potential
@@ -94,21 +73,10 @@ _ENTRY = {
 
 # (potential, entry, backend) that cannot be traced yet, with the failure mode.
 # Shrink this list; do not grow it without a stated reason.
-_NOT_TRACEABLE = {
-    # Same root cause as the TwoPowerSpherical entry below, and newly EXPOSED
-    # (not caused) by routing _psi through the backend hyp2f1: scipy's hyp2f1
-    # converts a traced value to numpy, so the backend router is required for
-    # jax -- and under inductor that router's own xp.where evaluates a singular
-    # dead side, giving inf where eager is finite. Fixing the router's
-    # dead-branch guards removes BOTH of these entries; tracked separately so
-    # this PR stays scoped to the two potentials.
-    ("TwoPowerTriaxialPotential", "__call__", "torch"),
-    # Compiles, but returns inf where eager returns -0.1979: the compiled graph
-    # evaluates the DEAD side of an xp.where (the alpha/beta special-case
-    # branch), which is singular at these parameters. Same hazard as the
-    # AD-NaN-poisoning one, surfacing through inductor instead of a gradient.
-    ("TwoPowerSphericalPotential", "__call__", "torch"),
-}
+# EMPTY: every default-constructible potential in the zoo now traces under both
+# jax.jit and torch.compile, on all four entry points. Keep it that way -- a new
+# entry here is a regression, not a TODO, unless it comes with a stated reason.
+_NOT_TRACEABLE = set()
 
 
 def _default_constructible():

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -11,6 +11,7 @@
 import numpy
 import pytest
 import scipy.special as scipy_special
+from conftest import torch_compiles
 
 from galpy.backend import as_numpy
 from galpy.backend import special as gsp
@@ -41,6 +42,7 @@ except ImportError:  # pragma: no cover
     torch = None
 
 AD_BACKENDS = [b for b in BACKENDS if b != "numpy"]
+_TORCH_COMPILES = torch_compiles()
 
 
 def _asarray(backend, x, requires_grad=False):
@@ -282,7 +284,10 @@ def test_hyp2f1_value_parity(backend, a, b, c):
     z = -_HYP2F1_W
     ref = scipy_special.hyp2f1(a, b, c, z)
     got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
-    rtol = 0.0 if backend == "numpy" else 1e-9  # fallback quadrature at r/a<~50
+    # numpy routes to scipy itself (exact); the jax/torch fallback quadrature
+    # measures 1.35e-14 worst-case over this grid, so 1e-12 keeps ~70x headroom
+    # for libm differences across platforms while still pinning real accuracy.
+    rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
 
 
@@ -295,6 +300,27 @@ def test_hyp2f1_extreme_z_bounded_error(backend, a, b, c):
     ref = scipy_special.hyp2f1(a, b, c, z)
     got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-8)
+
+
+@pytest.mark.skipif("'torch' not in BACKENDS or not _TORCH_COMPILES")
+@pytest.mark.parametrize("a,b,c", _HYP2F1_CASES, ids=[str(x) for x in _HYP2F1_CASES])
+def test_hyp2f1_survives_inductor_fusion(a, b, c):
+    # Regression: inductor's FUSED expm1 (unlike its standalone one, which is
+    # exact) degenerates to exp(x)-1 for tiny arguments and returns 0 there. The
+    # fallback's first quadrature node sits at XL ~ 1e-49, so T became 0, then
+    # T**(B-1) with B-1 < 0 became inf, and the whole quadrature was inf -- at
+    # EVERY z, not just extreme ones. That made TwoPowerSpherical/-Triaxial
+    # compile to inf while eager was correct, i.e. SILENTLY wrong output rather
+    # than an error. Compare compiled against scipy, not merely against eager,
+    # so a regression that breaks both paths at once still fails.
+    z = -_HYP2F1_W
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    compiled = torch.compile(
+        lambda zz: gsp.hyp2f1(a, b, c, zz), fullgraph=False, dynamic=False
+    )
+    got = as_numpy(compiled(_asarray("torch", z)))
+    assert numpy.all(numpy.isfinite(got)), "inductor reintroduced the inf blow-up"
+    numpy.testing.assert_allclose(got, ref, rtol=1e-9, atol=1e-10)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)


### PR DESCRIPTION
`torch.compile` silently returned `inf` from every `hyp2f1_fallback` call whose
Euler labeling gives `B < 1` — so `TwoPowerSphericalPotential.__call__` and (after
#1201 routes `_psi` through the backend router) `TwoPowerTriaxialPotential.__call__`
compiled to `inf` while eager stayed correct. Wrong output, not an error.

### Root cause

The boundary-layer substitution `X = xi^k` puts the first quadrature node at
`XL ~ 1e-49`. Inductor's **fused** `expm1` (its standalone one is exact)
degenerates to `exp(x)-1` there and returns `0`, so `T = 0`, and `T**(B-1)` with
`B < 1` is `inf` — poisoning the whole sum at *every* z, not just extreme ones.

Three earlier hypotheses were measured and refuted: denormal flush (1.55e-49 is a
normal double), "inductor lowers expm1 as exp(x)-1" (the standalone one is exact),
and the in-tree ledger comment blaming a dead `xp.where` branch. That last comment
was wrong and is removed here.

### Fix

Factor out `expm1(u)/u -> 1` and take its series below a crossover, so nothing tiny
ever reaches `expm1`. **Single path for all namespaces** — the numpy route never
reaches this fallback (the router dispatches numpy to scipy), so there is no
byte-identity concern and no dead branch left uncovered.

### `_NOT_TRACEABLE` is now empty

This clears both remaining torch entries. Every default-constructible potential in
the zoo now traces under **both** `jax.jit` and `torch.compile`, on all four entry
points. Verified with the list empty (no xfail net): **367 passed, 2 skipped, 0 xfailed**.

### Verification

- Fails without the fix — stash-and-rerun, the `(0.5, 1.0, 1.5)` case. Only `B < 1`
  cases ever blew up; `_euler_labeling` yields `B = 0.5` for exactly one of the six.
- Accuracy **measured**: fallback vs scipy is 1.35e-14 worst case on both jax and
  torch. The existing parity test sat at `rtol=1e-9` — ~74000x looser than the code's
  real accuracy — so it is tightened to `1e-12` (~70x headroom for platform libm).
- The new test compares **compiled vs scipy**, not compiled vs eager, so a future
  change that breaks both paths still fails.

### Housekeeping

Rather than copy two pieces of setup into a second test file, both are hoisted into
`conftest.py`: the private `TORCHINDUCTOR_CACHE_DIR` (must be set before torch is
imported anywhere) and the `torch.compile` capability probe. The cache hoist also
closes a latent gap — `--backend torch --jit` compiles too and had no private cache,
so xdist workers could collide there.

I also dropped a test I had written that duplicated `test_hyp2f1_value_parity`
outright, and tightened the existing one instead.