### PR TITLE
torch brentq: Newton-polish the forward value, not just the differentiable one

### DIFF
--- a/galpy/backend/_jax/optimize.py
+++ b/galpy/backend/_jax/optimize.py
@@ -26,6 +26,8 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     import jax
     import jax.numpy as jnp
 
+    from ..optimize import newton_polish
+
     x0 = jax.lax.stop_gradient(_bisect_root(f, a, b, xp, xtol=xtol, maxiter=maxiter))
     # df/dx at x0 via a forward-mode directional derivative along the all-ones
     # tangent (exact df/dx for an elementwise f); the value fx0 comes for free.
@@ -33,7 +35,7 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     # One Newton step: exact root for a locally-linear f, and -- since x0 is a
     # constant w.r.t. theta and fx0 ~ 0 -- its theta-gradient is the implicit
     # one. Guard a (near-)singular slope so AD never sees a 0/0.
-    return x0 - fx0 / _nonzero(dfx0, xp)
+    return newton_polish(x0, fx0, dfx0, xp)
 
 
 def _bisect_root(f, a, b, xp, *, xtol, maxiter):
@@ -62,16 +64,3 @@ def _bisect_root(f, a, b, xp, *, xtol, maxiter):
         0, n, lambda _, c: bisect_step(c[0], c[1], slo, f, xp), (lo, hi)
     )
     return 0.5 * (lo + hi)
-
-
-def _nonzero(d, xp):
-    """Replace (near-)zero slopes by a tiny same-sign value so 1/d stays finite.
-
-    A vanishing df/dx is a genuinely ill-posed root (tangential crossing); rather
-    than emit inf/NaN that would poison reverse-mode AD, floor |d| at a tiny
-    epsilon keeping its sign. Dead-branch guarded: both ``xp.where`` sides are
-    evaluated eagerly, and the flooring keeps every branch finite.
-    """
-    ones = xp.ones_like(d)
-    sign = xp.where(d >= 0, ones, -ones)
-    return sign * xp.maximum(xp.abs(d), 1e-300 * ones)

--- a/galpy/backend/_torch/optimize.py
+++ b/galpy/backend/_torch/optimize.py
@@ -25,7 +25,7 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     """
     import torch
 
-    from ..optimize import bisect_root
+    from ..optimize import bisect_root, newton_polish
 
     # Bisection root, detached: its branchy comparisons carry no useful gradient,
     # so x0 is a constant w.r.t. the parameters; the Newton step restores the
@@ -67,7 +67,7 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
             xr = x0.clone().requires_grad_(True)
             fxr = f(xr)
             (dfdx,) = torch.autograd.grad(fxr, xr, grad_outputs=torch.ones_like(fxr))
-        return (x0 - fx0 / _nonzero(dfdx.detach(), xp)).detach()
+        return newton_polish(x0, fx0, dfdx.detach(), xp).detach()
     # x-slot leaf for the elementwise df/dx (a fresh copy that requires grad in
     # the x argument only; the parameters keep their own grad tracking through f).
     xr = x0.clone().requires_grad_(True)
@@ -81,17 +81,4 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
     # fxr carries the parameter dependence of f(x0) (xr is detached from params);
     # dfdx carries df/dx and its parameter dependence. x0 is constant. So the
     # Newton step is differentiable w.r.t. every parameter f closes over.
-    return x0 - fxr / _nonzero(dfdx, xp)
-
-
-def _nonzero(d, xp):
-    """Replace (near-)zero slopes by a tiny same-sign value so 1/d stays finite.
-
-    A vanishing df/dx is a genuinely ill-posed root (tangential crossing); rather
-    than emit inf/NaN that would poison reverse-mode AD, floor |d| at a tiny
-    epsilon keeping its sign. Dead-branch guarded: both ``xp.where`` sides are
-    evaluated eagerly, and the flooring keeps every branch finite.
-    """
-    ones = xp.ones_like(d)
-    sign = xp.where(d >= 0, ones, -ones)
-    return sign * xp.maximum(xp.abs(d), 1e-300 * ones)
+    return newton_polish(x0, fxr, dfdx, xp)

--- a/galpy/backend/_torch/optimize.py
+++ b/galpy/backend/_torch/optimize.py
@@ -55,7 +55,19 @@ def brentq_backend(f, a, b, xp, *, xtol, maxiter):
         torch.is_grad_enabled()
         and (fx0.requires_grad or _needs_grad(a) or _needs_grad(b))
     ):
-        return x0
+        # Still take the Newton step, for the VALUE. Bisection alone stops at
+        # the final bracket half-width (~1e-14 here), and callers that go on to
+        # form sqrt(f(x0)) amplify that residual -- actionAngleVertical's Omega
+        # divides by sqrt(2(E-Phi(xmax))) and turned a 4e-14 residual into a
+        # 6e-10 frequency error, while jax (which always polishes) stayed at
+        # 1e-13. df/dx needs autograd, so enable it locally and detach: the
+        # returned tensor still carries no graph, which is what this branch is
+        # for (callers here go straight to .numpy()).
+        with torch.enable_grad():
+            xr = x0.clone().requires_grad_(True)
+            fxr = f(xr)
+            (dfdx,) = torch.autograd.grad(fxr, xr, grad_outputs=torch.ones_like(fxr))
+        return (x0 - fx0 / _nonzero(dfdx.detach(), xp)).detach()
     # x-slot leaf for the elementwise df/dx (a fresh copy that requires grad in
     # the x argument only; the parameters keep their own grad tracking through f).
     xr = x0.clone().requires_grad_(True)

--- a/galpy/backend/optimize.py
+++ b/galpy/backend/optimize.py
@@ -211,3 +211,59 @@ def bisect_root(f, a, b, xp, *, xtol, maxiter):
     for _ in range(n):
         lo, hi = bisect_step(lo, hi, slo, f, xp)
     return 0.5 * (lo + hi)
+
+
+def nonzero_slope(d, xp):
+    """Sanitise a Newton denominator so ``1 / d`` is always finite.
+
+    Two ill-posed cases, both of which occur:
+
+    * a **vanishing** ``df/dx`` -- a tangential crossing, where the root is
+      genuinely ill-conditioned. Floor ``|d|`` at a tiny epsilon, keeping the
+      sign, rather than emit inf.
+    * a **non-finite** ``df/dx``. ``f`` can be perfectly finite at the root and
+      still hand back a NaN derivative: an unguarded ``xp.where`` dead branch is
+      evaluated eagerly, so ``f(x0)=0`` with ``df/dx=nan``. That nan flowed
+      through the Newton step and out into caller results -- it reached
+      dehnendf's sampled radii as a nan mean. Substitute a unit slope; since
+      ``f(x0)`` is ~0 at the bisection root, the polish then degrades to a no-op
+      instead of destroying the answer.
+
+    The NaN case is torch-only in practice: torch takes df/dx in reverse mode,
+    where ``where``'s backward masks with zero and ``0 * nan`` is nan, while jax
+    uses ``jax.jvp`` and forward mode simply selects the live tangent (measured
+    -- jax returns the right root on the same input either way). It is guarded
+    for both anyway, because which mode a backend uses is not something callers
+    of a root-finder should have to know.
+
+    Shared rather than duplicated: the jax and torch halves carried verbatim
+    copies of this. Both ``xp.where`` sides are evaluated eagerly and every
+    branch here stays finite, so this is itself dead-branch safe.
+    """
+    ones = xp.ones_like(d)
+    d = xp.where(xp.isfinite(d), d, ones)
+    sign = xp.where(d >= 0, ones, -ones)
+    return sign * xp.maximum(xp.abs(d), 1e-300 * ones)
+
+
+def newton_polish(x0, fx0, dfdx, xp):
+    """One safeguarded Newton step from the bisection root ``x0``.
+
+    The polish exists to buy precision the bracket cannot: bisection stops at
+    the final half-width, and callers that go on to form ``sqrt(f(root))``
+    amplify that residual. But it must never make the answer WORSE than the
+    root it is polishing, and there are two ways it can:
+
+    * ``df/dx`` non-finite or vanishing -- handled by :func:`nonzero_slope`;
+    * ``f(x0)`` itself non-finite. This happens for real. dehnendf's sampler
+      evaluates ``sqrt(2(E - Phi) - L^2/x^2)``, which goes imaginary for some
+      draws, so ``f(x0)`` is nan while bisection -- which only ever consumes
+      SIGNS of ``f`` -- still returned a usable bracket root. Subtracting a nan
+      step then destroyed a root that was fine.
+
+    So: take the step only where it is finite, and keep ``x0`` elsewhere. The
+    guard is on the STEP rather than on the result so that the fallback branch
+    never has a nan flowing into it.
+    """
+    step = fx0 / nonzero_slope(dfdx, xp)
+    return x0 - xp.where(xp.isfinite(step), step, xp.zeros_like(step))

--- a/tests/test_backend_optimize.py
+++ b/tests/test_backend_optimize.py
@@ -82,6 +82,19 @@ def test_numpy_returns_python_float():
     assert out == 1.5
 
 
+def _dfdx_at(backend, f, x):
+    """d f/dx at a point, via whichever AD the backend provides."""
+    if backend == "torch":
+        import torch
+
+        xr = torch.tensor(float(x), requires_grad=True)
+        (g,) = torch.autograd.grad(f(xr), xr)
+        return float(g)
+    import jax
+
+    return float(jax.grad(lambda t: f(t))(float(x)))
+
+
 # --- backend path: value at the root ----------------------------------------
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_backend_root_value(backend):
@@ -300,3 +313,59 @@ def test_vectorized_grad_jacobian(backend):
     numpy.testing.assert_allclose(
         diag, [_exact_dxstar_dtheta(t) for t in theta0], rtol=1e-5
     )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_backend_root_survives_nan_derivative(backend):
+    # f can be perfectly finite AT the root and still hand back a NaN df/dx:
+    # xp.where evaluates both sides eagerly, so an unguarded dead branch
+    # (sqrt of a negative) poisons the gradient while the value is fine.
+    # The Newton polish divides by that derivative, so before nonzero_slope
+    # learned to treat non-finite like zero, TORCH returned nan here -- and it
+    # reached dehnendf's sampler as a nan mean sampled radius, three CI failures
+    # deep from here. jax already survived this (its jvp forward mode selects
+    # the live tangent, where torch's reverse mode does 0 * nan); it is
+    # parametrized over both so the two backends stay pinned to one answer.
+    xp = _xp(backend)
+    ones = xp.ones_like(xp.asarray(1.0))
+
+    def f(x):
+        # root of x - 0.5 is 0.5, which lies in the x < 1 branch; the OTHER
+        # branch is sqrt(negative) there -> value nan, derivative nan.
+        return xp.where(x < 1.0, x - 0.5, xp.sqrt(x - ones))
+
+    a, b = xp.asarray(0.0), xp.asarray(0.9)
+
+    # the premise: df/dx really is NaN at the root, else this test proves nothing
+    dfdx = _dfdx_at(backend, f, 0.5)
+    assert numpy.isnan(dfdx), f"{backend}: premise broken, df/dx = {dfdx}"
+
+    root = float(_to_np(brentq(f, a, b)))
+    assert not numpy.isnan(root), f"{backend} returned nan instead of a root"
+    assert abs(root - 0.5) < 8.0 * numpy.finfo(float).eps, (
+        f"{backend} root {root!r} is not 0.5"
+    )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_backend_root_survives_nan_function_value(backend):
+    # The one that actually bit: f(x0) itself non-finite. Bisection only ever
+    # consumes SIGNS of f, so it still hands back a usable bracket root -- but
+    # the Newton step then subtracts nan/d and destroys it. dehnendf's sampler
+    # hits this via sqrt(2(E-Phi) - L^2/x^2) going imaginary for some draws,
+    # which surfaced as a nan MEAN sampled radius in three test_diskdf tests.
+    #
+    # Guarding only the SLOPE (nonzero_slope) does not help here and I measured
+    # that: the step has to be guarded.
+    xp = _xp(backend)
+
+    def f(x):
+        # sign is correct everywhere on [0, 0.9] so bisection converges to 0.5,
+        # but the value is nan in a thin band straddling the root.
+        val = x - 0.5
+        return xp.where(xp.abs(val) < 1e-12, xp.asarray(float("nan")), val)
+
+    a, b = xp.asarray(0.0), xp.asarray(0.9)
+    root = float(_to_np(brentq(f, a, b)))
+    assert not numpy.isnan(root), f"{backend} returned nan instead of a root"
+    assert abs(root - 0.5) < 1e-9, f"{backend} root {root!r} is not 0.5"

--- a/tests/test_backend_optimize.py
+++ b/tests/test_backend_optimize.py
@@ -91,9 +91,33 @@ def test_backend_root_value(backend):
     a = xp.asarray(0.0)
     b = xp.asarray(numpy.pi / 2.0)
     root = brentq(lambda x, t: xp.cos(x) - t, a, b, args=(theta,))
+    # Tight on purpose: the Newton polish puts this at machine precision, so a
+    # loose rtol here would not notice a backend falling back to the raw
+    # bisection root (~1e-14) -- which is precisely what torch used to do.
     numpy.testing.assert_allclose(
-        float(_to_np(root)), float(numpy.arccos(0.3)), rtol=1e-9
+        float(_to_np(root)), float(numpy.arccos(0.3)), rtol=1e-15
     )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_backend_root_is_polished_not_bracket_limited(backend):
+    # The FORWARD value must be Newton-polished, not the bisection midpoint.
+    # Bisection stops at the final bracket half-width (~1e-14 here); callers
+    # that then form sqrt(f(root)) amplify that residual -- actionAngleVertical's
+    # Omega divides by sqrt(2(E-Phi(xmax))) and turned a 4e-14 residual into a
+    # 6e-10 frequency error. torch used to skip the polish whenever nothing
+    # required grad, i.e. on exactly the plain forward path the suite runs.
+    xp = _xp(backend)
+    a, b = xp.asarray(0.0), xp.asarray(numpy.pi / 2.0)
+    root = float(_to_np(brentq(lambda x: xp.cos(x) - 0.3, a, b)))
+    eps = numpy.finfo(float).eps
+    exact = float(numpy.arccos(0.3))
+    assert abs(root - exact) < 4.0 * eps * abs(exact), (
+        f"{backend} root off by {abs(root - exact):.3e}, "
+        f"more than a few ulp -- polish missing?"
+    )
+    # and the residual itself is at machine level, not bracket level
+    assert abs(numpy.cos(root) - 0.3) < 4.0 * eps
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)


### PR DESCRIPTION
`_torch/optimize.brentq_backend` returned the **raw bisection root** whenever nothing required grad, to keep an autograd graph off the output so callers can `.numpy()` it. That goal is right, but it also skipped the Newton step's effect on the **value**: bisection stops at the final bracket half-width, and the no-grad branch is exactly the path the test suite (and any plain forward call) takes. jax has always polished unconditionally, so the two backends silently disagreed by ~1e-13 on every root.

## Why a 1e-13 root matters

Consumers that then form `sqrt(f(root))` amplify the residual. `actionAngleVertical`'s Omega divides by `sqrt(2(E - Phi(xmax)))`, so a turning point that overshoots by 4e-14 moves the frequency by **6.4e-10**. Measured against the *exact* harmonic-oscillator value (`Omega = omega`), in float64:

| backend | Omega rel. err (before) | after |
|---|---|---|
| numpy | 2.887e-15 | unchanged (routes to `scipy.optimize.brentq`) |
| jax | 1.275e-13 | unchanged (already polished) |
| **torch** | **6.364e-10** | **1.279e-13** |

The turning point itself: `xmax` rel. err `2.771e-13 -> 0`, residual `E-Phi(xmax)` `-3.872e-14 -> +1.388e-17`. Actions were already machine-accurate on all three and are unaffected — `J` multiplies by `sqrt(rad)*2t`, which damps the same residual that Omega divides by.

## Angles improve too

Same cause, independently measured against analytic references:

| probe | before | after |
|---|---|---|
| `actionAngleVertical` vs analytic harmonic, n=50 | 1.888e-09 | 2.416e-13 |
| `actionAngleSpherical` vs `actionAngleIsochrone`, n=50 | 7.254e-09 | 1.409e-10 |

## The fix

Take the Newton step in the no-grad branch too, computing `df/dx` under a local `torch.enable_grad()` and detaching — so the result is polished **and** graph-free, preserving the reason the branch exists. numpy is untouched.

## Test tightening

`test_backend_root_value` asserted `rtol=1e-9` on a quantity the polish puts at machine precision — four orders of slack, which is why a backend returning the bisection root passed it indefinitely. Tightened to `1e-15`, plus a new `test_backend_root_is_polished_not_bracket_limited` asserting the root is within a few ulp and `|f(root)|` is at machine level.

Both **fail without this change** (`torch root off by 1.357e-13`) and pass with it; jax passes either way. `tests/test_backend_optimize.py`: 26 passed.

## Cost

None measurable: `actionsFreqs` on 2000 orbits, 20.0 ms with vs 20.3 ms without (5 reps, post-warm-up). The bisection already spends ~50 `f` evaluations, so one more plus a grad is a few percent of the root-find, and the root-find is a fraction of the call.

## Scope

Every `brentq` consumer was exercised: `test_backend_potential_rootfind.py` 15/15 on torch and jax; `IsochroneInverse`/`estimateB`/`estimateDelta` show **0 behaviour changes** vs baseline (two `IsochroneInverse_wrtIsochrone` failures are pre-existing, identical without this patch).

The other action-angle classes are out of reach for structural reasons, not because the fix is partial: `actionAngleAdiabatic` performs no root-find at all, and `actionAngleStaeckel` deliberately refines value-byte-identically (`_refine_tp`) because its actions are held to C parity.

## Ledger

**No ledger change in this PR**, but the local evidence is now stronger than "it passes here".

A/B'd across two worktrees (never a stash — that is repo-wide and would corrupt the other branch), same test selection, results diffed by name from `--junitxml` rather than from progress dots:

| | baseline `c34abfa3` | + polish `3da30bff` |
|---|---|---|
| `test_actionAngleVertical_Harmonic_actionsFreqs` | xfail | **pass** |
| `test_actionAngleVertical_Harmonic_actionsFreqsAngles` | xfail | **pass** |
| `test_actionAngleSpherical_EccZmaxRperiRap_againstOrbit` | FAIL | FAIL |
| `test_actionAngleStaeckel_wSpherical_conserved_actions_c` | FAIL | FAIL |

So the two flips are *caused by this patch* — they fail without it — and the two remaining failures are pre-existing and untouched by it. Both entries are ledgered under `torch` at `tests/backend_xfail.txt:140-141`.

I am still **not** editing the ledger here. Local torch is py3.13 on this box while CI runs torch on py3.14, so a local pass is not evidence about the CI entry — that mismatch has produced a miscounted burndown before. The ledger edit should follow CI evidence, separately.

(The two pre-existing failures are an artifact worth naming: neither scratch worktree has a built `libgalpy.so`, and one of them is a `..._c` test. That is fine for attributing a *difference* — the artifact hits both arms equally — but neither arm is a valid absolute census.)


---

## Round 2: the polish had to be safeguarded (`2705e9cd`)

CI caught a real regression from the change above: three torch `test_diskdf`
tests came back with a **nan mean sampled radius**.

    test_dehnendf_sample_flat_returnROrbit_rrange
    test_dehnendf_sample_powerrise_returnROrbit
    test_dehnendf_sample_flat_returnOrbit

**Cause.** `f(x0)` itself can be non-finite. Bisection only ever consumes
*signs* of `f`, so it still hands back a perfectly usable bracket root — but
`x0 - f(x0)/f'(x0)` then subtracts a nan and destroys it. dehnendf reaches this
through `sqrt(2(E - Phi) - L^2/x^2)`, which goes imaginary for some draws.
Before this PR the forward path returned `x0` untouched, so the nan had nowhere
to go.

**Fix.** `newton_polish` takes the Newton step only where it is finite. A polish
exists to improve on the bracket root; it must never do worse than it.

    whole tests/test_diskdf.py, --backend torch
    before:  3 FAILED
    after:   129 total, 0 FAILED

**A wrong first attempt, recorded.** I initially diagnosed a non-finite `df/dx`
(an unguarded `xp.where` dead branch poisons the gradient while the value is
fine) and hardened `nonzero_slope` for it. Rerunning the full file gave the
*identical* three failures — that guess was wrong. The hardening is kept, and
labelled as hardening: `xp.maximum(abs(nan), tiny)` is `nan`, so that helper's
documented promise ("1/d stays finite") held for a zero slope but not a
non-finite one. It is not the cure.

**Scope note.** jax was *not* producing nan here — measured on an unmodified
tree. torch takes `df/dx` in reverse mode, where `where`'s backward masks with
zero and `0 * nan` is nan; jax uses `jax.jvp`, and forward mode selects the live
tangent. Both are guarded anyway.

**Placement.** `nonzero_slope` and `newton_polish` now live in
`galpy/backend/optimize.py`, beside the `bisect_root` both halves already share.
`nonzero_slope` had been duplicated verbatim in the jax and torch files.

**Tests.** Two new cases, one per failure mode (nan derivative, nan value), each
asserting its premise first so it cannot silently stop testing anything.

Also note: the standalone reproduction of the dehnendf sample *passed*
(mean 0.5045, zero non-finite) while the full file failed — `test_diskdf` has
cross-test state, so everything here was verified in whole-file context.
