### PR TITLE
scipy 1.18 splines: shared pickle mixin + SCF, streamgapdf, time-dependent Multipole

### DIFF
--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -25,6 +25,7 @@ from ..orbit import Orbit
 from ..potential import MovingObjectPotential, PlummerPotential, evaluateRforces
 from ..potential.Potential import _check_potential_list_and_deprecate
 from ..util import _rotate_to_arbitrary_vector, conversion, coords, galpyWarning, multi
+from ..util._pickle import SplinePickleMixin
 from ..util.conversion import physical_conversion
 from . import streamdf
 from .df import df
@@ -57,8 +58,14 @@ def impact_check_range(func):
     return impact_wrapper
 
 
-class streamgapdf(streamdf.streamdf):
+class streamgapdf(streamdf.streamdf, SplinePickleMixin):
     """The DF of a gap in a tidal stream"""
+
+    # Measured under scipy 1.18: this is the ONLY unpicklable attribute on a
+    # built streamgapdf. The numpy/scipy kick path stores a real PPoly here;
+    # the backend path stores a plain SimpleNamespace, which packs through
+    # untouched, so one declaration covers both.
+    _PICKLE_SPLINE_ATTRS = ("_kick_interpdOpar_poly",)
 
     def __init__(self, *args, **kwargs):
         """

--- a/galpy/potential/MultipoleExpansionPotential.py
+++ b/galpy/potential/MultipoleExpansionPotential.py
@@ -29,6 +29,7 @@ from ..backend._namespaces import untraceable_setup
 from ..backend.special import assoc_legendre
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
+from ..util._pickle import SplinePickleMixin
 from ..util.special import compute_legendre, sph_harm_normalization
 from .Potential import Potential
 from .SphericalHarmonicPotentialMixin import SphericalHarmonicPotentialMixin
@@ -52,35 +53,9 @@ if _types.ModuleType not in _copy._deepcopy_dispatch:  # pragma: no branch
     _copy._deepcopy_dispatch[_types.ModuleType] = lambda module, memo: module
 
 
-# scipy 1.18 caches the array namespace -- a MODULE -- on PPoly/BPoly instances
-# (`_xp`), so any object holding one raises "cannot pickle 'module' object". The
-# coefficients themselves pickle fine, so drop the scipy object on the way out and
-# rebuild it through the public constructor on the way back in; that round-trips
-# bit-identically. Stripping `_xp` alone does NOT work -- scipy never recreates it
-# and the restored spline then raises AttributeError when evaluated.
-_SPLINE_SURROGATE = "__galpy_spline__"
-
-
-def _pack_splines(obj):
-    """Replace scipy piecewise-polynomials in a nested list with plain tuples."""
-    if isinstance(obj, (PPoly, BPoly)):
-        return (_SPLINE_SURROGATE, type(obj), obj.c, obj.x, obj.extrapolate, obj.axis)
-    if isinstance(obj, list):
-        return [_pack_splines(v) for v in obj]
-    return obj
-
-
-def _unpack_splines(obj):
-    """Inverse of _pack_splines."""
-    if isinstance(obj, tuple) and len(obj) == 6 and obj[0] == _SPLINE_SURROGATE:
-        _, cls, c, x, extrapolate, axis = obj
-        return cls(c, x, extrapolate=extrapolate, axis=axis)
-    if isinstance(obj, list):
-        return [_unpack_splines(v) for v in obj]
-    return obj
-
-
-class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
+class MultipoleExpansionPotential(
+    Potential, SphericalHarmonicPotentialMixin, SplinePickleMixin
+):
     r"""Class that implements a gravitational potential computed via multipole expansion of an arbitrary density distribution.
 
     This class decomposes a user-supplied density function into real spherical harmonics on a radial grid,
@@ -137,30 +112,24 @@ class MultipoleExpansionPotential(Potential, SphericalHarmonicPotentialMixin):
     second derivatives at arbitrary times within the ``tgrid`` range during orbit integration.
     """
 
-    # Attributes holding scipy piecewise-polynomials. The _sin pair exists only
-    # for a non-axisymmetric density, so both cases must be covered -- an
-    # axisymmetric-only check finds half the set.
+    # Attributes holding scipy piecewise-polynomials. The _sin set exists only
+    # for a non-axisymmetric density, and the *_interp set only for a
+    # time-dependent one, so all four combinations must be listed -- checking a
+    # single configuration finds a fraction of the set. (Measured: a
+    # time-dependent expansion has NO _I_inner_cos at all, only
+    # _I_inner_cos_interp, so the static names alone cover none of it.)
     _PICKLE_SPLINE_ATTRS = (
         "_I_inner_cos",
         "_I_inner_sin",
         "_I_outer_cos",
         "_I_outer_sin",
+        "_I_inner_cos_interp",
+        "_I_inner_sin_interp",
+        "_I_outer_cos_interp",
+        "_I_outer_sin_interp",
+        "_rho_cos_interp",
+        "_rho_sin_interp",
     )
-
-    # Pickling functions (see _pack_splines)
-    def __getstate__(self):
-        pdict = _copy.copy(self.__dict__)
-        for name in self._PICKLE_SPLINE_ATTRS:
-            if name in pdict:
-                pdict[name] = _pack_splines(pdict[name])
-        return pdict
-
-    def __setstate__(self, pdict):
-        self.__dict__ = pdict
-        for name in self._PICKLE_SPLINE_ATTRS:
-            if name in self.__dict__:
-                setattr(self, name, _unpack_splines(self.__dict__[name]))
-        return None
 
     def __init__(
         self,

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -28,6 +28,7 @@ from ..backend import use as _use_backend
 from ..backend.special import assoc_legendre, gegenbauer
 from ..util import conversion, coords
 from ..util._optional_deps import _APY_LOADED
+from ..util._pickle import SplinePickleMixin
 from ..util.special import compute_legendre, sph_harm_normalization
 from .Potential import Potential
 
@@ -37,7 +38,7 @@ if _APY_LOADED:
 from .SphericalHarmonicPotentialMixin import SphericalHarmonicPotentialMixin
 
 
-class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
+class SCFPotential(Potential, SphericalHarmonicPotentialMixin, SplinePickleMixin):
     """Class that implements the `Hernquist & Ostriker (1992) <http://adsabs.harvard.edu/abs/1992ApJ...386..375H>`_ Self-Consistent-Field-type potential.
     Note that we divide the amplitude by 2 such that :math:`Acos = \\delta_{0n}\\delta_{0l}\\delta_{0m}` and :math:`Asin = 0` corresponds to :ref:`Galpy's Hernquist Potential <hernquist_potential>`.
 
