### PR TITLE
Ledger: state the reducible-vs-blocked split so the count reads honestly

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -86,6 +86,22 @@
 #
 # format: <backend> <nodeid>   (conftest applies xfail(strict=False) per backend;
 # tests unrunnable-until-vectorized go in backend_slow_skip.txt instead, not here)
+#
+# READING THE COUNT (2026-07-29). The headline entry count overstates the
+# remaining migration work, because a third of it is ONE class that refuses
+# backends by construction:
+#
+#   total entries        156
+#   actionAngleVerticalInverse  48   (24 jax + 24 torch)
+#   -------------------------------
+#   reducible by fixes  108
+#
+# `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
+# as a backend is active (it builds scipy interpolation / ndimage grids), so those
+# 48 CANNOT be burned down by incremental backend fixes -- they move only if that
+# class is migrated, which is a scoping decision, not a bug hunt. Counting them
+# alongside the reducible 108 makes the ledger look ~44% larger than the work it
+# actually represents. Split it before quoting the number as progress.
 
 jax tests/test_SpiralArmsPotential.py::TestSpiralArmsPotential::test_Rzderiv
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c


### PR DESCRIPTION
The ledger entry count is what we quote as burndown progress. It currently
overstates the remaining migration work by **~44%**:

```
  total entries                156
  actionAngleVerticalInverse    48   (24 jax + 24 torch)
  ------------------------------------
  reducible by fixes           108
```

`actionAngleVerticalInverse._reject_backend` raises `NotImplementedError` the
moment a backend is active — it builds scipy interpolation / `ndimage` grids — so
those 48 entries **cannot be moved by incremental backend fixes at all**. They
shift only if that class is migrated, which is a scoping call rather than a bug
hunt. Counting them next to the reducible 108 makes the number look worse than
the work it represents.

Found while clustering the ledger to pick the next burndown slice: one class is
31% of all entries, and 45% of the two files that dominate it.

**Comment-only** — nothing about which tests xfail changes. Verified:

| check | result |
|---|---|
| ledger still parses | 156 entries counted |
| `tests/test_backend_ledger.py` | 5/5 pass |
| a ledgered test under `--jit` | still registers `x` (xfail), not a red |

Note on wording: the class's own docstring says "NOT **yet** backend-migrated
(under active development)", so I deliberately did not assert whether it is
deferred or permanently out of scope — the note states only the mechanical fact
that incremental fixes cannot reduce those entries. If it is in fact out of scope
for good, that is worth saying in the file too, and you are better placed to say
it than I am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH