### PR TITLE
actionAngle: one shared _BACKEND_GL_ORDER, and correct its documented floor

### DIFF
--- a/galpy/actionAngle/actionAngle.py
+++ b/galpy/actionAngle/actionAngle.py
@@ -10,6 +10,21 @@ from ..util.conversion import (
     physical_conversion_actionAngle,
 )
 
+# Gauss-Legendre order for the backend (jax/torch) action/freq/angle quadratures,
+# shared by the action-angle classes so the choice is made in one place.
+#
+# For ACTIONS, 50 matches scipy's adaptive quadrature to <1e-7 over the physical
+# orbit range (incl. near-radial L/Lcirc~1e-2: <1e-12 vs a tight reference); only
+# at pathological L/Lcirc<~1e-4 does scipy's own adaptive quad fail to ~1e-5.
+#
+# For ANGLES the floor is ~2e-6, i.e. ~20x looser, because the angle integrand
+# keeps the sqrt turning-point behaviour on a partial interval. Measured on
+# test_actionAngleSpherical_linear_angles: the deviation is 3.3e-6 at n=50,
+# 1.8e-6 at n=200, and 3.5e-6 at n=400 -- it does NOT converge, and round-off in
+# the larger node sum eventually makes it worse. Raising this constant is
+# therefore not a way to close a backend-vs-numpy angle gap.
+_BACKEND_GL_ORDER = 50
+
 
 # Metaclass for copying docstrings from subclass methods, first func
 # to copy func

--- a/galpy/actionAngle/actionAngleSpherical.py
+++ b/galpy/actionAngle/actionAngleSpherical.py
@@ -22,15 +22,9 @@ from ..potential.Potential import (
     _evaluatePotentials,
 )
 from ..util import quadpack
-from .actionAngle import UnboundError, actionAngle
+from .actionAngle import _BACKEND_GL_ORDER, UnboundError, actionAngle
 
 _EPS = 10.0**-15.0
-# Gauss-Legendre order for the backend (jax/torch) action/freq/angle quadratures.
-# 50 matches scipy's adaptive quadrature to <1e-7 over the physical orbit range
-# (incl. near-radial L/Lcirc~1e-2: <1e-12 vs a tight reference); only at
-# pathological L/Lcirc<~1e-4 does scipy's own adaptive quad fail to ~1e-5, an
-# irreducible quadrature-method difference where higher order does not help.
-_BACKEND_GL_ORDER = 50
 
 
 class actionAngleSpherical(actionAngle):

--- a/galpy/actionAngle/actionAngleVertical.py
+++ b/galpy/actionAngle/actionAngleVertical.py
@@ -15,11 +15,7 @@ from scipy import integrate, optimize
 from ..backend import device_of, get_namespace, promote_scalars
 from ..potential.linearPotential import evaluatelinearPotentials
 from ..potential.Potential import _check_potential_list_and_deprecate
-from .actionAngle import actionAngle
-
-# Gauss-Legendre order for the backend (jax/torch) action/freq/angle quadratures
-# (matches actionAngleSpherical's choice).
-_BACKEND_GL_ORDER = 50
+from .actionAngle import _BACKEND_GL_ORDER, actionAngle
 
 
 class actionAngleVertical(actionAngle):


### PR DESCRIPTION
The Gauss-Legendre order for the backend action/freq/angle quadratures was
defined **twice** — `actionAngleSpherical.py` and `actionAngleVertical.py` — with
the same value and a comment in the second reading *"(matches
actionAngleSpherical's choice)"*. The two were coupled by convention rather than
by code, which is how they drift. Five actionAngle modules use these quadrature
helpers, three of them via the shared `n=50` default, so the value had three
homes in practice.

Moves it to `galpy/actionAngle/actionAngle.py`, which both modules already import
from.

**Deliberately not `galpy/backend/quadrature.py`**, even though that is the more
"shared" location: the order is a property of the action-angle quadratures, and
putting it there would make the generic backend module carry domain knowledge
about actionAngle. Hoist to where it belongs, not as far up as possible.

### The comment was misleading in a way that matters

It claimed the GL-50 floor is `<1e-7`. That holds for **actions**; for **angles**
the floor is ~2e-6, because the angle integrand keeps the sqrt turning-point
behaviour on a partial interval. Measured by sweeping the order on the failing
Spherical linear-angles case:

| GL order | max deviation from linear |
|---|---|
| 50 | 3.3e-06 |
| 100 | 2.1e-06 |
| 200 | 1.8e-06 |
| **400** | **3.5e-06** — *worse* |

It does not converge, and round-off in the larger node sum eventually makes it
worse. Anyone reading the old comment would reasonably conclude a
backend-vs-numpy *angle* gap could be closed by raising the order; it cannot.
Those numbers are now in the comment so the next reader does not repeat the
experiment.

Pure relocation — no behaviour change, numpy path untouched, AA tests green.