### PR TITLE
actionAngleVertical: backend path forwards to the undecorated linear evaluators (244 -> 0 crossings)

### DIFF
--- a/galpy/actionAngle/actionAngleVertical.py
+++ b/galpy/actionAngle/actionAngleVertical.py
@@ -13,7 +13,10 @@ import numpy
 from scipy import integrate, optimize
 
 from ..backend import device_of, get_namespace, promote_scalars
-from ..potential.linearPotential import evaluatelinearPotentials
+from ..potential.linearPotential import (
+    _evaluatelinearPotentials,
+    evaluatelinearPotentials,
+)
 from ..potential.Potential import _check_potential_list_and_deprecate
 from .actionAngle import _BACKEND_GL_ORDER, actionAngle
 
@@ -319,9 +322,7 @@ class actionAngleVertical(actionAngle):
     # radial Jr/Or/ar.
 
     def _E_backend(self, x, vx):
-        return vx**2.0 / 2.0 + evaluatelinearPotentials(
-            self._pot, x, use_physical=False
-        )
+        return vx**2.0 / 2.0 + _evaluatelinearPotentials(self._pot, x)
 
     def _calc_xmax_backend(self, x, vx, E):
         """Vectorised turning point xmax (E == Phi(xmax)) via backend brentq."""
@@ -332,7 +333,7 @@ class actionAngleVertical(actionAngle):
         absx = xp.abs(x)
 
         def f(xm, E_):
-            return E_ - evaluatelinearPotentials(self._pot, xm, use_physical=False)
+            return E_ - _evaluatelinearPotentials(self._pot, xm)
 
         # Expanding upper bracket: double from 2|x| (1e-5 at x=0) until f <= 0.
         xend = iterate_bracket(
@@ -361,10 +362,7 @@ class actionAngleVertical(actionAngle):
             # (axis=-1), so the input shape is preserved either way.
             t = lim[..., None] * s
             xi = xmax[..., None] - t**2.0
-            rad = 2.0 * (
-                E[..., None]
-                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
-            )
+            rad = 2.0 * (E[..., None] - _evaluatelinearPotentials(self._pot, xi))
             rad = xp.where(rad > 0.0, rad, xp.zeros_like(rad))  # clip (AD guard)
             return xp.sqrt(rad) * 2.0 * t * lim[..., None]  # dx = 2t dt, dt = lim ds
 
@@ -387,10 +385,7 @@ class actionAngleVertical(actionAngle):
         def integrand(s):
             t = lim[..., None] * s
             xi = xmax[..., None] - t**2.0
-            rad = 2.0 * (
-                E[..., None]
-                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
-            )
+            rad = 2.0 * (E[..., None] - _evaluatelinearPotentials(self._pot, xi))
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))  # 2t->0 there anyway
             return 2.0 * t / xp.sqrt(rad) * lim[..., None]
 
@@ -419,10 +414,7 @@ class actionAngleVertical(actionAngle):
         def integrand(s):  # t = lo + span*s, xi = xmax - t^2
             t = lo[..., None] + span[..., None] * s
             xi = xmax[..., None] - t**2.0
-            rad = 2.0 * (
-                E[..., None]
-                - evaluatelinearPotentials(self._pot, xi, use_physical=False)
-            )
+            rad = 2.0 * (E[..., None] - _evaluatelinearPotentials(self._pot, xi))
             rad = xp.where(rad > 0.0, rad, xp.ones_like(rad))
             return 2.0 * t / xp.sqrt(rad) * span[..., None]  # dx = 2t dt, dt = span ds
 
@@ -439,9 +431,7 @@ class actionAngleVertical(actionAngle):
         """Mask of unbound orbits: the bracket expansion found no turning point,
         so E still exceeds Phi(xmax). The numpy path returns the 9999.99 sentinel
         (calcxmax == -9999.99 on overflow); match it for the vectorised path."""
-        return (
-            E - evaluatelinearPotentials(self._pot, xmax, use_physical=False)
-        ) > 1e-7
+        return (E - _evaluatelinearPotentials(self._pot, xmax)) > 1e-7
 
     def _evaluate_backend(self, x, vx):
         xp = get_namespace(x)

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -84,16 +84,14 @@ jax tests/test_interp_potential.py::test_interpolation_potential_c
 jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs_c
 jax tests/test_potential.py::test_2ndDeriv_potential[mockInterpRZPotentialwSecondDerivs]
 
