### PR TITLE
staeckel_c backends: keep C's unbound sentinel out of the azimuth wrap

### DIFF
--- a/galpy/backend/_jax/staeckel_c.py
+++ b/galpy/backend/_jax/staeckel_c.py
@@ -152,7 +152,17 @@ def actionsfreqsangles_with_jac(host_jac, coords, phi):
 
     _afa.defvjp(_fwd, _bwd)
     raw = _afa(coords)  # 8 values, differentiable w.r.t. the 5 coords via ajac/ojac
-    anglephi = jnp.remainder(raw[6] + phi, 2.0 * jnp.pi)
+    # C flags an unbound orbit by returning 9999.99 in every output, and that
+    # sentinel must survive the azimuth wrap -- folding it gives 3.44, which reads
+    # as an ordinary angle. The numpy C wrapper guards this the same way
+    # (actionAngleStaeckel_c.py, `badAngle = Anglephi != 9999.99`); the literal is
+    # the C ABI's, spelled out here as it is in every other consumer rather than
+    # importing it from galpy.actionAngle, which this module is imported BY.
+    # where() on the data, not a branch, so it still traces; both sides are finite,
+    # so the dead one cannot poison the gradient.
+    anglephi = jnp.where(
+        raw[6] == 9999.99, raw[6], jnp.remainder(raw[6] + phi, 2.0 * jnp.pi)
+    )
     return raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], anglephi, raw[7]
 
 

