### PR TITLE
diskdf: keep the scipy-quad scalar path off the backend (fixes a forced-backend regression from #1261)

### DIFF
--- a/galpy/df/diskdf.py
+++ b/galpy/df/diskdf.py
@@ -29,7 +29,7 @@ numpylog = numpy.lib.scimath.log  # somehow, this code produces log(negative), w
 from scipy import integrate, interpolate, optimize, stats
 
 from ..actionAngle import actionAngleAdiabatic
-from ..backend import as_numpy, get_namespace, is_backend_array
+from ..backend import as_numpy, get_namespace, is_backend_array, use
 from ..backend.quadrature import nested_quad
 from ..orbit import Orbit
 from ..potential import PowerSphericalPotential
@@ -463,9 +463,28 @@ class diskdf(df):
     # `__class__.__name__` builds the dfcorrection save filename -- a wrapper
     # would silently change that filename and regenerate corrections instead of
     # loading them.
+    # Three cases, because the cost of getting this wrong is measured in
+    # minutes: diskdf's scipy-quad path calls in here ~133k times per oortA().
+    #   * R is a backend array -> the caller is on the backend; go straight in.
+    #   * plain R, numpy active -> the common path. Skip the @backend_input
+    #     wrapper via __wrapped__: it can only be a no-op here (coerce_coords
+    #     returns numpy coords object-identical), and at this call count even a
+    #     no-op wrapper is worth ~12%.
+    #   * plain R, a backend FORCED -> a plain float resolves to that backend,
+    #     so leaving it alone coerces a scalar in and converts it back out on
+    #     every call. Pin numpy for the duration instead. The profile stays
+    #     island-free: it is the CONSUMER choosing numpy for its own numpy-only
+    #     quadrature, not the leaf dispatching on dtype.
     def _ssp(self, name, R, **kwargs):
-        out = getattr(self._surfaceSigmaProfile, name)(R, **kwargs)
-        return out if is_backend_array(R) else as_numpy(out)
+        ssp = self._surfaceSigmaProfile
+        bound = getattr(ssp, name)
+        if is_backend_array(R):
+            return bound(R, **kwargs)
+        if get_namespace(R) is numpy:
+            inner = getattr(bound, "__wrapped__", None)
+            return inner(ssp, R, **kwargs) if inner is not None else bound(R, **kwargs)
+        with use("numpy", force=True):
+            return as_numpy(bound(R, **kwargs))
 
     @physical_conversion("surfacedensitydistance", pop=True)
     def targetSurfacemassLOS(self, d, l, log=False, deg=True):

--- a/tests/test_backend_diskdf.py
+++ b/tests/test_backend_diskdf.py
@@ -87,6 +87,55 @@ def test_moment_parity(backend, dfname, df, fn):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "fn", ["surfacemass", "surfacemassDerivative", "sigma2", "sigma2Derivative"]
+)
+def test_ssp_plain_scalar_stays_on_numpy(backend, fn, monkeypatch):
+    # diskdf's scipy-quad path calls the surface/sigma profile with PLAIN scalars
+    # ~133k times per oortA(). Under a forced backend a plain float resolves to
+    # that backend, so if _ssp lets it through, every one of those is a scalar
+    # coerced in and converted back out -- measured at an 8.7x traced slowdown
+    # (25.3 s vs 2.9 s for one oortA) when it regressed.
+    #
+    # Asserting on the RETURN VALUE cannot see that: _ssp casts back with
+    # as_numpy either way, so the round trip is invisible except as float noise
+    # -- which jax happens to show and torch does not. Watch the coercion itself
+    # instead, so the guard works the same on both backends.
+    import galpy.backend._input as _bi
+
+    real, entered = _bi.coerce_coords, []
+
+    def spy(xp, *coords):
+        entered.append(getattr(xp, "__name__", str(xp)))
+        return real(xp, *coords)
+
+    monkeypatch.setattr(_bi, "coerce_coords", spy)
+
+    ref = getattr(_dehnen._surfaceSigmaProfile, fn)(0.8)
+    with use(backend, force=True):
+        got = _dehnen._ssp(fn, 0.8)
+    on_backend = [n for n in entered if "numpy" != n]
+    assert not on_backend, f"{fn}: plain scalar coerced onto {on_backend}"
+    assert not is_backend_array(got), f"{fn}: plain scalar leaked onto {backend}"
+    numpy.testing.assert_array_equal(got, ref, err_msg=f"{fn}: value changed")
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "fn", ["surfacemass", "surfacemassDerivative", "sigma2", "sigma2Derivative"]
+)
+def test_ssp_backend_array_uses_backend(backend, fn):
+    # The other half of the same contract: pinning numpy for plain scalars must
+    # not undo the migration, so a real backend array still gets the backend
+    # path (and stays differentiable there).
+    ref = float(getattr(_dehnen._surfaceSigmaProfile, fn)(0.8))
+    with use(backend, force=True):
+        got = _dehnen._ssp(fn, _scalar(backend, 0.8))
+    assert is_backend_array(got), f"{fn}: backend array fell back to numpy"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-14, atol=1e-300)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("dfname,df", _DFS)
 @pytest.mark.parametrize("fn", ["surfacemass", "sigmaR2"])
 def test_moment_grad_vs_fd(backend, dfname, df, fn):


### PR DESCRIPTION
`#1261` removed the numpy island in `expSurfaceSigmaProfile` by decorating its four R-evaluators with `@backend_input`. That is correct for dispatch, and it made every `diskdf` moment 5-10x slower under **any** forced backend. This is my own regression, caught by the traced sweep rather than by CI — `backend-tests` carries no `--jit` dimension, and eager jax still passes these tests, so nothing in CI could have seen it.

## Mechanism

`diskdf` is not migrated: its moment quadrature is scipy's adaptive rule, which calls the profile with **plain scalars**. Instrumenting the accessor:

```
_ssp branch counts: {'backend_array': 0, 'plain': 133332}
R types seen      : {'float': 24, 'float64': 133308}
```

Not one of the 133k calls per `oortA()` passes a backend array. And under a forced backend a plain `numpy.float64` still resolves to that backend:

```
plain ctx      : numpy
forced jax ctx : jax.numpy        <- the regression
nested numpy   : numpy
```

So each of those 133k calls coerced a scalar in, evaluated, and converted it straight back out. Values were correct throughout — this was never a correctness bug, only 133k round trips.

## Fix

`_ssp` splits three cases:

- **backend array** — the caller is on the backend; go straight in.
- **plain scalar, numpy active** — skip the `@backend_input` wrapper via `__wrapped__`. It can only be a no-op here (`coerce_coords` returns numpy coords object-identical), and at this call count even a no-op wrapper measured ~12%.
- **plain scalar, backend forced** — pin numpy for the call.

The leaf is untouched and **stays island-free**. This is the *consumer* choosing numpy for its own numpy-only quadrature — which `_ssp`'s existing comment already documents `diskdf` as doing — not the leaf dispatching on dtype.

**Correction to an earlier draft of this description:** I first wrote that migrating diskdf's quadrature (Pdf.3) is what would eventually remove this pin. That is wrong — the quadrature is *already* migrated. A backend array in gives a backend array out, matching numpy exactly, and differentiates:

```
oortA(jnp.asarray(1.0))   is_backend_array=True   0.4805462559   (numpy ref 0.4805462559)
jax.grad(oortA)(1.0)      = -0.485356
```

So the pin is not a placeholder awaiting migration. It is the permanent, correct dispatch for the one case that genuinely is numpy — scipy's adaptive quadrature calling back with plain scalars — and there is nothing further to remove.

## It is not a jit-only problem — corrected after measuring

