### PR TITLE
Traced backend lists inherit the eager ones ("<backend>-jit" -> "<backend>")

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,19 @@ def _load_backend_nodeids(path, backend_name):
 
     Shared by the xfail-ledger and the slow-skip list (same format). Lines may
     carry trailing "# ..." comments; blank/comment-only lines are ignored.
+
+    A traced backend ("<backend>-jit") INHERITS the eager "<backend>" entries.
+    Tracing does not repair an eager failure -- it cannot fix a numerical gap, a
+    `_reject_backend` guard, or an out-of-scope family -- and it only makes a
+    slow test slower, since the trace has to compile first. So "<backend>-jit"
+    means exactly **"applies ONLY when traced"**, and the eager lists stay the
+    single place a shared entry is written and later pruned. The rule lives here
+    rather than in the three callers because it is a property of the backend
+    name, not of which list is being read.
     """
+    names = {backend_name}
+    if backend_name.endswith("-jit"):
+        names.add(backend_name[: -len("-jit")])
     entries = set()
     if not os.path.exists(path):
         return entries
@@ -156,7 +168,7 @@ def _load_backend_nodeids(path, backend_name):
             if len(parts) != 2:
                 continue
             be, nodeid = parts[0].strip(), parts[1].strip()
-            if be == backend_name:
+            if be in names:
                 entries.add(nodeid)
     return entries
 
@@ -164,6 +176,23 @@ def _load_backend_nodeids(path, backend_name):
 def _load_ledger(backend_name):
     """Return the set of ledger nodeids for the given backend, or empty set."""
     return _load_backend_nodeids(_ledger_path(), backend_name)
+
+
+def _regen_entries(backend_name, failed):
+    """Sorted nodeids to write for a regen run of `backend_name`.
+
+    Regen xfails nothing, so a traced run reports the eager failures too. Those
+    are already inherited from the eager list, so writing them again duplicates
+    every entry and leaves two places to prune. Emit only what fails ONLY when
+    traced -- which is what "-jit" means.
+    """
+    failed = set(failed)
+    if backend_name.endswith("-jit"):
+        eager = _load_backend_nodeids(_ledger_path(), backend_name[: -len("-jit")])
+        # A base entry ("::test_y") covers every parametrization of that test,
+        # the same way the xfail hook matches it.
+        failed = {n for n in failed if n not in eager and _strip_param(n) not in eager}
+    return sorted(failed)
 
 
 def _load_slow_skip(backend_name):
@@ -365,7 +394,7 @@ def pytest_sessionfinish(session, exitstatus):
     if os.environ.get(_REGEN_ENV) == "1":
         backend_name = _run_backend(session.config)
         if backend_name != "numpy":
-            failed = sorted(_REGEN_STORE["failed"])
+            failed = _regen_entries(backend_name, _REGEN_STORE["failed"])
             outfile = _regen_outfile()
             try:
                 os.makedirs(os.path.dirname(outfile), exist_ok=True)

--- a/tests/test_backend_ledger.py
+++ b/tests/test_backend_ledger.py
@@ -1,0 +1,100 @@
+# Tests for the backend-list machinery in conftest.py itself (xfail ledger,
+# slow-skip, permanent skip). The "-jit inherits eager" rule below is otherwise
+# reachable only from a traced (--jit) dispatch, which does not run on every
+# push, so it would land unexercised.
+import conftest
+
+
+def _ledger(tmp_path, body):
+    path = tmp_path / "ledger.txt"
+    path.write_text(body)
+    return str(path)
+
+
+def test_backend_nodeids_selects_one_backend(tmp_path):
+    """The base case: a plain backend name reads only its own lines."""
+    path = _ledger(
+        tmp_path,
+        "# a comment line\n"
+        "\n"
+        "jax tests/test_a.py::test_one\n"
+        "jax tests/test_a.py::test_two  # trailing comment\n"
+        "torch tests/test_a.py::test_three\n",
+    )
+    assert conftest._load_backend_nodeids(path, "jax") == {
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+    }
+    assert conftest._load_backend_nodeids(path, "torch") == {
+        "tests/test_a.py::test_three"
+    }
+
+
+def test_jit_inherits_eager(tmp_path):
+    """A traced backend reads its own lines UNION the eager backend's lines."""
+    path = _ledger(
+        tmp_path,
+        "jax tests/test_a.py::test_eager_only\n"
+        "jax-jit tests/test_a.py::test_traced_only\n"
+        "torch tests/test_a.py::test_other_backend\n"
+        "torch-jit tests/test_a.py::test_other_backend_traced\n",
+    )
+    assert conftest._load_backend_nodeids(path, "jax-jit") == {
+        "tests/test_a.py::test_eager_only",
+        "tests/test_a.py::test_traced_only",
+    }
+    # Inheritance is one-directional and per-backend: the eager list never gains
+    # traced entries, and jax-jit never picks up anything torch.
+    assert conftest._load_backend_nodeids(path, "jax") == {
+        "tests/test_a.py::test_eager_only"
+    }
+    assert conftest._load_backend_nodeids(path, "torch-jit") == {
+        "tests/test_a.py::test_other_backend",
+        "tests/test_a.py::test_other_backend_traced",
+    }
+
+
+def test_jit_inheritance_applies_to_every_list(tmp_path, monkeypatch):
+    """Ledger, slow-skip and permanent-skip all inherit -- one shared rule.
+
+    A test too slow to run eager is slower still traced (it must compile first),
+    and a test excluded for hitting the network is excluded however it is run.
+    """
+    path = _ledger(tmp_path, "jax tests/test_a.py::test_eager_only\n")
+    for attr in ("_ledger_path", "_slow_skip_path", "_backend_skip_path"):
+        monkeypatch.setattr(conftest, attr, lambda path=path: path)
+    for loader in (
+        conftest._load_ledger,
+        conftest._load_slow_skip,
+        conftest._load_backend_skip,
+    ):
+        assert loader("jax-jit") == {"tests/test_a.py::test_eager_only"}, loader
+
+
+def test_regen_of_traced_run_drops_inherited_eager_entries(tmp_path, monkeypatch):
+    """Regen for "<backend>-jit" writes only what fails ONLY when traced.
+
+    Regen xfails nothing, so the traced run also reports every eager failure;
+    writing those back out would duplicate the whole eager list.
+    """
+    path = _ledger(
+        tmp_path,
+        "jax tests/test_a.py::test_eager\n"
+        "jax tests/test_b.py::test_parametrized\n",  # base entry, covers all params
+    )
+    monkeypatch.setattr(conftest, "_ledger_path", lambda: path)
+    observed = [
+        "tests/test_a.py::test_eager",  # inherited -> dropped
+        "tests/test_b.py::test_parametrized[Case1]",  # covered by base -> dropped
+        "tests/test_c.py::test_traced_only",  # genuinely new -> kept
+    ]
+    assert conftest._regen_entries("jax-jit", observed) == [
+        "tests/test_c.py::test_traced_only"
+    ]
+    # An eager regen is untouched -- it has nothing to inherit from.
+    assert conftest._regen_entries("jax", observed) == sorted(observed)
+
+
+def test_missing_file_is_empty(tmp_path):
+    """A backend with no list at all is not an error."""
+    assert conftest._load_backend_nodeids(str(tmp_path / "nope.txt"), "jax") == set()


