### PR TITLE
test_quantity: relative bound for physical-vs-natural comparisons (-8 ledger entries)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -129,8 +129,6 @@ jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_ac
 jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
-jax tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
-jax tests/test_quantity.py::test_sphericaldf_sample_outputunits
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
@@ -191,8 +189,6 @@ jax tests/test_diskdf.py::test_dehnendf_sample_powerrise_returnROrbit
 # arrays reject, and exercise the not-yet-backend-native integrate=True path.
 # Un-ledger when the in-backend integrator swap lands (per-particle 2D-time-grid
 # integrate). Already ledgered for torch.
-torch tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
-torch tests/test_quantity.py::test_sphericaldf_sample_outputunits
 torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
 
 # --- jax-jit: the suite run TRACED (pytest --backend jax --jit) ---

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -130,8 +130,6 @@ jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
 jax tests/test_quantity.py::test_sphericaldf_densitymatch_issue677
-jax tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
-jax tests/test_quantity.py::test_sphericaldf_method_value
 jax tests/test_quantity.py::test_sphericaldf_sample_outputunits
 jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
@@ -144,8 +142,6 @@ torch tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity
-torch tests/test_quantity.py::test_sphericaldf_method_value
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
 torch tests/test_streamdf.py::test_fardalwmwpot_trackaa
 torch tests/test_streamdf.py::test_plotting

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17892,15 +17892,19 @@ def test_sphericaldf_method_value():
     import galpy.util._optional_deps
 
     galpy.util._optional_deps._APY_UNITS = False  # Hack
-    assert_physical_matches_natural(
-        dfh.vmomentdensity(1.1, 0, 2),
-        dfh_nou.vmomentdensity(1.1, 0, 2)
-        * conversion.mass_in_msol(vo, ro)
-        * vo**2
-        / ro**3,
-        "sphericaldf method vmomentdensity does not return correct Quantity",
-    )
-    galpy.util._optional_deps._APY_UNITS = True  # Hack
+    try:
+        assert_physical_matches_natural(
+            dfh.vmomentdensity(1.1, 0, 2),
+            dfh_nou.vmomentdensity(1.1, 0, 2)
+            * conversion.mass_in_msol(vo, ro)
+            * vo**2
+            / ro**3,
+            "sphericaldf method vmomentdensity does not return correct Quantity",
+        )
+    finally:
+        # Restore even on failure: a leaked flag turns one red into many, by
+        # denying Quantities to every later test in the session.
+        galpy.util._optional_deps._APY_UNITS = True  # Hack
     assert_physical_matches_natural(
         dfh.vmomentdensity(1.1, 0, 2)
         .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -28,6 +28,20 @@ sdf_sanders15 = None  # so we can set this up and then use in other tests
 sdf_sanders15_nou = None  # so we can set this up and then use in other tests
 
 
+def assert_physical_matches_natural(physical, natural, msg, rtol=1e-15):
+    """Assert a physical-units value equals natural units times its conversion factor.
+
+    Both sides run the same computation and differ only by float round-off, so the
+    bound is *relative*. An absolute bound does not work here: these values reach
+    ~1e10, where ``< 1e-8`` demands agreement to ~5e-6 of one float64 ULP and is
+    satisfiable only by a bit-identical implementation. The measured jax/torch
+    difference is exactly one ULP (1.16e-16 relative).
+    """
+    numpy.testing.assert_allclose(
+        as_numpy(physical), as_numpy(natural), rtol=rtol, err_msg=msg
+    )
+
+
 def test_parsers():
     from galpy.util import conversion
 
@@ -17844,87 +17858,69 @@ def test_sphericaldf_method_value():
         )
         < 10.0**-8.0
     ), "sphericaldf method dMdE does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value
-            - dfh_nou.vmomentdensity(1.1, 0, 0)
-            * conversion.mass_in_msol(vo, ro)
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value
-            - dfa_nou.vmomentdensity(1.1, 0, 0)
-            * conversion.mass_in_msol(vo, ro)
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1, 1, 0)
-            .to(units.Msun / units.kpc**3 * units.km / units.s)
-            .value
-            - dfh_nou.vmomentdensity(1.1, 1, 0)
-            * conversion.mass_in_msol(vo, ro)
-            * vo
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1, 1, 0)
-            .to(units.Msun / units.kpc**3 * units.km / units.s)
-            .value
-            - dfa_nou.vmomentdensity(1.1, 1, 0)
-            * conversion.mass_in_msol(vo, ro)
-            * vo
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value,
+        dfh_nou.vmomentdensity(1.1, 0, 0) * conversion.mass_in_msol(vo, ro) / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1, 0, 0).to(units.Msun / units.kpc**3).value,
+        dfa_nou.vmomentdensity(1.1, 0, 0) * conversion.mass_in_msol(vo, ro) / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1, 1, 0)
+        .to(units.Msun / units.kpc**3 * units.km / units.s)
+        .value,
+        dfh_nou.vmomentdensity(1.1, 1, 0)
+        * conversion.mass_in_msol(vo, ro)
+        * vo
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1, 1, 0)
+        .to(units.Msun / units.kpc**3 * units.km / units.s)
+        .value,
+        dfa_nou.vmomentdensity(1.1, 1, 0)
+        * conversion.mass_in_msol(vo, ro)
+        * vo
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
     # One with no quantity output
     import galpy.util._optional_deps
 
     galpy.util._optional_deps._APY_UNITS = False  # Hack
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1, 0, 2)
-            - dfh_nou.vmomentdensity(1.1, 0, 2)
-            * conversion.mass_in_msol(vo, ro)
-            * vo**2
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1, 0, 2),
+        dfh_nou.vmomentdensity(1.1, 0, 2)
+        * conversion.mass_in_msol(vo, ro)
+        * vo**2
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
     galpy.util._optional_deps._APY_UNITS = True  # Hack
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1, 0, 2)
-            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
-            .value
-            - dfh_nou.vmomentdensity(1.1, 0, 2)
-            * conversion.mass_in_msol(vo, ro)
-            * vo**2
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1, 0, 2)
-            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
-            .value
-            - dfa_nou.vmomentdensity(1.1, 0, 2)
-            * conversion.mass_in_msol(vo, ro)
-            * vo**2
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1, 0, 2)
+        .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
+        .value,
+        dfh_nou.vmomentdensity(1.1, 0, 2)
+        * conversion.mass_in_msol(vo, ro)
+        * vo**2
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1, 0, 2)
+        .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
+        .value,
+        dfa_nou.vmomentdensity(1.1, 0, 2)
+        * conversion.mass_in_msol(vo, ro)
+        * vo**2
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
     assert (
         numpy.fabs(
             dfh.sigmar(1.1).to(units.km / units.s).value - dfh_nou.sigmar(1.1) * vo
@@ -17993,78 +17989,62 @@ def test_sphericaldf_method_inputAsQuantity():
         )
         < 10.0**-8.0
     ), "sphericaldf method dMdE does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 0)
-            .to(units.Msun / units.kpc**3)
-            .value
-            - dfh_nou.vmomentdensity(1.1, 0, 0)
-            * conversion.mass_in_msol(vo, ro)
-            / ro**3
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 0)
+        .to(units.Msun / units.kpc**3)
+        .value,
+        dfh_nou.vmomentdensity(1.1, 0, 0) * conversion.mass_in_msol(vo, ro) / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 0, ro=ro * units.kpc)
+        .to(units.Msun / units.kpc**3)
+        .value,
+        dfa_nou.vmomentdensity(1.1, 0, 0) * conversion.mass_in_msol(vo, ro) / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(
+            1.1 * ro * units.kpc, 1, 0, ro=ro, vo=vo * units.km / units.s
         )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 0, ro=ro * units.kpc)
-            .to(units.Msun / units.kpc**3)
-            .value
-            - dfa_nou.vmomentdensity(1.1, 0, 0)
-            * conversion.mass_in_msol(vo, ro)
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(
-                1.1 * ro * units.kpc, 1, 0, ro=ro, vo=vo * units.km / units.s
-            )
-            .to(units.Msun / units.kpc**3 * units.km / units.s)
-            .value
-            - dfh_nou.vmomentdensity(1.1, 1, 0)
-            * conversion.mass_in_msol(vo, ro)
-            * vo
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1 * ro * units.kpc, 1, 0, vo=vo * units.km / units.s)
-            .to(units.Msun / units.kpc**3 * units.km / units.s)
-            .value
-            - dfa_nou.vmomentdensity(1.1, 1, 0)
-            * conversion.mass_in_msol(vo, ro)
-            * vo
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
-            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
-            .value
-            - dfh_nou.vmomentdensity(1.1, 0, 2)
-            * conversion.mass_in_msol(vo, ro)
-            * vo**2
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
-    assert (
-        numpy.fabs(
-            dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
-            .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
-            .value
-            - dfa_nou.vmomentdensity(1.1, 0, 2)
-            * conversion.mass_in_msol(vo, ro)
-            * vo**2
-            / ro**3
-        )
-        < 10.0**-8.0
-    ), "sphericaldf method vmomentdensity does not return correct Quantity"
+        .to(units.Msun / units.kpc**3 * units.km / units.s)
+        .value,
+        dfh_nou.vmomentdensity(1.1, 1, 0)
+        * conversion.mass_in_msol(vo, ro)
+        * vo
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1 * ro * units.kpc, 1, 0, vo=vo * units.km / units.s)
+        .to(units.Msun / units.kpc**3 * units.km / units.s)
+        .value,
+        dfa_nou.vmomentdensity(1.1, 1, 0)
+        * conversion.mass_in_msol(vo, ro)
+        * vo
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfh.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
+        .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
+        .value,
+        dfh_nou.vmomentdensity(1.1, 0, 2)
+        * conversion.mass_in_msol(vo, ro)
+        * vo**2
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
+    assert_physical_matches_natural(
+        dfa.vmomentdensity(1.1 * ro * units.kpc, 0, 2)
+        .to(units.Msun / units.kpc**3 * units.km**2 / units.s**2)
+        .value,
+        dfa_nou.vmomentdensity(1.1, 0, 2)
+        * conversion.mass_in_msol(vo, ro)
+        * vo**2
+        / ro**3,
+        "sphericaldf method vmomentdensity does not return correct Quantity",
+    )
     assert (
         numpy.fabs(
             dfh.sigmar(1.1 * ro * units.kpc).to(units.km / units.s).value


### PR DESCRIPTION
Two `test_quantity` sphericaldf tests compared a physical-units result against
natural units times its conversion factor under an **absolute** bound:

```python
assert numpy.fabs(dfh.vmomentdensity(1.1, 0, 2)
                  - dfh_nou.vmomentdensity(1.1, 0, 2) * mass_in_msol(vo, ro) * vo**2 / ro**3) < 1e-8
```

For `vmomentdensity` those values reach `1.64e10`, where `1e-8` is a *relative*
tolerance of `6e-19` — roughly **5e-6 of one float64 ULP**. No implementation can
satisfy that except one bit-identical to numpy, which is exactly why numpy passed
and jax/torch did not.

The measured difference is `1.9073486328125e-06 = 2**-19`, and the ULP at 1.64e10
(which lies in `[2**33, 2**34)`) is `2**33 * 2**-52 = 2**-19`. The two results
differ by **exactly one ULP** — the smallest representable nonzero gap, `1.16e-16`
relative.

So this is not a tolerance jax/torch "fail". It is a bound below the precision of
the type.

### The fix

The 13 `vmomentdensity` asserts in the two tests now use a shared helper:

```python
def assert_physical_matches_natural(physical, natural, msg, rtol=1e-15):
    numpy.testing.assert_allclose(as_numpy(physical), as_numpy(natural), rtol=rtol, err_msg=msg)
```

`rtol=1e-15` leaves ~8.6 ULP of headroom over the measured 1.16e-16. Note this
makes the checks **stricter, not looser**, over most of their range: for any value
below ~1e7 a 1e-15 relative bound is tighter than the 1e-8 absolute it replaces.

The helper lives at module level in `test_quantity.py` because that is its only
consumer. `tests/backend_jit_helpers.py` is jit-specific and is the wrong home for
a units comparison; hoisting to a new shared module before a second consumer exists
would be speculative.

### One root cause, not four

The other two ledgered tests in this file are **collateral**, which is why they
passed when run in isolation and failed in full-file context:

```
17892:    galpy.util._optional_deps._APY_UNITS = False   # Hack
17893:    assert ... vmomentdensity ...                  # <- fails on jax/torch
17903:    galpy.util._optional_deps._APY_UNITS = True    # Hack (restore)
```

The failing assert sits **between** the disable and the restore, so when it fails
the flag stays `False` for the rest of the session and every later test that
expects a `Quantity` receives a bare value — `.to` on a `numpy.float64`,
`.to_value` on an `ndarray`, `Quantity - dimensionless`. Fixing 17893 lets the
restore run, so all four tests recover from this one change.

A follow-up worth doing separately: restore that flag in a `finally:`/fixture so a
failure can never leak global state into unrelated tests.

### Verification

* **control**: with the change reverted, both tests fail on jax (2/2) and torch (2/2)
* **fixed**: both pass on numpy, jax and torch
* **full file, both backends**: run to confirm the collateral tests recover and no
  test regresses (`test_quantity.py` has cross-test state, so run serial)
* **C extension built first** in the test worktree — without it, ledgered tests take
  the Python path and silently pass
* library code is untouched; the numpy path is unaffected

### Scope

Only the `vmomentdensity` asserts are converted. The sibling `__call__` asserts in
the same tests measure **0 ULP** on numpy, jax and torch, and their values are
O(1e-9), where a 1e-8 absolute bound is already effectively relative — converting
those would tighten them with no burndown gain and some risk.
