### PR TITLE
hyp2f1 fallback: cover the parameter domains galpy's DFs request (unlocks constant-beta DFs for beta ≥ 0.5 on jax/torch)

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -32,32 +32,106 @@ from ._quadrature import gauss_legendre_01
 _NODES = 128
 
 
+# Terms for the series route below. Its argument is z/(z-1), so accuracy is set
+# by how close that is to 1, i.e. by |z| -- not much by the parameters (even the
+# worst conditioning, a = b, is exact at |z| <~ 5). Measured worst case over the
+# both-non-positive triples galpy's DFs request plus a = b:
+#     |z|      1       5       20      50      200     500
+#     rel err  0       4e-14   9e-13   2e-6    7e-3    5e-2
+# 512 is chosen so that at |z| = 50 this matches what the quadrature route above
+# actually delivers there (also ~2e-6), i.e. up to |z| = 50 the series route is
+# no less accurate than the one galpy already ships. Past that it falls off
+# faster, because its convergence is algebraic in the term count rather than
+# spectral -- reaching the quadrature's ~5e-6 at |z| = 500 would need >2048
+# terms. galpy's own anisotropic DFs call this branch at |z| < 1 (measured), so
+# the exact range covers real use with a wide margin.
+_SERIES_TERMS = 512
+
+
+def _in_regime(a, b, c):
+    """True when the Euler integral below can be used for these parameters."""
+    return (a > 0 and (c - a) >= 1.0) or (b > 0 and (c - b) >= 1.0)
+
+
 def _euler_labeling(a, b, c):
     """Pick (B, A) with {A,B}={a,b}, B>0 and c-B >= 1.
 
     Requiring c-B >= 1 keeps the (1-t)^{c-B-1} endpoint non-singular so the
-    fixed-order quadrature stays accurate; galpy's 2F1 calls always satisfy
-    this (c-a is 1 or 2). A configuration with c-max(a,b) < 1 would need the
-    t=1 endpoint regularized too, so it raises rather than return a
-    low-accuracy value.
+    fixed-order quadrature stays accurate. Callers check _in_regime first; the
+    raise is a guard against reaching the integral with parameters it cannot
+    represent, and names BOTH conditions, because the binding one is often the
+    sign: with a and b both non-positive there is no admissible B at all, even
+    though c - max(a, b) >= 1 may well hold.
     """
     if a > 0 and (c - a) >= 1.0:
         return a, b
     if b > 0 and (c - b) >= 1.0:
         return b, a
     raise NotImplementedError(
-        f"hyp2f1 fallback requires c - max(a, b) >= 1 (galpy's regime); "
+        "hyp2f1 Euler integral needs some P in {a, b} with P > 0 and c - P >= 1; "
         f"got (a={a}, b={b}, c={c})"
     )
 
 
+def _pfaff_series(xp, a, b, c, z):
+    r"""2F1(a, b; c; z) for z <= 0 by Gauss series in the Pfaff variable.
+
+    Used when no transformation puts a parameter in the Euler integral's range,
+    which happens exactly when a and b are both non-positive. The two Pfaff
+    transformations are
+
+        2F1(a,b;c;z) = (1-z)^{-a} 2F1(a, c-b; c; x),  C-A-B = b-a
+                     = (1-z)^{-b} 2F1(c-a, b; c; x),  C-A-B = a-b
+
+    with x = z/(z-1) in [0, 1) for z <= 0. Taking whichever puts max(a, b) in
+    the c-. slot gives C-A-B = |a-b| > 0, so the series converges even in the
+    x -> 1 (z -> -inf) limit. |a-b| is invariant under Euler's transformation,
+    so this is the best conditioning available -- there is no relabeling that
+    converges faster.
+    """
+    if b > a:
+        A, B, pref_exp = a, c - b, -a
+    else:
+        A, B, pref_exp = c - a, b, -b
+    x = z / (z - 1.0)
+    term = xp.ones_like(x)
+    total = xp.ones_like(x)
+    for n in range(_SERIES_TERMS):
+        term = term * ((A + n) * (B + n) / ((c + n) * (n + 1.0))) * x
+        total = total + term
+    return (1.0 - z) ** pref_exp * total
+
+
 def hyp2f1_fallback(xp, a, b, c, z):
-    r"""2F1(a, b; c; z) for real z <= 0 via the boundary-layer Euler integral.
+    r"""2F1(a, b; c; z) for real z <= 0.
 
     a, b, c are scalars (galpy potential parameters); z is a backend array
     (or scalar) with z <= 0.
+
+    Three routes, in order of preference:
+
+    1. the boundary-layer Euler integral, when the parameters admit it;
+    2. Euler's transformation 2F1(a,b;c;z) = (1-z)^{c-a-b} 2F1(c-a,c-b;c;z),
+       which leaves z alone -- so the integral's z <= 0 machinery applies
+       verbatim -- and rescues the case where the only positive parameter has
+       c - P < 1 (e.g. a=-3.2, b=4.4, c=5.2 becomes 8.4, 0.8, 5.2);
+    3. otherwise a Gauss series, see _pfaff_series. Reached only when a and b
+       are both non-positive, where no transformation lands a parameter in the
+       integral's range.
+
+    Note a Pfaff transformation is NOT usable for route 2: it maps z <= 0 to
+    z/(z-1) in [0, 1), and the integral's substitutions assume z <= 0.
     """
     z = xp.asarray(z) * 1.0
+    if not _in_regime(a, b, c):
+        if _in_regime(c - a, c - b, c):
+            return (1.0 - z) ** (c - a - b) * _euler_integral(xp, c - a, c - b, c, z)
+        return _pfaff_series(xp, a, b, c, z)
+    return _euler_integral(xp, a, b, c, z)
+
+
+def _euler_integral(xp, a, b, c, z):
+    r"""2F1(a, b; c; z) for real z <= 0 via the boundary-layer Euler integral."""
     w = -z  # >= 0
     B, A = _euler_labeling(a, b, c)
     q = c - B  # exponent of (1-t) is q-1

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,16 +91,16 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        128
+#   total entries        122
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   80
+#   reducible by fixes   74
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
 # 48 CANNOT be burned down by incremental backend fixes -- they move only if that
 # class is migrated, which is a scoping decision, not a bug hunt. Counting them
-# alongside the reducible 80 makes the ledger look ~56% larger than the work it
+# alongside the reducible 74 makes the ledger look ~56% larger than the work it
 # actually represents. Split it before quoting the number as progress.
 #
 # STALENESS. xfail here is non-strict, so an entry that has since been fixed
@@ -159,9 +159,6 @@ jax tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 jax tests/test_quantity.py::test_sphericaldf_method_value
 jax tests/test_quantity.py::test_sphericaldf_sample_outputunits
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
-jax tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
-jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
-jax tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
 torch tests/test_FDMdynamfric.py::test_dynamfric_c
 torch tests/test_FDMdynamfric.py::test_dynamfric_c_minr
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
@@ -223,9 +220,6 @@ torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 torch tests/test_quantity.py::test_sphericaldf_method_value
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_dens_directint
-torch tests/test_sphericaldf.py::test_constantbetadf_against_hernquist
-torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits
-torch tests/test_sphericaldf.py::test_osipkovmerritt_hernquist_dMdE_limits_generalimplementation
 torch tests/test_streamTrack.py::test_streamTrack_cov_basis
 torch tests/test_streamTrack.py::test_streamTrack_cov_per_call_unit_overrides
 torch tests/test_streamTrack.py::test_streamTrack_out_of_range_returns_nan

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -283,15 +283,21 @@ def test_sample_numpy_side_forced(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_hyp2f1_domain_limit(backend):
-    # The shared galpy.backend.special.hyp2f1 fallback (Euler labeling requires
-    # a positive parameter B with c-B>=1) cannot reach the general-beta
-    # Hernquist DF for beta>=0.5 (b=1-2beta<=0 after the Pfaff transform); the
-    # numpy path (scipy) is unaffected. This locks that documented boundary.
-    dfh = constantbetaHernquistdf(pot=_HP, beta=0.7)
-    assert numpy.isfinite(dfh.fE(numpy.array([-0.5 * _PSI0]))[0])  # numpy OK
-    with pytest.raises(NotImplementedError):
-        dfh.fE(_arr(backend, numpy.array([-0.5 * _PSI0])))
+@pytest.mark.parametrize("beta", [0.5, 0.7, 0.9])
+def test_general_beta_hernquist_past_the_old_hyp2f1_limit(backend, beta):
+    # beta >= 0.5 gives b = 1-2beta <= 0, so BOTH 2F1 parameters are
+    # non-positive and no Euler labeling exists. The fallback used to raise
+    # NotImplementedError here, which made this whole DF family numpy-only; it
+    # now takes the Pfaff series route (see the hyp2f1 fallback). scipy on the
+    # numpy path is the reference, and the agreement is at double precision --
+    # the series is exact at the |z| these DFs evaluate at -- so this is a tight
+    # bound, not a smoke check.
+    dfh = constantbetaHernquistdf(pot=_HP, beta=beta)
+    Es = numpy.array([-0.8, -0.5, -0.3]) * _PSI0
+    ref = dfh.fE(Es)
+    assert numpy.all(numpy.isfinite(ref))
+    got = as_numpy(dfh.fE(_arr(backend, Es)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-13, atol=0.0)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -451,6 +451,99 @@ def test_hyp2f1_fallback_alt_labeling(backend):
     numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=1e-8)
 
 
+# Parameter sets the Euler integral cannot take directly. galpy's own anisotropic
+# DFs request all three (measured by instrumenting the fallback over
+# test_sphericaldf), and before the transformation/series routes existed each one
+# raised NotImplementedError.
+_HYP2F1_EULER_TRANSFORMED = [
+    (-3.2, 4.4, 5.2),  # only positive parameter has c-b = 0.8 < 1
+    (2.0, 2.0, 2.5),  # c-a = c-b = 0.5 < 1, both positive
+]
+_HYP2F1_BOTH_NONPOSITIVE = [
+    (-0.98, -0.04, 2.98),  # |a-b| = 0.94
+    (-0.51, -0.98, 2.51),  # |a-b| = 0.47
+    (-0.5, -0.5, 2.51),  # a == b: |a-b| = 0, the series' worst conditioning
+]
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+@pytest.mark.parametrize(
+    "a,b,c", _HYP2F1_EULER_TRANSFORMED, ids=[str(x) for x in _HYP2F1_EULER_TRANSFORMED]
+)
+def test_hyp2f1_fallback_euler_transformed(backend, a, b, c):
+    # Euler's transformation, 2F1(a,b;c;z) = (1-z)^(c-a-b) 2F1(c-a,c-b;c;z),
+    # leaves z alone, so the quadrature's z<=0 machinery applies verbatim to the
+    # transformed parameters. Accuracy is therefore the quadrature's own: this
+    # measures 1e-14 across the whole grid, so 1e-12 is a real bound, not a
+    # smoke check. Includes z=0 (where 2F1=1 exactly) and r/a=500.
+    z = -numpy.array([0.0, 1e-3, 0.06, 0.617, 1.0, 5.0, 50.0, 500.0])
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+@pytest.mark.parametrize(
+    "a,b,c", _HYP2F1_BOTH_NONPOSITIVE, ids=[str(x) for x in _HYP2F1_BOTH_NONPOSITIVE]
+)
+def test_hyp2f1_fallback_both_parameters_nonpositive(backend, a, b, c):
+    # With a and b both non-positive there is no admissible Euler labeling under
+    # ANY of the four standard transformations, so this routes to the Pfaff
+    # series. Over |z| <= 20 that is exact to double precision even for a == b
+    # (measured worst case 9e-13), which is where galpy's DFs actually call it
+    # (|z| < 1). The looser large-|z| behaviour is pinned separately below so
+    # this bound stays tight enough to catch a real regression.
+    z = -numpy.array([0.0, 1e-3, 0.06, 0.617, 1.0, 5.0, 20.0])
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_series_route_degrades_but_stays_bounded(backend):
+    # The counterpart: past |z| ~ 50 the series route falls off, because its
+    # convergence is algebraic in the term count rather than spectral. Pin the
+    # documented behaviour (2e-6 at |z|=50, see _SERIES_TERMS) so that neither a
+    # silent accuracy loss nor a divergence goes unnoticed.
+    a, b, c = -0.51, -0.98, 2.51
+    z = -numpy.array([50.0])
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    rel = numpy.max(numpy.fabs(got / ref - 1.0))
+    assert rel < 1e-5, f"series route worse than documented at |z|=50: {rel:.2e}"
+    assert rel > 1e-9, (
+        "series route is now MORE accurate than documented at |z|=50 "
+        f"({rel:.2e}); if _SERIES_TERMS grew, refresh the table in its comment"
+    )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+@pytest.mark.parametrize(
+    "a,b,c",
+    _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE,
+    ids=[str(x) for x in _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE],
+)
+def test_hyp2f1_new_routes_grad_vs_fd(backend, a, b, c):
+    # Both new routes must differentiate, not merely evaluate: the DFs that need
+    # them are consumed by gradient-based work. Central differences on scipy is
+    # the reference, so this checks the derivative of the RIGHT function and not
+    # just self-consistency of the backend graph.
+    x0, eps = 0.617, 1e-6
+
+    def f_np(w):
+        return float(scipy_special.hyp2f1(a, b, c, -w))
+
+    fd = (f_np(x0 + eps) - f_np(x0 - eps)) / (2 * eps)
+    if backend == "jax":
+        ad = float(jax.grad(lambda w: gsp.hyp2f1(a, b, c, -w))(jnp.asarray(x0)))
+    else:
+        wt = torch.tensor(x0, dtype=torch.float64, requires_grad=True)
+        gsp.hyp2f1(a, b, c, -wt).backward()
+        ad = float(wt.grad)
+    assert not numpy.isnan(ad), f"gradient is NaN for ({a}, {b}, {c})"
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-6)
+
+
 def test_fallback_unsupported_regimes_raise():
     # The fallbacks raise (rather than silently return a low-accuracy value)
     # outside the regime galpy needs and they are accurate in.


### PR DESCRIPTION
The backend 2F1 fallback evaluates Euler's integral, which needs some `P ∈ {a, b}` with `P > 0` and `c − P ≥ 1`. Outside that it raised `NotImplementedError` — deliberately, *"rather than return a low-accuracy value"*. But galpy's own anisotropic DFs ask for three parameter triples it refuses, so `constantbetadf` and `OsipkovMerritt` simply crash on jax and torch.

### What is actually requested

Instrumented the fallback over `test_sphericaldf` to find out, instead of guessing. The refused calls all sit at **small |z|**:

| (a, b, c) | in regime | \|z\| | why refused |
|---|---|---|---|
| (-3.2, 4.4, 5.2) | no | 0.617 | only positive parameter has `c−b = 0.8 < 1` |
| (-0.98, -0.04, 2.98) | no | 0.617 | **both** `a, b ≤ 0` |
| (-0.51, -0.98, 2.51) | no | 0.060 | **both** `a, b ≤ 0` |
| (-2.2,2.4,4.2), (-1.9,1.8,3.9), (-1.2,0.4,3.2) | yes | 0.617 | — |

### Two routes, added only for parameters that previously RAISED

**1. Euler's transformation** `2F1(a,b;c;z) = (1−z)^{c−a−b} 2F1(c−a,c−b;c;z)`. It leaves `z` alone, so the integral's `z ≤ 0` substitutions apply verbatim — `(-3.2, 4.4, 5.2)` becomes `(8.4, 0.8, 5.2)`, in regime. Measured **7e-15** relative across `|z| = 0.06 … 500`.

*A Pfaff transformation cannot be used here*: it maps `z ≤ 0` to `z/(z−1) ∈ [0,1)`, which the boundary-layer map does not accept. (I tried it first; testing caught it.)

**2. A Gauss series** for the both-non-positive case. No admissible labeling exists under *any* of the four standard transformations — enumerated: identity `(-0.51,-0.98)`, Euler `(3.02,3.49)`, Pfaff-1 `(-0.51,3.49)`, Pfaff-2 `(3.02,-0.98)`, none with a parameter in `(0, c=2.51)` — so the integral genuinely cannot represent it. The series runs in the Pfaff variable `x = z/(z−1) ∈ [0,1)`, taking whichever transformation puts `max(a,b)` in the `c−·` slot, which gives `C−A−B = |a−b| > 0` and therefore convergence even as `z → −∞`. `|a−b|` is invariant under Euler's transformation, so this is the best conditioning available.

### Byte-identical for everything that already worked

`_in_regime` is checked **first**, so in-regime parameters keep today's route and today's bits. Verified by comparing float *bytes* over 10 in-regime triples × 9 values of `z` from 0 to 500 — **all identical**. This is a pure capability addition.

That ordering is deliberate, not incidental: the routes are *complementary*, not ranked. Route 1 wins for `(1.5,2.5,3.5)` (6.8e-15 vs 1.1e-06); route 2 wins for `(-2.2,2.4,4.2)` (1.0e-14 vs 2.1e-06). Re-routing in-regime parameters would move existing numpy values in both directions, which is not this PR's business.

### Term count, chosen against the existing bar

Route 2's accuracy is the quadrature's own. The series' is set by how close `z/(z−1)` is to 1 — i.e. by `|z|`, barely by the parameters (even `a == b` is exact to `|z| ≲ 5`). 512 terms gives:

| \|z\| | 1 | 5 | 20 | 50 | 200 |
|---|---|---|---|---|---|
| rel err | 0 | 4e-14 | 9e-13 | 2e-6 | 7e-3 |

At `|z| = 50` that **equals what the quadrature route itself delivers there** (also ~2e-6), so up to `|z| = 50` the new route is no less accurate than the one galpy already ships. Past that it falls off faster — algebraic rather than spectral convergence — which is documented with these measured numbers and pinned by a test **from both sides**, so a silent loss and an accidental improvement both fail.

### The capability, which the ledger could not show

`beta ≥ 0.5` makes `b = 1−2beta` non-positive — exactly the both-non-positive case — so the **entire general-beta Hernquist family was numpy-only**. There was no ledger entry for it, because no test asserted it should work; one asserted it could not. That test (`test_hyp2f1_domain_limit`) is rewritten to lock the new boundary: parametrised over `beta = 0.5, 0.7, 0.9`, asserting parity with scipy at `rtol=1e-13`. Measured agreement: **1.55e-15**.

### Verification

- hyp2f1 was confirmed the **sole** blocker beforehand, by making the fallback return scipy's value for just these parameters: the three tests went to 0 failures. The real fix reproduces that on both backends.
- Tests: value parity for both new routes at 1e-12/1e-11 including `z=0` and `r/a=500`; the `a == b` worst-case conditioning; the documented large-`|z|` degradation bounded above *and* below; grad-vs-FD against central differences of scipy for all five new triples, since these DFs are consumed by gradient-based work. 63 hyp2f1 tests pass on jax and torch.
- Full `tests/test_backend*.py` shard (6460 tests, 2h13m) and `test_backend_constantbetadf.py` (36) clean; torch/jax `test_sphericaldf` and numpy `test_potential` clean.
- `_euler_labeling`'s message named only `c − max(a,b) ≥ 1`, which is misleading precisely in the both-non-positive case — there that quantity is 3.02 and satisfied, and the real blocker is the sign. It now names both conditions.

**Ledger 128 → 122.** Not dropped: torch `test_constantbeta_interpolatedpotentials_{beta,dens_directint}`, same file and family — measured rather than assumed, and they still fail with an unrelated cause (`vmap: ... data-dependent control flow`, the interpRZPotential track).