### PR TITLE
Keep the constant-beta fE integration limits on-backend

### DIFF
--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -17,7 +17,7 @@ from ..backend import (
 )
 from ..backend import random as grandom
 from ..backend import resolve_namespace, use
-from ..backend.interpolate import interp_linear
+from ..backend.interpolate import Spline1D, interp_linear
 from ..backend.quadrature import fixed_quad, fixed_quad_semiinfinite
 from ..potential import evaluateRforces, interpSphericalPotential
 from ..potential.Potential import _evaluatePotentials
@@ -494,7 +494,10 @@ class constantbetadf(_constantbetadf):
                         self._alpha,
                         self._rphi(Es[indx]),
                     )
-                self._logstartt = interpolate.InterpolatedUnivariateSpline(
+                # numpy queries hit the scipy spline (byte-identical); backend
+                # queries evaluate the frozen table natively, so the traced fE
+                # path can keep its integration limits on-backend
+                self._logstartt = Spline1D(
                     Es, numpy.log10(startt) + 10.0 / 3.0 * (1.0 - self._alpha), k=3
                 )
 
@@ -653,9 +656,10 @@ class constantbetadf(_constantbetadf):
         Ein = Ein if is_backend_array(Ein) else numpy.ascontiguousarray(Ein)
         Eb = xp.atleast_1d(xp.asarray(Ein) * 1.0)
         indx = (Eb < pinf) & (Eb >= emin)
-        # clamp out-of-bounds E for the frozen numpy interpolators (zeroed below)
-        Enp = as_numpy(xp.where(indx, Eb, xp.ones_like(Eb) * emin))
-        rphiE = xp.asarray(self._rphi(Enp)) * 1.0
+        # clamp out-of-bounds E (zeroed below); rphi/logstartt are both Spline1D,
+        # so the clamped energies stay on-backend and the limits stay traceable
+        Ecl = xp.where(indx, Eb, xp.ones_like(Eb) * emin)
+        rphiE = self._rphi(Ecl) * 1.0
         if self._halfint:
             val = self._deriv(xp, rphiE) / (
                 2.0
@@ -665,7 +669,7 @@ class constantbetadf(_constantbetadf):
             )
             return xp.where(indx, val, xp.zeros_like(val)).reshape(E.shape)
         alpha = self._alpha
-        lo = xp.asarray(10.0 ** self._logstartt(Enp)) * 1.0
+        lo = 10.0 ** self._logstartt(Ecl) * 1.0
         hi = rphiE ** (1.0 - alpha)
         Eb2 = Eb[..., None]
 

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -296,19 +296,6 @@ torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 #   * one-offs                               ~9  -- Cautun20, DehnenBinney98,
 #     ExpDisk_special, McMillan17, mass_spheroidal, plotting, ...
 # Only reachable via workflow_dispatch(jit=true); shrink it.
-# tests/test_sphericaldf.py, 2026-07-28: `constantbetadf.fE` itself is not
-# traceable -- it still converts a tracer to numpy (constantbetadf.py:735 has an
-# `_evalpot_asnumpy` escape hatch in the general-beta integrand, the likely site).
-# Measured, not guessed: the three sibling `dehnencore_in_nfw_*` tests monkeypatch
-# `dfh.fE = lambda x: dfh._fE_interp(x)` and now PASS traced, because the f(E)
-# spline builder became backend-native; `grep -c "dfh.fE = lambda"` over the file
-# is exactly 3 and matches the flip count. The five below call the real `fE`.
-# Un-ledger when fE is migrated. Eager jax/torch and numpy are all green.
-jax-jit tests/test_sphericaldf.py::test_constantbeta_differentpotentials_dens_directint
-jax-jit tests/test_sphericaldf.py::test_constantbeta_exptruncnfw_dens_directint
-jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_dens_directint
-jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_meanvr_directint
-jax-jit tests/test_sphericaldf.py::test_constantbeta_selfconsist_dehnencore_sigmar_directint
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_Cautun20
 jax-jit tests/test_potential.py::test_DehnenBinney98

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -315,6 +315,33 @@ def test_general_constantbetadf_fE_backend(backend):
         numpy.testing.assert_allclose(as_numpy(got), ref, rtol=rtol)
 
 
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_generic_fE_jit_traceable():
+    # The generic constantbetadf reads its fE integration limits off two frozen
+    # interpolators, r(Phi) and log10(startt). Both used to be queried with a
+    # concrete numpy energy (as_numpy of the clamped E), which made fE
+    # untraceable: under jax.jit that clamped energy is a tracer and the
+    # conversion raises. Both are Spline1D now, so the clamp stays on-backend.
+    # Covers both branches -- twobeta=-1 (half-integer, queries only r(Phi)) and
+    # beta=0.25 (the inversion integral, which also queries log10(startt)) --
+    # and the out-of-bounds clamp, which is the line that used to force numpy.
+    for kw in (dict(twobeta=-1), dict(beta=0.25)):
+        with galpy.backend.use("jax", force=True):
+            df = constantbetadf(pot=_DC, **kw)
+            Emin, pinf = float(df._Emin), float(df._potInf)
+            Es = numpy.concatenate(
+                [
+                    Emin + numpy.linspace(0.1, 0.9, 7) * (pinf - Emin),
+                    [pinf + 1.0, Emin - 1.0],  # out of bounds -> exactly zero
+                ]
+            )
+            eager = as_numpy(df.fE(jnp.asarray(Es)))
+            traced = as_numpy(jax.jit(df.fE)(jnp.asarray(Es)))
+        # tracing must not perturb the value: same kernel, same GL nodes
+        numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=0.0)
+        assert numpy.all(traced[-2:] == 0.0)
+
+
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_autodiff_ops_dispatch(backend):
     # autodiff_ops returns the functional (grad, vmap) pair for the backend's