### PR DESCRIPTION
A traced run reads the `<backend>-jit` lines of the xfail-ledger, the slow-skip list and the permanent-skip list. Those lists were independent of their eager counterparts, which is wrong in both directions:

- **Tracing does not repair an eager failure.** It cannot fix a numerical gap, a `_reject_backend` guard, or an out-of-scope family. Every eager entry had to be copied into the traced list, and then pruned in two places.
- **Tracing only makes a slow test slower** — it has to compile first. Yet `jax-jit` inherited *no* slow-skips and no permanent skips, so a traced dispatch would attempt every pathologically-slow test and every SIMBAD-network test.

Net effect: a traced dispatch could not be green, which is what blocks turning on `jit=true` CI at all.

## Change

`<backend>-jit` now reads its own lines **plus** the eager `<backend>` lines. The rule lives in the one shared parser rather than in the three loaders, because it is a property of the backend *name*, not of which list is being read.

| list | jax | jax-jit before | jax-jit after |
|---|---|---|---|
| xfail-ledger | 52 | 28 | **80** (28 + 52) |
| slow-skip | 215 | 0 | **215** |
| permanent-skip | 6 | 0 | **6** |

`torch`/`torch-jit` and the eager lists are unchanged; `numpy` has no `-jit` form and is unaffected.

This is **strictly widening**, and the marker is `xfail(strict=False)`, so it can only add expectations, never remove them — it cannot turn a genuine failure into a false green. The honest cost is that the traced run inherits the eager slow-skips, so it covers the fast tests only.

## Regen footgun closed

Regen mode xfails nothing, so a traced regen also reports the eager failures — and would have written the entire eager list back out as duplicate `-jit` entries. `_regen_entries` drops what the eager list already covers, including a base entry covering its parametrizations.

## Testing

`tests/test_backend_ledger.py` covers the selection, the inheritance (in both directions, and that it does not leak across backends), that all three lists inherit, and the regen subtraction. Without it the rule is reachable only from a traced dispatch, which does not run on every push, and would land unexercised.

`galpy/` is untouched — this is test-harness only, so the numpy path is byte-identical by construction.