### PR TITLE
parallel_map: do not fork while galpy is running traced

### DIFF
--- a/galpy/util/multi.py
+++ b/galpy/util/multi.py
@@ -187,6 +187,11 @@ def parallel_map(function, sequence, numcores=None, progressbar=False):
         number of cores to use
     progressbar : bool, optional
         if True, display a progress bar
+
+    Notes
+    -----
+    Runs serially, ignoring ``numcores``, on Windows and while galpy is running
+    traced (inside ``galpy.backend.jit``), because ``fork`` is unsafe there.
     """
     if not callable(function):
         raise TypeError("input function '%s' is not callable" % repr(function))
@@ -203,6 +208,20 @@ def parallel_map(function, sequence, numcores=None, progressbar=False):
         numcores = _ncpus
 
     if platform.system() == "Windows":  # JB: don't think this works on Win
+        return list(map(function, sequence))
+
+    # Same reason as Windows, different cause: forking is not safe while galpy
+    # is running traced. A child inherits the parent's COMPILED kernels and the
+    # thread pool they execute on, and hangs re-entering that pool -- measured
+    # under `--backend torch --jit`, where every child parked inside the
+    # generated inductor `call`. Capping the child's thread count (see
+    # galpy.backend.restrict_to_single_thread, which does cure the EAGER torch
+    # case) cannot help here: the parallelism is baked into the compiled kernel.
+    # Imported here, not at module scope, to keep galpy.util.multi importable
+    # without galpy.backend.
+    from ..backend import jit_mode
+
+    if jit_mode() != "off":
         return list(map(function, sequence))
 
     # Use fork-based parallelism (because spawn fails with pickling issues, #457)

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -402,13 +402,3 @@ jax tests/test_FDMdynamfric.py::test_dynamfric_c
 # timeout records FAILED and overrides xfail, so this is a slow-skip, not an
 # xfail. Its siblings are fine: FDM test_dynamfric_c 208s, both _minr 36s.
 torch tests/test_dynamfric.py::test_dynamfric_c
-
-# torch-jit: parallel_map DEADLOCKS under --jit (measured 2026-08-07: 12 forked
-# children all parked in futex_wait_queue, parent in do_wait, 64 min, 0% CPU
-# anywhere in the tree). The eager-torch fix (cap the child to 1 torch thread)
-# does not cover the traced path. A HANG cannot be xfailed -- an xfail-ledger
-# entry still RUNS the test, so it burns the shard's whole budget and lands as a
-# timeout instead of the expected failure. Skip until the --jit fork path is fixed.
-torch-jit tests/test_streamdf.py::test_streamTrack_multi_parallel
-torch-jit tests/test_streamdf.py::test_plotting
-torch-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -402,3 +402,14 @@ jax tests/test_FDMdynamfric.py::test_dynamfric_c
 # timeout records FAILED and overrides xfail, so this is a slow-skip, not an
 # xfail. Its siblings are fine: FDM test_dynamfric_c 208s, both _minr 36s.
 torch tests/test_dynamfric.py::test_dynamfric_c
+
+# torch-jit: interpRZPotential's grid build under torch.compile does not finish
+# inside the 300 s cap. MEASURED 2026-08-07 by an A/B run for the parallel_map
+# fork fix in this same PR: both arms (with and without the fix) gave the
+# IDENTICAL 2 failed / 38 passed at 300.0 s, 1530 s vs 1549 s total -- so this is
+# torch.compile cost, NOT the fork deadlock that fix cures. Nothing trips these
+# today only because backend-tests' normal runs carry no --jit dimension; they
+# are listed here so a workflow_dispatch(jit=true) run does not surface them as
+# a surprise red. Un-defer when the per-force-call overhead work lands.
+torch-jit tests/test_interp_potential.py::test_interpolation_potential_force_c  # 300s (timeout)
+torch-jit tests/test_interp_potential.py::test_interpolation_potential_secondderivs  # 300s (timeout)


### PR DESCRIPTION
`galpy.util.multi.parallel_map` forks, and **a forked child cannot run code the parent compiled**. Under `--backend torch --jit` every child deadlocked and the parent hung in `proc.join()` forever. Three `test_streamdf.py` tests were slow-skipped because of it.

### Root cause

`py-spy` could not attach (`ptrace_scope=1`), so the children reported themselves: a throwaway pytest plugin wrapped `galpy.util.multi.worker` so each child armed `faulthandler.dump_traceback_later`. Every child was in the same place:

```
/tmp/torchinductor_.../cefasp53....py:114 in call      <- the generated kernel
torch/_inductor/output_code.py:725 __call__
torch/_dynamo/eval_frame.py:1298 _fn
galpy/potential/IsochronePotential.py:62 _evaluate
galpy/backend/_jit.py:172 call                         <- the torch.compile shim
galpy/df/streamdf.py:4901 _determine_stream_track_single
```

The child is not stuck *compiling*. It is stuck **executing an inductor kernel the parent already compiled**, having inherited both the kernel and the thread pool it runs on.

Two things follow, and both were checked rather than assumed:

- **`restrict_to_single_thread()` cannot fix this.** It does cure the *eager* torch case — eager ops honour the child's `torch.set_num_threads(1)` — but a compiled kernel's parallelism is fixed at compile time, before the fork.
- **`TORCHINDUCTOR_COMPILE_THREADS=1` does not fix it either.** A/B with that set, everything else identical: same timeout, same `os.waitpid` stack. That knob governs *compile* parallelism, not the generated kernel's *runtime* parallelism.

### Fix

So the answer is not another knob — while traced, don't fork. That mirrors the branch three lines above, where Windows returns `list(map(function, sequence))` for the same underlying reason.

### Verification

A/B on the three tests that were slow-skipped for this hang:

| | outcome |
|---|---|
| **without** the fix (3 independent runs) | RC=1, pytest-timeout, parent parked in `os.waitpid` |
| **with** the fix | `test_streamTrack_multi_parallel` **27.7 s** ✅ · `test_plotting` **14.0 s** ✅ · `test_fardalwmwpot_trackaa` **45.4 s** ✅ |

A test that hung for 420 s now finishes in 27.7 s. The three entries come off `tests/backend_slow_skip.txt` (see the net figure at the end — a second commit puts two *different*, measured-too-slow entries on).

### Scope

**numpy is byte-identical by construction**: `jit_mode()` is `"off"` unless the caller entered `galpy.backend.jit`, so the numpy path never reaches the new branch. Eager torch keeps its fork-parallelism — that path is deliberately untouched. Checked directly that the forking path and the serial path return equal results.

**Tradeoff, stated rather than implied**: under a trace, `multi=` is now serial, so those tests no longer exercise fork-parallelism. They previously exercised nothing — they hung — so this is strictly more coverage, but it is a real limitation and is documented in the `parallel_map` docstring.

## One more thing the A/B settled: what the fix does NOT cover

`interpRZPotential` is also a `parallel_map` consumer, and its two
`test_interp_potential.py` tests time out under torch-jit — the same shape. So I
A/B'd that too, and the answer is **no**:

```
WITHOUT the fix : 2 failed, 38 passed, 1530.20 s
WITH the fix    : 2 failed, 38 passed, 1548.70 s
```

Identical nodeids, identical 300.0 s timeouts, ~1% apart in wall time. Those two
are `torch.compile` cost, not the deadlock, so **this PR claims only the three
streamdf tests it measured**.

They are still real reds, in neither the ledger nor the slow-skip list, hidden
only because `backend-tests`' normal runs carry no `--jit` dimension. The second
commit lists them with their measured number so a `workflow_dispatch(jit=true)`
run does not meet them as a surprise.

**Net effect on the list: −3 cured, +2 measured-too-slow, 210 → 209.**

