### PR TITLE
Reconcile the jax-jit ledger with reality: drop 8 inert, add 1 real

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -296,17 +296,14 @@ torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 #   * one-offs                               ~9  -- Cautun20, DehnenBinney98,
 #     ExpDisk_special, McMillan17, mass_spheroidal, plotting, ...
 # Only reachable via workflow_dispatch(jit=true); shrink it.
+# test_eccentricity is the same AnyAxisymmetricRazorThinDisk story seen through an
+# orbit: its traced GL forces carry ~1e-6 error, so a circular orbit comes back
+# with e=5.4e-6 against a 1e-8 tolerance. Passes eager jax. Un-ledger if the
+# tolerance is ever made backend-aware.
+jax-jit tests/test_orbit.py::test_eccentricity
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_Cautun20
-jax-jit tests/test_potential.py::test_DehnenBinney98
 jax-jit tests/test_potential.py::test_ExpDisk_special
-jax-jit tests/test_potential.py::test_McMillan17
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_potential_at_infinity[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_potential_at_zero[AnyAxisymmetricRazorThinDiskPotential]


### PR DESCRIPTION
### Drop 8

These tests are slow-skipped under `jax`, and `jax-jit` inherits the eager lists
(#1210), so they never run traced -- their xfail entries can never fire and only
inflate the ledger.

Measured, not assumed: running all eight with `--backend jax --jit` gives
**8 skipped, 0 failures**, and the same eight appear verbatim in
`backend_slow_skip.txt` under `jax`.

They most likely entered before the slow-skips existed: a heavy test that hits the
session timeout records FAILED, so a regen at that moment ledgers it; the later
slow-skip then makes the entry inert without removing it.

### Add 1

`test_orbit.py::test_eccentricity` fails under `--jit` and was in **none** of the
three lists, so a jit dispatch run would have shown it as a genuine red. Found by
sampling test_orbit with pytest-split, which makes that >90-minute file
measurable in 1/10 slices.

It is the same AnyAxisymmetricRazorThinDisk story the ledger header already
documents, seen through an orbit rather than a potential. `_bk_dispatch`
deliberately serves concrete input from scipy's adaptive quad and traced input
from fixed-order GL, so traced forces carry ~1e-6 error:

    Eccentricity of a circular orbit is not equal to zero by 2.94267e-11
    for potential AnyAxisymmetricRazorThinDiskPotential and integrator dopr54_c
    assert (5.42463803e-06)**2 < 1e-16

Passes eager jax. So this is the traced accuracy trade-off, **not a defect** --
that potential now accounts for five traced failures with the same underlying
cause.

Verified load-bearing: `x` (xfail) with the entry, `F` under `--runxfail`.

### Net

jax-jit ledger **14 -> 7**.

The alternative to ledgering -- a backend-aware tolerance, loose only on the
traced path with numpy untouched -- is left for a maintainer decision rather than
done unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH