### PR TITLE
backend jit tests: pin the traced value, not just that it is finite

### DIFF
--- a/tests/test_backend_anyspherical.py
+++ b/tests/test_backend_anyspherical.py
@@ -8,16 +8,17 @@
 # derivative become jit- and grad-safe under a trace.
 #
 # This proves: eager jax/torch return backend arrays matching numpy; jax.jacfwd
-# and jax.jit over evaluateRforces are finite (THE gap that defined this
-# migration); and the force gradient w.r.t. R and w.r.t. the amp parameter
-# h-converges to a central finite difference (a stringent grad-vs-FD check, not
-# finite-and-nonzero). Backends that are not installed self-skip, so this is
-# green on numpy alone.
+# and jax.jit over evaluateRforces reproduce the numpy force and its central-FD
+# derivative (THE gap that defined this migration); and the force gradient
+# w.r.t. R and w.r.t. the amp parameter h-converges to a central finite
+# difference (a stringent grad-vs-FD check, not finite-and-nonzero). Backends
+# that are not installed self-skip, so this is green on numpy alone.
 ###############################################################################
 import warnings
 
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.potential import (
@@ -104,21 +105,35 @@ def test_eager_backend_value_parity(backend_name, pot):
 
 @pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
 @pytest.mark.parametrize("pot", POTS, ids=POT_IDS)
-def test_jacfwd_and_jit_rforces_finite(pot):
-    # THE gap: jax.jacfwd / jax.jit over evaluateRforces must be finite (the old
-    # numpy.atleast_1d + scipy.integrate.quad internals crashed under a trace).
+def test_jacfwd_and_jit_rforces_match_numpy(pot):
+    # THE gap this migration closed: jax.jacfwd / jax.jit over evaluateRforces
+    # (the old numpy.atleast_1d + scipy.integrate.quad internals crashed under a
+    # trace). Finiteness alone would not distinguish a working trace from one
+    # that folded its argument away, so both are pinned to a value: the jit
+    # against the numpy force, the jacfwd against central FD, at every (R, z).
     for R0, z0 in _RZ:
         z = jnp.asarray(z0)
 
-        def rf(R):
-            return evaluateRforces(pot, R, z)
+        def rf(R, _z=z):
+            return evaluateRforces(pot, R, _z)
 
-        g = jax.jacfwd(rf)(jnp.asarray(R0))
-        assert bool(jnp.isfinite(g)), f"jacfwd non-finite at R={R0}"
-        jv = jax.jit(rf)(jnp.asarray(R0))
-        assert bool(jnp.isfinite(jv)), f"jit non-finite at R={R0}"
+        assert_jit_matches_eager(
+            rf,
+            jnp.asarray(R0),
+            rtol=1e-14,
+            atol=0.0,
+            ref=evaluateRforces(pot, R0, z0),
+            err_msg=f"Rforce at R={R0}",
+        )
+        h = 1e-5
+        fd = (evaluateRforces(pot, R0 + h, z0) - evaluateRforces(pot, R0 - h, z0)) / (
+            2.0 * h
+        )
         numpy.testing.assert_allclose(
-            float(jv), evaluateRforces(pot, R0, z0), rtol=1e-8
+            float(as_numpy(jax.jacfwd(rf)(jnp.asarray(R0)))),
+            fd,
+            rtol=1e-8,
+            err_msg=f"jacfwd d(Rforce)/dR vs FD at R={R0}",
         )
 
 

--- a/tests/test_backend_interprz.py
+++ b/tests/test_backend_interprz.py
@@ -22,6 +22,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy, is_backend_array
 from galpy.potential import (
@@ -134,16 +135,36 @@ def test_public_value_parity(backend_name, pot):
 
 
 @pytest.mark.parametrize("pot", CASES, ids=CASE_IDS)
-def test_jax_traced_finite(pot):
+def test_jax_traced_matches_numpy_and_fd(pot):
+    # Finiteness says nothing: a trace that folded its arguments away is finite
+    # too. Pin the traced VALUE to the plain-numpy one (and let
+    # assert_jit_matches_eager check the jaxpr really consumes its arguments),
+    # and the traced DERIVATIVE to central FD.
     if jax is None:  # pragma: no cover
         pytest.skip("jax not installed")
     Rj = jnp.asarray(_RS)
     zj = jnp.asarray(_ZS)
+    h = 1e-5
     for fn in (evaluatePotentials, evaluateRforces):
-        jitted = jax.jit(lambda R_, z_: fn(pot, R_, z_))(Rj, zj)
-        assert numpy.all(numpy.isfinite(as_numpy(jitted)))
-        jac = jax.jacfwd(lambda R_: fn(pot, R_, zj))(Rj)
-        assert numpy.all(numpy.isfinite(as_numpy(jac)))
+        assert_jit_matches_eager(
+            lambda R_, z_, _f=fn: _f(pot, R_, z_),
+            Rj,
+            zj,
+            rtol=1e-14,
+            atol=0.0,
+            ref=numpy.asarray(fn(pot, _RS, _ZS)),
+            err_msg=fn.__name__,
+        )
+        # elementwise in R, so the Jacobian is exactly diagonal
+        jac = as_numpy(jax.jacfwd(lambda R_, _f=fn: _f(pot, R_, zj))(Rj))
+        offdiag = jac - numpy.diag(numpy.diag(jac))
+        assert numpy.all(offdiag == 0.0), f"{fn.__name__}: Jacobian not diagonal"
+        fd = (
+            numpy.asarray(fn(pot, _RS + h, _ZS)) - numpy.asarray(fn(pot, _RS - h, _ZS))
+        ) / (2.0 * h)
+        numpy.testing.assert_allclose(
+            numpy.diag(jac), fd, rtol=2e-9, err_msg=f"{fn.__name__} d/dR vs FD"
+        )
 
 
 # One interior (R,z) point; grad w.r.t. R (Rforce) and z (potential).
@@ -266,15 +287,21 @@ def test_1d_grad_vcirc_vs_fd(backend_name, pot):
     numpy.testing.assert_allclose(ad, fd, rtol=1e-5, atol=1e-7)
 
 
-def test_1d_jax_traced_finite():
+def test_1d_jax_traced_matches_numpy():
     if jax is None:  # pragma: no cover
         pytest.skip("jax not installed")
     Rj = jnp.asarray(_RS_1D)
-    for pot in CASES_1D:
+    for case_id, pot in zip(CASE_IDS, CASES_1D):
         for method in _1D_METHODS:
             fn = getattr(pot, method)
-            jitted = jax.jit(lambda R_: fn(R_, use_physical=False))(Rj)
-            assert numpy.all(numpy.isfinite(as_numpy(jitted)))
+            assert_jit_matches_eager(
+                lambda R_, _f=fn: _f(R_, use_physical=False),
+                Rj,
+                rtol=1e-14,
+                atol=0.0,
+                ref=numpy.asarray(fn(_RS_1D, use_physical=False)),
+                err_msg=f"{method} ({case_id})",
+            )
 
 
 ###############################################################################

--- a/tests/test_backend_potential_convenience.py
+++ b/tests/test_backend_potential_convenience.py
@@ -18,6 +18,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.potential import (
     HernquistPotential,
@@ -545,11 +546,17 @@ def test_surfdens_analytic_route_traced_matches_numpy_jax():
         for z in (0.25, 10.0):
             ref = tp.surfdens(R, z, use_physical=False)
             with gb.use("jax", force=True):
-                got = jax.jit(lambda Rv, zv: tp.surfdens(Rv, zv, use_physical=False))(
-                    jnp.asarray(R), jnp.asarray(z)
+                # the helper also checks the jaxpr consumes (Rv, zv): a trace
+                # that folded them into a constant would match `ref` too
+                assert_jit_matches_eager(
+                    lambda Rv, zv: tp.surfdens(Rv, zv, use_physical=False),
+                    jnp.asarray(R),
+                    jnp.asarray(z),
+                    rtol=1e-10,
+                    atol=0.0,
+                    ref=ref,
+                    err_msg=f"FlattenedPower R={R} z={z}",
                 )
-            rel = numpy.abs(float(got) - ref) / numpy.abs(ref)
-            assert rel < 1e-10, f"FlattenedPower R={R} z={z}: rel={rel:g}"
 
 
 # --- whole-line surfdens, surfdens(R, z=None) -------------------------------
@@ -629,11 +636,14 @@ def test_surfdens_wholeline_traced_matches_numpy_jax(potname):
     for R in (0.5, 2.0):
         ref = tp.surfdens(R, None, use_physical=False)
         with gb.use("jax", force=True):
-            got = jax.jit(lambda Rv: tp.surfdens(Rv, None, use_physical=False))(
-                jnp.asarray(R)
+            assert_jit_matches_eager(
+                lambda Rv: tp.surfdens(Rv, None, use_physical=False),
+                jnp.asarray(R),
+                rtol=5e-12,
+                atol=0.0,
+                ref=ref,
+                err_msg=f"{potname} R={R}",
             )
-        rel = numpy.abs(float(got) - ref) / numpy.abs(ref)
-        assert rel < 5e-12, f"{potname} R={R}: rel={rel:g}"
 
 
 @pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -16,6 +16,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy as _np
 from galpy.backend import is_backend_array
@@ -376,9 +377,10 @@ def test_jax_jit():
         return jnp.sum(theta + jnp.exp(theta) * gr.normal(key, (5,)))
 
     th = jnp.asarray(0.7)
-    assert abs(float(jax.jit(f)(th)) - float(f(th))) < 1e-12
-    g = jax.grad(f)
-    assert abs(float(jax.jit(g)(th)) - float(g(th))) < 1e-10
+    # assert_jit_matches_eager also checks the jaxpr consumes theta -- a trace
+    # that folded the draw and theta into a constant would compare equal here.
+    assert_jit_matches_eager(f, th, rtol=0.0, atol=1e-12)
+    assert_jit_matches_eager(jax.grad(f), th, rtol=0.0, atol=1e-10)
 
 
 @pytest.mark.skipif(torch is None, reason="torch not installed")


### PR DESCRIPTION
Three of the backend jit tests asserted only `numpy.isfinite` on the traced result:

```python
jitted = jax.jit(lambda R_: fn(R_, use_physical=False))(Rj)
assert numpy.all(numpy.isfinite(as_numpy(jitted)))
```

A trace that folded its arguments away into a constant is finite too, so these could not fail for the reason they were written — they checked that `jax.jit` did not *raise*, not that it computed anything.

This routes them through the existing `assert_jit_matches_eager` helper (`tests/backend_jit_helpers.py`, already used by 10 modules), which pins the value **and** inspects the jaxpr to confirm the output really consumes the traced arguments.

### Tolerances are measured, not guessed

Each was probed before being written down, so they sit just above the achievable agreement:

| check | measured | written |
|---|---|---|
| `interpRZPotential` 2D, jit vs numpy | 3.8e-16 | `rtol=1e-14` |
| `interpRZPotential` 1D, jit vs numpy | 2.1e-16 | `rtol=1e-14` |
| `AnySphericalPotential` Rforce, jit vs numpy | 8.9e-16 | `rtol=1e-14` |
| `interpRZ` jacfwd vs central FD (h=1e-5) | 3.1e-10 | `rtol=2e-9` |
| `AnySpherical` jacfwd vs central FD (h=1e-5) | 7.0e-11 | `rtol=1e-8` |

### What changed

- **`test_backend_interprz.py`** — `test_jax_traced_finite` → `test_jax_traced_matches_numpy_and_fd`, and `test_1d_jax_traced_finite` → `test_1d_jax_traced_matches_numpy`. The traced value is pinned to the plain-numpy one; the `jacfwd`-is-finite assertion becomes a central-FD comparison. Since the map is elementwise in R, the Jacobian is additionally asserted **exactly diagonal** — the measured off-diagonal is identically `0.0`, so that check costs no tolerance at all.
- **`test_backend_anyspherical.py`** — `test_jacfwd_and_jit_rforces_finite` → `test_jacfwd_and_jit_rforces_match_numpy`. Same treatment, now at every `(R, z)` in the fixture rather than only the three radii the separate grad-vs-FD test covers.
- **`test_backend_potential_convenience.py`**, **`test_backend_random.py`** — three sites that already compared values, adopted purely for the dependence check. The two traced `surfdens` tests are where it matters most: the whole point of the `z=None` spelling is that it is *structural*, so "still produces an R-dependent trace" is exactly the property at risk.

### Scope

Tests only — no library code is touched, so the numpy path is unchanged by construction. Verified under `--backend numpy`, `--backend torch` and `--backend jax`.
