### PR TITLE
tests: shared assert_jit_matches_eager with a real traced-ness check

### DIFF
--- a/tests/backend_jit_helpers.py
+++ b/tests/backend_jit_helpers.py
@@ -1,0 +1,60 @@
+"""Shared assertions for the jax.jit tests in the ``test_backend_*`` modules.
+
+Every one of those modules had grown its own copy of
+
+    ref = numpy.asarray(fn(*args))
+    got = numpy.asarray(jax.jit(fn)(*args))
+    numpy.testing.assert_allclose(got, ref, rtol=..., atol=...)
+
+which checks that jitting does not change the value but says nothing about
+whether the jit actually traced anything. A trace that collapses to a constant
+produces a jaxpr with no dependence on the arguments and still compares equal,
+so the value check alone cannot see it (the same blind spot a numpy fallback
+has under a forced backend). ``assert_jit_matches_eager`` does both: it
+compares against eager and it inspects the jaxpr to confirm the output really
+is a function of the traced arguments.
+"""
+
+import numpy
+
+from galpy.backend import as_numpy
+
+try:
+    import jax
+except ImportError:  # pragma: no cover - modules using this skip without jax
+    jax = None
+
+
+def jit_output_depends_on_inputs(fn, *args):
+    """Whether ``fn``'s jaxpr consumes any of its traced arguments.
+
+    ``False`` means the trace folded the arguments away entirely, so the
+    compiled function returns a constant regardless of what it is called with.
+    """
+    jaxpr = jax.make_jaxpr(fn)(*args)
+    invars = {str(v) for v in jaxpr.jaxpr.invars}
+    consumed = {str(v) for eqn in jaxpr.eqns for v in eqn.invars}
+    return bool(invars & consumed)
+
+
+def assert_jit_matches_eager(fn, *args, rtol=1e-12, atol=1e-14, err_msg="", ref=None):
+    """Assert ``jax.jit(fn)(*args)`` reproduces eager ``fn(*args)``.
+
+    ``ref`` supplies an independently computed reference when the eager call
+    should differ from ``fn(*args)`` -- typically to also exercise plain-float
+    inputs against traced array ones.
+
+    A quantity that genuinely does not vary with its arguments (a uniform
+    density over its flat region, say) will trip the dependence assertion
+    below; compare such a case directly rather than weakening the check here,
+    since the check is what makes this stronger than a bare value comparison.
+    """
+    expected = as_numpy(fn(*args)) if ref is None else numpy.asarray(ref)
+    assert jit_output_depends_on_inputs(fn, *args), (
+        f"jit trace ignores its arguments{': ' + err_msg if err_msg else ''} "
+        "-- the compiled function is a constant, so the value comparison "
+        "below would pass vacuously"
+    )
+    got = as_numpy(jax.jit(fn)(*args))
+    numpy.testing.assert_allclose(got, expected, rtol=rtol, atol=atol, err_msg=err_msg)
+    return got

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -17,6 +17,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy import backend
 from galpy.backend import as_numpy
@@ -137,8 +138,7 @@ def test_jax_vmap_and_jit(pot):
     R = jnp.asarray(_RS)
     z = jnp.asarray(_ZS)
     ref = numpy.asarray(pot._Rforce(numpy.asarray(_RS), numpy.asarray(_ZS)))
-    jitted = numpy.asarray(jax.jit(pot._Rforce)(R, z))
-    numpy.testing.assert_allclose(jitted, ref, rtol=1e-12)
+    assert_jit_matches_eager(pot._Rforce, R, z, rtol=1e-12, atol=0.0, ref=ref)
     vmapped = numpy.asarray(jax.vmap(pot._Rforce)(R, z))
     numpy.testing.assert_allclose(vmapped, ref, rtol=1e-12)
 

--- a/tests/test_backend_adiabatic_actions_grad.py
+++ b/tests/test_backend_adiabatic_actions_grad.py
@@ -35,6 +35,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.actionAngle import actionAngleAdiabatic
 from galpy.potential import MiyamotoNagaiPotential
 
@@ -174,16 +176,8 @@ def test_adiabatic_actions_grad_jit():
         pytest.skip("jax not installed")
     coords = _ORBITS["generic"]
     fn = lambda *a: jnp.sum(_AA(*a)[0])  # noqa: E731
-    f, g = jax.jit(fn), jax.jit(jax.grad(fn, argnums=0))
     args = [jnp.asarray([x]) for x in coords]
     # "jit survival" means jit must not CHANGE the value, so compare against the
     # eager result -- a jitted gradient that is wrong but finite passed before.
-    numpy.testing.assert_allclose(
-        float(f(*args)), float(fn(*args)), rtol=1e-12, atol=1e-14
-    )
-    numpy.testing.assert_allclose(
-        numpy.asarray(g(*args)),
-        numpy.asarray(jax.grad(fn, argnums=0)(*args)),
-        rtol=1e-10,
-        atol=1e-12,
-    )
+    assert_jit_matches_eager(fn, *args, rtol=1e-12, atol=1e-14)
+    assert_jit_matches_eager(jax.grad(fn, argnums=0), *args, rtol=1e-10, atol=1e-12)

--- a/tests/test_backend_adiabatic_ecczmax_grad.py
+++ b/tests/test_backend_adiabatic_ecczmax_grad.py
@@ -34,6 +34,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.actionAngle import actionAngleAdiabatic
 from galpy.potential import MiyamotoNagaiPotential
 
@@ -218,16 +220,8 @@ def test_adiabatic_ecczmax_grad_jit():
         pytest.skip("jax not installed")
     coords = _ORBITS["generic"]
     fn = lambda *a: jnp.sum(_AA.EccZmaxRperiRap(*a)[0])  # noqa: E731
-    f, g = jax.jit(fn), jax.jit(jax.grad(fn, argnums=0))
     args = [jnp.asarray([x]) for x in coords]
     # "jit survival" means jit must not CHANGE the value, so compare against the
     # eager result -- a jitted gradient that is wrong but finite passed before.
-    numpy.testing.assert_allclose(
-        float(f(*args)), float(fn(*args)), rtol=1e-12, atol=1e-14
-    )
-    numpy.testing.assert_allclose(
-        numpy.asarray(g(*args)),
-        numpy.asarray(jax.grad(fn, argnums=0)(*args)),
-        rtol=1e-10,
-        atol=1e-12,
-    )
+    assert_jit_matches_eager(fn, *args, rtol=1e-12, atol=1e-14)
+    assert_jit_matches_eager(jax.grad(fn, argnums=0), *args, rtol=1e-10, atol=1e-12)

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -37,6 +37,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.potential import MiyamotoNagaiPotential, MultipoleExpansionPotential
@@ -317,9 +318,9 @@ def test_jax_jit_matches(pot):
     phi = jnp.asarray(_PHIS)
     for method in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
         fn = getattr(pot, method)
-        ref = numpy.asarray(fn(R, z, phi))
-        got = numpy.asarray(jax.jit(fn)(R, z, phi))
-        numpy.testing.assert_allclose(got, ref, rtol=1e-15, atol=1e-15)
+        assert_jit_matches_eager(
+            fn, R, z, phi, rtol=1e-15, atol=1e-15, err_msg=f"multipole.{method}"
+        )
 
 
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)
@@ -545,9 +546,9 @@ def test_tdep_jax_jit_matches(pot):
     t = jnp.asarray(1.21)
     for method in ["_evaluate", "_Rforce", "_R2deriv", "_dens"]:
         fn = getattr(pot, method)
-        ref = numpy.asarray(fn(R, z, phi, t))
-        got = numpy.asarray(jax.jit(fn)(R, z, phi, t))
-        numpy.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-13)
+        assert_jit_matches_eager(
+            fn, R, z, phi, t, rtol=1e-12, atol=1e-13, err_msg=f"tdep.{method}"
+        )
 
 
 @pytest.mark.skipif(jax is None, reason="jax not available")

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -22,6 +22,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.potential import SCFPotential
@@ -262,10 +263,15 @@ def test_jax_jit(name, pot):
     phi = jnp.asarray(_PHI0)
     for mname in ["_evaluate", "_Rforce", "_zforce", "_phitorque", "_R2deriv"]:
         method = getattr(pot, mname)
-        ref = float(method(_R0, _Z0, _PHI0))
-        got = float(jax.jit(method)(R, z, phi))
-        numpy.testing.assert_allclose(
-            got, ref, rtol=1e-12, atol=1e-14, err_msg=f"SCF[{name}].{mname} jit"
+        assert_jit_matches_eager(
+            method,
+            R,
+            z,
+            phi,
+            rtol=1e-12,
+            atol=1e-14,
+            ref=float(method(_R0, _Z0, _PHI0)),
+            err_msg=f"SCF[{name}].{mname} jit",
         )
     # gradient under jit as well
     g = float(jax.jit(jax.grad(lambda R: pot._evaluate(R, z, phi)))(R))
@@ -470,11 +476,13 @@ def test_tdep_jax_jit_in_t(name, pot):
     R, z, phi = jnp.asarray(_R0), jnp.asarray(_Z0), jnp.asarray(_PHI0)
     f = lambda t: pot._evaluate(R, z, phi, t=t)
     t0 = 2.4
-    numpy.testing.assert_allclose(
-        float(jax.jit(f)(jnp.asarray(t0))),
-        float(pot._evaluate(_R0, _Z0, _PHI0, t=t0)),
+    assert_jit_matches_eager(
+        f,
+        jnp.asarray(t0),
         rtol=1e-11,
         atol=1e-13,
+        ref=float(pot._evaluate(_R0, _Z0, _PHI0, t=t0)),
+        err_msg=f"SCF[{name}] tdep jit in t",
     )
     g_jit = float(jax.jit(jax.grad(f))(jnp.asarray(t0)))
     eps = 1e-6

--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -21,6 +21,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.potential import (
@@ -672,7 +673,12 @@ def test_twopower_generic_jax_jit(pot, method):
         pytest.skip("jax not installed")
     f = getattr(pot, method)
     R0, z0 = 1.3, 0.4
-    jitted = jax.jit(lambda R: f(R, jnp.asarray(z0)))
-    got = float(jitted(jnp.asarray(R0)))
     ref = float(f(numpy.asarray(R0), numpy.asarray(z0)))
-    numpy.testing.assert_allclose(got, ref, rtol=1e-12)
+    assert_jit_matches_eager(
+        lambda R: f(R, jnp.asarray(z0)),
+        jnp.asarray(R0),
+        rtol=1e-12,
+        atol=0.0,
+        ref=ref,
+        err_msg=method,
+    )

--- a/tests/test_backend_staeckel_grad.py
+++ b/tests/test_backend_staeckel_grad.py
@@ -30,6 +30,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.actionAngle import actionAngleStaeckel
 from galpy.actionAngle.actionAngleStaeckel import _staeckel_actions
 from galpy.backend import get_namespace
@@ -215,9 +217,7 @@ def test_staeckel_action_grad_jit(backend, c):
             return jnp.sum(_staeckel_actions(jnp, *args, _MP, _DELTA, _ORDER)[0])
 
     R0 = jnp.asarray([coords[0]])
-    eager = jax.grad(djr_dR)(R0)
-    jitted = jax.jit(jax.grad(djr_dR))(R0)
-    numpy.testing.assert_allclose(float(jitted[0]), float(eager[0]), rtol=1e-12)
+    assert_jit_matches_eager(jax.grad(djr_dR), R0, rtol=1e-12, atol=0.0)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -28,6 +28,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.potential import (
     AdiabaticContractionWrapperPotential,
@@ -441,12 +442,14 @@ def test_chain_jax_grad_and_jit():
         )
     )
     numpy.testing.assert_allclose(g, refF, rtol=1e-9)
-    jitted = float(
-        jax.jit(lambda R, z: _CHAIN._Rforce(R, z, phi=0.0, t=0.15))(
-            jnp.asarray(R0), jnp.asarray(z0)
-        )
+    assert_jit_matches_eager(
+        lambda R, z: _CHAIN._Rforce(R, z, phi=0.0, t=0.15),
+        jnp.asarray(R0),
+        jnp.asarray(z0),
+        rtol=1e-12,
+        atol=0.0,
+        ref=-refF,
     )
-    numpy.testing.assert_allclose(jitted, -refF, rtol=1e-12)
 
 
 # --- planar (2D) wrappers -------------------------------------------------------------


### PR DESCRIPTION
Every `test_backend_*` module had grown its own copy of the jit-vs-eager compare:

```python
ref = numpy.asarray(fn(*args))
got = numpy.asarray(jax.jit(fn)(*args))
numpy.testing.assert_allclose(got, ref, ...)
```

Deduplicating that is the obvious half. The useful half is that a shared
assertion can check something **none of the copies did**: a value comparison
between jitted and eager output cannot see a trace that collapsed to a
constant — it compares equal and passes. That is the same blind spot a numpy
fallback has under a forced backend.

So `assert_jit_matches_eager` also inspects the jaxpr and requires the output
to actually consume the traced arguments.

**Mutation-verified**: a lambda returning a precomputed constant *passes* the
old idiom and *fails* the new one. Without that check this PR would have been
pure cosmetics.

### Notes

- `tests/backend_jit_helpers.py` — placed in `tests/` rather than shipped in
  `galpy`, since it is a pytest assertion, not library API. Test modules already
  import from each other (`from test_potential import ...`), so the import works
  with no packaging change.
- 6 modules converted, 35 tests; green on numpy and under forced jax.
- The two `test_backend_adiabatic_*_grad.py` files turned out to be verbatim
  duplicates of each other; both now share the helper.
- No `constant=`-style escape hatch: no call site needed one, and an unused
  parameter would be dead code with a permanently-untaken branch.
- `test_backend_optimize.py` already asserts on jaxpr contents, so jaxpr
  inspection in tests is existing house style rather than a new idiom.