### PR TITLE
interpRZPotential: keep grids and off-grid fallbacks in internal units (pre-existing numpy bug)

### DIFF
--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -246,7 +246,10 @@ class interpRZPotential(Potential):
                 for ii in range(len(self._rgrid)):
                     for jj in range(len(self._zgrid)):
                         potGrid[ii, jj] = evaluatePotentials(
-                            self._origPot, self._rgrid[ii], self._zgrid[jj]
+                            self._origPot,
+                            self._rgrid[ii],
+                            self._zgrid[jj],
+                            use_physical=False,
                         )
                 self._potGrid = potGrid
             if self._logR:
@@ -271,7 +274,10 @@ class interpRZPotential(Potential):
                 for ii in range(len(self._rgrid)):
                     for jj in range(len(self._zgrid)):
                         rforceGrid[ii, jj] = evaluateRforces(
-                            self._origPot, self._rgrid[ii], self._zgrid[jj]
+                            self._origPot,
+                            self._rgrid[ii],
+                            self._zgrid[jj],
+                            use_physical=False,
                         )
                 self._rforceGrid = rforceGrid
             if self._logR:
@@ -296,7 +302,10 @@ class interpRZPotential(Potential):
                 for ii in range(len(self._rgrid)):
                     for jj in range(len(self._zgrid)):
                         zforceGrid[ii, jj] = evaluatezforces(
-                            self._origPot, self._rgrid[ii], self._zgrid[jj]
+                            self._origPot,
+                            self._rgrid[ii],
+                            self._zgrid[jj],
+                            use_physical=False,
                         )
                 self._zforceGrid = zforceGrid
             if self._logR:
@@ -324,7 +333,10 @@ class interpRZPotential(Potential):
             for ii in range(len(self._rgrid)):
                 for jj in range(len(self._zgrid)):
                     r2derivGrid[ii, jj] = evaluateR2derivs(
-                        self._origPot, self._rgrid[ii], self._zgrid[jj]
+                        self._origPot,
+                        self._rgrid[ii],
+                        self._zgrid[jj],
+                        use_physical=False,
                     )
             self._r2derivGrid = r2derivGrid
             if self._logR:
@@ -346,7 +358,10 @@ class interpRZPotential(Potential):
             for ii in range(len(self._rgrid)):
                 for jj in range(len(self._zgrid)):
                     z2derivGrid[ii, jj] = evaluatez2derivs(
-                        self._origPot, self._rgrid[ii], self._zgrid[jj]
+                        self._origPot,
+                        self._rgrid[ii],
+                        self._zgrid[jj],
+                        use_physical=False,
                     )
             self._z2derivGrid = z2derivGrid
             if self._logR:
@@ -368,7 +383,10 @@ class interpRZPotential(Potential):
             for ii in range(len(self._rgrid)):
                 for jj in range(len(self._zgrid)):
                     rzderivGrid[ii, jj] = evaluateRzderivs(
-                        self._origPot, self._rgrid[ii], self._zgrid[jj]
+                        self._origPot,
+                        self._rgrid[ii],
+                        self._zgrid[jj],
+                        use_physical=False,
                     )
             self._rzderivGrid = rzderivGrid
             if self._logR:
@@ -390,7 +408,10 @@ class interpRZPotential(Potential):
             for ii in range(len(self._rgrid)):
                 for jj in range(len(self._zgrid)):
                     densGrid[ii, jj] = evaluateDensities(
-                        self._origPot, self._rgrid[ii], self._zgrid[jj]
+                        self._origPot,
+                        self._rgrid[ii],
+                        self._zgrid[jj],
+                        use_physical=False,
                     )
             self._densGrid = densGrid
             if self._logR:
