### PR TITLE
torch --jit sweep: 15 eager slow-skip entries measured traced (delete 13, add 10)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -372,10 +372,6 @@ jax-jit tests/test_orbit.py::test_liouville_planar  # 265s
 # margin; --timeout-method=signal cannot interrupt C-bound tests, so PASS
 # does not imply under-cap -- these are classified by junitxml time).
 torch-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
 torch-jit tests/test_orbit.py::test_interprz_dxdv_3d
 torch-jit tests/test_orbit.py::test_analytic_zmax
 torch-jit tests/test_orbit.py::test_liouville_planar

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -36,7 +36,6 @@ jax tests/test_orbits.py::test_SOS_3D  # 269s -- inside the cap, but within 20% 
 # integration that finishes under the timeout, so only central_limit is deferred.)
 jax tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
 jax tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
-torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
 
 # --- jax quasi-isothermal DF (Track F df migration) ---
 # quasiisothermaldf is not yet backend-migrated; this test does many nested
@@ -180,19 +179,6 @@ jax tests/test_orbit.py::test_zmax  # 300s (failed)
 # >150s and was xfail (which still EXECUTES -> ~300s timeout each, ~65min total ->
 # the torch orbit shard hung near the 4500s cap). slow_skip (NOT executed) instead;
 # numpy covers them. (Same eager-EOM reason as the jax dxdv slow_skips.)
-torch tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[const_lnLambda]
-torch tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[minr_gate]
-torch tests/test_orbit.py::test_chandrasekhar_dxdv_fd_of_flow_branches[sigma_clamp]
-torch tests/test_orbit.py::test_chandrasekhar_dxdv_phase_volume_law
-torch tests/test_orbit.py::test_dissipative_dxdv_python_raises
-torch tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[const_FDMfactor]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[const_lnLambda_cdm_cutoff]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[intermediate]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[rhm_coulomb_log_cdm_cutoff]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[sigma_clamp]
-torch tests/test_orbit.py::test_fdm_dxdv_fd_of_flow_branches[zerovel]
-torch tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic
 
 # --- jax orbit: heavy eager-jax tests (>~45s) -- per-CI-group session-cap fit ---
 # Variational/wrapper/sigint/triaxial-liouville tests run 45-150s each on the dev
@@ -381,3 +367,15 @@ jax-jit tests/test_orbit.py::test_integrate_negative_time  # 300s cap
 # on where the margin sits; the other 12 hit the cap outright.
 jax-jit tests/test_orbit.py::test_energy_jacobi_conservation[BurkertPotentialNoC--10.0--10.0-False]  # 296s
 jax-jit tests/test_orbit.py::test_liouville_planar  # 265s
+
+# torch-jit: measured by the 2026-08-09 torch sweep (duration vs the 240s
+# margin; --timeout-method=signal cannot interrupt C-bound tests, so PASS
+# does not imply under-cap -- these are classified by junitxml time).
+torch-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+torch-jit tests/test_orbit.py::test_interprz_dxdv_3d
+torch-jit tests/test_orbit.py::test_analytic_zmax
+torch-jit tests/test_orbit.py::test_liouville_planar

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -351,3 +351,12 @@ jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazo
 torch-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 # same AnyAxisym root cause seen through an orbit (e=5.4e-6 vs 1e-8)
 torch-jit tests/test_orbit.py::test_eccentricity
+# torch-jit: the RotateAndTilt wrapper rejects the quadrature's node array, so
+# these FAIL fast (35.6 s for all four) -- they are defects, not slow tests. The
+# 2026-08-09 sweep measured them at 300-400 s because its worktree carried the
+# then-unmerged broadcast fix; on a clean tree they never get that far.
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
+torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -345,3 +345,9 @@ jax-jit tests/test_potential.py::test_Cautun20
 #    digits, traced does not. Cause not yet identified; do not start from the
 #    quadrature ladder.
 jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
+
+# torch-jit defects found by the 2026-08-09 torch sweep.
+# AnyAxisym traced GL forces ~1e-6; reproduces on jax too
+torch-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
+# same AnyAxisym root cause seen through an orbit (e=5.4e-6 vs 1e-8)
+torch-jit tests/test_orbit.py::test_eccentricity

--- a/tests/test_FDMdynamfric.py
+++ b/tests/test_FDMdynamfric.py
@@ -46,7 +46,7 @@ def test_FDMDynamicalFrictionForce_central_limit():
     o.integrate(t, Loghalo + fdf, method="dop853_c")
 
     # Compare to analytical solution
-    assert numpy.amax(numpy.fabs(o.r(t) - r_pred)) / r0 < 0.001, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.r(t)) - r_pred)) / r0 < 0.001, (
         "FDMDynamicalFrictionForce in the central limit does not agree with analytical solution for circular orbits in logarithmic potentials"
     )
 
@@ -56,7 +56,7 @@ def test_FDMDynamicalFrictionForce_central_limit():
     o.integrate(t, Loghalo + fdf, method="dop853")
 
     # Compare to analytical solution
-    assert numpy.amax(numpy.fabs(o.r(t) - r_pred)) / r0 < 0.001, (
+    assert numpy.amax(numpy.fabs(as_numpy(o.r(t)) - r_pred)) / r0 < 0.001, (
         "FDMDynamicalFrictionForce in the central limit does not agree with analytical solution for circular orbits in logarithmic potentials"
     )
     return None


### PR DESCRIPTION
The torch half of the traced measurement, which gh#1281 explicitly did not cover.

gh#1279 stopped `--jit` inheriting the eager slow-skip list. gh#1281 measured
what that un-deferred on **jax**. This is the same measurement for **torch**:
15 eager slow-skip entries across 3 files that had never been run traced.

## Method

Same harness as gh#1281 — each file run **whole**, alone on the machine,
per-test `--timeout=300 --timeout-method=signal`, `-v` streamed through a
timestamper so durations survive a kill. 4 files, **~1982 traced cases**, ~2h50m.

`test_potential.py` is included despite having **no** torch slow-skip entries:
all 8 of jax's traced defects were found there, and **defects are per-backend**,
so inheriting jax's answer would have been an assumption rather than a result.

## Classification is by DURATION, not by timeout-failure

This matters, and it is not the obvious choice. `--timeout-method=signal`
delivers SIGALRM, and Python cannot run the handler while inside a C extension
call that does not return to bytecode — so a C-bound slow test is **not**
interrupted and is recorded as a **PASS**. Measured here:
`const_FDMfactor` ran **534.0 s and passed** under `--timeout=300`.

Classifying by "failed with a Timeout" therefore silently drops every C-bound
slow test. Everything below is classified as
`slow = timeout_failure or duration > 240 s`. Re-auditing the **jax** sweep the
same way finds 5 such tests, and all 5 were already captured in gh#1281, which
classified by duration.

## Result: 15 eager entries → 1 keeper

| file | eager | traced verdict |
|---|---|---|
| `test_dynamfric` | 1 | **1 keeps** — `test_dynamfric_c` at the 300 s cap |
| `test_FDMdynamfric` | 1 | **1 reclassified**: not slow at all, **fails in 35.9 s** |
| `test_orbit` | 13 | **13 drop** — 9 of them run in **~5 s** against a 240 s margin |

**The torch slow-skip list is ~93% stale under tracing** (jax was 64%). The
mechanism is consistent: these were measured **eager**, where torch has no
compiled kernel and grinds; traced, the same work compiles once and runs in
seconds. For this family the eager list is not merely stale, it is
*systematically wrong in one direction*.

## And 10 additions no inheritance rule could reach

**8 slow**, by duration:

| entry | traced |
|---|---|
| `test_fdm_dxdv_fd_of_flow_branches[const_FDMfactor]` | 534.0 s |
| `test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14…]` | 398.5 s |
| `test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14…]` | 339.8 s |
| `test_poisson_surfdens_potential[mockOffsetMWP14…]` | 313.8 s |
| `test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14…wInclination]` | 300.0 s |
| `test_interprz_dxdv_3d` | 295.3 s |
| `test_analytic_zmax` | 269.0 s |
| `test_liouville_planar` | 250.0 s |

**2 defects:** `test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]`,
and a `torch-jit` line for `test_eccentricity` (already-diagnosed mechanism,
missing only because torch had never been measured traced).

Inheritance only propagates *eager* entries forward, so none of these was
reachable by any rule that transforms the existing list.

**Net: delete 13, add 10, keep 1, reclassify 1.**

Reconciling that with the raw diff, which now reads **−14 / +7** on
`backend_slow_skip.txt` (4 entries + 3 comment lines) and **+14** on
`backend_xfail.txt` (7 entries + 7 comment lines):

| diff line | why |
|---|---|
| −13 | the 13 `test_orbit` entries that pass traced |
| −1 | `central_limit`, reclassified as a defect and fixed here, so deleted rather than moved |
| +4 | the slow additions that survived re-checking (see the correction below) |
| +7 | the defect entries in `backend_xfail.txt` |

### Correction: 4 "slow" entries were defects, and a 5th was missed

The sweep ran in a worktree at `e1fa8bf9`, which carried the **then-unmerged**
`RotateAndTilt: broadcast over a trailing node axis` commit. With that fix the
wrapper accepts the quadrature's node array and the `poisson_surfdens` wrapper
tests run — slowly, 300–400 s, which is what got measured. Without it the array
guard rejects the input and they **fail fast**.

Re-measured against clean develop source under `torch --jit`: the four fail in
**35.6 s total**, and a fifth
(`mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination`, 28.3 s) fails the
same way and was never ledgered at all. All five are now `backend_xfail.txt`
entries.

This mattered: a slow-skip entry **skips** the test, so as originally filed this
PR would have silently masked four real failures in exactly the traced runs meant
to surface them. Per-PR CI is unaffected either way — `--jit` is only set by a
`workflow_dispatch` with `jit=true`, so the backend shards run eager.

The provenance note below flagged the KD `_mass` contamination on that same
worktree but missed this one. Checking a tree for *one* unmerged fix is not
checking it.

## Two cross-backend findings

**`AnyAxisym` reproduces identically on torch.** gh#1281 attributed its
`forceAsDeriv` failure to pre-existing behaviour by A/B against pre-gh#1278 —
a single-backend argument. Torch failing the same test the same way is much
stronger evidence for the same conclusion. It also shows up a second time as
`test_eccentricity` (a circular orbit returning `e≈5e-6` against a `1e-8` bar),
so one root cause spans **two files on two backends**.

**`RotateAndTilt` does not.** Where jax raises the array-input guard, torch
simply passes 4 of 5 and runs the fifth slowly — a *performance* problem, not a
correctness one. Of jax's 8 traced defects, **exactly one** reproduces on torch.

## Provenance

The tree under test carried the unmerged KD `_mass` fix, so `test_McMillan17`
and `test_Cautun20` passing here is evidence about **that fix**, not about
torch, and they are deliberately **not** claimed as torch-vs-jax differences.
Two rows were re-measured on a clean tree before being written down: the
`const_FDMfactor` timing (its original run overlapped a concurrent job) and
`test_dxdv_3d_c_vs_python[RotateAndTilt…]` (its original run was on the patched
tree).
