### PR TITLE
test_quantity: express turn_physical_off's contract backend-agnostically (6 entries)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,10 +91,10 @@
 # remaining migration work, because a third of it is ONE class that refuses
 # backends by construction:
 #
-#   total entries        156
+#   total entries        150
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes  108
+#   reducible by fixes  102
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
@@ -136,9 +136,6 @@ jax tests/test_actionAngle.py::test_physical_vertical
 jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
-jax tests/test_quantity.py::test_actionAngle_method_turnphysicaloff
-jax tests/test_quantity.py::test_potential_function_turnphysicaloff
-jax tests/test_quantity.py::test_potential_method_turnphysicaloff
 jax tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
 jax tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 jax tests/test_quantity.py::test_sphericaldf_method_value
@@ -218,9 +215,6 @@ torch tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_qdf.py::test_sampleV
 torch tests/test_qdf.py::test_sampleV_interpolate
 torch tests/test_qdf.py::test_sampleV_physical
-torch tests/test_quantity.py::test_actionAngle_method_turnphysicaloff
-torch tests/test_quantity.py::test_potential_function_turnphysicaloff
-torch tests/test_quantity.py::test_potential_method_turnphysicaloff
 torch tests/test_quantity.py::test_potential_paramunits
 torch tests/test_quantity.py::test_quasiisothermaldf_interpolate_sample
 torch tests/test_quantity.py::test_quasiisothermaldf_method_returntype

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17,7 +17,7 @@ _NUMPY_1_22 = (_NUMPY_VERSION > parse_version("1.21")) * (
 )  # For testing 1.22/1.24 precision issues
 from astropy import constants, units
 
-from galpy.backend import as_numpy  # noqa: E402
+from galpy.backend import as_numpy, is_backend_array  # noqa: E402
 
 # Backends installed here, for the units-through-a-backend regressions. Probed
 # rather than imported: importing torch/jax costs seconds and most of this file
@@ -11582,25 +11582,46 @@ def test_potential_method_turnphysicalon():
     return None
 
 
+def _plain_scalar_no_units(v):
+    """True when ``v`` is a plain number, i.e. what turn_physical_off() promises.
+
+    Replaces a bare ``isinstance(v, float)``, which is numpy-specific: under a
+    forced backend galpy returns a 0-d BACKEND array by design (that is what makes
+    these calls traceable), so the float check fails on a correct result.
+
+    On numpy this is EXACTLY as strict as the old check -- the first two branches
+    are all a numpy result can reach, so a Python float (incl. ``numpy.float64``,
+    a float subclass) passes and a 0-d ``ndarray`` still does not, because
+    ``is_backend_array`` answers False for numpy arrays. Only jax/torch 0-d arrays
+    are newly accepted. A Quantity is never acceptable: dropping units is the
+    whole point of turn_physical_off().
+    """
+    if isinstance(v, units.Quantity):
+        return False
+    if isinstance(v, float):
+        return True
+    return is_backend_array(v) and numpy.ndim(as_numpy(v)) == 0
+
+
 def test_potential_method_turnphysicaloff():
     from galpy import potential
 
     # 3D
     pot = potential.BurkertPotential(ro=7.0 * units.kpc)
     pot.turn_physical_off()
-    assert isinstance(pot(1.1, 0.1), float), (
+    assert _plain_scalar_no_units(pot(1.1, 0.1)), (
         "Potential method does not return float when turn_physical_off has been called"
     )
     # 2D
     pot = potential.EllipticalDiskPotential(ro=6.0 * units.kpc)
     pot.turn_physical_off()
-    assert isinstance(pot(1.1, phi=0.1), float), (
+    assert _plain_scalar_no_units(pot(1.1, phi=0.1)), (
         "Potential method does not return float when turn_physical_off has been called"
     )
     # 1D
     pot = potential.KGPotential(ro=5.0 * units.kpc)
     pot.turn_physical_off()
-    assert isinstance(pot(1.1), float), (
+    assert _plain_scalar_no_units(pot(1.1)), (
         "Potential method does not return float when turn_physical_off has been called"
     )
     return None
@@ -11683,37 +11704,38 @@ def test_potential_function_turnphysicaloff():
     # 3D
     pot = potential.BurkertPotential(ro=7.0 * units.kpc)
     potential.turn_physical_off(pot)
-    assert isinstance(potential.evaluatePotentials(pot, 1.1, 0.1), float), (
+    assert _plain_scalar_no_units(potential.evaluatePotentials(pot, 1.1, 0.1)), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     pot = potential.CompositePotential([potential.BurkertPotential(ro=7.0 * units.kpc)])
     potential.turn_physical_off(pot)
-    assert isinstance(potential.evaluatePotentials(pot, 1.1, 0.1), float), (
+    assert _plain_scalar_no_units(potential.evaluatePotentials(pot, 1.1, 0.1)), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     # 2D
     pot = potential.EllipticalDiskPotential(ro=6.0 * units.kpc)
     potential.turn_physical_off(pot)
-    assert isinstance(potential.evaluateplanarPotentials(pot, 1.1, phi=0.1), float), (
+    assert _plain_scalar_no_units(
+        potential.evaluateplanarPotentials(pot, 1.1, phi=0.1)
+    ), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     pot = potential.planarCompositePotential([pot])
     potential.turn_physical_off(pot)
-    assert isinstance(
+    assert _plain_scalar_no_units(
         potential.evaluateplanarPotentials(pot, 1.1, phi=0.1),
-        float,
     ), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     # 1D
     pot = potential.KGPotential(ro=5.0 * units.kpc)
     potential.turn_physical_off(pot)
-    assert isinstance(potential.evaluatelinearPotentials(pot, 1.1), float), (
+    assert _plain_scalar_no_units(potential.evaluatelinearPotentials(pot, 1.1)), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     cpot = potential.linearCompositePotential([pot])
     potential.turn_physical_off(cpot)
-    assert isinstance(potential.evaluatelinearPotentials(cpot, 1.1), float), (
+    assert _plain_scalar_no_units(potential.evaluatelinearPotentials(cpot, 1.1)), (
         "Potential function does not return float when function turn_physical_off has been called"
     )
     return None
@@ -13631,14 +13653,14 @@ def test_actionAngle_method_turnphysicaloff():
 
     aA = actionAngleIsochrone(b=0.8, ro=7.0 * units.kpc, vo=230.0 * units.km / units.s)
     aA.turn_physical_off()
-    assert isinstance(aA(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0], float), (
+    assert _plain_scalar_no_units(aA(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0]), (
         "actionAngle method does not return float when turn_physical_off has been called"
     )
-    assert isinstance(aA.actionsFreqs(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0], float), (
-        "actionAngle method does not return float when turn_physical_off has been called"
-    )
-    assert isinstance(
-        aA.actionsFreqsAngles(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0], float
+    assert _plain_scalar_no_units(
+        aA.actionsFreqs(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0]
+    ), "actionAngle method does not return float when turn_physical_off has been called"
+    assert _plain_scalar_no_units(
+        aA.actionsFreqsAngles(1.1, 0.1, 1.1, 0.1, 0.2, 0.0)[0][0]
     ), "actionAngle method does not return float when turn_physical_off has been called"
     return None
 


### PR DESCRIPTION
First slice of the eager-ledger burndown, picked by clustering the reducible
entries: after VerticalInverse, `test_quantity.py` is the largest cluster, and
`*_turnphysicaloff` is the tightest inside it — 3 tests × 2 backends, **one shared
mechanism**.

## The mechanism

Those tests assert `isinstance(result, float)`, which is a numpy-specific **proxy**
for "not a Quantity". Under a forced backend galpy returns a 0-d **backend array**
by design — that is precisely what makes these calls traceable — so a *correct*
result fails the check.

```
assert isinstance(pot(1.1, 0.1), float)
AssertionError: ... where False = isinstance(Array(-37.60824802, dtype=float64), float)
```

## The fix, and proof it does not weaken numpy

A local `_plain_scalar_no_units` predicate. On numpy it is **exactly** as strict as
before; the only newly-accepted case is a 0-d jax/torch array:

| value | old `isinstance(v, float)` | new predicate | |
|---|---|---|---|
| python float | True | True | SAME |
| `numpy.float64` | True | True | SAME (float subclass) |
| 0-d `ndarray` | False | False | SAME |
| 1-d `ndarray` | False | False | SAME |
| `Quantity` | False | False | SAME |
| **0-d jax array** | **False** | **True** | **CHANGED — intended** |
| 1-d jax array | False | False | SAME |

I got this wrong once on the way and want to be explicit: I first wrote a guard
against `numpy.ndarray` believing `is_backend_array` accepted numpy. It does not —
`is_backend_array(numpy.array(1.5))` is `False`, and the `True` I had seen came
from `numpy.float64` being a `float` subclass, which the original check accepted
too. The guard was dead code on a false premise; removed, and the prose claim
replaced by the table above.

## Verification

| mode | result |
|---|---|
| numpy | 3/3 |
| jax | 3/3 |
| torch | 3/3 |
| jax **without** the fix | FAILS — so the 6-entry drop is real |

Ledger **156 → 150**. Also refreshes the reading-note totals landed in #1222 so
they match the file after this drop (150 / 48 / 102, each checked against a live
count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH