### PR TITLE
--jit gets its own slow-skip list, populated by measurement (+ backend-aware actionAngle bars)

### DIFF
--- a/tests/backend_skip.txt
+++ b/tests/backend_skip.txt
@@ -96,3 +96,20 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_int
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_pointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform_bisect
+
+# --- jax-jit: streamdf's useTM tests reach actionAngleTorus ---
+# "NotImplementedError: actionAngleTorus wraps the external Torus C++ library
+# and is not jax-..." -- the same standing decision that excludes
+# test_actionAngleTorus from the all-backend suite: an external C++ wrapper is
+# out of scope for the backend goal, so this is a PERMANENT exclusion, not a
+# burndown item. Surfaced by the slow-skip inheritance split; the eager `jax`
+# whole-file slow-skip had been hiding them.
+#
+# Entered as jax-jit rather than jax because jax-jit is what was measured. The
+# guard is backend-shaped rather than trace-shaped so eager would very likely
+# fail the same way, but the eager case stays masked by the whole-file
+# slow-skip, so claiming it would be asserting past the evidence.
+jax-jit tests/test_streamdf.py::test_bovy14_useTM
+jax-jit tests/test_streamdf.py::test_bovy14_useTM_approxConstTrackFreq
+jax-jit tests/test_streamdf.py::test_bovy14_useTM_poterror
+jax-jit tests/test_streamdf.py::test_bovy14_useTM_useTMHessian

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -306,3 +306,29 @@ torch tests/test_dynamfric.py::test_dynamfric_c
 # a surprise red. Un-defer when the per-force-call overhead work lands.
 torch-jit tests/test_interp_potential.py::test_interpolation_potential_force_c  # 300s (timeout)
 torch-jit tests/test_interp_potential.py::test_interpolation_potential_secondderivs  # 300s (timeout)
+
+# --- jax-jit: measured under `--backend jax --jit`, 2026-08-09 ---
+# These exist because the slow-skip list no longer inherits eager entries (see
+# _load_backend_nodeids): a traced run defers only what is measured slow WHEN
+# TRACED. Measured serially -- ALONE on the machine -- because concurrent jax
+# processes each size their thread pool to the core count and oversubscribe,
+# which inflated an earlier set of these numbers by up to 6x.
+#
+# tests/test_noninertial.py, whole file, C extension present:
+#     53 cases -> 53 PASSED, 0 failed.  total 6308 s, median 11.1 s,
+#     9 over the 240 s margin (80% of the 300 s per-test cap).
+#
+# So of the 19 eager `jax` entries for this file, 11 are FAST traced and now run
+# (0.2 s - 210.9 s; nine under 20 s). Only these 9 stay deferred. One of them
+# was never eager-ledgered at all -- tracing made it SLOWER -- which inheritance
+# could not have surfaced.
+jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation  # 616s traced
+jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc  # 573s
+jax-jit tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz  # 529s
+jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz  # 477s
+jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot  # 454s
+jax-jit tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz  # 437s
+jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential  # 386s
+jax-jit tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega  # 381s
+# NOT in the eager jax list: fast eager, 354 s traced. Tracing made it slower.
+jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz  # 354s

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -332,3 +332,12 @@ jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpote
 jax-jit tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega  # 381s
 # NOT in the eager jax list: fast eager, 354 s traced. Tracing made it slower.
 jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz  # 354s
+# tests/test_streamTrack.py, whole file, serial: 45 cases -> 45 PASSED,
+# total 1215 s, median 8.7 s, 2 over the 240 s margin. The eager `jax` entry is
+# the WHOLE FILE (per-track eager XLA dispatch blows the shard); traced, 43 of
+# 45 run and only these two stay. Serial vs the earlier concurrent numbers moved
+# 498->452 and 348->314 s -- ~10% inflation, not the 6x that test_noninertial
+# saw, because this run had one competitor rather than four. Either way both
+# clear 240 s, so the split is unchanged.
+jax-jit tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 452s traced
+jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 314s traced

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -275,3 +275,24 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 # sides of an absolute 1e-16 bar is expected. Un-ledger if that bar is ever made
 # backend-aware; the tolerance proposal itself is separate and needs sign-off.
 jax-jit tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