### PR DESCRIPTION
`constantbetadf.fE` reads its integration limits off two frozen interpolators,
r(Phi) and log10(startt). Both were queried with a concrete numpy energy --
`as_numpy()` of the where-clamped E -- which made `fE` untraceable: under a trace
that clamped energy is a tracer and the conversion raises
`TracerArrayConversionError`.

Only one interpolator actually needed changing. r(Phi) is built by
`sphericaldf._setup_rphi_interpolator`, which already returns a backend-agnostic
`Spline1D`; log10(startt) was the last scipy `InterpolatedUnivariateSpline`, and it
has exactly one construction site, so it gets the same `Spline1D` treatment rather
than a hoist. The clamp then stays on-backend and both limits stay traceable.

### numpy is untouched

`Spline1D` dispatches on the query, so numpy input calls the same scipy spline.
Verified byte-identical: **70 hex-exact fE values across 10 DF configurations**
(DehnenCore/NFW x five betas). The spline itself matches scipy exactly (0.0
maxdiff) on array, scalar and extrapolated queries.

### Which half does the work

`beta=-0.5` and `twobeta=-1` are different DFs, which decides what each change
buys:

| construction | `_halfint` | `_logstartt` |
|---|---|---|
| `twobeta=-1` | True | absent |
| `beta=-0.5` / `beta=0.25` | False | built |

The five ledgered tests build with `twobeta=-1`, so they return before
log10(startt) and are fixed by the clamp drop alone. The `_logstartt` swap fixes
the non-half-integer branch, which was equally untraceable but had no ledgered
test. Both are needed.

### Verification

| check | result |
|---|---|
| `test_sphericaldf.py` numpy | 223 passed |
| `test_sphericaldf.py --backend jax --jit` | **223 tests, 0 failures** |
| `test_backend_constantbetadf.py` | 32 passed |
| `test_quantity.py -k sphericaldf` | 9 passed |
| traced vs eager | 7.8e-16 (`twobeta=-1`), 1.5e-13 (`beta=0.25`) |

The traced sphericaldf file is now fully green (223 -> 8 -> 5 -> **0** across
#1214 and this PR), and unmasked -- the five entries are removed, so they pass as
ordinary tests.

New test `test_generic_fE_jit_traceable` covers both branches plus the
out-of-bounds clamp at `rtol=1e-12` (~7x the measured 1.5e-13 floor). Confirmed
load-bearing by stashing only the source change: it fails with
`TracerArrayConversionError` at `_namespaces.py:204`, the exact site.

jax-jit ledger **19 -> 14**; also drops the now-obsolete comment block that #1214
added above those entries (it named a site this PR disproved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH