### PR TITLE
AnyAxisym: geometric panel grading so the a=R peak resolves at any |z|

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -172,9 +172,17 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             xp.minimum(4.0 * xp.abs(z) * ones, half),
             half,
         )
-        # dk decreasing: R/2, R/4, ... (clamped at dmin), so R-dk ascends
-        # and R+dk descends -- the right side is the one needing a reverse.
-        dk = [xp.maximum(Rp * (2.0**-k), dmin) for k in range(1, K + 1)]
+        # dk decreasing R/2 -> dmin, so R-dk ascends and R+dk descends -- the
+        # right side is the one needing a reverse.
+        #
+        # Geometric in dmin/half rather than dyadic: a fixed R/2, R/4, ...
+        # ladder only reaches R*2**-K, so for |z| < R*2**-K/4 it never gets
+        # near the peak and the answer degrades (K=24 is 0.5% low at
+        # |z|=1e-10, R=1). Spanning to dmin instead resolves the peak at any
+        # |z| with the SAME K, so the jit graph does not grow.
+        # ratio is 1 exactly at z==0, where grading is off by construction.
+        ratio = dmin / half
+        dk = [half * ratio ** (k / (K - 1.0)) for k in range(K)]
         left = [Rp - d for d in dk]  # ascending, ends near R
         right = [Rp + d for d in dk][::-1]  # ascending, starts near R
         lo = [xp.zeros_like(Rp)] + left + [Rp] + right

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -16,9 +16,13 @@
 #
 # Design note: a PLAIN concrete backend scalar reuses scipy's accurate value
 # (wrapped as a backend array); native GL runs only when a gradient is actually
-# taken (a tracer, or a grad-tracking torch tensor). GL cannot resolve the
-# small-z sheet structure the derivative FD-probes hit, so the concrete path
-# stays scipy-accurate while the differentiable path stays native.
+# taken (a tracer, or a grad-tracking torch tensor), which keeps a concrete
+# backend value bit-for-bit equal to the numpy one.
+#
+# That split is NOT because GL is the less accurate of the two: with panels
+# graded geometrically to dmin, GL tracks scipy to ~1e-15 wherever scipy is
+# trustworthy and stays correct at |z| = 1e-12, where scipy's own quad steps
+# over the a=R peak and returns nan.
 #
 # Backends that are not installed self-skip, so this is green on numpy alone.
 ###############################################################################
@@ -479,4 +483,35 @@ def test_rforce_finite_difference_in_R_stays_clean(backend_name, z):
         f"FD of Rforce on {backend_name} at z={z:g} gives {fd:.8e} vs "
         f"R2deriv {ref:.8e} (rel {rel:.2e}) -- the quadrature error is not "
         "varying smoothly in R"
+    )
+
+
+# The panel ladder graded toward a=R used to be dyadic (R/2, R/4, ... clamped at
+# dmin ~ 4|z|), which bottoms out at R*2**-K: for |z| below that the innermost
+# panel never reaches the peak and the force decays toward zero instead of
+# toward the sheet limit. K=24 is 0.5% low at |z|=1e-10 and ~95% low at 1e-12.
+# Spanning geometrically to dmin instead resolves the peak at any |z| with the
+# same K (so the jit graph does not grow).
+#
+# This is checked against the ANALYTIC sheet limit rather than against numpy:
+# scipy's own quad has the same peak problem here and is nan by |z|=1e-10
+# (galpy #1276 is the sibling defect in RazorThinExponentialDiskPotential), so
+# numpy is not a usable reference this far in.
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("R", [0.7, 1.0, 1.6])
+@pytest.mark.parametrize("z,tol", [(1e-10, 1e-7), (1e-12, 2e-5)])
+def test_zforce_at_tiny_z_reaches_sheet_limit(backend_name, R, z, tol):
+    """zforce -> -2 pi Sigma(R) as |z| -> 0+, on the differentiable GL path.
+
+    Bars are set just above the measured deviation (2.1e-8 at 1e-10, 3.9e-6 at
+    1e-12); the dyadic ladder misses them by 2.2e-3 and 0.92 respectively, so
+    this fails loudly if the grading regresses rather than merely drifting.
+    """
+    limit = -2.0 * numpy.pi * float(_surfdens(numpy.float64(R)))
+    got = _traced_call(backend_name, evaluatezforces, R, z)
+    rel = abs(got / limit - 1.0)
+    assert rel < tol, (
+        f"zforce on {backend_name} at R={R:g}, z={z:g} is {got:.8e} vs the "
+        f"sheet limit {limit:.8e} (rel {rel:.2e}) -- the a=R peak is not "
+        "resolved, so the graded panels are not reaching dmin"
     )


### PR DESCRIPTION
The panels graded toward the `a = R` peak in `_bk_split_quad` were spaced
**dyadically** — `dk = max(R*2**-k, dmin)` with `dmin ~ 4|z|` — so the ladder
bottoms out at `R*2**-K`. For `|z| < R*2**-K/4` the innermost panel never
reaches the peak, and `zforce` decays toward zero instead of toward the sheet
limit `-2 pi Sigma(R)`.

This PR spans the same K levels **geometrically** from `R/2` down to `dmin`
instead, which reaches the peak at any `|z|`.

## Measured

jax under `jit`, as a fraction of the analytic sheet limit. The GL path was
confirmed to actually run via a `_bk_split_quad` spy (see "the trap" below):

| \|z\| | dyadic K=24 | geometric K=24 |
|---|---|---|
| 1e-06 | 1.000001728 | 1.000001728 |
| 1e-08 | 1.000000017 | 1.000000017 |
| 1e-10 | **1.005054471** | 0.999999993 |
| 1e-12 | **0.054** | 1.000003514 |

Against scipy where scipy is itself trustworthy (`|z| >= 1e-6`), the geometric
path agrees to **6.5e-16 .. 6e-12**. Below that scipy is the less accurate of
the two: it returns `-3.87e-09` instead of `-0.2241463` at `|z|=1e-8` and `nan`
by `1e-10`.

## Why not a port of main's `cd81fbed`

The obvious move was to carry main's `a = R + |z| t` substitution into the
backend. It is not needed here, and would have been strictly worse.

main needs a threshold (`|z| < 1e-4 * R`) and the substitution because
`integrate.quad` chooses its own nodes and cannot be told where the peak is.
`_bk_split_quad` **places** its nodes at `R ± dk` with `dk` in closed form, so
it can simply put them in the right place. Consequences:

* no threshold, so **no data-dependent branch** — it traces with no `xp.where`
  evaluating both arms
* no separate substituted region to stitch to the rest
* correct at every `|z|`, not only below a cutoff
* same K, so **the jit graph does not grow**

The numpy half of the original report is a genuine defect, but it is main's
(`cd81fbed`), and the eventual rebase supplies it. Nothing here touches it.

## It also removes a kink

`xp.maximum(R*2**-k, dmin)` is non-differentiable where its two arms cross, so
panel edges moved non-smoothly in `R`. The geometric form has no such crossing.

This matters more than it looks: the file already carries
`test_rforce_finite_difference_in_R_stays_clean`, whose docstring records that
an earlier *unconditionally graded* schedule "passed every accuracy check above
and was wrong here by 193%". A caller's finite difference divides by `dr=1e-8`,
so non-smooth quadrature error is fatal there while being invisible in the
value. That test passes on this branch, on both backends, including its
deliberate `z=0` case.

## numpy is byte-identical

sha256 over 48 values (4 R x 4 z x {Phi, Rforce, zforce}):

```
WITH this PR      sha256 = 674eb2ec4b9bf838
WITHOUT           sha256 = 674eb2ec4b9bf838
```

`_bk_split_quad` is reachable only from the `*_gl` branch of `_bk_dispatch`, so
numpy cannot enter it. Measured rather than argued: one worktree, one file
toggled, restore verified. The positive control that the two file states really
differ is the backend value itself moving `1.005054471 -> 0.999999993`.

## Tests

12 new cases assert `zforce -> -2 pi Sigma(R)` at `|z| = 1e-10` and `1e-12`,
across three radii and both AD backends, on the differentiable GL path.

Bars are set just above the measured deviation rather than at a round number:

| \|z\| | bar | measured (this PR) | measured (dyadic) |
|---|---|---|---|
| 1e-10 | 1e-7 | 2.1e-8 | 2.2e-3 |
| 1e-12 | 2e-5 | 3.9e-6 | 0.92 |

A/B-verified: **12 fail** without the source change, **12 pass** with it.

Checked against the analytic sheet limit rather than against numpy, because
scipy has the same peak defect here and is `nan` by `1e-10` — numpy is not a
usable reference this far in. (The sibling defect in
`RazorThinExponentialDiskPotential` is filed as #1276.)

```
tests/test_backend_anyaxisymdisk.py     49 passed (jax), 49 passed (torch)
tests/test_backend_potential_diff.py    206 passed, 94 skipped (jax)
tests/test_backend_array_inputs.py      7 passed (jax)
tests/test_backend_conventions.py       43 passed (jax)
```

## The trap this sat behind

Worth recording, because it cost a full cycle and the same shape will recur.

`_bk_dispatch` routes **concrete** backend input to the *numpy* function; only a
tracer or a `requires_grad` tensor reaches the GL path. A probe that passes
plain `jnp.asarray(...)` scalars therefore measures scipy while appearing to
measure the backend.

The diagnostic that should have caught it immediately: monkeypatching
`_bk_split_quad` and sweeping `K` over 24/40/60 produced **byte-identical**
output. That is evidence about *reachability* before it is evidence about
*behaviour* — the function was never being called.

The docstring of `test_backend_anyaxisymdisk.py` claimed "GL cannot resolve the
small-z sheet structure", which was true when written and is false now; it is
updated here, since a stale rationale is what sends the next person porting a
fix they do not need.

## Audit: is the graded ladder duplicating `galpy.backend.quadrature`?

Checked, because a panel-grading scheme is exactly the sort of general-looking
thing that belongs in the shared backend helper rather than in one potential.

`quadrature.transformed_quad(..., interior_point=c)` already splits at an
interior near-singular point and clusters nodes toward it with the
`X = xi**k` boundary-layer map (`k = 3`). That is a **different mechanism with a
different reach**, so this is not a duplicate:

| | mechanism | closest approach to the singular point |
|---|---|---|
| `transformed_quad` | warps nodes *inside* 2 panels | `span * (1/n)**k` ~ **4e-6** (span 0.5, n=50, k=3) |
| `_bk_split_quad`, dyadic | refines *panels*, fixed ladder | `R * 2**-K` ~ **6e-8** |
| `_bk_split_quad`, geometric (this PR) | refines *panels*, spans to `dmin` | `dmin = 4\|z\|` — **any scale** |

Node-warping cannot resolve a peak narrower than its own innermost node, so
`transformed_quad` bottoms out three orders of magnitude *short* of where the
old dyadic ladder did, and eleven short of what this PR needs at
`|z| = 1e-12`. The two are complementary rather than redundant: warping handles
an algebraic endpoint singularity of unknown shape, panel refinement handles a
peak of *known width*.

Possible follow-up, deliberately not in this PR: give `transformed_quad` an
optional `peak_width=` that switches it to the geometric ladder, so the two
strategies live behind one interface. That is an API change to a shared helper
with several callers (`FerrersPotential`, `AnySphericalPotential`, five df
modules), and this PR only changes a spacing law inside an existing private
method.
