### PR TITLE
conversion: a 1D actionAngle __call__ is one action, not a sequence (fixes a plain-numpy IndexError)

### DIFF
--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -1203,22 +1203,26 @@ def physical_conversion_actionAngle(quantity, pop=False):
                     fac = [1.0, ro, ro, ro]
                     if _APY_UNITS:
                         u = [1.0, units.kpc, units.kpc, units.kpc]
-                if _APY_UNITS:
-                    newOut = ()
-                    try:
-                        for ii in range(len(out)):
-                            newOut = newOut + (
-                                units.Quantity(out[ii] * fac[ii], unit=u[ii]),
-                            )
-                    except TypeError:  # happens if out = scalar
-                        newOut = units.Quantity(out * fac[0], unit=u[0])
+                # `out` is either a SEQUENCE of separate quantities -- the 3D
+                # actions, or any (actions,freqs[,angles]) return -- or ONE
+                # array-valued quantity, which is what a 1D __call__ gives back
+                # (J alone). len() cannot tell those apart, because a
+                # length-N array has a len() too, so dispatch on the type: for
+                # a 1D __call__, `fac` is 3 long and scaling element-by-element
+                # silently returned a tuple of scalars below length 4 and raised
+                # IndexError at or above it.
+                if isinstance(out, (tuple, list)):
+                    if _APY_UNITS:
+                        newOut = tuple(
+                            units.Quantity(out[ii] * fac[ii], unit=u[ii])
+                            for ii in range(len(out))
+                        )
+                    else:
+                        newOut = tuple(out[ii] * fac[ii] for ii in range(len(out)))
+                elif _APY_UNITS:
+                    newOut = units.Quantity(out * fac[0], unit=u[0])
                 else:
-                    newOut = ()
-                    try:
-                        for ii in range(len(out)):
-                            newOut = newOut + (out[ii] * fac[ii],)
-                    except TypeError:  # happens if out = scalar
-                        newOut = out * fac[0]
+                    newOut = out * fac[0]
                 return newOut
             else:
                 return method(*args, **kwargs)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,16 +91,16 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        130
+#   total entries        128
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   82
+#   reducible by fixes   80
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
 # 48 CANNOT be burned down by incremental backend fixes -- they move only if that
 # class is migrated, which is a scoping decision, not a bug hunt. Counting them
-# alongside the reducible 82 makes the ledger look ~56% larger than the work it
+# alongside the reducible 80 makes the ledger look ~56% larger than the work it
 # actually represents. Split it before quoting the number as progress.
 #
 # STALENESS. xfail here is non-strict, so an entry that has since been fixed
@@ -151,7 +151,6 @@ jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_inter
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_pointtransform
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform_bisect
-jax tests/test_actionAngle.py::test_physical_vertical
 jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
@@ -200,7 +199,6 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_poi
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
-torch tests/test_actionAngle.py::test_physical_vertical
 torch tests/test_dynamfric.py::test_dynamfric_c
 torch tests/test_dynamfric.py::test_dynamfric_c_minr
 torch tests/test_galpypaper.py::test_orbmethods

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -496,6 +496,90 @@ def test_physical_vertical():
     return None
 
 
+def test_physical_1d_call_container_matches_natural():
+    # A 1D __call__ returns ONE quantity -- the action J -- not a sequence of
+    # them, so turning physical output on must not change the container. It used
+    # to: physical_conversion_actionAngle scaled element-by-element against a
+    # three-long factor list, which silently tuple-ified the result below length
+    # four and raised IndexError at or above it.
+    from galpy.actionAngle import actionAngleHarmonic, actionAngleVertical
+    from galpy.potential import IsothermalDiskPotential
+
+    ro, vo = 7.0, 230.0
+    pairs = (
+        (
+            actionAngleVertical(
+                pot=IsothermalDiskPotential(amp=1.0, sigma=0.5), ro=ro, vo=vo
+            ),
+            actionAngleVertical(pot=IsothermalDiskPotential(amp=1.0, sigma=0.5)),
+        ),
+        (
+            actionAngleHarmonic(omega=1.1, ro=ro, vo=vo),
+            actionAngleHarmonic(omega=1.1),
+        ),
+    )
+    for aA, aAnu in pairs:
+        name = aA.__class__.__name__
+        # 4 and 9 are past the old three-element ceiling, 1-3 below it
+        for n in (1, 2, 3, 4, 9):
+            x = numpy.linspace(-0.15, 0.2, n)
+            vx = numpy.linspace(0.05, 0.2, n)
+            phys = aA(x, vx)
+            nat = as_numpy(aAnu(x, vx))
+            assert not isinstance(phys, tuple), (
+                f"{name}: physical __call__ returned a tuple for n={n}, but the "
+                "natural call returns a single array of actions"
+            )
+            phys = as_numpy(phys)
+            assert phys.shape == nat.shape, (
+                f"{name}: physical __call__ gave shape {phys.shape} for n={n}, "
+                f"natural gave {nat.shape}"
+            )
+            # The decorator's only arithmetic is one multiply by ro*vo, so this
+            # holds exactly -- no tolerance needed or wanted.
+            assert numpy.all(phys == nat * (ro * vo)), (
+                f"{name}: physical __call__ for n={n} is not the natural value "
+                f"times ro*vo\n  physical: {phys!r}\n  natural*ro*vo: "
+                f"{nat * (ro * vo)!r}"
+            )
+    return None
+
+
+def test_physical_3d_call_stays_a_tuple():
+    # The counterpart to the test above: 3D methods genuinely return several
+    # separate quantities, and that must keep being a tuple whose entries are
+    # scaled by their own factors. Pins the discriminator in
+    # physical_conversion_actionAngle from being "simplified" back to len().
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.potential import MWPotential2014
+    from galpy.util import conversion
+
+    ro, vo = 8.0, 220.0
+    aA = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, ro=ro, vo=vo)
+    aAnu = actionAngleStaeckel(pot=MWPotential2014, delta=0.45)
+    o = (1.0, 0.1, 1.1, 0.1, 0.03, 0.2)
+    for meth, nout in (("__call__", 3), ("actionsFreqs", 6), ("EccZmaxRperiRap", 4)):
+        phys = getattr(aA, meth)(*o[:5])
+        assert isinstance(phys, tuple) and len(phys) == nout, (
+            f"actionAngleStaeckel.{meth} physical output should be a {nout}-tuple, "
+            f"got {type(phys).__name__} of length {numpy.size(phys)}"
+        )
+    # and the per-entry factors still differ: actions scale by ro*vo, the
+    # frequencies by freq_in_Gyr, which a single shared factor would break
+    aFphys = aA.actionsFreqs(*o[:5])
+    aFnat = aAnu.actionsFreqs(*o[:5])
+    for ii in range(3):
+        assert numpy.all(as_numpy(aFphys[ii]) == as_numpy(aFnat[ii]) * (ro * vo)), (
+            f"actionsFreqs entry {ii} (an action) is not scaled by ro*vo"
+        )
+    freqfac = conversion.freq_in_Gyr(vo, ro)
+    for ii in range(3, 6):
+        assert numpy.all(as_numpy(aFphys[ii]) == as_numpy(aFnat[ii]) * freqfac), (
+            f"actionsFreqs entry {ii} (a frequency) is not scaled by freq_in_Gyr"
+        )
+    return None
+
+
 # Basic sanity checking of the actionAngleIsochrone actions
 def test_actionAngleIsochrone_basic_actions():
     from galpy.actionAngle import actionAngleIsochrone


### PR DESCRIPTION
`physical_conversion_actionAngle` scales its method's output by per-entry factors, and decided whether that output was a *sequence* of quantities or a *single* one with:

```python
try:
    for ii in range(len(out)):
        newOut = newOut + (out[ii] * fac[ii],)
except TypeError:   # happens if out = scalar
    newOut = out * fac[0]
```

`len()` does not answer that question — a length-N array has a `len()` too. A 1D actionAngle `__call__` returns the action J alone, one array-valued quantity, so it took the loop; and `fac` for `"__call__"` is always three long. Hence, **on plain numpy, with no backend involved**:

```pycon
>>> aAV = actionAngleVertical(pot=IsothermalDiskPotential(amp=1., sigma=0.5), ro=7., vo=230.)
>>> aAV(numpy.linspace(-0.1, 0.2, 4), numpy.full(4, 0.1))
IndexError: list index out of range
```

and at n ≤ 3 it returns a *tuple of n scalars* where the natural call returns a length-n array:

| | scalar input | array input, n ≤ 3 | array input, n ≥ 4 |
|---|---|---|---|
| before | `(30.17,)` | tuple of n scalars | **IndexError** |
| after | `array([30.17])` | `array` of n | `array` of n |
| natural call | `array([0.0187])` | `array` of n | `array` of n |

`actionAngleVertical` and `actionAngleHarmonic` are both affected, in the plain and the astropy-`Quantity` branch alike. numpy broadcasting `tuple - ndarray` is the only reason this went unnoticed; jax/torch raise on `tuple - Tensor`, which is how `test_physical_vertical` came to be ledgered.

Fixed by dispatching on the type, which is what the code meant. `physical_conversion_actionAngleInverse` has the same shape but **not** the bug — its 1D `__call__` genuinely returns `(x, v)` — so it is left alone rather than "made consistent".

### Values are byte-identical

Verified by running 16 probes against both revisions and comparing float *bytes*: 3D `__call__` / `actionsFreqs` / `actionsFreqsAngles` / `EccZmaxRperiRap` for Staeckel, Isochrone and Spherical, array-valued 3D input, and the 1D `actionsFreqs` / `actionsFreqsAngles` — **all 16 identical**. What changes is the *container* of the 1D `__call__` under physical output, plus `n ≥ 4` returning a result instead of raising. Flagging that as a user-visible API change even though no value moves.

### Tests

- containers must match for both 1D classes at n = 1,2,3,4,9 (straddling the old ceiling) with **exact** equality — the decorator's only arithmetic is one multiply by `ro*vo`, so a tolerance would be admitting I don't know what it computes;
- a counterpart pinning the 3D methods as tuples whose entries keep their **own** factors (actions by `ro*vo`, frequencies by `freq_in_Gyr`), which is exactly what collapsing to one shared factor would break silently.

Both pass on numpy, jax and torch, and both fail without the fix. Full shards clean: numpy `test_actionAngle`, numpy `test_quantity`+`test_coords`, torch `test_actionAngle` (209/0), jax `test_actionAngle` (209/0).

Ledger **130 → 128**.

*Note:* `conversion.py` is shared and the `IndexError` has nothing to do with backends, so this is arguably `main` material — worth splitting a cherry-pick when you're back.