I first characterised this as a *traced* regression, because that is where it broke a test. It is not. The boundary cost is a **forced-backend** cost, and tracing is barely a factor:

| one `@backend_input` crossing, scalar arg | µs/call |
|---|---|
| undecorated, numpy | 1.3 |
| decorated, numpy | 2.8 |
| decorated, **forced jax eager** | **178.2** |
| decorated, forced jax + jit | 151.1 |

Eager is if anything *slower* than traced. Confirmed end-to-end on `oortA(1.0)` with the backend forced but **no jit**:

```
forced jax EAGER    without fix  31.09 s    with fix  4.65 s    6.7x
```

This matters for what was actually affected: `backend-tests` runs **eager** forced backends on every push, so #1261 slowed the routine `backend jax tests/test_diskdf.py` shard by ~2.8x (whole file 3613 s → 1295 s). It stayed green, so nothing flagged it. The traced timeouts were the visible symptom of a wider slowdown, not the whole of it.

## Measured

Min of 3 reps, `dehnendf.oortA(1.0)`, provenance printed on every arm:

| | numpy | traced jax | traced torch |
|---|---|---|---|
| pre-#1261 | 2.72 s | 2.90 s | — |
| tip (#1261 as merged) | 3.05 s | 25.26 s | 42.79 s |
| **this PR** | **2.82 s** | **4.40 s** | **4.09 s** |

**torch was hit harder than jax** (10.5x vs 5.7x). Whole file, both traced backends:

```
--backend=jax   --jit   124 passed / 5 skipped / 0 failed   (was 2 FAILED at 300s timeout)
--backend=torch --jit   129 passed / 0 skipped / 0 failed
  test_dehnendf_cold_flat_oortA        43.9s jax / 45.9s torch   (was 300.0s TIMEOUT)
  test_dehnendf_cold_powerrise_oortA   37.4s jax / 40.2s torch   (was 300.0s TIMEOUT)
```

jax's 124/5/0 matches pre-#1261 exactly. (torch shows 129 because it has no `diskdf` slow-skip entries.)

## numpy path: bit-identical, not just green

`test_diskdf.py` on plain numpy is **129 passed / 0 failed**. But this PR does change the numpy path — it now calls the undecorated function — so the suite passing is not the claim. 120 values (dehnendf/shudf x beta in {0, 0.2} x 5 radii x 6 moments), raw IEEE bits hashed:

```
WITH this PR     sha256 4175fc090f8f526e5d3090313a981c9c
WITHOUT it       sha256 4175fc090f8f526e5d3090313a981c9c
pre-#1261        sha256 4175fc090f8f526e5d3090313a981c9c
```

Three separate worktrees, provenance printed and the distinguishing source line grepped in each — because three identical hashes is also what one checkout compared with itself three times looks like.

## The guard watches the path, not the value

`_ssp` casts back with `as_numpy` either way, so the round trip leaves no trace in the result — not the type, not the value, except as last-bit float noise. My first attempt asserted on the value and appeared to flip; that was luck, since jax's round trip perturbs the last bits and **torch's is bit-exact**:

```
value-based guard   4 fail without the fix   (jax only)
path-based guard    8 fail without the fix   (4 jax + 4 torch)
```

Torch being the worse regression, the value guard would have been green on the more severe case. The committed guard spies on `coerce_coords`.

## Scope

- Deliberately **not** chased: traced is 4.40 s against pre-#1261's 2.90 s. Measured the obvious suspect — the 133k `use("numpy")` enters are **0.29 s** of that 1.5 s gap — so hoisting the context manager across ~30 call sites buys a fifth of the residual and is not worth it.
- Swept for other instances of this class (unmigrated consumer + decorated leaf + scipy quad). Five sites measured by coercion count; the signature is tens of thousands, the others are 2-36. **No second instance.** `sphericaldf`'s quadratures were not exercised, so this bounds what it sampled rather than proving absence.
