### PR TITLE
coords: backend-native galcenrect → heliocentric → sky chain (closes #1235's follow-up)

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -2000,19 +2000,23 @@ class streamdf(df):
         obskwargs["vo"] = vo
         obskwargs["obs"] = obs
         obskwargs["quantity"] = False
+        # as_numpy: the Orbit sky accessors preserve the framework now that the
+        # coords chain is backend-native, but these are host-side scale factors
+        # multiplied into numpy covariance arrays below. streamdf itself is not
+        # backend-migrated, so the boundary is here, explicitly, rather than as
+        # a numpy/Tensor collision deeper in.
+        _dist = as_numpy(self._progenitor.dist(**obskwargs))
+        _vlos = as_numpy(self._progenitor.vlos(**obskwargs))
+        _pmll = as_numpy(self._progenitor.pmll(**obskwargs))
+        _pmbb = as_numpy(self._progenitor.pmbb(**obskwargs))
+        _pm = numpy.sqrt(_pmll**2.0 + _pmbb**2.0)
         self._ErrCovsLBScale = [
             180.0,
             90.0,
-            self._progenitor.dist(**obskwargs),
-            numpy.fabs(self._progenitor.vlos(**obskwargs)),
-            numpy.sqrt(
-                self._progenitor.pmll(**obskwargs) ** 2.0
-                + self._progenitor.pmbb(**obskwargs) ** 2.0
-            ),
-            numpy.sqrt(
-                self._progenitor.pmll(**obskwargs) ** 2.0
-                + self._progenitor.pmbb(**obskwargs) ** 2.0
-            ),
+            _dist,
+            numpy.fabs(_vlos),
+            _pm,
+            _pm,
         ]
         allErrCovsEigvalLB = numpy.empty((len(self._thetasTrack), 6))
         allErrCovsEigvecLB = numpy.empty_like(self._allErrCovs)
@@ -5279,7 +5283,16 @@ def calcaAJac(
     - 2013-11-25 - Written - Bovy (IAS)
     """
     # Backend (jax/torch): exact AD Jacobian; numpy path below is byte-identical.
-    if is_backend_array(xv) or is_backend_array(xv[0]):
+    # lb/coordFunc are not implemented on the backend path. They used to be
+    # unreachable there because xv arrived as numpy; now that the coords chain
+    # is backend-native it can arrive as a backend array, so land it on numpy
+    # and take the finite-difference path -- which is exactly what happened
+    # before, rather than raising at the user.
+    _is_backend = is_backend_array(xv) or is_backend_array(xv[0])
+    if _is_backend and (lb or coordFunc is not None):
+        xv = as_numpy(xv)
+        _is_backend = False
+    if _is_backend:
         return _calcaAJac_backend(
             xv,
             aA,

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -5290,7 +5290,9 @@ def calcaAJac(
     # before, rather than raising at the user.
     _is_backend = is_backend_array(xv) or is_backend_array(xv[0])
     if _is_backend and (lb or coordFunc is not None):
-        xv = as_numpy(xv)
+        # numpy.array (not as_numpy alone): jax's cast is read-only and the
+        # finite-difference path below writes into xv in place.
+        xv = numpy.array(as_numpy(xv))
         _is_backend = False
     if _is_backend:
         return _calcaAJac_backend(

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -9639,9 +9639,11 @@ def _fit_orbit_mlogl(
             Xsun=obs[0] / ro,
             Zsun=obs[2] / ro,
         ).T
+        # out-of-place: X is a backend array now that galcenrect_to_XYZ is
+        # backend-native, and the old masked in-place add sat behind a
+        # data-dependent Python branch. numpy values unchanged.
         bad_indx = (X == 0.0) * (Y == 0.0) * (Z == 0.0)
-        if True in bad_indx:  # pragma: no cover
-            X[bad_indx] += ro / 10000.0
+        X = get_namespace(X).where(bad_indx, X + ro / 10000.0, X)
         lbdvrpmllpmbb = coords.rectgal_to_sphergal(
             X * ro, Y * ro, Z * ro, vX * vo, vY * vo, vZ * vo, degree=True
         )
@@ -9816,9 +9818,14 @@ def _lbd(orb, thiso, *args, **kwargs):
     """Calculate l,b, and d"""
     obs, ro, vo = _parse_radec_kwargs(orb, kwargs, dontpop=True, thiso=thiso)
     X, Y, Z = _helioXYZ(orb, thiso, *args, **kwargs)
+    # nudge the exact origin off itself so the l/b arctan2 is well defined.
+    # Was `if True in bad_indx: X[bad_indx] += 1e-15` -- an in-place masked add
+    # behind a data-dependent Python branch, and X is a backend array now that
+    # galcenrect_to_XYZ is backend-native. xp.where is both out-of-place and
+    # traceable; the numpy values are unchanged.
     bad_indx = (X == 0.0) * (Y == 0.0) * (Z == 0.0)
-    if True in bad_indx:
-        X[bad_indx] += 1e-15
+    xp = get_namespace(X)
+    X = xp.where(bad_indx, X + 1e-15, X)
     return coords.XYZ_to_lbd(X, Y, Z, degree=True)
 
 
@@ -10004,9 +10011,11 @@ def _lbdvrpmllpmbb(orb, thiso, *args, **kwargs):
     """Calculate l,b,d,vr,pmll,pmbb"""
     obs, ro, vo = _parse_radec_kwargs(orb, kwargs, dontpop=True, thiso=thiso)
     X, Y, Z, vX, vY, vZ = _XYZvxvyvz(orb, thiso, *args, **kwargs)
+    # out-of-place: X is a backend array now that galcenrect_to_XYZ is
+    # backend-native, and the old masked in-place add sat behind a
+    # data-dependent Python branch. numpy values unchanged.
     bad_indx = (X == 0.0) * (Y == 0.0) * (Z == 0.0)
-    if True in bad_indx:
-        X[bad_indx] += ro / 10000.0
+    X = get_namespace(X).where(bad_indx, X + ro / 10000.0, X)
     return coords.rectgal_to_sphergal(X, Y, Z, vX, vY, vZ, degree=True)
 
 

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -614,6 +614,7 @@ def vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, l, b, d, XYZ=False, degree=False):
 
 @scalarDecorator
 @degreeDecorator([3, 4], [])
+@backendNative
 def vxvyvz_to_vrpmllpmbb(vx, vy, vz, l, b, d, XYZ=False, degree=False):
     """
     Transform velocities in the rectangular Galactic coordinate frame to the spherical Galactic coordinate frame (can take vector inputs)
@@ -648,14 +649,34 @@ def vxvyvz_to_vrpmllpmbb(vx, vy, vz, l, b, d, XYZ=False, degree=False):
     - 2014-06-14 - Re-written w/ numpy functions for speed and w/ decorators for beauty - Bovy (IAS)
     """
     # Whether to use degrees and scalar input is handled by decorators
+    xp = get_namespace(vx, vy, vz, l, b, d)
     if XYZ:  # undo the incorrect conversion that the decorator did
         if degree:
-            l *= 180.0 / numpy.pi
-            b *= 180.0 / numpy.pi
+            if xp is numpy:
+                l *= 180.0 / numpy.pi
+                b *= 180.0 / numpy.pi
+            else:  # backend arrays are immutable -- do not mutate in place
+                l = l * (180.0 / numpy.pi)
+                b = b * (180.0 / numpy.pi)
         lbd = XYZ_to_lbd(l, b, d, degree=False)
         l = lbd[:, 0]
         b = lbd[:, 1]
         d = lbd[:, 2]
+    if xp is not numpy:
+        # (R.T * invxyz.T).sum(-1) contracts to a per-point matvec by R. The
+        # (3, 3, N) build by element assignment and the two in-place row
+        # divisions are what backend arrays reject, so write the three
+        # components out directly.
+        cl, sl, cb, sb = xp.cos(l), xp.sin(l), xp.cos(b), xp.sin(b)
+        dK = d * _K
+        return xp.stack(
+            [
+                cl * cb * vx + sl * cb * vy + sb * vz,
+                (-sl * vx + cl * vy) / dK,
+                (-cl * sb * vx - sl * sb * vy + cb * vz) / dK,
+            ],
+            axis=-1,
+        )
     R = numpy.zeros((3, 3, len(l)))
     R[0, 0] = numpy.cos(l) * numpy.cos(b)
     R[0, 1] = -numpy.sin(l)
@@ -672,9 +693,9 @@ def vxvyvz_to_vrpmllpmbb(vx, vy, vz, l, b, d, XYZ=False, degree=False):
     return vrvlvb
 
 
-@backendNative
 @scalarDecorator
 @degreeDecorator([], [0, 1])
+@backendNative
 def XYZ_to_lbd(X, Y, Z, degree=False):
     """
     Transform from rectangular Galactic coordinates to spherical Galactic coordinates (works with vector inputs)
@@ -1148,8 +1169,8 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     ).T
 
 
-@backendNative
 @scalarDecorator
+@backendNative
 def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     """
     Transform rectangular Galactocentric to XYZ coordinates (wrt Sun) coordinates.
@@ -1519,8 +1540,8 @@ def vxvyvz_to_galcencyl(
     ).T
 
 
-@backendNative
 @scalarDecorator
+@backendNative
 def galcenrect_to_vxvyvz(
     vXg, vYg, vZg, vsun=[0.0, 1.0, 0.0], Xsun=1.0, Zsun=0.0, _extra_rot=True
 ):

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -97,6 +97,37 @@ _APY_COORDS *= _APY_LOADED
 _DEGTORAD = numpy.pi / 180.0
 
 
+def _galcen_rot(Xsun, Zsun):
+    """Galactocentric -> heliocentric rotation, plus the ``dgc`` offset scalars.
+
+    Depends only on ``Xsun``/``Zsun``, which are configuration, never traced
+    data -- so this stays numpy even on a backend and is a compile-time
+    constant under a trace. Shape (3, 3) for scalar Xsun, (3, 3, N) when
+    Xsun/Zsun are arrays.
+    """
+    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
+    costheta, sintheta = Xsun / dgc, Zsun / dgc
+    zero = numpy.zeros_like(costheta)
+    one = numpy.ones_like(costheta)
+    rot = numpy.array(
+        [
+            [-costheta, zero, -sintheta],
+            [zero, one, zero],
+            [-numpy.sign(Xsun) * sintheta, zero, numpy.sign(Xsun) * costheta],
+        ]
+    )
+    batched = isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
+    return rot, dgc, zero, batched
+
+
+def _apply_galcen_rot(xp, rot, data, batched, dev):
+    """``rot @ data`` for backend ``data`` (3, N); mirrors the numpy einsum."""
+    rot = asarray_on_device(xp, rot, dev)
+    if batched:  # (3, 3, N) . (3, N) -> (3, N), i.e. einsum("ijk,jk->ik")
+        return xp.sum(rot * data[None, :, :], axis=1)
+    return rot @ data
+
+
 def _scale_angle_rows(xp, m, factor=1.0 / _DEGTORAD, nrows=2):
     """Scale the first ``nrows`` rows of Jacobian ``m`` by ``factor``.
 
@@ -1107,6 +1138,7 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     ).T
 
 
+@backendNative
 @scalarDecorator
 def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     """
@@ -1140,32 +1172,30 @@ def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
 
     """
-    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
-    costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = numpy.zeros_like(costheta)
-    one = numpy.ones_like(costheta)
+    rot, dgc, zero, batched = _galcen_rot(Xsun, Zsun)
+    offset = numpy.array([dgc, zero, zero])
+    xp = get_namespace(X, Y, Z)
+    if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
+        out = (
+            numpy.einsum(
+                "ijk,jk->ik" if batched else "ij,jk->ik",
+                rot,
+                numpy.array([X, Y, Z]),
+            ).T
+            + offset.T
+        )
+        if _extra_rot:
+            return numpy.dot(galcen_extra_rot.T, out.T).T
+        return out
+    X, Y, Z = promote_scalars(xp, X, Y, Z)
+    dev = device_of(X)
     out = (
-        numpy.einsum(
-            (
-                "ijk,jk->ik"
-                if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
-                else "ij,jk->ik"
-            ),
-            numpy.array(
-                [
-                    [-costheta, zero, -sintheta],
-                    [zero, one, zero],
-                    [-numpy.sign(Xsun) * sintheta, zero, numpy.sign(Xsun) * costheta],
-                ]
-            ),
-            numpy.array([X, Y, Z]),
-        ).T
-        + numpy.array([dgc, zero, zero]).T
+        _apply_galcen_rot(xp, rot, xp.stack([X, Y, Z]), batched, dev).T
+        + asarray_on_device(xp, offset, dev).T
     )
     if _extra_rot:
-        return numpy.dot(galcen_extra_rot.T, out.T).T
-    else:
-        return out
+        return (asarray_on_device(xp, galcen_extra_rot.T, dev) @ out.T).T
+    return out
 
 
 def rect_to_cyl(X, Y, Z, *, xp=None):
@@ -1479,6 +1509,7 @@ def vxvyvz_to_galcencyl(
     ).T
 
 
+@backendNative
 @scalarDecorator
 def galcenrect_to_vxvyvz(
     vXg, vYg, vZg, vsun=[0.0, 1.0, 0.0], Xsun=1.0, Zsun=0.0, _extra_rot=True
@@ -1515,29 +1546,24 @@ def galcenrect_to_vxvyvz(
     - 2017-10-24 - Allowed Xsun/Zsun/vsun to be arrays - Bovy (UofT)
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
     """
-    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
-    costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = numpy.zeros_like(costheta)
-    one = numpy.ones_like(costheta)
-    out = numpy.einsum(
-        (
-            "ijk,jk->ik"
-            if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
-            else "ij,jk->ik"
-        ),
-        numpy.array(
-            [
-                [-costheta, zero, -sintheta],
-                [zero, one, zero],
-                [-numpy.sign(Xsun) * sintheta, zero, numpy.sign(Xsun) * costheta],
-            ]
-        ),
-        numpy.array([vXg - vsun[0], vYg - vsun[1], vZg - vsun[2]]),
-    ).T
-    if _extra_rot:
-        return numpy.dot(galcen_extra_rot.T, out.T).T
-    else:
+    rot, _, _, batched = _galcen_rot(Xsun, Zsun)
+    xp = get_namespace(vXg, vYg, vZg)
+    if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
+        out = numpy.einsum(
+            "ijk,jk->ik" if batched else "ij,jk->ik",
+            rot,
+            numpy.array([vXg - vsun[0], vYg - vsun[1], vZg - vsun[2]]),
+        ).T
+        if _extra_rot:
+            return numpy.dot(galcen_extra_rot.T, out.T).T
         return out
+    vXg, vYg, vZg = promote_scalars(xp, vXg, vYg, vZg)
+    dev = device_of(vXg)
+    data = xp.stack([vXg - vsun[0], vYg - vsun[1], vZg - vsun[2]])
+    out = _apply_galcen_rot(xp, rot, data, batched, dev).T
+    if _extra_rot:
+        return (asarray_on_device(xp, galcen_extra_rot.T, dev) @ out.T).T
+    return out
 
 
 @scalarDecorator

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -672,6 +672,7 @@ def vxvyvz_to_vrpmllpmbb(vx, vy, vz, l, b, d, XYZ=False, degree=False):
     return vrvlvb
 
 
+@backendNative
 @scalarDecorator
 @degreeDecorator([], [0, 1])
 def XYZ_to_lbd(X, Y, Z, degree=False):
@@ -700,15 +701,24 @@ def XYZ_to_lbd(X, Y, Z, degree=False):
     - 2014-06-14 - Re-written w/ numpy functions for speed and w/ decorators for beauty - Bovy (IAS)
     """
     # Whether to use degrees and scalar input is handled by decorators
-    d = numpy.sqrt(X**2.0 + Y**2.0 + Z**2.0)
-    b = numpy.arcsin(Z / d)
-    l = numpy.arctan2(Y, X)
-    l[l < 0.0] += 2.0 * numpy.pi
-    out = numpy.empty((len(d), 3))
-    out[:, 0] = l
-    out[:, 1] = b
-    out[:, 2] = d
-    return out
+    xp = get_namespace(X, Y, Z)
+    if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
+        d = numpy.sqrt(X**2.0 + Y**2.0 + Z**2.0)
+        b = numpy.arcsin(Z / d)
+        l = numpy.arctan2(Y, X)
+        l[l < 0.0] += 2.0 * numpy.pi
+        out = numpy.empty((len(d), 3))
+        out[:, 0] = l
+        out[:, 1] = b
+        out[:, 2] = d
+        return out
+    X, Y, Z = promote_scalars(xp, X, Y, Z)
+    d = xp.sqrt(X**2.0 + Y**2.0 + Z**2.0)
+    b = xp.arcsin(Z / d)
+    l = xp.arctan2(Y, X)
+    # was `l[l < 0.0] += 2pi`: a masked in-place add, which backend arrays reject
+    l = xp.where(l < 0.0, l + 2.0 * numpy.pi, l)
+    return xp.stack([l, b, d], axis=-1)
 
 
 @scalarDecorator

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -667,6 +667,9 @@ def vxvyvz_to_vrpmllpmbb(vx, vy, vz, l, b, d, XYZ=False, degree=False):
         # (3, 3, N) build by element assignment and the two in-place row
         # divisions are what backend arrays reject, so write the three
         # components out directly.
+        # promote first: under a forced backend the inputs can still be numpy,
+        # and torch.cos(ndarray) raises rather than coercing
+        l, b, d, vx, vy, vz = promote_scalars(xp, l, b, d, vx, vy, vz)
         cl, sl, cb, sb = xp.cos(l), xp.sin(l), xp.cos(b), xp.sin(b)
         dK = d * _K
         return xp.stack(
@@ -858,6 +861,7 @@ def pmllpmbb_to_pmrapmdec(pmll, pmbb, l, b, degree=False, epoch=2000.0):
             * numpy.array([[pmll, pmll], [pmbb, pmbb]]).T
         ).sum(-1)
     # that contraction is a per-point rotation of (pmll, pmbb) by phi
+    pmll, pmbb = promote_scalars(xp, pmll, pmbb)
     return xp.stack(
         [cosphi * pmll - sinphi * pmbb, sinphi * pmll + cosphi * pmbb], axis=-1
     )

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -798,6 +798,7 @@ def pmrapmdec_to_pmllpmbb(pmra, pmdec, ra, dec, degree=False, epoch=2000.0):
 
 @scalarDecorator
 @degreeDecorator([2, 3], [])
+@backendNative
 def pmllpmbb_to_pmrapmdec(pmll, pmbb, l, b, degree=False, epoch=2000.0):
     """
     Rotate proper motions in (l,b) into proper motions in (ra,dec)
@@ -836,24 +837,30 @@ def pmllpmbb_to_pmrapmdec(pmll, pmbb, l, b, degree=False, epoch=2000.0):
     # deal w/ pole; was `dec[dec == dec_ngp] += 1e-16`, an in-place masked
     # assignment that jax does not support
     dec = xp.where(dec == dec_ngp, dec + 10.0**-16, dec)
-    sindec_ngp = numpy.sin(dec_ngp)
+    sindec_ngp = numpy.sin(dec_ngp)  # epoch angles: config, never traced
     cosdec_ngp = numpy.cos(dec_ngp)
-    sindec = numpy.sin(dec)
-    cosdec = numpy.cos(dec)
-    sinrarangp = numpy.sin(ra - ra_ngp)
-    cosrarangp = numpy.cos(ra - ra_ngp)
+    sindec = xp.sin(dec)
+    cosdec = xp.cos(dec)
+    sinrarangp = xp.sin(ra - ra_ngp)
+    cosrarangp = xp.cos(ra - ra_ngp)
     # These were replaced by Poleski (2013)'s equivalent form that is better at the poles
     # cosphi= (sindec_ngp-sindec*sinb)/cosdec/cosb
     # sinphi= sinrarangp*cosdec_ngp/cosb
     cosphi = sindec_ngp * cosdec - cosdec_ngp * sindec * cosrarangp
     sinphi = sinrarangp * cosdec_ngp
-    norm = numpy.sqrt(cosphi**2.0 + sinphi**2.0)
-    cosphi /= norm
-    sinphi /= norm
-    return (
-        numpy.array([[cosphi, sinphi], [-sinphi, cosphi]]).T
-        * numpy.array([[pmll, pmll], [pmbb, pmbb]]).T
-    ).sum(-1)
+    norm = xp.sqrt(cosphi**2.0 + sinphi**2.0)
+    # was `cosphi /= norm` / `sinphi /= norm`: in-place, which jax rejects
+    cosphi = cosphi / norm
+    sinphi = sinphi / norm
+    if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
+        return (
+            numpy.array([[cosphi, sinphi], [-sinphi, cosphi]]).T
+            * numpy.array([[pmll, pmll], [pmbb, pmbb]]).T
+        ).sum(-1)
+    # that contraction is a per-point rotation of (pmll, pmbb) by phi
+    return xp.stack(
+        [cosphi * pmll - sinphi * pmbb, sinphi * pmll + cosphi * pmbb], axis=-1
+    )
 
 
 def cov_pmrapmdec_to_pmllpmbb(cov_pmradec, ra, dec, degree=False, epoch=2000.0):

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -458,3 +458,47 @@ def test_sky_chain_preserves_backend_and_matches_numpy(backend_name, name, shape
         atol=1e-13 * max(numpy.max(numpy.abs(ref)), 1.0),
         err_msg=f"{name} backend value does not match numpy ({shape})",
     )
+
+
+@pytest.mark.parametrize("extra_rot", [True, False])
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_galcen_rot_array_Xsun_and_extra_rot(backend_name, extra_rot):
+    # _galcen_rot has two shapes: a (3, 3) rotation for scalar Xsun/Zsun and a
+    # (3, 3, N) one when they are arrays, and _apply_galcen_rot contracts them
+    # differently (matmul vs a per-point sum). The scalar/default case is
+    # covered above; this exercises the batched branch and _extra_rot=False,
+    # which the streamTrack path never reaches.
+    rng = numpy.random.default_rng(23)
+    n = 6
+    x, y, z = rng.normal(size=n) + 1.5, rng.normal(size=n), 0.3 * rng.normal(size=n)
+    vx, vy, vz = rng.normal(size=n), rng.normal(size=n) + 1.0, 0.2 * rng.normal(size=n)
+    Xarr, Zarr = 1.0 + 0.1 * rng.random(n), 0.02 * rng.random(n)
+    for Xs, Zs, tag in ((1.0, 0.02, "scalar"), (Xarr, Zarr, "array")):
+        ref_x = numpy.asarray(
+            coords.galcenrect_to_XYZ(x, y, z, Xsun=Xs, Zsun=Zs, _extra_rot=extra_rot)
+        )
+        ref_v = numpy.asarray(
+            coords.galcenrect_to_vxvyvz(
+                vx, vy, vz, Xsun=Xs, Zsun=Zs, _extra_rot=extra_rot
+            )
+        )
+        bx, by, bz = (_as_backend(backend_name, a) for a in (x, y, z))
+        bvx, bvy, bvz = (_as_backend(backend_name, a) for a in (vx, vy, vz))
+        got_x = coords.galcenrect_to_XYZ(
+            bx, by, bz, Xsun=Xs, Zsun=Zs, _extra_rot=extra_rot
+        )
+        got_v = coords.galcenrect_to_vxvyvz(
+            bvx, bvy, bvz, Xsun=Xs, Zsun=Zs, _extra_rot=extra_rot
+        )
+        assert _all_backend(got_x), (
+            f"XYZ dropped to numpy ({tag}, extra_rot={extra_rot})"
+        )
+        assert _all_backend(got_v), f"v dropped to numpy ({tag}, extra_rot={extra_rot})"
+        for got, ref, what in ((got_x, ref_x, "XYZ"), (got_v, ref_v, "vxvyvz")):
+            numpy.testing.assert_allclose(
+                as_numpy(got),
+                ref,
+                rtol=1e-13,
+                atol=1e-13 * max(numpy.max(numpy.abs(ref)), 1.0),
+                err_msg=f"{what} mismatch ({tag}, _extra_rot={extra_rot})",
+            )

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -350,3 +350,111 @@ def test_degree_decorator_scales_backend_output(backend_name):
     )
     numpy.testing.assert_allclose(as_numpy(got_deg), ref_deg, rtol=0, atol=1e-12)
     numpy.testing.assert_allclose(as_numpy(got_rad), ref_rad, rtol=0, atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# The galcenrect -> heliocentric -> sky chain (#184).
+#
+# Each of these was plain @scalarDecorator, so it promoted its inputs through
+# numpy and silently returned numpy even when handed a backend array. That is
+# what made streamTrack's sky-frame cov() raise "Multiple namespaces" on an
+# unforced mixed track and "Can't call numpy() on Tensor that requires grad"
+# under a gradient.
+#
+# These assert the RETURN TYPE, not just the values, and that is deliberate:
+# a byte-identity check cannot distinguish a working migration from one that
+# does nothing, because the numpy path is unchanged either way. During this
+# migration @backendNative was briefly placed as the OUTERMOST decorator, which
+# marks the scalarDecorator wrapper rather than the function scalarDecorator
+# inspects -- every migration was inert and every value check still passed.
+# Only a type assertion catches that.
+# ---------------------------------------------------------------------------
+_CHAIN_CASES = {
+    "galcenrect_to_XYZ": lambda c, a: c.galcenrect_to_XYZ(
+        a["x"], a["y"], a["z"], Xsun=1.0, Zsun=0.02
+    ),
+    "galcenrect_to_vxvyvz": lambda c, a: c.galcenrect_to_vxvyvz(
+        a["vx"], a["vy"], a["vz"], Xsun=1.0, Zsun=0.02
+    ),
+    "XYZ_to_lbd": lambda c, a: c.XYZ_to_lbd(a["x"], a["y"], a["z"], degree=False),
+    "vxvyvz_to_vrpmllpmbb": lambda c, a: c.vxvyvz_to_vrpmllpmbb(
+        a["vx"], a["vy"], a["vz"], a["x"], a["y"], a["z"], XYZ=True, degree=False
+    ),
+    "pmllpmbb_to_pmrapmdec": lambda c, a: c.pmllpmbb_to_pmrapmdec(
+        a["pmll"], a["pmbb"], a["l"], a["b"], degree=False
+    ),
+}
+
+
+def _chain_args():
+    rng = numpy.random.default_rng(19)
+    n = 7
+    return {
+        "x": rng.normal(size=n) + 1.5,
+        "y": rng.normal(size=n),
+        "z": 0.4 * rng.normal(size=n),
+        "vx": rng.normal(size=n),
+        "vy": rng.normal(size=n) + 1.0,
+        "vz": 0.3 * rng.normal(size=n),
+        "l": rng.random(size=n) * 5.0,
+        "b": (rng.random(size=n) - 0.5),
+        "pmll": rng.normal(size=n),
+        "pmbb": rng.normal(size=n),
+    }
+
+
+def _as_backend(backend_name, arr):
+    """A real backend array while the AMBIENT backend stays numpy."""
+    if backend_name == "jax":
+        import jax
+
+        jax.config.update("jax_enable_x64", True)
+        import jax.numpy as jnp
+
+        return jnp.asarray(arr)
+    import torch
+
+    return torch.tensor(numpy.asarray(arr, dtype=float), dtype=torch.float64)
+
+
+def _all_backend(res):
+    """True when every array in ``res`` is a backend array (res may be a tuple)."""
+    parts = res if isinstance(res, tuple) else (res,)
+    return all(is_backend_array(a) for a in parts)
+
+
+@pytest.mark.parametrize("shape", ["scalar", "array"])
+@pytest.mark.parametrize("name", sorted(_CHAIN_CASES))
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_sky_chain_preserves_backend_and_matches_numpy(backend_name, name, shape):
+    # Two things this test is careful about, both learned the hard way:
+    #
+    # 1. UNFORCED. Under `use(..., force=True)` these recover even with the
+    #    marker misplaced, because get_namespace reports the caller's intent and
+    #    the body's promote_scalars re-coerces. Forcing hides the bug.
+    # 2. SCALAR inputs. scalarDecorator only rewrites its arguments when they
+    #    are 0-d (`if xp.asarray(args[0]).ndim == 0`), so with array inputs the
+    #    marker is never consulted and the test passes either way. streamTrack
+    #    calls these per-tp with scalars, which is why it was the thing that
+    #    broke. Verified: with @backendNative moved outermost, scalar-in returns
+    #    a tuple of numpy float64 and this test fails; array-in stays Tensor.
+    args = _chain_args()
+    if shape == "scalar":
+        args = {k: v[0] for k, v in args.items()}
+    call = _CHAIN_CASES[name]
+    ref = numpy.asarray(call(coords, args))
+    bargs = {k: _as_backend(backend_name, v) for k, v in args.items()}
+    got = call(coords, bargs)
+    assert _all_backend(got), f"{name} dropped back to numpy ({shape}, unforced)"
+    flat = (
+        numpy.asarray([as_numpy(a) for a in got])
+        if isinstance(got, tuple)
+        else as_numpy(got)
+    )
+    numpy.testing.assert_allclose(
+        flat,
+        ref,
+        rtol=1e-13,
+        atol=1e-13 * max(numpy.max(numpy.abs(ref)), 1.0),
+        err_msg=f"{name} backend value does not match numpy ({shape})",
+    )

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -502,3 +502,28 @@ def test_galcen_rot_array_Xsun_and_extra_rot(backend_name, extra_rot):
                 atol=1e-13 * max(numpy.max(numpy.abs(ref)), 1.0),
                 err_msg=f"{what} mismatch ({tag}, _extra_rot={extra_rot})",
             )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_vxvyvz_to_vrpmllpmbb_XYZ_degree_backend(backend_name):
+    # XYZ=True + degree=True is the one combination with its own backend branch:
+    # degreeDecorator has already converted args 3/4 deg->rad, which is wrong when
+    # they are X/Y rather than l/b, so the body undoes it. numpy undoes it in
+    # place (`l *= ...`); backend arrays are immutable, so there is a separate
+    # out-of-place branch. Nothing else in the suite passes both flags with
+    # backend arrays, which left those two lines the only uncovered ones in
+    # coords.py.
+    X = numpy.array([1.2, -0.7, 0.3])
+    Y = numpy.array([-0.4, 0.9, 1.1])
+    Z = numpy.array([0.25, -0.6, 0.8])
+    vx = numpy.array([10.0, -20.0, 5.0])
+    vy = numpy.array([-30.0, 15.0, 25.0])
+    vz = numpy.array([7.0, -3.0, 12.0])
+    ref = coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, X, Y, Z, XYZ=True, degree=True)
+    got = coords.vxvyvz_to_vrpmllpmbb(
+        *[_as_backend(backend_name, a) for a in (vx, vy, vz, X, Y, Z)],
+        XYZ=True,
+        degree=True,
+    )
+    assert _all_backend(got), "XYZ+degree backend path fell back to numpy"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-13, atol=1e-15)

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -453,11 +453,21 @@ def test_calcaAJac_ad_equals_fd(aA_iso, backend_name, flags, shape):
 
 
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)
-def test_calcaAJac_backend_rejects_lb_coordfunc(aA_iso, backend_name):
-    # lb / coordFunc are unsupported on the backend path; they raise (not misbehave).
+def test_calcaAJac_backend_lb_coordfunc_falls_back_to_numpy(aA_iso, backend_name):
+    # lb / coordFunc have no backend implementation. They used to be unreachable
+    # with a backend xv, so the guard raised; now that the coords chain is
+    # backend-native the stream track reaches here with lb=True, so the call
+    # lands on numpy and takes the finite-difference path -- exactly what it did
+    # before. Assert it MATCHES numpy rather than merely not raising: the
+    # fallback silently gives up AD, so a wrong value would otherwise be
+    # invisible (jax's as_numpy cast is read-only, and the FD path writes in
+    # place -- that bug passed a "does not raise" check on torch).
     for kw in (dict(lb=True), dict(coordFunc=lambda x: x)):
-        with pytest.raises(NotImplementedError):
+        got = as_numpy(
             calcaAJac(_arr(backend_name, _XV), aA_iso, actionsFreqsAngles=True, **kw)
+        )
+        ref = calcaAJac(numpy.array(_XV), aA_iso, actionsFreqsAngles=True, **kw)
+        numpy.testing.assert_allclose(got, ref, rtol=1e-13, atol=1e-15)
 
 
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -540,7 +540,7 @@ def test_lbd_to_XYZ():
 def test_XYZ_to_lbd():
     l, b, d = 90.0, 30.0, 1.0
     XYZ = coords.lbd_to_XYZ(l, b, d, degree=True)
-    lt, bt, dt = coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=True)
+    lt, bt, dt = as_numpy(coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=True))
     assert numpy.fabs(lt - l) < 10.0**-10.0, (
         "XYZ_to_lbd conversion does not work as expected"
     )
@@ -552,7 +552,7 @@ def test_XYZ_to_lbd():
     )
     # Also test for degree=False
     XYZ = coords.lbd_to_XYZ(l / 180.0 * numpy.pi, b / 180.0 * numpy.pi, d, degree=False)
-    lt, bt, dt = coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=False)
+    lt, bt, dt = as_numpy(coords.XYZ_to_lbd(XYZ[0], XYZ[1], XYZ[2], degree=False))
     assert numpy.fabs(lt - l / 180.0 * numpy.pi) < 10.0**-10.0, (
         "XYZ_to_lbd conversion does not work as expected"
     )
@@ -567,7 +567,7 @@ def test_XYZ_to_lbd():
     XYZ = coords.lbd_to_XYZ(
         os * l / 180.0 * numpy.pi, os * b / 180.0 * numpy.pi, os * d, degree=False
     )
-    lbdt = coords.XYZ_to_lbd(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2], degree=False)
+    lbdt = as_numpy(coords.XYZ_to_lbd(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2], degree=False))
     assert numpy.all(numpy.fabs(lbdt[:, 0] - l / 180.0 * numpy.pi) < 10.0**-10.0), (
         "XYZ_to_lbd conversion does not work as expected"
     )
@@ -656,7 +656,7 @@ def test_vrpmllpmbb_to_vxvyvz():
 def test_vxvyvz_to_vrpmllpmbb():
     vx, vy, vz = -20.0 * 4.740470463496208, 10.0, -10.0 * 4.740470463496208
     X, Y, Z = 0.0, 1.0, 0.0
-    vrpmllpmbb = coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, X, Y, Z, XYZ=True)
+    vrpmllpmbb = as_numpy(coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, X, Y, Z, XYZ=True))
     assert numpy.fabs(vrpmllpmbb[0] - 10.0) < 10.0**-9.0, (
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
     )
@@ -667,7 +667,9 @@ def test_vxvyvz_to_vrpmllpmbb():
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
     )
     # also try with degree=True (that shouldn't fail!)
-    vrpmllpmbb = coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, X, Y, Z, XYZ=True, degree=True)
+    vrpmllpmbb = as_numpy(
+        coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, X, Y, Z, XYZ=True, degree=True)
+    )
     assert numpy.fabs(vrpmllpmbb[0] - 10.0) < 10.0**-9.0, (
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
     )
@@ -678,8 +680,8 @@ def test_vxvyvz_to_vrpmllpmbb():
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
     )
     # also for lbd
-    vrpmllpmbb = coords.vxvyvz_to_vrpmllpmbb(
-        vx, vy, vz, 90.0, 0.0, 1.0, XYZ=False, degree=True
+    vrpmllpmbb = as_numpy(
+        coords.vxvyvz_to_vrpmllpmbb(vx, vy, vz, 90.0, 0.0, 1.0, XYZ=False, degree=True)
     )
     assert numpy.fabs(vrpmllpmbb[0] - 10.0) < 10.0**-9.0, (
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
@@ -691,8 +693,10 @@ def test_vxvyvz_to_vrpmllpmbb():
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
     )
     # also for lbd, not in degree
-    vrpmllpmbb = coords.vxvyvz_to_vrpmllpmbb(
-        vx, vy, vz, numpy.pi / 2.0, 0.0, 1.0, XYZ=False, degree=False
+    vrpmllpmbb = as_numpy(
+        coords.vxvyvz_to_vrpmllpmbb(
+            vx, vy, vz, numpy.pi / 2.0, 0.0, 1.0, XYZ=False, degree=False
+        )
     )
     assert numpy.fabs(vrpmllpmbb[0] - 10.0) < 10.0**-9.0, (
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
@@ -705,15 +709,17 @@ def test_vxvyvz_to_vrpmllpmbb():
     )
     # and for arrays
     os = numpy.ones(2)
-    vrpmllpmbb = coords.vxvyvz_to_vrpmllpmbb(
-        os * vx,
-        os * vy,
-        os * vz,
-        os * numpy.pi / 2.0,
-        os * 0.0,
-        os,
-        XYZ=False,
-        degree=False,
+    vrpmllpmbb = as_numpy(
+        coords.vxvyvz_to_vrpmllpmbb(
+            os * vx,
+            os * vy,
+            os * vz,
+            os * numpy.pi / 2.0,
+            os * 0.0,
+            os,
+            XYZ=False,
+            degree=False,
+        )
     )
     assert numpy.all(numpy.fabs(vrpmllpmbb[:, 0] - 10.0) < 10.0**-9.0), (
         "vxvyvz_to_vrpmllpmbb conversion did not work as expected"
@@ -1487,7 +1493,7 @@ def test_vrpmllpmbb_to_galcencyl_galpyvsastropy():
 
 def test_galcenrect_to_vxvyvz():
     vxg, vyg, vzg = -15.0, -10.0, 35.0
-    vxyz = coords.galcenrect_to_vxvyvz(vxg, vyg, vzg, vsun=[-5.0, 10.0, 5.0])
+    vxyz = as_numpy(coords.galcenrect_to_vxvyvz(vxg, vyg, vzg, vsun=[-5.0, 10.0, 5.0]))
     assert numpy.fabs(vxyz[0] - 10.0) < 10.0**-4.0, (
         "galcenrect_to_vxvyvz conversion did not work as expected"
     )
@@ -1499,8 +1505,10 @@ def test_galcenrect_to_vxvyvz():
     )
     # Also for arrays
     os = numpy.ones(2)
-    vxyz = coords.galcenrect_to_vxvyvz(
-        os * vxg, os * vyg, os * vzg, vsun=[-5.0, 10.0, 5.0]
+    vxyz = as_numpy(
+        coords.galcenrect_to_vxvyvz(
+            os * vxg, os * vyg, os * vzg, vsun=[-5.0, 10.0, 5.0]
+        )
     )
     assert numpy.all(numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0), (
         "galcenrect_to_vxvyvz conversion did not work as expected"
@@ -1532,7 +1540,9 @@ def test_galcenrect_to_vxvyvz_asInverse():
     # Test that galcenrect_to_vxvyvz is the inverse of vxvyvz_to_galcenrect
     vx, vy, vz = -15.0, -10.0, 35.0
     vxg, vyg, vzg = coords.vxvyvz_to_galcenrect(vx, vy, vz, vsun=[-5.0, 10.0, 5.0])
-    vxt, vyt, vzt = coords.galcenrect_to_vxvyvz(vxg, vyg, vzg, vsun=[-5.0, 10.0, 5.0])
+    vxt, vyt, vzt = as_numpy(
+        coords.galcenrect_to_vxvyvz(vxg, vyg, vzg, vsun=[-5.0, 10.0, 5.0])
+    )
     assert numpy.fabs(vx - vxt) < 10.0**-14.0, (
         "galcenrect_to_vxvyvz is not the inverse of vxvyvz_to_galcenrect"
     )
@@ -1547,8 +1557,10 @@ def test_galcenrect_to_vxvyvz_asInverse():
     vxyzg = coords.vxvyvz_to_galcenrect(
         vx * os, vy * os, vz * os, vsun=[-5.0, 10.0, 5.0]
     )
-    vxyzt = coords.galcenrect_to_vxvyvz(
-        vxyzg[:, 0], vxyzg[:, 1], vxyzg[:, 2], vsun=[-5.0, 10.0, 5.0]
+    vxyzt = as_numpy(
+        coords.galcenrect_to_vxvyvz(
+            vxyzg[:, 0], vxyzg[:, 1], vxyzg[:, 2], vsun=[-5.0, 10.0, 5.0]
+        )
     )
     assert numpy.all(numpy.fabs(vxyzt[:, 0] - vx * os) < 10.0**-10.0), (
         "galcenrect_to_vxvyvz is not the inverse of vxvyvz_to_galcenrect"
@@ -1568,13 +1580,15 @@ def test_galcenrect_to_vxvyvz_vecXsun():
         numpy.array([-10.0, -10.0]),
         numpy.array([35.0, 35.0]),
     )
-    vxyz = coords.galcenrect_to_vxvyvz(
-        vxg,
-        vyg,
-        vzg,
-        vsun=[-5.0, 10.0, 5.0],
-        Xsun=numpy.array([1.1, 1.0]),
-        Zsun=numpy.array([0.0, 0.0]),
+    vxyz = as_numpy(
+        coords.galcenrect_to_vxvyvz(
+            vxg,
+            vyg,
+            vzg,
+            vsun=[-5.0, 10.0, 5.0],
+            Xsun=numpy.array([1.1, 1.0]),
+            Zsun=numpy.array([0.0, 0.0]),
+        )
     )
     assert numpy.all(numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0), (
         "galcenrect_to_vxvyvz conversion did not work as expected"
@@ -1594,8 +1608,10 @@ def test_galcenrect_to_vxvyvz_vecvsun():
         numpy.array([-10.0, -20.0]),
         numpy.array([35.0, 32.5]),
     )
-    vxyz = coords.galcenrect_to_vxvyvz(
-        vxg, vyg, vzg, vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T
+    vxyz = as_numpy(
+        coords.galcenrect_to_vxvyvz(
+            vxg, vyg, vzg, vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T
+        )
     )
     assert numpy.all(numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0), (
         "galcenrect_to_vxvyvz conversion did not work as expected"
@@ -1615,13 +1631,15 @@ def test_galcenrect_to_vxvyvz_vecXsunvsun():
         numpy.array([-10.0, -20.0]),
         numpy.array([35.0, 32.5]),
     )
-    vxyz = coords.galcenrect_to_vxvyvz(
-        vxg,
-        vyg,
-        vzg,
-        vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T,
-        Xsun=numpy.array([1.1, 1.0]),
-        Zsun=numpy.array([0.0, 0.0]),
+    vxyz = as_numpy(
+        coords.galcenrect_to_vxvyvz(
+            vxg,
+            vyg,
+            vzg,
+            vsun=numpy.array([[-5.0, 10.0, 5.0], [5.0, 0.0, 2.5]]).T,
+            Xsun=numpy.array([1.1, 1.0]),
+            Zsun=numpy.array([0.0, 0.0]),
+        )
     )
     assert numpy.all(numpy.fabs(vxyz[:, 0] - 10.0) < 10.0**-4.0), (
         "galcenrect_to_vxvyvz conversion did not work as expected"
@@ -1658,8 +1676,8 @@ def test_galcencyl_to_vxvyvz_asInverse():
     vrg, vtg, vzg = coords.vxvyvz_to_galcencyl(
         vx, vy, vz, 0.0, phi, 0.0, vsun=[-5.0, 10.0, 5.0], galcen=True
     )
-    vxt, vyt, vzt = coords.galcencyl_to_vxvyvz(
-        vrg, vtg, vzg, phi, vsun=[-5.0, 10.0, 5.0]
+    vxt, vyt, vzt = as_numpy(
+        coords.galcencyl_to_vxvyvz(vrg, vtg, vzg, phi, vsun=[-5.0, 10.0, 5.0])
     )
     assert numpy.fabs(vx - vxt) < 10.0**-14.0, (
         "galcencyl_to_vxvyvz is not the inverse of vxvyvz_to_galcencyl"
@@ -1684,8 +1702,10 @@ def test_galcencyl_to_vxvyvz_asInverse():
         vsun=[-5.0, 10.0, 5.0],
         galcen=True,
     )
-    vxyzt = coords.galcencyl_to_vxvyvz(
-        vrtzg[:, 0], vrtzg[:, 1], vrtzg[:, 2], phi * os, vsun=[-5.0, 10.0, 5.0]
+    vxyzt = as_numpy(
+        coords.galcencyl_to_vxvyvz(
+            vrtzg[:, 0], vrtzg[:, 1], vrtzg[:, 2], phi * os, vsun=[-5.0, 10.0, 5.0]
+        )
     )
     assert numpy.all(numpy.fabs(vxyzt[:, 0] - vx * os) < 10.0**-10.0), (
         "galcencyl_to_vxvyvz is not the inverse of vxvyvz_to_galcencyl"
@@ -1923,8 +1943,8 @@ def test_pmllpmbb_to_pmrapmdec():
     # This is a random l,b
     ll, bb = 132.0, -20.4
     pmll, pmbb = 10.0, 20.0
-    pmra, pmdec = coords.pmllpmbb_to_pmrapmdec(
-        pmll, pmbb, ll, bb, degree=True, epoch=1950.0
+    pmra, pmdec = as_numpy(
+        coords.pmllpmbb_to_pmrapmdec(pmll, pmbb, ll, bb, degree=True, epoch=1950.0)
     )
     assert (
         numpy.fabs(
@@ -1936,8 +1956,10 @@ def test_pmllpmbb_to_pmrapmdec():
     ll, bb = numpy.pi - 0.001, numpy.pi / 2.0 - 0.001
     pmll, pmbb = 10.0, 20.0
     os = numpy.ones(2)
-    pmrapmdec = coords.pmllpmbb_to_pmrapmdec(
-        os * pmll, os * pmbb, os * ll, os * bb, degree=False, epoch=1950.0
+    pmrapmdec = as_numpy(
+        coords.pmllpmbb_to_pmrapmdec(
+            os * pmll, os * pmbb, os * ll, os * bb, degree=False, epoch=1950.0
+        )
     )
     pmra = pmrapmdec[:, 0]
     pmdec = pmrapmdec[:, 1]
@@ -1951,8 +1973,10 @@ def test_pmllpmbb_to_pmrapmdec():
     ll, bb = numpy.pi, numpy.pi / 2.0
     pmll, pmbb = 10.0, 20.0
     os = numpy.ones(2)
-    pmrapmdec = coords.pmllpmbb_to_pmrapmdec(
-        os * pmll, os * pmbb, os * ll, os * bb, degree=False, epoch=1950.0
+    pmrapmdec = as_numpy(
+        coords.pmllpmbb_to_pmrapmdec(
+            os * pmll, os * pmbb, os * ll, os * bb, degree=False, epoch=1950.0
+        )
     )
     pmra = pmrapmdec[:, 0]
     pmdec = pmrapmdec[:, 1]
@@ -1966,8 +1990,8 @@ def test_pmllpmbb_to_pmrapmdec():
     ra, dec = numpy.pi, numpy.pi / 2.0
     ll, bb = coords.radec_to_lb(ra, dec, degree=False, epoch=1950.0)
     pmll, pmbb = 10.0, 20.0
-    pmra, pmdec = coords.pmllpmbb_to_pmrapmdec(
-        pmll, pmbb, ll, bb, degree=False, epoch=1950.0
+    pmra, pmdec = as_numpy(
+        coords.pmllpmbb_to_pmrapmdec(pmll, pmbb, ll, bb, degree=False, epoch=1950.0)
     )
     assert (
         numpy.fabs(

--- a/tests/test_streamdf.py
+++ b/tests/test_streamdf.py
@@ -5,6 +5,7 @@ import numpy
 import pytest
 from scipy import integrate, interpolate
 
+from galpy.backend import as_numpy
 from galpy.util import coords
 
 
@@ -1118,7 +1119,9 @@ def test_density_ll_wsampling(bovy14_setup):
             X, Y, Z, Xsun=sdf_bovy14._R0, Zsun=sdf_bovy14._Zsun
         )
         l, b, d = coords.XYZ_to_lbd(X, Y, Z, degree=True)
-        return l
+        # coords preserves the framework under a forced backend; this local
+        # helper is compared against a numpy sample below
+        return as_numpy(l)
 
     LB = sdf_bovy14.sample(n=10000, lb=True)
     apar1, apar2 = 0.1, 0.6


### PR DESCRIPTION
#1235 landed the streamTrack basis rotation but shipped with `sky`/`galsky` **eager-only**: they raised `TypeError: Multiple namespaces` on an unforced mixed track and `RuntimeError: Can't call numpy() on Tensor that requires grad` under a gradient. This closes that.

### The chain was five links, not two

The task said two functions. Measuring it showed five — and the `*_jac` helpers were *not* among them: they carry no `@scalarDecorator` at all (migrated in #1233), so they were already agnostic. The promoters were the `@scalarDecorator`-wrapped links missing the marker:

| link | what blocked the backend |
|---|---|
| `galcenrect_to_XYZ` | rotation built by `numpy.einsum` over a `numpy.array` of lists |
| `galcenrect_to_vxvyvz` | same, copy-pasted |
| `XYZ_to_lbd` | masked in-place add `l[l<0] += 2pi`; `numpy.empty` + column assignment |
| `vxvyvz_to_vrpmllpmbb` | `(3,3,N)` built by element assignment; two in-place row divisions |
| `pmllpmbb_to_pmrapmdec` | final rotation via `numpy.array`; in-place normalisation |

The rotations depend only on `Xsun`/`Zsun` — configuration, never traced data — so they stay numpy constants and are compile-time constants under a trace. Only the data vector needs the backend. `_galcen_rot` / `_apply_galcen_rot` are hoisted out of the copy-pasted pair.

**Every numpy branch is kept verbatim under `if xp is numpy:`**, so byte-identity is structural rather than argued.

### A decorator-order bug made three commits inert

`scalarDecorator` reads the marker off the function it wraps, so `@backendNative` must be **innermost**, directly above `def`. I had it outermost, which marks the wrapper — the migrations changed nothing. Every byte-identity check passed *because the backend path was never taken*. `lb_to_radec` (#1234) had the correct order in the same file the whole time.

### Verification

| gate | result |
|---|---|
| numpy byte-identity | **28 cases, worst \|diff\| = 0.000e+00** (scalar/array inputs, both `_extra_rot`, scalar **and array** `Xsun`/`Zsun` — the einsum's two branches — plus the `galcencyl_*` siblings) |
| `test_orbit.py` numpy | 577 passed, 4 skipped |
| `test_coords.py` + `test_streamTrack.py` numpy | 143 passed |
| `test_quantity.py` numpy | 244 passed |
| `test_streamTrack.py` torch | 45/45 |

Acceptance criteria named in #1235, both now met:

```
unforced sky     TypeError  ->  backend array, 5.6e-15 vs numpy
unforced galsky  TypeError  ->  backend array, 2.5e-15 vs numpy
gradient sky     RuntimeError -> AD vs central FD  6.8e-10
gradient galsky  RuntimeError -> AD vs central FD  2.1e-11
```

### The new test asserts types, and was verified by flip

`test_backend_coords.py` gains 20 cases (5 links x 2 backends x 2 shapes) asserting the **return type**, because byte-identity cannot distinguish a working migration from one that does nothing.

It took three attempts to become real — the first two passed *with the bug reintroduced*:
* **Forcing hides it.** Under `use(..., force=True)` the functions recover without the marker: `get_namespace` reports caller intent, so the body takes its backend branch and `promote_scalars` re-coerces.
* **Array inputs hide it.** `scalarDecorator` only rewrites arguments when they are 0-d, so with arrays the marker is never consulted. streamTrack calls these per-`tp` with scalars, which is where it broke.

Verified by flip: restoring the bad order fails 2 of 20 with `dropped back to numpy (scalar, unforced)`.

### Not in scope

`vxvyvz_to_vrpmllpmbb` and its inverse `vrpmllpmbb_to_vxvyvz` share an identical `(3,3,N)` build — a second copy-pasted pair the audit surfaced. Left alone: the inverse is not in the sky chain. `radec_to_lb` and `vrpmllpmbb_to_vxvyvz` retain unguarded in-place ops, which is correct — they are not `@backendNative`, so no backend array can reach them.