### PR TITLE
backend/interpolate: make eval_ppoly's coefficient reads survive vmap(grad)

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -101,7 +101,11 @@ def _take0(xp, a, idx):
         # (interpSphericalPotential._revaluate) depend on the scalar.
         return a[idx]
     flat = xp.reshape(idx, (-1,))
-    out = xp.take(a, flat, axis=0)
+    # xp may be the RAW torch module (not array-api-compat's), whose take() has
+    # no axis kwarg; and jax/numpy have no index_select. Prefer whichever the
+    # namespace actually provides -- both mean "gather along axis 0".
+    sel = getattr(xp, "index_select", None)
+    out = sel(a, 0, flat) if sel is not None else xp.take(a, flat, axis=0)
     return xp.reshape(out, tuple(idx.shape) + tuple(a.shape[1:]))
 
 

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -87,6 +87,24 @@ def spline_to_ppoly(spl):
     return numpy.append(ppoly.x[:-1][keep], ppoly.x[-1]), ppoly.c[:, keep]
 
 
+def _take0(xp, a, idx):
+    """``a[idx]`` along axis 0, written so torch survives ``vmap(grad(...))``.
+
+    Plain ``a[idx]`` with a *computed* index is fine under vmap alone and under
+    grad alone, but raises inside the composition that autodiff.py builds for
+    the fE chain. ``take`` is batched correctly; the reshape carries 0-d ``idx``
+    (one scalar per vmap element) through, since ``take`` wants a 1-D index.
+    """
+    if xp is numpy:
+        # numpy stays on the original expression: take() on a 0-d index returns
+        # a 0-d ARRAY where a[idx] returns a numpy SCALAR, and callers here
+        # (interpSphericalPotential._revaluate) depend on the scalar.
+        return a[idx]
+    flat = xp.reshape(idx, (-1,))
+    out = xp.take(a, flat, axis=0)
+    return xp.reshape(out, tuple(idx.shape) + tuple(a.shape[1:]))
+
+
 def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
     """Evaluate a piecewise polynomial in the power basis at ``r``.
 
@@ -136,7 +154,7 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         # division/log), so this stays AD-friendly.
         r = xp.clip(r, xb[0], xb[-1])
     idx = xp.clip(xp.searchsorted(xb, r, side="right") - 1, 0, cb.shape[1] - 1)
-    dr = r - xb[idx]
+    dr = r - _take0(xp, xb, idx)
     if cb.ndim == 3:
         # Batched coefficients (4, n-1, m): m independent splines on the SAME grid
         # (see cubic_spline_coeffs with 2-D y). cb[j, idx] carries the trailing m
@@ -144,13 +162,13 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         dr = dr[..., None]
     k = cb.shape[0] - 1  # polynomial degree
     if nu == 0:
-        out = cb[0, idx]
+        out = _take0(xp, cb[0], idx)
         for j in range(1, cb.shape[0]):
-            out = out * dr + cb[j, idx]
+            out = out * dr + _take0(xp, cb[j], idx)
         return out
     if nu > k:
         # derivative past the degree is identically zero (broadcast over r)
-        return cb[0, idx] * 0.0
+        return _take0(xp, cb[0], idx) * 0.0
     # Analytic nu-th derivative of sum_j c[j]*(dr)**(k-j): the term of original
     # power p=k-j survives with the falling-factorial factor p*(p-1)*...*(p-nu+1)
     # and reduced power p-nu. Horner over the surviving (descending-power) terms.
@@ -160,7 +178,7 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         fall = 1.0
         for m in range(nu):
             fall *= p - m
-        term = cb[j, idx] * fall
+        term = _take0(xp, cb[j], idx) * fall
         out = term if out is None else out * dr + term
     return out
 

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1115,3 +1115,30 @@ def test_spline2d_mode2_numpy_query(backend):
     Yg = numpy.array([-0.5, 0.3, 1.2, 1.8])
     got_g = s2(Xg, Yg, grid=True)
     numpy.testing.assert_allclose(got_g, spl(Xg, Yg, grid=True), rtol=1e-11, atol=1e-12)
+
+
+def test_eval_ppoly_survives_vmap_of_grad_torch():
+    # eval_ppoly reads its coefficients at a COMPUTED index (from searchsorted).
+    # Plain `a[idx]` is fine under torch's vmap alone and under grad alone, but
+    # raises inside the composition vmap(grad(...)) -- which is exactly what
+    # galpy/backend/autodiff.py builds for the fE chain. Hence the take()-based
+    # _take0. Guard the composition itself, not either layer.
+    torch = pytest.importorskip("torch")
+    import array_api_compat.torch as xp
+
+    from galpy.backend.interpolate import cubic_spline_coeffs, eval_ppoly
+
+    x = torch.linspace(0.5, 4.0, 24, dtype=torch.float64)
+    y = torch.sin(x) + 0.3 * x**2
+    c = cubic_spline_coeffs(xp, x, y)
+
+    def f(r):
+        return eval_ppoly(xp, x, c, r.reshape(())).reshape(())
+
+    rs = torch.tensor([0.8, 1.7, 2.9, 3.6], dtype=torch.float64)
+    got = torch.vmap(torch.func.grad(f))(rs)
+    # Compare against the analytic derivative of the same spline (nu=1), which
+    # eval_ppoly computes on a separate code path -- so this is a real value
+    # check, not just "it did not raise".
+    ref = eval_ppoly(xp, x, c, rs, nu=1)
+    numpy.testing.assert_allclose(as_numpy(got), as_numpy(ref), rtol=1e-11, atol=1e-13)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1142,3 +1142,23 @@ def test_eval_ppoly_survives_vmap_of_grad_torch():
     # check, not just "it did not raise".
     ref = eval_ppoly(xp, x, c, rs, nu=1)
     numpy.testing.assert_allclose(as_numpy(got), as_numpy(ref), rtol=1e-11, atol=1e-13)
+
+
+@pytest.mark.parametrize("nu", [0, 1, 2, 3, 5])
+def test_eval_ppoly_derivative_orders_match_scipy_numpy(nu):
+    # Covers eval_ppoly's three coefficient-read paths on NUMPY: the nu==0
+    # Horner loop, the nu>k identically-zero shortcut (k==3 here, so nu==5
+    # exercises it), and the analytic falling-factorial branch for 0<nu<=k.
+    # scipy's PPoly.derivative is the independent reference -- these are value
+    # checks, not "did not raise".
+    from galpy.backend.interpolate import eval_ppoly
+
+    x = numpy.linspace(0.5, 4.0, 24)
+    y = numpy.sin(x) + 0.3 * x**2
+    spl = si.CubicSpline(x, y, bc_type="natural")
+    pp = si.PPoly(spl.c, spl.x)
+    c = cubic_spline_coeffs(numpy, x, y)
+    r = numpy.array([0.7, 1.3, 2.2, 3.1, 3.9])
+    got = eval_ppoly(numpy, x, c, r, nu=nu)
+    ref = numpy.zeros_like(r) if nu > 3 else pp.derivative(nu)(r) if nu else pp(r)
+    numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-12)


### PR DESCRIPTION
## The bug

`eval_ppoly` reads knots/coefficients at a **computed** index (from `searchsorted`) — `xb[idx]`, `cb[j, idx]`. Under torch that raises the generic

```
RuntimeError: vmap: It looks like you're either (1) calling .item() on a Tensor or (2) ...
```

The message names three causes and **the real one is none of them** — there is no `.item()` anywhere in galpy source. Measured, the construct is fine under plain `vmap` *and* under `grad` alone. It fails only under the **composition** `vmap(grad(f))`, which is exactly what `galpy/backend/autodiff.py` builds for the fE chain:

| construct (under `vmap(grad(...))`) | result |
|---|---|
| `searchsorted` alone | OK |
| index with a **constant** index | OK |
| index with a **computed** index | **FAIL** |
| `take(xb, idx)` | OK |
| `index_select(xb, 0, idx)` | OK |

So the 5 tensor-index reads now go through a local `_take0()` built on `xp.take`.

## numpy is deliberately left alone

`take()` with a 0-d index returns a 0-d **array** where `a[idx]` returns a numpy **scalar**, and `interpSphericalPotential._revaluate` depends on the scalar — converting it made that path raise `Concatenation operation is not implemented for NumPy arrays`. So the numpy branch is `a[idx]` verbatim: **byte-identical by construction**, not by measurement.

## Effect

- Burns down `test_constantbeta_interpolatedpotentials_dens_directint` (torch).
- The sibling `..._beta` now fails **later and for a different reason** (a torch-built `_Phimax` meeting numpy `r` in `_revaluate`) — a distinct bug, left ledgered rather than papered over.
- More broadly this unblocks vmapped use of interpolated potentials, which matters for GPU batching beyond these two entries.

## Verification

- New `test_eval_ppoly_survives_vmap_of_grad_torch` compares the `vmap(grad)` result against `eval_ppoly`'s **separate `nu=1` analytic-derivative path** at rtol 1e-11 — a real value check, not "it did not raise".
- **Flip-verified by reverting only the source file** (the first attempt stashed the test too and was inconclusive).
- numpy: 8 passed on the interpolate consumers, no regression.

Note for the audit checklist: the failing construct is a data-dependent **index**, a cousin of the data-dependent **branch** we grep for — and invisible to that grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH