### PR TITLE
evolveddiskdf: differentiable + traceable direct (grid-free) velocity moments

### DIFF
--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -603,12 +603,17 @@ class evolveddiskdf(df):
                     return self._vmomentsurfacemassHierarchicalGrid(n, m, grido)
         # Calculate the initdf moment and then calculate the ratio
         initvmoment = self._initdf.vmomentsurfacemass(R, n, m, nsigma=nsigma, phi=phi)
+        # TRANSITIONAL data-guard, mirroring _buildvgrid's gate on is_backend_array
+        # (not on a forced namespace): a forced backend with a plain-float R keeps
+        # the adaptive scipy path, so the fast numpy suite does not get flipped onto
+        # orbit integration. Only a genuine backend R takes the differentiable route.
+        _direct_backend = is_backend_array(R)
         xp = get_namespace(R, sigmaR1, sigmaT1, meanvR, meanvT)
-        if xp is numpy:
+        if not _direct_backend:
             if initvmoment == 0.0:
                 initvmoment = 1.0
         else:
-            # Same guard, but selected rather than branched: under a trace the
+            # Same guard, selected rather than branched: under a trace the
             # comparison is a tracer and `if` raises TracerBoolConversionError.
             # Kept OFF the numpy path deliberately -- xp.where would return a 0-d
             # array there, changing the public return type from a float.
@@ -616,7 +621,7 @@ class evolveddiskdf(df):
         norm = sigmaR1 ** (n + 1) * sigmaT1 ** (m + 1) * initvmoment
         if isinstance(t, (list, numpy.ndarray)):
             raise OSError("list of times is only supported with grid-based calculation")
-        if xp is not numpy:
+        if _direct_backend:
             return (
                 self._vmomentsurface_direct_backend(
                     R, az, t, n, m, nsigma, sigmaR1, sigmaT1, meanvR, meanvT, xp

--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -7,6 +7,10 @@
 #      evolveddiskdf - top-level class that represents a distribution function
 ###############################################################################
 _NSIGMA = 4.0
+# GL nodes per dimension for the backend direct (grid-free) moment integral.
+# In polar coordinates the integrand is smooth, so 50^2 nodes is ample and
+# costs FEWER orbit integrations than the default grid path's 101^2.
+_DIRECT_GL_ORDER = 50
 _NTS = 1000
 _PROFILE = False
 import copy
@@ -18,6 +22,7 @@ import numpy
 from scipy import integrate
 
 from ..backend import device_of, get_namespace, is_backend_array
+from ..backend import quadrature as _bquad
 from ..orbit import Orbit
 from ..potential import calcRotcurve, planarCompositePotential, planarForce
 from ..potential.Potential import _check_c, _check_potential_list_and_deprecate, _dim
@@ -598,11 +603,27 @@ class evolveddiskdf(df):
                     return self._vmomentsurfacemassHierarchicalGrid(n, m, grido)
         # Calculate the initdf moment and then calculate the ratio
         initvmoment = self._initdf.vmomentsurfacemass(R, n, m, nsigma=nsigma, phi=phi)
-        if initvmoment == 0.0:
-            initvmoment = 1.0
+        xp = get_namespace(R, sigmaR1, sigmaT1, meanvR, meanvT)
+        if xp is numpy:
+            if initvmoment == 0.0:
+                initvmoment = 1.0
+        else:
+            # Same guard, but selected rather than branched: under a trace the
+            # comparison is a tracer and `if` raises TracerBoolConversionError.
+            # Kept OFF the numpy path deliberately -- xp.where would return a 0-d
+            # array there, changing the public return type from a float.
+            initvmoment = xp.where(initvmoment == 0.0, 1.0, initvmoment)
         norm = sigmaR1 ** (n + 1) * sigmaT1 ** (m + 1) * initvmoment
         if isinstance(t, (list, numpy.ndarray)):
             raise OSError("list of times is only supported with grid-based calculation")
+        if xp is not numpy:
+            return (
+                self._vmomentsurface_direct_backend(
+                    R, az, t, n, m, nsigma, sigmaR1, sigmaT1, meanvR, meanvT, xp
+                )
+                / initvmoment
+                * norm
+            )
         return (
             dblquad(
                 _vmomentsurfaceIntegrand,
@@ -621,6 +642,61 @@ class evolveddiskdf(df):
                 epsabs=epsabs,
             )[0]
             * norm
+        )
+
+    def _vmomentsurface_direct_backend(
+        self, R, az, t, n, m, nsigma, sigmaR1, sigmaT1, meanvR, meanvT, xp
+    ):
+        r"""Direct (grid-free) velocity moment on a backend, differentiably.
+
+        The numpy path integrates the normalised velocity plane with an adaptive
+        ``dblquad`` over a DISC of radius ``nsigma`` centred on
+        ``(meanvT/sigmaT1, meanvR/sigmaR1)``. scipy calls ``float()`` on its
+        integrand, so under a backend that silently breaks the graph -- the VALUE
+        comes out right (scipy just computes eagerly) while ``jax.grad`` raises
+        ``ConcretizationTypeError``. Hence a separate backend branch; numpy keeps
+        the adaptive rule untouched and stays byte-identical.
+
+        Substituting polar coordinates about the disc centre,
+
+            vT = meanvT/sigmaT1 + r cos(theta),  vR = meanvR/sigmaR1 + r sin(theta)
+
+        maps the disc EXACTLY onto the rectangle r in [0, nsigma],
+        theta in [0, 2 pi] with Jacobian ``r``, so the fixed-order tensor-product
+        rule in ``nested_quad`` applies directly. That also removes the
+        ``sqrt(nsigma^2 - ...)`` inner limits, whose square-root endpoints are
+        exactly what a fixed-order rule resolves worst.
+
+        Returns the integral WITHOUT the ``1/initvmoment`` factor; the caller
+        applies it, matching the numpy path's ordering.
+        """
+        vT_c = meanvT / sigmaT1
+        vR_c = meanvR / sigmaR1
+
+        def _integrand(r, th):
+            # vR, vT here are NORMALISED (units of sigmaR1 / sigmaT1), matching
+            # _vmomentsurfaceIntegrand's convention: the moment weight vR**n vT**m
+            # uses them as-is, but the orbit ICs need PHYSICAL velocities, which is
+            # what _df_at_velocities_backend expects (_buildvgrid_backend feeds it
+            # meanv +- nsigma*sigma, not normalised units).
+            vT = vT_c + r * xp.cos(th)
+            vR = vR_c + r * xp.sin(th)
+            shape = vT.shape
+            dfv = self._df_at_velocities_backend(
+                R,
+                az,
+                t,
+                xp.reshape(vR * sigmaR1, (-1,)),
+                xp.reshape(vT * sigmaT1, (-1,)),
+                xp,
+            )
+            return vR**n * vT**m * xp.reshape(dfv, shape) * r  # r = polar Jacobian
+
+        return _bquad.nested_quad(
+            xp,
+            _integrand,
+            [[0.0, nsigma], [0.0, 2.0 * numpy.pi]],
+            n=_DIRECT_GL_ORDER,
         )
 
     @potential_physical_input

--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -3005,8 +3005,6 @@ class evolveddiskdf(df):
         (_buildvgrid) is byte-identical; this runs only for backend inputs / under
         a forced backend. deriv= (the finite-difference moment derivative) is
         unsupported here -- differentiate the moment with autodiff instead."""
-        from .diskdf import vRvTRToEL
-
         if deriv is not None:
             raise NotImplementedError(
                 "evolveddiskdf grid deriv= is not supported on the jax/torch "
@@ -3033,6 +3031,27 @@ class evolveddiskdf(df):
         VR, VT = xp.meshgrid(out.vRgrid, out.vTgrid, indexing="ij")
         vRf = xp.reshape(VR, (-1,))
         vTf = xp.reshape(VT, (-1,))
+        dfvals = self._df_at_velocities_backend(R, phi, t, vRf, vTf, xp)
+        if isinstance(t, (list, numpy.ndarray)):
+            nt = len(numpy.atleast_1d(numpy.asarray(t)))
+            out.df = xp.reshape(dfvals, (gridpoints, gridpoints, nt))
+        else:
+            out.df = xp.reshape(dfvals, (gridpoints, gridpoints))
+        return out
+
+    def _df_at_velocities_backend(self, R, phi, t, vRf, vTf, xp):
+        """Evolved DF at arbitrary backend velocity POINTS ``(vRf, vTf)``, flat.
+
+        Shared by the grid build (``_buildvgrid_backend``, which reshapes this to
+        its meshgrid) and by the direct moment integral (which contracts it
+        against quadrature weights), so the batched multi-orbit integrate and the
+        gradient plumbing around it live in ONE place rather than being copied
+        per caller. ``R`` carries its gradient into every orbit's IC.
+
+        Returns ``(N,)`` for a scalar ``t`` and ``(N, nt)`` for a list of times.
+        """
+        from .diskdf import vRvTRToEL
+
         ones = xp.ones_like(vRf)
         ic = xp.stack([R * ones, vRf, vTf, phi * ones], axis=-1)  # (N, 4)
 
@@ -3047,45 +3066,36 @@ class evolveddiskdf(df):
         # would route there anyway, but pick it explicitly so a non-C
         # integrate_method (odeint/leapfrog) works too.
         bmethod = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
-        tlist = isinstance(t, (list, numpy.ndarray))
-        if tlist:
+        if isinstance(t, (list, numpy.ndarray)):
             t = numpy.atleast_1d(numpy.asarray(t))
             nt = len(t)
             if self._to == t[0]:  # no evolution: DF at the ICs, one per output time
                 df1 = _nan0(_idf(vRf, vTf, R * ones))
-                out.df = xp.reshape(
-                    xp.broadcast_to(df1[:, None], (df1.shape[0], nt)),
-                    (gridpoints, gridpoints, nt),
-                )
-            else:
-                # C-style output times (one per requested t) so the trajectory is
-                # sampled exactly at them; the backend solver saves at these times.
-                ts = xp.asarray(self._create_ts_tlist(t, "dopr54_c"))
-                o = Orbit(ic)
-                o.integrate(ts, self._pot, method=bmethod)
-                traj = o.getOrbit()  # (N, len(ts), 4)
-                if nt == 1:  # single time: the evolved endpoint (t -> self._to)
-                    end = traj[:, 1, :]
-                    dfvals = _nan0(_idf(end[:, 1], end[:, 2], end[:, 0]))[:, None]
-                else:  # DF along the trajectory, reversed to ascending-lag t order
-                    dfvals = _nan0(_idf(traj[..., 1], traj[..., 2], traj[..., 0]))
-                    dfvals = xp.flip(dfvals, axis=1)  # torch has no negative-step slice
-                out.df = xp.reshape(dfvals, (gridpoints, gridpoints, nt))
-        else:  # scalar t: DF at the single evolved endpoint (t -> self._to)
-            if self._to == t:  # no evolution
-                out.df = xp.reshape(
-                    _nan0(_idf(vRf, vTf, R * ones)), (gridpoints, gridpoints)
-                )
-            else:
-                ts = xp.asarray(numpy.linspace(float(t), float(self._to), 2))
-                o = Orbit(ic)
-                o.integrate(ts, self._pot, method=bmethod)
-                end = o.getOrbit()[:, -1, :]  # at self._to
-                Ro, vRo, vTo = end[:, 0], end[:, 1], end[:, 2]
-                eps = numpy.finfo(numpy.float64).eps
-                df = xp.where(Ro <= 0.0, eps, _idf(vRo, vTo, Ro))  # R<=0 -> eps
-                out.df = xp.reshape(_nan0(df), (gridpoints, gridpoints))
-        return out
+                return xp.broadcast_to(df1[:, None], (df1.shape[0], nt))
+            # C-style output times (one per requested t) so the trajectory is
+            # sampled exactly at them; the backend solver saves at these times.
+            ts = xp.asarray(self._create_ts_tlist(t, "dopr54_c"))
+            o = Orbit(ic)
+            o.integrate(ts, self._pot, method=bmethod)
+            traj = o.getOrbit()  # (N, len(ts), 4)
+            if nt == 1:  # single time: the evolved endpoint (t -> self._to)
+                end = traj[:, 1, :]
+                return _nan0(_idf(end[:, 1], end[:, 2], end[:, 0]))[:, None]
+            # DF along the trajectory, reversed to ascending-lag t order
+            dfvals = _nan0(_idf(traj[..., 1], traj[..., 2], traj[..., 0]))
+            return xp.flip(dfvals, axis=1)  # torch has no negative-step slice
+        # scalar t: DF at the single evolved endpoint (t -> self._to)
+        if self._to == t:  # no evolution
+            return _nan0(_idf(vRf, vTf, R * ones))
+        ts = xp.asarray(numpy.linspace(float(t), float(self._to), 2))
+        o = Orbit(ic)
+        o.integrate(ts, self._pot, method=bmethod)
+        end = o.getOrbit()[:, -1, :]  # at self._to
+        Ro, vRo, vTo = end[:, 0], end[:, 1], end[:, 2]
+        eps = numpy.finfo(numpy.float64).eps
+        # R<=0 -> eps; this guard is deliberately absent from the t-list branch
+        # above, matching the pre-extraction behaviour exactly.
+        return _nan0(xp.where(Ro <= 0.0, eps, _idf(vRo, vTo, Ro)))
 
     def _create_ts_tlist(self, t, integrate_method):
         # Check input

--- a/tests/test_backend_evolveddiskdf.py
+++ b/tests/test_backend_evolveddiskdf.py
@@ -290,3 +290,85 @@ def test_reduction_grad_vs_df(backend):
         moment_of_df(dt).backward()
         g_elem = float(dt.grad[idx])
     numpy.testing.assert_allclose(g_elem, expect, rtol=1e-8)
+
+
+# --- direct (grid-free) moment on a backend -------------------------------
+# Everything above exercises grid=True. The direct path had NO backend coverage
+# at all, which is why its non-differentiability went unnoticed: scipy's dblquad
+# computes the VALUE correctly under a backend (it just evaluates eagerly with
+# concrete floats), so any value-only check passes while jax.grad raises
+# ConcretizationTypeError because scipy calls float() on the tracer.
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_direct_moment_value_matches_numpy(backend):
+    # Polar-GL direct path vs numpy's adaptive dblquad. These are different
+    # quadrature rules, so this is a correctness check at quadrature tolerance,
+    # not a parity check.
+    edf = _make_edf()
+    ref = edf.vmomentsurfacemass(_R, 0, 0, phi=_PHI, grid=False, nsigma=3.0)
+    with use(backend, force=True):
+        got = edf.vmomentsurfacemass(
+            _scalar(backend, _R), 0, 0, phi=_PHI, grid=False, nsigma=3.0
+        )
+        assert is_backend_array(got), "direct path fell back to numpy"
+    numpy.testing.assert_allclose(float(as_numpy(got)), ref, rtol=1e-4)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_direct_moment_grad_through_evolution_vs_fd(backend):
+    # The point of the whole exercise: d(moment)/dR through the ORBIT EVOLUTION
+    # on the direct path. Before the backend branch this raised
+    # ConcretizationTypeError. FD is taken on the backend itself so the
+    # comparison is integrator- and quadrature-consistent (see
+    # test_moment_grad_through_evolution_vs_fd).
+    edf = _make_edf()
+    h = 1e-5
+
+    def val(R):
+        with use(backend, force=True):
+            return float(
+                as_numpy(
+                    edf.vmomentsurfacemass(R, 0, 0, phi=_PHI, grid=False, nsigma=3.0)
+                )
+            )
+
+    gfd = (val(_scalar(backend, _R + h)) - val(_scalar(backend, _R - h))) / (2.0 * h)
+    if backend == "jax":
+        with use("jax", force=True):
+            g = float(
+                jax.grad(
+                    lambda R: jnp.asarray(
+                        edf.vmomentsurfacemass(
+                            R, 0, 0, phi=_PHI, grid=False, nsigma=3.0
+                        )
+                    ).reshape(())
+                )(jnp.asarray(_R))
+            )
+    else:
+        Rt = torch.tensor(_R, requires_grad=True)
+        with use("torch", force=True):
+            edf.vmomentsurfacemass(Rt, 0, 0, phi=_PHI, grid=False, nsigma=3.0).reshape(
+                ()
+            ).backward()
+        g = float(Rt.grad)
+    numpy.testing.assert_allclose(g, gfd, rtol=2e-4, atol=1e-7)
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax required for jit")
+def test_direct_moment_jit_matches_eager():
+    # The direct path is not merely differentiable but TRACEABLE: the
+    # `if initvmoment == 0.0` guard is selected with xp.where on the backend
+    # (numpy keeps the branch, so its float return type is unchanged). Without
+    # that this raises TracerBoolConversionError.
+    edf = _make_edf()
+
+    def call(R):
+        return jnp.asarray(
+            edf.vmomentsurfacemass(R, 0, 0, phi=_PHI, grid=False, nsigma=3.0)
+        ).reshape(())
+
+    with use("jax", force=True):
+        eager = float(call(jnp.asarray(_R)))
+        jitted = float(jax.jit(call)(jnp.asarray(_R)))
+    numpy.testing.assert_allclose(jitted, eager, rtol=1e-12, atol=1e-14)


### PR DESCRIPTION
Makes `evolveddiskdf`'s **direct** (grid-free) velocity moments differentiable and
traceable on jax/torch. numpy keeps its adaptive `dblquad` untouched.

### The defect was silent, and the test suite could not see it

Under a backend the direct path produced the **right value** — scipy just
evaluates eagerly with concrete floats — while `jax.grad` raised
`ConcretizationTypeError`, because scipy's `quad` calls `float()` on the tracer.
So every value-comparison test passed and nothing was wrong-looking.

It stayed invisible for a second reason: **every** pre-existing test in
`tests/test_backend_evolveddiskdf.py` passes `grid=True` — all 12 call sites and
every entry of the `_MOMENTS` table. The direct path had *zero* backend
coverage, so nothing ever asked it for a gradient. This PR adds the first.

### Two commits

**1. Extraction (no behaviour change).** `_buildvgrid_backend`'s batched
multi-orbit integrate-and-evaluate becomes
`_df_at_velocities_backend(R, phi, t, vRf, vTf, xp)`, taking arbitrary velocity
*points*. Extracted rather than copied: a second hand-written batch would have
had to reproduce the deliberately non-`linspace` grid construction that exists
because `torch.linspace` drops the gradient w.r.t. tensor endpoints.

**2. Direct backend branch.** The numpy path integrates a **disc** of radius
`nsigma` centred on `(meanvT/sigmaT1, meanvR/sigmaR1)`. Substituting polar
coordinates about that centre maps the disc *exactly* onto
`r ∈ [0, nsigma] × θ ∈ [0, 2π]` with Jacobian `r`, so `nested_quad`'s
tensor-product rule applies directly — and the `sqrt(nsigma² - …)` inner limits
disappear, which is what a fixed-order rule resolves worst.

Also made traceable: `if initvmoment == 0.0` is a Python bool on a tracer.
Selected with `xp.where` on the **backend branch only** — `numpy.where` returns a
0-d array, which would change `vmomentsurfacemass`'s public numpy return type
from `float`.

### A regression I introduced and caught

My first version gated on `xp is not numpy`. Under a *forced* backend with a
plain-float `R`, `get_namespace` returns torch while the data are still scalars,
so `torch.where` got floats: **7 forced-torch failures**. numpy and jax passed
35/35 — their `where` accepts scalars, only torch's is strict. A jax-only gate
would have shipped it.

The fix was not to coerce. The sibling grid path (`_buildvgrid`, #141)
deliberately gates on `is_backend_array(R)`, so a forced backend with numpy data
keeps the fast path rather than being flipped onto orbit integration. I had made
two sibling paths in one method disagree; they now gate identically.

### Tests

Three added, the first backend coverage of `grid=False`:
- value vs numpy at quadrature tolerance, **with an `is_backend_array` assertion
  so a silent numpy fallback fails rather than passes**;
- gradient vs **backend-consistent** FD (not a numpy constant — backend and numpy
  use different solvers *and* different quadrature, so pinning numpy's number
  would force the tolerance to absorb both);
- jit-vs-eager.

Cost is not a regression: the new grad test runs 50.2s (torch) / 49.8s (jax)
against 48.6–50.2s for the existing grid grad tests.

### Gate

All four arms on the final tree, counts from `--junitxml`:

| suite | backend | result |
|---|---|---|
| `test_evolveddiskdf` | numpy | 35 passed, 0 failed |
| `test_evolveddiskdf` | torch | 35 passed, 0 failed |
| `test_evolveddiskdf` | jax | 35 passed, 0 failed |
| `test_backend_evolveddiskdf` | — | 41 passed, 0 failed |

Measured on this branch:

```
numpy direct (adaptive dblquad)   6.6802698135e-02   (float64, type unchanged)
jax   direct (polar GL)           6.6802596615e-02   rel 1.52e-06
jax.jit(direct)                   6.6802596615e-02   == eager
jax.grad d/dR                    -1.90281325e-01     (was ConcretizationTypeError)
backend FD d/dR                  -1.90281325e-01     rel 1.32e-10
```
