### PR TITLE
slow-skip: un-defer 5 measured-stale jax diskdf sampling entries (109 -> 104)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -101,17 +101,20 @@ jax tests/test_potential.py::test_2ndDeriv_potential[mockInterpRZPotentialwSecon
 jax tests/test_actionAngle.py::test_actionAngleAdiabatic_conserved_actions_cylsep
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_basicAndConserved_actions
 
-# --- jax diskdf sampling pass-but-slow (AA-native-redesign exposure, Track F: diskdf) ---
-# Making actionAngle run REAL jax flips diskdf sampling onto the jax path; with the
-# orbit 0-d-time len() fix these now PASS but run 39-238 s each under jax-eager (300 s
-# CI timeout risk), as diskdf samples ~300 orbits per call with no vectorization. These
-# are the ones that PASS slowly; the ones that still fail at a deeper diskdf gap are
-# in backend_xfail.txt. Un-skip when diskdf is vectorized for jax (Track F).
-jax tests/test_diskdf.py::test_dehnendf_sample_flat_returnROrbit
-jax tests/test_diskdf.py::test_shudf_sample_flat_returnOrbit
-jax tests/test_diskdf.py::test_shudf_sample_flat_returnROrbit
-jax tests/test_diskdf.py::test_shudf_sample_flat_returnROrbit_rrange
-jax tests/test_diskdf.py::test_shudf_sample_powerrise_returnROrbit
+# --- jax test_galpypaper diskdf (Track F: diskdf) ---
+# The five test_diskdf.py sampling entries that used to sit here were MEASURED STALE
+# 2026-08-07 and un-deferred: whole file, entries lifted, `--backend=jax --timeout=300`,
+# 129 passed / 0 failed, all five well inside the 240 s margin --
+#   test_dehnendf_sample_flat_returnROrbit       178.6 s   (60% of cap)
+#   test_shudf_sample_flat_returnROrbit_rrange    64.2 s
+#   test_shudf_sample_powerrise_returnROrbit      60.4 s
+#   test_shudf_sample_flat_returnOrbit            57.3 s
+#   test_shudf_sample_flat_returnROrbit           30.6 s
+# They went fast under the batched in-backend integrator / C-STM routing, NOT under the
+# diskdf boundary fix landing alongside this: an A/B across that fix gives a median
+# ratio of 0.97x on these five (178.6 vs 182.3, 57.3 vs 53.4, ...), i.e. no effect.
+# This one stays: test_galpypaper.py is a different file and was NOT covered by that
+# run, and absence of measurement is not evidence of speed.
 jax tests/test_galpypaper.py::test_diskdf
 
 # --- jax dissipative-force + MovingObject/orbit timeouts (#960 coercion ascent) ---


### PR DESCRIPTION
Five `jax` slow-skip entries for `test_diskdf.py` sampling are stale. Their comment block blames a mechanism that has since been fixed by other work:

> Making actionAngle run REAL jax flips diskdf sampling onto the jax path; […] diskdf samples ~300 orbits per call with no vectorization.

## Measured, whole file, in the entries' own backend

The entries are keyed to eager `jax`, so that is what was run — `tests/test_diskdf.py --backend=jax --timeout=300`, whole file, entries lifted, **129 passed / 0 failed**:

| nodeid | measured | % of cap |
|---|---|---|
| `test_dehnendf_sample_flat_returnROrbit` | **178.6 s** | 60% |
| `test_shudf_sample_flat_returnROrbit_rrange` | **64.2 s** | 21% |
| `test_shudf_sample_powerrise_returnROrbit` | **60.4 s** | 20% |
| `test_shudf_sample_flat_returnOrbit` | **57.3 s** | 19% |
| `test_shudf_sample_flat_returnROrbit` | **30.6 s** | 10% |

All clear the 240 s margin rule (80% of the 300 s cap) that the last slow-skip prune established, the slowest at 60% of it. CI runs these faster than this box (measured CI/local ≈ 0.71 on jax shards), so ~127 s for the worst.

Slow-skip goes **109 → 104**.

## What made them fast — explicitly NOT this author's recent diskdf work

I fixed a traced `diskdf` regression in #1268 and it would have been convenient to claim these five as a bonus. They are not. A/B, same whole-file command, with and without that fix:

| nodeid | with #1268 | without | ratio |
|---|---|---|---|
| `test_dehnendf_sample_flat_returnROrbit` | 178.6 s | 182.3 s | 1.02× |
| `test_shudf_sample_flat_returnOrbit` | 57.3 s | 53.4 s | 0.93× |
| `test_shudf_sample_flat_returnROrbit` | 30.6 s | 29.8 s | 0.97× |
| `test_shudf_sample_flat_returnROrbit_rrange` | 64.2 s | 65.0 s | 1.01× |
| `test_shudf_sample_powerrise_returnROrbit` | 60.4 s | 58.0 s | 0.96× |

Median **0.97×** — indistinguishable. These went stale under the batched in-backend integrator and the C-STM routing, which is what the original comment predicted would be needed ("~300 orbits per call with no vectorization").

Worth stating because the whole-file number points the other way and is misleading: without #1268 the file takes 3613 s vs 1295 s with it. That 2.8× is entirely the **moment** quadratures (`surfacemass`/`sigma2`/`oortA`), which #1268 does speed up and which dominate the file. Attributing it to the sampling tests would have been wrong, and the per-test A/B is what distinguishes the two.

## The sixth entry stays

`jax tests/test_galpypaper.py::test_diskdf` is left in place — it is a different file, was not covered by this run, and absence of measurement is not evidence of speed.
