### PR TITLE
jeans: drop the numpy island and make the semi-infinite quadrature map scale-invariant

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -296,7 +296,9 @@ def fixed_quad(xp, integrand, a, b, *, n=50, device=None, vectorized=True):
     return match_input_dtype(result, a, b)
 
 
-def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip", device=None):
+def fixed_quad_semiinfinite(
+    xp, integrand, a, *, n=50, kind="recip", scale=None, device=None
+):
     r"""``int_a^inf integrand(s) ds`` by fixed-order Gauss-Legendre quadrature.
 
     The semi-infinite range is mapped to a finite one before applying
@@ -327,6 +329,12 @@ def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip", device=None
         - ``'tan'``: ``s = a + tan(pi/2 * u)`` for ``u in [0, 1)``,
           ``ds = pi/2 * sec^2(pi/2 * u) du``. Good for slowly decaying /
           oscillatory tails (e.g. ``1/(1+s**2)``).
+    scale : scalar or backend array, optional
+        Transition scale ``L`` of the map, i.e. the width in ``s`` over which
+        the nodes crowd near the lower limit (``s = a - L + L/u**2`` for
+        ``'recip'``, ``s = a + L*tan(pi/2*u)`` for ``'tan'``). Defaults to
+        ``L = 1``. Pass the scale on which the integrand actually varies
+        whenever that is far from unity -- see Notes. Broadcasts against ``a``.
 
     Returns
     -------
@@ -340,27 +348,38 @@ def fixed_quad_semiinfinite(xp, integrand, a, *, n=50, kind="recip", device=None
     interior so those points are never evaluated, but the dead-branch guarding
     convention is still honoured: ``u`` is clamped strictly inside ``(0, 1)``
     before the map so no node can produce inf/NaN that would poison AD.
+
+    ``scale`` matters more than ``n``. Node spacing in ``s`` just above the
+    lower limit is ``O(L/n**2)``, so with the default ``L = 1`` an integrand
+    whose structure sits on a scale ``eps << 1`` is unresolved no matter how
+    many nodes are thrown at it -- accuracy collapses as ``eps -> 0`` rather
+    than converging. Passing ``scale`` makes the map scale-invariant with the
+    problem. Measured on ``df.jeans.sigmar`` (structure on scale ``a = r``):
+    at ``r = 1e-3`` the default map errs by ``1.1e-02`` and ``scale=r`` by
+    ``1.2e-06`` at the same ``n = 50``; at ``n = 100`` the latter reaches
+    ``8.8e-12``, the accuracy of the scipy reference.
     """
     dev = device if device is not None else device_of(a)
     x01, w01 = _gl01_on(xp, n, dev)
     a = asarray_on_device(xp, a, dev) * 1.0
     a_b = a[..., None]
+    L = 1.0 if scale is None else asarray_on_device(xp, scale, dev)[..., None] * 1.0
     if kind == "recip":
-        # s + (1 - a) = 1/u**2  =>  s = a - 1 + 1/u**2 ; ds = -2 u**-3 du.
+        # s + (L - a) = L/u**2  =>  s = a - L + L/u**2 ; ds = -2 L u**-3 du.
         # u=1 -> s=a, u->0 -> s->inf. Clamp u off 0 so 1/u**2 stays finite.
         u = xp.maximum(x01, xp.ones_like(x01) * 1e-300)
         inv_u2 = 1.0 / (u * u)
-        s = a_b - 1.0 + inv_u2
-        jac = 2.0 * inv_u2 / u  # |ds/du| = 2 / u**3
+        s = a_b - L + L * inv_u2
+        jac = 2.0 * L * inv_u2 / u  # |ds/du| = 2 L / u**3
     elif kind == "tan":
-        # s = a + tan(pi/2 * u) ; ds = (pi/2) sec^2(pi/2 * u) du.
+        # s = a + L tan(pi/2 * u) ; ds = L (pi/2) sec^2(pi/2 * u) du.
         # u=0 -> s=a, u->1 -> s->inf. Clamp u off 1 so tan stays finite.
         half_pi = numpy.pi / 2.0
         u = xp.minimum(x01, xp.ones_like(x01) * (1.0 - 1e-15))
         theta = half_pi * u
         tan_t = xp.tan(theta)
-        s = a_b + tan_t
-        jac = half_pi * (1.0 + tan_t * tan_t)  # sec^2 = 1 + tan^2
+        s = a_b + L * tan_t
+        jac = half_pi * L * (1.0 + tan_t * tan_t)  # sec^2 = 1 + tan^2
     else:  # pragma: no cover - guarded API misuse
         raise ValueError(
             f"fixed_quad_semiinfinite: unknown kind {kind!r} (use 'recip' or 'tan')"

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -2,7 +2,7 @@
 import numpy
 from scipy import integrate
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import get_namespace
 from ..backend.quadrature import fixed_quad_semiinfinite, quad
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
@@ -50,7 +50,7 @@ def sigmar(Pot, r, dens=None, beta=0.0):
             phi=numpy.pi / 4.0,
             use_physical=False,
         )
-    xp = get_namespace(r) if is_backend_array(r) else numpy
+    xp = get_namespace(r)
     if xp is numpy:
         # numpy path: scipy.integrate.quad over [r, inf) -- byte-identical.
         if callable(beta):
@@ -79,9 +79,19 @@ def sigmar(Pot, r, dens=None, beta=0.0):
             / intFactor(r)
         )
     # jax/torch: fixed-order Gauss-Legendre on the mapped semi-infinite range,
-    # differentiable in r and through the potential's parameters.
+    # differentiable in r and through the potential's parameters. Coerce r onto
+    # the resolved namespace first: under a forced backend the caller may still
+    # pass a numpy/Python scalar, and then `quad` below returns a plain float
+    # that `xp.exp` rejects (torch: "argument 'input' must be Tensor, not float").
+    r = xp.asarray(r)
     if callable(beta):
-        intFactor = lambda x: xp.exp(2.0 * quad(lambda y: beta(y) / y, 1.0, x))
+        # Substitute y = exp(t): int_1^x beta(y)/y dy = int_0^ln(x) beta(e^t) dt.
+        # The nodes of the outer map run out to very large x, where fixed-order
+        # GL on the raw 1/y integrand is hopeless (it has to resolve a log over
+        # decades); in t it is smooth and bounded over a range of length ln(x).
+        intFactor = lambda x: xp.exp(
+            2.0 * quad(lambda t: beta(xp.exp(t)), 0.0, xp.log(x))
+        )
     else:
         intFactor = lambda x: x ** (2.0 * beta)
     return xp.sqrt(
@@ -99,6 +109,12 @@ def sigmar(Pot, r, dens=None, beta=0.0):
                 )
             ),
             r,
+            # The integrand varies on scale r, so the map must too: with the
+            # default unit scale, accuracy collapses as r -> 0 (1.1e-2 at
+            # r=1e-3) instead of converging. n=100 then reaches scipy's own
+            # accuracy there; n=50 leaves 1.2e-6.
+            n=100,
+            scale=r,
         )
         / dens(r)
         / intFactor(r)
@@ -136,7 +152,7 @@ def sigmalos(Pot, R, dens=None, surfdens=None, beta=0.0, sigma_r=None):
     - 2018-08-27 - Written - Bovy (UofT)
     """
     Pot = _check_potential_list_and_deprecate(Pot)
-    xp = get_namespace(R) if is_backend_array(R) else numpy
+    xp = get_namespace(R)
     if dens is None:
         densPot = True
         dens = lambda r: evaluateDensities(

--- a/tests/test_backend_jeans.py
+++ b/tests/test_backend_jeans.py
@@ -188,3 +188,48 @@ def test_sigmar_small_r_matches_closed_form(backend, r):
     assert numpy.fabs(float(as_numpy(got)) - exact) < 1e-10, (
         f"sigmar off by {numpy.fabs(float(as_numpy(got)) - exact):.3e} at r={r}"
     )
+
+
+# --- jit ---------------------------------------------------------------------
+# sigmar carries no @backend_input decorator, so it is NOT a trace boundary and
+# the `--jit` harness never traces it as a unit: passing under `--backend jax
+# --jit` says nothing about whether it is jit-compatible. Trace it explicitly.
+# `scale=r` puts the caller's r inside the quadrature MAP (not just the limit),
+# which is the part that has to survive a tracer.
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+@pytest.mark.parametrize("r", [1e-3, 1e-2, 0.1, 1.0, 5.0])
+def test_sigmar_jit_matches_eager(r):
+    from backend_jit_helpers import assert_jit_matches_eager
+
+    from galpy.potential import LogarithmicHaloPotential
+
+    # A CONVERGENT configuration: dens ~ r**0.1 with beta(r) = -3r. (Pairing a
+    # rising density with a constant beta=0.5 makes the Jeans integrand ~x**0.1
+    # and the integral divergent -- the GL rule then returns a large number that
+    # barely moves with r, which is not a code defect.)
+    lp = LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    assert_jit_matches_eager(
+        lambda x: jeans.sigmar(
+            lp, x, beta=lambda y: -3.0 * y, dens=lambda y: y**0.1, use_physical=False
+        ),
+        jnp.asarray(r),
+        rtol=1e-13,
+        atol=0.0,
+        err_msg=f"sigmar under jit at r={r}",
+    )
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_sigmar_jit_of_grad_matches_eager_grad():
+    # The differentiable path has to survive tracing too, not just the value.
+    from backend_jit_helpers import assert_jit_matches_eager
+
+    from galpy.potential import LogarithmicHaloPotential
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    g = jax.grad(
+        lambda x: jeans.sigmar(
+            lp, x, beta=lambda y: -3.0 * y, dens=lambda y: y**0.1, use_physical=False
+        )
+    )
+    assert_jit_matches_eager(g, jnp.asarray(0.5), rtol=1e-11, atol=0.0)

--- a/tests/test_backend_jeans.py
+++ b/tests/test_backend_jeans.py
@@ -98,3 +98,93 @@ def test_jeans_sigmar_grad_vs_fd(backend):
         jeans.sigmar(_HP, t, use_physical=False).backward()
         g = float(t.grad)
     numpy.testing.assert_allclose(g, fd, rtol=1e-4)
+
+
+# --- forced-backend dispatch: numpy-typed input must NOT pin to scipy --------
+# This file's header says it exercises "resolved-namespace dispatch", but the
+# module actually guarded on the DATA:
+#     xp = get_namespace(r) if is_backend_array(r) else numpy
+# `get_namespace` already honours a forced context ("forced default beats the
+# data"), so that test overrode it and pinned numpy-typed input to scipy -- a
+# numpy island: under `use(backend, force=True)` a plain float went down the
+# non-differentiable path, silently. Nothing else here catches it, because every
+# other test passes an already-backend array, which the guard let through.
+#
+# ASSERT ON THE PATH, NOT THE RETURN TYPE. Under forced torch the scipy result is
+# converted to a Tensor downstream, so `is_tensor(result)` is True even when the
+# whole computation ran on scipy -- a type check passes for the wrong reason on
+# torch while correctly failing on jax. Spy on the backend quadrature instead.
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("fn", ["sigmar", "sigmalos"])
+def test_forced_backend_takes_the_backend_path_for_numpy_input(
+    backend, fn, monkeypatch
+):
+    from galpy.backend import use
+
+    calls = []
+    real = jeans.fixed_quad_semiinfinite
+    monkeypatch.setattr(
+        jeans,
+        "fixed_quad_semiinfinite",
+        lambda *a, **k: (calls.append(1), real(*a, **k))[1],
+    )
+    with use(backend, force=True):
+        getattr(jeans, fn)(_HP, numpy.float64(1.0))
+    assert calls, (
+        f"jeans.{fn} made no backend-quadrature call under a FORCED {backend} "
+        "backend: numpy-typed input is still pinned to the scipy path"
+    )
+
+
+@pytest.mark.parametrize("fn", ["sigmar", "sigmalos"])
+def test_numpy_path_unchanged_without_a_forced_backend(fn, monkeypatch):
+    # The other half of the contract: with no forced backend, numpy input must
+    # still resolve to numpy and go to scipy -- zero backend-quadrature calls.
+    calls = []
+    real = jeans.fixed_quad_semiinfinite
+    monkeypatch.setattr(
+        jeans,
+        "fixed_quad_semiinfinite",
+        lambda *a, **k: (calls.append(1), real(*a, **k))[1],
+    )
+    got = getattr(jeans, fn)(_HP, numpy.float64(1.0))
+    assert not calls, f"jeans.{fn} took the backend path with no forced backend"
+    assert isinstance(got, numpy.floating), type(got).__name__
+
+
+# --- accuracy at small r -----------------------------------------------------
+# The semi-infinite map's default transition scale is 1, so as r -> 0 the nodes
+# stop resolving the integrand and the backend answer diverges from the truth
+# (1.1e-02 at r=1e-3 -- not a tolerance question, a wrong number). sigmar passes
+# scale=r to make the map scale-invariant; this pins that down against the
+# CLOSED FORM, not against numpy, so it cannot be satisfied by agreeing with an
+# equally-wrong reference.
+#
+#   Logarithmic halo (vc=1), dens ~ r**gamma, beta(r) = -b*r  =>
+#   sigma_r(r)**2 = Gamma(-gamma) * Gammainc_upper(-gamma, 2 b r)
+#                   / ((2 b r)**-gamma * exp(-2 b r))
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("r", [1e-3, 1e-2, 1e-1, 1.0, 5.0])
+def test_sigmar_small_r_matches_closed_form(backend, r):
+    from scipy import special
+
+    from galpy.backend import use
+    from galpy.potential import LogarithmicHaloPotential
+
+    gamma, b = -0.1, 3.0
+    lp = LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    exact = numpy.sqrt(
+        special.gamma(-gamma)
+        * special.gammaincc(-gamma, 2.0 * b * r)
+        / ((2.0 * b * r) ** -gamma * numpy.exp(-2.0 * b * r))
+    )
+    with use(backend, force=True):
+        got = jeans.sigmar(
+            lp, _arr(backend, r), beta=lambda x: -b * x, dens=lambda x: x**-gamma
+        )
+    assert _is_backend_array(backend, got)
+    # 1e-10 absolute is the accuracy scipy's adaptive quad reaches here; the
+    # backend now matches it rather than merely being close.
+    assert numpy.fabs(float(as_numpy(got)) - exact) < 1e-10, (
+        f"sigmar off by {numpy.fabs(float(as_numpy(got)) - exact):.3e} at r={r}"
+    )

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -261,6 +261,82 @@ def test_semiinfinite_grad_in_limit(backend):
     numpy.testing.assert_allclose(ga, -numpy.exp(-a0), rtol=1e-5)
 
 
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("eps", [1.0, 1e-2, 1e-4, 1e-6])
+def test_semiinfinite_scale_makes_the_map_resolve_small_structure(backend, eps):
+    # The map's node spacing in s just above the lower limit is O(L/n**2), so
+    # with the default L=1 an integrand whose structure sits on a scale eps<<1
+    # is simply not sampled -- and no n rescues it. Passing scale=eps makes the
+    # map scale-invariant, so the error becomes INDEPENDENT of eps.
+    #   int_eps^inf ds / (1 + (s/eps)**2) = eps * pi/4
+    xp = _xp(backend)
+    got = float(
+        numpy.asarray(
+            fixed_quad_semiinfinite(
+                xp, lambda s: 1.0 / (1.0 + (s / eps) ** 2), eps, n=50, scale=eps
+            )
+        )
+    )
+    numpy.testing.assert_allclose(got, eps * numpy.pi / 4.0, rtol=1e-13)
+    #   int_0^inf ds / (eps**2 + s**2) = pi / (2 eps), via the 'tan' map
+    got = float(
+        numpy.asarray(
+            fixed_quad_semiinfinite(
+                xp,
+                lambda s: 1.0 / (eps**2 + s**2),
+                0.0,
+                n=50,
+                kind="tan",
+                scale=eps,
+            )
+        )
+    )
+    numpy.testing.assert_allclose(got, numpy.pi / (2.0 * eps), rtol=1e-13)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_semiinfinite_scale_broadcasts_against_the_limit(backend):
+    # One call, three lower limits spanning six decades, each with its own
+    # scale: the whole point is that a batched caller (jeans.sigmar over an r
+    # grid) gets every element resolved, not just the O(1) ones.
+    xp = _xp(backend)
+    eps = xp.asarray([1.0, 1e-3, 1e-6])
+    got = numpy.asarray(
+        fixed_quad_semiinfinite(
+            xp,
+            lambda s: 1.0 / (1.0 + (s / eps[..., None]) ** 2),
+            eps,
+            n=50,
+            scale=eps,
+        )
+    )
+    ref = numpy.asarray([1.0, 1e-3, 1e-6]) * numpy.pi / 4.0
+    numpy.testing.assert_allclose(got, ref, rtol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_semiinfinite_scale_grad_in_limit(backend):
+    # d/da int_a^inf f = -f(a); at a = eps with f = 1/(1+(s/eps)**2) that is
+    # exactly -1/2, independent of eps. Differentiating through a SCALED map is
+    # the path jeans.sigmar's r-gradient takes.
+    eps = 1e-5
+
+    def f(s):
+        return 1.0 / (1.0 + (s / eps) ** 2)
+
+    if backend == "jax":
+        ga = float(
+            jax.grad(lambda a: fixed_quad_semiinfinite(jnp, f, a, n=50, scale=eps))(
+                jnp.asarray(eps)
+            )
+        )
+    else:
+        at = torch.tensor(eps, requires_grad=True)
+        fixed_quad_semiinfinite(txp, f, at, n=50, scale=eps).backward()
+        ga = float(at.grad)
+    numpy.testing.assert_allclose(ga, -0.5, rtol=1e-10)
+
+
 # ---------------------------------------------------------------------------
 # Public definite-integral API: quad / gauss_legendre. numpy -> scipy (byte-
 # identical value); jax/torch -> fixed-order GL, differentiable in params AND


### PR DESCRIPTION
`jeans.sigmar`/`sigmalos` guarded the namespace on the DATA:

```python
xp = get_namespace(r) if is_backend_array(r) else numpy
```

`get_namespace` already honours a forced context, so that guard overrode it and pinned numpy-typed input to scipy: under `use(backend, force=True)` a plain float silently took the non-differentiable path. It was also load-bearing — it hid five real backend defects, **none of them ledgered**. Removing it surfaced all five; they are fixed here, not ledgered.

## 1. The map's transition scale was hardcoded to 1

`fixed_quad_semiinfinite` used `s = a - 1 + 1/u**2`, whose node spacing in `s` just above the lower limit is `O(1/n**2)` **absolute**. An integrand with structure on scale `eps << 1` is therefore unresolved *no matter how large n is* — accuracy collapses as `eps -> 0` rather than converging.

Added a general `scale=L` giving `s = a - L + L/u**2` (and `s = a + L*tan(pi/2*u)` for `'tan'`); `sigmar` passes `scale=r`.

## 2. `intFactor` integrated `beta(y)/y` over decades

A **second** defect, only visible once (1) was fixed: with callable `beta`, fixed-order GL had to resolve a logarithm out to the outer map's largest nodes. Substituting `y = exp(t)` turns it into `int_0^ln(x) beta(e^t) dt`, smooth and bounded.

## 3. Coerce `r` onto the resolved namespace

So a numpy scalar under a forced backend doesn't hand `xp.exp` a plain float.

## Result

`|sigmar - closed form|`, LogarithmicHalo, `dens ~ r**0.1`, `beta = -3r`:

| r | before | after | numpy (scipy quad) |
|---|---|---|---|
| 0.001 | 1.1e-02 | **8.8e-12** | 1.1e-11 |
| 0.010 | 8.9e-07 | 1.5e-13 | 1.5e-13 |
| 1.000 | 2.6e-15 | 4.4e-16 | 3.3e-16 |
| 5.000 | 1.4e-15 | 2.1e-15 | 4.6e-11 |

The backend now matches scipy's own accuracy at r=1e-3 (and beats it at r=5). `n` 50 -> 100 for this call: at n=50 the scaled map still leaves 1.2e-06, and past n=100 the error saturates at ~1.1e-11, the closed form's float64 floor.

`test_jeans.py`: jax 1 passed/4 failed -> **5 passed**; torch likewise; numpy 5 passed throughout.

## numpy path: bit-identical

`scale=None` gives `L = 1.0`, and multiplying by exactly 1.0 is exact in IEEE754 — verified bit-for-bit (`.view(int64)` equality) against a reimplementation of the pre-change formula over 18 cases (2 kinds x 3 integrands x 3 node counts). The other four callers (Ferrers, AnySpherical, AnyAxisym, constantbetadf) pass no `scale` and are untouched; `test_potential` Ferrers/AnySpherical/AnyAxisym passes 33/33 under **both** forced jax and forced torch, and constantbetadf 46/46.

## Tests, placed by scope

The `scale` mechanism is a `galpy.backend.quadrature` feature, so it is tested in `test_backend_quadrature.py` (value at four `eps` spanning six decades for both map kinds, array-scale broadcast, and grad in the lower limit vs the analytic `-f(a)`). The small-r accuracy claim is jeans-specific and lives in `test_backend_jeans.py`, asserted against the **closed form** rather than against numpy, so it cannot be satisfied by matching an equally wrong reference.

Also added path-asserting dispatch tests: under forced torch the scipy result is converted to a Tensor downstream, so `is_tensor(result)` passes even when scipy ran — these spy on the backend-only callee instead.

And a jit test, because `sigmar` carries no `@backend_input` decorator and so is **not** a trace boundary: passing under `--backend jax --jit` says nothing about it. Traced explicitly, jit reproduces eager to 1e-13 and `jit(grad)` reproduces eager `grad`. It reuses the existing shared `backend_jit_helpers.assert_jit_matches_eager`, which additionally asserts the jaxpr consumes its argument so a constant-folded trace cannot pass vacuously.

## Verified meaningful by A/B, not asserted

With `scale` deliberately ignored, **14 of the 17** new quadrature tests fail and `test_jeans` reverts to 4 failed on jax. The 3 that still pass are the `eps = 1` cases, where `L = 1` is correct.

## Ledger

No changes: there were **zero** `test_jeans` ledger entries. The island wasn't masking ledgered failures, it was preventing them from ever being observed.