-# --- jax actionAngleAdiabatic cylsep timeout (Track E action-angle, not yet jax-migrated) ---
-# test_actionAngleAdiabatic_conserved_actions_cylsep integrates the vertical action over a
-# CylindricallySeparable potential; under forced-jax the integration dispatches eager-jax
-# per step and exceeds the 300 s timeout. AdiabaticGrid_basicAndConserved_actions is its
-# sibling timeout (the AA-native-redesign regen ran without --timeout on a fast box, so it
-# "passed" slowly there and was wrongly dropped from the xfail-ledger; CI's 300 s timeout
-# fails it). Both are clean Timeouts, not wrong values; numpy runs them.
-# Defer until action-angle is backend-migrated/vectorized (Track E).
-jax tests/test_actionAngle.py::test_actionAngleAdiabatic_conserved_actions_cylsep
-jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_basicAndConserved_actions
+# (2026-08-08) The two jax actionAngleAdiabatic timeouts that lived here are
+# un-deferred: they were deferred because the vertical path dispatched eager-jax
+# per integration step, which is exactly what the adapter/closure fixes removed
+# (aAAdiabatic.actions: 4166 -> 251 -> 9 boundary crossings). Measured on this
+# branch, forced jax, C extension loaded:
+#     test_actionAngleAdiabaticGrid_basicAndConserved_actions   59.60 s
+#     test_actionAngleAdiabatic_conserved_actions_cylsep        27.44 s
+# vs the 300 s cap; CI runs jax shards at ~0.71x local, so ~42 s and ~19 s there.
 
 # --- jax test_galpypaper diskdf (Track F: diskdf) ---
 # The five test_diskdf.py sampling entries that used to sit here were MEASURED STALE

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -109,17 +109,15 @@ jax tests/test_potential.py::test_2ndDeriv_potential[mockInterpRZPotentialwSecon
 # run, and absence of measurement is not evidence of speed.
 jax tests/test_galpypaper.py::test_diskdf
 
-# --- jax dissipative-force + MovingObject/orbit timeouts (#960 coercion ascent) ---
-# #960's coercion newly exercises these under forced-jax: ChandrasekharDynamicalFriction
-# __init__ builds its sigma_r interpolation with per-scalar XLA dispatch, the
-# RZTo*/toVertical conversion tests construct such forces, and MovingObject integrates
-# an embedded Orbit -- all exceed the 300 s timeout (or hit the un-migrated-Orbit
-# interpolation error). Defer until the dissipative forces (Track B group-b) and Orbit
-# (Track D) are backend-migrated; numpy still exercises them.
-jax tests/test_potential.py::test_rforce_dissipative
-jax tests/test_potential.py::test_RZToplanarPotential
-jax tests/test_potential.py::test_RZToverticalPotential
-jax tests/test_potential.py::test_toVerticalPotential
+# (2026-08-08) Four entries from the #960 dissipative/MovingObject timeout block
+# are un-deferred: measured under forced jax with the C extension, they are
+#     test_toVerticalPotential      1.86 s      test_rforce_dissipative    1.05 s
+#     test_RZToplanarPotential      0.28 s      test_RZToverticalPotential 0.08 s
+# against the 300 s cap -- a >150x margin. Timed in isolation, not in the full
+# test_potential.py shard ([[handpicked-nodeid-batch-is-not-a-context]]); the
+# margin makes context effects implausible, and un-deferring puts them back in
+# the CI shard, which is the full-context check. If any is slow or fails there,
+# re-defer with the shard measurement attached.
 jax tests/test_potential.py::test_MovingObject_2ndderivs_fd
 # test_MultipoleExpansion_deepcopy (#980's regression test): deepcopies + fully
 # re-evaluates 4 Multipole potentials (incl. from_density L=4) over a grid x times x

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -2449,3 +2449,42 @@ def test_staeckel_unbound_sentinel_survives_the_azimuth_wrap(backend):
         f"{backend}: anglephi = {got[7]!r}; 9999.99 mod 2pi is "
         f"{9999.99 % (2.0 * numpy.pi)!r}, so the sentinel was wrapped"
     )
