### PR TITLE
slow-skip: un-defer 100 stale jax orbit entries (210 -> 110), measured in the CI shard context

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -23,18 +23,8 @@ jax tests/test_sphericaldf.py::test_king_sigmar
 # rE/LcE root-finds and Chandrasekhar friction integrate orbits under forced
 # jax and exceed the per-test budget (same eager-per-step cost as single-orbit;
 # numpy covers them). Un-defer as Track D in-backend vectorization lands.
-jax tests/test_orbits.py::test_ChandrasekharDynamicalFrictionForce_constLambda
-jax tests/test_orbits.py::test_LcE
-jax tests/test_orbits.py::test_SOS_2Dx
-jax tests/test_orbits.py::test_SOS_2Dy
-jax tests/test_orbits.py::test_SOS_3D
-jax tests/test_orbits.py::test_bruteSOS_2Dx
-jax tests/test_orbits.py::test_bruteSOS_2Dy
-jax tests/test_orbits.py::test_integrate_Cfallback_nonsymplec
-jax tests/test_orbits.py::test_integrate_Cfallback_symplec
-jax tests/test_orbits.py::test_integration_dxdv_2d
-jax tests/test_orbits.py::test_integration_dxdv_2d_rectInOut
-jax tests/test_orbits.py::test_rE
+jax tests/test_orbits.py::test_ChandrasekharDynamicalFrictionForce_constLambda  # 300s (failed)
+jax tests/test_orbits.py::test_SOS_3D  # 269s -- inside the cap, but within 20% of it
 
 # --- jax/torch FDM dynamical friction (Track A group-b dissipative migration) ---
 # The FDM friction force is not yet backend-vectorized: frictionFactor uses
@@ -169,60 +159,27 @@ jax tests/test_streamspraydf.py::test_center
 # steps per-force-call (~1 ms each) and exceeds the per-test budget. They validate
 # C-vs-Python STM numerics, which the numpy run already covers; the differentiable
 # in-backend (diffrax/torchdiffeq) STM is covered by tests/test_backend_orbit_stm.py.
-jax tests/test_orbit.py::test_SOS_3D
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[const_lnLambda]
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[minr_gate]
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[rhm_coulomb_log]
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[sigma_clamp]
-jax tests/test_orbit.py::test_chandrasekhar_dxdv_phase_volume_law
-jax tests/test_orbit.py::test_dissipative_dxdv_python_raises
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[CorotatingRotationWrapperPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[OblateStaeckelWrapperPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[PerfectEllipsoidPotential_oblate]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[PerfectEllipsoidPotential_triaxial]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[PowerTriaxialPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_norot_offset]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_offset]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TriaxialGaussianPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TriaxialHernquistPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TriaxialJaffePotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TriaxialNFWPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TwoPowerTriaxialPotential]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[const_FDMfactor]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[const_lnLambda_cdm_cutoff]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[intermediate]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[minr_gate]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[rhm_coulomb_log_cdm_cutoff]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[sigma_clamp]
-jax tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[zerovel]
-jax tests/test_orbit.py::test_fdm_dxdv_phase_volume_law
-jax tests/test_orbit.py::test_interprz_dxdv_3d
-jax tests/test_orbit.py::test_liouville_3d[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]
-jax tests/test_orbit.py::test_liouville_planar
-jax tests/test_orbit.py::test_lyapunov_c_vs_python
-jax tests/test_orbit.py::test_lyapunov_spectrum_api
-jax tests/test_orbit.py::test_lyapunov_spectrum_consistency
-jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic
-jax tests/test_orbit.py::test_movingobject_dxdv_3d_c_vs_python
-jax tests/test_orbit.py::test_spherical_dxdv_3d_c_vs_python_extra
+jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[OblateStaeckelWrapperPotential]  # 289s -- inside the cap, but within 20% of it
+jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_norot_offset]  # 300s (failed)
+jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_offset]  # 290s -- inside the cap, but within 20% of it
+jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]  # 300s (failed)
+jax tests/test_orbit.py::test_interprz_dxdv_3d  # 300s (failed)
+jax tests/test_orbit.py::test_liouville_planar  # 300s (failed)
+jax tests/test_orbit.py::test_lyapunov_spectrum_consistency  # 300s (failed)
+jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic  # 620s -- OVERRAN the 300s cap but reported passed (signal timeout cannot interrupt C)
 
 # --- jax single-orbit: misc slow (no-C-force potentials + Python-integrator paths) ---
 # energy/Jacobi over no-C-force potentials (Ferrers/*NoC: C integrator falls back to
 # Python force eval) + a few integrate paths that step in Python under jax. Track A
 # force vectorization / Track D in-backend default will let these un-defer.
-jax tests/test_orbit.py::test_energy_conservation_linear[FerrersPotential--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[BurkertPotentialNoC--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[FerrersPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[RazorThinExponentialDiskPotential--10.0--9.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[mockSpecialRotatingFlatSpiralArmsPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[nestedListPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_integrate_backwards
-jax tests/test_orbit.py::test_integrate_negative_time
-jax tests/test_orbit.py::test_integrate_notevenlyspaced_ok
-jax tests/test_orbit.py::test_zmax
+jax tests/test_orbit.py::test_integrate_backwards  # 300s (failed)
+jax tests/test_orbit.py::test_integrate_negative_time  # 300s (failed)
+jax tests/test_orbit.py::test_zmax  # 300s (failed)
 
 # --- torch orbit: dissipative/variational dxdv battery (slow under torch) ---
 # Chandrasekhar/FDM friction + lyapunov + a dxdv c_vs_python integrate the
@@ -249,27 +206,6 @@ torch tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic
 # box (~2.4x on the CI runner); even 5-way duration-split, a group clustering several
 # overflows the 4500s shard cap (jax orbit group 3 timed out). Defer the heaviest
 # until Track D vectorization; the faster majority stays un-deferred. numpy runs all.
-jax tests/test_orbit.py::test_SOS_2Dx
-jax tests/test_orbit.py::test_SOS_2Dy
-jax tests/test_orbit.py::test_apocenter
-jax tests/test_orbit.py::test_bruteSOS_3D
-jax tests/test_orbit.py::test_dehnenbar_dxdv_inside_rb_c_vs_python
-jax tests/test_orbit.py::test_doubleexp_dxdv_3d_c_vs_python
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[GaussianAmplitudeWrapperPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[KuzminKutuzovStaeckelPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[KuzminLikeWrapperPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[LogarithmicHaloPotential_triaxial]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[MN3ExponentialDiskPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[MWPotential2014]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[SoftenedNeedleBarPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[SoftenedNeedleBarPotential_static]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[SpiralArmsPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TimeDependentAmplitudeWrapperPotential]
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[TwoPowerSphericalPotential]
-jax tests/test_orbit.py::test_energy_conservation_linear[BurkertPotentialNoC--10.0-False]
-jax tests/test_orbit.py::test_energy_conservation_linear[RazorThinExponentialDiskPotential--10.0-False]
-jax tests/test_orbit.py::test_energy_conservation_linear[mockRotatedAndTiltedMWP14WrapperPotential--10.0-False]
-jax tests/test_orbit.py::test_energy_conservation_linear[nestedListPotential--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[AnySphericalPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[DoubleExponentialDiskPotential--6.0--6.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatCorotatingRotationSpiralArmsPotential--10.0--10.0-False]
@@ -278,43 +214,7 @@ jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatSolidBodyRotati
 jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatSpiralArmsPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[mockRotatedAndTiltedMWP14WrapperPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_energy_jacobi_conservation[mockRotatingFlatSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_integrate_SOS_2D
-jax tests/test_orbit.py::test_integrate_SOS_3D
-jax tests/test_orbit.py::test_integrate_dxdv_3d_base_orbit_integrity
-jax tests/test_orbit.py::test_integrate_dxdv_3d_staeckelwrappers_require_wrapped_hessian
-jax tests/test_orbit.py::test_integrate_indiv_t_3D
-jax tests/test_orbit.py::test_integrate_indiv_t_python_paths
-jax tests/test_orbit.py::test_liouville_3d[PerfectEllipsoidPotential_oblate]
-jax tests/test_orbit.py::test_liouville_3d[PerfectEllipsoidPotential_triaxial]
-jax tests/test_orbit.py::test_liouville_3d[PowerTriaxialPotential]
-jax tests/test_orbit.py::test_liouville_3d[TriaxialGaussianPotential]
-jax tests/test_orbit.py::test_liouville_3d[TriaxialHernquistPotential]
-jax tests/test_orbit.py::test_liouville_3d[TriaxialJaffePotential]
-jax tests/test_orbit.py::test_liouville_3d[TriaxialNFWPotential]
-jax tests/test_orbit.py::test_liouville_3d[TwoPowerTriaxialPotential]
-jax tests/test_orbit.py::test_liouville_3d_nonaxi_flow
-jax tests/test_orbit.py::test_logspiral_planar_dxdv_c_vs_python
-jax tests/test_orbit.py::test_lyapunov_spectrum_integrable
-jax tests/test_orbit.py::test_oblatestaeckelwrapper_dxdv_planar_c_vs_python
-jax tests/test_orbit.py::test_orbit_LcE
-jax tests/test_orbit.py::test_orbit_LcE_planar
-jax tests/test_orbit.py::test_orbit_c_sigint_full
-jax tests/test_orbit.py::test_orbit_c_sigint_planar
-jax tests/test_orbit.py::test_orbit_c_sigint_planardxdv
-jax tests/test_orbit.py::test_orbit_rE
-jax tests/test_orbit.py::test_orbit_rE_planar
-jax tests/test_orbit.py::test_orbit_rguiding
-jax tests/test_orbit.py::test_orbit_rguiding_planar
-jax tests/test_orbit.py::test_pericenter
-jax tests/test_orbit.py::test_softenedneedlebar_planar_dxdv_c_vs_python
-jax tests/test_orbit.py::test_softenedneedlebar_planar_dxdv_fd_of_flow
-jax tests/test_orbit.py::test_wrapper_complicatedsequence_2d
-jax tests/test_orbit.py::test_wrapper_complicatedsequence_3d
-jax tests/test_orbit.py::test_wrapper_followedbyanotherpotential_2d
-jax tests/test_orbit.py::test_wrapper_followedbyanotherpotential_3d
-jax tests/test_orbits.py::test_bruteSOS_3D
-jax tests/test_orbits.py::test_energy_jacobi_angmom
-jax tests/test_orbits.py::test_rguiding
+jax tests/test_orbit.py::test_integrate_indiv_t_python_paths  # 300s (failed)
 
 # --- jax NonInertialFrameForce func/vec-omega (eager-XLA timeout) ---
 # The func/vec omega_z frame-force variants build a per-timestep interpolation of

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -261,3 +261,17 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetric
 # backend-native; there is nothing to fix in the test.
 jax-jit tests/test_potential.py::test_pickling_potential_unitful_dens
 jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
+
+# jax-jit: actionAngleStaeckelGrid, MEASURED 2026-08-07 on the first traced run of
+# test_actionAngle.py (whole file, regen mode). This nodeid is ledgered for EAGER
+# TORCH but NOT for jax, and `-jit` inherits only the SAME backend's eager
+# entries -- so jax-jit was uncovered and would red a workflow_dispatch(jit=true).
+# It is a tolerance case, not a defect: the test asks a COMPUTED circular-orbit
+# eccentricity to vanish to 1e-16.
+#     eager jax   passes (no jax entry in the CI-regenerated ledger)
+#     jax-jit     e = 9.363e-12   vs 1e-16
+#     torch-jit   e = 1.5305e-10  vs 1e-16   (covered, inherits the torch entry)
+# Tracing is entitled to reassociate, so eager and traced landing on different
+# sides of an absolute 1e-16 bar is expected. Un-ledger if that bar is ever made
+# backend-aware; the tolerance proposal itself is separate and needs sign-off.
+jax-jit tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions


### PR DESCRIPTION
The jax `test_orbit.py` / `test_orbits.py` entries in `backend_slow_skip.txt` were deferred when eager jax could not finish them inside the 300 s per-test cap. The batched in-backend integrator, the C-STM routing and the accessor work have all landed underneath them since, and nothing had gone back to check.

## Measured, not assumed

Lifted all 127 and re-ran the suite **in the CI shard context** — the same command `backend-tests.yml` uses, all five `pytest-split` groups:

```
tests/test_orbit.py tests/test_orbits.py -k 'not test_energy_jacobi_conservation'
  --splits 5 --group N --durations-path tests/.test_orbit_durations
  --backend=jax --timeout=300 --timeout-method=signal
```

The xfail ledger was left **active**, so the only pass/fail signal in the junitxml is the lifted entries.

| | |
|---|---|
| covered by the run | 114 of 127 |
| **un-deferred** (measured < 240 s) | **100** |
| kept — passed but **overran the cap** | 1 |
| kept — margin band (240–300 s) | 3 |
| kept — still too slow (all exactly 300 s) | 10 |
| kept — not observed by any shard | 13 |

**88% of the measured entries were stale.** Slow-skip goes **210 → 110** (jax 192→92, torch 15, torch-jit 3).

## Three rules the numbers forced

- **Margin.** Only entries under **240 s** (80% of cap) are un-deferred. A test that tips over records FAILED, not skipped, so "probably fits" is the wrong bar when the failure mode is a red CI on the integration branch.
- **`passed` does not imply "within the cap".** `--timeout-method=signal` only fires when Python bytecode resumes, so a test inside a long C call overruns and still reports passed. One entry did exactly that at **620 s**, and an outcome-only rule would have un-deferred it.
- **Entries no shard covered stay.** Absence is not evidence of speed.

## Every retained entry now carries its measurement

```
jax ...::test_SOS_3D  # 269s -- inside the cap, but within 20% of it
jax ...[RotateAndTiltWrapperPotential_offset]  # 290s -- inside the cap, but within 20% of it
jax ...[RotateAndTiltWrapperPotential_norot_offset]  # 300s (failed)
```

so the next reader sees a number rather than an assumption.

## Verification

Generated by a script rather than hand-edited, and the rewritten file was **parsed back with the real loader** — `_load_backend_nodeids`, whose docstring already documents the trailing-`#` form and which strips it via `raw.split("#", 1)[0]`:

```
jax        92 nodeids, 0 malformed
torch      15 nodeids, 0 malformed
torch-jit  18 nodeids, 0 malformed   (15 inherited from torch + its own 3)
```

Had that parser used a plain `split(None, 1)`, the annotations would have been swallowed into the nodeids and the whole file would have silently stopped matching anything.

## Note

The 10 that are still too slow are all in the per-force-call-overhead class — eager jax costs ~5 ms per `evaluateRforces` call regardless of array size, so a test making tens of thousands of scalar force calls is essentially all framework overhead. That is tracked separately and is not something this PR attempts.

---

## Second commit: one ledger entry, also measured

The first-ever traced run of `test_actionAngle.py` turned up a one-sided
coverage gap. `test_actionAngleStaeckelGrid_basicAndConserved_actions` is
ledgered for **eager torch** but not for jax, and `-jit` inherits only the *same*
backend's eager entries — so torch-jit was covered and jax-jit was not:

```
eager jax   passes (no jax entry in the CI-regenerated ledger)
jax-jit     e = 9.363e-12   vs 1e-16     <- uncovered, would red
torch-jit   e = 1.5305e-10  vs 1e-16     <- covered, inherits torch's entry
```

It is a tolerance case, not a defect: the test asks a *computed* circular-orbit eccentricity to vanish to **1e-16**, and the measured values are 1e-10..1e-12 — physically zero. Tracing is entitled to reassociate, so eager and traced landing on opposite sides of an absolute 1e-16 bar is expected.

Whole-file measurements behind it:

```
test_actionAngle.py  jax --jit    179 passed / 24 skipped / 3 failed
test_actionAngle.py  torch --jit  182 passed / 24 skipped / 3 failed
```

The other two failures in each arm are already ledgered for their backend. Nothing tripped this before because `backend-tests`' normal runs carry no `--jit` dimension — it is only reachable via `workflow_dispatch(jit=true)`, which is exactly the run this entry keeps honest.

The underlying tolerance question is separate and needs sign-off; this commit only makes the ledger describe what the suite actually does.


---

## Interaction with #1266 (resolved)

**#1266 has now merged** (`b6bf4b54`), so the numbers above shift by its −3/+2:
this PR is **209 → 109**, not 210 → 110. The body above is left as originally
measured rather than rewritten, so the two states stay distinguishable.

Verified after #1266 landed, on the auto-merged result:

```
jax 92, torch 15, torch-jit 2   total 109
```

which is the 109 I predicted before either merged. **No rebase was needed** —
the two PRs edit different blocks of the same file, `git merge-tree` reported 0
conflicts against the real merge base, and GitHub reports MERGEABLE unchanged.
So this branch is deliberately *not* force-pushed.

The counts in this description are re-derived from the committed file, not from
a working tree mid-edit, and re-parsed with `_load_backend_nodeids`:

```
jax        92 nodeids
torch      15 nodeids
torch-jit  18 nodeids   (15 inherited from torch + its own 3)
```
