### PR TITLE
tests/interp_potential: backend-aware bound for the traced use_c grid compare

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -224,43 +224,6 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
 # with e=5.4e-6 against a 1e-8 tolerance. Passes eager jax. Un-ledger if the
 # tolerance is ever made backend-aware.
 jax-jit tests/test_orbit.py::test_eccentricity
-# tests/test_interp_potential.py, 2026-07-29: found by running this file traced
-# for the first time. Both PASS eager and fail only under --jit, and both compare
-# an interpRZPotential grid built with use_c=True against the same grid built in
-# Python, to 1e-14. Traced, that Python-side construction loses one to two digits:
-#
-#             pot grid   rforce grid   (bar 1e-14)
-#   eager     2.665e-15    1.776e-15
-#   jax --jit 5.596e-14    6.621e-13
-#
-# So this is NUMERICAL over-tolerance, not a wrong result -- the traced grid is
-# still right to ~1e-13.
-#
-# Root cause, localised: of MWPotential's three components only NFW moves
-# (MiyamotoNagai 3.5e-16, Hernquist 5.8e-16, NFW 1.1e-14), and its jax EAGER
-# value is BIT-IDENTICAL to numpy while its jitted value differs -- reproducibly,
-# same answer every run. So XLA compiles NFW's log1p(r/a)/(r/a) differently from
-# how it evaluates it eagerly, which is exactly the cancellation-prone shape for
-# that to show. A jit-mode numerical characteristic, not a galpy defect: nothing
-# to fix in the potential. Recorded rather than papered over, because the only
-# real remedy is a backend-aware tolerance and loosening one needs Jo's sign-off.
-jax-jit tests/test_interp_potential.py::test_interpolation_potential_use_c
-jax-jit tests/test_interp_potential.py::test_interpolation_potential_force_use_c
-# torch-jit, 2026-07-29: the FIRST torch-jit entries. Until now torch.compile
-# never reached the traced quadrature at all -- `_quad_needs_backend` used a
-# concreteness probe, and dynamo makes float(x) symbolic, so torch silently took
-# the scipy branch (and could return a wrong number: AnyAxisym surfdens came back
-# 2.2e-15 instead of 0.0662, order-dependently). With the gate on `under_trace`,
-# torch now takes the same GL path as jax.
-#
-# The remaining AnyAxisymmetricRazorThinDisk entries are NOT the scalar-only
-# decorator (DoubleExponentialDisk had the same symptom and was fixed by making
-# its Ogata evaluation broadcast over the node axis). They are the razor-thin
-# sheet: its traced GL integrand is exact to 1.6e-12 at |z|=1e-2 but degrades to
-# 6e-2 at 1e-3, 17x at 1e-4 and 2e4x at 1e-5, and the Poisson quadrature clusters
-# its nodes at z=0 precisely there. Opening the array gate for this potential
-# would convert a loud TypeError into a silently wrong ~0, so it stays shut until
-# the a=R principal value is resolved; same root cause as test_2ndDeriv below.
 torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/test_interp_potential.py
+++ b/tests/test_interp_potential.py
@@ -1,7 +1,28 @@
 import numpy
 
 from galpy import potential
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, jit_mode
+
+# The use_c=True/use_c=False grid comparisons below hold to a few ulp eagerly but
+# lose one to two digits under --jit, where the Python side is built traced:
+#
+#             pot grid   rforce grid   (eager bar 1e-14 / 1e-13)
+#   eager     2.665e-15    1.776e-15
+#   jax --jit 5.596e-14    6.621e-13
+#
+# Localised: of MWPotential's three components only NFW moves (MiyamotoNagai
+# 3.5e-16, Hernquist 5.8e-16, NFW 1.1e-14), and its jax EAGER value is
+# bit-identical to numpy while its jitted value differs, reproducibly. XLA
+# compiles NFW's log1p(r/a)/(r/a) differently from how it evaluates it eagerly --
+# exactly the cancellation-prone shape for that to show. A jit-mode numerical
+# characteristic, not a galpy defect, so the traced comparison gets a wider bound
+# (~5x headroom over what was measured); eager/numpy bounds are unchanged.
+_TRACED_GRID_TOL_FACTOR = 30.0
+
+
+def _grid_tol(eager_tol):
+    """``eager_tol``, widened only when the suite is running traced."""
+    return eager_tol * _TRACED_GRID_TOL_FACTOR if jit_mode() != "off" else eager_tol
 
 
 def test_errors():
@@ -432,8 +453,10 @@ def test_interpolation_potential_use_c():
         zsym=True,
         use_c=True,
     )
-    assert numpy.all(numpy.fabs(rzpot._potGrid - rzpot_c._potGrid) < 10.0**-14.0), (
-        "Potential interpolation grid calculated with use_c does not agree with that calculated in python"
+    assert numpy.all(
+        numpy.fabs(rzpot._potGrid - rzpot_c._potGrid) < _grid_tol(10.0**-14.0)
+    ), (
+        f"Potential interpolation grid calculated with use_c does not agree with that calculated in python, max diff = {numpy.amax(numpy.fabs(rzpot._potGrid - rzpot_c._potGrid))}"
     )
     return None
 
@@ -1063,12 +1086,12 @@ def test_interpolation_potential_force_use_c():
         use_c=True,
     )
     assert numpy.all(
-        numpy.fabs(rzpot._rforceGrid - rzpot_c._rforceGrid) < 10.0**-13.0
+        numpy.fabs(rzpot._rforceGrid - rzpot_c._rforceGrid) < _grid_tol(10.0**-13.0)
     ), (
         f"Potential interpolation grid of Rforce  calculated with use_c does not agree with that calculated in python, max diff = {numpy.amax(numpy.fabs(rzpot._rforceGrid - rzpot_c._rforceGrid))}"
     )
     assert numpy.all(
-        numpy.fabs(rzpot._zforceGrid - rzpot_c._zforceGrid) < 10.0**-13.0
+        numpy.fabs(rzpot._zforceGrid - rzpot_c._zforceGrid) < _grid_tol(10.0**-13.0)
     ), (
         f"Potential interpolation grid of zforce  calculated with use_c does not agree with that calculated in python, max diff = {numpy.amax(numpy.fabs(rzpot._zforceGrid - rzpot_c._zforceGrid))}"
     )


### PR DESCRIPTION
Clears the two `jax-jit` `test_interp_potential` ledger entries. **Ledger 44 → 42; jax-jit 5 → 3.**

## What

The two `use_c=True` vs `use_c=False` grid comparisons hold to a few ulp eagerly but lose one to two digits under `--jit`:

|            | pot grid  | rforce grid | (eager bar 1e-14 / 1e-13) |
|------------|-----------|-------------|---------------------------|
| eager      | 2.665e-15 | 1.776e-15   | |
| jax `--jit`| 5.596e-14 | 6.621e-13   | |

Numerical over-tolerance, not a wrong result. The ledger entry had already localised it: of `MWPotential`'s three components only NFW moves, and its jax **eager** value is bit-identical to numpy while its jitted value differs, reproducibly. XLA compiles NFW's `log1p(r/a)/(r/a)` differently from how it evaluates it eagerly — exactly the cancellation-prone shape for that to show. A jit-mode numerical characteristic, not a galpy defect.

So the comparison gets a bound that widens **only** when `jit_mode()` is on (30×, ~5× headroom over the measured maxima). The eager/numpy bounds are byte-for-byte unchanged. The potential-grid assertion now also reports its max diff, which the force one already did — that number is invisible otherwise, since numpy truncates the printed array.

## Verification

- passes traced;
- **fails traced with the factor set to 1.0**, so the widening is what carries it, not something else;
- numpy and jax-eager still pass on the untouched tight bound.

## Note on the tolerance call

The removed ledger comment ended "the only real remedy is a backend-aware tolerance and loosening one needs Jo's sign-off." That sign-off was given for this category — B, traced-only, kept stringent. 5.6×/6.6× is minor, and since the eager path is untouched this is trivially reversible if you'd rather it went the other way.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016sKbf5DRnKirtgFivwBWBH