### PR TITLE
test_backend_disk: adopt assert_jit_matches_eager for the RazorThin jit test

### DIFF
--- a/tests/test_backend_disk.py
+++ b/tests/test_backend_disk.py
@@ -11,6 +11,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.potential import (
@@ -571,13 +572,17 @@ def test_razorthin_public_methods_jit_traceable(method):
     def call(R, z):
         return _RAZOR(R, z) if method == "__call__" else getattr(_RAZOR, method)(R, z)
 
-    jitted = jax.jit(call)
     for R0, z0 in _RAZOR_ZERO_POINTS + _RAZOR_ZNZ_POINTS + [(1.3, 1e-9), (12.0, 0.0)]:
-        got = float(jitted(jnp.asarray(R0), jnp.asarray(z0)))
-        ref = float(call(R0, z0))
-        numpy.testing.assert_allclose(
-            got,
-            ref,
+        # ref= keeps the plain-float eager call as the reference, so this still
+        # crosses float input against traced-array input; the helper adds the
+        # jaxpr check that the trace really consumes R and z. zforce is exactly
+        # 0 at z=0 but still depends on its arguments -- the check is structural,
+        # not numerical, so those points pass it too.
+        assert_jit_matches_eager(
+            call,
+            jnp.asarray(R0),
+            jnp.asarray(z0),
+            ref=float(call(R0, z0)),
             rtol=1e-11,
             atol=1e-14,
             err_msg=f"jit RazorThin.{method} at (R,z)=({R0},{z0})",


### PR DESCRIPTION
`test_razorthin_public_methods_jit_traceable` hand-rolled the jit-vs-eager comparison that `tests/backend_jit_helpers.py` exists to centralise. The helper adds what the hand-rolled version could not see: it inspects the jaxpr to confirm the compiled function still consumes R and z. A trace that folds its arguments away returns a constant and compares equal, so a bare value check passes vacuously — the same blind spot a numpy fallback has under a forced backend.

Passes `ref=float(call(R0, z0))` so the reference stays the **plain-float** eager call while the jitted side gets traced arrays. That float-vs-array cross was the point of the original test; letting the helper compute its own reference from the same traced args would have quietly narrowed it to array-vs-array while looking like a pure refactor.

**Measured before adopting**, since the helper's docstring warns that a quantity which genuinely does not vary with its arguments will trip the dependence assertion: across all 3 methods × 8 points, **0 of 24 trip it**. `zforce` is exactly 0.0 at every z=0 point and still reports `depends=True` — the check is structural (does the jaxpr consume its invars), not numerical, so a zero-valued output is not a constant-folded one.

**Verified the new assertion can fail**: a deliberately constant lambda is rejected with "jit trace ignores its arguments". A check that cannot fail is not worth adding.

`tests/test_backend_disk.py`: 240 passed, 4 skipped.