### PR TITLE
vertical adapters: forward to the undecorated evaluators (1708 -> 244 boundary crossings)

### DIFF
--- a/galpy/potential/verticalPotential.py
+++ b/galpy/potential/verticalPotential.py
@@ -11,6 +11,8 @@ from .Potential import (
     PotentialError,
     _check_backend_compatible,
     _check_potential_list_and_deprecate,
+    _evaluatePotentials,
+    _evaluatezforces,
 )
 
 
@@ -122,7 +124,7 @@ class verticalPotential(linearPotential):
         xp = get_namespace(z) if is_backend_array(z) else numpy
         tR = self._R if not hasattr(z, "__len__") else self._R * xp.ones_like(z)
         tphi = self._phi if not hasattr(z, "__len__") else self._phi * xp.ones_like(z)
-        return self._Pot(tR, z, phi=tphi, t=t, use_physical=False) - self._midplanePot
+        return _evaluatePotentials(self._Pot, tR, z, phi=tphi, t=t) - self._midplanePot
 
     def _force(self, z, t=0.0):
         """
@@ -153,7 +155,7 @@ class verticalPotential(linearPotential):
         xp = get_namespace(z) if is_backend_array(z) else numpy
         tR = self._R if not hasattr(z, "__len__") else self._R * xp.ones_like(z)
         tphi = self._phi if not hasattr(z, "__len__") else self._phi * xp.ones_like(z)
-        return self._Pot.zforce(tR, z, phi=tphi, t=t, use_physical=False)
+        return _evaluatezforces(self._Pot, tR, z, phi=tphi, t=t)
 
     def _force2deriv(self, z, t=0.0):
         # d^2 Phi / dz^2 of the wrapped 3D potential at (R,z,phi), mirroring
@@ -209,8 +211,8 @@ class _BatchedVerticalPotential(verticalPotential):
         xp = get_namespace(z)
         Rb = self._Rb(z)
         tphi = self._phi * xp.ones_like(z)
-        full = self._Pot(Rb, z, phi=tphi, t=t, use_physical=False)
-        mid = self._Pot(Rb, 0.0 * z, phi=tphi, t=t, use_physical=False)
+        full = _evaluatePotentials(self._Pot, Rb, z, phi=tphi, t=t)
+        mid = _evaluatePotentials(self._Pot, Rb, 0.0 * z, phi=tphi, t=t)
         return full - mid
 
 

--- a/tests/test_backend_linearpotential.py
+++ b/tests/test_backend_linearpotential.py
@@ -275,3 +275,71 @@ def test_isodisk_raw_methods_numpy_scalar_forced_backend(backend_name):
                 numpy.testing.assert_allclose(
                     float(got), ref[m], rtol=1e-12, atol=1e-14, err_msg=f"{m} x={x0}"
                 )
+
+
+###############################################################################
+# Boundary-crossing guard for the vertical->3D adapter forwards.
+#
+# verticalPotential wraps a 3D potential at fixed (R,phi). Those forwards used
+# to go through the DECORATED public API (self._Pot(...), .zforce), so under a
+# forced backend every call re-entered @backend_input and paid a coercion --
+# actionAngleVertical.Jz crossed 1708 times per call because of it.
+#
+# The values stay correct when that regresses; only time changes. So this
+# watches the coercion, not the result.
+###############################################################################
+
+
+def _count_vertical_coercions(fn, backend):
+    """Run fn() under a forced backend; count non-numpy coerce_coords calls."""
+    import galpy.backend._input as _bi
+
+    real = _bi.coerce_coords
+    n = [0]
+
+    def spy(xp, *coords):
+        if xp is not numpy:
+            n[0] += 1
+        return real(xp, *coords)
+
+    _bi.coerce_coords = spy
+    try:
+        with use(backend, force=True):
+            fn()
+    finally:
+        _bi.coerce_coords = real
+    return n[0]
+
+
+def _assert_vertical_adapters_do_not_recross(backend, mk):
+    from galpy.potential import MiyamotoNagaiPotential
+
+    vp = toVerticalPotential(MiyamotoNagaiPotential(a=0.5, b=0.05, normalize=1.0), 1.0)
+    z = mk([0.1])
+    for name, fn in [
+        ("verticalPotential._evaluate", lambda: vp._evaluate(z, t=0.0)),
+        ("verticalPotential._force", lambda: vp._force(z, t=0.0)),
+    ]:
+        assert _count_vertical_coercions(fn, backend) == 0, (
+            f"{name} re-crossed the @backend_input boundary; it should forward "
+            "to the undecorated inner evaluator"
+        )
+    # Negative control: _force2deriv is deliberately NOT migrated (there is no
+    # _evaluatez2derivs), so it must still cross. Without this, a spy that
+    # stopped working would make the assertions above pass vacuously.
+    assert _count_vertical_coercions(lambda: vp._force2deriv(z, t=0.0), backend) > 0, (
+        "control failed: _force2deriv should still cross, so a zero here means "
+        "the counter is broken, not that the code improved"
+    )
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="jax not installed")
+def test_vertical_adapter_forwards_do_not_recross_boundary_jax():
+    _assert_vertical_adapters_do_not_recross("jax", jnp.asarray)
+
+
+@pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+def test_vertical_adapter_forwards_do_not_recross_boundary_torch():
+    _assert_vertical_adapters_do_not_recross(
+        "torch", lambda v: torch.tensor(v, dtype=torch.float64)
+    )

--- a/tests/test_backend_linearpotential.py
+++ b/tests/test_backend_linearpotential.py
@@ -34,6 +34,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import count_boundary_crossings
 
 from galpy.backend import use
 from galpy.potential import (
@@ -290,27 +291,6 @@ def test_isodisk_raw_methods_numpy_scalar_forced_backend(backend_name):
 ###############################################################################
 
 
-def _count_vertical_coercions(fn, backend):
-    """Run fn() under a forced backend; count non-numpy coerce_coords calls."""
-    import galpy.backend._input as _bi
-
-    real = _bi.coerce_coords
-    n = [0]
-
-    def spy(xp, *coords):
-        if xp is not numpy:
-            n[0] += 1
-        return real(xp, *coords)
-
-    _bi.coerce_coords = spy
-    try:
-        with use(backend, force=True):
-            fn()
-    finally:
-        _bi.coerce_coords = real
-    return n[0]
-
-
 def _assert_vertical_adapters_do_not_recross(backend, mk):
     from galpy.potential import MiyamotoNagaiPotential
 
@@ -320,14 +300,14 @@ def _assert_vertical_adapters_do_not_recross(backend, mk):
         ("verticalPotential._evaluate", lambda: vp._evaluate(z, t=0.0)),
         ("verticalPotential._force", lambda: vp._force(z, t=0.0)),
     ]:
-        assert _count_vertical_coercions(fn, backend) == 0, (
+        assert count_boundary_crossings(fn, backend) == 0, (
             f"{name} re-crossed the @backend_input boundary; it should forward "
             "to the undecorated inner evaluator"
         )
     # Negative control: _force2deriv is deliberately NOT migrated (there is no
     # _evaluatez2derivs), so it must still cross. Without this, a spy that
     # stopped working would make the assertions above pass vacuously.
-    assert _count_vertical_coercions(lambda: vp._force2deriv(z, t=0.0), backend) > 0, (
+    assert count_boundary_crossings(lambda: vp._force2deriv(z, t=0.0), backend) > 0, (
         "control failed: _force2deriv should still cross, so a zero here means "
         "the counter is broken, not that the code improved"
     )


### PR DESCRIPTION
Same defect as #1271, in `verticalPotential.py`, and **hotter**: the vertical→3D
adapters forwarded through the decorated public API (`self._Pot(...)`,
`.zforce`), so under a forced backend every call re-entered `@backend_input`.
`actionAngleVertical.Jz` crossed **1708 times per call**, 1464 of them from
`verticalPotential._evaluate`.

Found by asking whether the #1271 pattern recurred rather than assuming it was
unique to the planar adapters.

## Change

Four forwards now call the existing undecorated inner:

| forward | now calls |
|---|---|
| `verticalPotential._evaluate` | `_evaluatePotentials` |
| `verticalPotential._force` | `_evaluatezforces` |
| `_BatchedVerticalPotential._evaluate` (full and mid) | `_evaluatePotentials` |

`_force2deriv` is **unchanged**: there is no `_evaluatez2derivs`, and it is not
on a hot path. It also serves as the guard's negative control. The one-time
`_midplanePot` construction call is left alone — it runs once per instance.

## Measured

```
aAVertical.Jz            1708 -> 244
aAVertical.actionsFreqs  1722 -> 246
```

The residual 244 is a **different** site — `actionAngleVertical`'s own bisection
closure, tracked separately — not something this change leaves undone.

## numpy is byte-identical

sha256 over **7218 values** (3 potentials × 3 radii × 401 heights × {value,
force}, including the `MWPotential2014` component list), computed in two separate
worktrees, matches develop exactly.

## Guard

Mirrors #1271's, using the `count_boundary_crossings` helper that #1271 hoisted
into `tests/backend_jit_helpers.py`, with `_force2deriv` as the negative control
so a broken counter cannot make it pass vacuously.

**A/B-verified**: 2 passed on this branch, 2 failed on develop.

## Gates

```
numpy  test_potential.py + test_actionAngle.py   1492 passed / 0 failed
jax    test_actionAngle.py --backend=jax          180 passed / 0 failed
torch  test_actionAngle.py --backend=torch        182 passed / 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm