### PR TITLE
AnyAxisym: resolve the a=R peak so small-|z| second derivatives (and their gradients) are right

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -139,7 +139,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     # scipy value is wrapped as a backend array so no downstream ``xp.`` op meets
     # a bare python float.
     # -----------------------------------------------------------------------
-    def _bk_split_quad(self, integrand, R, xp, dev):
+    def _bk_split_quad(self, integrand, R, xp, dev, z=None, K=24, n=50):
         # int_0^inf integrand(a) da as [0, R] + [R, 2R] + [2R, inf); the
         # symmetric plain-GL split at R handles the a=R (m->1) singularity.
         #
@@ -157,9 +157,44 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         Rs = xp.where(finite, R, xp.ones_like(R))
         positive = Rs > 0
         Rp = xp.where(positive, Rs, xp.ones_like(Rs))
-        inner = _bquad.fixed_quad(
-            xp, integrand, xp.zeros_like(Rp), Rp, n=_GLORDER, device=dev
-        ) + _bquad.fixed_quad(xp, integrand, Rp, 2.0 * Rp, n=_GLORDER, device=dev)
+        if z is None:
+            inner = _bquad.fixed_quad(
+                xp, integrand, xp.zeros_like(Rp), Rp, n=_GLORDER, device=dev
+            ) + _bquad.fixed_quad(xp, integrand, Rp, 2.0 * Rp, n=_GLORDER, device=dev)
+        else:
+            # Dyadic panels graded toward the a=R peak (width ~|z|), issued as ONE
+            # batched fixed_quad over a leading panel axis: as separate calls the
+            # jit graph is ~16x more expensive to compile.
+            #
+            # dmin bounds how close panels may approach a=R. At z=0 the integral
+            # is singular there and marching panels in makes a finite difference
+            # of this potential in R blow up, so grading is switched off; for
+            # z>0 the peak is genuinely resolvable and the FD stays clean.
+            ones = xp.ones_like(Rp)
+            half = 0.5 * Rp
+            dmin = xp.where(
+                xp.abs(z) * ones > 0.0,
+                xp.minimum(4.0 * xp.abs(z) * ones, half),
+                half,
+            )
+            # dk decreasing: R/2, R/4, ... (clamped at dmin), so R-dk ascends
+            # and R+dk descends -- the right side is the one needing a reverse.
+            dk = [xp.maximum(Rp * (2.0**-k), dmin) for k in range(1, K + 1)]
+            left = [Rp - d for d in dk]  # ascending, ends near R
+            right = [Rp + d for d in dk][::-1]  # ascending, starts near R
+            lo = [xp.zeros_like(Rp)] + left + [Rp] + right
+            hi = left + [Rp] + right + [2.0 * Rp]
+            inner = xp.sum(
+                _bquad.fixed_quad(
+                    xp,
+                    integrand,
+                    xp.stack(lo, axis=-1),
+                    xp.stack(hi, axis=-1),
+                    n=n,
+                    device=dev,
+                ),
+                axis=-1,
+            )
         out = xp.where(positive, inner, xp.zeros_like(inner)) + (
             _bquad.fixed_quad_semiinfinite(
                 xp, integrand, 2.0 * Rs, n=_GLORDER, device=dev
@@ -237,7 +272,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             m1, aRz = self._bk_m1_aRz(a, R, z2, xp)
             return a * sdens(a) / xp.sqrt(aRz) * _bspecial.ellipkm1(m1)
 
-        return -4.0 * self._bk_split_quad(potint, R, xp, dev)
+        return -4.0 * self._bk_split_quad(potint, R, xp, dev, z)
 
     # ------------------------------- Rforce --------------------------------
     @check_potential_inputs_not_arrays
@@ -291,7 +326,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / xp.sqrt(aRz)
             )
 
-        return 2.0 * self._bk_split_quad(rforceint, R, xp, dev)
+        return 2.0 * self._bk_split_quad(rforceint, R, xp, dev, z)
 
     # ------------------------------- zforce --------------------------------
     @check_potential_inputs_not_arrays
@@ -342,7 +377,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / xp.sqrt(aRz)
             )
 
-        integral = self._bk_split_quad(zforceint, R, xp, dev)
+        integral = self._bk_split_quad(zforceint, R, xp, dev, z)
         return xp.where(z == 0, xp.zeros_like(z), -4.0 * z * integral)
 
     # ------------------------------ R2deriv --------------------------------
@@ -413,7 +448,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / (2.0 * R2 * ((a - R) ** 2 + z2) ** 2 * aRz**1.5)
             )
 
-        return -4.0 * self._bk_split_quad(r2derivint, R, xp, dev)
+        return -4.0 * self._bk_split_quad(r2derivint, R, xp, dev, z)
 
     # ------------------------------ z2deriv --------------------------------
     @check_potential_inputs_not_arrays
@@ -469,7 +504,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / (((a - R) ** 2 + z2) ** 2 * aRz**1.5)
             )
 
-        return -4.0 * self._bk_split_quad(z2derivint, R, xp, dev)
+        return -4.0 * self._bk_split_quad(z2derivint, R, xp, dev, z)
 
     # ------------------------------ Rzderiv --------------------------------
     @check_potential_inputs_not_arrays
@@ -549,7 +584,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / aRz**1.5
             )
 
-        integral = self._bk_split_quad(rzderivint, R, xp, dev)
+        integral = self._bk_split_quad(rzderivint, R, xp, dev, z)
         return xp.where(z == 0, xp.zeros_like(z), -2.0 * z * integral)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -139,7 +139,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     # scipy value is wrapped as a backend array so no downstream ``xp.`` op meets
     # a bare python float.
     # -----------------------------------------------------------------------
-    def _bk_split_quad(self, integrand, R, xp, dev, z=None, K=24, n=50):
+    def _bk_split_quad(self, integrand, R, xp, dev, z, K=24, n=50):
         # int_0^inf integrand(a) da as [0, R] + [R, 2R] + [2R, inf); the
         # symmetric plain-GL split at R handles the a=R (m->1) singularity.
         #
@@ -157,44 +157,39 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         Rs = xp.where(finite, R, xp.ones_like(R))
         positive = Rs > 0
         Rp = xp.where(positive, Rs, xp.ones_like(Rs))
-        if z is None:
-            inner = _bquad.fixed_quad(
-                xp, integrand, xp.zeros_like(Rp), Rp, n=_GLORDER, device=dev
-            ) + _bquad.fixed_quad(xp, integrand, Rp, 2.0 * Rp, n=_GLORDER, device=dev)
-        else:
-            # Dyadic panels graded toward the a=R peak (width ~|z|), issued as ONE
-            # batched fixed_quad over a leading panel axis: as separate calls the
-            # jit graph is ~16x more expensive to compile.
-            #
-            # dmin bounds how close panels may approach a=R. At z=0 the integral
-            # is singular there and marching panels in makes a finite difference
-            # of this potential in R blow up, so grading is switched off; for
-            # z>0 the peak is genuinely resolvable and the FD stays clean.
-            ones = xp.ones_like(Rp)
-            half = 0.5 * Rp
-            dmin = xp.where(
-                xp.abs(z) * ones > 0.0,
-                xp.minimum(4.0 * xp.abs(z) * ones, half),
-                half,
-            )
-            # dk decreasing: R/2, R/4, ... (clamped at dmin), so R-dk ascends
-            # and R+dk descends -- the right side is the one needing a reverse.
-            dk = [xp.maximum(Rp * (2.0**-k), dmin) for k in range(1, K + 1)]
-            left = [Rp - d for d in dk]  # ascending, ends near R
-            right = [Rp + d for d in dk][::-1]  # ascending, starts near R
-            lo = [xp.zeros_like(Rp)] + left + [Rp] + right
-            hi = left + [Rp] + right + [2.0 * Rp]
-            inner = xp.sum(
-                _bquad.fixed_quad(
-                    xp,
-                    integrand,
-                    xp.stack(lo, axis=-1),
-                    xp.stack(hi, axis=-1),
-                    n=n,
-                    device=dev,
-                ),
-                axis=-1,
-            )
+        # Dyadic panels graded toward the a=R peak (width ~|z|), issued as ONE
+        # batched fixed_quad over a leading panel axis: as separate calls the
+        # jit graph is ~16x more expensive to compile.
+        #
+        # dmin bounds how close panels may approach a=R. At z=0 the integral
+        # is singular there and marching panels in makes a finite difference
+        # of this potential in R blow up, so grading is switched off; for
+        # z>0 the peak is genuinely resolvable and the FD stays clean.
+        ones = xp.ones_like(Rp)
+        half = 0.5 * Rp
+        dmin = xp.where(
+            xp.abs(z) * ones > 0.0,
+            xp.minimum(4.0 * xp.abs(z) * ones, half),
+            half,
+        )
+        # dk decreasing: R/2, R/4, ... (clamped at dmin), so R-dk ascends
+        # and R+dk descends -- the right side is the one needing a reverse.
+        dk = [xp.maximum(Rp * (2.0**-k), dmin) for k in range(1, K + 1)]
+        left = [Rp - d for d in dk]  # ascending, ends near R
+        right = [Rp + d for d in dk][::-1]  # ascending, starts near R
+        lo = [xp.zeros_like(Rp)] + left + [Rp] + right
+        hi = left + [Rp] + right + [2.0 * Rp]
+        inner = xp.sum(
+            _bquad.fixed_quad(
+                xp,
+                integrand,
+                xp.stack(lo, axis=-1),
+                xp.stack(hi, axis=-1),
+                n=n,
+                device=dev,
+            ),
+            axis=-1,
+        )
         out = xp.where(positive, inner, xp.zeros_like(inner)) + (
             _bquad.fixed_quad_semiinfinite(
                 xp, integrand, 2.0 * Rs, n=_GLORDER, device=dev

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -411,3 +411,72 @@ def test_degenerate_guards_do_not_break_gradients_torch():
             fd = float((f(torch.tensor(R0 + h)) - f(torch.tensor(R0 - h))) / (2.0 * h))
             rel = abs(ad - fd) / abs(fd)
             assert rel < 1e-9, f"torch R={R0}: AD vs FD rel={rel:g}"
+
+
+# --- small-|z| quadrature: the regime every probe above skips --------------
+# _ZS is [0.15, 0.3, 0.25, 0.4] and the traced 2nd-deriv test uses z=0.25, so no
+# backend test ever entered 0 < |z| << R. That is exactly where the plain
+# two-panel GL split failed: the integrand has a peak of width ~|z| at a=R, and
+# once |z| drops below the Legendre node spacing near the panel edge the peak
+# falls BETWEEN nodes. Measured before the graded split, R=1:
+#     z/R    1e-06     1e-04     1e-03     3e-03
+#     rel    3.67e+03  1.15e+03  8.38e-01  5.79e-04
+# numpy is immune because scipy's quad(..., points=[R]) subdivides adaptively.
+# This reaches users as a wrong GRADIENT too, not just a wrong jit value, since
+# _bk_dispatch routes requires_grad input down the same GL path.
+_SMALL_ZS = [1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1]
+
+
+def _traced_call(backend_name, fn, R, z):
+    """Evaluate fn on the GL path (jit for jax, requires_grad for torch)."""
+    if backend_name == "jax":
+        return float(
+            jax.jit(lambda RR: fn(_POT, RR, jnp.asarray(z, dtype=jnp.float64)))(
+                jnp.asarray(R, dtype=jnp.float64)
+            )
+        )
+    Rt = torch.tensor(R, dtype=torch.float64, requires_grad=True)
+    return float(fn(_POT, Rt, torch.tensor(z, dtype=torch.float64)))
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("z", _SMALL_ZS)
+def test_second_derivs_at_small_z_match_scipy(backend_name, z):
+    """The GL path must track scipy down to |z|/R ~ 1e-6, not just at |z| >= 0.15."""
+    R = 1.0
+    for fn in (evaluateR2derivs, evaluatez2derivs):
+        ref = float(fn(_POT, numpy.float64(R), numpy.float64(z)))
+        got = _traced_call(backend_name, fn, R, z)
+        rel = abs(got - ref) / abs(ref)
+        assert rel < 1e-4, (
+            f"{fn.__name__} on {backend_name} at z={z:g} is off by {rel:.2e}; "
+            "the a=R peak (width ~|z|) is not resolved by the quadrature"
+        )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("z", [0.0, 1e-3, 1e-2, 0.125])
+def test_rforce_finite_difference_in_R_stays_clean(backend_name, z):
+    """A finite difference of Rforce in R must still reproduce R2deriv.
+
+    Panel edges scale with R, so refining them toward a=R can make the
+    quadrature error vary non-smoothly in R -- harmless for the value, fatal for
+    a caller's finite difference, which divides by dr=1e-8. An earlier
+    unconditionally-graded version passed every accuracy check above and was
+    wrong here by 193%. z=0 is the sensitive case and is included deliberately.
+    """
+    R = 1.0
+    dr = 1e-8
+    dr = (R + dr) - R  # representable
+    f0 = _traced_call(backend_name, evaluateRforces, R, z)
+    f1 = _traced_call(backend_name, evaluateRforces, R + dr, z)
+    fd = (f0 - f1) / dr
+    # At z=0 the analytic 2nd derivative is a divergent integral, so compare the
+    # FD against the numpy/scipy value rather than the backend's own.
+    ref = float(evaluateR2derivs(_POT, numpy.float64(R), numpy.float64(z)))
+    rel = abs(fd - ref) / abs(ref)
+    assert rel < 1e-3, (
+        f"FD of Rforce on {backend_name} at z={z:g} gives {fd:.8e} vs "
+        f"R2deriv {ref:.8e} (rel {rel:.2e}) -- the quadrature error is not "
+        "varying smoothly in R"
+    )


### PR DESCRIPTION
`_bk_split_quad` used a plain two-panel Gauss-Legendre split at `a = R`. The
integrand has a peak of **width ~|z|** there, so once `|z|` drops below the
Legendre node spacing near the panel edge the peak falls *between* nodes and the
rule integrates garbage. numpy is immune because `quad(..., points=[R])`
subdivides adaptively.

Relative error vs scipy, R = 1:

| z/R | before | after |
|---|---|---|
| 1e-06 | 3.67e+03 | 5.93e-07 |
| 1e-04 | 1.15e+03 | 1.25e-10 |
| 1e-03 | 8.38e-01 | 6.97e-13 |
| 1e-02 | 6.35e-10 | 1.06e-13 |
| 1.25e-01 | ~1e-14 | 1.70e-14 |

### This is not only a jit issue

`_bk_dispatch` sends *concrete* input to scipy but routes tracers **and
`requires_grad` input** down this same GL path. So a torch/jax **gradient**
through `R2deriv`/`z2deriv` at small `|z|` was computed from the broken
quadrature — wrong value and wrong gradient, in eager, with no jit involved.

### The fix

Dyadic panels graded toward `a = R`, issued as **one batched `fixed_quad`** over a
leading panel axis. Written as separate per-panel calls the jit graph costs 16x
more to compile (0.61 s -> 9.62 s); batched it is 0.87 s.

```python
dmin = where(|z| > 0, min(4|z|, R/2), R/2)
```

bounds how close panels may approach `a = R`. It is a traced select on a
**scalar**, so there is one quadrature either way — no branch, no extra cost.

### Why `dmin` turns grading off at z = 0 (the subtle part)

Panel edges scale with R, so refining them into the `a = R` singularity makes the
quadrature error vary **non-smoothly in R**. Harmless for the value; fatal for a
caller's finite difference, which divides by `dr = 1e-8`. An unconditionally
graded version passed every accuracy check above and was **wrong by 193%** on an
FD of `Rforce` at z=0.

The binding constraint is smoothness of the error in R, not raw accuracy. I swept
grading depth to confirm: no depth satisfies both at z=0, while at every z != 0
full grading keeps the FD clean (1.3e-05 at z=1e-4 down to 7.9e-09 at z=0.25).

### Cost

eager 644 -> 1215 ms, jit-compile 0.61 -> 0.87 s, jit-run 0.134 -> 0.336 ms.
~2x, for second derivatives that were previously off by 1e3.

### Residual, stated rather than buried

- At z=0 exactly, `Rforce` is **1.6e-05 vs 8.3e-06** before — 2x worse on a
  quantity already accurate to 1e-5, because the collapsed split places its 200
  nodes differently.
- `R2deriv`/`z2deriv` at z=0 remain wrong. That integral genuinely **diverges**
  (integrand ~ `Sigma(R)/(2(a-R)^2)`, verified at five radii), so no sampling
  scheme recovers it — it needs a Hadamard finite part, which is a separate
  change. **The ledger is unchanged by this PR.**

### numpy untouched

`_bk_split_quad` is reached only from the `_gl` functions; every `_*_numpy`
variant calls scipy's `quad` directly. Byte-identity is not at risk.

### Tests

The existing file's `_ZS` is `[0.15, 0.3, 0.25, 0.4]` and its traced
second-derivative test uses z=0.25 — **no backend test had ever entered
`0 < |z| << R`**, which is why this survived. Added a z-sweep from 1e-6 to 1e-1
and a finite-difference-smoothness guard pinning the regression above.

Verified meaningful by A/B rather than asserted:

```
with the fix        20 passed
without it           8 failed   (small-z, jax AND torch)
```

Gates — 10 passed / 1 skipped on each, identical to numpy:

```
numpy  tests/test_potential.py -k AnyAxisym
jax    same, --backend jax   --runxfail
torch  same, --backend torch --runxfail
tests/test_backend_anyaxisymdisk.py   36 passed
```

The one failure in that file, `test_torch_compile_takes_the_backend_gl_path`, is
**pre-existing** (fails identically without this change) and local-only: a newer
torch's `torch.jit.script_method` DeprecationWarning that the test's filter list
does not cover. Not ledgered, and CI is green on it.
