### PR TITLE
Ledger accuracy: two source fixes, three re-homes, a stale prune, and readable backend CI logs

### DIFF
--- a/galpy/potential/interpSphericalPotential.py
+++ b/galpy/potential/interpSphericalPotential.py
@@ -4,7 +4,7 @@
 import numpy
 from scipy import interpolate
 
-from ..backend import get_namespace, match_input_dtype
+from ..backend import as_numpy, get_namespace, match_input_dtype
 from ..backend.interpolate import eval_ppoly as _ppoly_eval
 from ..backend.interpolate import spline_to_ppoly as _spline_to_ppoly_data
 from ..util.conversion import get_physical, physical_compatible
@@ -75,7 +75,14 @@ class interpSphericalPotential(SphericalPotential):
         )
         # Get potential and r2deriv as splines for the integral and derivative
         self._pot_spline = self._force_spline.antiderivative()
-        self._Phi0 = Phi0 + self._pot_spline(self._rgrid[0])
+        # Freeze Phi0 on the numpy side: every other derived scalar here comes
+        # from a scipy spline and is numpy, and _revaluate's numpy branch mixes
+        # them directly. Built under a forced backend, _evaluatePotentials returns
+        # a backend scalar, which used to make _Phi0/_Phimax backend arrays while
+        # _total_mass/_rmax stayed numpy -- numpy expression + Tensor on line ~105.
+        # Nothing is lost: the splines are scipy, so parameter gradients are
+        # already unavailable, and the backend branch coerces with xp.asarray.
+        self._Phi0 = as_numpy(Phi0) + self._pot_spline(self._rgrid[0])
         self._r2deriv_spline = self._force_spline.derivative()
         # Piecewise-power (PPoly) representation of the three splines for the
         # non-numpy backends (see _ppoly_eval). The antiderivative/derivative

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -80,7 +80,20 @@ jax tests/test_qdf.py::test_sampleV_interpolate
 # runners (proactive defer, same rationale as test_MultipoleExpansion_deepcopy below):
 #  - test_interpolation_potential_c (263 s), _secondderivs_c (274 s)  [test_interp_potential]
 #  - test_2ndDeriv_potential[mockInterpRZPotentialwSecondDerivs] (263 s)  [test_potential]
+# RE-HOMED here from backend_xfail.txt 2026-08-05: two more of the same family that
+# were mis-filed as xfail. Timed with `--backend jax --runxfail` over the WHOLE file
+# (36 passed, 4 skipped, 0 FAILED -- the 4 skips are the entries already listed here):
+#   PASS 1311.1s test_interpolation_potential_force_c        <- was xfail-ledgered
+#   PASS  989.8s test_interpolation_potential_secondderivs   <- was xfail-ledgered
+#   PASS  203.7s test_interpolation_potential_force_c_vdiffgridsizes
+#   PASS  144.9s test_interpolation_potential
+# They PASS, at 4.4x and 3.3x the 300 s timeout, so they are not numerical gaps --
+# they never finish, time out, record FAILED, and the xfail absorbs it. Every sibling
+# under 300 s is in neither list. Bookkeeping, not burndown: xfail -2, deferred +2;
+# skipping them also returns ~38 min of jax shard time per run.
 # Defer all until interpRZ is backend-vectorized (group d); numpy runs them, values correct.
+jax tests/test_interp_potential.py::test_interpolation_potential_force_c
+jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_interp_potential.py::test_interpolation_potential_dens
 jax tests/test_interp_potential.py::test_interpolation_potential_force
 jax tests/test_interp_potential.py::test_interpolation_potential_c

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -332,6 +332,20 @@ jax tests/test_noninertial.py::test_lsrframe_vecomegaz_2d
 jax tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential
+# Re-homed from backend_xfail.txt 2026-08-05: same class as the block above, and
+# the two slowest members of it. Timed under `--backend jax --runxfail` (nothing
+# masked), whole -k arbitraryaxisrotation family:
+#   PASS 581.6s test_arbitraryaxisrotation           <- was xfail-ledgered
+#   PASS 559.9s test_arbitraryaxisrotation_omegafunc <- was xfail-ledgered
+#   PASS 182.0s test_python_vs_c_arbitraryaxisrotation_omegadot
+#   PASS 159.1s test_arbitraryaxisrotation_omegadot_nullpotential
+#   PASS 140.1s test_arbitraryaxisrotation_nullpotential
+#   PASS 116.9s test_python_vs_c_arbitraryaxisrotation
+# Both PASS, at ~2x the 300 s per-test CI timeout -- they are not numerical gaps,
+# they never finish. Every sibling that runs UNDER 300 s is in neither list, so
+# the split is exactly the runtime one. Not a burndown: xfail -2, deferred +2.
+jax tests/test_noninertial.py::test_arbitraryaxisrotation
+jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc
 
 # --- streamdf under jax (Track F streamdf vectorization) ---
 # The closed-form actionAngleIsochrone backend migration (same PR) makes

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -1,3 +1,16 @@
+# SOURCE-FIX burn + RE-HOME (2026-08-05). Two entries burned by fixes in this
+# same PR: jax SpiralArms test_Rzderiv (the test's finite-difference reference was
+# built with dx=1e-8, which amplifies a 1.9e-13 float64 reassociation in Rforce by
+# 5e7; dx=1e-6 makes the reference ~150x more accurate) and torch
+# test_constantbeta_interpolatedpotentials_beta (interpSphericalPotential froze
+# _Phi0/_Phimax as Tensors while _total_mass/_rmax stayed numpy). Separately, the
+# 2 jax test_arbitraryaxisrotation{,_omegafunc} entries are RE-HOMED to
+# backend_slow_skip.txt, not pruned: timed under `--backend jax --runxfail` they
+# PASS at 581.6 s and 559.9 s, i.e. ~2x the 300 s per-test CI timeout -- the same
+# TIMEOUT class as their 3 siblings re-homed on 2026-07-23 below, and the two
+# slowest members of it. Re-homing is bookkeeping accuracy, not burndown: the
+# xfail ledger drops 2 and the deferred list gains 2.
+#
 # REGEN-MILESTONE prune (2026-07-23, full-matrix REGEN run 29979778304 on
 # feat/backends c08577ff -- post-#1185; all 44 jax+torch shards ran to
 # completion (conclusion=success), no session-timeout truncation, and the
@@ -122,7 +135,6 @@
 # (test_analytic_ecc_rperi_rap: passes locally, xfails in CI group g3). Same
 # blind spot that made an earlier local regen report false failures.
 
-jax tests/test_SpiralArmsPotential.py::TestSpiralArmsPotential::test_Rzderiv
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
@@ -140,9 +152,6 @@ torch tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
 torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta
-jax tests/test_noninertial.py::test_arbitraryaxisrotation
-jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc
 
 # --- jax single-orbit: action-angle accessors (Track E) ---
 # o.jr()/jz()/e()/zmax()/rperi()/rap() and physical/quantity/plotting paths that call

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -141,7 +141,6 @@ jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_ac
 jax tests/test_interp_potential.py::test_interpolation_potential_force_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
-jax tests/test_sphericaldf.py::test_anisotropic_hernquist_negdf
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 torch tests/test_actionAngle.py::test_actionAngleSpherical_almostnoninclinedorbit_linear_angles

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -234,3 +234,13 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetric
 torch-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa
 torch-jit tests/test_streamdf.py::test_plotting
 torch-jit tests/test_streamdf.py::test_streamTrack_multi_parallel
+# A units-based density is NOT TRACEABLE, and this is by construction rather
+# than a defect. AnySphericalPotential._backend_dens deliberately evaluates such
+# a density on the numpy node --  astropy Quantity arithmetic strips a jax/torch
+# node to numpy, so the density is inherently non-differentiable -- and anchors
+# the result back (see its docstring). That routes through as_numpy(), i.e.
+# numpy.asarray(), which a tracer cannot satisfy. Eager jax/torch are fine: a
+# concrete array converts. Un-ledger only if units handling ever becomes
+# backend-native; there is nothing to fix in the test.
+jax-jit tests/test_potential.py::test_pickling_potential_unitful_dens
+jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -1,3 +1,18 @@
+# BURNED BY #1255 (2026-08-05). Six torch actionAngle angle/freq entries -- the
+# ~1e-7 precision cluster that was queued up as a TOLERANCE batch -- are pruned
+# here as a straight fix, with no tolerance touched. #1255 Newton-polishes the
+# root that `brentq` returns, and actionAngleSpherical / actionAngleVertical angle
+# computations are root-find consumers, so a more accurate root closes the gap.
+# Verified by A/B rather than inferred from the coincidence:
+#     pre-#1255  (7696c88e, own C build)  torch --runxfail   FAILED x6
+#     post-#1255 (this tree)              torch --runxfail   passed x6
+# and by the CI artifacts either side of the boundary (skip TYPE read, so an
+# xfail is not confused with a slow-skip):
+#     run 31022290797  base 18ddfd9b = #1255   XPASS x6
+#     run 30997129449  base 7696c88e = #1254   xfail x6
+#     run 30982182601  base 7b6f5ae4 = #1252   xfail x6
+#     run 30953851163  base c34abfa3           xfail x6
+#
 # SOURCE-FIX burn + RE-HOME (2026-08-05). Two entries burned by fixes in this
 # same PR: jax SpiralArms test_Rzderiv (the test's finite-difference reference was
 # built with dx=1e-8, which amplifies a 1.9e-13 float64 reassociation in Rforce by
@@ -143,13 +158,7 @@ jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
-torch tests/test_actionAngle.py::test_actionAngleSpherical_almostnoninclinedorbit_linear_angles
-torch tests/test_actionAngle.py::test_actionAngleSpherical_linear_angles
-torch tests/test_actionAngle.py::test_actionAngleSpherical_linear_angles_fixed_quad
-torch tests/test_actionAngle.py::test_actionAngleSpherical_noninclinedorbit_linear_angles
 torch tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
-torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqs
-torch tests/test_actionAngle.py::test_actionAngleVertical_Harmonic_actionsFreqsAngles
 torch tests/test_qdf.py::test_call_diffinoutputs
 
 # --- jax single-orbit: action-angle accessors (Track E) ---

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -153,8 +153,6 @@
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
-jax tests/test_interp_potential.py::test_interpolation_potential_force_c
-jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
 jax tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,10 +435,24 @@ def pytest_sessionfinish(session, exitstatus):
             target=lambda: (time.sleep(60), _backend_force_exit(exitstatus)),
             daemon=True,
         ).start()
-    # --- let junitxml + terminalreporter write everything, THEN force-exit ---
+    # --- let junitxml write, THEN hand off to pytest_unconfigure ---
     yield
     if forced:
-        _backend_force_exit(exitstatus)
+        # NOT here: pytest's short summary ("N passed, M failed") is emitted by
+        # TerminalReporter AFTER this hook unwinds, so force-exiting at this
+        # point silently truncates every forced-backend log to a row of dots --
+        # junit is intact, but a human reading CI sees no counts. Defer to
+        # pytest_unconfigure, which runs last; the 60 s daemon armed above still
+        # covers a hang in the summary itself.
+        session.config._galpy_force_exit_status = exitstatus
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    """Force-exit the forced-backend run once the terminal summary is out."""
+    status = getattr(config, "_galpy_force_exit_status", None)
+    if status is not None:
+        _backend_force_exit(status)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_SpiralArmsPotential.py
+++ b/tests/test_SpiralArmsPotential.py
@@ -1631,7 +1631,7 @@ class TestSpiralArmsPotential(unittest.TestCase):
 
     def test_Rzderiv(self):
         """Test Rzderiv against a numerical derivative."""
-        dx = 1e-8
+        dx = 1e-6
         rtol = _NUMPY_1_23 * 3e-6 + (1 - _NUMPY_1_23) * 1e-6
 
         pot = spiral()

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1190,7 +1190,16 @@ def test_pickling_potential(potname):
                 expected = getattr(tp, method)(R, z)
             except Exception:  # not supported by this potential/at this point
                 continue
-            assert getattr(up, method)(R, z) == expected, (
+            got = getattr(up, method)(R, z)
+            # Exact equality, with one carve-out: a NaN has to compare equal to
+            # itself. Under a trace some potentials return NaN off-domain by
+            # design (RazorThinExponentialDisk._R2deriv: the domain cannot be
+            # decided at trace time), and `nan == nan` is False, so a plain ==
+            # fails on two values that in fact agree.
+            both_nan = bool(numpy.isnan(as_numpy(got))) and bool(
+                numpy.isnan(as_numpy(expected))
+            )
+            assert both_nan or got == expected, (
                 f"Unpickled {potname}.{method}({R}, {z}) differs from the original"
             )
             nchecked += 1
@@ -1203,7 +1212,8 @@ def test_pickling_potential(potname):
 # pickle cannot look up by name any more than it can a lambda, so the tests
 # would fail on their own fixtures rather than on the potential.
 def _pickletest_dens(R, z):
-    return 13.5 * numpy.exp(-3.0 * R) * numpy.exp(-27.0 * numpy.fabs(z))
+    xp = get_namespace(R, z)
+    return 13.5 * xp.exp(-3.0 * R) * xp.exp(-27.0 * xp.abs(z))
 
 
 def _pickletest_dens_tdep(R, z, t=0.0):
@@ -1215,27 +1225,30 @@ def _pickletest_dens_nonaxi(R, z, phi):
 
 
 def _pickletest_Sigma(R):
-    return numpy.exp(-R / 0.3)
+    return get_namespace(R).exp(-R / 0.3)
 
 
 def _pickletest_dSigmadR(R):
-    return -numpy.exp(-R / 0.3) / 0.3
+    return -get_namespace(R).exp(-R / 0.3) / 0.3
 
 
 def _pickletest_d2SigmadR2(R):
-    return numpy.exp(-R / 0.3) / 0.3**2.0
+    return get_namespace(R).exp(-R / 0.3) / 0.3**2.0
 
 
 def _pickletest_hz(z):
-    return 1.0 / 2.0 / 0.04 * numpy.exp(-numpy.fabs(z) / 0.04)
+    xp = get_namespace(z)
+    return 1.0 / 2.0 / 0.04 * xp.exp(-xp.abs(z) / 0.04)
 
 
 def _pickletest_Hz(z):
-    return (numpy.exp(-numpy.fabs(z) / 0.04) - 1.0 + numpy.fabs(z) / 0.04) * 0.04 / 2.0
+    xp = get_namespace(z)
+    return (xp.exp(-xp.abs(z) / 0.04) - 1.0 + xp.abs(z) / 0.04) * 0.04 / 2.0
 
 
 def _pickletest_dHzdz(z):
-    return 0.5 * numpy.sign(z) * (1.0 - numpy.exp(-numpy.fabs(z) / 0.04))
+    xp = get_namespace(z)
+    return 0.5 * xp.sign(z) * (1.0 - xp.exp(-xp.abs(z) / 0.04))
 
 
 def _pickletest_spherical_dens(r):


### PR DESCRIPTION
Six files, one theme: **make the burndown numbers and the CI logs tell the truth.**
Two real fixes that burn a ledger entry each, one re-home and one prune that correct
mis-classifications, two by-construction non-traceable cases recorded as such, a
test-fixture traceability pass, and one harness fix so a forced-backend CI log is
readable again.

This started as two PRs. They were merged into one because both edit
`tests/backend_xfail.txt` — shipping them separately guaranteed a rebase and a
second full CI cycle, which is expensive on a runner that currently has 60+ jobs
queued.

---

## 1. `interpSphericalPotential`: freeze `Phi0` on the numpy side

Burns `torch tests/test_sphericaldf.py::test_constantbeta_interpolatedpotentials_beta`.

`TypeError: Concatenation operation is not implemented for NumPy arrays` at
`interpSphericalPotential.py:105`. Built inside a forced backend, the class froze
its derived scalars **inconsistently**:

```
_Phi0        Tensor    <- _evaluatePotentials() under forced torch
_Phimax      Tensor    <- contaminated by _Phi0
_total_mass  float64   <- straight from the scipy spline
_rmax        float64
```

`_revaluate`'s numpy branch does `out[mask] = -self._total_mass / r[mask] +
self._Phimax` — a numpy expression plus a Tensor, assigned into a numpy array.

`constantbetadf` reaches that branch *deliberately*: it forces numpy under torch
because its fE setup is scipy quadrature, so `r` arrives numpy while the potential
was built under torch.

Fix: `self._Phi0 = as_numpy(Phi0) + ...`. Nothing is lost — every spline in this
class is scipy, so parameter gradients were already unavailable, and the backend
branch coerces with `xp.asarray` regardless. `as_numpy` on an already-numpy value
is a no-op, so the numpy path is unchanged.

---

## 2. `test_Rzderiv`: `dx = 1e-8 -> 1e-6`

Burns `jax tests/test_SpiralArmsPotential.py::TestSpiralArmsPotential::test_Rzderiv`.

**This strengthens the test; it is not a tolerance loosening.** The assertion
compares analytic `Rzderiv` against a central finite difference of `Rforce`.
`Rforce` differs numpy-vs-jax by ~1.9e-13 (ordinary float64 reassociation in the
spiral-arm sum); the central difference divides by `2*dx`, amplifying that by 5e7
into 2.5e-6 **in the reference**. The analytic values agree between backends to
~2e-13 — galpy's derivative is fine, the test's reference was fragile.

Error of the FD reference against the analytic truth, each column asserted on its
backend via `is_backend_array`:

| dx | numpy | jax |
|---|---|---|
| 1e-08 | 5.122e-07 | 2.521e-06 |
| 1e-07 | 5.735e-08 | 5.705e-08 |
| **1e-06** | **3.262e-09** | **3.262e-09** |
| 1e-05 | 9.329e-10 | 9.359e-10 |
| 1e-04 | 3.066e-08 | 3.066e-08 |

At 1e-8 the reference was only good to ~5e-7 **even on numpy** — it passed there
by luck. At 1e-6 it is ~150x more accurate and the backends agree to three figures.

This touches a numpy-path test. It does not weaken it — the reference gets better
— but flagging it explicitly. Related: `_NUMPY_1_23 = (>1.22)*(<1.27)` is False on
numpy 2.4, so the looser 3e-6 band that used to mask this no longer applies, which
is why the entry exists now and not earlier.

---

## 3. noninertial: re-home 2 mis-filed entries, xfail → slow-skip

Timed with `--backend jax --runxfail`, so nothing is masked:

```
PASS 581.6s test_arbitraryaxisrotation            <- was xfail-ledgered
PASS 559.9s test_arbitraryaxisrotation_omegafunc  <- was xfail-ledgered
PASS 182.0s test_python_vs_c_arbitraryaxisrotation_omegadot
PASS 159.1s test_arbitraryaxisrotation_omegadot_nullpotential
PASS 140.1s test_arbitraryaxisrotation_nullpotential
PASS 116.9s test_python_vs_c_arbitraryaxisrotation
skip   0.0s x3 (already slow-skipped)
```

Both PASS, at roughly **2x the 300 s per-test CI timeout**. They are not numerical
gaps — they never finish, time out, get recorded FAILED, and the xfail absorbs it.
This is the same class as the 3 siblings re-homed on 2026-07-23 for exactly this
reason, and these two are the slowest members of the family. Every sibling that
runs under 300 s is in neither list, so the split is precisely the runtime one.
`backend_xfail.txt`'s own header already states the policy: *"A timeout OVERRIDES
xfail (records FAILED), so slow-skip — not xfail — is the correct home."*

**Bookkeeping, not burndown**: the xfail ledger drops 2 and the deferred list gains
2, so total deferred work is unchanged. Said that way in the ledger header too, so
the -4 below cannot be read as more progress than it is.

---

## 4. `conftest`: force-exit *after* the terminal summary, not before

`pytest_sessionfinish`'s docstring claimed it force-exited "AFTER the junit XML and
**the terminal summary** have been written". True for junit, false for the summary,
which `TerminalReporter` emits after that hook unwinds — so **every forced-backend
run ended in a row of dots with no `N passed` line**, exit code 0:

```
--backend numpy     -> "7 passed, 91 deselected in 6.08s"
--backend jax       -> (nothing)
--backend torch     -> (nothing)
```

Not a `--jit` thing — any non-numpy backend. This is why backend triage has always
needed the junit artifact downloaded.

Deferred to a `trylast` `pytest_unconfigure`, which runs last. The 60 s daemon
backstop still covers a hang inside the summary itself.

Verified with an **atexit probe**, because `os._exit` skips atexit and a silently
disarmed force-exit would trade a truncated log for a hung CI job:

```
numpy  summary + ATEXIT_RAN  -> normal shutdown, correctly not armed
jax    summary + NO atexit   -> os._exit still fires
torch  summary + NO atexit   -> os._exit still fires
```

`backend-tests.yml`'s census parses the junit XML, not stdout, so restoring the
line is purely additive and cannot affect a CI step.

---

## 5. Pickling tests: traceable where they legitimately can be

Six module-level density/profile fixtures used `numpy.exp`/`numpy.fabs`/`numpy.sign`
directly, which a tracer cannot take; they now resolve `get_namespace(...)`. Plus
one carve-out in `test_pickling_potential`: some potentials return NaN off-domain
by design under a trace (`RazorThinExponentialDisk._R2deriv` — the domain cannot be
decided at trace time), and `nan == nan` is False, so a plain `==` failed on two
values that in fact agree. `nchecked > 0` is still asserted, so a potential whose
methods all get skipped still fails rather than passing vacuously.

Known inconsistency, deliberately left: `_pickletest_dens_tdep` and
`_pickletest_dens_nonaxi` still call `numpy.sin`/`numpy.cos` while their six
siblings were migrated. All 60 pickling tests are FAILED=0 under `--jit`, so no
failure motivates the change and making it would be churn.

## 6. Ledger: a units-based density is not traceable (2 jax-jit entries)

`AnySphericalPotential._backend_dens` deliberately evaluates a units-based density
on the numpy node — astropy Quantity arithmetic strips a jax/torch node to numpy,
so such a density is inherently non-differentiable — then anchors the result back
on the input's backend/dtype/device. That routes through `as_numpy()`, which a
tracer cannot satisfy. Eager jax/torch are unaffected. Recorded with the reasoning
inline so the entries are not later mistaken for a regression; **there is nothing
to fix in the tests.**

## 7. Ledger: prune one stale entry

`jax test_sphericaldf.py::test_anisotropic_hernquist_negdf`, found by intersecting
the ledger with the tests that PASSED in a CI run's `backend-junit-*` artifacts —
free, no extra runner cost. Verified XPASS locally before removing rather than
trusting one CI observation. Track F's spherical-DF migration fixed it; the entry
outlived its cause.

---

## 8. Ledger: #1255 fixed 6 torch actionAngle entries (the biggest burn here)

These six were queued as an actionAngle **tolerance batch** — the ~1e-7 torch
precision cluster. They turn out not to need a tolerance change at all: #1255
(brentq Newton-polish, merged this morning) fixed them. `actionAngleSpherical` /
`actionAngleVertical` angle computations consume brentq roots, so polishing the
returned root closes the gap.

Found while characterising a *different* cluster: running the whole
`test_actionAngle.py` under `--runxfail` showed torch with 9 ledgered entries but
only 3 failures, while jax matched exactly (3 ledgered, 3 failed) — the asymmetry
is what made it visible.

A local pass is one version point, and torch precision entries are exactly the
class that is environment-dependent, so this is not pruned on that alone. A/B on a
pre-#1255 tree (7696c88e, its own C build):

```
pre-#1255   torch --runxfail   FAILED x6
post-#1255  torch --runxfail   passed x6
```

plus the CI artifacts either side of the boundary, reading the skip **type** so an
xfail is not mistaken for a slow-skip:

```
run 31022290797  base 18ddfd9b = #1255   XPASS x6
run 30997129449  base 7696c88e = #1254   xfail x6
run 30982182601  base 7b6f5ae4 = #1252   xfail x6
run 30953851163  base c34abfa3           xfail x6
```

Three consecutive runs xfail, XPASS on the first run after #1255, and a direct A/B
that fails without it.

The remaining torch `test_actionAngle` entries (`AdiabaticGrid_outsidegrid_c`,
`Adiabatic_linear_angles_cylsep`, `StaeckelGrid_basicAndConserved_actions`) still
fail on **both** backends and stay ledgered — a separate correctness cluster, not
a tolerance one.

---

## 9. Ledger: 2 more mis-filed timeouts (interp_potential), xfail -> slow-skip

Same class as #3, found the same way. Whole `test_interp_potential.py` under
`--backend jax --runxfail` -- 36 passed, 4 skipped, **0 FAILED**:

```
PASS 1311.1s test_interpolation_potential_force_c        <- was xfail-ledgered
PASS  989.8s test_interpolation_potential_secondderivs   <- was xfail-ledgered
PASS  203.7s test_interpolation_potential_force_c_vdiffgridsizes
PASS  144.9s test_interpolation_potential
PASS  138.9s test_interpolation_potential_force_diffinputs
```

Both PASS, at **4.4x and 3.3x** the 300 s per-test timeout. Every sibling under
300 s is in neither list, so the split is precisely the runtime one.

They go into the **existing** "jax interpRZ timeouts / near-timeouts" block, which
already holds their siblings (`_dens`, `_force`, `_c`, `_secondderivs_c`) with the
same rationale and the same un-defer condition. Note the nodeids are confusingly
close: `_force_c` and `_secondderivs` are *not* the already-listed `_force` and
`_secondderivs_c`.

Bookkeeping, not burndown. Side benefit: skipping rather than timing out returns
**~38 min of jax shard time per run**.

---

## Gates

Whole files, `--runxfail` on the backend runs so the ledger masks nothing:

```
torch  test_sphericaldf.py                223 total, 223 passed, 0 FAILED, 0 xfail
numpy  test_sphericaldf.py                223 total, 223 passed, 0 FAILED, 0 skipped
jax    test_SpiralArmsPotential.py         19 total,  19 passed, 0 FAILED
numpy  test_SpiralArmsPotential.py         19 total,  19 passed, 0 FAILED
numpy  test_potential -k interpSpherical   22 total,  20 passed, 2 skipped
jax --jit  test_potential -k pickling      60 total,  58 passed, 0 FAILED, 2 xfail
numpy      test_potential -k pickling      60 total,  60 passed, 0 FAILED
```

The 2 numpy skips are pre-existing capability skips (`no explicit _surfdens /
missing derivs`), checked rather than assumed. The torch `test_sphericaldf.py` run
shows **0 xfail** under `--runxfail`, which is the evidence the burned entry
genuinely passes rather than being absorbed; the numpy run of the same file is the
byte-identity gate for `interpSphericalPotential`'s other consumer.

## Ledger

jax xfail 15 → 11, torch xfail 15 → 14, jax-jit 3 → 5, jax slow-skip 188 → 190.

Read that honestly: of the 4 jax drops, **1 is a real fix** (SpiralArms), **1 is a
stale-entry prune**, and **2 are re-homed to the deferred list** — so net deferred
work falls by 2, not 4. jax-jit *grows* by 2, because two by-construction
non-traceable cases are now recorded as such instead of being invisible.
