### PR TITLE
Unblock the two "Pspecial-blocked" closed-form masses

### DIFF
--- a/galpy/potential/TriaxialGaussianPotential.py
+++ b/galpy/potential/TriaxialGaussianPotential.py
@@ -8,9 +8,9 @@
 #
 ###############################################################################
 import numpy
-from scipy import special
 
 from ..backend import get_namespace
+from ..backend import special as _bspecial
 from ..util import conversion
 from .EllipsoidalPotential import EllipsoidalPotential
 
@@ -120,8 +120,7 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
     def _mass(self, R, z=None, t=0.0):
         if not z is None:
             raise AttributeError  # Hack to fall back to general
-        # Pspecial-blocked: closed-form mass requires scipy.special.erf, which has
-        # no backend-agnostic (jax/torch array-API) replacement -> numpy only.
+        xp = get_namespace(R)
         return (
             numpy.pi
             * self._b
@@ -130,7 +129,7 @@ class TriaxialGaussianPotential(EllipsoidalPotential):
             * self._sigma
             * (
                 numpy.sqrt(2.0 * numpy.pi)
-                * special.erf(R / self._sigma / numpy.sqrt(2.0))
-                - 2.0 * R / self._sigma * numpy.exp(-(R**2.0) / self._twosigma2)
+                * _bspecial.erf(R / self._sigma / numpy.sqrt(2.0))
+                - 2.0 * R / self._sigma * xp.exp(-(R**2.0) / self._twosigma2)
             )
         )

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -16,6 +16,7 @@ import numpy
 from scipy import special
 
 from ..backend import get_namespace
+from ..backend import special as _bspecial
 from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
 from .EllipsoidalPotential import EllipsoidalPotential
@@ -183,8 +184,6 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
     def _mass(self, R, z=None, t=0.0):
         if not z is None:
             raise AttributeError  # Hack to fall back to general
-        # Pspecial-blocked: closed-form mass requires scipy.special.hyp2f1, which
-        # has no backend-agnostic (jax/torch array-API) replacement -> numpy only.
         return (
             4.0
             * numpy.pi
@@ -193,7 +192,7 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
             / (3.0 - self.alpha)
             * self._b
             * self._c
-            * special.hyp2f1(
+            * _bspecial.hyp2f1(
                 3.0 - self.alpha, self.betaminusalpha, 4.0 - self.alpha, -R / self.a
             )
         )

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -301,7 +301,6 @@ jax-jit tests/test_potential.py::test_Cautun20
 jax-jit tests/test_potential.py::test_DehnenBinney98
 jax-jit tests/test_potential.py::test_ExpDisk_special
 jax-jit tests/test_potential.py::test_McMillan17
-jax-jit tests/test_potential.py::test_mass_spheroidal
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]


### PR DESCRIPTION
`TwoPowerTriaxialPotential._mass` and `TriaxialGaussianPotential._mass` each carried a comment saying their closed form *"requires scipy.special.hyp2f1 / scipy.special.erf, which has no backend-agnostic (jax/torch array-API) replacement → numpy only"*.

That has not been true since the Pspecial work: **both functions are in `galpy.backend.special`'s router**. The comments were simply stale, and they were the whole reason `test_mass_spheroidal` sat in the `jax-jit` ledger. Routed both through the router, whose numpy path dispatches straight back to scipy.

## The stale comment hid a second bug

`TriaxialGaussian` needed a fix the comment gave no hint of: the same expression also calls `numpy.exp` on `R`, which converts a tracer. Fixing the *named* blocker alone left the test still failing — only after routing that through the namespace did it trace. Measured rather than assumed, which is the only reason it was caught.

Also removed the now-dead `from scipy import special` in `TriaxialGaussianPotential` (pycln left it). Checked with a word-boundary match first, since `_bspecial.erf` contains `special.` as a substring and a naive grep would call it still-used.

## Results

| check | result |
|---|---|
| eager jax / traced jax / eager torch | **0 failures** each |
| numpy byte-identity | **48 hex-exact mass values** — 8 potentials (TriaxialGaussian at 4 axis ratios, TwoPowerTriaxial at 4 α/β pairs) × 6 radii spanning 0.05–1000 |

Pre-flighted against the shards that actually consume these potentials, not just the test being chased:

| shard | result |
|---|---|
| `test_backend_ellipsoidal` + `amp_grad` + `dtype_policy`, **torch** | 1048 tests, 0 failures |
| same three, **jax** | 1048 tests, 0 failures |
| `test_quantity.py -k "mass or dens or surfdens"` | 7 tests, 0 failures |

## Testing

No new test. Both call sites are unconditional — no backend branch — so the numpy coverage shard exercises them, and `test_mass_spheroidal` itself now runs under the eager jax/torch shards and traced. A separate backend test would only duplicate it.

`jax-jit` ledger: one entry pruned (15 → 14).