### PR TITLE
Cherry-pick three main fixes onto feat/backends-develop (droppable in the later rebase)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2052,7 +2052,7 @@ class Orbit:
                     """numerical instabilities)""",
                     galpyWarning,
                 )
-        elif (
+        if (
             isinstance(
                 pot,
                 (

--- a/galpy/potential/TwoPowerSphericalPotential.py
+++ b/galpy/potential/TwoPowerSphericalPotential.py
@@ -933,8 +933,6 @@ class NFWPotential(TwoPowerSphericalPotential):
         self._backend_compatible = True
         if conc is None and rmax is None:
             self.a = a
-            self.alpha = 1
-            self.beta = 3
             if normalize or (
                 isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
             ):
@@ -962,6 +960,8 @@ class NFWPotential(TwoPowerSphericalPotential):
             # Turn on physical output, because mass is given in 1e12 Msun (see #465)
             self._roSet = True
             self._voSet = True
+        self.alpha = 1
+        self.beta = 3
         self._scale = self.a
         self.hasC = True
         self.hasC_dxdv = True

--- a/tests/test_SpiralArmsPotential.py
+++ b/tests/test_SpiralArmsPotential.py
@@ -1,12 +1,6 @@
-import numpy
-from packaging.version import parse as parse_version
-
-_NUMPY_VERSION = parse_version(numpy.__version__)
-_NUMPY_1_23 = (_NUMPY_VERSION > parse_version("1.22")) * (
-    _NUMPY_VERSION < parse_version("1.27")
-)  # For testing 1.23/1.24/1.25/1.26 precision issues
 import unittest
 
+import numpy
 from numpy.testing import assert_allclose
 
 from galpy.potential import SpiralArmsPotential as spiral
@@ -1214,7 +1208,10 @@ class TestSpiralArmsPotential(unittest.TestCase):
     def test_phi2deriv(self):
         """Test phi2deriv against a numerical derivative -d(phitorque) / d(phi)."""
         dx = 1e-8
-        rtol = rtol = _NUMPY_1_23 * 3e-7 + (1 - _NUMPY_1_23) * 1e-7
+        # Compared against a finite difference with dx = 1e-8 below, so the
+        # reference is amplification-bound: FD divides by dx, turning a
+        # last-bit force difference (~1e-13) into ~1e-5 in the reference.
+        rtol = 3e-7
 
         pot = spiral()
         R, z = 0.3, 0
@@ -1631,8 +1628,13 @@ class TestSpiralArmsPotential(unittest.TestCase):
 
     def test_Rzderiv(self):
         """Test Rzderiv against a numerical derivative."""
+        # dx stays 1e-6 (backend branch, galpy #1258): at 1e-8 the finite
+        # difference is amplification-bound and fails under jax. main's
+        # 80a10d66 dropped the expired _NUMPY_1_23 conditional -- take that
+        # cleanup, keep the backend-compatible dx.
         dx = 1e-6
-        rtol = _NUMPY_1_23 * 3e-6 + (1 - _NUMPY_1_23) * 1e-6
+        # Amplification-bound finite-difference reference; see test_phi2deriv.
+        rtol = 3e-6
 
         pot = spiral()
         R, z, phi, t = 1, 0, 0, 0

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -10948,3 +10948,41 @@ def test_orbits_MultipoleExpansionPotential_outside_interpolation_range_warning(
         "should make clear that the reported range is over all orbits"
     )
     return None
+
+
+def test_orbits_interpSphericalPotential_outside_interpolation_range_warning_with_fdm():
+    # Test that the interpSphericalPotential outside-of-interpolation-range
+    # warning still fires when the composite potential also contains an
+    # FDMDynamicalFrictionForce (used to be silently skipped, because the
+    # check was an elif chained to the FDMDynamicalFrictionForce check)
+    import warnings
+
+    from galpy.orbit import Orbit
+    from galpy.potential import (
+        FDMDynamicalFrictionForce,
+        LogarithmicHaloPotential,
+        interpSphericalPotential,
+    )
+    from galpy.util import galpyWarning
+
+    lp = LogarithmicHaloPotential(normalize=1.0)
+    ip = interpSphericalPotential(rforce=lp, rgrid=numpy.geomspace(0.5, 1.5, 101))
+    fdf = FDMDynamicalFrictionForce(GMs=0.0, rhm=0.125, dens=lp, minr=0.0001, maxr=25.0)
+    # Orbit strays outside of the interpSphericalPotential interpolation range
+    o = Orbit([1.0, 0.5, 0.3, 0.0])
+    ts = numpy.linspace(0.0, 20.0, 1001)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        o.integrate(ts, ip + fdf)
+        range_warnings = [
+            str(warning.message)
+            for warning in w
+            if issubclass(warning.category, galpyWarning)
+            and "outside of the interpolation range" in str(warning.message)
+        ]
+    assert len(range_warnings) == 1, (
+        "Integrating an orbit outside of the interpolation range of "
+        "interpSphericalPotential should raise a warning even when the "
+        "composite potential also contains an FDMDynamicalFrictionForce"
+    )
+    return None


### PR DESCRIPTION
Carries three `main` fixes onto `feat/backends-develop` so the backend branch is
not missing them for the next few days. All three are `git cherry-pick -x`, so
each records its `main` SHA and they drop cleanly out of the eventual rebase.

`feat/backends-develop` was **9 commits behind `main`**. This picks the code
fixes and leaves the rest (dependabot, pre-commit autoupdate, notebook outputs,
a docs tutorial) for the rebase.

| picked | from | note |
|---|---|---|
| `8ccaaa65` | `93105a46` | NFWPotential: set alpha/beta on the rmax/conc init paths |
| `350c2348` | `b87eb09f` | interpSphericalPotential range checked independently of FDM friction (#1107) |
| `7b195b5f` | `80a10d66` | drop the expired `_NUMPY_1_23` tolerance conditional in `test_SpiralArms` |

## The one deliberately NOT picked: `cd81fbed` (#1245)

`cd81fbed` fixes `AnyAxisymmetricRazorThinDisk`'s small-|z| band on main. It is
**not** in this PR, and that is a considered choice rather than an omission.

Both branches independently reworked that file — 6 commits here since the
merge-base (notably #1254 exact-complement K via `ellipkm1`, #1259 graded-dyadic
quadrature for the a=R singularity) against 1 on main — so the file differs by
+108/-368 and `merge-tree` shows 8 conflict regions.

**The fix is still needed.** Measured `zforce(1.0, z)` against the thin-disk
limit `-2*pi*G*Sigma(R)`:

```
                z=1e-6            z=1e-8
main     ratio  1.0000017281      1.0000000173   <- correct
develop  ratio  1.0000017281      0.0000000173   <- collapses to ~0
```

So this branch has a real defect below |z| ~ 1e-7 (galpy task #207) that main
does not.

**But a mechanical cherry-pick would regress the backend work.** main's fix is
built on `_quad_apeak`, a scipy-`quad` construction; dropping it in would replace
the backend-native, jit-traceable graded-dyadic path with a numpy-only one. The
right move is to *port the idea* — the a = R + |z|t substitution that resolves the
peak — into the backend-native implementation, with the AnyAxisym accuracy checks
re-run. That is a real piece of work, not a merge resolution, so I have left it
for review rather than doing it unilaterally.

## Conflict resolution (1 of 3)

`80a10d66` conflicted in `test_Rzderiv`. main drops the expired numpy-version
conditional but keeps `dx = 1e-8`; this branch deliberately uses `dx = 1e-6`
(galpy #1258) because at `1e-8` the finite difference is amplification-bound and
fails under jax. Resolved by taking **main's cleanup with this branch's `dx`**:

```python
dx = 1e-6
rtol = 3e-6
```

Verified: `test_Rzderiv` passes on numpy **and** under `--backend jax`.

## Note on a pre-existing failure

`test_potential.py::test_ExpTruncNFW_smallr_series_c` fails on this branch — and
fails identically on `feat/backends-develop` without these commits, under the
identical command. Not introduced here. (Both arms ran without the C extension
built and it is a `_c` test, so it may itself be a missing-`.so` artifact.)