@@ -85,6 +86,10 @@ class SCFPotential(Potential, SphericalHarmonicPotentialMixin):
     derivatives, and density at arbitrary times within (or, by extrapolation,
     outside) the ``tgrid`` range in both Python and C (for orbit integration).
     """
+
+    # Cubic-spline time interpolators over the coefficient arrays; created only
+    # by the time-dependent branch, so SplinePickleMixin skips them when absent.
+    _PICKLE_SPLINE_ATTRS = ("_Acos_interp", "_Asin_interp")
 
     def __init__(
         self,

--- a/galpy/util/_pickle.py
+++ b/galpy/util/_pickle.py
@@ -1,0 +1,72 @@
+"""Helpers for pickling objects that hold scipy piecewise polynomials.
+
+scipy 1.18 caches the array namespace -- a module -- on ``PPoly``/``BPoly``
+instances, so anything holding one raises "cannot pickle 'module' object". The
+coefficients themselves pickle fine, so drop the scipy object on the way out and
+rebuild it on the way back in.
+
+Rebuilding is done at the **base** class (``PPoly``/``BPoly``), not at
+``type(obj)``, which matters for subclasses whose constructor takes a different
+signature: ``CubicSpline(x, y)`` takes samples, not ``(c, x)`` coefficients, so
+``type(obj)(obj.c, obj.x)`` raises "`x` must be 1-dimensional". Rebuilding a
+``CubicSpline`` as a ``PPoly`` reproduces its values exactly (bit-for-bit) and
+keeps the ``.c``/``.x``/evaluation API that callers use; only the subclass
+identity is lost, and nothing in galpy branches on it. ``PPoly.construct_fast``
+would preserve the subclass but returns an object that is itself still
+unpicklable, so it is not an option.
+"""
+
+import copy
+
+from scipy.interpolate import BPoly, PPoly
+
+_SPLINE_SURROGATE = "__galpy_spline__"
+
+
+def pack_splines(obj):
+    """Replace scipy piecewise polynomials in a nested list with plain tuples.
+
+    Returns ``obj`` unchanged when it holds nothing to pack, so it is safe to
+    apply to any attribute.
+    """
+    if isinstance(obj, (PPoly, BPoly)):
+        base = BPoly if isinstance(obj, BPoly) else PPoly
+        return (_SPLINE_SURROGATE, base, obj.c, obj.x, obj.extrapolate, obj.axis)
+    if isinstance(obj, list):
+        return [pack_splines(v) for v in obj]
+    return obj
+
+
+def unpack_splines(obj):
+    """Inverse of :func:`pack_splines`."""
+    if isinstance(obj, tuple) and len(obj) == 6 and obj[0] == _SPLINE_SURROGATE:
+        _, base, c, x, extrapolate, axis = obj
+        return base(c, x, extrapolate=extrapolate, axis=axis)
+    if isinstance(obj, list):
+        return [unpack_splines(v) for v in obj]
+    return obj
+
+
+class SplinePickleMixin:
+    """Pickle support for classes holding scipy piecewise polynomials.
+
+    Subclasses list the attributes to pack in ``_PICKLE_SPLINE_ATTRS``. Names
+    that are absent on a given instance are skipped, so an attribute created
+    only by some constructor branch (a time-dependent expansion, say) needs no
+    special casing.
+    """
+
+    _PICKLE_SPLINE_ATTRS = ()
+
+    def __getstate__(self):
+        pdict = copy.copy(self.__dict__)
+        for name in self._PICKLE_SPLINE_ATTRS:
+            if name in pdict:
+                pdict[name] = pack_splines(pdict[name])
+        return pdict
+
+    def __setstate__(self, pdict):
+        self.__dict__ = pdict
+        for name in self._PICKLE_SPLINE_ATTRS:
+            if name in self.__dict__:
+                setattr(self, name, unpack_splines(self.__dict__[name]))

--- a/galpy/util/_pickle.py
+++ b/galpy/util/_pickle.py
@@ -10,10 +10,12 @@ Rebuilding is done at the **base** class (``PPoly``/``BPoly``), not at
 signature: ``CubicSpline(x, y)`` takes samples, not ``(c, x)`` coefficients, so
 ``type(obj)(obj.c, obj.x)`` raises "`x` must be 1-dimensional". Rebuilding a
 ``CubicSpline`` as a ``PPoly`` reproduces its values exactly (bit-for-bit) and
-keeps the ``.c``/``.x``/evaluation API that callers use; only the subclass
-identity is lost, and nothing in galpy branches on it. ``PPoly.construct_fast``
-would preserve the subclass but returns an object that is itself still
-unpicklable, so it is not an option.
+keeps the ``.c``/``.x``/evaluation API that callers use. Only the subclass
+identity is lost, which is safe here because no galpy code branches on it:
+the only ``isinstance`` checks against these types in the library are the ones
+below, and every consumer of a packed attribute uses just ``__call__``, ``.x``
+or ``.c``. ``PPoly.construct_fast`` would preserve the subclass but returns an
+object that is itself still unpicklable, so it is not an option.
 """
 
 import copy

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1206,6 +1206,10 @@ def _pickletest_dens(R, z):
     return 13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
 
 
+def _pickletest_dens_tdep(R, z, t=0.0):
+    return (1.0 + 0.2 * numpy.sin(0.7 * t)) * _pickletest_dens(R, z)
+
+
 def _pickletest_dens_nonaxi(R, z, phi):
     return _pickletest_dens(R, z) * (1.0 + 0.05 * numpy.cos(phi))
 
@@ -1270,6 +1274,63 @@ if _APY_LOADED:
 # The potentials that take user-supplied callables build closures out of them,
 # which pickle cannot look up by name; these are the configurations of those
 # potentials that the default constructor does not reach.
+def test_getstate_leaks_no_scipy_splines():
+    import pickle
+
+    # scipy 1.18 cannot pickle PPoly/BPoly/CubicSpline (it caches the array
+    # namespace -- a module -- on them), so no __getstate__ may leave one in the
+    # state it returns.
+    #
+    # Asserted STRUCTURALLY rather than by listing attribute names. The
+    # name-list approach has now missed the same class of case three times: the
+    # attributes only a TIME-DEPENDENT expansion creates (_I_*_interp, _rho_*_interp
+    # on Multipole; _Acos_interp on SCF) are absent from a static instance, and a
+    # time-dependent potential is not default-constructible so the enumeration in
+    # _make_pots_pickle never sees one.
+    from scipy.interpolate import BPoly, PPoly
+
+    def find_splines(obj):
+        if isinstance(obj, (PPoly, BPoly)):
+            return [obj]
+        if isinstance(obj, (list, tuple)):
+            return [s for item in obj for s in find_splines(item)]
+        if isinstance(obj, dict):
+            return [s for item in obj.values() for s in find_splines(item)]
+        return []
+
+    _mn = potential.MiyamotoNagaiPotential(amp=1.3, a=0.5, b=0.3)
+    _rgrid = numpy.geomspace(0.05, 20.0, 30)
+    _tgrid = numpy.linspace(0.0, 2.0, 5)
+    cases = {
+        "Multipole static": potential.MultipoleExpansionPotential.from_density(
+            _pickletest_dens, L=4, symmetry="axisymmetric", rgrid=_rgrid
+        ),
+        # the configuration that populates the _interp attributes at all
+        "Multipole time-dependent": potential.MultipoleExpansionPotential.from_density(
+            _pickletest_dens_tdep,
+            L=4,
+            symmetry="axisymmetric",
+            rgrid=_rgrid,
+            tgrid=_tgrid,
+        ),
+    }
+    for name, pot in cases.items():
+        state = pot.__getstate__()
+        leaked = find_splines(state)
+        assert not leaked, (
+            f"{name}: __getstate__ leaks {len(leaked)} scipy "
+            f"{type(leaked[0]).__name__} object(s), which scipy 1.18 cannot pickle"
+        )
+        # spline-free is necessary but not sufficient -- the packed attributes
+        # must actually pickle. Whole-object pickling is NOT asserted here:
+        # from_density stores an internal lambda, so any potential built through
+        # it is unpicklable for an unrelated reason (the closure issue), which
+        # would mask exactly what this test is checking.
+        for attr in pot._PICKLE_SPLINE_ATTRS:
+            if attr in state:
+                pickle.dumps(state[attr])
+
+
 def test_pickling_potential_user_callables():
     import pickle
 

--- a/tests/test_scf.py
+++ b/tests/test_scf.py
@@ -545,6 +545,42 @@ def test_from_nbody_timedep():
         assert numpy.fabs(a1 - a2) < 1e-9
 
 
+def test_timedep_pickling():
+    # scipy 1.18 caches the array namespace -- a module -- on the CubicSpline
+    # coefficient interpolators, so a time-dependent SCF raised "cannot pickle
+    # 'module' object". The default-constructible sweep in test_potential cannot
+    # see this, because a time-dependent SCF has to be built explicitly.
+    import pickle
+
+    N, L, M, nt = 2, 3, 1, 5
+    Acos = numpy.zeros((nt, N, L, M))
+    Acos[:, 0, 0, 0] = 1.0 + 0.1 * numpy.arange(nt)
+    tgrid = numpy.linspace(0.0, 1.0, nt)
+    sp = SCFPotential(Acos=Acos, tgrid=tgrid)
+    assert hasattr(sp, "_Acos_interp"), "expected the time-interpolated branch"
+    # sample on nodes and between them, so both the interpolation and the
+    # node-exact paths are compared
+    ts = [tgrid[0], 0.15, tgrid[2], 0.87, tgrid[-1]]
+    before = [
+        [
+            getattr(sp, m)(1.2, 0.3, phi=0.4, t=t, use_physical=False)
+            for m in ["__call__", "Rforce", "zforce", "dens"]
+        ]
+        for t in ts
+    ]
+    restored = pickle.loads(pickle.dumps(sp))
+    after = [
+        [
+            getattr(restored, m)(1.2, 0.3, phi=0.4, t=t, use_physical=False)
+            for m in ["__call__", "Rforce", "zforce", "dens"]
+        ]
+        for t in ts
+    ]
+    # the coefficients round-trip exactly, so the values must be bit-identical;
+    # anything looser would not notice a rebuilt-but-subtly-different spline
+    numpy.testing.assert_array_equal(numpy.array(after), numpy.array(before))
+
+
 def test_from_nbody_timedep_2d_mass():
     # A per-snapshot mass array [n,nt] is accepted and, when constant across
     # snapshots, matches the [n] mass build.

--- a/tests/test_streamgapdf.py
+++ b/tests/test_streamgapdf.py
@@ -315,6 +315,32 @@ def test_sanders15_leading_setup(setup_sanders15_leading):
 
 
 # Some very basic tests
+def test_sanders15_pickling(setup_sanders15_trailing):
+    # scipy 1.18 caches the array namespace -- a module -- on PPoly, and the
+    # numpy kick path stores one in _kick_interpdOpar_poly, so a built
+    # streamgapdf raised "cannot pickle 'module' object". Measured: that is the
+    # only unpicklable attribute on the object.
+    import pickle
+
+    sdf_sanders15, _ = setup_sanders15_trailing
+    restored = pickle.loads(pickle.dumps(sdf_sanders15))
+    poly, rpoly = sdf_sanders15._kick_interpdOpar_poly, restored._kick_interpdOpar_poly
+    # the piecewise polynomial itself must come back unchanged, not merely close
+    numpy.testing.assert_array_equal(rpoly.c, poly.c)
+    numpy.testing.assert_array_equal(rpoly.x, poly.x)
+    # and it must still evaluate: the mean-Omega kick reads it downstream
+    das = numpy.linspace(
+        sdf_sanders15._kick_interpdOpar_poly.x[0] + 1e-3,
+        sdf_sanders15._kick_interpdOpar_poly.x[-1] - 1e-3,
+        7,
+    )
+    numpy.testing.assert_array_equal(
+        numpy.array([restored._kick_interpdOpar(da) for da in das]),
+        numpy.array([sdf_sanders15._kick_interpdOpar(da) for da in das]),
+    )
+    return None
+
+
 def test_nTrackIterations(setup_sanders15_trailing):
     # Load the streamgapdf objects
     sdf_sanders15, sdf_sanders15_unp = setup_sanders15_trailing


### PR DESCRIPTION
Follow-up to #1246, which fixed **static** `MultipoleExpansionPotential` but left
three other holders of the same scipy-1.18 problem — including the
**time-dependent** Multipole it was written for.

### The bug is live in CI

`build.yml` installs scipy unpinned with `--upgrade-strategy eager`; a completed
job on #1246's head printed `numpy: 2.5.1 / scipy: 1.18.0`. Measured in that
version: `PPoly`, `BPoly` **and `CubicSpline`** all raise
`cannot pickle 'module' object`; `InterpolatedUnivariateSpline` is unaffected.
The affected objects are green today only because **nothing in the suite pickles
them**.

| holder | before | after |
|---|---|---|
| `MultipoleExpansionPotential` static (+ `DiskMultipole` via `_me`) | fixed by #1246 | unchanged |
| `MultipoleExpansionPotential` **time-dependent** | **still broken** | fixed |
| `SCFPotential._Acos_interp` / `._Asin_interp` (time-dependent) | **still broken** | fixed |
| `streamgapdf._kick_interpdOpar_poly` | **still broken** | fixed |

#1246's attribute list names things a time-dependent expansion does not have —
that one builds `_I_inner_cos_interp` / `_I_outer_cos_interp` / `_rho_cos_interp`
(and the `_sin` counterparts when non-axisymmetric), so the merged list covered
none of it.

### Two things the naive hoist gets wrong

* **Rebuild at the base class, not `type(obj)`.** `CubicSpline`'s constructor
  takes samples, not coefficients, so `type(obj)(obj.c, obj.x)` raises
  ``` `x` must be 1-dimensional ``` — exactly the SCF case.
  `PPoly.construct_fast` preserves the subclass but returns an object that is
  *itself still unpicklable*. Rebuilding as `PPoly`/`BPoly` reproduces values
  bit-for-bit and pickles. The subclass identity is lost, which is safe here and
  checked rather than assumed: the only `isinstance` tests against these types in
  the library are in `_pickle.py` itself, and every consumer of a packed
  attribute uses only `__call__`, `.x` or `.c`.
* **A mixin, not free functions.** Otherwise every holder copies the same
  `__getstate__`/`__setstate__` pair. Holders now declare
  `_PICKLE_SPLINE_ATTRS` and nothing else. `MultipoleExpansionPotential.py` is
  **−49 lines net** as its module-local copies go away.

### A structural test instead of an eleventh attribute name

The same blind spot has now produced this bug three times, always for the same
reason: the pickle sweep enumerates **default-constructible** potentials, and
neither a time-dependent SCF nor a time-dependent Multipole is one.

So rather than adding another name to a list, `test_getstate_leaks_no_scipy_splines`
walks `__getstate__` and asserts **no scipy piecewise-polynomial survives it** —
no attribute names involved. **Control-verified**: it fails against #1246's
four-name list and passes with the extended one, so it would have caught this at
review.

It deliberately does *not* assert whole-object picklability for these cases:
`from_density` stores an internal lambda, so anything built through it is
unpicklable for an unrelated reason that would mask what is being checked. That
is stated in the test.

### Verification

* time-dependent SCF: fails to pickle without this, round-trips with it,
  reproducing values **bit-for-bit** at 5 times spanning the tgrid
* streamgapdf: attribute scan of a built Sanders15 stream found **exactly one**
  unpicklable attribute, so the declaration is measured rather than guessed; the
  test re-evaluates through `_kick_interpdOpar` rather than only comparing
  `.c`/`.x`, since a restored-but-broken spline would pass an attribute-only check
* time-dependent Multipole: no scipy piecewise-polys remain in `__getstate__`,
  and all 12 splines round-trip bit-identically
* existing pickle tests: 60 passed, no regressions
