### PR TITLE
KuijkenDubinski _mass: backend quadrature (2 traced defects; RotateAndTilt attempted + reverted)

### DIFF
--- a/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
+++ b/galpy/potential/KuijkenDubinskiDiskExpansionPotential.py
@@ -5,7 +5,6 @@
 import copy
 
 import numpy
-from scipy import integrate
 
 from ..backend import coerce_coords, get_namespace
 from ..backend.special import logsumexp
@@ -469,20 +468,28 @@ class KuijkenDubinskiDiskExpansionPotential(Potential):
             raise AttributeError  # Hack to fall back to general
         out = self._me.mass(R, z=None, use_physical=False)
         r = R
+        # Same shell quadrature as Potential.mass: numpy -> scipy (byte-identical),
+        # jax/torch -> backend Gauss-Legendre, so the mass differentiates wrt R.
+        from ..backend.quadrature import quad as _bk_quad
+
+        xp = get_namespace(R)
 
         def _integrand(theta):
             # ~ rforce
-            tz = r * numpy.cos(theta)
-            tR = r * numpy.sin(theta)
+            tz = r * xp.cos(theta)
+            tR = r * xp.sin(theta)
             out = 0.0
             for a, s, ds, H, dH in zip(
                 self._Sigma_amp, self._Sigma, self._dSigmadR, self._Hz, self._dHzdz
             ):
-                out += a * ds(r) * H(tz) * tR**2
-                out += a * (ds(r) * H(tz) * tz / r + s(r) * dH(tz)) * tz * r
-            return out * numpy.sin(theta)
+                out = out + a * ds(r) * H(tz) * tR**2
+                out = out + a * (ds(r) * H(tz) * tz / r + s(r) * dH(tz)) * tz * r
+            return out * xp.sin(theta)
 
-        return out + 2.0 * numpy.pi * integrate.quad(_integrand, 0.0, numpy.pi)[0]
+        # Anchor the constant limits on the namespace so dispatch follows R.
+        return out + 2.0 * numpy.pi * _bk_quad(
+            _integrand, xp.asarray(0.0), xp.asarray(numpy.pi)
+        )
 
 
 def phiME_dens(R, z, phi, dens, Sigma, dSigmadR, d2SigmadR2, hz, Hz, dHzdz, Sigma_amp):

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -43,13 +43,6 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     A final `offset` option allows one to apply a static offset in Cartesian coordinate space to be applied to the potential following the rotation and tilt.
     """
 
-    # Evaluation broadcasts over a trailing node axis: the coordinate stack and
-    # the Hessian stack both build at a common rank, and the rotation is a
-    # matmul that carries batch axes. The scalars-only numpy contract still
-    # holds -- the guard additionally requires every argument to be a backend
-    # array.
-    _backend_accepts_arrays = True
-
     def __init__(
         self,
         amp=1.0,
@@ -184,17 +177,11 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
             y = xp.where(Rinf, 0.0, y)
         else:
             x, y, z = coords.cyl_to_rect(R, phi, z)
-        # With a trailing node axis only z carries it, so the stack would mix
-        # rank 0 and rank 1; (3,3) @ (3,N) is the same matmul as (3,3) @ (3,).
-        x, y, z = xp.broadcast_arrays(x, y, z)
         xyzp = xp.stack([x, y, z])
         if not self._norot:
             xyzp = as_backend_constant(xp, self._rot, xyzp) @ xyzp
         if self._offset is not None:
-            # Offset is (3,); give it a trailing singleton per node axis so it
-            # broadcasts down the (3, N) stack. No-op when xyzp is (3,).
-            offset = as_backend_constant(xp, self._offset, xyzp)
-            xyzp = xyzp + xp.reshape(offset, (3,) + (1,) * (xyzp.ndim - 1))
+            xyzp = xyzp + as_backend_constant(xp, self._offset, xyzp)
         return xyzp
 
     @check_potential_inputs_not_arrays
@@ -238,20 +225,20 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            xp.cos(phi) ** 2.0 * phi2[..., 0, 0]
-            + xp.sin(phi) ** 2.0 * phi2[..., 1, 1]
-            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
+            xp.cos(phi) ** 2.0 * phi2[0, 0]
+            + xp.sin(phi) ** 2.0 * phi2[1, 1]
+            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
         )
 
     @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return xp.cos(phi) * phi2[..., 0, 2] + xp.sin(phi) * phi2[..., 1, 2]
+        return xp.cos(phi) * phi2[0, 2] + xp.sin(phi) * phi2[1, 2]
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[..., 2, 2]
+        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[2, 2]
 
     @check_potential_inputs_not_arrays
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
@@ -259,9 +246,9 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return R**2.0 * (
-            xp.sin(phi) ** 2.0 * phi2[..., 0, 0]
-            + xp.cos(phi) ** 2.0 * phi2[..., 1, 1]
-            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
+            xp.sin(phi) ** 2.0 * phi2[0, 0]
+            + xp.cos(phi) ** 2.0 * phi2[1, 1]
+            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
         ) + R * (xp.cos(phi) * Fxyz[0] + xp.sin(phi) * Fxyz[1])
 
     @check_potential_inputs_not_arrays
@@ -270,8 +257,8 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            R * xp.cos(phi) * xp.sin(phi) * (phi2[..., 1, 1] - phi2[..., 0, 0])
-            + R * xp.cos(2.0 * phi) * phi2[..., 0, 1]
+            R * xp.cos(phi) * xp.sin(phi) * (phi2[1, 1] - phi2[0, 0])
+            + R * xp.cos(2.0 * phi) * phi2[0, 1]
             + xp.sin(phi) * Fxyz[0]
             - xp.cos(phi) * Fxyz[1]
         )
@@ -280,7 +267,7 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return R * (xp.cos(phi) * phi2[..., 1, 2] - xp.sin(phi) * phi2[..., 0, 2])
+        return R * (xp.cos(phi) * phi2[1, 2] - xp.sin(phi) * phi2[0, 2])
 
     def _2ndderiv_xyz(self, R, z, phi=0.0, t=0.0):
         """Get the rectangular forces in the transformed frame"""
@@ -333,17 +320,12 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         )
         xzderivp = Rzderivp * cp - phizderivp * sp / Rp
         yzderivp = Rzderivp * sp + phizderivp * cp / Rp
-        # Build as (..., 3, 3) -- tensor axes LAST -- so any node axis is a
-        # leading batch axis that matmul carries through. einsum would also
-        # broadcast but picks a different contraction order and is NOT numpy
-        # byte-identical; chained matmul on (3,3) executes exactly as before.
         deriv2p = xp.stack(
             [
-                xp.stack([x2derivp, xyderivp, xzderivp], axis=-1),
-                xp.stack([xyderivp, y2derivp, yzderivp], axis=-1),
-                xp.stack([xzderivp, yzderivp, z2derivp], axis=-1),
-            ],
-            axis=-2,
+                xp.stack([x2derivp, xyderivp, xzderivp]),
+                xp.stack([xyderivp, y2derivp, yzderivp]),
+                xp.stack([xzderivp, yzderivp, z2derivp]),
+            ]
         )
         inv_rot = as_backend_constant(xp, self._inv_rot, deriv2p)
         inv_rot_T = as_backend_constant(xp, self._inv_rot.T, deriv2p)

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -43,6 +43,13 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     A final `offset` option allows one to apply a static offset in Cartesian coordinate space to be applied to the potential following the rotation and tilt.
     """
 
+    # Evaluation broadcasts over a trailing node axis: the coordinate stack and
+    # the Hessian stack both build at a common rank, and the rotation is a
+    # matmul that carries batch axes. The scalars-only numpy contract still
+    # holds -- the guard additionally requires every argument to be a backend
+    # array.
+    _backend_accepts_arrays = True
+
     def __init__(
         self,
         amp=1.0,
@@ -177,11 +184,17 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
             y = xp.where(Rinf, 0.0, y)
         else:
             x, y, z = coords.cyl_to_rect(R, phi, z)
+        # With a trailing node axis only z carries it, so the stack would mix
+        # rank 0 and rank 1; (3,3) @ (3,N) is the same matmul as (3,3) @ (3,).
+        x, y, z = xp.broadcast_arrays(x, y, z)
         xyzp = xp.stack([x, y, z])
         if not self._norot:
             xyzp = as_backend_constant(xp, self._rot, xyzp) @ xyzp
         if self._offset is not None:
-            xyzp = xyzp + as_backend_constant(xp, self._offset, xyzp)
+            # Offset is (3,); give it a trailing singleton per node axis so it
+            # broadcasts down the (3, N) stack. No-op when xyzp is (3,).
+            offset = as_backend_constant(xp, self._offset, xyzp)
+            xyzp = xyzp + xp.reshape(offset, (3,) + (1,) * (xyzp.ndim - 1))
         return xyzp
 
     @check_potential_inputs_not_arrays
@@ -225,20 +238,20 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            xp.cos(phi) ** 2.0 * phi2[0, 0]
-            + xp.sin(phi) ** 2.0 * phi2[1, 1]
-            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
+            xp.cos(phi) ** 2.0 * phi2[..., 0, 0]
+            + xp.sin(phi) ** 2.0 * phi2[..., 1, 1]
+            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
         )
 
     @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return xp.cos(phi) * phi2[0, 2] + xp.sin(phi) * phi2[1, 2]
