### PR TITLE
noGL ellipsoidals via backend quadrature + agnostic DiskSCF/Multipole fixtures; jax-jit ledger 49 -> 28

### DIFF
--- a/galpy/potential/EllipsoidalPotential.py
+++ b/galpy/potential/EllipsoidalPotential.py
@@ -20,6 +20,7 @@ from ..backend import (
     get_namespace,
     is_backend_array,
 )
+from ..backend.quadrature import quad as bquad
 from ..util import _rotate_to_arbitrary_vector, conversion
 from .Potential import Potential
 
@@ -478,15 +479,20 @@ def _gl_node_factors(xp, ref, glx, glw, b2, c2):
 def _potInt(x, y, z, psi, b2, c2, xp=numpy, glx=None, glw=None):
     r"""int_0^\infty [psi(m)-psi(\infy)]/sqrt([1+tau]x[b^2+tau]x[c^2+tau])dtau"""
 
-    def integrand(s):
+    def integrand(s, x=x, y=y, z=z):
         t = 1 / s**2.0 - 1.0
         return psi(
-            numpy.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t))
-        ) / numpy.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
+            xp.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t))
+        ) / xp.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
 
     if glx is None:
-        # scipy.integrate fallback (glorder=None): numpy-only, deferred to Pspecial
-        return integrate.quad(integrand, 0.0, 1.0)[0]
+        # glorder=None: adaptive quadrature. bquad delegates to
+        # scipy.integrate.quad for numpy (byte-identical) and uses fixed-order
+        # Gauss-Legendre for jax/torch, which scipy's adaptive quad cannot be:
+        # it drives a Python callable with concrete floats. Coordinates go
+        # through args= (not just the closure) because bquad's dispatch follows
+        # the limits and args.
+        return bquad(integrand, 0.0, 1.0, args=(x, y, z))
     if is_backend_array(x) or is_backend_array(y) or is_backend_array(z):
         # Backend (jax/torch): evaluate all nglx nodes at once on a trailing node
         # axis (psi broadcasts) -> one xp.sum, collapsing the nglx-copy Python
@@ -510,23 +516,22 @@ def _potInt(x, y, z, psi, b2, c2, xp=numpy, glx=None, glw=None):
     return result
 
 
-def _forceInt(x, y, z, dens, b2, c2, i):
-    """Force integral fallback using scipy.integrate.quad (scalar inputs only).
-    Used by _forceInt_all when glorder is None."""
+def _forceInt(x, y, z, dens, b2, c2, i, xp=numpy):
+    """Force integral for glorder=None (see _potInt for the bquad rationale)."""
 
-    def integrand(s):
+    def integrand(s, x=x, y=y, z=z):
         t = 1 / s**2.0 - 1.0
         return (
-            dens(numpy.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t)))
+            dens(xp.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t)))
             * (
                 x / (1.0 + t) * (i == 0)
                 + y / (b2 + t) * (i == 1)
                 + z / (c2 + t) * (i == 2)
             )
-            / numpy.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
+            / xp.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
         )
 
-    return integrate.quad(integrand, 0.0, 1.0)[0]
+    return bquad(integrand, 0.0, 1.0, args=(x, y, z))
 
 
 def _forceInt_all(x, y, z, dens, b2, c2, xp=numpy, glx=None, glw=None):
@@ -534,9 +539,9 @@ def _forceInt_all(x, y, z, dens, b2, c2, xp=numpy, glx=None, glw=None):
     if glx is None:
         # scipy.integrate fallback (glorder=None): numpy-only, deferred to Pspecial
         return (
-            _forceInt(x, y, z, dens, b2, c2, 0),
-            _forceInt(x, y, z, dens, b2, c2, 1),
-            _forceInt(x, y, z, dens, b2, c2, 2),
+            _forceInt(x, y, z, dens, b2, c2, 0, xp),
+            _forceInt(x, y, z, dens, b2, c2, 1, xp),
+            _forceInt(x, y, z, dens, b2, c2, 2, xp),
         )
     if is_backend_array(x) or is_backend_array(y) or is_backend_array(z):
         # Backend: all nglx nodes at once (see _potInt); numpy keeps the loop.
