### PR TITLE
planar adapters: derive _backend_compatible from the potential they adapt

### DIFF
--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -4,7 +4,7 @@ import pickle
 import numpy
 from scipy import integrate
 
-from ..backend import backend_input, get_namespace
+from ..backend import backend_input, get_namespace, is_backend_compatible
 from ..util import config, conversion, plot
 from ..util.conversion import (
     physical_compatible,
@@ -569,6 +569,13 @@ class planarPotentialFromRZPotential(planarAxiPotential):
         self.hasC = RZPot.hasC and _hasC_planar
         self.hasC_dxdv = RZPot.hasC_dxdv and _hasC_planar
         self.hasC_dens = RZPot.hasC_dens
+        # Capability flags are derived from the wrapped potential, exactly as
+        # hasC is above: an adapter is only as backend-aware as what it adapts.
+        # Without this the object falls through to the leaf branch of
+        # is_backend_compatible and reads its own (absent) flag, so the
+        # coercion boundary rejects it even when the wrapped potential is
+        # migrated.
+        self._backend_compatible = is_backend_compatible(RZPot)
         return None
 
     def __repr__(self):
@@ -748,6 +755,13 @@ class planarPotentialFromFullPotential(planarPotential):
         self.hasC = Pot.hasC and _hasC_planar
         self.hasC_dxdv = Pot.hasC_dxdv and _hasC_planar
         self.hasC_dens = Pot.hasC_dens
+        # Capability flags are derived from the wrapped potential, exactly as
+        # hasC is above: an adapter is only as backend-aware as what it adapts.
+        # Without this the object falls through to the leaf branch of
+        # is_backend_compatible and reads its own (absent) flag, so the
+        # coercion boundary rejects it even when the wrapped potential is
+        # migrated.
+        self._backend_compatible = is_backend_compatible(Pot)
         return None
 
     def __repr__(self):

--- a/tests/test_backend_array_inputs.py
+++ b/tests/test_backend_array_inputs.py
@@ -156,3 +156,44 @@ def test_doubleexp_traced_poisson_surfdens_matches_numpy():
     assert numpy.fabs(traced - ref) / numpy.fabs(ref) < 1e-10, (
         f"traced Poisson surfdens {traced!r} does not reproduce numpy {ref!r}"
     )
+
+
+def test_planar_adapter_inherits_backend_compatibility():
+    # planarPotentialFromRZPotential / planarPotentialFromFullPotential are
+    # ADAPTERS: neither a composite nor a WrapperPotential, so
+    # is_backend_compatible falls through to its leaf branch and reads the
+    # adapter's own flag. Deriving that flag from the wrapped potential (the way
+    # hasC already is) is what lets the coercion boundary accept a planar view of
+    # a migrated potential.
+    #
+    # The negative case uses a SYNTHETIC opted-out potential rather than a real
+    # one, so the test cannot silently stop testing anything when that real
+    # potential is later migrated.
+    from galpy.backend import is_backend_compatible
+    from galpy.potential import MiyamotoNagaiPotential, Potential
+
+    class _Unmigrated(Potential):
+        def __init__(self):
+            Potential.__init__(self, amp=1.0)
+            self._backend_compatible = False
+            self.hasC = False
+            self.hasC_dxdv = False
+            self.hasC_dens = False
+
+        def _evaluate(self, R, z, phi=0.0, t=0.0):
+            return -1.0 / numpy.sqrt(R**2.0 + z**2.0)
+
+        def _Rforce(self, R, z, phi=0.0, t=0.0):
+            return -R / (R**2.0 + z**2.0) ** 1.5
+
+    migrated = MiyamotoNagaiPotential(normalize=1.0)
+    unmigrated = _Unmigrated()
+    assert is_backend_compatible(migrated.toPlanar()), (
+        "planar view of a migrated potential must be backend-compatible"
+    )
+    assert not is_backend_compatible(unmigrated.toPlanar()), (
+        "planar view of an unmigrated potential must STILL be rejected -- the "
+        "flag has to track what is wrapped, not simply be asserted"
+    )
+    # and composing them must not launder the unmigrated one
+    assert not is_backend_compatible([migrated.toPlanar(), unmigrated.toPlanar()])


### PR DESCRIPTION
`planarPotentialFromRZPotential` and `planarPotentialFromFullPotential` are
**adapters** — neither composites nor `WrapperPotential` subclasses — so
`is_backend_compatible` falls through to its leaf branch and reads their own,
absent, `_backend_compatible`. A planar view of a fully migrated potential was
therefore turned away at the coercion boundary.

The fix is the idiom already used two lines above in the same constructor:

```python
self.hasC       = RZPot.hasC and _hasC_planar
self.hasC_dxdv  = RZPot.hasC_dxdv and _hasC_planar
self._backend_compatible = is_backend_compatible(RZPot)   # <- added
```

An adapter is only as capable as what it adapts.

### What this is, and what it is not

**It is a tracing gain.** Under `jit_mode=jax`, counting only calls where the
gate sees the adapter:

| | reaches `traced_call` | **actually traced** |
|---|---|---|
| with this change | 21 | **20** |
| before | 0 | **0** |

Before, the adapter never reaches the trace point at all.

**It is *not* a bug fix, and should not be described as one.** Measured with and
without, for a jax input: result type, `is_backend_array`, and `jax.grad` value
are **identical**. The *wrapped* potential's own `@backend_input` boundary
already coerced correctly — the adapter's rejection only meant coercion happened
one level deeper. So while the boundary metric attributes 3,862 gated calls to
these two classes, those are gate rejections, **not user-visible failures**.

**It costs jax compile time.** More traced calls means more XLA compilation; a
metric run that completed comfortably on the baseline overran a 40-minute limit
with this change in place. Existing mitigation: 140 `test_orbit`/`test_orbits`
entries are already slow-skipped on jax, so the reach is bounded. Flagging it
explicitly because it is a real cost, not a rounding error.

### Scope: deliberately only the adapters

Of the 9,871 gated calls the metric found, 5,481 are `planarCompositePotential`
and `CompositePotential` — and those are rejected **correctly**.
`is_backend_compatible` already walks composites recursively; they fail because a
*member* is unmigrated. Declaring the flag there too would have passed its tests
(members are usually migrated in the suite) while breaking exactly the case the
gate exists for. A further 528 are test mocks. This PR touches neither.

### Call-site note for future work

`pl._Rforce(R)` does **not** show the adapter to the gate — it delegates to the
wrapped 3D potential, so `_backend_ready` sees `MiyamotoNagaiPotential`. The
adapter reaches the gate only through the module-level
`evaluateplanarRforces` / `evaluateplanarPotentials` / `evaluateplanarR2derivs`,
where `args[0]` is the potential. Any probe of this behaviour must use those.

### Verification

* **control**: the new test fails with the two derivations removed
* **both directions**: a *synthetic* opted-out potential stays `False` through
  the adapter, and `[migrated, unmigrated]` stays `False` — the negative case is
  synthetic on purpose, so it cannot quietly stop testing anything when some real
  potential is later migrated
* **gate flip**: 80 adapter checks, all gated out before, all passing after
* **forced torch and forced jax**: backend suites plus `test_potential -k planar`
  green on both
* **numpy byte-identity**: 13 value rows at 17 significant digits, bit-for-bit
  unchanged (expected — the gate short-circuits on `xp is numpy` — but measured
  rather than argued)
* **ordering**: neither constructor calls `normalize()`, so the
  set-before-normalize issue does not apply here