+        return xp.cos(phi) * phi2[..., 0, 2] + xp.sin(phi) * phi2[..., 1, 2]
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[2, 2]
+        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[..., 2, 2]
 
     @check_potential_inputs_not_arrays
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
@@ -246,9 +259,9 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return R**2.0 * (
-            xp.sin(phi) ** 2.0 * phi2[0, 0]
-            + xp.cos(phi) ** 2.0 * phi2[1, 1]
-            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
+            xp.sin(phi) ** 2.0 * phi2[..., 0, 0]
+            + xp.cos(phi) ** 2.0 * phi2[..., 1, 1]
+            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
         ) + R * (xp.cos(phi) * Fxyz[0] + xp.sin(phi) * Fxyz[1])
 
     @check_potential_inputs_not_arrays
@@ -257,8 +270,8 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            R * xp.cos(phi) * xp.sin(phi) * (phi2[1, 1] - phi2[0, 0])
-            + R * xp.cos(2.0 * phi) * phi2[0, 1]
+            R * xp.cos(phi) * xp.sin(phi) * (phi2[..., 1, 1] - phi2[..., 0, 0])
+            + R * xp.cos(2.0 * phi) * phi2[..., 0, 1]
             + xp.sin(phi) * Fxyz[0]
             - xp.cos(phi) * Fxyz[1]
         )
@@ -267,7 +280,7 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return R * (xp.cos(phi) * phi2[1, 2] - xp.sin(phi) * phi2[0, 2])
+        return R * (xp.cos(phi) * phi2[..., 1, 2] - xp.sin(phi) * phi2[..., 0, 2])
 
     def _2ndderiv_xyz(self, R, z, phi=0.0, t=0.0):
         """Get the rectangular forces in the transformed frame"""
@@ -320,12 +333,17 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         )
         xzderivp = Rzderivp * cp - phizderivp * sp / Rp
         yzderivp = Rzderivp * sp + phizderivp * cp / Rp
+        # Build as (..., 3, 3) -- tensor axes LAST -- so any node axis is a
+        # leading batch axis that matmul carries through. einsum would also
+        # broadcast but picks a different contraction order and is NOT numpy
+        # byte-identical; chained matmul on (3,3) executes exactly as before.
         deriv2p = xp.stack(
             [
-                xp.stack([x2derivp, xyderivp, xzderivp]),
-                xp.stack([xyderivp, y2derivp, yzderivp]),
-                xp.stack([xzderivp, yzderivp, z2derivp]),
-            ]
+                xp.stack([x2derivp, xyderivp, xzderivp], axis=-1),
+                xp.stack([xyderivp, y2derivp, yzderivp], axis=-1),
+                xp.stack([xzderivp, yzderivp, z2derivp], axis=-1),
+            ],
+            axis=-2,
         )
         inv_rot = as_backend_constant(xp, self._inv_rot, deriv2p)
         inv_rot_T = as_backend_constant(xp, self._inv_rot.T, deriv2p)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -299,11 +299,6 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #    AnyAxisym opt-out is deliberate for exactly that reason; this one looks
 #    unverified rather than intentional, which is why it is xfail and not skip.)
 #    All 5 fail in 0.0-0.1 s -- they refuse immediately, they never compute.
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 #
 # 2) jax ConcretizationTypeError -- and the two share ONE root: `mass()` is not
 #    traceable, because it integrates with scipy.integrate.quad, which calls
@@ -320,8 +315,6 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14
 #    backend-native mass quadrature, hit once during evaluation and once during
 #    a wrapper's __init__. Fixing mass to use the backend quadrature (as the
 #    other migrations did) should clear both together.
-jax-jit tests/test_potential.py::test_McMillan17
-jax-jit tests/test_potential.py::test_Cautun20
 #
 # 3) AnyAxisym: the TRACED potential is wrong at exactly the disk plane.
 #    Measured at (R,z) = (0.5, 0.0):
@@ -344,4 +337,9 @@ jax-jit tests/test_potential.py::test_Cautun20
 #    It is eager-vs-traced: eager has Phi(z=0) and Phi(z=1e-8) agreeing to 11
 #    digits, traced does not. Cause not yet identified; do not start from the
 #    quadrature ladder.
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -299,6 +299,11 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #    AnyAxisym opt-out is deliberate for exactly that reason; this one looks
 #    unverified rather than intentional, which is why it is xfail and not skip.)
 #    All 5 fail in 0.0-0.1 s -- they refuse immediately, they never compute.
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 #
 # 2) jax ConcretizationTypeError -- and the two share ONE root: `mass()` is not
 #    traceable, because it integrates with scipy.integrate.quad, which calls
@@ -337,9 +342,4 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #    It is eager-vs-traced: eager has Phi(z=0) and Phi(z=1e-8) agreeing to 11
 #    digits, traced does not. Cause not yet identified; do not start from the
 #    quadrature ladder.
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]


### PR DESCRIPTION
Fixes the **2 traced defects** from gh#1281 that turned out to be fixable, and
drops their ledger entries.

gh#1281 measured `test_potential.py` traced for the first time and filed 8
defects with mechanisms rather than fixes. This is the fix pass for the pair
with one shared root cause. The other 6 are **not** fixed here — see below,
including one I attempted and reverted.

## `KuijkenDubinskiDiskExpansionPotential._mass` — scipy quad rejects a tracer

`Potential.mass()` already routes its shell quadrature through
`backend.quadrature.quad`. This **per-potential `_mass` override** — the same
shell-quadrature shape — was left on `scipy.integrate.quad`, which calls
`float()` and so rejects a tracer. One copy of a pattern migrated, its sibling
missed.

`DiskSCFPotential` inherits it, which is how `McMillan17` reaches it;
`Cautun20` arrives at the same bottom via
`AdiabaticContractionWrapper.__init__ → Potential.mass → CompositePotential._mass`,
so one fix clears both.

Swapped onto the **existing** helper rather than adding one: namespace-anchored
limits so dispatch follows `R`, `xp.cos/sin`, dead `scipy` import dropped.

**Verified:**

* **numpy byte-identical** — sha256 of `mass()` at 4 radii is `a0b8d1c4…` on
  both an unmodified worktree at this base commit and the patched tree.
* traced vs numpy differ by **6.0e-6 relative** — the
  Gauss-Legendre-vs-adaptive floor, inside the tests' own ~1.5e-2 band.
* `mass()` is now differentiable in `R`: `d mass/dR = 1.0158e+08` (jax) and
  `1.0158e+08` (torch, via autograd) at `R = 50/8.21`, agreeing to ~6e-7.
* both backends checked — the fix is in shared code, but torch was verified
  separately rather than assumed.

## Duplication audit

23 `_mass` overrides in the tree; exactly **two** used `scipy.integrate.quad`.
The other is `EllipsoidalPotential._mass`, which carries an explicit
"Pspecial-blocked … no backend-agnostic replacement -> numpy only" comment. That
comment now looks stale (`backend.quadrature.quad` exists, and the same file
uses it 35 lines later), but nothing in either sweep demands the change, so it
is **left alone and recorded as a lead** rather than widened into this PR.

## What this does NOT fix

**`RotateAndTiltWrapperPotential` (5 entries) — attempted and reverted.** The
wrapper never sets `_backend_accepts_arrays`, and three internal sites assume
rank. Making all three broadcast works, and is bit-identical to the scalar loop
(40/40 checks across 4 geometries × 10 methods, numpy sha unchanged) — but the
tests **still fail**, differently:

    (R,Z,phi) = (0.500, 10.000, 0.000)
    tpoissondens = 0.07701375  vs  tdens = 0.07209774
    rel. diff = 6.8e-02   against a 1e-8 bar

Opting the wrapper in trades a hard `TypeError` for a **silent 6.8% error**:
once the node array is accepted, the traced Poisson surfdens runs on fixed-order
Gauss-Legendre where scipy's adaptive `quad` had been coping, and at |Z|=10 that
is not enough. Reverted. Opting it in first requires the traced surfdens
quadrature to be **range-aware**, not merely rank-correct.

**`AnyAxisym forceAsDeriv` (1 entry)** — pre-existing, filed separately, and now
confirmed **cross-backend** (torch reproduces it identically, and again as
`test_eccentricity` in `test_orbit`).

## Ledger

Drops exactly 2 entries, `test_McMillan17` and `test_Cautun20`. Verified by set
difference against the branch point: 2 removed, 0 added.
