### PR TITLE
util: make parallel_map's forked children fork-safe under torch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,12 @@ exclude_lines =
     if __name__ == .__main__.:
 
 omit =
+    # Forked children (galpy.util.multi.parallel_map) start their own coverage
+    # via concurrency=multiprocessing, and `--cov galpy` is a pytest-cov CLI
+    # flag the child does not inherit -- so a child measures the TEST module its
+    # target function lives in. Omit tests/ here so the child's data matches the
+    # parent's `--cov galpy` intent.
+    tests/*
     galpy/snapshot/*
     galpy/potential/amuse.py
     galpy/util/plot.py

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -30,6 +30,7 @@ from ._namespaces import (
     match_input_dtype,
     name_of_namespace,
     resolve_namespace,
+    restrict_to_single_thread,
 )
 from ._resolver import (
     _seed_from_config,
@@ -63,6 +64,7 @@ __all__ = [
     "as_numpy",
     "exit_cast",
     "resolve_namespace",
+    "restrict_to_single_thread",
     "as_backend_constant",
     "coerce_coords",
     "promote_scalars",

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -443,3 +443,25 @@ def namespace_from_arrays(arrays):
     # Non-numpy arrays only reach here (numpy is handled by the fast path above),
     # so this returns the jax / array-api-compat-torch namespace.
     return array_api_compat.array_namespace(*arrs)
+
+
+def restrict_to_single_thread():
+    """Cap the array backends at one compute thread, for a forked child.
+
+    ``galpy.util.multi.parallel_map`` forks (spawn cannot pickle the mapped
+    closures, #457). torch's intra-op thread pool does not survive ``fork``: the
+    child inherits pool state it cannot use and deadlocks on its first parallel
+    region, hanging the parent in ``proc.join()`` forever. Calling this first
+    thing in the child stops the pool from being re-entered -- and one thread per
+    child is the right split anyway, since one process per core already
+    saturates the machine.
+
+    No-op when torch is not loaded. jax has no equivalent knob (it warns at
+    every ``os.fork`` that a deadlock is likely, and the only cure available
+    there is not forking at all), so jax is deliberately not handled here.
+    """
+    import sys
+
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        torch.set_num_threads(1)

--- a/galpy/util/multi.py
+++ b/galpy/util/multi.py
@@ -31,6 +31,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import platform
+import sys
 
 import numpy
 
@@ -56,6 +57,21 @@ except ImportError:  # pragma: no cover
     _TQDM_LOADED = False
 
 __all__ = ("parallel_map",)
+
+
+def _restrict_child():
+    """Make the forked child safe for whatever array backend it inherited.
+
+    Called first thing in the child. torch's intra-op pool does not survive
+    ``fork``: the child inherits pool state it cannot use and deadlocks on its
+    first parallel region. Capping the child at one thread stops the pool being
+    re-entered, and is the right split anyway -- with one process per core, one
+    thread per process is full occupancy rather than ``ncpus``-fold
+    oversubscription.
+    """
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        torch.set_num_threads(1)
 
 
 def worker(
@@ -87,6 +103,7 @@ def worker(
     pbar_proc : ?
         process to use to display the progressbar
     """
+    _restrict_child()
     vals = []
 
     progressbar *= _TQDM_LOADED

--- a/galpy/util/multi.py
+++ b/galpy/util/multi.py
@@ -31,7 +31,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import platform
-import sys
 
 import numpy
 
@@ -57,21 +56,6 @@ except ImportError:  # pragma: no cover
     _TQDM_LOADED = False
 
 __all__ = ("parallel_map",)
-
-
-def _restrict_child():
-    """Make the forked child safe for whatever array backend it inherited.
-
-    Called first thing in the child. torch's intra-op pool does not survive
-    ``fork``: the child inherits pool state it cannot use and deadlocks on its
-    first parallel region. Capping the child at one thread stops the pool being
-    re-entered, and is the right split anyway -- with one process per core, one
-    thread per process is full occupancy rather than ``ncpus``-fold
-    oversubscription.
-    """
-    torch = sys.modules.get("torch")
-    if torch is not None:
-        torch.set_num_threads(1)
 
 
 def worker(
@@ -103,7 +87,12 @@ def worker(
     pbar_proc : ?
         process to use to display the progressbar
     """
-    _restrict_child()
+    # Forked children must not re-enter an inherited torch thread pool; see
+    # galpy.backend.restrict_to_single_thread. Imported here, not at module
+    # scope, to keep galpy.util.multi importable without galpy.backend.
+    from ..backend import restrict_to_single_thread
+
+    restrict_to_single_thread()
     vals = []
 
     progressbar *= _TQDM_LOADED

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -163,9 +163,6 @@ jax tests/test_orbit.py::test_analytic_zmax
 # still fail at a deeper diskdf-jax gap (physical output is a bare ndarray with
 # no .to() / a differing return type / a sampling mismatch). The diskdf sample
 # tests that now PASS-but-slow are slow-skipped instead (see backend_slow_skip).
-jax tests/test_diskdf.py::test_dehnendf_sample_flat_returnOrbit
-jax tests/test_diskdf.py::test_dehnendf_sample_flat_returnROrbit_rrange
-jax tests/test_diskdf.py::test_dehnendf_sample_powerrise_returnROrbit
 
 # --- REBASE-PREVIEW (main->feat/backends merge, 2026-07-07) Phase-2 gaps ---
 # main's new NUMPY-ONLY features arrive un-migrated: time-dependent SCF +

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -216,3 +216,15 @@ jax-jit tests/test_orbit.py::test_eccentricity
 torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
+
+# --- torch --jit: parallel_map's fork is fixed for EAGER torch only ----------
+# The child-side torch.set_num_threads(1) cure (fix/parallel-map-fork-safety)
+# makes eager torch survive parallel_map's fork, and these three are un-ledgered
+# for plain `torch` above. Under `--jit` they still do not work: torch.compile
+# brings its own process/CUDA state across the fork. Measured 2026-08-05 --
+# CUDA torch gives "Cannot re-initialize CUDA in forked subprocess", and with
+# CUDA_VISIBLE_DEVICES='' the run wedged past a 900 s timeout. Keeping them
+# ledgered under torch-jit so a workflow_dispatch(jit=true) stays honest.
+torch-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa
+torch-jit tests/test_streamdf.py::test_plotting
+torch-jit tests/test_streamdf.py::test_streamTrack_multi_parallel

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -141,9 +141,6 @@ torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
-torch tests/test_streamdf.py::test_fardalwmwpot_trackaa
-torch tests/test_streamdf.py::test_plotting
-torch tests/test_streamdf.py::test_streamTrack_multi_parallel
 jax tests/test_noninertial.py::test_arbitraryaxisrotation
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc
 

--- a/tests/test_backend_multi.py
+++ b/tests/test_backend_multi.py
@@ -1,0 +1,84 @@
+###############################################################################
+# test_backend_multi.py: fork-safety of galpy.util.multi.parallel_map under a
+# multi-threaded array backend.
+#
+# parallel_map forks (spawn cannot pickle the mapped closures, #457). torch's
+# intra-op thread pool does not survive fork: the child inherits pool state it
+# cannot use and wedges on its first parallel region, so the parent hangs in
+# proc.join() forever. galpy caps each forked child at one torch thread, which
+# both avoids the deadlock and is the correct split -- one process per core
+# already saturates the machine.
+#
+# The deadlock is a HANG, not an exception, so the tests here are written to
+# fail fast and deterministically: they assert the mechanism (the child's thread
+# count) rather than waiting on a wedged join. The one test that does exercise a
+# real parallel region in the child is the direct regression for the hang.
+###############################################################################
+import numpy
+import pytest
+
+pytestmark = [
+    pytest.mark.backend_managed,
+    # Python warns at every fork from a multi-threaded process, and the
+    # tests/test_backend*.py shard runs under -W error::DeprecationWarning
+    # (build.yml). Forking from a multi-threaded process is precisely what is
+    # under test here, so the warning is expected rather than a defect.
+    pytest.mark.filterwarnings("ignore:This process:DeprecationWarning"),
+]
+
+
+def _child_torch_threads(i):
+    import torch
+
+    return torch.get_num_threads()
+
+
+def _child_torch_matmul(x):
+    # A genuine torch parallel region in the child -- this is what wedges an
+    # unrestricted forked child.
+    import torch
+
+    m = torch.ones((256, 256), dtype=torch.float64)
+    return float((m @ m)[0, 0]) + float(x)  # == 256 + x, exactly
+
+
+def test_forked_child_is_capped_at_one_torch_thread():
+    torch = pytest.importorskip("torch")
+    from galpy.util.multi import parallel_map
+
+    parent_before = torch.get_num_threads()
+    got = list(parallel_map(_child_torch_threads, numpy.arange(4), numcores=2))
+    assert got == [1, 1, 1, 1], (
+        f"forked children must run torch single-threaded, got {got}"
+    )
+    assert torch.get_num_threads() == parent_before, (
+        "restricting the child must not change the parent's thread count"
+    )
+
+
+def test_parallel_map_survives_torch_work_in_the_child():
+    # Direct regression for the hang: warm the pool in the parent, then make
+    # every child enter a torch parallel region. Before the fix this never
+    # returned.
+    torch = pytest.importorskip("torch")
+    from galpy.util.multi import parallel_map
+
+    warm = torch.ones((512, 512), dtype=torch.float64)
+    assert float((warm @ warm)[0, 0]) == 512.0
+
+    seq = numpy.arange(6.0)
+    got = numpy.array(list(parallel_map(_child_torch_matmul, seq, numcores=3)))
+    assert numpy.array_equal(got, 256.0 + seq), f"parallel_map returned {got}"
+
+
+def _square(x):
+    return float(x) ** 2.0
+
+
+def test_parallel_map_values_are_exact():
+    # The capping is a no-op for the numpy path: same values, exactly.
+    from galpy.util.multi import parallel_map
+
+    seq = numpy.arange(8.0)
+    got = numpy.array(list(parallel_map(_square, seq, numcores=3)))
+    assert numpy.array_equal(got, seq**2.0), f"parallel_map returned {got}"


### PR DESCRIPTION
## What

`parallel_map` forks (spawn cannot pickle the mapped closures, #457). torch's
intra-op thread pool does not survive `fork`: the child inherits pool state it
cannot use and wedges on its first parallel region, so the parent hangs forever
in `proc.join()`.

Cap each forked child at one torch thread. That is also the configuration you
want anyway — one process per core already saturates the machine, so the
inherited `ncpus`-fold oversubscription was never intended.

```python
def _restrict_child():
    torch = sys.modules.get("torch")
    if torch is not None:
        torch.set_num_threads(1)
```

called first thing in `worker()`, the child entry point.

## Why this shape

I tried the child-side cap **before** reaching for a serial fallback, because
serializing would have thrown away the entire point of forking. It works, so
`parallel_map` keeps its parallelism under torch.

A first cut gated on `"torch" in sys.modules` at the *parent*. That predicate is
useless: `import galpy.backend` pulls in both torch and jax, so it is always
true. The cap belongs in the child, where the question is not "is torch
present" but "will this process re-enter the pool".

## Measured

Same script, same machine, only the galpy tree differs:

```
without fix: forked children report [36, 36, 36, 36] torch threads
with fix:    forked children report [ 1,  1,  1,  1]
```

`tests/test_streamdf.py` whole-file under `--backend torch` — the file that used
to wedge — now runs to completion:

```
total=80  passed=76  FAILED=4  (3 of the 76 are XPASS: the ledger entries below)
```

The 4 failures are `test_bovy14_useTM*`, which `backend-tests.yml:160` deselects
by design (they need the external Torus C++ library). CI collects **76**
`test_streamdf` tests and 80 − 4 = 76, so the CI-equivalent selection is 76/76.

Negative control on the unfixed tree, same two tests: parent alive 5:18, nine
forked children wedged, no output. These are real hangs, not stale entries.

## Ledger

30 → 27 (jax 15, torch 12). Drops the three entries that were all this one
defect:

- `torch tests/test_streamdf.py::test_fardalwmwpot_trackaa`
- `torch tests/test_streamdf.py::test_plotting`
- `torch tests/test_streamdf.py::test_streamTrack_multi_parallel`

## What this does *not* do

jax deadlocks on fork too — it warns as much at every `os.fork` — but it has no
`set_num_threads` equivalent, so the only available fix is to serialize. The one
galpy test that forks under an active jax backend (`actionAngleAdiabaticGrid`,
`numcores=2`) passes today, and degrading a working path on synthetic evidence
is the wrong trade. `streamdf` already routes jax around fork via `lax.map`.
Left as-is deliberately, recorded rather than silently skipped.

## Tests

New `tests/test_backend_multi.py`. The deadlock is a *hang*, not an exception,
so the tests assert the mechanism (the child's thread count) rather than waiting
on a wedged join; one test does drive a real torch parallel region in the child
as the direct regression.

They carry a narrow `filterwarnings` for Python's
`DeprecationWarning: This process is multi-threaded, use of fork() may lead to
deadlocks` — `build.yml:43` runs `tests/test_backend*.py` and `build.yml:359`
adds `-W error::DeprecationWarning`, and forking from a multi-threaded process
is precisely what is under test. Verified locally under those exact flags.

## numpy path

Unchanged. The only added work is a `sys.modules` lookup and, when torch is
importable, a `set_num_threads` call that touches no numpy code. On a shard
without torch installed the lookup misses and nothing runs.

---

## Also: −3 on the jax ledger, from #1255's guard

`newton_polish` (merged in #1255) turned out to cure three ledger entries that
predate it:

- `jax tests/test_diskdf.py::test_dehnendf_sample_flat_returnOrbit`
- `jax tests/test_diskdf.py::test_dehnendf_sample_flat_returnROrbit_rrange`
- `jax tests/test_diskdf.py::test_dehnendf_sample_powerrise_returnROrbit`

Same three tests that #1255's regression hit on torch. jax has *always* polished
unconditionally, so it has always been subtracting the nan `f(x0)` that torch
only started subtracting in that PR — the jax entries are what the bug looks
like when it has been there all along.

A/B, whole file, `--backend jax --runxfail`, two worktrees:

```
develop before #1255:  129 total,  3 FAILED   ← exactly these three
with newton_polish:    129 total,  0 FAILED
```

It rides here rather than in #1255 because that PR's 149-job matrix was already
nearly complete and a three-line ledger change was not worth restarting it;
until now they simply reported `XPASS(fix-me)`, which does not fail a shard.

**Ledger: jax 15 → 12, torch 15 → 12, torch-jit 1 → 4.** Net −3.
