### PR TITLE
Orbits: accept backend arrays in obs= (ledger 109 → 107)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -9373,6 +9373,23 @@ class _1DInterp:
         return self._ip(t)[:, None]
 
 
+def _obs_asnumpy(obs):
+    """Land a user-supplied ``obs=`` sequence on numpy.
+
+    ``obs`` is a reference position, and under a forced backend a user builds it
+    the natural way -- ``obs=[o.x(t), o.y(t), 0.]`` -- which yields backend
+    arrays while the integrated orbit state stays numpy. The branches that
+    consume it are written in numpy (``numpy.arctan2``/``numpy.sqrt``/
+    ``numpy.zeros_like``), so a backend element there raises ndarray-vs-Tensor.
+
+    This makes ``obs=`` ACCEPT backend arrays; it does not migrate those
+    accessors, which stay numpy by construction. A no-op for numpy input, so the
+    numpy path is byte-identical, and a read-only cast is fine because obs is
+    only ever read here.
+    """
+    return [as_numpy(o) if is_backend_array(o) else o for o in obs]
+
+
 def _from_name_oneobject(name, obs):
     """
     Query Simbad for the phase-space coordinates of one object.
@@ -9733,6 +9750,7 @@ def _helioXYZ(orb, thiso, *args, **kwargs):
         raise AttributeError("orbit must track azimuth to use radeclbd functions")
     elif len(thiso[:, 0]) == 4:  # planarOrbit
         if isinstance(obs, (numpy.ndarray, list)):
+            obs = _obs_asnumpy(obs)
             X, Y, Z = coords.galcencyl_to_XYZ(
                 thiso[0],
                 thiso[3] - numpy.arctan2(obs[1], obs[0]),
@@ -9764,6 +9782,7 @@ def _helioXYZ(orb, thiso, *args, **kwargs):
             obs.turn_physical_on()
     else:  # FullOrbit
         if isinstance(obs, (numpy.ndarray, list)):
+            obs = _obs_asnumpy(obs)
             X, Y, Z = coords.galcencyl_to_XYZ(
                 thiso[0, :],
                 thiso[5, :] - numpy.arctan2(obs[1], obs[0]),
@@ -9816,6 +9835,7 @@ def _XYZvxvyvz(orb, thiso, *args, **kwargs):
         raise AttributeError("orbit must track azimuth to use radeclbduvw functions")
     elif len(thiso[:, 0]) == 4:  # planarOrbit
         if isinstance(obs, (numpy.ndarray, list)):
+            obs = _obs_asnumpy(obs)
             Xsun = numpy.sqrt(obs[0] ** 2.0 + obs[1] ** 2.0)
             X, Y, Z = coords.galcencyl_to_XYZ(
                 thiso[0, :],
@@ -9902,6 +9922,7 @@ def _XYZvxvyvz(orb, thiso, *args, **kwargs):
             obs.turn_physical_on()
     else:  # FullOrbit
         if isinstance(obs, (numpy.ndarray, list)):
+            obs = _obs_asnumpy(obs)
             Xsun = numpy.sqrt(obs[0] ** 2.0 + obs[1] ** 2.0)
             X, Y, Z = coords.galcencyl_to_XYZ(
                 thiso[0, :],

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,16 +91,16 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        109
+#   total entries        107
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   61
+#   reducible by fixes   59
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
 # 48 CANNOT be burned down by incremental backend fixes -- they move only if that
 # class is migrated, which is a scoping decision, not a bug hunt. Counting them
-# alongside the reducible 61 makes the ledger look ~56% larger than the work it
+# alongside the reducible 59 makes the ledger look ~56% larger than the work it
 # actually represents. Split it before quoting the number as progress.
 #
 # STALENESS. xfail here is non-strict, so an entry that has since been fixed
@@ -194,8 +194,6 @@ torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsA
 torch tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
 torch tests/test_galpypaper.py::test_qdf
 torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
-torch tests/test_orbit.py::test_orbit_obs_Orbits_issue322
-torch tests/test_orbit.py::test_orbit_obsvel_Orbits_issue322
 torch tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_qdf.py::test_sampleV
 torch tests/test_qdf.py::test_sampleV_interpolate


### PR DESCRIPTION
Under a forced backend a user builds the observer position the natural way:

```python
o.helioX(t, obs=[other.x(t), other.y(t), 0.0])
```

and the accessors return backend arrays — so `obs` arrives as `[Tensor, Tensor, float]` while the integrated orbit state stays numpy. The branches consuming it are written in numpy (`numpy.arctan2` / `numpy.sqrt` / `numpy.zeros_like`), so this raised:

```
TypeError: unsupported operand type(s) for -: 'numpy.ndarray' and 'Tensor'
```

**That is a real gap in a user-facing parameter, not a test artefact.** The awkward list is exactly what any caller under a forced backend would produce. I nearly filed it with the test-side casts — the test *is* building the list — and pulling the failing frame out of the junitxml is what showed the collision happens inside galpy, not at an assertion.

### The fix

One module-level `_obs_asnumpy`, called at **all four** `isinstance(obs, (numpy.ndarray, list))` branches — not only the two a ledgered test happens to cover, so the same latent bug is fixed at the other two as well.

```python
return [as_numpy(o) if is_backend_array(o) else o for o in obs]
```

**Scope, stated plainly:** this makes `obs=` *accept* backend arrays. It does **not** migrate these accessors, which remain numpy by construction — that is a separate, larger piece of work, and a 4-line coercion shouldn't be dressed up as "helioX is backend-agnostic now".

A read-only cast is safe here because `obs` is only ever *read* (`arctan2`, `sqrt`, divide), never mutated — checked rather than assumed, having just been bitten by jax's `as_numpy` being read-only.

### Verification

- **numpy byte-identical**: 15 float-byte probes across `helioX/Y/Z`, the 3D `U/V/W`, and both the `obs=Orbit` and `obs=[list]` forms — all identical, since the helper is a pass-through when nothing is a backend array.
- **both backends**: the two ledgered tests with `--runxfail` — jax 2/2, torch 2/2.
- **regression guard**: numpy `test_orbit.py -k obs` → 7/7.

Running both backends is the point: the previous PR shipped a jax regression precisely because a test-side change was verified only on the backend whose entries were being retired.

**Ledger 109 → 107**, reducible-by-fixes 61 → 59.