### PR TITLE
Whole-line surface density and the RazorThin degenerate radii, traceable

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -47,6 +47,7 @@ from ._namespaces import (
     device_of,
     is_backend_array,
     match_input_dtype,
+    under_trace,
 )
 
 # Default number of Gauss-Legendre nodes for the public backend ``quad``. High
@@ -437,6 +438,58 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None, device=N
     int_r = (b - c) * xp.sum(wX * vals_r, axis=-1)
     result = int_l + int_r
     return match_input_dtype(result, a, b, c)
+
+
+def symmetric_quad(xp, integrand, b, *, n=50, interior_point=0.0, device=None):
+    r"""``int_{-|b|}^{|b|} integrand(s) ds``, for finite **or infinite** ``b``.
+
+    A finite ``b`` is handed to `transformed_quad`, which splits at
+    ``interior_point`` and clusters nodes there. An infinite ``b`` cannot go
+    through any finite-range rule: the affine map sends the nodes to +-inf and
+    the weighted sum is nan. It is split into two semi-infinite halves instead,
+    each mapped by `fixed_quad_semiinfinite`.
+
+    The two halves are integrated separately rather than doubling one of them,
+    because the integrand need not be even in ``s`` -- an offset or tilted
+    wrapper potential is not.
+
+    Only a *concretely* infinite ``b`` takes the split path; a traced ``b`` of
+    unknown magnitude keeps the finite rule, since the choice cannot be made
+    inside a trace.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace.
+    integrand : callable
+        Called with the quadrature nodes.
+    b : float or array
+        Limit; the interval is ``[-|b|, |b|]``. May be ``inf``. Pass the RAW
+        limit, not one already mapped through the namespace: the finite/infinite
+        choice is made from it and a namespace op would have made it a tracer.
+    n : int, optional
+        Gauss-Legendre order (default 50).
+    interior_point : float, optional
+        Split point for the finite branch (default 0.0).
+    device : optional
+        Device to anchor the nodes on.
+    """
+    # Decide on the RAW limit, before it touches the namespace. Inside a trace
+    # ``xp.abs(numpy.inf)`` is already a tracer -- jax traces the op rather than
+    # folding it -- so asking about the converted limit always answers "unknown"
+    # and the infinite branch would be unreachable. A Python/numpy ``b`` is still
+    # concrete here and answers directly.
+    if not under_trace(b) and not bool(numpy.all(numpy.isfinite(numpy.asarray(b)))):
+        zero = asarray_on_device(xp, 0.0, device)
+        return fixed_quad_semiinfinite(
+            xp, integrand, zero, n=n, device=device
+        ) + fixed_quad_semiinfinite(
+            xp, lambda u: integrand(-u), zero, n=n, device=device
+        )
+    absb = numpy.fabs(b) if xp is numpy else xp.abs(b)
+    return transformed_quad(
+        xp, integrand, -absb, absb, n=n, interior_point=interior_point, device=device
+    )
 
 
 def nested_quad(xp, integrand, bounds, *, n=50, device=None):

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -148,9 +148,9 @@ def sigmalos(Pot, R, dens=None, surfdens=None, beta=0.0, sigma_r=None):
         called_surfdens = surfdens(R)
     elif surfdens is None:
         if densPot:
-            called_surfdens = evaluateSurfaceDensities(
-                Pot, R, numpy.inf, use_physical=False
-            )
+            # z=None asks for the whole line structurally; z=inf would be a value
+            # a trace cannot inspect (it returns NaN under jit).
+            called_surfdens = evaluateSurfaceDensities(Pot, R, None, use_physical=False)
         # xp.isnan == numpy.isnan on the numpy path (byte-identical); the
         # surfdens is a scalar here (scipy.quad / the R-scalar backend path).
         if not densPot or xp.isnan(called_surfdens):

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -146,15 +146,30 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     def _bk_split_quad(self, integrand, R, xp, dev):
         # int_0^inf integrand(a) da as [0, R] + [R, 2R] + [2R, inf); the
         # symmetric plain-GL split at R handles the a=R (m->1) singularity.
-        zero = xp.zeros_like(R)
-        two_R = 2.0 * R
-        return (
-            _bquad.fixed_quad(xp, integrand, zero, R, n=_GLORDER, device=dev)
-            + _bquad.fixed_quad(xp, integrand, R, two_R, n=_GLORDER, device=dev)
-            + _bquad.fixed_quad_semiinfinite(
-                xp, integrand, two_R, n=_GLORDER, device=dev
+        #
+        # Both degenerate radii need a guard, or the traced path returns NaN
+        # where the concrete scipy path is finite:
+        #   R = 0   -- the first two panels have zero width, but the integrand is
+        #              0/0 at a=0, so they evaluate to 0*nan. The tail alone is
+        #              then the whole [0, inf) integral, which is exactly right.
+        #   R = inf -- every panel spans an infinite range. All of these
+        #              quantities vanish as R -> inf, so the answer is 0.
+        # Selected with xp.where (no data-dependent branch, so it traces), and
+        # each dead branch is evaluated at a harmless R so a nan cannot leak back
+        # through a gradient.
+        finite = xp.isfinite(R)
+        Rs = xp.where(finite, R, xp.ones_like(R))
+        positive = Rs > 0
+        Rp = xp.where(positive, Rs, xp.ones_like(Rs))
+        inner = _bquad.fixed_quad(
+            xp, integrand, xp.zeros_like(Rp), Rp, n=_GLORDER, device=dev
+        ) + _bquad.fixed_quad(xp, integrand, Rp, 2.0 * Rp, n=_GLORDER, device=dev)
+        out = xp.where(positive, inner, xp.zeros_like(inner)) + (
+            _bquad.fixed_quad_semiinfinite(
+                xp, integrand, 2.0 * Rs, n=_GLORDER, device=dev
             )
         )
+        return xp.where(finite, out, xp.zeros_like(out))
 
     @staticmethod
     def _bk_m_aRz(a, R, z2, xp):

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -807,10 +807,9 @@ class Potential(Force):
                 # range, so one node count holds at every |z|.
                 # [..., None] so R/phi broadcast against the trailing node axis
                 # (0-d becomes (1,), which broadcasts either way).
-                inner = _bquad.transformed_quad(
+                inner = _bquad.symmetric_quad(
                     xp,
                     poisson_integrand(_node_axis(R), _node_axis(phi)),
-                    -absz,
                     absz,
                     n=50,
                     interior_point=0.0,
@@ -861,10 +860,9 @@ class Potential(Force):
             return integrate.quad(
                 lambda x: self._dens(R, x, phi=phi, t=t), -absz, absz
             )[0]
-        return _bquad.transformed_quad(
+        return _bquad.symmetric_quad(
             xp,
             lambda x: self._dens(_node_axis(R), x, phi=_node_axis(phi), t=t),
-            -absz,
             absz,
             n=50,
             interior_point=0.0,

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -732,14 +732,18 @@ class Potential(Force):
         ----------
         R : float or Quantity
             Cylindrical Galactocentric radius.
-        z : float or Quantity
-            Vertical height.
+        z : float, Quantity, or None
+            Vertical height; the integral runs over ``[-z, z]``. Pass ``None`` for
+            the whole line, ``int_{-inf}^{+inf}``. ``None`` rather than ``inf``
+            because the choice must be structural: under a jax/torch trace the
+            magnitude of a ``z=inf`` argument is not inspectable, so asking for the
+            whole line by value cannot work there (it yields NaN).
         phi : float or Quantity, optional
             Azimuth (default: 0.0).
         t : float or Quantity, optional
             Time (default: 0.0).
         forcepoisson : bool, optional
-            If True, calculate the surface density through the Poisson equation, even if an explicit expression for the surface density exists (default: False).
+            If True, calculate the surface density through the Poisson equation, even if an explicit expression for the surface density exists (default: False). Ignored when ``z is None``, which always integrates the density directly.
 
         Returns
         -------
@@ -752,6 +756,29 @@ class Potential(Force):
         - 2021-04-19 - Adjusted for non-z-symmetric densities - Bovy (UofT)
 
         """
+        if z is None:
+            # Whole line, Sigma(R) = int_{-inf}^{+inf} rho dz'. This is a
+            # STRUCTURAL request -- ``z is None`` is decided on a Python object,
+            # never on a value -- which is the point: under a trace the magnitude
+            # of a ``z=inf`` argument is unknowable, so asking for the whole line
+            # by value cannot work. Integrating the density directly also avoids
+            # the +-inf boundary terms the Poisson route below would need.
+            xp = get_namespace(R, phi, t)
+            if xp is numpy:  # same scipy call the z=inf spelling makes: identical
+                return (
+                    self._amp
+                    * integrate.quad(
+                        lambda x: self._dens(R, x, phi=phi, t=t),
+                        -numpy.inf,
+                        numpy.inf,
+                    )[0]
+                )
+            return self._amp * _bquad.symmetric_quad(
+                xp,
+                lambda x: self._dens(_node_axis(R), x, phi=_node_axis(phi), t=t),
+                numpy.inf,  # a local constant, so concrete even inside a trace
+                n=50,
+            )
         try:
             if forcepoisson:
                 raise AttributeError  # Hack!

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -305,5 +305,3 @@ jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThi
 jax-jit tests/test_potential.py::test_ExpDisk_special
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
-jax-jit tests/test_potential.py::test_potential_at_infinity[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_potential_at_zero[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -283,3 +283,70 @@ def test_torch_compile_takes_the_backend_gl_path():
         )
     # GL vs scipy adaptive quad differ only at the quadrature floor
     numpy.testing.assert_allclose(got, ref, rtol=1e-10)
+
+
+# --- degenerate radii under a trace -----------------------------------------
+# The a=R split makes R=0 and R=inf special: at R=0 the [0,R] and [R,2R] panels
+# have zero width while the integrand is 0/0 there, so they evaluate to 0*nan;
+# at R=inf every panel spans an infinite range. Both returned NaN under a trace
+# while the concrete scipy path was finite. Guarded in _bk_split_quad.
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_degenerate_radii_traced_match_numpy_jax():
+    """Phi(0) and Phi(inf) trace to the concrete values, not NaN.
+
+    Must jit: eagerly the input is concrete and the scipy branch is taken, so an
+    eager run would never touch the guarded quadrature. Compared by VALUE
+    against the numpy path -- asserting merely 'not NaN' would pass on any
+    finite garbage, and Phi(0) is a real number (~-2.79) worth pinning.
+    """
+    import galpy.backend as gb
+
+    tp = AnyAxisymmetricRazorThinDiskPotential()
+    tp.normalize(1.0)
+    for R in (0.0, numpy.inf):
+        ref = float(evaluatePotentials(tp, R, 0, phi=0.0, t=0.0))
+        with gb.use("jax", force=True):
+            got = float(
+                jax.jit(
+                    lambda Rv: evaluatePotentials(
+                        tp,
+                        Rv,
+                        jnp.asarray(0.0),
+                        phi=jnp.asarray(0.0),
+                        t=jnp.asarray(0.0),
+                    )
+                )(jnp.asarray(R))
+            )
+        assert numpy.isfinite(got), f"R={R}: traced gave {got}"
+        numpy.testing.assert_allclose(got, ref, rtol=1e-8, atol=1e-12)
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_finite_radii_unchanged_by_degenerate_guards_jax():
+    """The guards must not perturb ordinary radii -- they only select branches.
+
+    Tolerance is the pre-existing traced-GL vs scipy-adaptive floor for this
+    potential, not a licence for the guards to move anything: a guard that
+    accidentally clamped a finite R would miss by far more than this.
+    """
+    import galpy.backend as gb
+
+    tp = AnyAxisymmetricRazorThinDiskPotential()
+    tp.normalize(1.0)
+    for R in (0.3, 1.0, 3.0):
+        ref = float(evaluatePotentials(tp, R, 0.2, phi=0.0, t=0.0))
+        with gb.use("jax", force=True):
+            got = float(
+                jax.jit(
+                    lambda Rv: evaluatePotentials(
+                        tp,
+                        Rv,
+                        jnp.asarray(0.2),
+                        phi=jnp.asarray(0.0),
+                        t=jnp.asarray(0.0),
+                    )
+                )(jnp.asarray(R))
+            )
+        numpy.testing.assert_allclose(got, ref, rtol=1e-9)

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -350,3 +350,37 @@ def test_finite_radii_unchanged_by_degenerate_guards_jax():
                 )(jnp.asarray(R))
             )
         numpy.testing.assert_allclose(got, ref, rtol=1e-9)
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_degenerate_guards_do_not_break_gradients_jax():
+    """The xp.where guards must not poison AD.
+
+    Both guards evaluate their dead branch (that is what xp.where does eagerly),
+    so a nan there would reach the gradient even though the value is correct.
+    Checked as grad-vs-central-FD with h-convergence rather than
+    finite-and-nonzero: halving h must improve agreement, which a nan-poisoned or
+    merely-plausible derivative would not do.
+    """
+    import galpy.backend as gb
+
+    tp = AnyAxisymmetricRazorThinDiskPotential()
+    tp.normalize(1.0)
+    with gb.use("jax", force=True):
+
+        def f(R):
+            return evaluatePotentials(
+                tp, R, jnp.asarray(0.2), phi=jnp.asarray(0.0), t=jnp.asarray(0.0)
+            )
+
+        g = jax.grad(f)
+        for R0 in (0.3, 1.0, 3.0):
+            ad = float(g(jnp.asarray(R0)))
+            rels = []
+            for h in (1e-4, 1e-5):
+                fd = float(
+                    (f(jnp.asarray(R0 + h)) - f(jnp.asarray(R0 - h))) / (2.0 * h)
+                )
+                rels.append(abs(ad - fd) / abs(fd))
+            assert rels[-1] < 1e-9, f"R={R0}: AD vs FD rel={rels[-1]:g}"
+            assert rels[-1] < rels[0], f"R={R0}: no h-convergence {rels}"

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -384,3 +384,30 @@ def test_degenerate_guards_do_not_break_gradients_jax():
                 rels.append(abs(ad - fd) / abs(fd))
             assert rels[-1] < 1e-9, f"R={R0}: AD vs FD rel={rels[-1]:g}"
             assert rels[-1] < rels[0], f"R={R0}: no h-convergence {rels}"
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_degenerate_guards_do_not_break_gradients_torch():
+    """Same gradient check on torch: `requires_grad` also selects the GL path.
+
+    Worth having on both backends rather than trusting jax to speak for torch --
+    the guards are namespace-agnostic, so this is the assertion that says so.
+    """
+    import galpy.backend as gb
+
+    tp = AnyAxisymmetricRazorThinDiskPotential()
+    tp.normalize(1.0)
+    with gb.use("torch", force=True):
+        z, ph, t = torch.tensor(0.2), torch.tensor(0.0), torch.tensor(0.0)
+
+        def f(Rv):
+            return evaluatePotentials(tp, Rv, z, phi=ph, t=t)
+
+        for R0 in (0.3, 1.0, 3.0):
+            R = torch.tensor(R0, requires_grad=True)
+            f(R).backward()
+            ad = float(R.grad)
+            h = 1e-5
+            fd = float((f(torch.tensor(R0 + h)) - f(torch.tensor(R0 - h))) / (2.0 * h))
+            rel = abs(ad - fd) / abs(fd)
+            assert rel < 1e-9, f"torch R={R0}: AD vs FD rel={rel:g}"

--- a/tests/test_backend_potential_convenience.py
+++ b/tests/test_backend_potential_convenience.py
@@ -550,3 +550,103 @@ def test_surfdens_analytic_route_traced_matches_numpy_jax():
                 )
             rel = numpy.abs(float(got) - ref) / numpy.abs(ref)
             assert rel < 1e-10, f"FlattenedPower R={R} z={z}: rel={rel:g}"
+
+
+# --- whole-line surfdens, surfdens(R, z=None) -------------------------------
+# The whole line has to be asked for STRUCTURALLY, because under a trace the
+# magnitude of a z=inf argument is not inspectable (it used to come back NaN).
+# numpy keeps the same scipy call the z=inf spelling makes, so both spellings
+# must agree exactly there; the backend rule is a fixed-order GL pair of
+# semi-infinite halves, so it is compared by value, not merely for finiteness.
+
+_WHOLELINE_POTS = [
+    "LogarithmicHaloPotential",  # generic density-integral route
+    "MiyamotoNagaiPotential",  # has its own analytic _surfdens (bypassed)
+    "DoubleExponentialDiskPotential",  # analytic _surfdens that already did inf
+]
+
+
+@pytest.mark.parametrize(
+    "potname", ["LogarithmicHaloPotential", "MiyamotoNagaiPotential"]
+)
+def test_surfdens_wholeline_numpy_matches_inf_spelling(potname):
+    """On numpy, z=None is the SAME scipy integral as the z=inf spelling.
+
+    Byte-equality, not a tolerance: both spellings must reach
+    ``scipy.integrate.quad(..., -inf, inf)``. If z=None ever drifts onto the
+    backend GL rule on numpy this fails, which is the point -- it would silently
+    change every numpy caller (jeans.sigmalos among them).
+
+    DoubleExponentialDisk is excluded deliberately: its analytic ``_surfdens``
+    already handles z=inf, so the two spellings take different (both correct)
+    routes there. That case is covered below.
+    """
+    from galpy import potential
+
+    tp = getattr(potential, potname)()
+    tp.normalize(1.0)
+    for R in (0.5, 2.0):
+        by_value = tp.surfdens(R, numpy.inf, use_physical=False)
+        structural = tp.surfdens(R, None, use_physical=False)
+        assert float(by_value).hex() == float(structural).hex(), (
+            f"{potname} R={R}: z=inf {by_value!r} != z=None {structural!r}"
+        )
+
+
+def test_surfdens_wholeline_agrees_with_analytic_inf_form():
+    """Where a potential HAS an inf-capable closed form, the whole-line integral
+    must reproduce it -- that is what says the integral is right, not merely
+    self-consistent. DoubleExponentialDisk is the one such case today; the two
+    routes differ only at quadrature level (~4e-14), not structurally.
+    """
+    from galpy import potential
+
+    tp = potential.DoubleExponentialDiskPotential()
+    tp.normalize(1.0)
+    for R in (0.5, 2.0):
+        analytic = tp.surfdens(R, numpy.inf, use_physical=False)
+        integral = tp.surfdens(R, None, use_physical=False)
+        rel = numpy.abs(integral - analytic) / numpy.abs(analytic)
+        assert rel < 1e-12, f"R={R}: analytic {analytic!r} vs integral {integral!r}"
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="jax not installed")
+@pytest.mark.parametrize("potname", _WHOLELINE_POTS)
+def test_surfdens_wholeline_traced_matches_numpy_jax(potname):
+    """Traced whole-line surfdens matches numpy. Every one of these was NaN before.
+
+    Must jit: eagerly the limit is concrete and scipy is used, so an eager run
+    would assert nothing about the semi-infinite backend rule. Tolerance is set
+    just above the measured floor (worst 7.0e-13, MiyamotoNagai), so a
+    regression to a single finite-range panel -- which returns NaN here -- fails
+    loudly rather than passing.
+    """
+    import galpy.backend as gb
+    from galpy import potential
+
+    tp = getattr(potential, potname)()
+    tp.normalize(1.0)
+    for R in (0.5, 2.0):
+        ref = tp.surfdens(R, None, use_physical=False)
+        with gb.use("jax", force=True):
+            got = jax.jit(lambda Rv: tp.surfdens(Rv, None, use_physical=False))(
+                jnp.asarray(R)
+            )
+        rel = numpy.abs(float(got) - ref) / numpy.abs(ref)
+        assert rel < 5e-12, f"{potname} R={R}: rel={rel:g}"
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+def test_surfdens_wholeline_eager_torch_matches_numpy():
+    """Eager torch takes the backend rule too (the namespace, not the limit, picks it)."""
+    import galpy.backend as gb
+    from galpy import potential
+
+    tp = potential.LogarithmicHaloPotential(q=1.0)
+    tp.normalize(1.0)
+    ref = tp.surfdens(1.0, None, use_physical=False)
+    with gb.use("torch", force=True):
+        got = tp.surfdens(torch.tensor(1.0), None, use_physical=False)
+    assert torch.is_tensor(got)
+    rel = numpy.abs(float(got) - ref) / numpy.abs(ref)
+    assert rel < 5e-12, f"torch whole-line: rel={rel:g}"

--- a/tests/test_jeans.py
+++ b/tests/test_jeans.py
@@ -259,7 +259,9 @@ def test_sigmalos_wlog_zerobeta():
                         lp,
                         r,
                         dens=lambda x: lp.dens(x, 0.0),
-                        surfdens=lambda x: lp.surfdens(x, numpy.inf),
+                        # z=None is the whole-line spelling; z=inf is a value a
+                        # trace cannot inspect (byte-identical here on numpy)
+                        surfdens=lambda x: lp.surfdens(x, None),
                         sigma_r=lambda x: 1.0 / numpy.sqrt(2.0),
                     )
                     for r in rs
@@ -282,7 +284,7 @@ def test_sigmalos_wlog_zerobeta():
                         lp,
                         r,
                         dens=lambda x: lp.dens(x, 0.0),
-                        surfdens=lp.surfdens(r, numpy.inf),
+                        surfdens=lp.surfdens(r, None),
                         sigma_r=lambda x: 1.0 / numpy.sqrt(2.0),
                     )
                     for r in rs


### PR DESCRIPTION
Fixes the silent-NaN defect #1212 introduced, plus the two degenerate-radius NaNs
in the same family.

## 1. `surfdens(R, z=None)` -- the whole line, asked for structurally

`surfdens(R, inf)` returned **NaN under a trace**. Narrow cause:
`transformed_quad` cannot integrate an infinite range (its affine map sends the
nodes to +-inf and the sum is nan), and #1212 routed every traced call there, inf
included. Before #1212 the same call *raised*, so that PR traded a loud crash for
a silent wrong value.

It cannot be fixed by detecting inf: `@backend_input` coerces z at the boundary,
so by the time the method runs z is a `DynamicJaxprTracer` whose magnitude is not
inspectable (measured with a spy, not assumed). So the whole line is now
requested **structurally**, with `z=None` -- a decision made on a Python object,
never on a value.

| potential | numpy | traced (was NaN) |
|---|---|---|
| LogarithmicHalo | 0.25 | **0.25** |
| MiyamotoNagai | 0.18494223 | **0.18494223** |
| DoubleExpDisk | 0.07164229 | 0.07164229 |

**numpy is untouched.** `z=None` on numpy makes the same
`scipy.integrate.quad(..., -inf, inf)` call the `z=inf` spelling already made --
asserted as **hex equality**, not a tolerance, so future drift fails loudly. The
pre-existing `z=inf` spelling is not changed at all.

Adds `galpy.backend.quadrature.symmetric_quad`: `[-|b|, |b|]` for finite or
infinite b, the infinite case splitting into two **separate** semi-infinite halves
rather than doubling one, because the integrand need not be even in z (offset and
tilted wrappers are not).

`jeans.sigmalos` switches to `z=None`; **test_jeans goes 4 passed/1 failed ->
5 passed** under --jit, and stays 5/5 on numpy and torch.

## 2. RazorThin degenerate radii

`AnyAxisymmetricRazorThinDisk` returned NaN under a trace at R=0 and R=inf.
Instrumenting the three panels of the a=R split shows two different causes:

- **R=0** -- the [0,R] and [R,2R] panels have zero width but the integrand is 0/0
  at a=0, so each is `0*nan`. The [2R,inf) panel is finite and is already the
  whole integral.
- **R=inf** -- every panel spans an infinite range; these quantities vanish there.

Guarded with `xp.where` in the **shared** `_bk_split_quad`, so all six _gl kernels
benefit. Backend-only -- the concrete path goes to scipy via `_bk_dispatch`.

| | numpy | traced |
|---|---|---|
| Phi(0) | -2.7855674 | **-2.7855674** (was nan) |
| Phi(inf) | 0 | **0** (was nan) |

Finite radii unchanged (6.7e-15 / 4.7e-13 / 2.5e-11 at R=0.3/1/3 -- the
pre-existing GL-vs-scipy floor).

## Verification

- **Gradients survive the guards**: grad-vs-central-FD with h-convergence, on
  **both** jax and torch (torch reaches the guarded split via `requires_grad`, a
  different door). 1.8e-10 / 2.4e-11 / 3.5e-11 at h=1e-5; error shrinks ~100x for
  10x smaller h, which a poisoned derivative would not do.
- **Full traced test_potential.py**: 5 splits, **1326 tests, 0 failures**. Checking
  the whole file matters because the guard lives in a shared helper.
- test_backend_anyaxisymdisk 17 passed; test_backend_potential_convenience 119
  passed; test_backend_quadrature 44 passed.

jax-jit ledger **7 -> 5**. The two remaining RazorThin entries are different
problems: test_2ndDeriv is the by-design GL accuracy limit, test_poisson_surfdens
is the scalar-only-inputs decorator.

## Known rough edge

For a potential with an inf-capable closed form, `z=None` and `z=inf` can differ
at quadrature level (DoubleExpDisk, ~4e-14) because z=None integrates the density
while z=inf uses the closed form. Letting such potentials serve z=None from their
closed form is a natural opt-in, left as a follow-up rather than guessed at. A
bonus of the same property: `z=None` returns a correct finite value where
`z=inf` gives NaN even on numpy (NFW 0.2747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH

## Also repairs torch tracing, not just jax

Measured after opening this PR: `test_jeans` passes under `--backend torch --jit`
**only with this branch** -- the whole-line `surfdens` change is backend-agnostic,
so the same NaN it fixes under jax tracing was breaking torch tracing too. The
body above only claimed eager torch.

Context for that measurement: `torch --jit` had never been exercised at all (the
ledger has 51 jax / 5 jax-jit / 99 torch / **0 torch-jit** entries). Sweeping it
across 10 suites -- sphericaldf, diskdf, coords, scf, qdf, streamspraydf,
evolveddiskdf, conversion, dynamfric, jeans -- gives **702 tests, 0 failures**,
so no `torch-jit` ledger entries are needed anywhere. torch tracing has been
working the whole time; it had simply never been looked at.
