### PR TITLE
streamdf: out-of-place LB jacobian scaling (burns 10 jax-jit ledger entries)

### DIFF
--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -2026,10 +2026,13 @@ class streamdf(df):
         for ii in range(self._nTrackChunks):
             tjacXY = coords.galcenrect_to_XYZ_jac(*self._ObsTrackXY[ii])
             tjacLB = coords.lbd_to_XYZ_jac(*self._ObsTrackLB[ii], degree=True)
-            tjacLB[:3, :] /= ro
-            tjacLB[3:, :] /= vo
-            for jj in range(6):
-                tjacLB[:, jj] *= self._ErrCovsLBScale[jj]
+            # Out-of-place: lbd_to_XYZ_jac returns a backend array under a forced
+            # backend, and jax arrays reject in-place item assignment. Per element
+            # (i,j) this is still (a_ij / r_i) * s_j -- the same two operations in
+            # the same order as the row-divides and the column-multiply loop it
+            # replaces -- so numpy is byte-identical.
+            tjacLB = tjacLB / numpy.array([ro, ro, ro, vo, vo, vo])[:, numpy.newaxis]
+            tjacLB = tjacLB * numpy.asarray(self._ErrCovsLBScale)
             tjac = numpy.dot(numpy.linalg.inv(tjacLB), tjacXY)
             allErrCovsLB[ii] = numpy.dot(
                 tjac, numpy.dot(self._allErrCovsXY[ii], tjac.T)

--- a/tests/backend_skip.txt
+++ b/tests/backend_skip.txt
@@ -97,7 +97,7 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_int
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform_bisect
 
-# --- jax-jit: streamdf's useTM tests reach actionAngleTorus ---
+# --- streamdf's useTM tests reach actionAngleTorus ---
 # "NotImplementedError: actionAngleTorus wraps the external Torus C++ library
 # and is not jax-..." -- the same standing decision that excludes
 # test_actionAngleTorus from the all-backend suite: an external C++ wrapper is
@@ -105,11 +105,23 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_poi
 # burndown item. Surfaced by the slow-skip inheritance split; the eager `jax`
 # whole-file slow-skip had been hiding them.
 #
-# Entered as jax-jit rather than jax because jax-jit is what was measured. The
-# guard is backend-shaped rather than trace-shaped so eager would very likely
-# fail the same way, but the eager case stays masked by the whole-file
-# slow-skip, so claiming it would be asserting past the evidence.
+# The guard is backend-shaped, not trace-shaped, and torch confirms it: a whole
+# -file `--backend torch` run fails these 4 and only these 4, identically with
+# and without the streamdf out-of-place fix. So torch is entered too, and the
+# permanent-skip list inherits it for torch-jit.
+#
+# CI never sees any of this: these tests need the external Torus C++ library,
+# which is built on the dev box but not in CI, so there they skip before ever
+# reaching the backend guard. Local-only exposure -- which is exactly why it
+# needs a list entry rather than a CI observation.
+#
+# Plain `jax` is deliberately NOT entered: the eager whole-file slow-skip means
+# it has never been measured, and claiming it would assert past the evidence.
 jax-jit tests/test_streamdf.py::test_bovy14_useTM
 jax-jit tests/test_streamdf.py::test_bovy14_useTM_approxConstTrackFreq
 jax-jit tests/test_streamdf.py::test_bovy14_useTM_poterror
 jax-jit tests/test_streamdf.py::test_bovy14_useTM_useTMHessian
+torch tests/test_streamdf.py::test_bovy14_useTM
+torch tests/test_streamdf.py::test_bovy14_useTM_approxConstTrackFreq
+torch tests/test_streamdf.py::test_bovy14_useTM_poterror
+torch tests/test_streamdf.py::test_bovy14_useTM_useTMHessian

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -272,24 +272,3 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 # sides of an absolute 1e-16 bar is expected. Un-ledger if that bar is ever made
 # backend-aware; the tolerance proposal itself is separate and needs sign-off.
 jax-jit tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions
-
-# --- jax-jit: test_streamdf, surfaced by the slow-skip inheritance split ---
-# The eager `jax` slow-skip covers the WHOLE FILE, so under the old inheritance
-# rule these never ran traced either. Traced they run (79 cases, 704 s total,
-# median 0.08 s, NONE over the 240 s margin) and 10 fail with one shared root:
-#
-#   TypeError: JAX arrays are immutable and do not support in-place item
-#              assignment
-#
-# i.e. streamdf writes into arrays it has already built. One defect, ten tests;
-# un-ledger together when the assignments become out-of-place.
-jax-jit tests/test_streamdf.py::test_bovy14_track_spread
-jax-jit tests/test_streamdf.py::test_calc_stream_lb_deprecation
-jax-jit tests/test_streamdf.py::test_fardalpot_trackaa
-jax-jit tests/test_streamdf.py::test_fardalwmwpot_trackaa
-jax-jit tests/test_streamdf.py::test_plotting
-jax-jit tests/test_streamdf.py::test_setup_progIsTrack
-jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_equatorial_to_galactic
-jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_per_call_override
-jax-jit tests/test_streamdf.py::test_streamTrack_custom_sky_transform_setter
-jax-jit tests/test_streamdf.py::test_streamTrack_raises_when_spread_not_setup


### PR DESCRIPTION
Stacked on #1279 — review that one first; this PR's diff against it is 3 files.

`streamdf._determine_stream_spreadLB` scaled the l/b/d Jacobian in place. Since
the streams coords PR made `coords.lbd_to_XYZ_jac` backend-native, under a
forced jax backend `tjacLB` is a jax array and every one of those writes raises

    TypeError: JAX arrays are immutable and do not support in-place item assignment

One defect, ten ledgered tests. #1279 is what surfaced it: the eager `jax`
whole-file slow-skip had been inherited by `jax-jit`, so a real jax defect was
sitting behind a *performance* deferral.

## The change

```python
tjacLB[:3, :] /= ro                    tjacLB = tjacLB / row_scale[:, None]
tjacLB[3:, :] /= vo             ->
for jj in range(6):                    tjacLB = tjacLB * col_scale
    tjacLB[:, jj] *= scale[jj]
```

Per element `(i, j)` both forms are `(a_ij / r_i) * s_j` — the same two
operations on the same operands in the same order.

## numpy is byte-identical, measured

sha256 of every array the function produces, from the Bovy (2014) stream, built
in a patched tree and an unpatched copy at the same base commit:

| array | |
|---|---|
| `_allErrCovsLBUnscaled` | `6a8a7fce…8bf1b9` **==** |
| `_interpolatedAllErrCovsLBUnscaled` | `ee1986fc…fcd36b` **==** |
| `_trackLogDetJacLB` | `efd8821b…0da119` **==** |
| `_interpolatedTrackLogDetJacLB` | `c7746b22…36cee0` **==** |
| `_ErrCovsLBScale` | `11e2d1c7…594576` **==** |

The probe prints `galpy.__file__`, so the editable-install shadow is ruled out
by evidence rather than by assumption.

## Verification

Whole file, C extension present, alone on the machine:

| run | result |
|---|---|
| `test_streamdf.py --backend jax --jit` | 65 passed, 4 skipped, **10 xpassed**, 0 failed, 776 s |
| `test_streamdf.py --backend torch` | 76 passed, 4 skipped, 0 failed |
| `test_streamgapdf.py --backend jax --jit` | 31 passed |
| `test_streamgapdf.py --backend torch` | 31 passed |

All **10** ledger entries xpass and are removed.

## The 4 skips, and why they are new here

They are `test_bovy14_useTM*`, all `NotImplementedError: actionAngleTorus wraps
the external Torus C++ library` — the standing decision that also excludes
`test_actionAngleTorus` from the all-backend suite. #1279 entered them for
`jax-jit`; a torch run fails exactly those 4 and only those 4, **identically
with and without this fix**, so torch is entered too (and `torch-jit` inherits).

Worth stating plainly: **CI has never seen these and cannot.** The tests need
the external Torus C++ library, which is built on the dev box but not in CI, so
there they skip before reaching the backend guard. A list entry is the only
thing that can cover local-only exposure.

Plain `jax` is deliberately *not* entered — the eager whole-file slow-skip means
it has never been measured there, and entering it would assert past the
evidence.

## Two things deliberately not done

**The accumulator loops.** The same file has pre-allocated-then-written loops
that look like the same class — `ObsTrack[ii, :] = multiOut[3]` (lines
1318/1348/1368/1394), and `trackLogDetJacLB[ii] = numpy.log(det(tjacLB))` at
2107/2113, the latter *inside this very function* and fed by the same
`lbd_to_XYZ_jac`. With this one site fixed none of them fail (measured: the
traced run above is 0 failed).

They are a genuinely different case, and the distinction is worth naming
because it is what makes this a one-line fix rather than a sweep:

* writing **into** a jax array is impossible — jax arrays are immutable, so
  `tjacLB[:3, :] /= ro` raises whatever the values are;
* writing a jax **value into a numpy array** is fine, because the target is
  numpy (`numpy.empty_like` returns `ndarray`) and numpy converts the incoming
  concrete jax scalar.

The second holds as long as the value is concrete, which it is: `--jit` traces
at the `@backend_input` boundary, so streamdf itself is not inside a trace and
`tjacLB` is a concrete jax array, not a tracer. That last step is *reasoned from
where the trace boundary sits, not measured* — flagging it explicitly. The
measured claim is only the 0-failed line. If streamdf were ever placed inside an
end-to-end trace these loops would need revisiting.

**`streamgapdf.py`.** An AST scan finds **10** sites of the same shape there
across 5 functions (`Om[0, :] += dOr`, `tilew[:, 1] -= …`, …) — more than the
4 I first counted by grep. None are reached with a backend array, and not by
luck:

* `impulse_deltav_general` — the public impulse kernel, and the most exposed of
  them — returns early **above** the in-place line:

  ```python
  if is_backend_array(v) or is_backend_array(y) or is_backend_array(w):
      return _impulse_deltav_general_backend(v, y, b, w, pot)
  ...
  tilew[:, 1] -= numpy.sqrt(...)        # numpy-only side of the guard
  ```

  i.e. the standard leaf data-guard: the backend path is a separate function.
* The rest write into arrays born from `numpy.dot` / `numpy.tile` / scipy
  interpolators, so they are numpy by construction.

Consistent with `test_streamgapdf.py` passing 31/31 traced and 31/31 on torch,
and it is in no deferral list. So this is **not** a deferred fix — there is
nothing to fix. Worth stating because the obvious reading of the grep says
otherwise.
