### PR TITLE
One f(E) spline builder on sphericaldf, not two divergent copies

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -513,24 +513,6 @@ class constantbetadf(_constantbetadf):
             R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )
 
-    def _ensure_fE_interp(self):
-        """Build the f(E) interpolator if not already built."""
-        if not hasattr(self, "_fE_interp"):
-            Es4interp = numpy.hstack(
-                (
-                    numpy.geomspace(1e-8, 0.5, 101, endpoint=False),
-                    sorted(1.0 - numpy.geomspace(1e-4, 0.5, 101)),
-                )
-            )
-            Es4interp = (Es4interp * (self._Emin - self._potInf) + self._potInf)[::-1]
-            # scipy spline over the numpy energy grid: pull the (backend) fE
-            # values back to numpy for the frozen interpolator
-            fE4interp = as_numpy(self.fE(Es4interp))
-            iindx = numpy.isfinite(fE4interp)
-            self._fE_interp = interpolate.InterpolatedUnivariateSpline(
-                Es4interp[iindx], fE4interp[iindx], k=3, ext=3
-            )
-
     def _make_func(self, grad):
         """Build the m-th (dens r^2beta)/dPsi^m derivative closure using ``grad``.
 

--- a/galpy/df/eddingtondf.py
+++ b/galpy/df/eddingtondf.py
@@ -109,38 +109,6 @@ class eddingtondf(isotropicsphericaldf):
             self, R=R, z=z, phi=phi, n=n, return_orbit=return_orbit, rmin=rmin, key=key
         )
 
-    def _ensure_fE_interp(self):
-        """Build the f(E) interpolator if not already built."""
-        if not hasattr(self, "_fE_interp"):
-            Es4interp = numpy.hstack(
-                (
-                    numpy.geomspace(1e-8, 0.5, 101, endpoint=False),
-                    sorted(1.0 - numpy.geomspace(1e-4, 0.5, 101)),
-                )
-            )
-            # scipy/backend spline table is built on a numpy grid; under a
-            # forced backend the potential bounds are backend scalars, so pull
-            # them numpy-side (no-op on the numpy path)
-            Emin = as_numpy(self._Emin)
-            potInf = as_numpy(self._potInf)
-            Es4interp = (Es4interp * (Emin - potInf) + potInf)[::-1]
-            xp = get_namespace()  # context/forced default only (grid is numpy)
-            if xp is numpy:
-                fE4interp = self.fE(Es4interp)
-                iindx = numpy.isfinite(fE4interp)
-                self._fE_interp = interpolate.InterpolatedUnivariateSpline(
-                    Es4interp[iindx], fE4interp[iindx], k=3, ext=3
-                )
-            else:
-                # forced backend: one vectorized fE eval, pulled numpy-side for
-                # the frozen table (Spline1D queries numpy scipy / backend native);
-                # ascontiguousarray drops the [::-1] negative stride (torch rejects)
-                fE4interp = as_numpy(self.fE(numpy.ascontiguousarray(Es4interp)))
-                iindx = numpy.isfinite(fE4interp)
-                self._fE_interp = Spline1D(
-                    Es4interp[iindx], fE4interp[iindx], k=3, ext=3
-                )
-
     def fE(self, E):
         """
         Calculate the energy portion of a DF computed using the Eddington inversion

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -390,6 +390,44 @@ class sphericaldf(df):
             *_inp,
         )
 