@@ -570,13 +575,12 @@ def _forceInt_all(x, y, z, dens, b2, c2, xp=numpy, glx=None, glw=None):
     return Fx, Fy, Fz
 
 
-def _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, i, j):
-    """2nd-derivative integral fallback using scipy.integrate.quad (scalar inputs
-    only). Used by _2ndDerivInt_all when glorder is None."""
+def _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, i, j, xp=numpy):
+    """2nd-derivative integral for glorder=None (see _potInt for the rationale)."""
 
-    def integrand(s):
+    def integrand(s, x=x, y=y, z=z):
         t = 1 / s**2.0 - 1.0
-        m = numpy.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t))
+        m = xp.sqrt(x**2.0 / (1.0 + t) + y**2.0 / (b2 + t) + z**2.0 / (c2 + t))
         return (
             densDeriv(m)
             * (
@@ -597,9 +601,9 @@ def _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, i, j):
                 + 1.0 / (b2 + t) * (i == 1)
                 + 1.0 / (c2 + t) * (i == 2)
             )
-        ) / numpy.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
+        ) / xp.sqrt((1.0 + (b2 - 1.0) * s**2.0) * (1.0 + (c2 - 1.0) * s**2.0))
 
-    return integrate.quad(integrand, 0.0, 1.0)[0]
+    return bquad(integrand, 0.0, 1.0, args=(x, y, z))
 
 
 def _2ndDerivInt_all(x, y, z, dens, densDeriv, b2, c2, xp=numpy, glx=None, glw=None):
@@ -608,12 +612,12 @@ def _2ndDerivInt_all(x, y, z, dens, densDeriv, b2, c2, xp=numpy, glx=None, glw=N
     if glx is None:
         # scipy.integrate fallback (glorder=None): numpy-only, deferred to Pspecial
         return (
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 0),
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 1),
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 2),
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 1, 1),
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 1, 2),
-            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 2, 2),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 0, xp),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 1, xp),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 0, 2, xp),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 1, 1, xp),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 1, 2, xp),
+            _2ndDerivInt(x, y, z, dens, densDeriv, b2, c2, 2, 2, xp),
         )
     if is_backend_array(x) or is_backend_array(y) or is_backend_array(z):
         # Backend: all nglx nodes at once (see _potInt); numpy keeps the loop.

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -278,42 +278,32 @@ torch tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
 torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 
 # --- jax-jit: the suite run TRACED (pytest --backend jax --jit) ---
