### PR TITLE
tests: land backend arrays on numpy where they enter, not where they fail (ledger 120 → 109)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -398,3 +398,9 @@ jax tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles
 # Un-skip when the jax dynamical-friction path is vectorized.
 jax tests/test_dynamfric.py::test_dynamfric_c
 jax tests/test_FDMdynamfric.py::test_dynamfric_c
+# torch test_dynamfric_c: with the assertion-site ndarray/Tensor collision fixed
+# it no longer aborts early, and integrating orbits WITH dynamical friction under
+# torch eager then takes 3598s (measured) -- 12x the 300s per-test CI timeout. A
+# timeout records FAILED and overrides xfail, so this is a slow-skip, not an
+# xfail. Its siblings are fine: FDM test_dynamfric_c 208s, both _minr 36s.
+torch tests/test_dynamfric.py::test_dynamfric_c

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,16 +91,16 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        120
+#   total entries        109
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   72
+#   reducible by fixes   61
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
 # 48 CANNOT be burned down by incremental backend fixes -- they move only if that
 # class is migrated, which is a scoping decision, not a bug hunt. Counting them
-# alongside the reducible 72 makes the ledger look ~56% larger than the work it
+# alongside the reducible 61 makes the ledger look ~56% larger than the work it
 # actually represents. Split it before quoting the number as progress.
 #
 # STALENESS. xfail here is non-strict, so an entry that has since been fixed
@@ -158,8 +158,6 @@ jax tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 jax tests/test_quantity.py::test_sphericaldf_method_value
 jax tests/test_quantity.py::test_sphericaldf_sample_outputunits
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
-torch tests/test_FDMdynamfric.py::test_dynamfric_c
-torch tests/test_FDMdynamfric.py::test_dynamfric_c_minr
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 torch tests/test_actionAngle.py::test_actionAngleSpherical_almostnoninclinedorbit_linear_angles
@@ -194,14 +192,7 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_poi
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
-torch tests/test_dynamfric.py::test_dynamfric_c
-torch tests/test_dynamfric.py::test_dynamfric_c_minr
-torch tests/test_galpypaper.py::test_orbmethods
 torch tests/test_galpypaper.py::test_qdf
-torch tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz
-torch tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz
-torch tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalaromegaz
-torch tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_vecomegaz
 torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
 torch tests/test_orbit.py::test_orbit_obs_Orbits_issue322
 torch tests/test_orbit.py::test_orbit_obsvel_Orbits_issue322
@@ -212,7 +203,6 @@ torch tests/test_qdf.py::test_sampleV_physical
 torch tests/test_quantity.py::test_quasiisothermaldf_interpolate_sample
 torch tests/test_quantity.py::test_quasiisothermaldf_method_returntype
 torch tests/test_quantity.py::test_quasiisothermaldf_method_returnunit
-torch tests/test_quantity.py::test_quasiisothermaldf_method_value
 torch tests/test_quantity.py::test_quasiisothermaldf_sample
 torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 torch tests/test_quantity.py::test_sphericaldf_method_value
@@ -228,7 +218,6 @@ torch tests/test_streamdf.py::test_plotting
 torch tests/test_streamdf.py::test_streamTrack_multi_parallel
 jax tests/test_noninertial.py::test_arbitraryaxisrotation
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc
-torch tests/test_potential.py::test_rE_MWPotential2014
 
 # --- jax single-orbit: action-angle accessors (Track E) ---
 # o.jr()/jz()/e()/zmax()/rperi()/rap() and physical/quantity/plotting paths that call

--- a/tests/test_FDMdynamfric.py
+++ b/tests/test_FDMdynamfric.py
@@ -400,7 +400,9 @@ def test_dynamfric_c():
         op = o()
         op.integrate(ttimes, p + fdf, method=py_integrator)
         # Compare r (most important)
-        assert numpy.amax(numpy.fabs(o.r(ttimes) - op.r(ttimes))) < 10**ttol, (
+        assert (
+            numpy.amax(numpy.fabs(as_numpy(o.r(ttimes) - op.r(ttimes)))) < 10**ttol
+        ), (
             f"Dynamical friction in C does not agree with dynamical friction in Python for potential {pname}"
         )
     return None
@@ -431,7 +433,7 @@ def test_dynamfric_c_minr():
     op = o()
     op.integrate(times, pot, method=integrator)
     # Compare r (most important)
-    assert numpy.amax(numpy.fabs(o.r(times) - op.r(times))) < 10**-8.0, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.r(times) - op.r(times)))) < 10**-8.0, (
         "Dynamical friction in C does not properly use minr"
     )
     return None

--- a/tests/test_dynamfric.py
+++ b/tests/test_dynamfric.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+from galpy.backend import as_numpy
+
 PY3 = sys.version > "3"
 PY_GE_314 = sys.version_info >= (3, 14)
 import numpy
@@ -405,7 +407,9 @@ def test_dynamfric_c():
         op = o()
         op.integrate(ttimes, p + cdf, method=py_integrator)
         # Compare r (most important)
-        assert numpy.amax(numpy.fabs(o.r(ttimes) - op.r(ttimes))) < 10**ttol, (
+        assert (
+            numpy.amax(numpy.fabs(as_numpy(o.r(ttimes) - op.r(ttimes)))) < 10**ttol
+        ), (
             f"Dynamical friction in C does not agree with dynamical friction in Python for potential {pname}"
         )
     return None
@@ -436,7 +440,7 @@ def test_dynamfric_c_minr():
     op = o()
     op.integrate(times, pot, method=integrator)
     # Compare r (most important)
-    assert numpy.amax(numpy.fabs(o.r(times) - op.r(times))) < 10**-8.0, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.r(times) - op.r(times)))) < 10**-8.0, (
         "Dynamical friction in C does not properly use minr"
     )
     return None

--- a/tests/test_galpypaper.py
+++ b/tests/test_galpypaper.py
@@ -7,6 +7,8 @@ import os
 import numpy
 import pytest
 
+from galpy.backend import as_numpy
+
 
 def test_overview():
     from galpy.potential import NFWPotential
