### PR TITLE
interpolate: pair map_coordinates' boundary mode with the spline_filter prefilter (875x error at grid-boundary nodes)

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -804,7 +804,7 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
         raise NotImplementedError(
             "backend map_coordinates only implements order=3 (cubic)"
         )
-    if mode not in ("mirror", "nearest"):  # pragma: no cover
+    if mode not in ("mirror", "nearest"):
         raise NotImplementedError(
             "backend map_coordinates only implements mode='mirror'|'nearest'"
         )

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -737,7 +737,7 @@ def _cubic_bspline_weights(xp, f):
     return out  # list of 4 weight arrays
 
 
-def map_coordinates(filtered, coords, order=3, mode="nearest", prefilter=False):
+def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
     """Backend-agnostic cubic ``map_coordinates`` off a prefiltered grid.
 
     A drop-in for ``scipy.ndimage.map_coordinates(filtered, coords, order=3,
@@ -767,12 +767,18 @@ def map_coordinates(filtered, coords, order=3, mode="nearest", prefilter=False):
         Spline order; only ``3`` (cubic) is implemented for the backend path
         (the numpy path forwards any order to scipy). Default 3.
     mode : str, optional
-        Boundary mode for taps outside ``[0, n_d - 1]``. Only ``'nearest'``
-        (clamp the tap index to the edge) is implemented on the backend path; it
-        is forwarded to scipy on the numpy path. The action-angle grids clamp
-        their coordinates in-range before calling, so the boundary mode is
-        rarely exercised, but ``'nearest'`` is the documented/default choice.
-        Default ``'nearest'``.
+        Boundary mode for taps outside ``[0, n_d - 1]``. Default ``'mirror'``,
+        which is the PAIR to :func:`spline_filter`'s ``mode='mirror'`` prefilter:
+        filter-then-evaluate only reconstructs the input when the two modes
+        match. Only ``'mirror'`` and ``'nearest'`` are implemented on the backend
+        path; both are forwarded to scipy on the numpy path.
+
+        Clamping the *coordinates* in-range does NOT make the boundary mode
+        irrelevant -- the cubic kernel's *taps* still reach outside at a query on
+        or near an edge node. With ``'nearest'`` on mirror-prefiltered
+        coefficients the error at boundary nodes reached 6.8 in a log-valued
+        actionAngle grid (~875x in the value) while the interior stayed exact,
+        which is why interior-only tests never saw it.
     prefilter : bool, optional
         Whether to prefilter inside this call. The intended usage prefilters once
         at setup via :func:`spline_filter` and passes ``prefilter=False`` here;
@@ -798,9 +804,9 @@ def map_coordinates(filtered, coords, order=3, mode="nearest", prefilter=False):
         raise NotImplementedError(
             "backend map_coordinates only implements order=3 (cubic)"
         )
-    if mode != "nearest":  # pragma: no cover - galpy uses the clamped path
+    if mode not in ("mirror", "nearest"):  # pragma: no cover
         raise NotImplementedError(
-            "backend map_coordinates only implements mode='nearest'"
+            "backend map_coordinates only implements mode='mirror'|'nearest'"
         )
     import array_api_compat
 
@@ -833,7 +839,13 @@ def map_coordinates(filtered, coords, order=3, mode="nearest", prefilter=False):
         wt = None
         for d in range(D):
             idx_d = base[d] + offs[combo[d]]
-            idx_d = xp.clip(idx_d, 0, shape[d] - 1)
+            if mode == "mirror":
+                # Whole-sample symmetric fold, the pair to spline_filter's
+                # mode='mirror': i<0 -> -i ; i>n-1 -> 2(n-1)-i.
+                hi = shape[d] - 1
+                idx_d = hi - xp.abs(hi - xp.abs(idx_d))
+            else:  # 'nearest': clamp the tap index to the edge
+                idx_d = xp.clip(idx_d, 0, shape[d] - 1)
             gather_idx.append(idx_d)
             w_d = weights[d][combo[d]]
             wt = w_d if wt is None else wt * w_d
@@ -865,10 +877,11 @@ class MapCoordinates:
     order : int, optional
         Spline order (default 3, cubic).
     mode : str, optional
-        Boundary mode for the backend path (default ``'nearest'``).
+        Boundary mode (default ``'mirror'``, pairing with the prefilter -- see
+        :func:`map_coordinates`).
     """
 
-    def __init__(self, grid, order=3, mode="nearest"):
+    def __init__(self, grid, order=3, mode="mirror"):
         self._order = order
         self._mode = mode
         self._filtered = spline_filter(grid, order=order)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -26,6 +26,21 @@
 # slowest members of it. Re-homing is bookkeeping accuracy, not burndown: the
 # xfail ledger drops 2 and the deferred list gains 2.
 #
+# SOURCE-FIX burn (2026-08-05, map_coordinates boundary mode). The JAX
+# StaeckelGrid_basicAndConserved entry is pruned here: the circular-orbit JR it
+# asserts goes 4.836e-14 -> 6.04e-24 once the evaluator's boundary mode is paired
+# with the mode='mirror' prefilter (assert is < 1e-16). Measured whole-file,
+# --runxfail: jax 3 failures -> 2, no new failures, numpy 209/209 unchanged.
+#
+# The TORCH entry of the same test deliberately STAYS. There the fix clears the JR
+# and Jz asserts but a later eccentricity assert still fails (1.53e-10). That
+# residual is NOT interpolation -- both backends now match scipy to 3.55e-15 --
+# it is setup-time grid construction under a forced backend:
+#     grids built on numpy, called under backend : jax 6.38e-12, torch 6.38e-12
+#     grids BUILT under the forced backend       : jax 0.0,      torch 1.53e-10
+# i.e. the evaluation path is backend-agnostic; construction is not. Separate
+# (deferred setup-path) work, so the torch entry remains ledgered and honest.
+#
 # REGEN-MILESTONE prune (2026-07-23, full-matrix REGEN run 29979778304 on
 # feat/backends c08577ff -- post-#1185; all 44 jax+torch shards ran to
 # completion (conclusion=success), no session-timeout truncation, and the
@@ -152,7 +167,6 @@
 
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
-jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
 jax tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -612,8 +612,13 @@ def test_map_coordinates_vs_scipy(backend):
     # ndimage cubic map_coordinates: setup-time scipy spline_filter prefilter,
     # then backend interpolation off the coefficients. numpy byte-identical;
     # jax/torch ~1e-12 vs scipy.ndimage.map_coordinates.
+    #
+    # The reference MUST use the same boundary mode as spline_filter (mirror).
+    # These refs previously pinned mode="nearest" to match what the evaluator
+    # happened to do, so both sides shared one wrong rule and agreed by
+    # construction -- see test_map_coordinates_reproduces_every_node_* below.
     filt = spline_filter(_MGRID, order=3)
-    ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="nearest")
+    ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="mirror")
     got = as_numpy(map_coordinates(filt, _asarray(backend, _MCOORDS)))
     rtol = 0.0 if backend == "numpy" else 1e-12
     numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-13)
@@ -622,7 +627,7 @@ def test_map_coordinates_vs_scipy(backend):
 def test_map_coordinates_numpy_byte_identical():
     # numpy path is a literal scipy.ndimage.map_coordinates passthrough.
     filt = spline_filter(_MGRID, order=3)
-    ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="nearest")
+    ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="mirror")
     numpy.testing.assert_array_equal(map_coordinates(filt, _MCOORDS), ref)
 
 
@@ -633,7 +638,7 @@ def test_mapcoordinates_class_matches_function(backend):
     mc = MapCoordinates(_MGRID, order=3)
     numpy.testing.assert_array_equal(mc.filtered, spline_filter(_MGRID, order=3))
     ref = sndi.map_coordinates(
-        mc.filtered, _MCOORDS, order=3, prefilter=False, mode="nearest"
+        mc.filtered, _MCOORDS, order=3, prefilter=False, mode="mirror"
     )
     got = as_numpy(mc(_asarray(backend, _MCOORDS)))
     rtol = 0.0 if backend == "numpy" else 1e-12
@@ -952,7 +957,7 @@ def test_mapcoordinates_native_filtered_vs_scipy(backend):
         _MC3,
         order=3,
         prefilter=False,
-        mode="nearest",
+        mode="mirror",
     )
     got = as_numpy(mc(_asarray(backend, _MC3)))
     numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-12)
@@ -1162,3 +1167,57 @@ def test_eval_ppoly_derivative_orders_match_scipy_numpy(nu):
     got = eval_ppoly(numpy, x, c, r, nu=nu)
     ref = numpy.zeros_like(r) if nu > 3 else pp.derivative(nu)(r) if nu else pp(r)
     numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=1e-12)
+
+
+# --- boundary-node reproduction (the check that was missing) -----------------
+# Every probe above draws query points from the interior extent, where no cubic
+# tap reaches outside the array and so EVERY boundary mode agrees. That is why a
+# mismatched evaluator mode survived: with mode='nearest' on mode='mirror'
+# prefiltered coefficients, boundary-node error reached 6.8 in a log-valued
+# actionAngle grid (~875x in the value) while the interior stayed exact.
+#
+# filter+evaluate must return the input at EVERY node, edges included. One
+# assertion pins the filter/evaluator mode pairing; interior-only probes cannot.
+_BN_SHAPE = (6, 7, 5)
+_BN_GRID = _rng.uniform(0.1, 2.0, _BN_SHAPE)
+_BN_NODES = numpy.indices(_BN_SHAPE).reshape(3, -1).astype(float)
+
+
+def _bn_on_boundary(shape):
+    onb = numpy.zeros(shape, dtype=bool)
+    for d in range(len(shape)):
+        sl = [slice(None)] * len(shape)
+        sl[d] = 0
+        onb[tuple(sl)] = True
+        sl[d] = shape[d] - 1
+        onb[tuple(sl)] = True
+    return onb.ravel()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_map_coordinates_reproduces_every_node_including_boundaries(backend):
+    filt = spline_filter(_BN_GRID, order=3)
+    got = as_numpy(map_coordinates(filt, _asarray(backend, _BN_NODES)))
+    err = numpy.abs(got - _BN_GRID.ravel())
+    onb = _bn_on_boundary(_BN_SHAPE)
+    # Reported separately: a boundary-only regression must not hide behind a
+    # healthy interior, and that asymmetry IS the signature of a mode mismatch.
+    assert err[~onb].max() < 1e-12, (
+        f"interior nodes not reproduced: max|err| = {err[~onb].max():.3e}"
+    )
+    assert err[onb].max() < 1e-12, (
+        f"BOUNDARY nodes not reproduced: max|err| = {err[onb].max():.3e} "
+        f"(interior fine at {err[~onb].max():.3e}) -- the evaluator's boundary "
+        "mode does not match spline_filter's mode='mirror'"
+    )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_map_coordinates_nearest_still_available(backend):
+    # 'nearest' remains selectable and still matches scipy; only the DEFAULT moved.
+    filt = spline_filter(_BN_GRID, order=3)
+    ref = sndi.map_coordinates(
+        filt, _BN_NODES, order=3, prefilter=False, mode="nearest"
+    )
+    got = as_numpy(map_coordinates(filt, _asarray(backend, _BN_NODES), mode="nearest"))
+    numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-12)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1221,3 +1221,13 @@ def test_map_coordinates_nearest_still_available(backend):
     )
     got = as_numpy(map_coordinates(filt, _asarray(backend, _BN_NODES), mode="nearest"))
     numpy.testing.assert_allclose(got, ref, rtol=0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_map_coordinates_rejects_unimplemented_mode(backend):
+    # The mode guard is reachable only with backend-array coords (numpy coords
+    # are a scipy passthrough that accepts every scipy mode), and this PR widened
+    # it from 'nearest' to 'mirror'|'nearest' -- so cover it rather than pragma it.
+    filt = spline_filter(_BN_GRID, order=3)
+    with pytest.raises(NotImplementedError, match="mirror.*nearest"):
+        map_coordinates(filt, _asarray(backend, _BN_NODES), mode="reflect")


### PR DESCRIPTION
`galpy.backend.interpolate.map_coordinates` defaulted to `mode='nearest'` while the
grids it reads are prefiltered with `mode='mirror'` (scipy's `spline_filter`
default). **A cubic spline filter and its evaluator must use the same boundary
rule** — otherwise filter-then-evaluate does not reconstruct the input. Interior
queries never reach a tap outside the array, so every mode agrees there, and the
mismatch was invisible to every existing test.

## The measurement

Node reproduction over **all** nodes of a filtered grid, per mode:

| mode | max\|err\| interior | max\|err\| **boundary** |
|---|---|---|
| `constant` | 2.132e-14 | 2.487e-14 |
| `mirror` | 2.132e-14 | 2.487e-14 |
| **`nearest`** (was the default) | 2.132e-14 | **6.775e+00** |
| `reflect` | 2.132e-14 | 6.775e+00 |

On `actionAngleStaeckelGrid`'s log-valued grids, **6.775 in the log is e^6.775 ≈
875×** in the interpolated value, at boundary nodes.

## How it surfaced

`test_actionAngleStaeckelGrid_basicAndConserved_actions` asserts a circular orbit
has `|JR| < 1e-16`. numpy returns exactly `0.0`; the backends returned `4.836e-14`.

At first glance `< 1e-16` looks like a defective assertion — it is below float64
eps. It is not: numpy returns a hard zero, so it is a legitimate exactness check
and the backends were what changed. The query lands at `[3.762, 24.0, 24.0]` on a
20×25×25 grid — the **last node in two axes**. Full chain, reproduced:

```
interpolated log off by 5.38e-05  ->  exp()  ->  5.38e-15  ->  x 8.985  ->  4.8357e-14
```

which is exactly the value in the failure message. With the fix, `JR = 6.04e-24`.

## Changes

- default `mode` `'nearest'` → `'mirror'`, on both `map_coordinates` and
  `MapCoordinates`
- backend tap index: whole-sample mirror fold (`i<0 → -i`, `i>n-1 → 2(n-1)-i`);
  `'nearest'` remains selectable and still clamps
- **corrected the docstring rationale that produced the bug.** It claimed callers
  "clamp their coordinates in-range before calling, so the boundary mode is rarely
  exercised". Clamping *coordinates* does not stop the cubic kernel's *taps* from
  reaching outside — which is exactly what a query on an edge node does.

## Why it survived — the test side

The existing references pinned scipy to `mode="nearest"`:

```python
ref = sndi.map_coordinates(filt, _MCOORDS, order=3, prefilter=False, mode="nearest")
```

so both sides shared the wrong rule and agreed **by construction**. Those 4 sites
now use `'mirror'`. Note `_MCOORDS` are random points in `[0, n-1]` that *do* land
near boundaries — the coverage existed; the pinned mode blinded it.

Added `test_map_coordinates_reproduces_every_node_including_boundaries`: asserts
filter+evaluate returns the input at **every** node, reporting interior and
boundary **separately**, so a boundary-only regression cannot hide behind a healthy
interior — that asymmetry is the signature of a mode mismatch. Plus a test that
`mode='nearest'` is still selectable and still matches scipy.

**Verified meaningful by A/B, not asserted:**

```
WITH the source fix      161 passed
WITHOUT it (tests kept)  3 failed — numpy, jax AND torch
```

## numpy path: no production behaviour change

Audited every consumer of the changed default. The only ones are
`actionAngleStaeckelGrid`'s six `MapCoordinates` instances — all `_b`-suffixed and
reached only from `_evaluate_backend` / `_EccZmaxRperiRap_backend`. That class's
numpy path calls `ndimage.map_coordinates` directly and is untouched, as are
`actionAngleVerticalInverse`'s four direct `ndimage` sites.

## Gates

Whole `test_actionAngle.py`, `--runxfail` so nothing is masked:

```
numpy  209 total, 209 passed, FAILED=0        (byte-identity, unchanged)
jax    209 total, 180 passed, FAILED=2        (was 3)
torch  209 total, 182 passed, FAILED=3        (unchanged)

jax BURNED: test_actionAngleStaeckelGrid_basicAndConserved_actions
NEW on any backend: none
```

plus `tests/test_backend_interpolate.py` 161 passed (numpy + jax + torch).

## Ledger

Burns `jax tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions`
with **no tolerance change**, and prunes that entry here — a source-fix PR should
not leave the ledger overstating the work left.

**It does not burn the torch entry, and that is deliberate.** On torch the same
test now passes its `JR` and `Jz` asserts but fails a later assertion on
*eccentricity*. That residual is **not** interpolation — probed directly, both
backends now match scipy identically (`+3.55e-15`). Localised instead to
**setup-time grid construction** under a forced backend:

```
grids built on NUMPY, called under forced backend:  jax 6.38e-12   torch 6.38e-12
grids BUILT under the forced backend (what CI does): jax 0.0        torch 1.53e-10
```

The evaluation path is backend-agnostic — the two backends agree to the last bit.
The divergence is entirely in construction, which belongs to the deferred
setup-path migration family, not to this PR.
