### PR TITLE
jit ledger: un-ledger test_ExpDisk_special, record two measured interpRZPotential gaps

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -318,5 +318,4 @@ jax-jit tests/test_orbit.py::test_eccentricity
 # the a=R principal value is resolved; same root cause as test_2ndDeriv below.
 torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_ExpDisk_special
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -301,6 +301,28 @@ torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 # with e=5.4e-6 against a 1e-8 tolerance. Passes eager jax. Un-ledger if the
 # tolerance is ever made backend-aware.
 jax-jit tests/test_orbit.py::test_eccentricity
+# tests/test_interp_potential.py, 2026-07-29: found by running this file traced
+# for the first time. Both PASS eager and fail only under --jit, and both compare
+# an interpRZPotential grid built with use_c=True against the same grid built in
+# Python, to 1e-14. Traced, that Python-side construction loses one to two digits:
+#
+#             pot grid   rforce grid   (bar 1e-14)
+#   eager     2.665e-15    1.776e-15
+#   jax --jit 5.596e-14    6.621e-13
+#
+# So this is NUMERICAL over-tolerance, not a wrong result -- the traced grid is
+# still right to ~1e-13.
+#
+# Root cause, localised: of MWPotential's three components only NFW moves
+# (MiyamotoNagai 3.5e-16, Hernquist 5.8e-16, NFW 1.1e-14), and its jax EAGER
+# value is BIT-IDENTICAL to numpy while its jitted value differs -- reproducibly,
+# same answer every run. So XLA compiles NFW's log1p(r/a)/(r/a) differently from
+# how it evaluates it eagerly, which is exactly the cancellation-prone shape for
+# that to show. A jit-mode numerical characteristic, not a galpy defect: nothing
+# to fix in the potential. Recorded rather than papered over, because the only
+# real remedy is a backend-aware tolerance and loosening one needs Jo's sign-off.
+jax-jit tests/test_interp_potential.py::test_interpolation_potential_use_c
+jax-jit tests/test_interp_potential.py::test_interpolation_potential_force_use_c
 # torch-jit, 2026-07-29: the FIRST torch-jit entries. Until now torch.compile
 # never reached the traced quadrature at all -- `_quad_needs_backend` used a
 # concreteness probe, and dynamo makes float(x) symbolic, so torch silently took

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -4300,12 +4300,23 @@ def test_ExpDisk_special():
     # Check the PotentialError for z=/=0 evaluation of R2deriv of RazorThinDiskPotential
     rp = potential.RazorThinExponentialDiskPotential(normalize=1.0)
     try:
-        rp.R2deriv(1.0, 0.1)
+        rpR2deriv = rp.R2deriv(1.0, 0.1)
     except potential.PotentialError:
-        pass
+        pass  # off-plane is outside the domain: the documented refusal
     else:
-        raise AssertionError(
-            "RazorThinExponentialDiskPotential's R2deriv did not raise AttributeError for z=/= 0 input"
+        # Under a trace the domain cannot be decided at trace time -- z is a
+        # tracer -- so refusing would mean refusing to trace at all. The chosen
+        # contract there is NaN off-plane instead. That is the ONLY circumstance
+        # in which not raising is acceptable: on numpy the refusal still stands.
+        from galpy.backend import get_namespace
+
+        assert get_namespace(1.0) is not numpy, (
+            "RazorThinExponentialDiskPotential's R2deriv did not raise "
+            "PotentialError for z=/=0 input on the numpy path"
+        )
+        assert numpy.isnan(as_numpy(rpR2deriv)), (
+            "RazorThinExponentialDiskPotential's R2deriv neither raised nor "
+            f"returned NaN for z=/=0 input; got {rpR2deriv!r}"
         )
     return None
 


### PR DESCRIPTION
Two changes that make the jit ledger match measured reality. Net **-1 / +2**, but
in the direction that matters: one entry is genuinely fixed, and two silent gaps
become documented ones with numbers attached.

## 1. `test_ExpDisk_special` un-ledgered (a real flip)

Its last block asserts `RazorThinExponentialDisk.R2deriv` **raises** for z≠0 —
correct, since off-plane is outside its domain. But #1218 made the traced path
return **NaN** there instead (your call: "let's do NaN"), because under a trace
`z` is a tracer, the domain cannot be decided, and raising would mean refusing to
trace at all. The test had no way to say that, so it was ledgered.

It now asserts the actual two-regime contract: a non-raise is acceptable **only**
on a backend, and only as NaN. The numpy refusal is still required, so this is
not a weakening — it states the case the old assertion could not express.

Verified in all four modes, and confirmed the flip is real rather than a test
that was passing anyway:

```
  numpy    -> PASS       WITHOUT the fix, jax --jit -> FAIL
  jax      -> PASS       (test_potential.py:4307 AssertionError)
  jaxjit   -> PASS
  torchjit -> PASS
```

## 2. Two measured jit-only interpRZPotential gaps, ledgered

Found by running `tests/test_interp_potential.py` traced for the first time. The
file already had two ledger entries — for *different* tests. These two compare an
interpRZPotential grid built with `use_c=True` against the same grid built in
Python, to 1e-14, and they **pass eager, fail only under `--jit`**:

```
            pot grid   rforce grid   (bar 1e-14)
  eager     2.665e-15    1.776e-15
  jax --jit 5.596e-14    6.621e-13
```

Root-caused rather than left as a symptom. Of MWPotential's three components only
NFW moves (MiyamotoNagai 3.5e-16, Hernquist 5.8e-16, **NFW 1.1e-14**), and at the
worst grid point jax **eager** is bit-identical to numpy while only the **jitted**
value differs — reproducibly:

```
  eager numpy   -4.08407232333320369e+00
  jax EAGER     -4.08407232333320369e+00   rel = 0.000e+00
  jax jit       -4.08407232333324721e+00   rel = 1.066e-14
```

So XLA compiles NFW's `log1p(r/a)/(r/a)` differently from how it evaluates it
eagerly — exactly the cancellation-prone shape for that to surface. **A jit-mode
numerical characteristic, not a galpy defect**: nothing in the potential to fix,
and the traced grid is still right to ~1e-13.

Recorded rather than papered over, because the only real remedy is a
backend-aware tolerance and loosening a tolerance is yours to approve. Verified
both register as `xx`, not reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH