### PR TITLE
Gate the traced quadrature on under_trace: torch.compile could return a silently wrong surfdens

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -27,11 +27,11 @@ from ..backend import (
     backend_input,
     coerce_coords,
     get_namespace,
-    has_concrete_truth_value,
     is_backend_array,
     is_backend_compatible,
 )
 from ..backend import quadrature as _bquad
+from ..backend._namespaces import under_trace
 from ..util import conversion, coords, galpyWarning, plot
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -114,24 +114,29 @@ def potential_positional_arg(func):
 
 
 def _quad_needs_backend(xp, absz):
-    """True only when scipy.integrate.quad CANNOT be used: the limit is a tracer.
+    """True only when scipy.integrate.quad CANNOT be used: we are inside a trace.
 
     The backend Gauss-Legendre rule exists here for exactly one reason -- under a
     trace scipy is unusable, so the integral must be built from array ops.
-    Whenever the limit is concrete (numpy, and eager jax/torch alike) scipy is
-    still the better tool: it is adaptive, it handles an infinite limit by
-    transformation (``jeans.sigmalos`` integrates the whole line of sight), and it
-    calls the integrand node-by-node so scalar-only potentials keep working.
+    Outside a trace (numpy, and eager jax/torch alike) scipy is still the better
+    tool: it is adaptive, and it calls the integrand node-by-node so scalar-only
+    potentials keep working.
 
-    Gating on concreteness rather than on "does this potential accept an array"
+    Gating on tracedness rather than on "does this potential accept an array"
     matters because the latter is NOT decidable: `_force_accepts_arrays` sees only
     the top-level type, and a potential that composes or wraps a scalar-only one
     forwards through its own undecorated ``_Rforce`` and so looks array-safe.
-    Concreteness is decidable, and it leaves every eager path untouched.
+
+    ``under_trace`` and NOT a concreteness probe: under ``torch.compile`` dynamo
+    turns ``float(x)`` into a symbolic scalar, so a probe answers "concrete", the
+    scipy branch runs inside the compiled region, and the result was silently
+    wrong -- AnyAxisymmetricRazorThinDisk's surfdens came back 2.2e-15 instead of
+    0.0662, order-dependently. ``under_trace`` asks
+    ``torch.compiler.is_compiling()``, which dynamo cannot fool.
     """
     if xp is numpy:
         return False
-    return not has_concrete_truth_value(xp.all(xp.isfinite(absz)))
+    return under_trace(absz)
 
 
 def _node_axis(v):

--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -8,8 +8,9 @@ import math
 
 import numpy
 
-from ..backend import coerce_coords, get_namespace, has_concrete_truth_value
+from ..backend import coerce_coords, get_namespace
 from ..backend import special as bspecial
+from ..backend._namespaces import under_trace
 from ..util import conversion
 from .Potential import Potential
 
@@ -252,9 +253,12 @@ class RazorThinExponentialDiskPotential(Potential):
                 - bspecial.k1(y) * (3.0 * bspecial.i0(y) + bspecial.iv(2, y))
             )
             allin = xp.all(inplane)
-            if not has_concrete_truth_value(allin):
+            if under_trace(z):
                 # Traced: the domain cannot be decided at trace time, so return
-                # NaN off-plane rather than refusing to trace at all.
+                # NaN off-plane rather than refusing to trace at all. Asked via
+                # under_trace, not a concreteness probe: dynamo makes float(x)
+                # symbolic, so a probe answers "decidable" under torch.compile and
+                # this falls through to the raise below instead of the NaN.
                 return xp.where(inplane, val, xp.asarray(xp.nan))
             if not allin:
                 raise AttributeError(

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -301,6 +301,15 @@ torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 # with e=5.4e-6 against a 1e-8 tolerance. Passes eager jax. Un-ledger if the
 # tolerance is ever made backend-aware.
 jax-jit tests/test_orbit.py::test_eccentricity
+# torch-jit, 2026-07-29: the FIRST torch-jit entries. Until now torch.compile
+# never reached the traced quadrature at all -- `_quad_needs_backend` used a
+# concreteness probe, and dynamo makes float(x) symbolic, so torch silently took
+# the scipy branch (and could return a wrong number: AnyAxisym surfdens came back
+# 2.2e-15 instead of 0.0662, order-dependently). With the gate on `under_trace`,
+# torch now takes the same GL path as jax and hits the same scalar-only-inputs
+# decorator. Same cause as the jax-jit entries just below; fix both together.
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[DoubleExponentialDiskPotential]
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_ExpDisk_special
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]


### PR DESCRIPTION
## The bug

```
AnyAxisymmetricRazorThinDisk.surfdens(1.0, 0.5, forcepoisson=True)
  numpy / torch eager :  0.06621732146004472
  under torch.compile :  2.2352231511396381e-15     <-- ~13 orders out
  under jax.jit       :  raises TypeError (GL path)
```

and **order-dependent**: in a process that had already compiled `surfdens` for
other potentials it returned the right answer. A suite can go green while a
user's script is wrong.

Found by running `--backend torch --jit` for the first time -- the ledger had
51 jax / 5 jax-jit / 99 torch / **0 torch-jit** entries, so torch tracing had
never been exercised.

## Cause

`_quad_needs_backend` asked `has_concrete_truth_value(...)`, which is a
`float()` probe in disguise. `under_trace`'s own docstring already warned why
that fails: dynamo turns `float(x)` into a symbolic scalar, so the probe answers
"concrete", the scipy branch runs inside the compiled region, and nothing raises.

jax was unaffected -- a tracer has no concrete truth value, so jax always took the
GL path. That is why the two tracers silently disagreed about the same code.

`under_trace` asks `torch.compiler.is_compiling()`, which dynamo cannot fool.

## Second site, same probe

`RazorThinExponentialDisk._R2deriv` chooses between "return NaN off-plane under a
trace" and "raise". torch.compile fell through to the raise, so it did not honour
the traced contract. Both tracers now return NaN off-plane; in-plane values are
unchanged (-1.45788525278796).

An audit of **every** `has_concrete_truth_value` gate and raw `float()` probe in
galpy found exactly these two exposed sites. AnyAxisymmetricRazorThinDisk's own
probe was already guarded with `under_trace` -- which is where the warning
docstring came from.

## Intended consequence

torch now takes the same GL path as jax and hits the same scalar-only-inputs
decorator, so the two `poisson_surfdens` tests start failing under torch --jit
exactly as they already do under jax --jit. Ledgered as the first two
`torch-jit` entries. **A loud shared failure beats an order-dependent silent
wrong number.**

## Verification

| check | result |
|---|---|
| torch --jit test_potential.py (5 splits) | **1326 tests, 0 failures** |
| jax --jit jeans + anyaxisymdisk + potential_convenience | **141 tests, 0 failures** |
| numpy test_potential -k "RazorThin or AnyAxisym" | 15 passed |
| torch.compile surfdens | now raises like jax (was 2.2e-15) |
| torch.compile R2deriv off-plane | now NaN like jax (was raising) |

numpy cannot reach the changed line at all -- the gate returns False for numpy
before anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH