### PR TITLE
qdf: land the sampler's DF values on numpy where they enter numpy code (ledger 107 → 101)

### DIFF
--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -2179,7 +2179,12 @@ class quasiisothermaldf(df):
         # so squeeze out single dimensions by hand
         maxVT = numpy.squeeze(
             optimize.fmin_powell(
-                (lambda x: -self(R, 0.0, x, z, 0.0, log=True, use_physical=False)), 1.0
+                (
+                    lambda x: (
+                        -as_numpy(self(R, 0.0, x, z, 0.0, log=True, use_physical=False))
+                    )
+                ),
+                1.0,
             )
         )
         # as_numpy: fmin_powell's optimum is fed straight into the numpy
@@ -2340,8 +2345,16 @@ class quasiisothermaldf(df):
                         optimize.fmin_powell(
                             (
                                 lambda x: (
-                                    -self(
-                                        R, 0.0, x, z, 0.0, log=True, use_physical=False
+                                    -as_numpy(
+                                        self(
+                                            R,
+                                            0.0,
+                                            x,
+                                            z,
+                                            0.0,
+                                            log=True,
+                                            use_physical=False,
+                                        )
                                     )
                                 )
                             ),

--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -8,6 +8,7 @@ from scipy import integrate, interpolate, optimize
 from .. import actionAngle, potential
 from ..actionAngle import actionAngleIsochrone
 from ..backend import (
+    as_numpy,
     coerce_coords,
     get_namespace,
     is_backend_array,
@@ -2181,7 +2182,12 @@ class quasiisothermaldf(df):
                 (lambda x: -self(R, 0.0, x, z, 0.0, log=True, use_physical=False)), 1.0
             )
         )
-        logmaxVD = self(R, maxVR, maxVT, z, maxVz, log=True, use_physical=False)
+        # as_numpy: fmin_powell's optimum is fed straight into the numpy
+        # rejection arithmetic below; under a forced backend self() hands back a
+        # backend scalar here too. No-op on numpy.
+        logmaxVD = as_numpy(
+            self(R, maxVR, maxVT, z, maxVz, log=True, use_physical=False)
+        )
         # Now rejection-sample
         vRs = []
         vTs = []
@@ -2192,15 +2198,22 @@ class quasiisothermaldf(df):
             propvR = numpy.random.normal(size=nmore) * 2.0 * self._sr
             propvT = numpy.random.normal(size=nmore) * 2.0 * self._sr + maxVT
             propvz = numpy.random.normal(size=nmore) * 2.0 * self._sz
+            # as_numpy: the rejection sampler below is numpy (numpy.random draws,
+            # numpy fancy-indexing, a numpy output array), but under a forced
+            # backend self() returns a backend array for array coords, and
+            # `Tensor > ndarray` raises. Land it here, where it enters the numpy
+            # code, rather than at the comparison. No-op on numpy.
             VDatprop = (
-                self(
-                    R + numpy.zeros(nmore),
-                    propvR,
-                    propvT,
-                    z + numpy.zeros(nmore),
-                    propvz,
-                    log=True,
-                    use_physical=False,
+                as_numpy(
+                    self(
+                        R + numpy.zeros(nmore),
+                        propvR,
+                        propvT,
+                        z + numpy.zeros(nmore),
+                        propvz,
+                        log=True,
+                        use_physical=False,
+                    )
                 )
                 - logmaxVD
             )
@@ -2389,7 +2402,12 @@ class quasiisothermaldf(df):
         # Determine the maximum of the velocity distribution
         maxVR = numpy.zeros(length)
         maxVz = numpy.zeros(length)
-        logmaxVD = self(R, maxVR, maxVT, z, maxVz, log=True, use_physical=False)
+        # as_numpy: fmin_powell's optimum is fed straight into the numpy
+        # rejection arithmetic below; under a forced backend self() hands back a
+        # backend scalar here too. No-op on numpy.
+        logmaxVD = as_numpy(
+            self(R, maxVR, maxVT, z, maxVz, log=True, use_physical=False)
+        )
         # Now rejection-sample
         # Initialize boolean index of position remaining to be sampled
         remain_indx = numpy.full(length, True)
@@ -2400,15 +2418,18 @@ class quasiisothermaldf(df):
                 numpy.random.normal(size=nmore) * 2.0 * self._sr + maxVT[remain_indx]
             )
             propvz = numpy.random.normal(size=nmore) * 2.0 * self._sz
+            # as_numpy for the same reason as in sampleV above
             VDatprop = (
-                self(
-                    R[remain_indx],
-                    propvR,
-                    propvT,
-                    z[remain_indx],
-                    propvz,
-                    log=True,
-                    use_physical=False,
+                as_numpy(
+                    self(
+                        R[remain_indx],
+                        propvR,
+                        propvT,
+                        z[remain_indx],
+                        propvz,
+                        log=True,
+                        use_physical=False,
+                    )
                 )
                 - logmaxVD[remain_indx]
             )

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -91,10 +91,10 @@
 # remaining migration work, because more than a third of it is ONE class that
 # refuses backends by construction:
 #
-#   total entries        107
+#   total entries        101
 #   actionAngleVerticalInverse  48   (24 jax + 24 torch)
 #   -------------------------------
-#   reducible by fixes   59
+#   reducible by fixes   53
 #
 # `actionAngleVerticalInverse._reject_backend` raises NotImplementedError as soon
 # as a backend is active (it builds scipy interpolation / ndimage grids), so those
@@ -192,16 +192,10 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_poi
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_actionAngle.py::test_actionAngleVertical_linear_angles
-torch tests/test_galpypaper.py::test_qdf
 torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
 torch tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_qdf.py::test_sampleV
-torch tests/test_qdf.py::test_sampleV_interpolate
-torch tests/test_qdf.py::test_sampleV_physical
-torch tests/test_quantity.py::test_quasiisothermaldf_interpolate_sample
 torch tests/test_quantity.py::test_quasiisothermaldf_method_returntype
 torch tests/test_quantity.py::test_quasiisothermaldf_method_returnunit
-torch tests/test_quantity.py::test_quasiisothermaldf_sample
 torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
 torch tests/test_quantity.py::test_sphericaldf_method_value
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta

--- a/tests/test_backend_qdf.py
+++ b/tests/test_backend_qdf.py
@@ -318,3 +318,52 @@ def test_moment_array_R_parity(backend):
         got = _qdf.density(Rs, zs, use_physical=False)
     assert is_backend_array(got)
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-6, atol=1e-9)
+
+
+# --- sampler numpy boundary -------------------------------------------------
+# The rejection samplers are numpy end to end (numpy.random proposals, numpy
+# fancy-indexing, a numpy output array), but under a forced backend the DF value
+# they accept/reject on comes back as a backend array, and `Tensor > ndarray`
+# raises. quasiisothermaldf lands the DF value (and fmin_powell's optimum) on
+# numpy where they enter that arithmetic. What the sampler returns is therefore
+# plain numpy on every backend -- that is the contract these tests pin.
+#
+# The samples are NOT bit-identical to the numpy path: fmin_powell converges in a
+# slightly different number of evaluations on a backend (46 vs 37 here), so maxVT
+# differs in its last bits and shifts the proposals. Measured max |difference|
+# over a 12-sample draw is 4.5e-10, so 1e-8 is a ~20x margin -- tight enough that
+# a real regression in the boundary (wrong values, wrong draw order) cannot pass.
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sampleV_returns_numpy(backend):
+    numpy.random.seed(17)
+    ref = _qdf.sampleV(0.9, 0.05, n=12, use_physical=False)
+    with galpy.backend.use(backend, force=True):
+        numpy.random.seed(17)
+        got = _qdf.sampleV(0.9, 0.05, n=12, use_physical=False)
+    assert isinstance(got, numpy.ndarray), (
+        f"sampleV under forced {backend} must return a numpy array, got {type(got)}"
+    )
+    assert not is_backend_array(got)
+    assert got.shape == ref.shape == (12, 3)
+    numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-8)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sampleV_interpolate_returns_numpy(backend):
+    # sampleV_interpolate drives the second sampler, _sampleV_preoptimized, whose
+    # accept step is a separate site from sampleV's.
+    # the (R, z) spread has to cover several R_pixel/z_pixel cells, or the
+    # internal RectBivariateSpline gets a degenerate grid
+    Rs = numpy.linspace(0.7, 1.3, 40)
+    zs = numpy.linspace(0.02, 0.3, 40)
+    numpy.random.seed(23)
+    ref = _qdf.sampleV_interpolate(Rs, zs, 0.1, 0.05, use_physical=False)
+    with galpy.backend.use(backend, force=True):
+        numpy.random.seed(23)
+        got = _qdf.sampleV_interpolate(Rs, zs, 0.1, 0.05, use_physical=False)
+    assert isinstance(got, numpy.ndarray), (
+        f"sampleV_interpolate under forced {backend} must return numpy, got {type(got)}"
+    )
+    assert not is_backend_array(got)
+    assert got.shape == ref.shape == (40, 3)
+    numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-8)