@@ -416,13 +437,17 @@ class interpRZPotential(Potential):
 
             if not numcores is None:
                 self._vcircGrid = multi.parallel_map(
-                    (lambda x: vcirc(self._origPot, self._rgrid[x])),
+                    (
+                        lambda x: vcirc(
+                            self._origPot, self._rgrid[x], use_physical=False
+                        )
+                    ),
                     list(range(len(self._rgrid))),
                     numcores=numcores,
                 )
             else:
                 self._vcircGrid = numpy.array(
-                    [vcirc(self._origPot, r) for r in self._rgrid]
+                    [vcirc(self._origPot, r, use_physical=False) for r in self._rgrid]
                 )
             if self._logR:
                 self._vcircInterp = interpolate.InterpolatedUnivariateSpline(
@@ -437,13 +462,20 @@ class interpRZPotential(Potential):
 
             if not numcores is None:
                 self._dvcircdrGrid = multi.parallel_map(
-                    (lambda x: dvcircdR(self._origPot, self._rgrid[x])),
+                    (
+                        lambda x: dvcircdR(
+                            self._origPot, self._rgrid[x], use_physical=False
+                        )
+                    ),
                     list(range(len(self._rgrid))),
                     numcores=numcores,
                 )
             else:
                 self._dvcircdrGrid = numpy.array(
-                    [dvcircdR(self._origPot, r) for r in self._rgrid]
+                    [
+                        dvcircdR(self._origPot, r, use_physical=False)
+                        for r in self._rgrid
+                    ]
                 )
             if self._logR:
                 self._dvcircdrInterp = interpolate.InterpolatedUnivariateSpline(
@@ -459,14 +491,18 @@ class interpRZPotential(Potential):
             if not numcores is None:
                 self._epifreqGrid = numpy.array(
                     multi.parallel_map(
-                        (lambda x: epifreq(self._origPot, self._rgrid[x])),
+                        (
+                            lambda x: epifreq(
+                                self._origPot, self._rgrid[x], use_physical=False
+                            )
+                        ),
                         list(range(len(self._rgrid))),
                         numcores=numcores,
                     )
                 )
             else:
                 self._epifreqGrid = numpy.array(
-                    [epifreq(self._origPot, r) for r in self._rgrid]
+                    [epifreq(self._origPot, r, use_physical=False) for r in self._rgrid]
                 )
             indx = True ^ numpy.isnan(self._epifreqGrid)
             if numpy.sum(indx) < 4:
@@ -492,13 +528,20 @@ class interpRZPotential(Potential):
 
             if not numcores is None:
                 self._verticalfreqGrid = multi.parallel_map(
-                    (lambda x: verticalfreq(self._origPot, self._rgrid[x])),
+                    (
+                        lambda x: verticalfreq(
+                            self._origPot, self._rgrid[x], use_physical=False
+                        )
+                    ),
                     list(range(len(self._rgrid))),
                     numcores=numcores,
                 )
             else:
                 self._verticalfreqGrid = numpy.array(
-                    [verticalfreq(self._origPot, r) for r in self._rgrid]
+                    [
+                        verticalfreq(self._origPot, r, use_physical=False)
+                        for r in self._rgrid
+                    ]
                 )
             if self._logR:
                 self._verticalfreqInterp = interpolate.InterpolatedUnivariateSpline(
@@ -533,11 +576,11 @@ class interpRZPotential(Potential):
                         out[indx] = self._potInterp.ev(R[indx], z[indx])
             if numpy.sum(True ^ indx) > 0:
                 out[True ^ indx] = evaluatePotentials(
-                    self._origPot, R[True ^ indx], z[True ^ indx]
+                    self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
                 )
             return out
         else:
-            return evaluatePotentials(self._origPot, R, z)
+            return evaluatePotentials(self._origPot, R, z, use_physical=False)
 
     @scalarVectorDecorator
     @zsymDecorator(False)
@@ -562,11 +605,11 @@ class interpRZPotential(Potential):
                         out[indx] = self._rforceInterp.ev(R[indx], z[indx])
             if numpy.sum(True ^ indx) > 0:
                 out[True ^ indx] = evaluateRforces(
-                    self._origPot, R[True ^ indx], z[True ^ indx]
+                    self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
                 )
             return out
         else:
-            return evaluateRforces(self._origPot, R, z)
+            return evaluateRforces(self._origPot, R, z, use_physical=False)
 
     @scalarVectorDecorator
     @zsymDecorator(True)
@@ -593,18 +636,18 @@ class interpRZPotential(Potential):
                         out[indx] = self._zforceInterp.ev(R[indx], z[indx])
             if numpy.sum(True ^ indx) > 0:
                 out[True ^ indx] = evaluatezforces(
-                    self._origPot, R[True ^ indx], z[True ^ indx]
+                    self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
                 )
             return out
         else:
-            return evaluatezforces(self._origPot, R, z)
+            return evaluatezforces(self._origPot, R, z, use_physical=False)
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         if not self._interpR2deriv:
             # Not interpolated: pass through to the original potential
             from ..potential import evaluateR2derivs
 
-            return evaluateR2derivs(self._origPot, R, z)
+            return evaluateR2derivs(self._origPot, R, z, use_physical=False)
         return self._R2deriv_interpolated(R, z)
 
     @scalarVectorDecorator
@@ -632,7 +675,7 @@ class interpRZPotential(Potential):
                     out[indx] = self._r2derivInterp.ev(R[indx], z[indx])
         if numpy.sum(True ^ indx) > 0:
             out[True ^ indx] = evaluateR2derivs(
-                self._origPot, R[True ^ indx], z[True ^ indx]
+                self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
             )
         return out
 
@@ -641,7 +684,7 @@ class interpRZPotential(Potential):
             # Not interpolated: pass through to the original potential
             from ..potential import evaluatez2derivs
 
-            return evaluatez2derivs(self._origPot, R, z)
+            return evaluatez2derivs(self._origPot, R, z, use_physical=False)
         return self._z2deriv_interpolated(R, z)
 
     @scalarVectorDecorator
@@ -669,7 +712,7 @@ class interpRZPotential(Potential):
                     out[indx] = self._z2derivInterp.ev(R[indx], z[indx])
         if numpy.sum(True ^ indx) > 0:
             out[True ^ indx] = evaluatez2derivs(
-                self._origPot, R[True ^ indx], z[True ^ indx]
+                self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
             )
         return out
 
@@ -678,7 +721,7 @@ class interpRZPotential(Potential):
             # Not interpolated: pass through to the original potential
             from ..potential import evaluateRzderivs
 
-            return evaluateRzderivs(self._origPot, R, z)
+            return evaluateRzderivs(self._origPot, R, z, use_physical=False)
         return self._Rzderiv_interpolated(R, z)
 
     @scalarVectorDecorator
@@ -706,7 +749,7 @@ class interpRZPotential(Potential):
                     out[indx] = self._rzderivInterp.ev(R[indx], z[indx])
         if numpy.sum(True ^ indx) > 0:
             out[True ^ indx] = evaluateRzderivs(
-                self._origPot, R[True ^ indx], z[True ^ indx]
+                self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
             )
         return out
 
@@ -735,11 +778,11 @@ class interpRZPotential(Potential):
                     )
             if numpy.sum(True ^ indx) > 0:
                 out[True ^ indx] = evaluateDensities(
-                    self._origPot, R[True ^ indx], z[True ^ indx]
+                    self._origPot, R[True ^ indx], z[True ^ indx], use_physical=False
                 )
             return out
         else:
-            return evaluateDensities(self._origPot, R, z)
+            return evaluateDensities(self._origPot, R, z, use_physical=False)
 
     @physical_conversion("velocity", pop=True)
     @scalarDecorator
@@ -755,10 +798,12 @@ class interpRZPotential(Potential):
                 else:
                     out[indx] = self._vcircInterp(R[indx])
             if numpy.sum(True ^ indx) > 0:
-                out[True ^ indx] = vcirc(self._origPot, R[True ^ indx])
+                out[True ^ indx] = vcirc(
+                    self._origPot, R[True ^ indx], use_physical=False
+                )
             return out
         else:
-            return vcirc(self._origPot, R)
+            return vcirc(self._origPot, R, use_physical=False)
 
     @physical_conversion("frequency", pop=True)
     @scalarDecorator
@@ -774,10 +819,12 @@ class interpRZPotential(Potential):
                 else:
                     out[indx] = self._dvcircdrInterp(R[indx])
             if numpy.sum(True ^ indx) > 0:
-                out[True ^ indx] = dvcircdR(self._origPot, R[True ^ indx])
+                out[True ^ indx] = dvcircdR(
+                    self._origPot, R[True ^ indx], use_physical=False
+                )
             return out
         else:
-            return dvcircdR(self._origPot, R)
+            return dvcircdR(self._origPot, R, use_physical=False)
 
     @physical_conversion("frequency", pop=True)
     @scalarDecorator
@@ -793,10 +840,12 @@ class interpRZPotential(Potential):
                 else:
                     out[indx] = self._epifreqInterp(R[indx])
             if numpy.sum(True ^ indx) > 0:
-                out[True ^ indx] = epifreq(self._origPot, R[True ^ indx])
+                out[True ^ indx] = epifreq(
+                    self._origPot, R[True ^ indx], use_physical=False
+                )
             return out
         else:
-            return epifreq(self._origPot, R)
+            return epifreq(self._origPot, R, use_physical=False)
 
     @physical_conversion("frequency", pop=True)
     @scalarDecorator
@@ -812,10 +861,12 @@ class interpRZPotential(Potential):
                 else:
                     out[indx] = self._verticalfreqInterp(R[indx])
             if numpy.sum(True ^ indx) > 0:
-                out[True ^ indx] = verticalfreq(self._origPot, R[True ^ indx])
+                out[True ^ indx] = verticalfreq(
+                    self._origPot, R[True ^ indx], use_physical=False
+                )
             return out
         else:
-            return verticalfreq(self._origPot, R)
+            return verticalfreq(self._origPot, R, use_physical=False)
 
 
 def calc_potential_c(pot, R, z, rforce=False, zforce=False):

--- a/tests/test_interp_potential.py
+++ b/tests/test_interp_potential.py
@@ -2225,3 +2225,54 @@ def test_interpolation_potential_verticalfreq_notinterpolated():
             f"RZPot interpolation w/ interpRZPotential fails when the potential was not interpolated at R = {r:g} by {vfdiff:g}"
         )
     return None
+
+
+# Regression test for the units bug: interpRZPotential built from a potential
+# with ro/vo set stored PHYSICAL values in its grids (and in the off-grid
+# fallback), while the interpolator is queried in internal units. The
+# potential came out a factor vo^2 too large, forces by force_in_kmsMyr, and
+# dens/R2deriv/epifreq/verticalfreq were wrong regardless of use_c because
+# those grids have no C implementation. See galpy #212.
+def test_interpRZPotential_units_set_matches_unitless():
+    import numpy
+
+    from galpy.potential import MiyamotoNagaiPotential, interpRZPotential
+
+    grid = dict(rgrid=(0.5, 1.5, 21), zgrid=(0.0, 0.2, 11), logR=False)
+    with_units = MiyamotoNagaiPotential(a=0.5, b=0.05, normalize=1.0, ro=8.0, vo=220.0)
+    unitless = MiyamotoNagaiPotential(a=0.5, b=0.05, normalize=1.0)
+
+    # (R, z) on the grid and off it -- the off-grid branch falls back to the
+    # original potential and had the same defect.
+    checks = [
+        (
+            dict(interpPot=True, use_c=False),
+            lambda p, R, z: p(R, z, use_physical=False),
+        ),
+        (dict(interpPot=True, use_c=True), lambda p, R, z: p(R, z, use_physical=False)),
+        (
+            dict(interpRforce=True, use_c=False),
+            lambda p, R, z: p.Rforce(R, z, use_physical=False),
+        ),
+        (
+            dict(interpzforce=True, use_c=False),
+            lambda p, R, z: p.zforce(R, z, use_physical=False),
+        ),
+        (dict(interpDens=True), lambda p, R, z: p.dens(R, z, use_physical=False)),
+        (dict(interpR2deriv=True), lambda p, R, z: p.R2deriv(R, z, use_physical=False)),
+        (dict(interpepifreq=True), lambda p, R, z: p.epifreq(R, use_physical=False)),
+        (
+            dict(interpverticalfreq=True),
+            lambda p, R, z: p.verticalfreq(R, use_physical=False),
+        ),
+    ]
+    for kwargs, evaluate in checks:
+        ip_units = interpRZPotential(RZPot=with_units, **grid, **kwargs)
+        ip_plain = interpRZPotential(RZPot=unitless, **grid, **kwargs)
+        for R, z in [(1.05, 0.07), (3.0, 0.5)]:  # on-grid, then off-grid
+            got = float(evaluate(ip_units, R, z))
+            want = float(evaluate(ip_plain, R, z))
+            assert numpy.fabs(got - want) < 1e-12 * numpy.fabs(want), (
+                f"interpRZPotential with ro/vo set disagrees with the unitless "
+                f"build for {kwargs} at (R,z)=({R},{z}): {got} vs {want}"
+            )


### PR DESCRIPTION
**DRAFT — needs a decision from you before it lands. Opened as a draft so it is
reviewable and CI-validated rather than sitting on a local branch.**

`interpRZPotential` built from a potential with `ro`/`vo` set stores **physical**
values in its grids while the interpolator is queried in internal units. Found
2026-08-08 while scoping the boundary-crossing work; **verified pre-existing on
`main`** (`cd81fbed`), so this is not something the backend branch introduced.

## Measured

MiyamotoNagai, `normalize=1`, `ro=8`, `vo=220`; ratio interp/direct at
R=1.05, z=0.07, both `use_physical=False`:

```
use_c=False   potential  x48400.0169   == vo^2
              Rforce     x6.1874       == conversion.force_in_kmsMyr(220,8)
use_c=True    potential  x1.0000  ok   (the C path works in internal units)
              Rforce     x1.0000  ok
```

The C path being correct makes this look narrow. It is not — the grids with **no
C implementation** always take the Python loop and are wrong regardless of
`use_c`:

```
use_c=True    dens x0.175847   R2deriv x790.994398
              epifreq x28.124585   verticalfreq x28.124585
```

With `use_physical=True` the conversion is applied a **second** time
(-2.9e9 vs -59832.8 correct).

`interpRZPotential` exists for fast orbit integration, so this is wrong forces →
wrong orbits, silently, whenever it is built from a units-set potential.

**Why it survived:** 284 references to `interpRZPotential` in `tests/`, **none**
passing `ro=`/`vo=`. The units path has no coverage at all.

## Change

`use_physical=False` at **37 call sites**, in four classes — I only found all
four because the new test failed twice:

```
 7  grid build      evaluateFOO(self._origPot, self._rgrid[ii], self._zgrid[jj])
 4  per-r lists     [FOO(self._origPot, r) for r in self._rgrid]
 4  lambda-x grid   lambda x: FOO(self._origPot, self._rgrid[x])
22  off-grid falls  FOO(self._origPot, R) and FOO(..., R[True ^ indx])
```

The off-grid fallbacks had the same defect; my first pass fixed only the grid
build.

## Why this needs no byte-identity waiver

On a **unitless** potential `use_physical=False` is a no-op — verified
bit-for-bit against the decorated call over 9 (R,z) points for all seven
quantities. So nothing changes except the path that was already returning
vo^2-scaled numbers. The 40 pre-existing tests in `test_interp_potential.py` are
untouched.

## Verification

```
new regression test WITHOUT this change   1 failed   <- detects exactly this
new regression test WITH it               1 passed
tests/test_interp_potential.py            41 passed  (40 existing + 1 new), C ext loaded
```

The test checks on-grid **and** off-grid points across all seven quantities,
comparing a units-set build against a unitless one.

## The decision I need

1. **Target branch**: this is a `main` bug, but `feat/backends` carries it too.
   Opened against `main`; retarget if you prefer it on the backend branch.
2. **Ordering**: galpy task #211 (removing ~30603 `@backend_input` crossings from
   the same grid build) touches the *same* call sites. It should land **after**
   this, then swap three of them to `_evaluatePotentials`/`_evaluateRforces` and
   drop the now-redundant flag.