--- a/galpy/backend/_torch/staeckel_c.py
+++ b/galpy/backend/_torch/staeckel_c.py
@@ -96,7 +96,17 @@ def actionsfreqsangles_with_jac(host_jac, R, vR, vT, z, vz, phi):
     (jr,jz,Or,Op,Oz,angler,anglephi_raw,anglez,jac) with the 8 values (N,) --
     angler/anglez wrapped, anglephi WITHOUT phi -- and jac (N,8,5)."""
     raw = _ActionsFreqsAnglesJacFunction.apply(host_jac, R, vR, vT, z, vz)
-    anglephi = torch.remainder(raw[6] + phi, 2.0 * torch.pi)
+    # C flags an unbound orbit by returning 9999.99 in every output, and that
+    # sentinel must survive the azimuth wrap -- folding it gives 3.44, which reads
+    # as an ordinary angle. The numpy C wrapper guards this the same way
+    # (actionAngleStaeckel_c.py, `badAngle = Anglephi != 9999.99`); the literal is
+    # the C ABI's, spelled out here as it is in every other consumer rather than
+    # importing it from galpy.actionAngle, which this module is imported BY.
+    # where() on the data, not a branch, so it still traces; both sides are finite,
+    # so the dead one cannot poison the gradient.
+    anglephi = torch.where(
+        raw[6] == 9999.99, raw[6], torch.remainder(raw[6] + phi, 2.0 * torch.pi)
+    )
     return raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], anglephi, raw[7]
 
 

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,16 +91,16 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        122
+#   total entries        120
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   74
+#   reducible by fixes   72
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
 # 48 CANNOT be burned down by incremental backend fixes -- they move only if that
 # class is migrated, which is a scoping decision, not a bug hunt. Counting them
-# alongside the reducible 74 makes the ledger look ~56% larger than the work it
+# alongside the reducible 72 makes the ledger look ~56% larger than the work it
 # actually represents. Split it before quoting the number as progress.
 #
 # STALENESS. xfail here is non-strict, so an entry that has since been fixed
@@ -126,7 +126,6 @@ jax tests/test_SpiralArmsPotential.py::TestSpiralArmsPotential::test_Rzderiv
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
-jax tests/test_actionAngle.py::test_actionAngleStaeckel_unboundr_angles_c
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_convergence_warnings
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_bisect
@@ -168,7 +167,6 @@ torch tests/test_actionAngle.py::test_actionAngleSpherical_linear_angles
 torch tests/test_actionAngle.py::test_actionAngleSpherical_linear_angles_fixed_quad
 torch tests/test_actionAngle.py::test_actionAngleSpherical_noninclinedorbit_linear_angles
 torch tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
-torch tests/test_actionAngle.py::test_actionAngleStaeckel_unboundr_angles_c
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_convergence_warnings
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_bisect

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -2413,3 +2413,39 @@ def test_dePeriod_backend_matches_numpy(backend):
     assert numpy.array_equal(as_numpy(got), expected), (
         f"max |backend - numpy| = {numpy.abs(as_numpy(got) - expected).max()!r}"
     )
+
+
+# The C Staeckel entry flags an unbound orbit by returning 9999.99 in EVERY
+# output. Its numpy wrapper protects that sentinel from the final azimuth wrap
+# (actionAngleStaeckel_c.py, `badAngle = Anglephi != 9999.99`); the differentiable
+# jax/torch wrappers around the same C call did not, so anglephi came back as
+# 9999.99 mod 2pi = 3.442 -- indistinguishable from an ordinary angle, and
+# quietly below any "is this unbound?" threshold a caller might use.
+_UNBOUND_ORBIT = (1.0, 0.1, 10.0, 0.1, 0.0, 0.0)  # vT=10 -> unbound in MWPotential
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_staeckel_unbound_sentinel_survives_the_azimuth_wrap(backend):
+    import galpy.backend as gb
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.potential import MWPotential2014
+
+    aAS = actionAngleStaeckel(pot=MWPotential2014, delta=0.71, c=True)
+
+    def _flat(out):
+        return [float(numpy.asarray(as_numpy(x)).ravel()[0]) for x in out]
+
+    ref = _flat(aAS.actionsFreqsAngles(*_UNBOUND_ORBIT))
+    with gb.use(backend, force=True):
+        got = _flat(aAS.actionsFreqsAngles(*_UNBOUND_ORBIT))
+    names = ("jr", "Lz", "jz", "Omegar", "Omegaphi", "Omegaz", "ar", "aphi", "az")
+    # Exact: the sentinel is a constant the C code writes, so every output the
+    # backend produces for an unbound orbit must equal numpy's bit for bit --
+    # there is no arithmetic left to disagree about.
+    for name, a, b in zip(names, ref, got):
+        assert a == b, f"{backend}: {name} = {b!r}, numpy gives {a!r}"
+    # and specifically that anglephi was not folded
+    assert got[7] == 9999.99, (
+        f"{backend}: anglephi = {got[7]!r}; 9999.99 mod 2pi is "
+        f"{9999.99 % (2.0 * numpy.pi)!r}, so the sentinel was wrapped"
+    )


### PR DESCRIPTION
The C Staeckel entry flags an unbound orbit by writing `9999.99` into every output. Its **numpy** wrapper protects that from the final azimuth fold (`actionAngleStaeckel_c.py`, `badAngle = Anglephi != 9999.99`) — but the differentiable jax/torch wrappers around the same C call folded unconditionally:

```python
anglephi = remainder(raw[6] + phi, 2*pi)
```

so an unbound orbit came back with `anglephi = 9999.99 mod 2π = 3.4421762772780866`.

### Why that is worse than a wrong number

`3.442` sits **inside `[0, 2π)`**, so it reads as a perfectly ordinary azimuthal angle. A caller asking "is this orbit unbound?" — by testing the other eight outputs, which all *do* carry the sentinel — would be satisfied, while `anglephi` quietly said "bound". A NaN would have been loud; this was silent.

| | numpy | jax/torch before | jax/torch after |
|---|---|---|---|
| `jr`, `Lz`, `jz`, `Ω×3`, `ar`, `az` | 9999.99 | 9999.99 | 9999.99 |
| `aphi` | 9999.99 | **3.4421762772780866** | 9999.99 |

### The fix

```python
anglephi = xp.where(raw[6] == 9999.99, raw[6],
                    xp.remainder(raw[6] + phi, 2.0 * pi))
```

`where()` on the data, not a branch, so it still traces. Both sides are finite (`remainder` of the sentinel is just 3.44), so the dead branch cannot poison the gradient, and `d(anglephi)/dphi` stays 1 on the real branch — which is the reason the wrap is done in Python here at all.

The sentinel is spelled as the literal, matching the other ~8 consumers in galpy. Importing it from `galpy.actionAngle` is not available: that package imports *this* module.

### No numpy code is touched

Both files are backend-only, so numpy byte-identity is structural rather than something to argue for. Under the CI configuration (jax x64 / torch float64) both backends are now **bit-identical to numpy on all nine outputs**.

### Verification

- New test in `tests/test_backend_actionAngle.py`: every output for an unbound orbit must equal numpy's **exactly** — the sentinel is a constant the C code writes, so there is no arithmetic left to disagree about — plus a specific assertion naming the folded value, so a regression says *what* happened. Fails on both backends without the fix (`aphi = 3.4421762772780866`).
- Full `tests/test_backend*.py` shard: **6767 tests, 0 failures, 0 errors** (133 min).
- `tests/test_actionAngle.py` clean on numpy, torch and jax.
- The ledgered test verified passing with `--runxfail` on both backends.

**Ledger 122 → 120.**

*Not dropped*: the `test_qdf.py::test_call_diffinoutputs` pair, same "unbound orbit" theme. That test requires `UnboundError` to be **raised**; under a backend it gets `Jr=inf`. That is deliberate and documented — raising means branching on a traced value — so those stay ledgered until the test becomes backend-aware. A test-design decision, not a bug.