### PR TITLE
coords: sky-frame leaves backend-agnostic — completes the *_jac family (6 of 6)

### DIFF
--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -81,7 +81,9 @@ from functools import wraps
 import numpy
 
 from ..backend import (
+    asarray_on_device,
     coerce_coords,
+    device_of,
     get_namespace,
     is_backend_array,
     promote_scalars,
@@ -119,17 +121,38 @@ if _APY_COORDS:
         _APY_COORDS = False
 
 
+def backendNative(func):
+    """Mark a coords function as safe to be handed jax/torch arrays.
+
+    ``scalarDecorator`` promotes scalar inputs through ``numpy``, which strips the
+    framework off a backend array before the wrapped function ever runs. That
+    conversion is load-bearing for the functions that are still numpy-only, so it
+    stays the default; marking a function opts it into a framework-preserving
+    promotion instead. Migrate a function, then mark it -- no flag day.
+
+    Notes
+    -----
+    - 2026-08-01 - Written - Claude
+    """
+    func._galpy_backend_native = True
+    return func
+
+
 def scalarDecorator(func):
     """Decorator to return scalar outputs as a set"""
 
     @wraps(func)
     def scalar_wrapper(*args, **kwargs):
-        if numpy.array(args[0]).shape == ():
+        # numpy unless the wrapped function has opted in (see backendNative):
+        # promoting through numpy would silently downgrade a backend array.
+        xp = (
+            get_namespace(*args)
+            if getattr(func, "_galpy_backend_native", False)
+            else numpy
+        )
+        if xp.asarray(args[0]).ndim == 0:
             scalarOut = True
-            newargs = ()
-            for ii in range(len(args)):
-                newargs = newargs + (numpy.array([args[ii]]),)
-            args = newargs
+            args = tuple(xp.reshape(xp.asarray(a), (1,)) for a in args)
         else:
             scalarOut = False
         result = func(*args, **kwargs)
@@ -265,6 +288,7 @@ def radec_to_lb(ra, dec, degree=False, epoch=2000.0):
 
 @scalarDecorator
 @degreeDecorator([0, 1], [0, 1])
+@backendNative
 def lb_to_radec(l, b, degree=False, epoch=2000.0):
     """
     Transform from Galactic coordinates to equatorial coordinates
@@ -291,7 +315,13 @@ def lb_to_radec(l, b, degree=False, epoch=2000.0):
     - 2014-06-14 - Re-written w/ numpy functions for speed and w/ decorators for beauty - Bovy (IAS)
     - 2016-05-13 - Added support for using astropy's coordinate transformations and for non-standard epochs - Bovy (UofT)
     """
-    if _APY_COORDS:
+    xp = get_namespace(l, b)
+    l, b = promote_scalars(xp, l, b)
+    # astropy's SkyCoord is numpy-only and not differentiable, so a backend
+    # array takes the rotation-matrix branch below instead. The two agree to
+    # ~1.6e-15 rad (measured), i.e. to roundoff; numpy keeps astropy so its
+    # results are unchanged.
+    if _APY_COORDS and xp is numpy:
         epoch, frame = _parse_epoch_frame_apy(epoch)
         c = apycoords.SkyCoord(l * units.rad, b * units.rad, frame="galactic")
         if not epoch is None and "J" in epoch:
@@ -328,15 +358,18 @@ def lb_to_radec(l, b, degree=False, epoch=2000.0):
             ),
         ),
     )
+    # T is built from epoch constants, so it stays a plain numpy matrix and is
+    # moved onto the input's namespace/device once.
+    T = asarray_on_device(xp, T, device_of(l))
     # Whether to use degrees and scalar input is handled by decorators
-    XYZ = numpy.array(
-        [numpy.cos(b) * numpy.cos(l), numpy.cos(b) * numpy.sin(l), numpy.sin(b)]
-    )
-    eqXYZ = numpy.dot(T, XYZ)
-    dec = numpy.arcsin(eqXYZ[2])
-    ra = numpy.arctan2(eqXYZ[1], eqXYZ[0])
-    ra[ra < 0.0] += 2.0 * numpy.pi
-    return numpy.array([ra, dec]).T
+    XYZ = xp.stack([xp.cos(b) * xp.cos(l), xp.cos(b) * xp.sin(l), xp.sin(b)])
+    eqXYZ = T @ XYZ
+    dec = xp.asin(eqXYZ[2])
+    ra = xp.atan2(eqXYZ[1], eqXYZ[0])
+    # was `ra[ra < 0.0] += 2*pi`; in-place masked assignment is not available on
+    # jax and would not trace
+    ra = xp.where(ra < 0.0, ra + 2.0 * numpy.pi, ra)
+    return xp.stack([ra, dec], axis=-1)
 
 
 @scalarDecorator

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2261,26 +2261,30 @@ def galsky_to_sky_jac(*args, **kwargs):
     else:
         raise ValueError("galsky_to_sky_jac expects 2 or 4 arguments")
     epoch = kwargs.get("epoch", 2000.0)
+    xp = get_namespace(l, b, pmll, pmbb, xp=kwargs.get("xp", None))
+    l, b, pmll, pmbb = promote_scalars(xp, l, b, pmll, pmbb)
     if kwargs.get("degree", False):
         l = l * _DEGTORAD
         b = b * _DEGTORAD
     _, dec_ngp, ra_ngp = get_epoch_angles(epoch)
-    cosb = numpy.cos(b)
-    radec = lb_to_radec(numpy.atleast_1d(l), numpy.atleast_1d(b), degree=False)
-    ra = float(radec[0, 0] if radec.ndim == 2 else radec[0])
-    dec_val = float(radec[0, 1] if radec.ndim == 2 else radec[1])
-    sindec = numpy.sin(dec_val)
-    cosdec = numpy.cos(dec_val)
+    cosb = xp.cos(b)
+    # keep ra/dec as arrays: float() would sever the trace and the gradient
+    radec = lb_to_radec(xp.atleast_1d(l), xp.atleast_1d(b), degree=False)
+    radec = xp.reshape(xp.asarray(radec), (-1, 2))
+    ra = radec[0, 0]
+    dec_val = radec[0, 1]
+    sindec = xp.sin(dec_val)
+    cosdec = xp.cos(dec_val)
     sindec_ngp = numpy.sin(dec_ngp)
     cosdec_ngp = numpy.cos(dec_ngp)
-    sin_rrngp = numpy.sin(ra - ra_ngp)
-    cos_rrngp = numpy.cos(ra - ra_ngp)
+    sin_rrngp = xp.sin(ra - ra_ngp)
+    cos_rrngp = xp.cos(ra - ra_ngp)
     # cos α, sin α match ``pmllpmbb_to_pmrapmdec`` (κ, σ are the
     # un-normalized numerator/denominator; nrm² = κ² + σ²).
     kappa = sindec_ngp * cosdec - cosdec_ngp * sindec * cos_rrngp
     sigma = sin_rrngp * cosdec_ngp
     nrm2 = kappa * kappa + sigma * sigma
-    nrm = numpy.sqrt(nrm2)
+    nrm = xp.sqrt(nrm2)
     cosa = kappa / nrm
     sina = sigma / nrm
     # dα/d(ra, dec) via α = atan2(σ, κ) ⇒ dα = (κ·dσ − σ·dκ)/(κ²+σ²).
@@ -2298,27 +2302,33 @@ def galsky_to_sky_jac(*args, **kwargs):
     pmdec = sina * pmll + cosa * pmbb
     dalpha_dl = dalpha_dra * dra_dl + dalpha_ddec * ddec_dl
     dalpha_db = dalpha_dra * dra_db + dalpha_ddec * ddec_db
-    out = numpy.zeros((6, 6))
-    out[0, 0] = dra_dl
-    out[0, 1] = dra_db
-    out[1, 0] = ddec_dl
-    out[1, 1] = ddec_db
-    out[2, 2] = 1.0  # D pass-through
-    out[3, 0] = -pmdec * dalpha_dl
-    out[3, 1] = -pmdec * dalpha_db
-    out[3, 3] = cosa
-    out[3, 4] = -sina
-    out[4, 0] = pmra * dalpha_dl
-    out[4, 1] = pmra * dalpha_db
-    out[4, 3] = sina
-    out[4, 4] = cosa
-    out[5, 5] = 1.0  # vlos pass-through
+    o = xp.zeros_like(xp.reshape(cosa, ()))
+    i1 = o + 1.0
+
+    # Rows stacked rather than assigned into a zeros((6,6)): jax arrays are
+    # immutable.
+    def _r(*v):
+        return xp.stack([xp.reshape(xp.asarray(x), ()) for x in v])
+
+    out = xp.stack(
+        [
+            _r(dra_dl, dra_db, o, o, o, o),
+            _r(ddec_dl, ddec_db, o, o, o, o),
+            _r(o, o, i1, o, o, o),  # D pass-through
+            _r(-pmdec * dalpha_dl, -pmdec * dalpha_db, o, cosa, -sina, o),
+            _r(pmra * dalpha_dl, pmra * dalpha_db, o, sina, cosa, o),
+            _r(o, o, o, o, o, i1),  # vlos pass-through
+        ]
+    )
     if kwargs.get("degree", False):
         # input cols 0,1 (l, b) and output rows 0,1 (ra, dec) in degrees.
         # Angular-vs-angular entries: dimensionless, unchanged. PM-vs-angle
         # cols scale by π/180; angle-vs-PM (none, those entries are zero
         # in this Jacobian); PM-vs-PM entries unchanged.
-        out[3:5, 0:2] *= _DEGTORAD
+        # was `out[3:5, 0:2] *= _DEGTORAD` (in-place block assignment)
+        blk = numpy.ones((6, 6))
+        blk[3:5, 0:2] = _DEGTORAD
+        out = out * asarray_on_device(xp, blk, device_of(out))
         # angle-vs-(D, PM, vlos) entries: also need scaling? Output rows 0,1
         # in degrees means ∂(ra_deg)/∂X = (1/_DEGTORAD)·∂(ra_rad)/∂X for any X
         # that is not itself an angle. But this Jacobian has zeros there for

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2384,26 +2384,31 @@ def sky_to_customsky_jac(*args, **kwargs):
     T = kwargs.get("T", None)
     if T is None:
         raise ValueError("sky_to_customsky_jac requires T= rotation matrix")
+    xp = get_namespace(ra, dec, pmra, pmdec, xp=kwargs.get("xp", None))
+    ra, dec, pmra, pmdec = promote_scalars(xp, ra, dec, pmra, pmdec)
     if kwargs.get("degree", False):
         ra = ra * _DEGTORAD
         dec = dec * _DEGTORAD
-    sindec = numpy.sin(dec)
-    cosdec = numpy.cos(dec)
+    sindec = xp.sin(dec)
+    cosdec = xp.cos(dec)
+    # The pole depends only on T, never on the traced inputs, so pinning it to
+    # host floats costs no gradient and keeps it out of the graph.
     ra_pole, dec_pole = custom_to_radec(0.0, numpy.pi / 2.0, T=T)
-    sinr_rp = numpy.sin(ra - ra_pole)
-    cosr_rp = numpy.cos(ra - ra_pole)
+    ra_pole = float(ra_pole)
+    dec_pole = float(dec_pole)
+    sinr_rp = xp.sin(ra - ra_pole)
+    cosr_rp = xp.cos(ra - ra_pole)
     sindec_p = numpy.sin(dec_pole)
     cosdec_p = numpy.cos(dec_pole)
     kappa2 = sindec_p * cosdec - cosdec_p * sindec * cosr_rp
     sigma2 = sinr_rp * cosdec_p
     nrm2_2 = kappa2 * kappa2 + sigma2 * sigma2
-    nrm2 = numpy.sqrt(nrm2_2)
+    nrm2 = xp.sqrt(nrm2_2)
     cosa2 = kappa2 / nrm2
     sina2 = sigma2 / nrm2
-    p12 = radec_to_custom(
-        numpy.atleast_1d(ra), numpy.atleast_1d(dec), T=T, degree=False
-    )
-    cosphi2 = numpy.cos(float(p12[0, 1]))
+    p12 = radec_to_custom(xp.atleast_1d(ra), xp.atleast_1d(dec), T=T, degree=False)
+    # keep as an array: float() would sever the trace and the gradient
+    cosphi2 = xp.cos(xp.reshape(xp.asarray(p12), (-1, 2))[0, 1])
     dsig2_dra = cosdec_p * cosr_rp
     dkap2_dra = cosdec_p * sindec * sinr_rp
     dkap2_ddec = -sindec_p * sindec - cosdec_p * cosdec * cosr_rp
@@ -2419,23 +2424,29 @@ def sky_to_customsky_jac(*args, **kwargs):
     dphi1_ddec = sina2 / cosphi2
     dphi2_dra = -sina2 * cosdec
     dphi2_ddec = cosa2
-    out = numpy.zeros((6, 6))
-    out[0, 0] = dphi1_dra
-    out[0, 1] = dphi1_ddec
-    out[1, 0] = dphi2_dra
-    out[1, 1] = dphi2_ddec
-    out[2, 2] = 1.0
-    out[3, 0] = pmphi2 * dalpha2_dra
-    out[3, 1] = pmphi2 * dalpha2_ddec
-    out[3, 3] = cosa2
-    out[3, 4] = sina2
-    out[4, 0] = -pmphi1 * dalpha2_dra
-    out[4, 1] = -pmphi1 * dalpha2_ddec
-    out[4, 3] = -sina2
-    out[4, 4] = cosa2
-    out[5, 5] = 1.0
+    o = xp.zeros_like(xp.reshape(cosa2, ()))
+    i1 = o + 1.0
+
+    def _r(*v):
+        return xp.stack([xp.reshape(xp.asarray(x), ()) for x in v])
+
+    # Rows stacked rather than assigned into a zeros((6,6)): jax arrays are
+    # immutable.
+    out = xp.stack(
+        [
+            _r(dphi1_dra, dphi1_ddec, o, o, o, o),
+            _r(dphi2_dra, dphi2_ddec, o, o, o, o),
+            _r(o, o, i1, o, o, o),
+            _r(pmphi2 * dalpha2_dra, pmphi2 * dalpha2_ddec, o, cosa2, sina2, o),
+            _r(-pmphi1 * dalpha2_dra, -pmphi1 * dalpha2_ddec, o, -sina2, cosa2, o),
+            _r(o, o, o, o, o, i1),
+        ]
+    )
     if kwargs.get("degree", False):
-        out[3:5, 0:2] *= _DEGTORAD
+        # was `out[3:5, 0:2] *= _DEGTORAD` (in-place block assignment)
+        blk = numpy.ones((6, 6))
+        blk[3:5, 0:2] = _DEGTORAD
+        out = out * asarray_on_device(xp, blk, device_of(out))
     return out
 
 
@@ -2976,6 +2987,7 @@ def lambdanu_to_Rz(l, n, ac=5.0, Delta=1.0):
 
 @scalarDecorator
 @degreeDecorator([0, 1], [0, 1])
+@backendNative
 def radec_to_custom(ra, dec, T=None, degree=False):
     """
     Transform from equatorial coordinates to a custom set of sky coordinates
@@ -3004,16 +3016,18 @@ def radec_to_custom(ra, dec, T=None, degree=False):
     """
     if T is None:
         raise ValueError("Must set T= for radec_to_custom")
+    xp = get_namespace(ra, dec)
+    ra, dec = promote_scalars(xp, ra, dec)
+    T = asarray_on_device(xp, numpy.asarray(T), device_of(ra))
     # Whether to use degrees and scalar input is handled by decorators
-    XYZ = numpy.array(
-        [numpy.cos(dec) * numpy.cos(ra), numpy.cos(dec) * numpy.sin(ra), numpy.sin(dec)]
-    )
-    galXYZ = numpy.dot(T, XYZ)
-    b = numpy.arcsin(galXYZ[2])  # [-pi/2, pi/2]
-    l = numpy.arctan2(galXYZ[1], galXYZ[0])
-    l[l < 0] += 2 * numpy.pi  # fix range to [0, 2 pi]
-    out = numpy.array([l, b])
-    return out.T
+    XYZ = xp.stack([xp.cos(dec) * xp.cos(ra), xp.cos(dec) * xp.sin(ra), xp.sin(dec)])
+    galXYZ = T @ XYZ
+    b = xp.asin(galXYZ[2])  # [-pi/2, pi/2]
+    l = xp.atan2(galXYZ[1], galXYZ[0])
+    # fix range to [0, 2 pi]; was `l[l < 0] += 2*pi`, an in-place masked
+    # assignment that jax does not support
+    l = xp.where(l < 0, l + 2 * numpy.pi, l)
+    return xp.stack([l, b], axis=-1)
 
 
 @scalarDecorator
@@ -3051,8 +3065,17 @@ def pmrapmdec_to_custom(pmra, pmdec, ra, dec, T=None, degree=False):
         raise ValueError("Must set T= for pmrapmdec_to_custom")
     # Need to figure out ra_ngp and dec_ngp for this custom set of sky coords
     ra_ngp, dec_ngp = custom_to_radec(0.0, numpy.pi / 2, T=T)
+    # The pole depends only on T, never on the inputs, so pin it to host floats:
+    # radec_to_custom is backend-native now and would otherwise hand back a
+    # backend scalar that collides with numpy inputs here.
+    ra_ngp = float(ra_ngp)
+    dec_ngp = float(dec_ngp)
     # Whether to use degrees and scalar input is handled by decorators
-    dec[dec == dec_ngp] += 10.0**-16  # deal w/ pole.
+    # was `dec[dec == dec_ngp] += 1e-16`; in-place masked assignment. Dispatch on
+    # what dec IS: this function is not backend-native, so under a forced backend
+    # its dec is still a plain ndarray and the forced namespace would reject it.
+    _xp = get_namespace(dec) if is_backend_array(dec) else numpy
+    dec = _xp.where(dec == dec_ngp, dec + 10.0**-16, dec)  # deal w/ pole.
     sindec_ngp = numpy.sin(dec_ngp)
     cosdec_ngp = numpy.cos(dec_ngp)
     sindec = numpy.sin(dec)

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -201,8 +201,18 @@ def degreeDecorator(inDegrees, outDegrees):
                 ]
             out = func(*args, **kwargs)
             if isdeg:
+                # was `out[:, i] *= 180/pi`; in-place column assignment is not
+                # available on jax. Multiplying by a row of ones with 180/pi in
+                # the converted columns is the same arithmetic per element.
+                scale = numpy.ones(out.shape[-1])
                 for i in outDegrees:
-                    out[:, i] *= 180.0 / numpy.pi
+                    scale[i] = 180.0 / numpy.pi
+                # Dispatch on what `out` actually IS, not on the forced default:
+                # this decorator also wraps functions that are still numpy-only,
+                # whose `out` is a plain ndarray even under a forced backend.
+                if is_backend_array(out):
+                    scale = asarray_on_device(get_namespace(out), scale, device_of(out))
+                out = out * scale
             return out
 
         return wrapped
@@ -744,9 +754,12 @@ def pmllpmbb_to_pmrapmdec(pmll, pmbb, l, b, degree=False, epoch=2000.0):
     theta, dec_ngp, ra_ngp = get_epoch_angles(epoch)
     # Whether to use degrees and scalar input is handled by decorators
     radec = lb_to_radec(l, b, degree=False, epoch=epoch)
+    xp = get_namespace(radec)
     ra = radec[:, 0]
     dec = radec[:, 1]
-    dec[dec == dec_ngp] += 10.0**-16  # deal w/ pole.
+    # deal w/ pole; was `dec[dec == dec_ngp] += 1e-16`, an in-place masked
+    # assignment that jax does not support
+    dec = xp.where(dec == dec_ngp, dec + 10.0**-16, dec)
     sindec_ngp = numpy.sin(dec_ngp)
     cosdec_ngp = numpy.cos(dec_ngp)
     sindec = numpy.sin(dec)

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -304,3 +304,49 @@ def test_uv_to_Rz_indiv_delta_forced_backend(backend_name, oblate):
     numpy.testing.assert_allclose(as_numpy(z), zref, rtol=1e-13, atol=1e-14)
     numpy.testing.assert_allclose(as_numpy(R2), Rref2, rtol=1e-13, atol=1e-14)
     numpy.testing.assert_allclose(as_numpy(z2), zref2, rtol=1e-13, atol=1e-14)
+
+
+# --- degreeDecorator's backend branch + lb_to_radec's rotation branch --------
+# Two lines that a numpy-only run can never reach, and the coverage-uploading
+# shards run numpy (see the backend-branch coverage note): degreeDecorator's
+# `if is_backend_array(out): scale = asarray_on_device(...)` and the
+# rotation-matrix branch of lb_to_radec, which numpy skips because astropy is
+# present. Exercised here with a real backend array, which is the only way to
+# reach them.
+_LDEG = numpy.array([12.0, 200.0, 351.0])
+_BDEG = numpy.array([-40.0, 5.0, 62.0])
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_lb_to_radec_backend_branch_matches_numpy(backend_name):
+    # Backend-vs-numpy parity. NOTE the reference path is environment
+    # dependent: with astropy present numpy uses SkyCoord, and on the
+    # astropy-free test_backend shard it uses the same rotation matrix as the
+    # backend. Both agree to roundoff (astropy-vs-rotation measured at
+    # ~1.6e-15 rad), so the assertion holds either way.
+    ref = coords.lb_to_radec(_LDEG, _BDEG, degree=True)
+    with use(backend_name, force=True):
+        got = coords.lb_to_radec(_LDEG, _BDEG, degree=True)
+        assert is_backend_array(got), "lb_to_radec did not preserve the backend"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=0, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_degree_decorator_scales_backend_output(backend_name):
+    # degree=True must scale the output columns for a backend array too; this
+    # is the `is_backend_array(out)` branch of degreeDecorator.
+    ref_deg = coords.lb_to_radec(_LDEG, _BDEG, degree=True)
+    ref_rad = coords.lb_to_radec(
+        numpy.radians(_LDEG), numpy.radians(_BDEG), degree=False
+    )
+    with use(backend_name, force=True):
+        got_deg = coords.lb_to_radec(_LDEG, _BDEG, degree=True)
+        got_rad = coords.lb_to_radec(
+            numpy.radians(_LDEG), numpy.radians(_BDEG), degree=False
+        )
+    # the degree output is exactly 180/pi times the radian one, elementwise
+    numpy.testing.assert_allclose(
+        as_numpy(got_deg), numpy.degrees(as_numpy(got_rad)), rtol=1e-13, atol=0
+    )
+    numpy.testing.assert_allclose(as_numpy(got_deg), ref_deg, rtol=0, atol=1e-12)
+    numpy.testing.assert_allclose(as_numpy(got_rad), ref_rad, rtol=0, atol=1e-13)

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -292,7 +292,7 @@ def test_lb_to_radec():
     _turn_off_apy()
     ra, dec = 120, 60.0
     lb = coords.radec_to_lb(ra, dec, degree=True, epoch=2000.0)
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=2000.0)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=2000.0))
     assert numpy.fabs(ra - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -303,7 +303,7 @@ def test_lb_to_radec():
     lb = coords.radec_to_lb(
         ra / 180.0 * numpy.pi, dec / 180.0 * numpy.pi, degree=False, epoch=2000.0
     )
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=2000.0)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=2000.0))
     assert numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -318,7 +318,9 @@ def test_lb_to_radec():
         degree=False,
         epoch=2000.0,
     )
-    ratdect = coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=2000.0)
+    ratdect = as_numpy(
+        coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=2000.0)
+    )
     rat = ratdect[:, 0]
     dect = ratdect[:, 1]
     assert numpy.all(numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0), (
@@ -329,7 +331,7 @@ def test_lb_to_radec():
     )
     # Also test for a negative l
     l, b = 240.0, 60.0
-    ra, dec = coords.lb_to_radec(l, b, degree=True)
+    ra, dec = as_numpy(coords.lb_to_radec(l, b, degree=True))
     lt, bt = coords.radec_to_lb(ra, dec, degree=True)
     assert numpy.fabs(lt - l) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
@@ -345,7 +347,7 @@ def test_lb_to_radec():
 def test_lb_to_radec_apy():
     ra, dec = 120, 60.0
     lb = coords.radec_to_lb(ra, dec, degree=True, epoch=2000.0)
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=2000.0)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=2000.0))
     assert numpy.fabs(ra - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -356,7 +358,7 @@ def test_lb_to_radec_apy():
     lb = coords.radec_to_lb(
         ra / 180.0 * numpy.pi, dec / 180.0 * numpy.pi, degree=False, epoch=2000.0
     )
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=2000.0)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=2000.0))
     assert numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -371,7 +373,9 @@ def test_lb_to_radec_apy():
         degree=False,
         epoch=2000.0,
     )
-    ratdect = coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=2000.0)
+    ratdect = as_numpy(
+        coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=2000.0)
+    )
     rat = ratdect[:, 0]
     dect = ratdect[:, 1]
     assert numpy.all(numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0), (
@@ -382,7 +386,7 @@ def test_lb_to_radec_apy():
     )
     # Also test for a negative l
     l, b = 240.0, 60.0
-    ra, dec = coords.lb_to_radec(l, b, degree=True)
+    ra, dec = as_numpy(coords.lb_to_radec(l, b, degree=True))
     lt, bt = coords.radec_to_lb(ra, dec, degree=True)
     assert numpy.fabs(lt - l) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
@@ -397,7 +401,7 @@ def test_lb_to_radec_apy():
 def test_lb_to_radec_apy_icrs():
     ra, dec = 120, 60.0
     lb = coords.radec_to_lb(ra, dec, degree=True, epoch=None)
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=None)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=True, epoch=None))
     assert numpy.fabs(ra - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -408,7 +412,7 @@ def test_lb_to_radec_apy_icrs():
     lb = coords.radec_to_lb(
         ra / 180.0 * numpy.pi, dec / 180.0 * numpy.pi, degree=False, epoch=None
     )
-    rat, dect = coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=None)
+    rat, dect = as_numpy(coords.lb_to_radec(lb[0], lb[1], degree=False, epoch=None))
     assert numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
     )
@@ -423,7 +427,7 @@ def test_lb_to_radec_apy_icrs():
         degree=False,
         epoch=None,
     )
-    ratdect = coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=None)
+    ratdect = as_numpy(coords.lb_to_radec(lb[:, 0], lb[:, 1], degree=False, epoch=None))
     rat = ratdect[:, 0]
     dect = ratdect[:, 1]
     assert numpy.all(numpy.fabs(ra / 180.0 * numpy.pi - rat) < 10.0**-10.0), (
@@ -434,7 +438,7 @@ def test_lb_to_radec_apy_icrs():
     )
     # Also test for a negative l
     l, b = 240.0, 60.0
-    ra, dec = coords.lb_to_radec(l, b, degree=True)
+    ra, dec = as_numpy(coords.lb_to_radec(l, b, degree=True))
     lt, bt = coords.radec_to_lb(ra, dec, degree=True)
     assert numpy.fabs(lt - l) < 10.0**-10.0, (
         "lb_to_radec is not the inverse of radec_to_lb"
@@ -3035,7 +3039,7 @@ def test_galsky_to_sky_jac():
     pmll, pmbb = 5.0, -3.0
 
     def fwd(s):
-        radec = coords.lb_to_radec(s[0], s[1], degree=False)
+        radec = as_numpy(coords.lb_to_radec(s[0], s[1], degree=False))
         pmrd = coords.pmllpmbb_to_pmrapmdec(s[3], s[4], s[0], s[1], degree=False)
         return numpy.array([radec[0], radec[1], s[2], pmrd[0], pmrd[1], s[5]])
 
@@ -3661,7 +3665,7 @@ def test_align_to_orbit():
     # The orbit point should land at phi1=180, phi2≈0 (default center_phi1)
     XYZ = coords.galcenrect_to_XYZ(x, y, z, Xsun=Xsun, Zsun=Zsun)
     lbd = coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=True)
-    radec = coords.lb_to_radec(lbd[0], lbd[1], degree=True)
+    radec = as_numpy(coords.lb_to_radec(lbd[0], lbd[1], degree=True))
     p12 = coords.radec_to_custom(
         numpy.atleast_1d(radec[0]),
         numpy.atleast_1d(radec[1]),

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -3075,8 +3075,10 @@ def test_sky_to_customsky_jac():
     pmra, pmdec = 4.0, -1.5
 
     def fwd(s):
-        p12 = coords.radec_to_custom(s[0], s[1], T=T, degree=False)
-        pm12 = coords.pmrapmdec_to_custom(s[3], s[4], s[0], s[1], T=T, degree=False)
+        p12 = as_numpy(coords.radec_to_custom(s[0], s[1], T=T, degree=False))
+        pm12 = as_numpy(
+            coords.pmrapmdec_to_custom(s[3], s[4], s[0], s[1], T=T, degree=False)
+        )
         return numpy.array([p12[0], p12[1], s[2], pm12[0], pm12[1], s[5]])
 
     J = coords.sky_to_customsky_jac(ra, dec, pmra, pmdec, T=T, degree=False)
@@ -3319,7 +3321,7 @@ def test_cyl_to_rect_jac():
 def test_radec_to_custom_valueerror():
     # Test the radec_to_custom without T raises a ValueError
     with pytest.raises(ValueError):
-        xieta = coords.radec_to_custom(20.0, 30.0)
+        xieta = as_numpy(coords.radec_to_custom(20.0, 30.0))
     return None
 
 
@@ -3353,7 +3355,7 @@ def test_radec_to_custom_againstlb():
         ),
     )
     lb_direct = coords.radec_to_lb(ra, dec, degree=True)
-    lb_custom = coords.radec_to_custom(ra, dec, T=T.T, degree=True)
+    lb_custom = as_numpy(coords.radec_to_custom(ra, dec, T=T.T, degree=True))
     assert numpy.fabs(lb_direct[0] - lb_custom[0]) < 10.0**-8.0, (
         "radec_to_custom for transformation to l,b does not work properly"
     )
@@ -3363,7 +3365,7 @@ def test_radec_to_custom_againstlb():
     # Array
     s = numpy.arange(2)
     lb_direct = coords.radec_to_lb(ra * s, dec * s, degree=True)
-    lb_custom = coords.radec_to_custom(ra * s, dec * s, T=T.T, degree=True)
+    lb_custom = as_numpy(coords.radec_to_custom(ra * s, dec * s, T=T.T, degree=True))
     assert numpy.all(numpy.fabs(lb_direct - lb_custom) < 10.0**-8.0), (
         "radec_to_custom for transformation to l,b does not work properly"
     )
@@ -3391,7 +3393,7 @@ def test_radec_to_custom_pal5():
             ]
         ),
     )
-    xieta = coords.radec_to_custom(_RAPAL5, _DECPAL5, T=_TPAL5, degree=False)
+    xieta = as_numpy(coords.radec_to_custom(_RAPAL5, _DECPAL5, T=_TPAL5, degree=False))
 
     def checkrng(x, xpct, dom, shift):
         return numpy.fabs(((numpy.fabs(x - xpct) + shift) % dom) - shift)
@@ -3404,7 +3406,7 @@ def test_radec_to_custom_pal5():
         "radec_to_custom does not work properly for Pal 5 transformation"
     )
     # One more, rough estimate based on visual inspection of plot
-    xieta = coords.radec_to_custom(240.0, 6.0, T=_TPAL5, degree=True)
+    xieta = as_numpy(coords.radec_to_custom(240.0, 6.0, T=_TPAL5, degree=True))
     assert checkrng(xieta[0], 11.0, 2 * numpy.pi, 0) < 0.2, (
         "radec_to_custom does not work properly for Pal 5 transformation"
     )
@@ -3417,7 +3419,7 @@ def test_radec_to_custom_pal5():
 def test_pmrapmdec_to_custom_valueerror():
     # Test the pmrapmdec_to_custom without T raises a ValueError
     with pytest.raises(ValueError):
-        xieta = coords.pmrapmdec_to_custom(1.0, 1.0, 20.0, 30.0)
+        xieta = as_numpy(coords.pmrapmdec_to_custom(1.0, 1.0, 20.0, 30.0))
     return None
 
 
@@ -3452,7 +3454,9 @@ def test_pmrapmdec_to_custom_againstlb():
         ),
     )
     pmlb_direct = coords.pmrapmdec_to_pmllpmbb(pmra, pmdec, ra, dec, degree=True)
-    pmlb_custom = coords.pmrapmdec_to_custom(pmra, pmdec, ra, dec, T=T.T, degree=True)
+    pmlb_custom = as_numpy(
+        coords.pmrapmdec_to_custom(pmra, pmdec, ra, dec, T=T.T, degree=True)
+    )
     assert numpy.fabs(pmlb_direct[0] - pmlb_custom[0]) < 10.0**-8.0, (
         "pmrapmdec_to_custom for transformation to pml,pmb does not work properly"
     )
@@ -3477,7 +3481,7 @@ def test_pmrapmdec_to_custom_againstlb():
 def test_custom_to_radec_valueerror():
     # Test the custom_to_radec without T raises a ValueError
     with pytest.raises(ValueError):
-        xieta = coords.custom_to_radec(20.0, 30.0)
+        xieta = as_numpy(coords.custom_to_radec(20.0, 30.0))
     return None
 
 
@@ -3511,7 +3515,7 @@ def test_custom_to_radec_againstlb():  # FIXME COMPARE TO DOCUMENT
         ),
     )
     lb_direct = coords.radec_to_lb(ra, dec, degree=True)
-    lb_custom = coords.custom_to_radec(ra, dec, T=T, degree=True)
+    lb_custom = as_numpy(coords.custom_to_radec(ra, dec, T=T, degree=True))
     assert numpy.fabs(lb_direct[0] - lb_custom[0]) < 10.0**-8.0, (
         "custom_to_radec for transformation to l,b does not work properly"
     )
@@ -3521,7 +3525,7 @@ def test_custom_to_radec_againstlb():  # FIXME COMPARE TO DOCUMENT
     # Array
     s = numpy.arange(2)
     lb_direct = coords.radec_to_lb(ra * s, dec * s, degree=True)
-    lb_custom = coords.custom_to_radec(ra * s, dec * s, T=T, degree=True)
+    lb_custom = as_numpy(coords.custom_to_radec(ra * s, dec * s, T=T, degree=True))
     assert numpy.all(numpy.fabs(lb_direct - lb_custom) < 10.0**-8.0), (
         "radec_to_custom for transformation to l,b does not work properly"
     )
@@ -3549,7 +3553,9 @@ def test_custom_to_radec_pal5():  # FIXME COMPARE TO DOCUMENT
             ]
         ),
     )
-    xieta = coords.custom_to_radec(_RAPAL5, _DECPAL5, T=_TPAL5.T, degree=False)
+    xieta = as_numpy(
+        coords.custom_to_radec(_RAPAL5, _DECPAL5, T=_TPAL5.T, degree=False)
+    )
 
     def checkrng(x, xpct, dom, shift):
         return numpy.fabs(((numpy.fabs(x - xpct) + shift) % dom) - shift)
@@ -3562,7 +3568,7 @@ def test_custom_to_radec_pal5():  # FIXME COMPARE TO DOCUMENT
         "custom_to_radec does not work properly for Pal 5 transformation"
     )
     # One more, rough estimate based on visual inspection of plot
-    xieta = coords.custom_to_radec(240.0, 6.0, T=_TPAL5.T, degree=True)
+    xieta = as_numpy(coords.custom_to_radec(240.0, 6.0, T=_TPAL5.T, degree=True))
     assert checkrng(xieta[0], 11.0, 2 * numpy.pi, 0) < 0.2, (
         "custom_to_radec does not work properly for Pal 5 transformation"
     )
@@ -3575,7 +3581,7 @@ def test_custom_to_radec_pal5():  # FIXME COMPARE TO DOCUMENT
 def test_custom_to_pmrapmdec_valueerror():
     # Test the pmrapmdec_to_custom without T raises a ValueError
     with pytest.raises(ValueError):
-        xieta = coords.custom_to_pmrapmdec(1.0, 1.0, 20.0, 30.0)
+        xieta = as_numpy(coords.custom_to_pmrapmdec(1.0, 1.0, 20.0, 30.0))
     return None
 
 
@@ -3610,7 +3616,9 @@ def test_custom_to_pmrapmdec_againstlb():
         ),
     )
     pmlb_direct = coords.pmrapmdec_to_pmllpmbb(pmra, pmdec, ra, dec, degree=True)
-    pmlb_custom = coords.custom_to_pmrapmdec(pmra, pmdec, ra, dec, T=T, degree=True)
+    pmlb_custom = as_numpy(
+        coords.custom_to_pmrapmdec(pmra, pmdec, ra, dec, T=T, degree=True)
+    )
 
     assert numpy.fabs(pmlb_direct[0] - pmlb_custom[0]) < 10.0**-8.0, (
         "custom_to_pmrapmdec for transformation to pml,pmb does not work properly"

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -16,6 +16,8 @@ import numpy
 import pytest
 from conftest import _to_numpy
 
+from galpy.backend import as_numpy
+
 PY2 = sys.version < "3"
 _APY3 = astropy.__version__ > "3"
 from test_actionAngle import reset_warning_registry
@@ -5978,7 +5980,6 @@ def test_bruteSOS_2Dx():
             force_map="rk" in method,
             surface="x",
         )
-        from galpy.backend import as_numpy
 
         xs = as_numpy(o.x(o.t))
         vxs = as_numpy(o.vx(o.t))
@@ -6003,7 +6004,6 @@ def test_bruteSOS_2Dy():
             force_map="rk" in method,
             surface="y",
         )
-        from galpy.backend import as_numpy
 
         ys = as_numpy(o.y(o.t))
         vys = as_numpy(o.vy(o.t))
@@ -10881,13 +10881,13 @@ def test_SkyCoord():
     ras = numpy.array([s.ra.degree for s in o.SkyCoord(times)])
     decs = numpy.array([s.dec.degree for s in o.SkyCoord(times)])
     dists = numpy.array([s.distance.kpc for s in o.SkyCoord(times)])
-    assert numpy.all(numpy.fabs(ras - o.ra(times)) < 10.0**-13.0), (
+    assert numpy.all(numpy.fabs(ras - as_numpy(o.ra(times))) < 10.0**-13.0), (
         "Orbit SkyCoord ra and direct ra do not agree"
     )
-    assert numpy.all(numpy.fabs(decs - o.dec(times)) < 10.0**-13.0), (
+    assert numpy.all(numpy.fabs(decs - as_numpy(o.dec(times))) < 10.0**-13.0), (
         "Orbit SkyCoord dec and direct dec do not agree"
     )
-    assert numpy.all(numpy.fabs(dists - o.dist(times)) < 10.0**-13.0), (
+    assert numpy.all(numpy.fabs(dists - as_numpy(o.dist(times))) < 10.0**-13.0), (
         "Orbit SkyCoord distance and direct distance do not agree"
     )
     # Check that the GC frame parameters are correctly propagated

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import _to_numpy
 
 from galpy import potential
+from galpy.backend import as_numpy
 
 _APY3 = astropy.__version__ > "3"
 
@@ -1190,54 +1191,80 @@ def test_integrate_3d_diffro():
         )
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(as_numpy((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)))
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
     return None
@@ -1271,54 +1298,80 @@ def test_integrate_3d_diffzo():
         )
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of zo does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(as_numpy((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)))
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of zo does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of zo does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of zo does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of zo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of zo does not work as expected"
     return None
@@ -1352,54 +1405,80 @@ def test_integrate_3d_diffvo():
         )
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(as_numpy((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)))
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
     return None
@@ -1437,54 +1516,80 @@ def test_integrate_3d_diffsolarmotion():
         )
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(as_numpy((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
     return None
@@ -1533,54 +1638,80 @@ def test_integrate_3d_diffallsolarparams():
         )
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(as_numpy((all_orbs.z(times)[ii] - orb.z(times)) / orb.z(times)))
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vz(times)[ii] - orb.vz(times)) / orb.vz(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
     return None
@@ -1616,48 +1747,70 @@ def test_integrate_2d_diffro():
         ).toPlanar()
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of ro does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of ro does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of ro does not work as expected"
     return None
@@ -1693,48 +1846,70 @@ def test_integrate_2d_diffvo():
         ).toPlanar()
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of vo does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of vo does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of vo does not work as expected"
     return None
@@ -1772,48 +1947,70 @@ def test_integrate_2d_diffsolarmotion():
         ).toPlanar()
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
     return None
@@ -1862,48 +2059,70 @@ def test_integrate_2d_diffallsolarparams():
         ).toPlanar()
         orb.integrate(times, potential.MWPotential2014)
         assert numpy.all(
-            numpy.fabs((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times)) < 1e-7
+            numpy.fabs(as_numpy((all_orbs.R(times)[ii] - orb.R(times)) / orb.R(times)))
+            < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
             numpy.fabs(
-                (
-                    (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
-                    % (2.0 * numpy.pi)
+                as_numpy((all_orbs.vR(times)[ii] - orb.vR(times)) / orb.vR(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vT(times)[ii] - orb.vT(times)) / orb.vT(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (
+                        (all_orbs.phi(times)[ii] - orb.phi(times) + numpy.pi)
+                        % (2.0 * numpy.pi)
+                    )
+                    - numpy.pi
                 )
-                - numpy.pi
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         # Also some observed values like ra, dec, ...
         assert numpy.all(
-            numpy.fabs((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times)) < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
-            numpy.fabs((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
-            < 1e-7
-        ), "Orbits initialization with array of solarmotion does not work as expected"
-        assert numpy.all(
             numpy.fabs(
-                (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                as_numpy((all_orbs.ra(times)[ii] - orb.ra(times)) / orb.ra(times))
             )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
         assert numpy.all(
-            numpy.fabs((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            numpy.fabs(
+                as_numpy((all_orbs.dec(times)[ii] - orb.dec(times)) / orb.dec(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.dist(times)[ii] - orb.dist(times)) / orb.dist(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.pmra(times)[ii] - orb.pmra(times)) / orb.pmra(times))
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy(
+                    (all_orbs.pmdec(times)[ii] - orb.pmdec(times)) / orb.pmdec(times)
+                )
+            )
+            < 1e-7
+        ), "Orbits initialization with array of solarmotion does not work as expected"
+        assert numpy.all(
+            numpy.fabs(
+                as_numpy((all_orbs.vlos(times)[ii] - orb.vlos(times)) / orb.vlos(times))
+            )
             < 1e-7
         ), "Orbits initialization with array of solarmotion does not work as expected"
     return None


### PR DESCRIPTION
Completes what #1233 started. #1233 migrated the 4 `*_jac` helpers with no
sky-frame dependency; the last two needed their leaves migrating first, which is
this PR. Retires no ledger entries directly — it unblocks the streamTrack
sky-basis `cov()` work, which retires 5.

**Shape:** three shared pieces, three leaves, two jac helpers.

| piece | note |
|---|---|
| `backendNative` marker | opt-in; `scalarDecorator` keeps promoting through numpy by default |
| `scalarDecorator` | framework-preserving promotion **only** for marked functions |
| `degreeDecorator` | `out[:, i] *= 180/pi` -> multiply by a scale row |
| `lb_to_radec` | numpy keeps astropy untouched; backend arrays take the xp-native rotation branch |
| `radec_to_custom` / `custom_to_radec` | xp-native; `l[l<0] += 2pi` -> `xp.where` |
| `galsky_to_sky_jac`, `sky_to_customsky_jac` | `float()` casts dropped, rows stacked |

**Why the marker rather than migrating the decorator outright.** I tried that
first and measured it: `scalarDecorator` wraps **18** functions and **0** were
backend-aware, so making it framework-preserving fed backend arrays into 17
numpy-only bodies — torch 98->97, jax 98->94. Its numpy conversion is currently
load-bearing. The marker lets functions migrate one at a time with no flag day.

**Verified:**

```
tests/test_coords.py     numpy 98/98   torch 98/98   jax 98/98
numpy byte-identity      1200/1200 (decorators + lb_to_radec family)
                          600/600  (galsky_to_sky_jac)
                         1000/1000 (custom-sky family)
torch / jax vs numpy     8.9e-16
jax.jit                  traces
grad-vs-FD               7.4e-07 -> 1.1e-10 (h-convergent, float64)
```

Also ran the exact CI shard pairing (`test_quantity` + `test_coords`, torch,
serial): 342 tests, the only 2 failures are the known local-only pair —
`test_streamgapdf_sample` (documented in the `backend_xfail.txt` header as an
env-specific false failure CI passes) and
`test_sphericaldf_quantity_radius_is_not_coerced_on_a_backend[jax]`, which
**cannot occur on CI**: that test parametrizes over *installed* backends and
`backend-tests.yml` installs exactly one per shard. `test_coords.py` contributed
zero failures.

**The if -> array-input class**, which is most of this PR: two in-place masked
assignments (`l[l<0] += 2pi`, `dec[dec==dec_ngp] += 1e-16`) and two in-place
block/column scalings become `xp.where` / out-of-place multiplies. The sky pole
depends only on `T`, never on the inputs, so it is pinned to host floats rather
than dragged into the graph.