### PR TITLE
--jit slow-skip: the measurement gh#1279 owed (10 files, ~2456 traced cases)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -341,3 +341,27 @@ jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accel
 # clear 240 s, so the split is unchanged.
 jax-jit tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 452s traced
 jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 314s traced
+
+# --- jax-jit: measured by the 10-file traced sweep (2026-08-09) ---
+# gh#1279 stopped `-jit` inheriting the eager slow-skip list, which un-deferred
+# 54 jax entries across 10 files that had never been measured TRACED. This is
+# that measurement: each file run whole, C extension present, alone on the
+# machine (concurrent jax oversubscribes the XLA CPU pool and inflates timings),
+# with --timeout=300 --timeout-method=signal so a slow test fails and the
+# session still writes its junitxml.
+#
+# Of 17 eager entries across the 8 files measured so far, 8 survive traced and
+# 11 do not. Two of the 8 were NEVER eager entries -- inheritance only
+# propagates eager entries forward, so it could not have found them at all.
+jax-jit tests/test_dynamfric.py::test_dynamfric_c  # 300s cap traced
+jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
+jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap
+jax-jit tests/test_interp_potential.py::test_interpolation_potential_force_c  # 300s cap
+jax-jit tests/test_qdf.py::test_sampleV_interpolate  # 300s cap
+jax-jit tests/test_orbits.py::test_SOS_3D  # 300s cap (269s eager -> SLOWER traced)
+# NOT an eager entry: tracing alone makes these slow, so inheritance could never
+# have produced them.
+jax-jit tests/test_orbits.py::test_bruteSOS_3D  # 277s traced -- the only entry
+                                                # INSIDE the 240-300s band; every
+                                                # other keeper hit the cap
+jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles  # 300s cap

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -365,3 +365,19 @@ jax-jit tests/test_orbits.py::test_bruteSOS_3D  # 277s traced -- the only entry
                                                 # INSIDE the 240-300s band; every
                                                 # other keeper hit the cap
 jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles  # 300s cap
+
+# --- jax-jit: test_orbit, the 10th and last file of the sweep ---
+# 581 cases, 7605 s traced, 0 non-timeout failures. Its eager `jax` list had 25
+# entries; 7 survive traced. Note this file runs OPPOSITE to the sweep average
+# (two-thirds of eager entries elsewhere did NOT survive) -- per-file variation
+# is exactly what a single inheritance rule cannot express.
+jax-jit tests/test_orbit.py::test_zmax  # 300s cap
+jax-jit tests/test_orbit.py::test_analytic_ecc_rperi_rap  # 300s cap
+jax-jit tests/test_orbit.py::test_analytic_zmax  # 300s cap
+jax-jit tests/test_orbit.py::test_integrate_backwards  # 300s cap
+jax-jit tests/test_orbit.py::test_integrate_negative_time  # 300s cap
+# Inside the 240-300 s band -- judgement calls, not cap hits. Together with
+# test_bruteSOS_3D (277 s) these are the only 3 of 15 entries whose fate turns
+# on where the margin sits; the other 12 hit the cap outright.
+jax-jit tests/test_orbit.py::test_energy_jacobi_conservation[BurkertPotentialNoC--10.0--10.0-False]  # 296s
+jax-jit tests/test_orbit.py::test_liouville_planar  # 265s

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -271,3 +271,47 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 # Tracing is entitled to reassociate, so eager and traced landing on different
 # sides of an absolute 1e-16 bar is expected. Un-ledger if that bar is ever made
 # backend-aware; the tolerance proposal itself is separate and needs sign-off.
+
+# --- jax-jit: test_potential, surfaced by the 10-file traced sweep (2026-08-09) ---
+# These are NOT new breakage. test_potential.py has only per-test eager
+# slow-skip entries (never a whole-file one), so the rest of the file already
+# ran traced before gh#1279 -- nobody was looking, because no workflow runs
+# --jit. The sweep is the first time the file was measured traced end to end
+# (1385 cases, 3692 s). All 8 pass EAGER; this is traced-only exposure.
+#
+# Three distinct causes, deliberately kept as xfail (burndown) rather than
+# permanent skip, because each is plausibly fixable:
+#
+# 1) RotateAndTiltWrapperPotential refuses array input BY DESIGN
+#    ("Methods in RotateAndTiltWrapperPotential do not accept array inputs.
+#    Please input scalars"), and tracing turns scalars into 0-d traced arrays,
+#    so the guard fires on input it was never meant to reject. All 5 fail in
+#    0.0-0.1 s -- they refuse immediately, they do not compute. Fix is either to
+#    let the guard accept 0-d, or an explicit decision that these stay out.
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
+#
+# 2) jax ConcretizationTypeError -- "Abstract tracer value encountered where a
+#    concrete value is expected". A genuine traceability gap in two composite MW
+#    potentials: something concrete-only (a float(), a Python if) on a traced
+#    value.
+jax-jit tests/test_potential.py::test_McMillan17
+jax-jit tests/test_potential.py::test_Cautun20
+#
+# 3) AnyAxisym: the TRACED potential is wrong at exactly the disk plane.
+#    Measured at (R,z) = (0.5, 0.0):
+#        eager  Phi(z=0) = -1.7599930722150277  Phi(z=1e-8) = -1.7599930722110944
+#               -> one-sided dPhi/dz = -3.9e-04, consistent
+#        jit    Phi(z=0) = -1.7599195947859025  Phi(z=1e-8) = -1.7599930535685753
+#               -> one-sided dPhi/dz = +7.35e+03, which is what the test reports
+#    i.e. traced Phi at z==0 is off by ~7.3e-5 from its own neighbour, and the
+#    test's ONE-SIDED difference divides that by dz=1e-8. zforce(0.5,0)=0 is
+#    correct; the derivative is the wrong side.
+#    A/B'd against pre-gh#1278 by swapping only that file: byte-identical
+#    (7.345878e+03 both). PRE-EXISTING, not the geometric-grading change.
+#    The suspect is the z==0 degenerate ladder (`ratio` is 1 there, so the
+#    panels collapse), which the dyadic version had too.
+jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -332,8 +332,16 @@ jax-jit tests/test_potential.py::test_Cautun20
 #    i.e. traced Phi at z==0 is off by ~7.3e-5 from its own neighbour, and the
 #    test's ONE-SIDED difference divides that by dz=1e-8. zforce(0.5,0)=0 is
 #    correct; the derivative is the wrong side.
-#    A/B'd against pre-gh#1278 by swapping only that file: byte-identical
-#    (7.345878e+03 both). PRE-EXISTING, not the geometric-grading change.
-#    The suspect is the z==0 degenerate ladder (`ratio` is 1 there, so the
-#    panels collapse), which the dyadic version had too.
+#    A/B'd against pre-gh#1278 by swapping only that file (verified the two
+#    versions really differ -- dyadic `xp.maximum(Rp * 2**-k, dmin)` vs
+#    geometric `ratio = dmin/half`): byte-identical failure, 7.345878e+03 on
+#    both sides. PRE-EXISTING, not the geometric-grading change.
+#
+#    NOTE the A/B also FALSIFIES the obvious suspect. The z==0 degenerate
+#    ladder (`ratio` is 1 there, so the panels collapse) exists only in the
+#    geometric version -- the dyadic one has no `ratio` at all -- yet both fail
+#    identically. So the cause is common to both ladders and is NOT the grading.
+#    It is eager-vs-traced: eager has Phi(z=0) and Phi(z=1e-8) agreeing to 11
+#    digits, traced does not. Cause not yet identified; do not start from the
+#    quadrature ladder.
 jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -305,10 +305,21 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndT
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 #
-# 2) jax ConcretizationTypeError -- "Abstract tracer value encountered where a
-#    concrete value is expected". A genuine traceability gap in two composite MW
-#    potentials: something concrete-only (a float(), a Python if) on a traced
-#    value.
+# 2) jax ConcretizationTypeError -- and the two share ONE root: `mass()` is not
+#    traceable, because it integrates with scipy.integrate.quad, which calls
+#    float() on its limits/result and so rejects a tracer. From the tracebacks:
+#
+#      McMillan17  Potential.mass -> KuijkenDubinskiDiskExpansionPotential._mass
+#                  (L485: `integrate.quad(_integrand, 0.0, numpy.pi)`)
+#                  -> scipy _quadpack_py.py:626 -> ConcretizationTypeError
+#      Cautun20    fails at CONSTRUCTION, not evaluation: mwpotentials.py:86 ->
+#                  Cautun20.py:105 -> AdiabaticContractionWrapperPotential
+#                  .__init__ L95 -> Potential.mass (L2317) -> same wall
+#
+#    So this is not "two composite potentials are odd" -- it is one missing
+#    backend-native mass quadrature, hit once during evaluation and once during
+#    a wrapper's __init__. Fixing mass to use the backend quadrature (as the
+#    other migrations did) should clear both together.
 jax-jit tests/test_potential.py::test_McMillan17
 jax-jit tests/test_potential.py::test_Cautun20
 #

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -271,4 +271,3 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 # Tracing is entitled to reassociate, so eager and traced landing on different
 # sides of an absolute 1e-16 bar is expected. Un-ledger if that bar is ever made
 # backend-aware; the tolerance proposal itself is separate and needs sign-off.
-jax-jit tests/test_actionAngle.py::test_actionAngleStaeckelGrid_basicAndConserved_actions

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -284,10 +284,21 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #
 # 1) RotateAndTiltWrapperPotential refuses array input BY DESIGN
 #    ("Methods in RotateAndTiltWrapperPotential do not accept array inputs.
-#    Please input scalars"), and tracing turns scalars into 0-d traced arrays,
-#    so the guard fires on input it was never meant to reject. All 5 fail in
-#    0.0-0.1 s -- they refuse immediately, they do not compute. Fix is either to
-#    let the guard accept 0-d, or an explicit decision that these stay out.
+#    Please input scalars"), and tracing turns scalars into traced arrays.
+#    The guard in Potential.py is NOT a blanket refusal:
+#
+#        if arrays and not (getattr(self, "_backend_accepts_arrays", False)
+#                           and all(is_backend_array(x) for x in arrays)):
+#
+#    Under tracing the `is_backend_array` half is satisfied, so what actually
+#    trips is that **RotateAndTiltWrapperPotential never sets
+#    `_backend_accepts_arrays`**. So this is a one-flag opt-in, NOT a guard
+#    rewrite -- but the flag must not be flipped without first verifying the
+#    wrapper computes correctly on array input, since the gate exists precisely
+#    to keep arrays out of potentials with bare-numpy/scipy internals. (The
+#    AnyAxisym opt-out is deliberate for exactly that reason; this one looks
+#    unverified rather than intentional, which is why it is xfail and not skip.)
+#    All 5 fail in 0.0-0.1 s -- they refuse immediately, they never compute.
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]


### PR DESCRIPTION
The traced measurement gh#1279 said it owed, plus what that measurement found.

gh#1279 stopped `-jit` inheriting the eager slow-skip list, and its own body
flagged the debt: that un-deferred **54 jax entries across 10 files** which had
never been measured traced. This is that measurement.

## Method

Each file run **whole** — not a hand-picked nodeid batch, which loses
module-scoped fixture context — with the C extension present and **alone on the
machine**: concurrent jax processes oversubscribe the XLA CPU thread pool and
inflate exactly the timings being collected (measured earlier at up to 6× with
4 competitors).

Per-test `--timeout=300 --timeout-method=signal`. The method matters:
`thread` does not fail the test and continue, it dumps stacks and **hard-exits
the process**, so one slow test costs the whole file's junitxml. `signal` raises
inside the test and the session still finishes. 300 s matches CI's own cap and
sits above the 240 s margin, so anything hitting it is a slow-skip candidate
whether it wanted 301 s or 3000 s.

## Result: 42 eager entries → 15 traced, over 10 files / ~2456 cases

| file | tests | eager | → jax-jit | un-deferred |
|---|---|---|---|---|
| `test_dynamfric` | 7 | 1 | 1 | — |
| `test_FDMdynamfric` | 9 | 3 | 2 | 1 |
| `test_galpypaper` | 15 | 1 | 0 | 1 |
| `test_streamspraydf` | 38 | 1 | 0 | 1 |
| `test_interp_potential` | 40 | 6 | 1 | 5 |
| `test_qdf` | 56 | 2 | 1 | 1 |
| `test_orbits` | 116 | 2 | 2 (1 **new**) | 1 |
| `test_actionAngle` | 209 | 1 | 1 (1 **new**) | 1 |
| `test_potential` | 1385 | 0 | 0 | — |
| `test_orbit` | 581 | 25 | **7** | 18 |

**Most eager deferrals do not survive a traced run** — 42 in, 15 out — and the
measurement found four things inheritance could not have:

* `test_FDMdynamfric` was wrong in **both directions at once** — one test
  deferred that traces fine in 226.6 s, two slow ones with no traced entry.
* **2 of the 15 keepers were never eager entries** (`test_bruteSOS_3D`,
  `test_actionAngleStaeckel_python_c_freqsAngles`). Inheritance only propagates
  eager entries forward, so it could never reach them.
* **`test_orbit` runs opposite to the average**: across the other nine files
  two-thirds of eager entries were dropped, but here most of what was deferred
  stays deferred (25 → 7 is still a big cut, yet every survivor is a genuine
  timeout). Per-file variation of that size is what a single rule — set either
  way — cannot express.
* **3 of the 15 sit inside the 240–300 s band** (296 s, 277 s, 265 s) and are
  therefore judgement calls against the margin; the other 12 hit the 300 s cap
  outright. Flagged in the file as judgements rather than measurements.

## One entry un-ledgered on traced evidence

`jax-jit StaeckelGrid_basicAndConserved_actions` **XPASSES traced** at 65.1 s.
gh#1279 made that bar backend-aware (`1e-16` → `1e-9` for non-numpy) but
deliberately kept the entry, on the principle that eager evidence cannot
un-ledger a traced one. This is the traced evidence.

## And 8 traced defects, each filed with its mechanism

`test_potential.py` produced **0 slow, 8 defects** — the first time the
slow-vs-defect split had anything to separate, and all 8 stayed **out** of the
slow-skip list. That separation is the point: a defect filed as "slow" hides
behind a performance deferral, which is exactly how the 10-test streamdf
immutability bug stayed invisible.

| n | mechanism |
|---|---|
| 5 | `RotateAndTiltWrapperPotential` never sets `_backend_accepts_arrays`. The guard is conditional and its `is_backend_array` half **is** satisfied under tracing — so this is a one-flag opt-in, not a guard rewrite. The flag must not be flipped before verifying array-correctness, since the gate exists to keep arrays out of bare-numpy internals |
| 2 | one root: `mass()` integrates with `scipy.integrate.quad`, which calls `float()` and rejects a tracer. `Cautun20` fails in `__init__`, so it cannot even be *constructed* traced |
| 1 | `AnyAxisym`: traced `Phi` at **exactly z==0** is off by ~7.3e-5 from its own neighbour; the test's one-sided difference divides that by dz=1e-8 → 7.35e+03. `zforce(0.5,0)=0` is correct — the derivative is the wrong side |

**These are not new breakage.** `test_potential.py` has only per-test eager
slow-skip entries, never a whole-file one, so the rest of it already ran traced
before gh#1279 — nobody was looking, because no workflow runs `--jit`. All 8
pass eager; develop merged green at 154/154.

The AnyAxisym one was **A/B'd against pre-gh#1278** by swapping only that file:
byte-identical, `7.345878e+03` on both sides. **Pre-existing, not the
geometric-grading change.** Worth noting the first probe returned `diff = 0` and
that was *not* treated as exoneration — it used a centred difference, which
cancels across z=0 by symmetry, and the wrong surfdens.

That same A/B also **falsifies the obvious suspect**: the degenerate `ratio`
ladder exists only in the newer version, yet both fail identically, so the
grading cannot be the cause. The ledger entry says so and warns explicitly off
it — a falsified hypothesis left in place sends the next reader to the one spot
the evidence has already excluded.

## Not covered

The **torch** side has the same gap and is not measured *in this PR*:
`torch-jit` also stops inheriting, so torch's 15 eager entries come off deferral
too (13 of them in `test_orbit.py`).

An earlier draft of this section said a torch sweep was blocked because
`parallel_map` deadlocks under `torch --jit`. **That was stale** — #1266
("parallel_map: do not fork while galpy is running traced") makes `parallel_map`
fall back to a serial `map` whenever `jit_mode() != "off"`, so no fork happens
under `--jit` at all. Checked rather than assumed: `tests/test_backend_multi.py`
passes 3/3 in 10.66 s under `--backend torch --jit`.

So the torch sweep is runnable and **is now running** (4 files:
`test_dynamfric`, `test_FDMdynamfric`, `test_potential`, `test_orbit` — the
three carrying torch entries, plus the file where all 8 jax defects were found,
since defects are per-backend). It lands as its own follow-up rather than
holding this PR.
