### PR TITLE
slow-skip: un-defer 6 measured-stale jax entries (104 -> 98)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -16,7 +16,6 @@
 # it) it passes in 1028.6 s under forced jax. CI runs ~0.71x this box's wall time
 # on the same code, so that still projects to ~730 s. Needs KingPotential
 # vectorization, not merely the sampling port.
-jax tests/test_sphericaldf.py::test_king_sigmar
 #
 # --- jax multi-orbit (test_orbits.py): slow battery (Track D/E) ---
 # Surface-of-section, multi-orbit dxdv (Python STM reference), C-fallback,
@@ -51,11 +50,6 @@ jax tests/test_qdf.py::test_meanjz_noaac_issue300
 # 300 s per-test timeout under forced jax. torch completes them (faster eager),
 # so torch keeps them ledgered xfail. Un-defer once the moment engine is
 # vectorized/jit-friendly; numpy exercises every one.
-jax tests/test_pv2qdf.py::test_pvRvT_staeckel
-jax tests/test_pv2qdf.py::test_pvRvT_staeckel_diffngl
-jax tests/test_pv2qdf.py::test_pvRvz_staeckel_diffngl
-jax tests/test_pv2qdf.py::test_pvTvz_staeckel
-jax tests/test_pv2qdf.py::test_pvTvz_staeckel_diffngl
 jax tests/test_qdf.py::test_sampleV_interpolate
 
 # --- jax interpRZ timeouts / near-timeouts (Track A/d interpRZ 2D-interp vectorization) ---


### PR DESCRIPTION
Un-defers 6 `backend_slow_skip.txt` entries that were measured, in the real
shard context, to run far under the 300 s cap.

## Measured (whole-file, `--backend=jax --timeout=300`, entries lifted)

| entry | in-file | % of cap |
|---|---|---|
| `test_sphericaldf.py::test_king_sigmar` | **9.1 s** | 3% |
| `test_pv2qdf.py::test_pvRvz_staeckel_diffngl` | 61.8 s | 21% |
| `test_pv2qdf.py::test_pvRvT_staeckel` | 67.3 s | 22% |
| `test_pv2qdf.py::test_pvTvz_staeckel` | 71.9 s | 24% |
| `test_pv2qdf.py::test_pvTvz_staeckel_diffngl` | 143.2 s | 48% |
| `test_pv2qdf.py::test_pvRvT_staeckel_diffngl` | 151.8 s | 51% |

All clear the **240 s margin** (80% of cap). CI runs ~0.71x local on jax shards,
so the effective margin is wider. `test_king_sigmar` was ledgered at **1028.6 s**
and is 113x stale — its cost went away with the batched integrator / C-STM
routing, not with anything in this PR.

Whole-file results with the entries lifted: `test_sphericaldf.py` **223 passed /
0 failed**; all 5 `test_pv2qdf.py` entries passed.

## Deliberately NOT un-deferred

The same sweep lifted the 6 `jax tests/test_interp_potential.py` entries. **All
six time out at exactly 300.0 s** — they are genuinely slow and stay deferred.
They fail as timeouts, not assertions, which is the distinction that matters: an
assertion failure would have meant the slow-skip was masking a defect.

## Why measured in-file rather than per-nodeid

A single nodeid profiled alone is not the context the cap applies to — module
fixtures and accumulated jax compilation caches move per-test cost both ways.
`test_king_sigmar` is 21.9 s solo and 9.1 s in-file.

Ledger-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm