### PR TITLE
coords: backend-agnostic Jacobian helpers (4 of 6; keystone for differentiable stream covariance)

### DIFF
--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1972,79 +1972,117 @@ def XYZ_to_lbd_jac(*args, **kwargs):
     else:
         raise ValueError("XYZ_to_lbd_jac expects 3 or 6 arguments")
 
+    xp = get_namespace(*args, xp=kwargs.get("xp", None))
+    X, Y, Z = promote_scalars(xp, X, Y, Z)
+    if with_vel:
+        vX, vY, vZ = promote_scalars(xp, vX, vY, vZ)
     R2 = X * X + Y * Y
-    D = numpy.sqrt(R2 + Z * Z)
-    r = numpy.sqrt(R2)
+    D = xp.sqrt(R2 + Z * Z)
+    r = xp.sqrt(R2)
     cb = r / D
     sb = Z / D
     # On the celestial pole (r==0) ``l`` is undefined; pick (cl, sl) = (1, 0)
     # so the spatial inverse stays finite (consistent with atan2(0, 0) = 0).
-    if r == 0.0:
-        cl, sl = 1.0, 0.0
-    else:
-        cl = X / r
-        sl = Y / r
+    # Each xp.where's dead branch is computed too (eagerly and under a trace),
+    # so divide by a safe denominator or the 0/0 NaN poisons the gradient.
+    at_pole = r == 0.0
+    r_safe = xp.where(at_pole, 1.0, r)
+    cl = xp.where(at_pole, 1.0, X / r_safe)
+    sl = xp.where(at_pole, 0.0, Y / r_safe)
 
-    out = numpy.zeros((6, 6) if with_vel else (3, 3))
-    # Position 3x3: ∂(l, b, D)/∂(X, Y, Z)
-    if cb != 0.0:  # else: at the pole, ∂l/∂(X, Y) blows up — leave as zero
-        out[0, 0] = -sl / (D * cb)
-        out[0, 1] = cl / (D * cb)
-    out[1, 0] = -sb * cl / D
-    out[1, 1] = -sb * sl / D
-    out[1, 2] = cb / D
-    out[2, 0] = cb * cl
-    out[2, 1] = cb * sl
-    out[2, 2] = sb
+    o = xp.zeros_like(cb)
+    # Position 3x3: ∂(l, b, D)/∂(X, Y, Z). At the pole ∂l/∂(X, Y) blows up, so
+    # those two entries stay zero (same convention as the scalar version).
+    Dcb = D * cb
+    Dcb_safe = xp.where(Dcb == 0.0, 1.0, Dcb)
+    dl_dX = xp.where(Dcb == 0.0, 0.0, -sl / Dcb_safe)
+    dl_dY = xp.where(Dcb == 0.0, 0.0, cl / Dcb_safe)
+    P = xp.stack(
+        [
+            xp.stack([dl_dX, dl_dY, o], axis=-1),
+            xp.stack([-sb * cl / D, -sb * sl / D, cb / D], axis=-1),
+            xp.stack([cb * cl, cb * sl, sb], axis=-1),
+        ],
+        axis=-2,
+    )
+
+    def _degree_scale(m):
+        # was `out[0, :] *= 1/_DEGTORAD` on rows 0 and 1
+        if not kwargs.get("degree", False):
+            return m
+        n = m.shape[-2]
+        s = xp.stack(
+            [xp.full_like(cb, 1.0 / _DEGTORAD)] * 2 + [xp.ones_like(cb)] * (n - 2),
+            axis=-1,
+        )
+        return m * s[..., :, None]
 
     if not with_vel:
-        if kwargs.get("degree", False):
-            out[0, :] *= 1.0 / _DEGTORAD
-            out[1, :] *= 1.0 / _DEGTORAD
-        return out
+        return _degree_scale(P)
 
     # Velocity 3x3: ∂(vlos, pmll, pmbb)/∂(vX, vY, vZ) at fixed position.
     # forward velocity block is R · diag(1, K·D, K·D) with R orthonormal
     # ⇒ inverse = diag(1, 1/(K·D), 1/(K·D)) · Rᵀ.
     KD = _K * D
-    out[3, 3] = cl * cb
-    out[3, 4] = sl * cb
-    out[3, 5] = sb
-    if KD != 0.0:  # pragma: no branch (D > 0 always — guard catches the
-        # heliocentric-origin singularity if a caller passes (X, Y, Z) = 0)
-        out[4, 3] = -sl / KD
-        out[4, 4] = cl / KD
-        out[5, 3] = -cl * sb / KD
-        out[5, 4] = -sl * sb / KD
-        out[5, 5] = cb / KD
+    # D > 0 always; the guard catches a caller passing (X, Y, Z) = 0.
+    sing = KD == 0.0
+    KD_safe = xp.where(sing, 1.0, KD)
+    M = xp.stack(
+        [
+            xp.stack([cl * cb, sl * cb, sb], axis=-1),
+            xp.stack(
+                [
+                    xp.where(sing, 0.0, -sl / KD_safe),
+                    xp.where(sing, 0.0, cl / KD_safe),
+                    o,
+                ],
+                axis=-1,
+            ),
+            xp.stack(
+                [
+                    xp.where(sing, 0.0, -cl * sb / KD_safe),
+                    xp.where(sing, 0.0, -sl * sb / KD_safe),
+                    xp.where(sing, 0.0, cb / KD_safe),
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=-2,
+    )
 
     # Bottom-left coupling: -inv(M) · Q · inv(P).
     # Q is the velocity-vs-position block of lbd_to_XYZ_jac, evaluated at
     # the current vlos/pmll/pmbb (themselves derived from vX,vY,vZ via the
     # velocity inverse just computed).
     vlos = cl * cb * vX + sl * cb * vY + sb * vZ
-    if KD != 0.0:
-        pmll = (-sl * vX + cl * vY) / KD
-        pmbb = (-cl * sb * vX - sl * sb * vY + cb * vZ) / KD
-    else:  # pragma: no cover (defensive: Sun is never the track mean)
-        pmll = 0.0
-        pmbb = 0.0
-    Q = numpy.zeros((3, 3))
-    Q[0, 0] = -sl * cb * vlos - cl * KD * pmll + sb * sl * KD * pmbb
-    Q[0, 1] = -cl * sb * vlos - cb * cl * KD * pmbb
-    Q[0, 2] = -sl * _K * pmll - sb * cl * _K * pmbb
-    Q[1, 0] = cl * cb * vlos - sl * KD * pmll - cl * sb * KD * pmbb
-    Q[1, 1] = -sl * sb * vlos - sl * cb * KD * pmbb
-    Q[1, 2] = cl * _K * pmll - sl * sb * _K * pmbb
-    Q[2, 0] = 0.0
-    Q[2, 1] = cb * vlos - sb * KD * pmbb
-    Q[2, 2] = cb * _K * pmbb
-    out[3:6, 0:3] = -out[3:6, 3:6] @ Q @ out[0:3, 0:3]
-
-    if kwargs.get("degree", False):
-        out[0, :] *= 1.0 / _DEGTORAD
-        out[1, :] *= 1.0 / _DEGTORAD
-    return out
+    pmll = xp.where(sing, 0.0, (-sl * vX + cl * vY) / KD_safe)
+    pmbb = xp.where(sing, 0.0, (-cl * sb * vX - sl * sb * vY + cb * vZ) / KD_safe)
+    Q = xp.stack(
+        [
+            xp.stack(
+                [
+                    -sl * cb * vlos - cl * KD * pmll + sb * sl * KD * pmbb,
+                    -cl * sb * vlos - cb * cl * KD * pmbb,
+                    -sl * _K * pmll - sb * cl * _K * pmbb,
+                ],
+                axis=-1,
+            ),
+            xp.stack(
+                [
+                    cl * cb * vlos - sl * KD * pmll - cl * sb * KD * pmbb,
+                    -sl * sb * vlos - sl * cb * KD * pmbb,
+                    cl * _K * pmll - sl * sb * _K * pmbb,
+                ],
+                axis=-1,
+            ),
+            xp.stack([o, cb * vlos - sb * KD * pmbb, cb * _K * pmbb], axis=-1),
+        ],
+        axis=-2,
+    )
+    C = -M @ Q @ P
+    Z3 = xp.zeros_like(P)
+    out = xp.concat([xp.concat([P, Z3], axis=-1), xp.concat([C, M], axis=-1)], axis=-2)
+    return _degree_scale(out)
 
 
 def galcencyl_to_galcenrect(R, vR, vT, z, vz, phi):

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1851,51 +1851,71 @@ def lbd_to_XYZ_jac(*args, **kwargs):
     -----
     - 2013-12-09 - Written - Bovy (IAS)
     """
-    out = numpy.zeros((6, 6))
     if len(args) == 3:
         l, b, D = args
         vlos, pmll, pmbb = 0.0, 0.0, 0.0
     elif len(args) == 6:
         l, b, D, vlos, pmll, pmbb = args
-    if kwargs.get("degree", False):
-        l *= _DEGTORAD
-        b *= _DEGTORAD
-    cl = numpy.cos(l)
-    sl = numpy.sin(l)
-    cb = numpy.cos(b)
-    sb = numpy.sin(b)
-    out[0, 0] = -D * cb * sl
-    out[0, 1] = -D * sb * cl
-    out[0, 2] = cb * cl
-    out[1, 0] = D * cb * cl
-    out[1, 1] = -D * sb * sl
-    out[1, 2] = cb * sl
-    out[2, 1] = D * cb
-    out[2, 2] = sb
+    xp = get_namespace(*args, xp=kwargs.get("xp", None))
+    l, b, D, vlos, pmll, pmbb = promote_scalars(xp, l, b, D, vlos, pmll, pmbb)
+    degree = kwargs.get("degree", False)
+    if degree:
+        # out-of-place: `l *= ...` would mutate a caller's tensor
+        l = l * _DEGTORAD
+        b = b * _DEGTORAD
+    cl = xp.cos(l)
+    sl = xp.sin(l)
+    cb = xp.cos(b)
+    sb = xp.sin(b)
+    o = xp.zeros_like(cl)
+    # Rows stacked rather than assigned into a zeros((6,6)): jax arrays are
+    # immutable, and stacking is what makes a batched (..., 6, 6) fall out.
+    rows = [
+        xp.stack([-D * cb * sl, -D * sb * cl, cb * cl, o, o, o], axis=-1),
+        xp.stack([D * cb * cl, -D * sb * sl, cb * sl, o, o, o], axis=-1),
+        xp.stack([o, D * cb, sb, o, o, o], axis=-1),
+    ]
+    if len(args) == 6:
+        rows += [
+            xp.stack(
+                [
+                    -sl * cb * vlos - cl * _K * D * pmll + sb * sl * _K * D * pmbb,
+                    -cl * sb * vlos - cb * cl * _K * D * pmbb,
+                    -sl * _K * pmll - sb * cl * _K * pmbb,
+                    cl * cb,
+                    -sl * _K * D,
+                    -cl * sb * _K * D,
+                ],
+                axis=-1,
+            ),
+            xp.stack(
+                [
+                    cl * cb * vlos - sl * _K * D * pmll - cl * sb * _K * D * pmbb,
+                    -sl * sb * vlos - sl * cb * _K * D * pmbb,
+                    cl * _K * pmll - sl * sb * _K * pmbb,
+                    sl * cb,
+                    cl * _K * D,
+                    -sl * sb * _K * D,
+                ],
+                axis=-1,
+            ),
+            xp.stack(
+                [o, cb * vlos - sb * _K * D * pmbb, cb * _K * pmbb, sb, o, cb * _K * D],
+                axis=-1,
+            ),
+        ]
+    out = xp.stack(rows, axis=-2)
     if len(args) == 3:
-        if kwargs.get("degree", False):
-            out[:, 0] *= _DEGTORAD
-            out[:, 1] *= _DEGTORAD
-        return out[:3, :3]
-    out[3, 0] = -sl * cb * vlos - cl * _K * D * pmll + sb * sl * _K * D * pmbb
-    out[3, 1] = -cl * sb * vlos - cb * cl * _K * D * pmbb
-    out[3, 2] = -sl * _K * pmll - sb * cl * _K * pmbb
-    out[3, 3] = cl * cb
-    out[3, 4] = -sl * _K * D
-    out[3, 5] = -cl * sb * _K * D
-    out[4, 0] = cl * cb * vlos - sl * _K * D * pmll - cl * sb * _K * D * pmbb
-    out[4, 1] = -sl * sb * vlos - sl * cb * _K * D * pmbb
-    out[4, 2] = cl * _K * pmll - sl * sb * _K * pmbb
-    out[4, 3] = sl * cb
-    out[4, 4] = cl * _K * D
-    out[4, 5] = -sl * sb * _K * D
-    out[5, 1] = cb * vlos - sb * _K * D * pmbb
-    out[5, 2] = cb * _K * pmbb
-    out[5, 3] = sb
-    out[5, 5] = cb * _K * D
-    if kwargs.get("degree", False):
-        out[:, 0] *= _DEGTORAD
-        out[:, 1] *= _DEGTORAD
+        out = out[..., :3, :3]
+    if degree:
+        # was `out[:, 0] *= _DEGTORAD` on columns 0 and 1
+        n = out.shape[-1]
+        col = xp.stack(
+            [_DEGTORAD * xp.ones_like(cl), _DEGTORAD * xp.ones_like(cl)]
+            + [xp.ones_like(cl)] * (n - 2),
+            axis=-1,
+        )
+        out = out * col[..., None, :]
     return out
 
 

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2045,56 +2045,63 @@ def galcencyl_to_galcenrect(R, vR, vT, z, vz, phi):
     return numpy.column_stack([x, y, zc, vx, vy, vzc])
 
 
-def galcenrect_to_galcencyl_jac(x, y, z, vx, vy, vz):
+def galcenrect_to_galcencyl_jac(x, y, z, vx, vy, vz, *, xp=None):
     """
     Calculate the Jacobian of the Galactocentric rectangular → cylindrical
     coordinates transformation, evaluated at the given point.
 
     Parameters
     ----------
-    x, y, z : float
+    x, y, z : float or array
         Galactocentric Cartesian position.
-    vx, vy, vz : float
+    vx, vy, vz : float or array
         Galactocentric Cartesian velocity.
+    xp : module or str, optional
+        Explicit array-namespace override forwarded to get_namespace (e.g.
+        ``numpy`` to pin host-side bookkeeping regardless of the forced default).
 
     Returns
     -------
-    numpy.ndarray
+    array
         6x6 Jacobian of ``(R, vR, vT, z, vz, phi)`` w.r.t. ``(x, y, z, vx, vy, vz)``.
+        Batched inputs give a ``(..., 6, 6)`` stack.
 
     Notes
     -----
     - 2026-04-26 - Written - Bovy (UofT)
+    - 2026-07-31 - Backend-agnostic (rows stacked, not item-assigned) - Claude
     """
-    R = numpy.sqrt(x * x + y * y)
-    if R == 0.0:
-        R = 1e-30
+    xp = get_namespace(x, y, z, vx, vy, vz, xp=xp)
+    x, y, vx, vy = promote_scalars(xp, x, y, vx, vy)
+    R = xp.sqrt(x * x + y * y)
+    # was `if R == 0.0: R = 1e-30`; array inputs and tracing need the branch
+    # expressed as a select
+    R = xp.where(R == 0.0, 1e-30, R)
     cp = x / R
     sp = y / R
     vR_ = cp * vx + sp * vy
     vT_ = -sp * vx + cp * vy
-    J = numpy.zeros((6, 6))
-    # row 0: R = sqrt(x²+y²)
-    J[0, 0] = cp
-    J[0, 1] = sp
-    # row 1: vR = cos(phi) * vx + sin(phi) * vy (depends on phi via x, y)
-    J[1, 0] = -sp * vT_ / R
-    J[1, 1] = cp * vT_ / R
-    J[1, 3] = cp
-    J[1, 4] = sp
-    # row 2: vT = -sin(phi) * vx + cos(phi) * vy
-    J[2, 0] = sp * vR_ / R
-    J[2, 1] = -cp * vR_ / R
-    J[2, 3] = -sp
-    J[2, 4] = cp
-    # row 3: z = z
-    J[3, 2] = 1.0
-    # row 4: vz = vz
-    J[4, 5] = 1.0
-    # row 5: phi = atan2(y, x)
-    J[5, 0] = -sp / R
-    J[5, 1] = cp / R
-    return J
+    o = xp.zeros_like(cp)
+    i = xp.ones_like(cp)
+    # Rows stacked rather than assigned into a zeros((6,6)): jax arrays are
+    # immutable, and stacking is what makes a batched (..., 6, 6) fall out.
+    return xp.stack(
+        [
+            # row 0: R = sqrt(x²+y²)
+            xp.stack([cp, sp, o, o, o, o], axis=-1),
+            # row 1: vR = cos(phi) * vx + sin(phi) * vy (depends on phi via x, y)
+            xp.stack([-sp * vT_ / R, cp * vT_ / R, o, cp, sp, o], axis=-1),
+            # row 2: vT = -sin(phi) * vx + cos(phi) * vy
+            xp.stack([sp * vR_ / R, -cp * vR_ / R, o, -sp, cp, o], axis=-1),
+            # row 3: z = z
+            xp.stack([o, o, i, o, o, o], axis=-1),
+            # row 4: vz = vz
+            xp.stack([o, o, o, o, o, i], axis=-1),
+            # row 5: phi = atan2(y, x)
+            xp.stack([-sp / R, cp / R, o, o, o, o], axis=-1),
+        ],
+        axis=-2,
+    )
 
 
 def galsky_to_sky_jac(*args, **kwargs):

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1797,20 +1797,28 @@ def galcenrect_to_XYZ_jac(*args, **kwargs):
 
     """
     Xsun = kwargs.get("Xsun", 1.0)
-    dgc = numpy.sqrt(Xsun**2.0 + kwargs.get("Zsun", 0.0) ** 2.0)
-    costheta, sintheta = Xsun / dgc, kwargs.get("Zsun", 0.0) / dgc
-    out = numpy.zeros((6, 6))
-    out[0, 0] = -costheta
-    out[0, 2] = -sintheta
-    out[1, 1] = 1.0
-    out[2, 0] = -numpy.sign(Xsun) * sintheta
-    out[2, 2] = numpy.sign(Xsun) * costheta
-    out[3, 3] = -costheta
-    out[3, 5] = -sintheta
-    out[4, 4] = 1.0
-    out[5, 3] = -numpy.sign(Xsun) * sintheta
-    out[5, 5] = numpy.sign(Xsun) * costheta
-    return out[: len(args), : len(args)]
+    Zsun = kwargs.get("Zsun", 0.0)
+    xp = get_namespace(*args, Xsun, Zsun, xp=kwargs.get("xp", None))
+    Xsun, Zsun = promote_scalars(xp, Xsun, Zsun)
+    dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
+    costheta, sintheta = Xsun / dgc, Zsun / dgc
+    sgn = xp.sign(Xsun)
+    o = xp.zeros_like(costheta)
+    i = xp.ones_like(costheta)
+    # Rows stacked rather than assigned into a zeros((6,6)): jax arrays are
+    # immutable, and stacking is what makes a batched (..., 6, 6) fall out.
+    out = xp.stack(
+        [
+            xp.stack([-costheta, o, -sintheta, o, o, o], axis=-1),
+            xp.stack([o, i, o, o, o, o], axis=-1),
+            xp.stack([-sgn * sintheta, o, sgn * costheta, o, o, o], axis=-1),
+            xp.stack([o, o, o, -costheta, o, -sintheta], axis=-1),
+            xp.stack([o, o, o, o, i, o], axis=-1),
+            xp.stack([o, o, o, -sgn * sintheta, o, sgn * costheta], axis=-1),
+        ],
+        axis=-2,
+    )
+    return out[..., : len(args), : len(args)]
 
 
 def lbd_to_XYZ_jac(*args, **kwargs):

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -2950,6 +2950,62 @@ def test_galcenrect_to_galcencyl_jac():
     return None
 
 
+def test_galcenrect_to_XYZ_jac():
+    # Check the analytic Jacobian against central finite differences of the
+    # forward transform it differentiates. Both the 3-arg (spatial) and 6-arg
+    # (spatial+velocity) forms, and a non-zero Zsun so the sin(theta) entries
+    # are actually exercised (Zsun=0 would leave them zero and hide a sign).
+    Xsun, Zsun = 8.2, 0.025
+    x, y, z, vx, vy, vz = 1.3, -0.7, 0.4, 12.0, -215.0, 7.0
+
+    # NOTE _extra_rot=False: galcenrect_to_XYZ_jac differentiates the transform
+    # WITHOUT the extra rotation, while galcenrect_to_XYZ defaults to
+    # _extra_rot=True. Against the default forward transform the analytic
+    # Jacobian is off by ~1.5e-6 (vs 1.9e-10 here) -- a pre-existing mismatch,
+    # not introduced by the backend migration. See the note in the PR: callers
+    # that pair the Jacobian with a default-argument forward call (e.g.
+    # streamTrack._analytical_jacobian) inherit that small inconsistency.
+    def fwd(state):
+        X, Y, Z = coords.galcenrect_to_XYZ(
+            state[0], state[1], state[2], Xsun=Xsun, Zsun=Zsun, _extra_rot=False
+        )
+        vX, vY, vZ = coords.galcenrect_to_vxvyvz(
+            state[3], state[4], state[5], Xsun=Xsun, Zsun=Zsun, _extra_rot=False
+        )
+        return numpy.array([X, Y, Z, vX, vY, vZ])
+
+    J = as_numpy(
+        coords.galcenrect_to_XYZ_jac(x, y, z, vx, vy, vz, Xsun=Xsun, Zsun=Zsun)
+    )
+    s0 = numpy.array([x, y, z, vx, vy, vz])
+    J_fd = numpy.empty((6, 6))
+    for k in range(6):
+        # step scaled to the component: the velocities are O(200), so a fixed
+        # absolute h makes the differenced values lose ~8 digits to roundoff
+        hk = 1e-6 * max(1.0, abs(s0[k]))
+        dk = numpy.zeros(6)
+        dk[k] = hk
+        J_fd[:, k] = (fwd(s0 + dk) - fwd(s0 - dk)) / (2.0 * hk)
+    assert numpy.max(numpy.abs(J - J_fd)) < 1e-9, (
+        "galcenrect_to_XYZ_jac does not match finite differences of the forward "
+        f"transform: max|J - J_fd| = {numpy.max(numpy.abs(J - J_fd))}"
+    )
+    # 3-arg form is the spatial sub-block of the 6-arg one
+    J3 = as_numpy(coords.galcenrect_to_XYZ_jac(x, y, z, Xsun=Xsun, Zsun=Zsun))
+    assert J3.shape == (3, 3), "galcenrect_to_XYZ_jac 3-arg form is not 3x3"
+    assert numpy.all(J3 == J[:3, :3]), (
+        "galcenrect_to_XYZ_jac 3-arg form is not the spatial block of the 6-arg form"
+    )
+    # a negative Xsun flips the sign() entries; check that branch too
+    Jneg = as_numpy(
+        coords.galcenrect_to_XYZ_jac(x, y, z, vx, vy, vz, Xsun=-Xsun, Zsun=Zsun)
+    )
+    assert numpy.sign(Jneg[2, 0]) == -numpy.sign(J[2, 0]), (
+        "galcenrect_to_XYZ_jac sign(Xsun) branch did not flip"
+    )
+    return None
+
+
 def test_galcenrect_to_galcencyl_jac_on_z_axis():
     # On the z-axis (R=0) the Jacobian is singular; the implementation
     # falls back to a tiny epsilon so the matrix stays finite. Check that

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -2719,7 +2719,7 @@ def test_pupv_to_vRvz_oblate():
 def test_lbd_to_XYZ_jac():
     # Just position
     l, b, d = 180.0, 30.0, 2.0
-    jac = coords.lbd_to_XYZ_jac(l, b, d, degree=True)
+    jac = as_numpy(coords.lbd_to_XYZ_jac(l, b, d, degree=True))
     assert numpy.fabs(jac[0, 0] - 0.0) < 10.0**-10.0, (
         "lbd_to_XYZ_jac calculation did not work as expected"
     )
@@ -2750,7 +2750,7 @@ def test_lbd_to_XYZ_jac():
     # 6D
     l, b, d = 3.0 * numpy.pi / 2.0, numpy.pi / 6.0, 2.0
     vr, pmll, pmbb = 10.0, 20.0, -30.0
-    jac = coords.lbd_to_XYZ_jac(l, b, d, vr, pmll, pmbb, degree=False)
+    jac = as_numpy(coords.lbd_to_XYZ_jac(l, b, d, vr, pmll, pmbb, degree=False))
     assert numpy.fabs(jac[0, 0] - numpy.sqrt(3.0)) < 10.0**-9.0, (
         "lbd_to_XYZ_jac calculation did not work as expected"
     )
@@ -2854,28 +2854,28 @@ def test_XYZ_to_lbd_jac_inverse():
     # composing them should give the identity (no LAPACK round-off).
     l, b, d = 0.7, 0.3, 5.0
     vlos, pmll, pmbb = 30.0, -2.5, 1.7
-    J_fwd = coords.lbd_to_XYZ_jac(l, b, d, vlos, pmll, pmbb, degree=False)
+    J_fwd = as_numpy(coords.lbd_to_XYZ_jac(l, b, d, vlos, pmll, pmbb, degree=False))
     X, Y, Z = coords.lbd_to_XYZ(l, b, d, degree=False)
     vX, vY, vZ = coords.vrpmllpmbb_to_vxvyvz(
         vlos, pmll, pmbb, l, b, d, XYZ=False, degree=False
     )
-    J_inv = coords.XYZ_to_lbd_jac(X, Y, Z, vX, vY, vZ, degree=False)
+    J_inv = as_numpy(coords.XYZ_to_lbd_jac(X, Y, Z, vX, vY, vZ, degree=False))
     assert numpy.allclose(J_inv @ J_fwd, numpy.eye(6), atol=1e-12), (
         "XYZ_to_lbd_jac · lbd_to_XYZ_jac != I"
     )
     # 3x3 spatial-only branch
-    J_fwd3 = coords.lbd_to_XYZ_jac(l, b, d, degree=False)
-    J_inv3 = coords.XYZ_to_lbd_jac(X, Y, Z, degree=False)
+    J_fwd3 = as_numpy(coords.lbd_to_XYZ_jac(l, b, d, degree=False))
+    J_inv3 = as_numpy(coords.XYZ_to_lbd_jac(X, Y, Z, degree=False))
     assert numpy.allclose(J_inv3 @ J_fwd3, numpy.eye(3), atol=1e-12), (
         "XYZ_to_lbd_jac (spatial 3x3) · lbd_to_XYZ_jac != I"
     )
     # degree=True: l, b output rows scaled by 180/π
-    J_inv_deg = coords.XYZ_to_lbd_jac(X, Y, Z, vX, vY, vZ, degree=True)
+    J_inv_deg = as_numpy(coords.XYZ_to_lbd_jac(X, Y, Z, vX, vY, vZ, degree=True))
     assert numpy.allclose(J_inv_deg[0], J_inv[0] * 180.0 / numpy.pi)
     assert numpy.allclose(J_inv_deg[1], J_inv[1] * 180.0 / numpy.pi)
     assert numpy.allclose(J_inv_deg[2:], J_inv[2:])
     # Same scaling rule on the 3x3-only branch
-    J_inv3_deg = coords.XYZ_to_lbd_jac(X, Y, Z, degree=True)
+    J_inv3_deg = as_numpy(coords.XYZ_to_lbd_jac(X, Y, Z, degree=True))
     assert numpy.allclose(J_inv3_deg[0], J_inv3[0] * 180.0 / numpy.pi)
     assert numpy.allclose(J_inv3_deg[1], J_inv3[1] * 180.0 / numpy.pi)
     assert numpy.allclose(J_inv3_deg[2], J_inv3[2])
@@ -2941,7 +2941,7 @@ def test_galcenrect_to_galcencyl_jac():
         )
         return numpy.array([R, vR, vT, zc, vZ, phi])
 
-    J = coords.galcenrect_to_galcencyl_jac(x, y, z, vx, vy, vz)
+    J = as_numpy(coords.galcenrect_to_galcencyl_jac(x, y, z, vx, vy, vz))
     J_fd = _finite_difference_jac(fwd, numpy.array([x, y, z, vx, vy, vz]))
     assert numpy.allclose(J, J_fd, atol=1e-7), (
         f"galcenrect_to_galcencyl_jac mismatch with FD, max diff "
@@ -2954,7 +2954,7 @@ def test_galcenrect_to_galcencyl_jac_on_z_axis():
     # On the z-axis (R=0) the Jacobian is singular; the implementation
     # falls back to a tiny epsilon so the matrix stays finite. Check that
     # the call returns a finite 6x6.
-    J = coords.galcenrect_to_galcencyl_jac(0.0, 0.0, 1.0, 10.0, 20.0, 30.0)
+    J = as_numpy(coords.galcenrect_to_galcencyl_jac(0.0, 0.0, 1.0, 10.0, 20.0, 30.0))
     assert J.shape == (6, 6)
     assert numpy.all(numpy.isfinite(J))
 
@@ -2964,10 +2964,10 @@ def test_XYZ_to_lbd_jac_at_celestial_pole():
     # and the (l, b) angular coordinates are undefined; the implementation
     # should still produce a finite 3x3 (and 6x6 with velocities) without
     # NaNs by picking an arbitrary tangent (cl, sl) = (1, 0).
-    J = coords.XYZ_to_lbd_jac(0.0, 0.0, 1.0)
+    J = as_numpy(coords.XYZ_to_lbd_jac(0.0, 0.0, 1.0))
     assert J.shape == (3, 3)
     assert numpy.all(numpy.isfinite(J))
-    J6 = coords.XYZ_to_lbd_jac(0.0, 0.0, 1.0, 10.0, 20.0, 30.0)
+    J6 = as_numpy(coords.XYZ_to_lbd_jac(0.0, 0.0, 1.0, 10.0, 20.0, 30.0))
     assert J6.shape == (6, 6)
     assert numpy.all(numpy.isfinite(J6))
 


### PR DESCRIPTION
Keystone for the streamTrack sky-basis `cov()` work — same shape as Streams PR-1
(migrate the coords leaf first, then the consumer).

Four `*_jac` helpers made backend-agnostic. Each was pure numpy: a
`numpy.zeros((6,6))` filled by item assignment, which jax cannot do (immutable
arrays) and which forces one matrix per call. Rows are now built with
`xp.stack`, so batched inputs give a `(..., 6, 6)` stack for free.

| helper | numpy byte-identical | torch | jax x64 | jit | grad-vs-FD |
|---|---|---|---|---|---|
| `galcenrect_to_galcencyl_jac` | 400/400 (+ R=0 edge) | 0.0 | 0.0 | yes | 4.6e-11 |
| `galcenrect_to_XYZ_jac` | 600/600 (3-/6-arg, ±Xsun) | 0.0 | 0.0 | yes | 1.4e-11 |
| `lbd_to_XYZ_jac` | 800/800 (4 call forms) | 0.0 | 0.0 | yes | 6.5e-11 |
| `XYZ_to_lbd_jac` | 800/800 (+ r=0 pole) | 6.9e-17 | 0.0 | yes | 6.1e-11 |

`tests/test_coords.py`: 97 passed. Gradients are grad-vs-FD with h-convergence
(not finite-and-nonzero), checked at float64 — jax's float32 default makes an FD
check *diverge* as h shrinks and is not evidence of anything.

**The if -> array-input class** (what this PR is really about):
* `if R == 0.0: R = 1e-30` -> `xp.where`
* `if cb != 0.0` / `if KD != 0.0` / `if r == 0.0` -> `xp.where`, each dividing by
  a **safe** denominator first. Eager and traced `where` evaluates both branches,
  so a raw 0/0 in the dead branch NaN-poisons the gradient even where the value
  is selected away.
* `l *= _DEGTORAD` mutated the **caller's** array in place -> out-of-place.
* Static branches (`len(args)`, `degree=`) stay Python-level: arity/flag
  decisions, not data-dependent.

**Known and documented:** the gradient at the exact celestial pole (r=0) is NaN,
from `sqrt(0)` having infinite derivative, not from the guards. dl/dX genuinely
does not exist there, so NaN is the honest signal (same call as RazorThin
R2deriv off-plane). Verified **element-local**: a pole element in a batch does
not poison its neighbours.

**Scope, stated rather than quietly narrowed:** the remaining two helpers
(`galsky_to_sky_jac`, `sky_to_customsky_jac`) each depend on a numpy-only coords
leaf — `lb_to_radec` (74 lines, 32 numpy refs, 0 xp) and
`custom_to_radec`/`radec_to_custom`. Finishing them means migrating those leaves,
which is a follow-up PR rather than something to smuggle in here or fake by
duplicating their logic inline. Numpy path is byte-identical throughout, so
nothing regresses in the meantime.