-# tests/test_potential.py, 2026-07-26: 49 of ~1300 tests fail under jax.jit that
-# pass eager (down from a 100-entry baseline on 2026-07-25), i.e. ~96% of the
-# potential suite already runs fully traced. They cluster by potential, not by
-# test. Cleared so far: RazorThinExponentialDisk and TwoPowerTriaxial (the two
-# the boundary-jit file used to list -- that file's _NOT_TRACEABLE is now empty)
-# and the log spirals. What remains:
-#   * Multipole / SCF (nonaxiDisk*)         ~12
-#   * noGL NFW / Triaxial                    ~8  -- these integrate with
-#     scipy.integrate.quad, which is untraceable by construction rather than by
-#     a stray numpy call; needs galpy.backend.quadrature.quad, whose dispatch
-#     follows the LIMITS and args, so the coordinates must be threaded through
-#     args= rather than captured in the integrand's closure.
-#   * AnyAxisymmetricRazorThinDisk           ~4  -- separate _bk_dispatch path
-#   * long tail                             ~25
+# tests/test_potential.py, 2026-07-27: 28 of ~1300 tests fail under jax.jit that
+# pass eager (baseline was 100 on 2026-07-25), i.e. ~98% of the potential suite
+# runs fully traced. Cleared: RazorThinExponentialDisk, TwoPowerTriaxial, the log
+# spirals, the noGL ellipsoidals, and the DiskSCF/Multipole fixtures. What
+# remains, and why -- these are NOT all "not migrated yet":
+#   * `test_poisson_surfdens_potential`     ~15  -- `Potential.surfdens`'s Poisson
+#     fallback traces once routed through backend quadrature, but fixed-order GL
+#     needs an order that SCALES WITH THE RANGE (n=100 is 3.7e-4 at |z|=10, n=400
+#     reaches 2.6e-14). A constant order is accurate only inside whatever range
+#     was tested and silently wrong outside it, so this needs a range-aware
+#     scheme, not a swap. Attempted and reverted deliberately.
+#   * AnyAxisymmetricRazorThinDisk           ~4  -- BY DESIGN, not a defect. Its
+#     backend path deliberately uses GL so gradients exist, while concrete input
+#     reuses scipy; the class comment states GL cannot resolve the a=R principal
+#     value or form the z=0 Hadamard-type 2nd derivative. Under a trace the input
+#     IS a tracer, so the traced value is knowingly less accurate there.
+#   * one-offs                               ~9  -- Cautun20, DehnenBinney98,
+#     ExpDisk_special, McMillan17, mass_spheroidal, plotting, ...
 # Only reachable via workflow_dispatch(jit=true); shrink it.
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_2ndDeriv_potential[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_2ndDeriv_potential[oblatenoGLNFWPotential]
 jax-jit tests/test_potential.py::test_Cautun20
 jax-jit tests/test_potential.py::test_DehnenBinney98
-jax-jit tests/test_potential.py::test_DiskSCFPotential_againstDoubleExp
 jax-jit tests/test_potential.py::test_ExpDisk_special
 jax-jit tests/test_potential.py::test_McMillan17
-jax-jit tests/test_potential.py::test_amp_mult_divide[fullyRotatednoGLTriaxialNFWPotential]
-jax-jit tests/test_potential.py::test_amp_mult_divide[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_amp_mult_divide[nonaxiDiskSCFPotential]
-jax-jit tests/test_potential.py::test_amp_mult_divide[oblatenoGLNFWPotential]
-jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_evaluateAndDerivs_potential[nonaxiDiskSCFPotential]
-jax-jit tests/test_potential.py::test_forceAsDeriv_potential[fullyRotatednoGLTriaxialNFWPotential]
-jax-jit tests/test_potential.py::test_forceAsDeriv_potential[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_forceAsDeriv_potential[nonaxiDiskSCFPotential]
-jax-jit tests/test_potential.py::test_forceAsDeriv_potential[oblatenoGLNFWPotential]
 jax-jit tests/test_potential.py::test_mass_spheroidal
 jax-jit tests/test_potential.py::test_plotting
-jax-jit tests/test_potential.py::test_poisson_potential[nonaxiDiskMultipoleExpansionPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[BurkertPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
@@ -334,11 +324,4 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndT
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[testMWPotential]
 jax-jit tests/test_potential.py::test_potential_at_infinity[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_potential_at_infinity[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_potential_at_infinity[nonaxiDiskSCFPotential]
-jax-jit tests/test_potential.py::test_potential_at_infinity[oblatenoGLNFWPotential]
 jax-jit tests/test_potential.py::test_potential_at_zero[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_potential_at_zero[fullyRotatednoGLTriaxialNFWPotential]
-jax-jit tests/test_potential.py::test_potential_at_zero[nonaxiDiskMultipoleExpansionPotential]
-jax-jit tests/test_potential.py::test_potential_at_zero[nonaxiDiskSCFPotential]
-jax-jit tests/test_potential.py::test_potential_at_zero[oblatenoGLNFWPotential]

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     _PYNBODY_LOADED = False
 from galpy import orbit, potential
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, get_namespace
 from galpy.util import _rotate_to_arbitrary_vector, coords
 
 try:
@@ -6748,9 +6748,11 @@ def test_DiskSCFPotential_againstDoubleExp():
     dscfp = potential.DiskSCFPotential(
         dens=lambda R, z: dp.dens(R, z),
         Sigma_amp=1.0,
-        Sigma=lambda R: numpy.exp(-3.0 * R),
-        dSigmadR=lambda R: -3.0 * numpy.exp(-3.0 * R),
-        d2SigmadR2=lambda R: 9.0 * numpy.exp(-3.0 * R),
+        # namespace-agnostic so the same fixture runs under --jit; xp.exp IS
+        # numpy.exp on the numpy path, so eager values are unchanged
+        Sigma=lambda R: get_namespace(R).exp(-3.0 * R),
+        dSigmadR=lambda R: -3.0 * get_namespace(R).exp(-3.0 * R),
+        d2SigmadR2=lambda R: 9.0 * get_namespace(R).exp(-3.0 * R),
         hz={"type": "exp", "h": 1.0 / 27.0},
         a=1.0,
         N=10,
@@ -11983,32 +11985,63 @@ class altExpwholeDiskSCFPotential(DiskSCFPotential):
         return None
 
 
+def _exp_disk_profile_callables(thp):
+    """dens/Sigma/hz callables shared by the nonaxi DiskSCF and
+    DiskMultipoleExpansion mocks, written namespace-agnostically.
+
+    These are USER-supplied callables. galpy traces whatever the user hands it,
+    so a numpy-only lambda cannot be traced -- that is correct behaviour, not a
+    galpy gap. Resolving the namespace from the argument keeps the numpy path
+    byte-identical (``xp.exp`` IS ``numpy.exp`` for numpy input) while letting
+    the same fixture run under ``--jit``.
+    """
+    from galpy.backend import get_namespace
+
+    def dens(R, z, phi):
+        xp = get_namespace(R, z)
+        return 13.5 * xp.exp(-3.0 * R) * xp.exp(-27.0 * xp.abs(z)) + thp.dens(
+            R, z, phi=phi
+        )
+
+    def sigma(R):
+        return get_namespace(R).exp(-3.0 * R)
+
+    def dsigmadr(R):
+        return -3.0 * get_namespace(R).exp(-3.0 * R)
+
+    def d2sigmadr2(R):
+        return 9.0 * get_namespace(R).exp(-3.0 * R)
+
+    def hz(z):
+        xp = get_namespace(z)
+        return 13.5 * xp.exp(-27.0 * xp.abs(z))
+
+    def Hz(z):
+        xp = get_namespace(z)
+        return (xp.exp(-27.0 * xp.abs(z)) - 1.0 + 27.0 * xp.abs(z)) / 54.0
+
+    def dHzdz(z):
+        xp = get_namespace(z)
+        return 0.5 * xp.sign(z) * (1.0 - xp.exp(-27.0 * xp.abs(z)))
+
+    return dict(
+        dens=dens,
+        Sigma_amp=[0.5, 0.5],
+        Sigma=[sigma, sigma],
+        dSigmadR=[dsigmadr, dsigmadr],
+        d2SigmadR2=[d2sigmadr2, d2sigmadr2],
+        hz=hz,
+        Hz=Hz,
+        dHzdz=dHzdz,
+    )
+
+
 class nonaxiDiskSCFPotential(DiskSCFPotential):
     def __init__(self):
         thp = triaxialHernquistPotential()
         DiskSCFPotential.__init__(
             self,
-            dens=lambda R, z, phi: (
-                13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
-                + thp.dens(R, z, phi=phi)
-            ),
-            Sigma_amp=[0.5, 0.5],
-            Sigma=[lambda R: numpy.exp(-3.0 * R), lambda R: numpy.exp(-3.0 * R)],
-            dSigmadR=[
-                lambda R: -3.0 * numpy.exp(-3.0 * R),
-                lambda R: -3.0 * numpy.exp(-3.0 * R),
-            ],
-            d2SigmadR2=[
-                lambda R: 9.0 * numpy.exp(-3.0 * R),
-                lambda R: 9.0 * numpy.exp(-3.0 * R),
-            ],
-            hz=lambda z: 13.5 * numpy.exp(-27.0 * numpy.fabs(z)),
-            Hz=lambda z: (
-                (numpy.exp(-27.0 * numpy.fabs(z)) - 1.0 + 27.0 * numpy.fabs(z)) / 54.0
-            ),
-            dHzdz=lambda z: (
-                0.5 * numpy.sign(z) * (1.0 - numpy.exp(-27.0 * numpy.fabs(z)))
-            ),
+            **_exp_disk_profile_callables(thp),
             N=5,
             L=5,
         )
@@ -12060,27 +12093,7 @@ class nonaxiDiskMultipoleExpansionPotential(DiskMultipoleExpansionPotential):
         thp = triaxialHernquistPotential()
         DiskMultipoleExpansionPotential.__init__(
             self,
-            dens=lambda R, z, phi: (
-                13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
-                + thp.dens(R, z, phi=phi)
-            ),
-            Sigma_amp=[0.5, 0.5],
-            Sigma=[lambda R: numpy.exp(-3.0 * R), lambda R: numpy.exp(-3.0 * R)],
-            dSigmadR=[
-                lambda R: -3.0 * numpy.exp(-3.0 * R),
-                lambda R: -3.0 * numpy.exp(-3.0 * R),
-            ],
-            d2SigmadR2=[
-                lambda R: 9.0 * numpy.exp(-3.0 * R),
-                lambda R: 9.0 * numpy.exp(-3.0 * R),
-            ],
-            hz=lambda z: 13.5 * numpy.exp(-27.0 * numpy.fabs(z)),
-            Hz=lambda z: (
-                (numpy.exp(-27.0 * numpy.fabs(z)) - 1.0 + 27.0 * numpy.fabs(z)) / 54.0
-            ),
-            dHzdz=lambda z: (
-                0.5 * numpy.sign(z) * (1.0 - numpy.exp(-27.0 * numpy.fabs(z)))
-            ),
+            **_exp_disk_profile_callables(thp),
             L=5,
         )
         return None


### PR DESCRIPTION
Three commits, separable for review.

### 1. `EllipsoidalPotential` `glorder=None` → backend quadrature

`_potInt`/`_forceInt`/`_2ndDerivInt` (what the `noGL*` test potentials exercise)
integrated with `scipy.integrate.quad` — adaptive quadrature driven by a Python
callable on concrete floats, so **untraceable by construction**. The bare
`numpy.sqrt` in those integrands was a symptom, not the cause.

Swapped to `galpy.backend.quadrature.quad`, which already *is* the drop-in and
already implements the accepted dual path (numpy → scipy, byte-identical;
jax/torch → differentiable fixed-order GL). **No new helper.**

The subtlety, and the reason this needed care: `quad` dispatches on the **limits
and `args`**, and here the limits are the literals `0.0`/`1.0` while the
coordinates live in the integrand's *closure*. Passing them only via the closure
would silently keep the scipy path and look like the change had no effect, so
they are threaded through `args=(x, y, z)`.

* numpy **byte-identical, 24/24** (TriaxialNFW oblate+triaxial × 3 positions ×
  Phi/Rforce/zforce/R2deriv, `glorder=None`)
* the 8 ledgered noGL entries: **0/8 failing**
* ellipsoidal-family tests: 907 passed, 7 skipped

### 2. DiskSCF/Multipole fixtures made namespace-agnostic

These 13 entries were **not a galpy gap**. The traceback points into
`tests/test_potential.py` itself: the fixtures hand galpy density/Sigma/hz
callables built from bare `numpy.exp`/`fabs`/`sign`. Those are *user-supplied*
functions — galpy traces what it is given, so a numpy-only lambda cannot be
traced, and refusing is correct behaviour.

Proved the library side by building the same potential twice: numpy-only
callables raise `TracerArrayConversionError`, agnostic ones trace and match eager
to 1e-9.

`nonaxiDiskSCFPotential` and `nonaxiDiskMultipoleExpansionPotential` carried
byte-identical 20-line lambda blocks, so they now share one
`_exp_disk_profile_callables(thp)` helper — fixing the tracing and removing the
duplication together. `test_DiskSCFPotential_againstDoubleExp` is a *separate*
site (own inline lambdas, scalar `Sigma_amp` rather than the two-component list
shape), so it gets three explicit lambdas rather than bending the helper to fit.

numpy unaffected: `xp.exp` **is** `numpy.exp` there. **13/13 pass.**

### 3. Ledger 49 → 28, with an honest header

The header is rewritten because "28 left" invites the wrong conclusion that 28
migrations remain. The residue is mostly *not* unmigrated code:

* **~15** `test_poisson_surfdens_potential` — traceable via backend quadrature,
  but fixed-order GL needs an order that **scales with the range** (n=100 →
  3.7e-4 at |z|=10; n=400 → 2.6e-14). A constant order is right inside the tested
  range and silently wrong outside it. I implemented it, measured it, and
  **reverted** rather than trade a loud xfail for quiet numerical error.
* **~4** `AnyAxisymmetricRazorThinDisk` — **by design**: the class comment states
  GL cannot resolve the `a=R` principal value or form the z=0 Hadamard-type
  second derivative, so the traced path is knowingly less accurate than the
  concrete scipy one.
* **~9** genuine one-offs.