### PR TITLE
potential: survive scipy 1.18's unpicklable spline objects

### DIFF
--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -52,6 +52,34 @@ if _types.ModuleType not in _copy._deepcopy_dispatch:  # pragma: no branch
     _copy._deepcopy_dispatch[_types.ModuleType] = lambda module, memo: module
 
 
+# scipy 1.18 caches the array namespace -- a MODULE -- on PPoly/BPoly instances
+# (`_xp`), so any object holding one raises "cannot pickle 'module' object". The
+# coefficients themselves pickle fine, so drop the scipy object on the way out and
+# rebuild it through the public constructor on the way back in; that round-trips
+# bit-identically. Stripping `_xp` alone does NOT work -- scipy never recreates it
+# and the restored spline then raises AttributeError when evaluated.
+_SPLINE_SURROGATE = "__galpy_spline__"
+
+
+def _pack_splines(obj):
+    """Replace scipy piecewise-polynomials in a nested list with plain tuples."""
+    if isinstance(obj, (PPoly, BPoly)):
+        return (_SPLINE_SURROGATE, type(obj), obj.c, obj.x, obj.extrapolate, obj.axis)
+    if isinstance(obj, list):
+        return [_pack_splines(v) for v in obj]
+    return obj
+
+
+def _unpack_splines(obj):
+    """Inverse of _pack_splines."""
+    if isinstance(obj, tuple) and len(obj) == 6 and obj[0] == _SPLINE_SURROGATE:
+        _, cls, c, x, extrapolate, axis = obj
+        return cls(c, x, extrapolate=extrapolate, axis=axis)
+    if isinstance(obj, list):
+        return [_unpack_splines(v) for v in obj]
+    return obj
+
+
 class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
     r"""Class that implements a gravitational potential computed via multipole expansion of an arbitrary density distribution.
 
@@ -108,6 +136,31 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
     using piecewise polynomials. This allows efficient evaluation of the potential, forces, and
     second derivatives at arbitrary times within the ``tgrid`` range during orbit integration.
     """
+
+    # Attributes holding scipy piecewise-polynomials. The _sin pair exists only
+    # for a non-axisymmetric density, so both cases must be covered -- an
+    # axisymmetric-only check finds half the set.
+    _PICKLE_SPLINE_ATTRS = (
+        "_I_inner_cos",
+        "_I_inner_sin",
+        "_I_outer_cos",
+        "_I_outer_sin",
+    )
+
+    # Pickling functions (see _pack_splines)
+    def __getstate__(self):
+        pdict = _copy.copy(self.__dict__)
+        for name in self._PICKLE_SPLINE_ATTRS:
+            if name in pdict:
+                pdict[name] = _pack_splines(pdict[name])
+        return pdict
+
+    def __setstate__(self, pdict):
+        self.__dict__ = pdict
+        for name in self._PICKLE_SPLINE_ATTRS:
+            if name in self.__dict__:
+                setattr(self, name, _unpack_splines(self.__dict__[name]))
+        return None
 
     def __init__(
         self,

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -109,17 +109,7 @@ def _make_pots_pickle():
     # normalize membership minus the mock potentials defined in this module
     # (which are not attributes of galpy.potential), because this test is about
     # what the library exports, not about the mocks.
-    pots = [p for p in _make_pots_normalize() if hasattr(potential, p)]
-    # The multipole potentials hold scipy BPoly splines (`_I_inner_cos` etc.).
-    # scipy 1.18 caches the array namespace -- a MODULE -- on its spline objects,
-    # so anything holding one raises "cannot pickle 'module' object ... when
-    # serializing dict item '_xp' ... BPoly state". That is upstream and predates
-    # this test: MultipoleExpansionPotential is affected too and nothing here
-    # touches it. Excluded until it is reproduced against scipy 1.18 and either
-    # fixed (drop the cached namespace on the way out) or reported upstream.
-    for p in ["MultipoleExpansionPotential", "DiskMultipoleExpansionPotential"]:
-        pots.remove(p)
-    return pots
+    return [p for p in _make_pots_normalize() if hasattr(potential, p)]
 
 
 def _make_pots_forceAsDeriv():
@@ -1305,6 +1295,12 @@ def test_pickling_potential_user_callables():
         ),
         # non-axisymmetric: takes the other branch of _set_dens_funcs
         "DiskSCF nonaxi": potential.DiskSCFPotential(dens=_pickletest_dens_nonaxi),
+        # non-axisymmetric multipole: the ONLY configuration that populates the
+        # _I_*_sin spline attributes, so an axisymmetric case alone would not
+        # exercise half of what __getstate__ has to pack
+        "DiskMultipole nonaxi": potential.DiskMultipoleExpansionPotential(
+            dens=_pickletest_dens_nonaxi
+        ),
         "AnySpherical": potential.AnySphericalPotential(
             dens=_pickletest_spherical_dens
         ),


### PR DESCRIPTION
scipy 1.18 caches the array namespace — a **module** — on `PPoly`/`BPoly` instances
as `_xp`, so any object holding one raises:

```
TypeError: cannot pickle 'module' object
  when serializing dict item '_xp' ... BPoly state
```

Surfaced by #1230's new pickle round-trip on the Windows py3.14 runner, which
installs scipy 1.18 while the dev env has 1.17.

## Radius: measured, not inferred

My first estimate came from grepping for spline references and named ~22 modules.
Running it under scipy 1.18 with galpy imported:

```
default-constructible potentials:  62 picklable, 2 UNPICKLABLE
interpRZPotential ......... OK      actionAngleStaeckelGrid ... OK
interpSphericalPotential .. OK      actionAngleAdiabaticGrid .. OK
quasiisothermaldf ......... OK      dehnendf .................. OK
isotropicHernquistdf ...... OK      Orbit(integrated) ......... OK
```

Only `MultipoleExpansionPotential` and `DiskMultipoleExpansionPotential`. The bound
is principled, not just empirical — only `_interpolate.py`'s polynomial classes
gained `_xp`:

```
BPoly / PPoly / CubicSpline     _xp=True   pickle FAIL
InterpolatedUnivariateSpline    _xp=False  pickle OK
UnivariateSpline                _xp=False  pickle OK
RectBivariateSpline             _xp=False  pickle OK
```

## Fix

The splines live in `MultipoleExpansionPotential._I_{inner,outer}_{cos,sin}`, and
`DiskMultipoleExpansionPotential` holds them only through its `_me` sub-potential —
so **one** `__getstate__`/`__setstate__` covers both.

Drop the scipy object on the way out, rebuild through the **public constructor** on
the way back in. Stripping `_xp` alone does **not** work: scipy never recreates it
and the restored spline raises `AttributeError` when evaluated.

## Verification

Bit-identical (`__call__`/`Rforce`/`zforce`/`dens` at 3 points) on **both scipy 1.18
and 1.17**, for `MultipoleExpansionPotential`, `DiskMultipoleExpansionPotential`, and
a **non-axisymmetric** `DiskMultipoleExpansionPotential`.

The non-axi case is not decoration: `_I_*_sin` is populated **only** for a
non-axisymmetric density, so an axisymmetric-only check exercises half the packing
and still passes — it would have shipped something that silently restored non-axi
potentials with wrong values.

Re-includes both classes in `test_pickling_potential` (excluded in #1230 with the
cause named in code) and adds a non-axisymmetric multipole to the user-callables
round-trip.

numpy: `test_MultipoleExpansionPotential.py` + `test_scf.py` 201 passed.

Worth reporting upstream separately — a class that pickled for years no longer does.