+
+# --- jax-jit: test_streamdf, surfaced by the slow-skip inheritance split ---
+# The eager `jax` slow-skip covers the WHOLE FILE, so under the old inheritance
+# rule these never ran traced either. Traced they run (79 cases, 704 s total,
+# median 0.08 s, NONE over the 240 s margin) and 10 fail with one shared root:
+#
+#   TypeError: JAX arrays are immutable and do not support in-place item
+#              assignment
+#
+# i.e. streamdf writes into arrays it has already built. One defect, ten tests;
+# un-ledger together when the assignments become out-of-place.
+jax-jit tests/test_streamdf.py::test_bovy14_track_spread
+jax-jit tests/test_streamdf.py::test_calc_stream_lb_deprecation
+jax-jit tests/test_streamdf.py::test_fardalpot_trackaa
+jax-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa
+jax-jit tests/test_streamdf.py::test_plotting
+jax-jit tests/test_streamdf.py::test_setup_progIsTrack
+jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_equatorial_to_galactic
+jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_per_call_override
+jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_setter
+jax-jit tests/test_streamdf.py::test_streamTrack_raises_when_spread_not_setup

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -166,11 +166,8 @@
 # blind spot that made an earlier local regen report false failures.
 
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
-jax tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
 jax tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
-torch tests/test_actionAngle.py::test_actionAngleAdiabatic_linear_angles_cylsep
-torch tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
 torch tests/test_qdf.py::test_call_diffinoutputs
 
 # --- jax single-orbit: action-angle accessors (Track E) ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,23 +138,31 @@ def _strip_param(nodeid):
     return nodeid.split("[", 1)[0]
 
 
-def _load_backend_nodeids(path, backend_name):
+def _load_backend_nodeids(path, backend_name, inherit_eager=True):
     """Parse a "<backend> <nodeid>" file, returning the nodeids for one backend.
 
     Shared by the xfail-ledger and the slow-skip list (same format). Lines may
     carry trailing "# ..." comments; blank/comment-only lines are ignored.
 
-    A traced backend ("<backend>-jit") INHERITS the eager "<backend>" entries.
-    Tracing does not repair an eager failure -- it cannot fix a numerical gap, a
-    `_reject_backend` guard, or an out-of-scope family -- and it only makes a
-    slow test slower, since the trace has to compile first. So "<backend>-jit"
-    means exactly **"applies ONLY when traced"**, and the eager lists stay the
-    single place a shared entry is written and later pruned. The rule lives here
-    rather than in the three callers because it is a property of the backend
-    name, not of which list is being read.
+    With `inherit_eager`, a traced backend ("<backend>-jit") also picks up the
+    eager "<backend>" entries, so "<backend>-jit" means "applies ONLY when
+    traced" and the eager list stays the single place a shared entry is written
+    and later pruned.
+
+    That is right for FAILURES and wrong for SLOWNESS, so it is a property of
+    the list being read, not of the backend name:
+
+    * xfail-ledger (inherit): tracing cannot repair an eager failure -- not a
+      numerical gap, a `_reject_backend` guard, or an out-of-scope family.
+    * slow-skip (do NOT inherit): tracing changes the runtime in BOTH
+      directions. The dominant eager cost in this suite is per-call dispatch,
+      which is exactly what tracing removes -- the streamdf and streamTrack
+      entries below name "per-trackpoint XLA dispatch" as their reason and say
+      to un-skip once jit-vectorized. Inheriting made them unmeasurable under
+      --jit: skipped for a cost the traced run may not pay.
     """
     names = {backend_name}
-    if backend_name.endswith("-jit"):
+    if inherit_eager and backend_name.endswith("-jit"):
         names.add(backend_name[: -len("-jit")])
     entries = set()
     if not os.path.exists(path):
@@ -196,8 +204,12 @@ def _regen_entries(backend_name, failed):
 
 
 def _load_slow_skip(backend_name):
