### PR TITLE
ledger: move the 3 torch-jit streamdf entries from xfail to slow-skip (they HANG)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -402,3 +402,13 @@ jax tests/test_FDMdynamfric.py::test_dynamfric_c
 # timeout records FAILED and overrides xfail, so this is a slow-skip, not an
 # xfail. Its siblings are fine: FDM test_dynamfric_c 208s, both _minr 36s.
 torch tests/test_dynamfric.py::test_dynamfric_c
+
+# torch-jit: parallel_map DEADLOCKS under --jit (measured 2026-08-07: 12 forked
+# children all parked in futex_wait_queue, parent in do_wait, 64 min, 0% CPU
+# anywhere in the tree). The eager-torch fix (cap the child to 1 torch thread)
+# does not cover the traced path. A HANG cannot be xfailed -- an xfail-ledger
+# entry still RUNS the test, so it burns the shard's whole budget and lands as a
+# timeout instead of the expected failure. Skip until the --jit fork path is fixed.
+torch-jit tests/test_streamdf.py::test_streamTrack_multi_parallel
+torch-jit tests/test_streamdf.py::test_plotting
+torch-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -251,9 +251,6 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetric
 # CUDA torch gives "Cannot re-initialize CUDA in forked subprocess", and with
 # CUDA_VISIBLE_DEVICES='' the run wedged past a 900 s timeout. Keeping them
 # ledgered under torch-jit so a workflow_dispatch(jit=true) stays honest.
-torch-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa
-torch-jit tests/test_streamdf.py::test_plotting
-torch-jit tests/test_streamdf.py::test_streamTrack_multi_parallel
 # A units-based density is NOT TRACEABLE, and this is by construction rather
 # than a defect. AnySphericalPotential._backend_dens deliberately evaluates such
 # a density on the numpy node --  astropy Quantity arithmetic strips a jax/torch


### PR DESCRIPTION
An xfail-ledger entry still **runs** the test — it is `xfail(strict=False)`, not a skip. A test that HANGS therefore cannot usefully be xfailed: it burns the shard's entire time budget and lands as a timeout instead of as the expected failure. All three torch-jit `test_streamdf` entries hang, so all three belong in the slow-skip list.

Measured with the ledger disabled (`GALPY_BACKEND_XFAIL_REGEN=1`) so the entries actually execute — whole file, `--backend torch --jit`, `--timeout=900`, counts from `--junitxml`:

| entry | outcome |
|---|---|
| `test_streamTrack_multi_parallel` | **deadlock**, observed directly |
| `test_plotting` | Timeout (>900s) |
| `test_fardalwmwpot_trackaa` | Timeout (>900s) |

80 tests: 73 passed, 1 skipped, 6 failed — the 2 timeouts above plus 4 `test_bovy14_useTM*` raising `NotImplementedError` (actionAngleTorus wraps the external Torus C++ library; out of scope by design, failing only because regen mode disables their own ledger entries).

The deadlock was confirmed directly rather than inferred from slowness: 12 forked `parallel_map` children **all** parked in `futex_wait_queue`, parent in `do_wait`, 64 minutes, with no descendant anywhere in the tree consuming CPU.

**This PR does not claim the three share a cause.** `multi_parallel` is a clean `parallel_map` fork deadlock; the other two block in `waiter.acquire`, which may be a different lock. What they share is the only property the ledger cares about — they hang rather than fail.

Note these are the **first** torch-jit entries in `tests/backend_slow_skip.txt`, which had 207 entries and none for that backend.

Follow-up (not this PR): the eager-torch `parallel_map` fork fix does not cover the `--jit` path.