### PR TITLE
actionAngleVertical: fix 0-d indexing in the backend integrands (untraceable with scalar input)

### DIFF
--- a/galpy/actionAngle/actionAngleVertical.py
+++ b/galpy/actionAngle/actionAngleVertical.py
@@ -358,14 +358,19 @@ class actionAngleVertical(actionAngle):
 
         lim = xp.sqrt(xmax)
 
-        def integrand(s):  # s: (n,) -> (N, n); t = lim*s, x = xmax - t^2
-            t = lim[:, None] * s[None, :]
-            xi = xmax[:, None] - t**2.0
+        def integrand(s):  # s: (n,) -> (..., n); t = lim*s, x = xmax - t^2
+            # `...` not `:` so a 0-d xmax/E works too: under a trace a scalar
+            # input stays 0-d, and `[:, None]` on 0-d raises IndexError. The
+            # nodes broadcast on a NEW TRAILING axis that fixed_quad reduces
+            # (axis=-1), so the input shape is preserved either way.
+            t = lim[..., None] * s
+            xi = xmax[..., None] - t**2.0
             rad = 2.0 * (
-                E[:, None] - evaluatelinearPotentials(self._pot, xi, use_physical=False)
+                E[..., None]
+                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
             )
             rad = xp.where(rad > 0.0, rad, xp.zeros_like(rad))  # clip (AD guard)
-            return xp.sqrt(rad) * 2.0 * t * lim[:, None]  # dx = 2t dt, dt = lim ds
+            return xp.sqrt(rad) * 2.0 * t * lim[..., None]  # dx = 2t dt, dt = lim ds
 
         # device=: scalar limits, so anchor the GL nodes on the input device (xmax)
         # -- else torch raises on CUDA input. No-op on numpy (device_of -> None).
@@ -384,13 +389,14 @@ class actionAngleVertical(actionAngle):
         lim = xp.sqrt(xmax)
 
         def integrand(s):
-            t = lim[:, None] * s[None, :]
-            xi = xmax[:, None] - t**2.0
+            t = lim[..., None] * s
+            xi = xmax[..., None] - t**2.0
             rad = 2.0 * (
-                E[:, None] - evaluatelinearPotentials(self._pot, xi, use_physical=False)
+                E[..., None]
+                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
             )
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))  # 2t->0 there anyway
-            return 2.0 * t / xp.sqrt(rad) * lim[:, None]
+            return 2.0 * t / xp.sqrt(rad) * lim[..., None]
 
         return (
             numpy.pi
@@ -415,13 +421,14 @@ class actionAngleVertical(actionAngle):
         span = hi - lo
 
         def integrand(s):  # t = lo + span*s, xi = xmax - t^2
-            t = lo[:, None] + span[:, None] * s[None, :]
-            xi = xmax[:, None] - t**2.0
+            t = lo[..., None] + span[..., None] * s
+            xi = xmax[..., None] - t**2.0
             rad = 2.0 * (
-                E[:, None] - evaluatelinearPotentials(self._pot, xi, use_physical=False)
+                E[..., None]
+                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
             )
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
-            return 2.0 * t / xp.sqrt(rad) * span[:, None]  # dx = 2t dt, dt = span ds
+            return 2.0 * t / xp.sqrt(rad) * span[..., None]  # dx = 2t dt, dt = span ds
 
         angle = Omega * fixed_quad(
             xp, integrand, 0.0, 1.0, n=_BACKEND_GL_ORDER, device=device_of(xmax)


### PR DESCRIPTION
`actionAngleVertical` could not be traced with **scalar** coordinates at all.

Its backend integrands did `lim[:, None]`, `xmax[:, None]`, `E[:, None]`, which
assumes 1-D input. Under a trace a scalar stays **0-d**, and `[:, None]` on a 0-d
array raises:

```
IndexError: Too many indices: array is 0-dimensional, but 1 were indexed
```

### Fix

Index with `...` instead of `:`. The quadrature nodes then broadcast on a **new
trailing axis**, which `fixed_quad` reduces (`axis=-1`), so the input shape is
preserved for 0-d and 1-D alike. This is the same idiom as the RazorThin
vectorisation fix, rather than a new one invented for this site.

Applied to **all three** integrands (J, omega, angle), not only the one in the
traceback — grep showed the identical pattern at each, so fixing just the first
would have moved the crash to the next site and looked like a fix.

### Verification

Across every input shape, not only the failing one:

| input | result |
|---|---|
| numpy scalar | 0.023128601561541364 |
| numpy array | unchanged |
| jax 0-d | 0.023128601561541395 |
| **jax traced** | **0.023128601561541392** — previously `IndexError` |

Traced and numpy agree to ~1e-15. numpy regression check: **32 passed, 0 failed**.
`test_actionAngleVertical_linear_angles` now passes under `--jit`.

### How it was found

By diagnosing the action-angle `--jit` failures **individually** rather than
ledgering them by test name. Filed by name, this would have been recorded as
"actionAngle traced-accuracy residue" and looked like an accepted tradeoff
indefinitely. One junitxml run separated two real bugs from four genuine
tradeoffs; this is the first of the two.