+    def _ensure_fE_interp(self):
+        """Build the frozen f(E) spline over the numpy energy grid, once.
+
+        Shared by every subclass that interpolates f(E) (eddingtondf,
+        constantbetadf). It lived in both of those independently and only one
+        copy ever grew the backend branch, so the other silently kept building a
+        scipy spline under a forced backend -- which then could not be traced.
+        One copy here, on their common ancestor, is the fix.
+        """
+        if hasattr(self, "_fE_interp"):
+            return
+        Es4interp = numpy.hstack(
+            (
+                numpy.geomspace(1e-8, 0.5, 101, endpoint=False),
+                sorted(1.0 - numpy.geomspace(1e-4, 0.5, 101)),
+            )
+        )
+        # the spline table is built on a numpy grid; under a forced backend the
+        # potential bounds are backend scalars, so pull them numpy-side (no-op
+        # on the numpy path)
+        Emin = as_numpy(self._Emin)
+        potInf = as_numpy(self._potInf)
+        Es4interp = (Es4interp * (Emin - potInf) + potInf)[::-1]
+        xp = get_namespace()  # context/forced default only (grid is numpy)
+        if xp is numpy:
+            fE4interp = self.fE(Es4interp)
+            iindx = numpy.isfinite(fE4interp)
+            self._fE_interp = scipy.interpolate.InterpolatedUnivariateSpline(
+                Es4interp[iindx], fE4interp[iindx], k=3, ext=3
+            )
+        else:
+            # forced backend: one vectorized fE eval, pulled numpy-side for the
+            # frozen table (Spline1D queries numpy scipy / backend native);
+            # ascontiguousarray drops the [::-1] negative stride (torch rejects)
+            fE4interp = as_numpy(self.fE(numpy.ascontiguousarray(Es4interp)))
+            iindx = numpy.isfinite(fE4interp)
+            self._fE_interp = Spline1D(Es4interp[iindx], fE4interp[iindx], k=3, ext=3)
+
     @physical_conversion("massenergydensity", pop=True)
     def dMdE(self, E):
         """

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -296,6 +296,19 @@ torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 #   * one-offs                               ~9  -- Cautun20, DehnenBinney98,
 #     ExpDisk_special, McMillan17, mass_spheroidal, plotting, ...
 # Only reachable via workflow_dispatch(jit=true); shrink it.
+# tests/test_sphericaldf.py, 2026-07-28: `constantbetadf.fE` itself is not
+# traceable -- it still converts a tracer to numpy (constantbetadf.py:735 has an
+# `_evalpot_asnumpy` escape hatch in the general-beta integrand, the likely site).
+# Measured, not guessed: the three sibling `dehnencore_in_nfw_*` tests monkeypatch
+# `dfh.fE = lambda x: dfh._fE_interp(x)` and now PASS traced, because the f(E)
+# spline builder became backend-native; `grep -c "dfh.fE = lambda"` over the file
+# is exactly 3 and matches the flip count. The five below call the real `fE`.
+# Un-ledger when fE is migrated. Eager jax/torch and numpy are all green.
+jax-jit tests/test_sphericaldf.py::test_constantbeta_differentpotentials_dens_directint
+jax-jit tests/test_sphericaldf.py::test_constantbeta_exptruncnfw_dens_directint
+jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_dens_directint
+jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_meanvr_directint
+jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_sigmar_directint
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_Cautun20
 jax-jit tests/test_potential.py::test_DehnenBinney98


### PR DESCRIPTION
`eddingtondf` and `constantbetadf` each carried their own `_ensure_fE_interp` — same energy grid, same purpose — but **only eddington's ever grew the backend branch**. constantbeta's always built a scipy `InterpolatedUnivariateSpline`, so under a forced backend it produced a frozen scipy object that cannot be traced, where eddington built a traceable `Spline1D`.

The two classes share exactly one non-trivial ancestor (`sphericaldf`; constantbeta reaches it via `_constantbetadf → anisotropicsphericaldf`), so neither inherited the other's fix. The divergence was invisible because **on numpy the two copies behave identically — they only disagree under a trace.**

## Change

Hoisted eddington's version — a strict superset, it additionally `as_numpy`s the bounds, a no-op on numpy — onto `sphericaldf`, and deleted both copies. `sphericaldf` already imported `as_numpy`, `get_namespace`, `Spline1D` and `scipy.interpolate`, which is a fair sign the method belongs there.

## Verification

Checked on **both** classes, since the way a hoist goes wrong is silently changing the one that wasn't broken:

| check | result |
|---|---|
| numpy f(E) — constantbeta at β = 0, 0.25, −0.3 **plus** eddington, 5 energies each | **20 hex-exact values, byte-identical** |
| numpy | 223 tests, **0 failures** |
| eager torch | 223 tests, **0 failures** |
| traced jax | **8 → 5 failures** |

## The flip is exactly the 3 tests that route through the interpolator

The three that now pass (`dehnencore_in_nfw_{dens,meanvr,sigmar}_directint`) are precisely those that monkeypatch `dfh.fE = lambda x: dfh._fE_interp(x)`. `grep -c "dfh.fE = lambda"` over the file returns **3**, matching the flip count — so the attribution is measured, not inferred.

The other five call the real `constantbetadf.fE`, which has a **separate** numpy island: `_fE_backend` (constantbetadf.py:657) calls `as_numpy` so the frozen `_rphi`/`_logstartt` scipy splines can be queried. That is a different bug needing the same treatment these got, so it is ledgered here with that reason rather than bundled in.

Note the `jax-jit` ledger grows by 5. That is **measurement, not regression**: those five were always broken traced, but `test_sphericaldf.py` had never been run under a trace before this vacation.

---

Third de-duplication of this shape this vacation (`dePeriod` #1211, the two `_surfdens` routes #1212, this one). Same story each time: one routine, two copies, one migrated, and nothing notices until something traces.