--- a/tests/test_qdf.py
+++ b/tests/test_qdf.py
@@ -791,9 +791,9 @@ def test_sampleV():
         < 0.05
     ), "sampleV vR stddev is not equal to sigmaR"
     # test vT
-    assert numpy.fabs(numpy.mean(samples[:, 1] - qdf.meanvT(0.8, 0.1))) < 0.015, (
-        "sampleV vT mean is not equal to meanvT"
-    )
+    assert (
+        numpy.fabs(numpy.mean(samples[:, 1] - as_numpy(qdf.meanvT(0.8, 0.1)))) < 0.015
+    ), "sampleV vT mean is not equal to meanvT"
     assert (
         numpy.fabs(
             numpy.log(numpy.std(samples[:, 1])) - 0.5 * numpy.log(qdf.sigmaT2(0.8, 0.1))
@@ -832,7 +832,8 @@ def test_sampleV_physical():
     ), "sampleV vR stddev is not equal to sigmaR"
     # test vT
     assert (
-        numpy.fabs(numpy.mean(samples[:, 1] - qdf.meanvT(0.8, 0.1, vo=vo))) < 0.015 * vo
+        numpy.fabs(numpy.mean(samples[:, 1] - as_numpy(qdf.meanvT(0.8, 0.1, vo=vo))))
+        < 0.015 * vo
     ), "sampleV vT mean is not equal to meanvT"
     assert (
         numpy.fabs(
@@ -892,9 +893,10 @@ def test_sampleV_interpolate():
             < 0.05
         ), "sampleV interpolate vR stddev is not equal to sigmaR"
         # test vT
-        assert numpy.fabs(numpy.mean(samples[:, 1] - qdf.meanvT(0.8, 0.1))) < 0.015, (
-            "sampleV interpolate vT mean is not equal to meanvT"
-        )
+        assert (
+            numpy.fabs(numpy.mean(samples[:, 1] - as_numpy(qdf.meanvT(0.8, 0.1))))
+            < 0.015
+        ), "sampleV interpolate vT mean is not equal to meanvT"
         assert (
             numpy.fabs(
                 numpy.log(numpy.std(samples[:, 1]))


### PR DESCRIPTION
The `quasiisothermaldf` rejection samplers are numpy end to end — `numpy.random`
proposals, numpy fancy-indexing, a numpy output array — but under a forced backend
`self(...)` returns a backend array for array coords, and the accept step raises

```
TypeError: '>' not supported between instances of 'Tensor' and 'numpy.ndarray'
```

Land the two values that cross into that arithmetic — the DF evaluated at the
proposals, and `fmin_powell`'s optimum `logmaxVD` — with `as_numpy`, **at the point
they enter it** rather than at the comparison that happens to trip. Four sites:
`sampleV` and `_sampleV_preoptimized` each have one of each.

`as_numpy` on a numpy array returns **the same object**, so the numpy path is
structurally unchanged rather than merely numerically equal, and the `numpy.random`
draw order is untouched.

This is a **boundary cast, not a numpy island**: the DF itself still evaluates on the
backend. It does not make sampling differentiable or GPU-resident — that needs the
backend RNG shim and stays separate.

Three test-side `samples - qdf.meanvT(...)` assertions needed the same landing
(`ndarray - Tensor`), the class already fixed in #1228.

## Ledger 107 → 101

Six torch entries, **each verified to fail without this change**:
`test_qdf::test_sampleV` / `::test_sampleV_interpolate` / `::test_sampleV_physical`,
`test_galpypaper::test_qdf`, and
`test_quantity::test_quasiisothermaldf_sample` / `::test_quasiisothermaldf_interpolate_sample`.

`test_qdf::test_call_diffinoutputs` is **not** in this group — that one is the
by-design unbound-orbit case and stays ledgered.

## Tests

`test_backend_qdf.py` gains sampler-boundary coverage for both samplers on both
backends, asserting the return is a plain numpy array and agrees with the numpy path
to 1e-8.

Deliberately **not** asserted bit-identical: `fmin_powell` converges in a different
number of evaluations on a backend (46 vs 37), so `maxVT` differs in its last bits
and shifts the proposals themselves. Measured max difference is 4.5e-10, so 1e-8 is
a ~20x margin — tight enough that a real regression in draw order or values cannot
pass, and honest about where the residual comes from. Both torch cases fail without
the source fix; the jax parametrisations are guards, not flips (`jax_array > ndarray`
happens to work).

numpy: `test_qdf.py` 56 passed.