-    """Return the set of slow-skip nodeids for the given backend, or empty set."""
-    return _load_backend_nodeids(_slow_skip_path(), backend_name)
+    """Return the set of slow-skip nodeids for the given backend, or empty set.
+
+    No eager inheritance: a traced run defers only what is measured slow WHEN
+    TRACED. See _load_backend_nodeids.
+    """
+    return _load_backend_nodeids(_slow_skip_path(), backend_name, inherit_eager=False)
 
 
 # Tests skipped under a backend for a PERMANENT reason -- one no amount of porting

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2068,12 +2068,19 @@ def test_actionAngleAdiabatic_linear_angles():
 # increase linearly to very good approximation
 def test_actionAngleAdiabatic_linear_angles_cylsep():
     from galpy.actionAngle import actionAngleAdiabatic
+    from galpy.backend import name_of_namespace, resolve_namespace
     from galpy.orbit import Orbit
     from galpy.potential import CylindricallySeparablePotentialWrapper, MWPotential2014
 
     pot = CylindricallySeparablePotentialWrapper(pot=MWPotential2014, Rp=1.1)
     aAA = actionAngleAdiabatic(pot=pot, c=False, gamma=0.0)
     obs = Orbit([1.05, 0.02, 1.05, 0.03, 0.0, 0.0])
+    # The three linear-trend bars are backend-aware. numpy keeps -7.0 exactly;
+    # jax/torch reassociate the accumulated angle sum differently and land just
+    # over it -- measured 1.67707e-07 (jax) and 1.77912e-07 (torch) against
+    # 1e-7, i.e. a factor 1.7-1.8, not a wrong answer. -6.5 (3.16e-7) clears
+    # both with ~1.8x margin and still fails anything genuinely broken.
+    lin = -7.0 if name_of_namespace(resolve_namespace()) == "numpy" else -6.5
     check_actionAngle_linear_angles(
         aAA,
         obs,
@@ -2084,9 +2091,9 @@ def test_actionAngleAdiabatic_linear_angles_cylsep():
         -8.0,
         -8.0,
         -8.0,
-        -7.0,
-        -7.0,
-        -7.0,
+        lin,
+        lin,
+        lin,
         ntimes=1001,
     )  # need fine sampling for de-period
     return None
@@ -4440,6 +4447,7 @@ def test_actionAngleStaeckel_smallu():
 # Basic sanity checking of the actionAngleStaeckelGrid actions (incl. conserved and ecc etc., bc takes a lot of time)
 def test_actionAngleStaeckelGrid_basicAndConserved_actions():
     from galpy.actionAngle import actionAngleStaeckelGrid
+    from galpy.backend import name_of_namespace, resolve_namespace
     from galpy.orbit import Orbit
     from galpy.potential import MWPotential
 
@@ -4455,7 +4463,20 @@ def test_actionAngleStaeckelGrid_basicAndConserved_actions():
         "Circular orbit in the MWPotential does not have Jz=0"
     )
     te, tzmax, _, _ = aAA.EccZmaxRperiRap(R, vR, vT, z, vz)
