### PR TITLE
linearPotential: coerce x on the raw 1D entries under a forced backend

### DIFF
--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -5,7 +5,7 @@ import pickle
 
 import numpy
 
-from ..backend import backend_input
+from ..backend import backend_input, coerce_coords, get_namespace
 from ..util import config, conversion, plot
 from ..util.conversion import (
     physical_compatible,
@@ -19,6 +19,28 @@ from .Potential import (
     potential_list_of_potentials_input,
     potential_positional_arg,
 )
+
+
+def _coerce_x(pot, x):
+    """Bring ``x`` onto the active backend for a backend-compatible potential.
+
+    The ``_*_nodecorator`` entries below are the RAW ones the integrators call,
+    so they bypass ``@backend_input`` -- which is the point, no per-step
+    decorator cost -- but it means that under a forced backend they see whatever
+    the integrator hands over, i.e. a numpy scalar. A migrated 1D potential then
+    does real backend arithmetic on it (``xp.sqrt(x**2 + D2)``) and torch
+    rejects a numpy scalar outright.
+
+    This is the 1D analogue of the coercion
+    :func:`~galpy.potential.Potential.check_potential_inputs_not_arrays` already
+    performs for 3D, and it is gated the same way. ``t`` is left alone, also as
+    in 3D: it may be used as a hashable cache key downstream. The numpy path is
+    byte-identical -- ``coerce_coords`` is an object-identical pass-through when
+    the namespace is numpy.
+    """
+    if not getattr(pot, "_backend_compatible", False):
+        return x
+    return coerce_coords(get_namespace(x), x)[0]
 
 
 class linearPotential:
@@ -258,6 +280,7 @@ class linearPotential:
 
     def _call_nodecorator(self, x, t=0.0):
         # Separate, so it can be used during orbit integration
+        x = _coerce_x(self, x)
         try:
             return self._amp * self._evaluate(x, t=t)
         except AttributeError:  # pragma: no cover
@@ -293,6 +316,7 @@ class linearPotential:
 
     def _force_nodecorator(self, x, t=0.0):
         # Separate, so it can be used during orbit integration
+        x = _coerce_x(self, x)
         try:
             return self._amp * self._force(x, t=t)
         except AttributeError:  # pragma: no cover
@@ -304,6 +328,7 @@ class linearPotential:
         # the 1D variational (dxdv) equations; the RHS applies the sign to get
         # the force gradient dF/dx = -d^2 Phi / dx^2. Separate, so it can be
         # used during orbit integration.
+        x = _coerce_x(self, x)
         try:
             return self._amp * self._force2deriv(x, t=t)
         except AttributeError:  # pragma: no cover

--- a/tests/test_linear_dxdv.py
+++ b/tests/test_linear_dxdv.py
@@ -12,6 +12,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 SYMPLECTIC = ["leapfrog_c", "symplec4_c", "symplec6_c"]
 ORDER = {"leapfrog_c": 2, "symplec4_c": 4, "symplec6_c": 6}
 # Fixed-step methods whose 1D dxdv base is byte-identical to plain integrate
@@ -163,7 +165,9 @@ def test_linear_dxdv_closed_form_harmonic():
             o = Orbit(ic)
             tpre = numpy.linspace(0.0, T, 51)
             o.integrate(tpre, pot, method="dop853_c")
-            assert numpy.amax(numpy.fabs(o.x(tpre))) < 0.9 * hs.R
+            # as_numpy: o.x() is a backend array under a forced backend, and
+            # numpy.amax dispatches to Tensor.max(axis=, out=), which torch rejects.
+            assert numpy.amax(numpy.fabs(as_numpy(o.x(tpre)))) < 0.9 * float(hs.R)
         # RK / pure-Python: high-order/adaptive -> tight
         for method in RK:
             dt = 0.005

--- a/tests/test_symplectic_dxdv.py
+++ b/tests/test_symplectic_dxdv.py
@@ -14,6 +14,8 @@
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 SYMPLECTIC = ["leapfrog_c", "symplec4_c", "symplec6_c"]
 ORDER = {"leapfrog_c": 2, "symplec4_c": 4, "symplec6_c": 6}
 
@@ -238,8 +240,14 @@ def test_symplectic_dxdv_closed_form_harmonic():
     o = Orbit(_IC)
     times_pre = numpy.linspace(0.0, T, 51)
     o.integrate(times_pre, pot, method="dop853_c")
-    r = numpy.sqrt(o.x(times_pre) ** 2 + o.y(times_pre) ** 2 + o.z(times_pre) ** 2)
-    assert numpy.amax(r) < 0.9 * pot.R
+    # as_numpy: the accessors return backend arrays under a forced backend and
+    # numpy.amax dispatches to Tensor.max(axis=, out=), which torch rejects.
+    r = numpy.sqrt(
+        as_numpy(o.x(times_pre)) ** 2
+        + as_numpy(o.y(times_pre)) ** 2
+        + as_numpy(o.z(times_pre)) ** 2
+    )
+    assert numpy.amax(r) < 0.9 * float(pot.R)
     # order-appropriate absolute tolerances at dt=0.02 (a lower-order method
     # cannot reach a higher-order method's bound)
     abstol = {"leapfrog_c": 1e-3, "symplec4_c": 1e-6, "symplec6_c": 1e-9}
@@ -465,8 +473,8 @@ def test_symplectic_dxdv_planar_closed_form_harmonic():
     o = Orbit(_IC_p)
     tpre = numpy.linspace(0.0, T, 51)
     o.integrate(tpre, pot, method="dop853_c")
-    r = numpy.sqrt(o.x(tpre) ** 2 + o.y(tpre) ** 2)
-    assert numpy.amax(r) < 0.9 * hs.R
+    r = numpy.sqrt(as_numpy(o.x(tpre)) ** 2 + as_numpy(o.y(tpre)) ** 2)
+    assert numpy.amax(r) < 0.9 * float(hs.R)
     abstol = {"leapfrog_c": 1e-3, "symplec4_c": 1e-6, "symplec6_c": 1e-9}
     for method in SYMPLECTIC:
         dt = 0.02


### PR DESCRIPTION
## A pre-existing torch bug, not a jit gap

`tests/test_linear_dxdv.py` and `tests/test_symplectic_dxdv.py` had **never been
run under `--backend torch` by anything** — not CI, not the earlier sweeps — so
7 failures sat there unledgered and unseen. Found by sweeping the
never-torch-traced suites.

I checked whether it was jit-specific before concluding anything: **torch eager
fails identically (5/9)**. So this is plain pre-existing breakage.

```
x = np.float64(0.3), t = np.float64(0.0)
return -x * (self._K / xp.sqrt(x**2 + self._D2) + 2.0 * self._F)
TypeError: sqrt(): argument 'input' must be Tensor, not numpy.float64
    galpy/potential/KGPotential.py:79
```

## Cause: the 1D analogue of an existing 3D coercion is missing

The `_*_nodecorator` entries are the raw ones the integrators call, so they
bypass `@backend_input` — deliberately, to avoid per-step decorator cost — and
under a forced backend they receive whatever the integrator hands over, i.e. a
numpy scalar. `get_namespace` then resolves to torch and the potential's own
backend arithmetic rejects it.

The 3D path does not have this problem, because
`check_potential_inputs_not_arrays` already coerces for `_backend_compatible`
potentials. **The 1D analogue was simply never written.**

Added it at the three shared 1D entries (`_call_` / `_force_` /
`_force2deriv_nodecorator`), gated the same way, leaving `t` alone for the same
reason 3D does (it can be a hashable cache key downstream). One helper, one
place, every 1D potential — not a per-potential patch.

Coerce rather than data-guard, per the standing rule that a forced backend must
actually **run** on the backend. numpy is byte-identical: `coerce_coords` is an
object-identical pass-through when the namespace is numpy.

## Two causes, one symptom

The `sqrt` errors vanished immediately but **3 of the 7 failures survived**, and
they were something else: three assertions feed a backend Orbit accessor straight
into `numpy.amax`, which dispatches to `Tensor.max(axis=, out=)` and torch
rejects. Cast with `as_numpy` at those sites (a no-op on numpy). Had I stopped at
"torch 7 → 3, good enough", this would have been half a fix.

## Verification

| mode | result |
|---|---|
| numpy | **21/21** |
| torch (eager) | **21/21** |
| torch `--jit` | **21/21** |
| jax (eager) | **21/21** |
| jax `--jit` | **21/21** |

No ledger change: these were never ledgered, because nothing had ever run them
on torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH