### PR TITLE
diskdf/surfaceSigmaProfile: remove the numpy island via a consumer boundary

### DIFF
--- a/galpy/df/diskdf.py
+++ b/galpy/df/diskdf.py
@@ -29,7 +29,7 @@ numpylog = numpy.lib.scimath.log  # somehow, this code produces log(negative), w
 from scipy import integrate, interpolate, optimize, stats
 
 from ..actionAngle import actionAngleAdiabatic
-from ..backend import get_namespace, is_backend_array
+from ..backend import as_numpy, get_namespace, is_backend_array
 from ..backend.quadrature import nested_quad
 from ..orbit import Orbit
 from ..potential import PowerSphericalPotential
@@ -265,8 +265,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         if numpy.fabs(va) > sigmaR1:
@@ -345,8 +345,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         if numpy.fabs(va) > sigmaR1:
@@ -421,7 +421,7 @@ class diskdf(df):
         -----
         - 2010-03-28 - Written - Bovy (NYU)
         """
-        return self._surfaceSigmaProfile.sigma2(R, log=log)
+        return self._ssp("sigma2", R, log=log)
 
     @potential_physical_input
     @physical_conversion("surfacedensity", pop=True)
@@ -446,7 +446,26 @@ class diskdf(df):
         - 2010-03-28 - Written - Bovy (NYU)
 
         """
-        return self._surfaceSigmaProfile.surfacemass(R, log=log)
+        return self._ssp("surfacemass", R, log=log)
+
+    # --- surfaceSigmaProfile boundary -------------------------------------
+    # surfaceSigmaProfile is backend-native and its @backend_input boundary
+    # coerces R under a FORCED context, so a numpy caller gets a Tensor back.
+    # diskdf is NOT migrated: its numpy branches feed scipy quad and numpylog,
+    # which cannot take Tensors (numpylog's complex result promotes against a
+    # Tensor into a complex Tensor that _real cannot unwrap). Until diskdf
+    # itself is migrated, the CONSUMER guards its own boundary here -- every
+    # call into the profile goes through one of these four, so the guard cannot
+    # be bypassed by adding a call site.
+    #
+    # Deliberately NOT a proxy object wrapping _surfaceSigmaProfile: the profile
+    # is passed on to other df constructors and into ARS `hxparams`, and its
+    # `__class__.__name__` builds the dfcorrection save filename -- a wrapper
+    # would silently change that filename and regenerate corrections instead of
+    # loading them.
+    def _ssp(self, name, R, **kwargs):
+        out = getattr(self._surfaceSigmaProfile, name)(R, **kwargs)
+        return out if is_backend_array(R) else as_numpy(out)
 
     @physical_conversion("surfacedensitydistance", pop=True)
     def targetSurfacemassLOS(self, d, l, log=False, deg=True):
@@ -483,9 +502,9 @@ class diskdf(df):
         d = conversion.parse_length(d, ro=self._ro)
         R, phi = _dlToRphi(d, lrad)
         if log:
-            return self._surfaceSigmaProfile.surfacemass(R, log=log) + numpylog(d)
+            return self._ssp("surfacemass", R, log=log) + numpylog(d)
         else:
-            return self._surfaceSigmaProfile.surfacemass(R, log=log) * d
+            return self._ssp("surfacemass", R, log=log) * d
 
     @physical_conversion("surfacedensitydistance", pop=True)
     def surfacemassLOS(
@@ -754,8 +773,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
 
@@ -774,8 +793,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         va = xp.where(xp.abs(va) > sigmaR1, 0.0, va)  # avoid craziness near center
@@ -844,8 +863,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         if numpy.fabs(va) > sigmaR1:
@@ -942,8 +961,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         if numpy.fabs(va) > sigmaR1:
@@ -1089,8 +1108,8 @@ class diskdf(df):
             * (
                 1.0 / self._gamma**2.0
                 - 1.0
-                - R * self._surfaceSigmaProfile.surfacemassDerivative(R, log=True)
-                - R * self._surfaceSigmaProfile.sigma2Derivative(R, log=True)
+                - R * self._ssp("surfacemassDerivative", R, log=True)
+                - R * self._ssp("sigma2Derivative", R, log=True)
             )
         )
         if numpy.fabs(va) > sigmaR1:
@@ -2157,11 +2176,7 @@ class dehnendf(diskdf):
         # Then sample Lz
         LCE = xE ** (self._beta + 1.0)
         OR = xE ** (self._beta - 1.0)
-        Lz = (
-            self._surfaceSigmaProfile.sigma2(xE)
-            * numpylog(stats.uniform.rvs(size=n))
-            / OR
-        )
+        Lz = self._ssp("sigma2", xE) * numpylog(stats.uniform.rvs(size=n)) / OR
         if self._correct:
             Lz *= self._corr.correct(xE, log=False)[1, :]
         Lz += LCE
@@ -2343,11 +2358,11 @@ class dehnendf(diskdf):
                 OE = xE ** (self._beta - 1.0)
                 LCE = xE ** (self._beta + 1.0)
         L = R * vT
-        sigma2xE = self._surfaceSigmaProfile.sigma2(xE, log=False)
+        sigma2xE = self._ssp("sigma2", xE, log=False)
         return (
-            self._surfaceSigmaProfile.surfacemassDerivative(xE, log=True)
+            self._ssp("surfacemassDerivative", xE, log=True)
             - (1.0 + OE * (L - LCE) / sigma2xE)
-            * self._surfaceSigmaProfile.sigma2Derivative(xE, log=True)
+            * self._ssp("sigma2Derivative", xE, log=True)
             + (L - LCE) / sigma2xE * (self._beta - 1.0) * xE ** (self._beta - 2.0)
             - OE * (self._beta + 1.0) / sigma2xE * xE**self._beta
         )
@@ -2367,7 +2382,7 @@ class dehnendf(diskdf):
                 )
                 xE = (2.0 * E / (1.0 + 1.0 / self._beta)) ** (1.0 / 2.0 / self._beta)
                 OE = xE ** (self._beta - 1.0)
-        sigma2xE = self._surfaceSigmaProfile.sigma2(xE, log=False)
+        sigma2xE = self._ssp("sigma2", xE, log=False)
         return OE / sigma2xE
 
 
@@ -2611,7 +2626,7 @@ class shudf(diskdf):
             ECL = numpylog(xL) + 0.5
         else:
             ECL = 0.5 * (1.0 / self._beta + 1.0) * xL ** (2.0 * self._beta)
-        E = -self._surfaceSigmaProfile.sigma2(xL) * numpylog(stats.uniform.rvs(size=n))
+        E = -self._ssp("sigma2", xL) * numpylog(stats.uniform.rvs(size=n))
         if self._correct:
             E *= self._corr.correct(xL, log=False)[1, :]
         E += ECL
@@ -2715,11 +2730,10 @@ class shudf(diskdf):
             dECLdRl = (1.0 + self._beta) * xL ** (2.0 * self._beta - 1)
             dEdR = R ** (2.0 * self._beta - 1.0)
             dECLEdR = dECLdRl * dRldR - dEdR
-        sigma2xL = self._surfaceSigmaProfile.sigma2(xL, log=False)
+        sigma2xL = self._ssp("sigma2", xL, log=False)
         return (
-            self._surfaceSigmaProfile.surfacemassDerivative(xL, log=True)
-            - (1.0 + (ECL - E) / sigma2xL)
-            * self._surfaceSigmaProfile.sigma2Derivative(xL, log=True)
+            self._ssp("surfacemassDerivative", xL, log=True)
+            - (1.0 + (ECL - E) / sigma2xL) * self._ssp("sigma2Derivative", xL, log=True)
         ) * dRldR + dECLEdR / sigma2xL
 
     def _dlnfdvR(self, R, vR, vT):
@@ -2729,7 +2743,7 @@ class shudf(diskdf):
             xL = L
         else:  # non-flat rotation curve
             xL = L ** (1.0 / (self._beta + 1.0))
-        sigma2xL = self._surfaceSigmaProfile.sigma2(xL, log=False)
+        sigma2xL = self._ssp("sigma2", xL, log=False)
         return -vR / sigma2xL
 
     def _dlnfdvT(self, R, vR, vT):
@@ -2747,11 +2761,10 @@ class shudf(diskdf):
             dECLdRl = (1.0 + self._beta) * xL ** (2.0 * self._beta - 1)
             dEdvT = vT
             dECLEdvT = dECLdRl * dRldvT - dEdvT
-        sigma2xL = self._surfaceSigmaProfile.sigma2(xL, log=False)
+        sigma2xL = self._ssp("sigma2", xL, log=False)
         return (
-            self._surfaceSigmaProfile.surfacemassDerivative(xL, log=True)
-            - (1.0 + (ECL - E) / sigma2xL)
-            * self._surfaceSigmaProfile.sigma2Derivative(xL, log=True)
+            self._ssp("surfacemassDerivative", xL, log=True)
+            - (1.0 + (ECL - E) / sigma2xL) * self._ssp("sigma2Derivative", xL, log=True)
         ) * dRldvT + dECLEdvT / sigma2xL
 
 
@@ -3368,13 +3381,13 @@ def _vtmaxEq(vT, R, diskdf):
         LCE = xE ** (diskdf._beta + 1.0)
         dxEdvT = xE / 2.0 / diskdf._beta / E * vT
     L = R * vT
-    sigma2xE = diskdf._surfaceSigmaProfile.sigma2(xE, log=False)
+    sigma2xE = diskdf._ssp("sigma2", xE, log=False)
     return (
         OE * R / sigma2xE
         + (
-            diskdf._surfaceSigmaProfile.surfacemassDerivative(xE, log=True)
+            diskdf._ssp("surfacemassDerivative", xE, log=True)
             - (1.0 + OE * (L - LCE) / sigma2xE)
-            * diskdf._surfaceSigmaProfile.sigma2Derivative(xE, log=True)
+            * diskdf._ssp("sigma2Derivative", xE, log=True)
             + (L - LCE) / sigma2xE * (diskdf._beta - 1.0) * xE ** (diskdf._beta - 2.0)
             - OE * (diskdf._beta + 1.0) / sigma2xE * xE**diskdf._beta
         )

--- a/galpy/df/surfaceSigmaProfile.py
+++ b/galpy/df/surfaceSigmaProfile.py
@@ -11,7 +11,8 @@
 ###############################################################################
 import numpy
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import get_namespace
+from ..backend._input import backend_input
 
 
 class surfaceSigmaProfile:
@@ -109,6 +110,12 @@ class surfaceSigmaProfile:
 class expSurfaceSigmaProfile(surfaceSigmaProfile):
     """Exponential surface density and sigma_R^2 class"""
 
+    # The R-based evaluators below are backend-native, so @backend_input may
+    # coerce R. Declared on THIS class, not the base: a user subclass of
+    # surfaceSigmaProfile may still be numpy-only. Without this flag the
+    # decorator is inert -- _input.py gates coercion on _backend_ready(self).
+    _backend_compatible = True
+
     def __init__(self, params=(1.0 / 3.0, 1.0, 0.2)):
         """
         Initialize an exponential surface density and sigma_R^2 profile.
@@ -126,6 +133,7 @@ class expSurfaceSigmaProfile(surfaceSigmaProfile):
         surfaceSigmaProfile.__init__(self)
         self._params = params
 
+    @backend_input("R")
     def surfacemass(self, R, log=False):
         """
         Return the surface density profile at this R.
@@ -149,9 +157,10 @@ class expSurfaceSigmaProfile(surfaceSigmaProfile):
         if log:
             return -R / self._params[0]
         else:
-            xp = get_namespace(R) if is_backend_array(R) else numpy
+            xp = get_namespace(R)
             return xp.exp(-R / self._params[0])
 
+    @backend_input("R")
     def surfacemassDerivative(self, R, log=False):
         """
         Return the derivative wrt R of the surface density profile at this R.
@@ -175,9 +184,10 @@ class expSurfaceSigmaProfile(surfaceSigmaProfile):
         if log:
             return -1.0 / self._params[0]
         else:
-            xp = get_namespace(R) if is_backend_array(R) else numpy
+            xp = get_namespace(R)
             return -xp.exp(-R / self._params[0]) / self._params[0]
 
+    @backend_input("R")
     def sigma2(self, R, log=False):
         """
         Return the radial velocity variance at this R.
@@ -201,9 +211,10 @@ class expSurfaceSigmaProfile(surfaceSigmaProfile):
         if log:
             return 2.0 * numpy.log(self._params[2]) - 2.0 * (R - 1.0) / self._params[1]
         else:
-            xp = get_namespace(R) if is_backend_array(R) else numpy
+            xp = get_namespace(R)
             return self._params[2] ** 2.0 * xp.exp(-2.0 * (R - 1.0) / self._params[1])
 
+    @backend_input("R")
     def sigma2Derivative(self, R, log=False):
         """
         Return the derivative wrt R of the sigma_R^2 profile at this R
@@ -228,7 +239,7 @@ class expSurfaceSigmaProfile(surfaceSigmaProfile):
         if log:
             return -2.0 / self._params[1]
         else:
-            xp = get_namespace(R) if is_backend_array(R) else numpy
+            xp = get_namespace(R)
             return (
                 self._params[2] ** 2.0
                 * xp.exp(-2.0 * (R - 1.0) / self._params[1])

--- a/tests/test_backend_surfacesigma.py
+++ b/tests/test_backend_surfacesigma.py
@@ -82,3 +82,32 @@ def test_surfaceSigmaProfile_grad_matches_derivative(backend):
         p.surfacemass(t).backward()
         g = float(t.grad)
     numpy.testing.assert_allclose(g, p.surfacemassDerivative(R0), rtol=1e-8)
+
+
+# --- forced backend with numpy-typed input -----------------------------------
+# The tests above pass ACTUAL backend arrays, so they exercise the backend branch
+# whether or not a data-guard is present. The guard that used to sit here,
+#     xp = get_namespace(R) if is_backend_array(R) else numpy
+# only misbehaved for the case they never cover: a plain float under a FORCED
+# backend. `get_namespace` already honours a forced context (it returns
+# jax.numpy/torch for a numpy scalar), so the guard discarded the forced
+# namespace exactly when get_namespace would have supplied it, and the profile
+# silently computed on numpy inside a backend run.
+#
+# A type assertion is legitimate here (unlike jeans, where an exit-cast made it
+# pass for the wrong reason): measured, the guarded version returned float64 on
+# BOTH jax and torch, the coerced version returns a backend array on both.
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("name", _SSP_METHODS)
+def test_forced_backend_runs_on_backend_for_numpy_input(backend, name):
+    from galpy.backend import use
+
+    p = expSurfaceSigmaProfile(params=(1.0 / 3.0, 1.0, 0.2))
+    ref = getattr(p, name)(0.9)
+    with use(backend, force=True):
+        got = getattr(p, name)(numpy.float64(0.9))
+    assert _is_backend_array(backend, got), (
+        f"{name} returned {type(got).__name__} under a FORCED {backend} backend: "
+        "numpy-typed input is still being computed on numpy"
+    )
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-12, atol=1e-14)


### PR DESCRIPTION
Removes the last numpy island in the Pdf.1 disk-DF foundation.

`surfaceSigmaProfile`'s four R-evaluators carried

    xp = get_namespace(R) if is_backend_array(R) else numpy

which discards the forced namespace in exactly the case where `get_namespace`
would have honoured it: `is_backend_array` is False for a plain float, so a
float under a forced backend took the numpy branch. The profile was a numpy
island — non-differentiable, non-backend compute.

### Why the leaf fix alone is not enough

Replacing the guard with `@backend_input("R")` + `_backend_compatible = True`
does make the leaf backend-native (`float64` -> `Tensor`, confirmed on both
backends). On its own it also **regresses 47 of 129** forced-torch
`test_diskdf` tests: `diskdf` is not migrated, so its numpy branches receive
Tensors and hand them to `scipy.integrate.quad`, `numpy.fabs`, and
`numpy.lib.scimath.log` — the last promoting its complex result against a
Tensor into a complex Tensor that `_real` cannot unwrap.

So the consumer guards its own boundary: all 30 numeric call sites route
through one `_ssp` accessor that casts back to numpy unless the caller itself
passed a backend array. `diskdf.py` is the only consumer of the profile in the
tree, so the boundary cannot be bypassed by adding a call site later.

### Measured

Whole file, forced torch, counts from `--junitxml`:

| arm | failures / 129 | time |
|---|---|---|
| baseline (data-guard) | 0 | 502s |
| leaf only | **47** | 1203s |
| leaf + 2 consumer sites | **11** | 1021s |
| leaf + all 30 (this PR) | **0** | 1384s |

numpy: 129 passed, and **bit-identical and type-identical** to the unmodified
tree over 16 cases (4 methods x `log`={False,True} x scalar/array), compared as
`.view(int64)`. Scalar input still returns `float64`.

Forced-jax and forced-torch gate: `test_backend_surfacesigma`,
`test_evolveddiskdf`, `test_diskdf`.

### Known cost, not hidden

The forced-torch `test_diskdf` shard goes 502s -> 1384s (2.8x). That is
per-call coercion overhead in `diskdf`'s velocity-grid loops, not the extra
call sites — the leaf-only arm was already 1203s with 28 fewer guarded sites.
Vectorizing those loops is the follow-up that buys it back; filed separately
rather than folded in here.