@@ -303,7 +305,7 @@ def test_orbmethods():
     )
     o.L()  # Angular momentum
     assert numpy.all(
-        numpy.fabs(o.L() - numpy.array([[0.0, -0.16, 0.6]])) < 10.0**-5.0
+        numpy.fabs(as_numpy(o.L()) - numpy.array([[0.0, -0.16, 0.6]])) < 10.0**-5.0
     ), "Orbit method does not work as expected"
     o.Jacobi(OmegaP=0.65)  # Jacobi integral E-OmegaP Lz
     assert (

--- a/tests/test_noninertial.py
+++ b/tests/test_noninertial.py
@@ -4,6 +4,19 @@ import pytest
 
 from galpy import potential
 from galpy.backend import as_numpy
+
+
+def _np_rw(x):
+    """as_numpy, but WRITABLE.
+
+    jax arrays are immutable, so as_numpy hands back a read-only view and the
+    in-place `+=` the reference arithmetic below uses raises "output array is
+    read-only". torch's cast happens to be writable, which is why this only
+    shows up on jax. Copy so both backends behave the same.
+    """
+    return numpy.array(as_numpy(x), copy=True)
+
+
 from galpy.orbit import Orbit
 from galpy.util import coords
 
@@ -1575,9 +1588,9 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         # numpy inputs, so the reference arithmetic below (which mixes in the
         # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
         # back on numpy here, as the orbit accessors above already are.
-        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
+        Rp, phip, _ = (_np_rw(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0
-        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
+        op_xs, op_ys, _ = (_np_rw(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1589,10 +1602,10 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
-        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
+        vRp, vTp = _np_rw(vRp), _np_rw(vTp)
         vTp += omega * Rp + omegadot * ts * Rp
         op_vxs, op_vys, _ = (
-            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+            _np_rw(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
         )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
@@ -1683,9 +1696,9 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         # numpy inputs, so the reference arithmetic below (which mixes in the
         # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
         # back on numpy here, as the orbit accessors above already are.
-        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
+        Rp, phip, _ = (_np_rw(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0
-        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
+        op_xs, op_ys, _ = (_np_rw(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1697,10 +1710,10 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
-        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
+        vRp, vTp = _np_rw(vRp), _np_rw(vTp)
         vTp += omega * Rp + omegadot * ts * Rp
         op_vxs, op_vys, _ = (
-            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+            _np_rw(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
         )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
@@ -1793,9 +1806,9 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         # numpy inputs, so the reference arithmetic below (which mixes in the
         # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
         # back on numpy here, as the orbit accessors above already are.
-        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
+        Rp, phip, _ = (_np_rw(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
-        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
+        op_xs, op_ys, _ = (_np_rw(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1807,10 +1820,10 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
-        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
+        vRp, vTp = _np_rw(vRp), _np_rw(vTp)
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
         op_vxs, op_vys, _ = (
-            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+            _np_rw(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
         )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
@@ -1907,9 +1920,9 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
         # numpy inputs, so the reference arithmetic below (which mixes in the
         # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
         # back on numpy here, as the orbit accessors above already are.
-        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
+        Rp, phip, _ = (_np_rw(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
-        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
+        op_xs, op_ys, _ = (_np_rw(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1921,10 +1934,10 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
-        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
+        vRp, vTp = _np_rw(vRp), _np_rw(vTp)
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
         op_vxs, op_vys, _ = (
-            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+            _np_rw(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
         )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"

--- a/tests/test_noninertial.py
+++ b/tests/test_noninertial.py
@@ -1571,9 +1571,13 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
         op_xs = as_numpy(op.x(ts)) + x0[0](ts)
         op_ys = as_numpy(op.y(ts)) + x0[1](ts)
         op_zs = as_numpy(op.z(ts)) + x0[2](ts)
-        Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
+        # coords.* are backend-agnostic: under a FORCED backend they coerce even
+        # numpy inputs, so the reference arithmetic below (which mixes in the
+        # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
+        # back on numpy here, as the orbit accessors above already are.
+        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0
-        op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
+        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1585,8 +1589,11 @@ def test_linacc_changingacc_xyz_accellsrframe_scalaromegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
+        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
         vTp += omega * Rp + omegadot * ts * Rp
-        op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        op_vxs, op_vys, _ = (
+            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1672,9 +1679,13 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
         op_xs = as_numpy(op.x(ts)) + x0[0](ts)
         op_ys = as_numpy(op.y(ts)) + x0[1](ts)
         op_zs = as_numpy(op.z(ts)) + x0[2](ts)
-        Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
+        # coords.* are backend-agnostic: under a FORCED backend they coerce even
+        # numpy inputs, so the reference arithmetic below (which mixes in the
+        # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
+        # back on numpy here, as the orbit accessors above already are.
+        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0
-        op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
+        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1686,8 +1697,11 @@ def test_linacc_changingacc_xyz_accellsrframe_vecomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
+        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
         vTp += omega * Rp + omegadot * ts * Rp
-        op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        op_vxs, op_vys, _ = (
+            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1775,9 +1789,13 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
         op_xs = as_numpy(op.x(ts)) + x0[0](ts)
         op_ys = as_numpy(op.y(ts)) + x0[1](ts)
         op_zs = as_numpy(op.z(ts)) + x0[2](ts)
-        Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
+        # coords.* are backend-agnostic: under a FORCED backend they coerce even
+        # numpy inputs, so the reference arithmetic below (which mixes in the
+        # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
+        # back on numpy here, as the orbit accessors above already are.
+        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
-        op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
+        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1789,8 +1807,11 @@ def test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
+        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
-        op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        op_vxs, op_vys, _ = (
+            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )
@@ -1882,9 +1903,13 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
         op_xs = as_numpy(op.x(ts)) + x0[0](ts)
         op_ys = as_numpy(op.y(ts)) + x0[1](ts)
         op_zs = as_numpy(op.z(ts)) + x0[2](ts)
-        Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)
+        # coords.* are backend-agnostic: under a FORCED backend they coerce even
+        # numpy inputs, so the reference arithmetic below (which mixes in the
+        # plain-numpy x0/v0 callables) would hit ndarray-vs-Tensor. Land them
+        # back on numpy here, as the orbit accessors above already are.
+        Rp, phip, _ = (as_numpy(c) for c in coords.rect_to_cyl(op_xs, op_ys, op_zs))
         phip += omega * ts + omegadot * ts**2.0 / 2.0 + omegadotdot * ts**3.0 / 6.0
-        op_xs, op_ys, _ = coords.cyl_to_rect(Rp, phip, op_zs)
+        op_xs, op_ys, _ = (as_numpy(c) for c in coords.cyl_to_rect(Rp, phip, op_zs))
         op_vxs = as_numpy(op.vx(ts)) + v0[0](ts)
         op_vys = as_numpy(op.vy(ts)) + v0[1](ts)
         op_vzs = as_numpy(op.vz(ts)) + v0[2](ts)
@@ -1896,8 +1921,11 @@ def test_linacc_changingacc_xyz_accellsrframe_funcomegaz():
             as_numpy(op.y(ts)) + x0[1](ts),
             as_numpy(op.z(ts)) + x0[2](ts),
         )
+        vRp, vTp = as_numpy(vRp), as_numpy(vTp)
         vTp += omega * Rp + omegadot * ts * Rp + omegadotdot * ts**2.0 / 2.0 * Rp
-        op_vxs, op_vys, _ = coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        op_vxs, op_vys, _ = (
+            as_numpy(c) for c in coords.cyl_to_rect_vec(vRp, vTp, op_vzs, phi=phip)
+        )
         assert numpy.amax(numpy.fabs(o_xs - op_xs)) < tol, (
             f"Integrating an orbit in a linearly-accelerating, acceleratingly-rotating frame with constant acceleration does not agree with the equivalent orbit in the inertial frame for method {method}"
         )

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -4030,11 +4030,15 @@ def test_rE_MWPotential2014():
         ) ** 2.0 / 2.0 + potential.evaluatePotentials(potential.MWPotential2014, r, 0.0)
 
     rmin, rmax = 1e-8, 1e5
-    Emin = Ec(rmin)
-    Emax = Ec(rmax)
+    # Ec returns a backend array under a forced backend; land the energy grid on
+    # numpy at the source so linspace does not carry Tensors into the comparison
+    Emin = as_numpy(Ec(rmin))
+    Emax = as_numpy(Ec(rmax))
     Es = numpy.linspace(Emin, Emax, 101)
-    rEs = numpy.array([potential.rE(potential.MWPotential2014, E) for E in Es])
-    Ecs = numpy.array([Ec(rE) for rE in rEs])
+    rEs = numpy.array(
+        [as_numpy(potential.rE(potential.MWPotential2014, E)) for E in Es]
+    )
+    Ecs = numpy.array([as_numpy(Ec(rE)) for rE in rEs])
     assert numpy.amax(numpy.fabs(Ecs - Es)) < 1e-8, (
         "rE method does not give the expected result for MWPotential2014"
     )

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -16772,7 +16772,7 @@ def test_quasiisothermaldf_method_value():
     assert (
         numpy.fabs(
             qdf(o).to(1 / units.kpc**3 / (units.km / units.s) ** 3).value
-            - qdfnou(o) / ro**3 / vo**3
+            - as_numpy(qdfnou(o)) / ro**3 / vo**3
         )
         < 10.0**-8.0
     ), "quasiisothermaldf method __call__ does not return correct Quantity"


### PR DESCRIPTION
Eleven torch xfail-ledger entries are collisions between a numpy function and a torch Tensor. All are test-side — the numpy path is untouched, and `as_numpy` is a pass-through there.

### Two shapes, and the second is the interesting one

**Simple (6 sites)** — a reduction straight over a backend value: `numpy.amax(numpy.fabs(o.r(t) - op.r(t)))` in dynamfric ×2 files ×2 tests, `numpy.all(numpy.fabs(o.L() - <ndarray>))` in galpypaper, and two list comprehensions in `test_rE_MWPotential2014` that build object arrays of Tensors.

**Via a migrated helper (4 `test_noninertial` tests, 12 casts)** — those tests already `as_numpy` every orbit accessor, carefully. The Tensors re-enter *afterwards*:

```python
op_xs = as_numpy(op.x(ts)) + x0[0](ts)                 # numpy
Rp, phip, _ = coords.rect_to_cyl(op_xs, op_ys, op_zs)  # → Tensor
...
vTp += omega * Rp                                      # ndarray * Tensor
```

`coords.rect_to_cyl` is backend-agnostic and under a **forced** backend coerces even numpy inputs — correct, deliberate behaviour. So the failure isn't at an assertion at all; it's mid-test, and casting at the assertion would not have helped. The casts go where each `coords.*` result returns, which is what the surrounding code already does for the accessors.

The same "patch where the value **enters**, not where the error **surfaces**" mistake caught me once here: `test_rE_MWPotential2014` still failed after I cast its two comprehensions, because the energy grid is seeded from backend values (`Emin = Ec(rmin)`, then `numpy.linspace` carries Tensors into `Es`). Casting at the source fixes it; casting downstream did not.

### Ledger: 10 retired, 1 re-homed — not 11 retired

| test | torch time | disposition |
|---|---:|---|
| `test_galpypaper::test_orbmethods` | 1s | un-ledgered |
| `test_rE_MWPotential2014` | 11s | un-ledgered |
| both `test_dynamfric_c_minr` | 36s | un-ledgered |
| `test_quasiisothermaldf_method_value` | 67s | un-ledgered |
| the four `test_noninertial` | ~43s ea | un-ledgered |
| `test_FDMdynamfric::test_dynamfric_c` | 208s | un-ledgered |
| **`test_dynamfric::test_dynamfric_c`** | **3598s** | **→ `backend_slow_skip.txt`** |

That last one is **12× the 300s per-test CI timeout**. Before this PR it aborted early at the TypeError; fixing that makes it run to completion. A timeout records FAILED and **overrides** xfail, so un-ledgering it would red the shard.

The distinction is easy to get wrong: **an xfail test still runs.** Its FDM sibling already spends 208s in CI today as a ledgered xfail without timing out, so un-ledgering *that* one changes nothing about its cost. Only `test_dynamfric_c`'s runtime actually changes, because only it was exiting early.

**Ledger 120 → 109**, reducible-by-fixes 72 → 61.