-    assert numpy.fabs(te) < 10.0**-16.0, (
+    # `e` here is the one absolute bar in this file that a backend cannot meet:
+    # it asks a COMPUTED eccentricity to vanish to 1e-16 -- machine epsilon on
+    # an O(1) quantity -- which holds only if the arithmetic associates exactly
+    # as numpy's does. torch measures 1.5305e-10, i.e. accumulated rounding in
+    # the interpolated-grid eccentricity, not a wrong answer. numpy keeps 1e-16.
+    #
+    # Only this one moves. JR/Jz/zmax around it, and the seven sibling
+    # "does not have e=0" assertions elsewhere in this file, are all measured to
+    # clear 1e-16 on every backend, so they stay as they are -- the ledger lists
+    # exactly this nodeid and no other.
+    ecc_tol = (
+        10.0**-16.0 if name_of_namespace(resolve_namespace()) == "numpy" else 10.0**-9.0
+    )
+    assert numpy.fabs(te) < ecc_tol, (
         "Circular orbit in the MWPotential does not have e=0"
     )
     assert numpy.fabs(tzmax) < 10.0**-16.0, (

--- a/tests/test_backend_ledger.py
+++ b/tests/test_backend_ledger.py
@@ -54,21 +54,40 @@ def test_jit_inherits_eager(tmp_path):
     }
 
 
-def test_jit_inheritance_applies_to_every_list(tmp_path, monkeypatch):
-    """Ledger, slow-skip and permanent-skip all inherit -- one shared rule.
+def test_jit_inheritance_is_per_list_not_per_backend(tmp_path, monkeypatch):
+    """FAILURE lists inherit eager entries; the SLOWNESS list does not.
 
-    A test too slow to run eager is slower still traced (it must compile first),
-    and a test excluded for hitting the network is excluded however it is run.
+    The rule used to be "every list inherits", justified by "a test too slow to
+    run eager is slower still traced (it must compile first)". That is false,
+    and measurably so: the dominant eager cost in this suite is per-call
+    dispatch, which is exactly what tracing removes. test_streamdf.py is
+    slow-skipped under jax because it takes >90 min eager (the shard cancels);
+    traced it is 13 min for the whole file, with a 0.11 s median test.
+
+    So inheritance is a property of WHICH LIST is being read:
+
+      xfail ledger    inherit -- tracing cannot repair a numerical gap, a
+                                 `_reject_backend` guard, or an out-of-scope family
+      permanent skip  inherit -- a test excluded for hitting the network is
+                                 excluded however it is run
+      slow-skip       DO NOT  -- tracing changes runtime in BOTH directions, so a
+                                 traced run must defer only what is measured slow
+                                 WHEN TRACED
     """
     path = _ledger(tmp_path, "jax tests/test_a.py::test_eager_only\n")
     for attr in ("_ledger_path", "_slow_skip_path", "_backend_skip_path"):
         monkeypatch.setattr(conftest, attr, lambda path=path: path)
-    for loader in (
-        conftest._load_ledger,
-        conftest._load_slow_skip,
-        conftest._load_backend_skip,
-    ):
+    for loader in (conftest._load_ledger, conftest._load_backend_skip):
         assert loader("jax-jit") == {"tests/test_a.py::test_eager_only"}, loader
+    # The whole point of the split: an eager slow-skip entry does NOT silence
+    # the traced run, so tests that tracing makes fast start running again.
+    assert conftest._load_slow_skip("jax-jit") == set()
+    # ... while a traced-only entry still applies, and the eager list is
+    # unaffected in both directions.
+    jit_path = _ledger(tmp_path, "jax-jit tests/test_a.py::test_traced_only\n")
+    monkeypatch.setattr(conftest, "_slow_skip_path", lambda: jit_path)
+    assert conftest._load_slow_skip("jax-jit") == {"tests/test_a.py::test_traced_only"}
+    assert conftest._load_slow_skip("jax") == set()
 
 
 def test_regen_of_traced_run_drops_inherited_eager_entries(tmp_path, monkeypatch):


### PR DESCRIPTION
The slow-skip list stops inheriting eager entries under `--jit`, and the traced
list is populated from measurement instead.

All six files are under `tests/`. No `galpy/` source changes, so numpy behaviour
is untouched by construction; the only numpy-visible edit is a tolerance bar,
and numpy's value there is unchanged.

## The rule was wrong for one of the three lists

`_load_backend_nodeids` applied inheritance to every backend list on one rule,
justified in its own docstring by:

> "A test too slow to run eager is slower still traced (it must compile first)"

That is false for this suite, and measurably so — the dominant eager cost here is
per-call dispatch, which is exactly what tracing removes:

| file | eager | traced |
|---|---|---|
| `test_streamdf.py` | >90 min, shard **cancelled** | **12 min**, median 0.08 s |
| `test_streamTrack.py` | over the per-test cap, whole file deferred | 45/45 pass, median 8.7 s |

So inheritance is a property of **which list is read**, not of the backend name:

| list | inherit | why |
|---|---|---|
| xfail ledger | **yes** | tracing cannot repair a numerical gap, a `_reject_backend` guard, or an out-of-scope family |
| permanent skip | **yes** | excluded for hitting the network is excluded however it is run |
| slow-skip | **no** | tracing changes runtime in *both* directions |

`test_jit_inheritance_applies_to_every_list` asserted the old contract and is
replaced by `test_jit_inheritance_is_per_list_not_per_backend`, which asserts the
3-way split and carries the measured rationale. A/B-verified: it **fails**
without the conftest change (1 failed / 4 passed) and passes with it (5 passed).

## Measured, serially

Every traced entry below comes from a run of the **whole file**, C extension
present, **alone on the machine**.

| file | traced result | jit slow-skip entries |
|---|---|---|
| `test_noninertial.py` | 53/53 pass, 6308 s, median 11.1 s | **9** (8 kept + 1 new) |
| `test_streamTrack.py` | 45/45 pass, 1215 s, median 8.7 s | **2** |
| `test_streamdf.py` | 65 pass / 14 fail, 704 s, median 0.08 s | **0** |

The eager `jax` list is **unchanged at 75**. These tests are still slow eager;
this PR changes only what a *traced* run defers.

### Scope of the un-deferral, stated exactly

Inheritance was applying all **75** eager entries to `jax-jit`, across **13**
files — not just the three above. After this PR `jax-jit` carries **11**
measured entries, so **67** entries stop being deferred traced:

| file | entries un-deferred | measured traced? |
|---|---|---|
| `test_noninertial.py` | 11 | **yes** (53/53, 6308 s) |
| `test_streamTrack.py` | 1 | **yes** (45/45, 1215 s) |
| `test_streamdf.py` | 1 | **yes** (79 cases, 704 s) |
| `test_orbit.py` | 25 | not yet |
| `test_potential.py` | 12 | not yet |
| `test_interp_potential.py` | 6 | not yet |
| `test_FDMdynamfric.py` | 3 | not yet |
| `test_orbits.py` | 2 | not yet |
| `test_qdf.py` | 2 | not yet |
| `test_actionAngle.py`, `test_dynamfric.py`, `test_galpypaper.py`, `test_streamspraydf.py` | 1 each | not yet |

So **54 entries in 10 files** are un-deferred without a traced measurement
behind them.

**And the same applies to torch**, which the table above does not cover: the
rule is per-list, so `torch-jit` also stops inheriting, and `torch`'s 15 eager
entries come off deferral too — 13 in `test_orbit.py`, 1 each in
`test_dynamfric.py` and `test_FDMdynamfric.py`, none measured traced.

    jax   : eager 75  →  jax-jit   11 measured  →  67 un-deferred (54 unmeasured)
    torch : eager 15  →  torch-jit  2 measured  →  15 un-deferred (15 unmeasured)

A serial whole-file traced sweep of the ten jax files is running. It is slow by
construction — one file at a time, because concurrent jax processes oversubscribe
the XLA thread pool and corrupt exactly the timings it exists to produce — so it
will likely outlast this PR's CI. Whichever finishes first: results land here if
the sweep wins, in a follow-up if CI does. Any entry measured slow *when traced*
gets a `jax-jit` line.

The torch sweep is **not** running, deliberately: `parallel_map` still deadlocks
under `torch --jit`, and `--timeout-method=signal` cannot interrupt a wedged
fork child, so a `test_orbit.py` torch-traced run could hang rather than report.
That is a follow-up needing the deadlock fixed first, and it is called out here
rather than left as a silent hole.

This does not affect CI (no workflow runs `--jit` — see below), so the exposure
is to local traced runs only. It is called out rather than buried because the
whole premise of this PR is that a slow-skip entry must be measured on the
mode it applies to, and 54 of them currently are not.

## Why "alone on the machine" is in that sentence

An earlier set of these numbers was taken with several jax runs in parallel and
had to be discarded. XLA sizes its CPU thread pool to the core count, so
concurrent jax processes oversubscribe; per-process `%CPU` still looks healthy,
which is why nothing appeared wrong.

Re-measured serially, the error turned out to scale with concurrency:

| file | competitors | inflation | effect on the verdict |
|---|---|---|---|
| `test_noninertial` | 4 | **6x** | — |
| `test_streamTrack` | 1 | ~10% | none, split unchanged |
| `test_streamdf` | 2 | ~20% | **flipped it** |

`test_progenitor_coordtransformparams` measured 242.6 s concurrent — 1% *over*
the 240 s margin — and 197.5 s alone. On the concurrent number this PR would
have carried a needless deferral. One confirmed, one unchanged, one flipped:
that spread is why all three were re-run rather than reasoned about.

## Two things inheritance was hiding

streamdf's 14 traced failures are not timing at all:

* **10** share one defect — `TypeError: JAX arrays are immutable and do not
  support in-place item assignment`, i.e. streamdf writing into arrays it built.
  Ledgered `jax-jit`; they clear together when those assignments go out-of-place.
* **4** reach `actionAngleTorus` ("wraps the external Torus C++ library and is
  not jax-..."), the standing out-of-scope decision for an external C++ wrapper
  → `backend_skip.txt`, permanent, not a burndown item.

Both were invisible: the eager whole-file slow-skip meant the old rule skipped
them traced as well. **A real jax defect and a permanent exclusion were sitting
behind a *performance* deferral** — which is the thing a slow-skip entry must
never do.

Similarly, one `test_noninertial` entry is new because tracing made it *slower*
(354 s traced, not eager-ledgered at all). Inheritance could not surface that by
construction: it only ever propagates eager entries forward.

## Tolerances (#171), and the burndown they earn

Two ledgered failures where the backend answer is right and the bar is
numpy-shaped. numpy's bars are unchanged; only the non-numpy arms move, keyed on
`name_of_namespace(resolve_namespace())`.

| test | measured | old bar | new (non-numpy) |
|---|---|---|---|
| `Adiabatic_linear_angles_cylsep` | 1.677e-07 jax / 1.779e-07 torch | `1e-7` | `10**-6.5` = 3.16e-7 |
| `StaeckelGrid_basicAndConserved` | 1.5305e-10 torch | **absolute `1e-16`** | `1e-9` |

The second asked a *computed* eccentricity to vanish to machine epsilon on an
O(1) quantity — only true if the arithmetic associates exactly as numpy's does.

Applied at the **call site**, not inside `check_actionAngle_linear_angles`: that
helper is shared by many tests and a bar moved inside it would loosen all of them
silently. Likewise only the one `e` bar moves — the JR/Jz/zmax bars beside it,
the seven sibling `"does not have e=0"` assertions elsewhere in the file, and 53
other `1e-16` bars are untouched, because they are measured to clear on every
backend.

Verified with `--runxfail` over the whole file on both backends, so **3 ledger
entries are removed here**:

    linear_angles_cylsep            jax PASS   torch PASS   -> un-ledgered
    StaeckelGrid_basicAndConserved  jax PASS   torch PASS   -> un-ledgered
    AdiabaticGrid_outsidegrid_c     jax FAIL                -> STAYS

That third line is the point. It is off by 4.7e-3 against a 1e-8 bar — 470,000x,
an accuracy defect, not a tolerance — so its bar was deliberately not moved and it
still fails. It belongs with the AA grid off-grid work, not with a bar.

The `jax-jit` StaeckelGrid entry is also **not** removed: the verification above
is eager, and eager evidence cannot un-ledger a traced entry.

## CI impact: none

No workflow runs `--jit` (checked across all 10 files in `.github/workflows/`),
so flipping the inheritance rule cannot change any CI job. The traced lists are
exercised only locally today.

That is worth flagging separately: it means the traced ledger, the traced
slow-skip list and `assert_jit_matches_eager`'s premise are validated on a dev
box and nowhere else. Adding a `--jit` shard needs workflow scope I do not have,
so it is noted rather than done.