+
+
+###############################################################################
+# Boundary-crossing guard for actionAngleVertical's backend path.
+#
+# Its bracketing/root-find closure and quadrature integrands used to call the
+# DECORATED evaluatelinearPotentials, so under a forced backend every bisection
+# iteration re-entered @backend_input: 244 of the crossings in one
+# actionsFreqs() call came from that closure alone.
+#
+# Values stay correct when this regresses -- only time changes -- so this
+# watches the coercion itself, as for the planar/vertical adapters.
+###############################################################################
+
+
+def _mk(backend, v):
+    return jnp.asarray(v) if backend == "jax" else torch.tensor(v, dtype=torch.float64)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_aavertical_backend_path_uses_undecorated_evaluators(backend):
+    from backend_jit_helpers import count_boundary_crossings
+
+    from galpy.potential import MWPotential2014, toVerticalPotential
+
+    aAV = actionAngleVertical(pot=toVerticalPotential(MWPotential2014, 1.0))
+    x, vx = _mk(backend, [0.1]), _mk(backend, [0.05])
+
+    # The whole backend call still crosses for OTHER reasons (the vertical
+    # adapter, fixed separately), so pin the closure's own contribution: with the
+    # undecorated inner it must be a small constant, not one crossing per
+    # bisection iteration. 244 was the regressed value; the bracketing schedule
+    # is 80 steps, so anything >=80 means the per-iteration crossing is back.
+    n = count_boundary_crossings(lambda: aAV.actionsFreqs(x, vx), backend)
+    assert n < 80, (
+        f"actionAngleVertical backend path crossed the @backend_input boundary "
+        f"{n} times; the bracketing/root-find closure should call the "
+        "undecorated _evaluatelinearPotentials, not the decorated entry point"
+    )


### PR DESCRIPTION
Third and last measured instance of the defect fixed in #1271 (planar adapters)
and #1272 (vertical adapters): an internal loop calling a **decorated** public
entry point, so every iteration re-enters `@backend_input` and pays ~178 µs of
coercion.

Here it is `actionAngleVertical`'s own bracketing/root-find closure and its
quadrature integrands calling `evaluatelinearPotentials`.

## Change

Six **backend-only** call sites now use the existing undecorated inner
`_evaluatelinearPotentials`:

| line | site |
|---|---|
| 322 | `_E_backend` |
| 335 | `_calc_xmax_backend::f` ← the hot one |
| 366 / 392 / 424 | `_calc_{J,omega,angle}_backend::integrand` |
| 443 | `_unbound_backend` |

The **13 numpy/shared sites are untouched** (`_evaluate`, `_actionsFreqs`,
`_actionsFreqsAngles`, `calcxmax`). The split follows the `*_backend` naming
convention exactly, so the safety criterion is mechanical rather than a judgement
call.

Two things the inner API forced, both found by running rather than reading: it is
`(Pot, x, t=0.0)` with **no `use_physical`** kwarg (that comes from the
decorator), and the module previously imported only the decorated name.

## Measured

With this and #1272, the `actionAngleVertical` path stops crossing the boundary
entirely:

```
                          pre-#1272   post-#1272   +this PR
aAVertical.Jz                  1708          244          0
aAVertical.actionsFreqs        1722          246          0
```

Measured with the C extension loaded (asserted inside the run) and jax x64 on.

### It also fixes a consumer that was never a target

`actionAngleAdiabatic` reaches the same closure through
`toVerticalPotential`. Found by censusing 27 previously-unmeasured workloads
(2026-08-08) — it was the **hottest workload in the library** and nobody had
looked at it:

```
                          develop   +#1272   +#1272+#210
aAAdiabatic.actions          4166      251             9
```

A 460x reduction, none of it targeted. Attribution named
`actionAngleVertical.py:f` for 236 of the residual 251, and the table above is
the A/B that confirms it rather than trusting the attribution.

The same sweep is the evidence that this defect class is **concentrated**: with
#1271/#1272 in, the other 26 workloads all scored ≤ 153.

## numpy is byte-identical

sha256 over 24 values (4 heights × 3 velocities × {Jz, Oz}) is unchanged:

```
WITH this PR      sha256 = e2a8028f60e8f046
WITHOUT           sha256 = e2a8028f60e8f046
```

Computed on the rebased branch in **one worktree with one C-extension state**
(`_ext_loaded=True`, asserted in the run), toggling only
`actionAngleVertical.py`, so the comparison isolates this diff.

## Guard

Uses `count_boundary_crossings` (hoisted into `tests/backend_jit_helpers.py` by
#1271). Asserts the total for one `actionsFreqs()` stays **under 80** — the
bracketing schedule is 80 steps, so ≥80 means the per-iteration crossing is back.

A/B-verified rather than assumed:

```
on this branch    2 passed   (jax + torch)
#1272 only        2 failed   ← detects exactly this fix
```

**This is why the PR is stacked on #1272** and not independent: `merge-tree`
reports 0 conflicts and the files are disjoint, but the threshold is only
meaningful once the adapter's ~1464 crossings are gone. Independent in git,
dependent in measurement.
