### PR TITLE
RotateAndTilt surfdens: split the vertical quadrature at the potential's mid-plane (clears 5 traced entries)

### DIFF
--- a/galpy/potential/CompositePotential.py
+++ b/galpy/potential/CompositePotential.py
@@ -1,6 +1,9 @@
 ###############################################################################
 #   CompositePotential.py: class that represents a combination of potentials
 ###############################################################################
+import numpy
+
+from ..backend import get_namespace
 from ..util.conversion import physical_compatible
 from .baseCompositePotential import baseCompositePotential
 from .DissipativeForce import DissipativeForce, _isDissipative
@@ -278,6 +281,76 @@ class CompositePotential(baseCompositePotential, DissipativeForce, Potential):
         """
         return sum(
             pot.dens(R, z, phi=phi, t=t, use_physical=False)
+            for pot in self._potlist
+            if not pot.isDissipative
+        )
+
+    def _surfdens(self, R, z, phi=0.0, t=0.0):
+        """
+        Evaluate the surface density.
+
+        Parameters
+        ----------
+        R : float
+            Cylindrical Galactocentric radius.
+        z : float
+            Vertical height.
+        phi : float, optional
+            Azimuth (default: 0.0).
+        t : float, optional
+            Time (default: 0.0).
+
+        Returns
+        -------
+        float
+            Surface density at (R,z,phi,t).
+
+        """
+        # Sigma of a sum is the sum of the Sigmas, so integrate each component
+        # separately on a backend: each then splits its vertical quadrature at
+        # its OWN mid-plane (see Potential._vertical_quad_split). Integrating
+        # the summed density instead splits at this composite's plane, which is
+        # 0 -- wrong for any displaced or tilted component. numpy keeps the
+        # inherited single scipy quadrature, so its result is byte-identical.
+        xp = get_namespace(R, z, phi, t)
+        if xp is numpy:
+            return Potential._surfdens(self, R, z, phi=phi, t=t)
+        return sum(
+            pot.surfdens(R, z, phi=phi, t=t, use_physical=False)
+            for pot in self._potlist
+            if not pot.isDissipative
+        )
+
+    def _surfdens_poisson(self, R, z, phi=0.0, t=0.0):
+        """
+        Evaluate the surface density via the Poisson equation.
+
+        Parameters
+        ----------
+        R : float
+            Cylindrical Galactocentric radius.
+        z : float
+            Vertical height.
+        phi : float, optional
+            Azimuth (default: 0.0).
+        t : float, optional
+            Time (default: 0.0).
+
+        Returns
+        -------
+        float
+            Surface density at (R,z,phi,t).
+
+        """
+        # Forces and their derivatives are additive, so the Poisson route is too
+        # -- delegate for the same reason as _surfdens above, so each component
+        # splits its quadrature at its own mid-plane. numpy keeps the inherited
+        # single scipy quadrature and stays byte-identical.
+        xp = get_namespace(R, z, phi, t)
+        if xp is numpy:
+            return Potential._surfdens_poisson(self, R, z, phi=phi, t=t)
+        return sum(
+            pot._surfdens_poisson(R, z, phi=phi, t=t)
             for pot in self._potlist
             if not pot.isDissipative
         )

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -794,45 +794,53 @@ class Potential(Force):
                 raise AttributeError  # Hack!
             return self._amp * self._surfdens(R, z, phi=phi, t=t)
         except AttributeError:
-            # Use the Poisson equation to get the surface density
-            xp = get_namespace(R, z, phi, t)
+            return self._surfdens_poisson(R, z, phi=phi, t=t)
 
-            def poisson_integrand(Rv, pv):
-                return lambda x: (
-                    -self.Rforce(Rv, x, phi=pv, t=t, use_physical=False) / Rv
-                    + self.R2deriv(Rv, x, phi=pv, t=t, use_physical=False)
-                    + self.phi2deriv(Rv, x, phi=pv, t=t, use_physical=False) / Rv**2.0
-                )
+    def _surfdens_poisson(self, R, z, phi=0.0, t=0.0):
+        """Surface density from the Poisson equation.
 
-            # numpy.fabs on a backend array emits a NumPy 2 __array_wrap__
-            # DeprecationWarning, which the coverage shard turns into an error.
-            absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
-            if not _quad_needs_backend(xp, absz):
-                inner = integrate.quad(poisson_integrand(R, phi), -absz, absz)[0]
-            else:
-                # Fixed-order GL over the whole [-z, z] needs an order that grows
-                # with the range (n=100 is only 3.7e-4 at |z|=10). Splitting at
-                # the mid-plane and clustering nodes toward the split puts them
-                # where a decaying integrand has its mass, and does so RELATIVE
-                # to the range, so one node count holds at every |z|.
-                # [..., None] so R/phi broadcast against the trailing node axis
-                # (0-d becomes (1,), which broadcasts either way).
-                inner = _bquad.symmetric_quad(
-                    xp,
-                    poisson_integrand(_bquad.node_axis(R), _bquad.node_axis(phi)),
-                    absz,
-                    n=50,
-                    interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
-                )
-            return (
-                (
-                    -self.zforce(R, absz, phi=phi, t=t, use_physical=False)
-                    + self.zforce(R, -absz, phi=phi, t=t, use_physical=False)
-                    + inner
-                )
-                / 4.0
-                / numpy.pi
+        Split out of ``surfdens`` so a composite can delegate it component-wise
+        (every term below is additive over the components), the same way
+        ``CompositePotential._surfdens`` delegates the direct route.
+        """
+        xp = get_namespace(R, z, phi, t)
+
+        def poisson_integrand(Rv, pv):
+            return lambda x: (
+                -self.Rforce(Rv, x, phi=pv, t=t, use_physical=False) / Rv
+                + self.R2deriv(Rv, x, phi=pv, t=t, use_physical=False)
+                + self.phi2deriv(Rv, x, phi=pv, t=t, use_physical=False) / Rv**2.0
             )
+
+        # numpy.fabs on a backend array emits a NumPy 2 __array_wrap__
+        # DeprecationWarning, which the coverage shard turns into an error.
+        absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
+        if not _quad_needs_backend(xp, absz):
+            inner = integrate.quad(poisson_integrand(R, phi), -absz, absz)[0]
+        else:
+            # Fixed-order GL over the whole [-z, z] needs an order that grows
+            # with the range (n=100 is only 3.7e-4 at |z|=10). Splitting at the
+            # mid-plane and clustering nodes toward the split puts them where a
+            # decaying integrand has its mass, and does so RELATIVE to the
+            # range, so one node count holds at every |z|.
+            # [..., None] so R/phi broadcast against the trailing node axis
+            # (0-d becomes (1,), which broadcasts either way).
+            inner = _bquad.symmetric_quad(
+                xp,
+                poisson_integrand(_bquad.node_axis(R), _bquad.node_axis(phi)),
+                absz,
+                n=50,
+                interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
+            )
+        return (
+            (
+                -self.zforce(R, absz, phi=phi, t=t, use_physical=False)
+                + self.zforce(R, -absz, phi=phi, t=t, use_physical=False)
+                + inner
+            )
+            / 4.0
+            / numpy.pi
+        )
 
     def _vertical_quad_split(self, R, phi=0.0, t=0.0):
         """z at which this potential's mid-plane crosses the vertical line at
@@ -846,17 +854,21 @@ class Potential(Force):
     def _vertical_quad_interior(self, xp, R, absz, phi, t):
         """``_vertical_quad_split`` clamped into the integration range.
 
-        A split outside ``[-|z|, |z|]`` would invert a panel. Clamping
-        degenerates that panel to zero width instead, which is still exact:
-        the mid-plane is then outside the range and the integrand is monotonic
-        across it, so clustering at the near end is what we want anyway.
+        A split outside ``[-|z|, |z|]`` would invert a panel, and clamping it to
+        the boundary is worse than useless: that degenerates one panel to zero
+        width and throws away the clustering entirely. Measured on the tilted
+        (near edge-on) wrappers, where the crossing runs off to large |z|,
+        clamping cost 2-6x accuracy versus just splitting at 0. So fall back to
+        0 whenever the mid-plane does not actually cross the interval.
         """
         c = self._vertical_quad_split(R, phi=phi, t=t)
         # Ordinary potentials keep the literal 0.0 they used before this hook
         # existed, so their quadrature is untouched.
         if isinstance(c, float) and c == 0.0:
             return 0.0
-        return xp.clip(c, -absz, absz)
+        # xp.where, not a Python branch: c is traced. Both arms are finite, so
+        # there is no dead-branch NaN to poison reverse-mode AD.
+        return xp.where((c > -absz) & (c < absz), c, 0.0)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         """

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -812,9 +812,9 @@ class Potential(Force):
             else:
                 # Fixed-order GL over the whole [-z, z] needs an order that grows
                 # with the range (n=100 is only 3.7e-4 at |z|=10). Splitting at
-                # z=0 and clustering nodes toward the split puts them where a
-                # decaying integrand has its mass, and does so RELATIVE to the
-                # range, so one node count holds at every |z|.
+                # the mid-plane and clustering nodes toward the split puts them
+                # where a decaying integrand has its mass, and does so RELATIVE
+                # to the range, so one node count holds at every |z|.
                 # [..., None] so R/phi broadcast against the trailing node axis
                 # (0-d becomes (1,), which broadcasts either way).
                 inner = _bquad.symmetric_quad(
@@ -822,7 +822,7 @@ class Potential(Force):
                     poisson_integrand(_bquad.node_axis(R), _bquad.node_axis(phi)),
                     absz,
                     n=50,
-                    interior_point=0.0,
+                    interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
                 )
             return (
                 (
@@ -833,6 +833,30 @@ class Potential(Force):
                 / 4.0
                 / numpy.pi
             )
+
+    def _vertical_quad_split(self, R, phi=0.0, t=0.0):
+        """z at which this potential's mid-plane crosses the vertical line at
+        (R, phi) -- where the vertical quadratures below should split.
+
+        Zero unless a subclass displaces or tilts its structure relative to
+        z = 0; see ``RotateAndTiltWrapperPotential``.
+        """
+        return 0.0
+
+    def _vertical_quad_interior(self, xp, R, absz, phi, t):
+        """``_vertical_quad_split`` clamped into the integration range.
+
+        A split outside ``[-|z|, |z|]`` would invert a panel. Clamping
+        degenerates that panel to zero width instead, which is still exact:
+        the mid-plane is then outside the range and the integrand is monotonic
+        across it, so clustering at the near end is what we want anyway.
+        """
+        c = self._vertical_quad_split(R, phi=phi, t=t)
+        # Ordinary potentials keep the literal 0.0 they used before this hook
+        # existed, so their quadrature is untouched.
+        if isinstance(c, float) and c == 0.0:
+            return 0.0
+        return xp.clip(c, -absz, absz)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         """
@@ -861,9 +885,12 @@ class Potential(Force):
 
         """
         # Same dual path as the Poisson branch of surfdens(): numpy keeps scipy
-        # (byte-identical), a backend takes the split-at-zero, node-clustered GL
-        # rule so it traces and stays accurate at large |z|. Scalar-only
-        # potentials keep scipy either way -- they reject the node array.
+        # (byte-identical), a backend takes the split-at-the-mid-plane,
+        # node-clustered GL rule so it traces and stays accurate at large |z|.
+        # Scalar-only potentials keep scipy either way -- they reject the node
+        # array. The split matters far more here than in the Poisson branch:
+        # this integrand is the density, which for a displaced disk is sharply
+        # peaked off z=0 (6.4e-2 error vs 1.8e-4) -- see _vertical_quad_split.
         xp = get_namespace(R, z, phi, t)
         absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
         if not _quad_needs_backend(xp, absz):
@@ -877,7 +904,7 @@ class Potential(Force):
             ),
             absz,
             n=50,
-            interior_point=0.0,
+            interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
         )
 
     @potential_physical_input

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -188,7 +188,12 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         if self._norot and self._offset is None:
             return 0.0
         xp = get_namespace(R, phi)
-        r22 = 1.0 if self._norot else self._rot[2, 2]
+        # float(), not the numpy scalar: dividing a backend array by a
+        # numpy.float64 hands the op to numpy, which emits the numpy-2.0
+        # __array_wrap__ deprecation (96 of them across the traced-torch
+        # surfdens tests). A plain float stays a weak scalar, so it also will
+        # not upcast a float32 backend array the way as_backend_constant would.
+        r22 = 1.0 if self._norot else float(self._rot[2, 2])
         if r22 == 0.0:
             return 0.0
         num = 0.0

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -163,6 +163,36 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     def __getattr__(self, attribute):
         return super().__getattr__(attribute)
 
+    def _vertical_quad_split(self, R, phi=0.0, t=0.0):
+        """z where the WRAPPED potential's mid-plane crosses the vertical line
+        at (R, phi).
+
+        ``_rect_transformed`` maps (R, phi, z) to ``rot @ (x,y,z) + offset``, so
+        the wrapped z' vanishes at
+
+            z = -(rot[2,0] x + rot[2,1] y + offset[2]) / rot[2,2] .
+
+        Rotating or offsetting the potential moves its disk plane away from
+        z = 0, and the vertical quadratures cluster their nodes at the split;
+        splitting at 0 then samples a sharply-peaked density where it is flat.
+        Edge-on (rot[2,2] == 0) has no crossing -- the wrapped plane contains
+        the line of integration -- so keep 0 there.
+        """
+        if self._norot and self._offset is None:
+            return 0.0
+        xp = get_namespace(R, phi)
+        r22 = 1.0 if self._norot else self._rot[2, 2]
+        if r22 == 0.0:
+            return 0.0
+        num = 0.0
+        if not self._norot:
+            x, y, _ = coords.cyl_to_rect(R, phi, 0.0 * R)
+            rot2 = as_backend_constant(xp, self._rot[2, :2], x)
+            num = num + rot2[0] * x + rot2[1] * y
+        if self._offset is not None:
+            num = num + as_backend_constant(xp, self._offset, R)[2]
+        return -num / r22
+
     def _rect_transformed(self, xp, R, z, phi, guard_inf=False):
         """Rectangular coordinates in the rotated/tilted (+offset) frame.
 

--- a/galpy/potential/RotateAndTiltWrapperPotential.py
+++ b/galpy/potential/RotateAndTiltWrapperPotential.py
@@ -43,6 +43,13 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     A final `offset` option allows one to apply a static offset in Cartesian coordinate space to be applied to the potential following the rotation and tilt.
     """
 
+    # Evaluation broadcasts over a trailing node axis: the coordinate stack and
+    # the Hessian stack both build at a common rank, and the rotation is a
+    # matmul that carries batch axes. The scalars-only numpy contract still
+    # holds -- the guard additionally requires every argument to be a backend
+    # array.
+    _backend_accepts_arrays = True
+
     def __init__(
         self,
         amp=1.0,
@@ -207,11 +214,17 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
             y = xp.where(Rinf, 0.0, y)
         else:
             x, y, z = coords.cyl_to_rect(R, phi, z)
+        # With a trailing node axis only z carries it, so the stack would mix
+        # rank 0 and rank 1; (3,3) @ (3,N) is the same matmul as (3,3) @ (3,).
+        x, y, z = xp.broadcast_arrays(x, y, z)
         xyzp = xp.stack([x, y, z])
         if not self._norot:
             xyzp = as_backend_constant(xp, self._rot, xyzp) @ xyzp
         if self._offset is not None:
-            xyzp = xyzp + as_backend_constant(xp, self._offset, xyzp)
+            # Offset is (3,); give it a trailing singleton per node axis so it
+            # broadcasts down the (3, N) stack. No-op when xyzp is (3,).
+            offset = as_backend_constant(xp, self._offset, xyzp)
+            xyzp = xyzp + xp.reshape(offset, (3,) + (1,) * (xyzp.ndim - 1))
         return xyzp
 
     @check_potential_inputs_not_arrays
@@ -255,20 +268,20 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            xp.cos(phi) ** 2.0 * phi2[0, 0]
-            + xp.sin(phi) ** 2.0 * phi2[1, 1]
-            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
+            xp.cos(phi) ** 2.0 * phi2[..., 0, 0]
+            + xp.sin(phi) ** 2.0 * phi2[..., 1, 1]
+            + 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
         )
 
     @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return xp.cos(phi) * phi2[0, 2] + xp.sin(phi) * phi2[1, 2]
+        return xp.cos(phi) * phi2[..., 0, 2] + xp.sin(phi) * phi2[..., 1, 2]
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[2, 2]
+        return self._2ndderiv_xyz(R, z, phi=phi, t=t)[..., 2, 2]
 
     @check_potential_inputs_not_arrays
     def _phi2deriv(self, R, z, phi=0.0, t=0.0):
@@ -276,9 +289,9 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return R**2.0 * (
-            xp.sin(phi) ** 2.0 * phi2[0, 0]
-            + xp.cos(phi) ** 2.0 * phi2[1, 1]
-            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[0, 1]
+            xp.sin(phi) ** 2.0 * phi2[..., 0, 0]
+            + xp.cos(phi) ** 2.0 * phi2[..., 1, 1]
+            - 2.0 * xp.cos(phi) * xp.sin(phi) * phi2[..., 0, 1]
         ) + R * (xp.cos(phi) * Fxyz[0] + xp.sin(phi) * Fxyz[1])
 
     @check_potential_inputs_not_arrays
@@ -287,8 +300,8 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         Fxyz = self._force_xyz(R, z, phi=phi, t=t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
         return (
-            R * xp.cos(phi) * xp.sin(phi) * (phi2[1, 1] - phi2[0, 0])
-            + R * xp.cos(2.0 * phi) * phi2[0, 1]
+            R * xp.cos(phi) * xp.sin(phi) * (phi2[..., 1, 1] - phi2[..., 0, 0])
+            + R * xp.cos(2.0 * phi) * phi2[..., 0, 1]
             + xp.sin(phi) * Fxyz[0]
             - xp.cos(phi) * Fxyz[1]
         )
@@ -297,7 +310,7 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
     def _phizderiv(self, R, z, phi=0.0, t=0.0):
         xp = get_namespace(R, z, phi, t)
         phi2 = self._2ndderiv_xyz(R, z, phi=phi, t=t)
-        return R * (xp.cos(phi) * phi2[1, 2] - xp.sin(phi) * phi2[0, 2])
+        return R * (xp.cos(phi) * phi2[..., 1, 2] - xp.sin(phi) * phi2[..., 0, 2])
 
     def _2ndderiv_xyz(self, R, z, phi=0.0, t=0.0):
         """Get the rectangular forces in the transformed frame"""
@@ -350,12 +363,17 @@ class RotateAndTiltWrapperPotential(WrapperPotential):
         )
         xzderivp = Rzderivp * cp - phizderivp * sp / Rp
         yzderivp = Rzderivp * sp + phizderivp * cp / Rp
+        # Build as (..., 3, 3) -- tensor axes LAST -- so any node axis is a
+        # leading batch axis that matmul carries through. einsum would also
+        # broadcast but picks a different contraction order and is NOT numpy
+        # byte-identical; chained matmul on (3,3) executes exactly as before.
         deriv2p = xp.stack(
             [
-                xp.stack([x2derivp, xyderivp, xzderivp]),
-                xp.stack([xyderivp, y2derivp, yzderivp]),
-                xp.stack([xzderivp, yzderivp, z2derivp]),
-            ]
+                xp.stack([x2derivp, xyderivp, xzderivp], axis=-1),
+                xp.stack([xyderivp, y2derivp, yzderivp], axis=-1),
+                xp.stack([xzderivp, yzderivp, z2derivp], axis=-1),
+            ],
+            axis=-2,
         )
         inv_rot = as_backend_constant(xp, self._inv_rot, deriv2p)
         inv_rot_T = as_backend_constant(xp, self._inv_rot.T, deriv2p)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -299,11 +299,6 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #    AnyAxisym opt-out is deliberate for exactly that reason; this one looks
 #    unverified rather than intentional, which is why it is xfail and not skip.)
 #    All 5 fail in 0.0-0.1 s -- they refuse immediately, they never compute.
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
-jax-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 #
 # 2) jax ConcretizationTypeError -- and the two share ONE root: `mass()` is not
 #    traceable, because it integrates with scipy.integrate.quad, which calls

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -562,3 +562,103 @@ def test_scalar_only_python_float_inputs_forced_backend(backend_name, pot, metho
     with backend.use(backend_name, force=True):
         got = getattr(pot, method)(R, z, phi=phi, t=0.0)  # floats -> decorator coerces
     numpy.testing.assert_allclose(float(got), ref, rtol=1e-12, atol=1e-14)
+
+
+# --- vertical-quadrature split point for displaced / tilted wrappers ----------
+# The traced surfdens quadratures split the vertical interval at the potential's
+# mid-plane and cluster nodes there. Splitting at z=0 is only right when the
+# structure sits at z=0; an offset or tilted RotateAndTilt puts it elsewhere,
+# and sampling a sharply-peaked density where it is flat costs many orders.
+_MWLIKE = MiyamotoNagaiPotential(amp=1.0, a=3.0 / 8.0, b=0.28 / 8.0)
+_S3 = numpy.sqrt(1.0 / 3.0)
+_SPLIT_CASES = [
+    ("offset", dict(zvec=None, galaxy_pa=None, offset=[1.0, 1.0, 1.0])),
+    ("tilted", dict(zvec=[_S3, _S3, _S3], galaxy_pa=0.4, offset=None)),
+    (
+        "tilted+offset",
+        dict(zvec=[_S3, _S3, _S3], galaxy_pa=0.4, offset=[1.0, 1.0, 1.0]),
+    ),
+    ("edge-on", dict(zvec=[0.0, 1.0, 0.0], galaxy_pa=0.3, offset=None)),
+]
+
+
+@pytest.mark.parametrize("case", _SPLIT_CASES, ids=[c[0] for c in _SPLIT_CASES])
+def test_vertical_quad_split_is_the_mid_plane_crossing(case):
+    """The split is where the WRAPPED potential's own z' vanishes.
+
+    Checked against ``_rect_transformed`` rather than against a formula, so this
+    would catch a sign error or a transposed rotation that a self-consistent
+    re-derivation would not.
+    """
+    _, kw = case
+    pot = RotateAndTiltWrapperPotential(pot=_MWLIKE, **kw)
+    for R, phi in ((0.5, 0.0), (1.3, 0.9), (0.2, 2.7)):
+        c = float(pot._vertical_quad_split(R, phi=phi))
+        zp = float(pot._rect_transformed(numpy, R, c, phi)[2])
+        if kw["zvec"] == [0.0, 1.0, 0.0]:
+            # Edge-on: the wrapped plane contains the line of integration, so
+            # there is no unique crossing and the split must stay at 0.
+            assert c == 0.0
+        else:
+            assert abs(zp) < 1e-12, f"z' = {zp:e} at the split {c:e}"
+
+
+def test_vertical_split_makes_the_density_quadrature_accurate():
+    """The split is worth ~8 orders on a displaced disk, and z=0 is not enough.
+
+    Both arms are asserted: the fix must be accurate AND the unfixed rule must
+    be visibly wrong, so this cannot pass by the integrand happening to be easy.
+    """
+    from scipy import integrate
+
+    from galpy.backend import quadrature as bq
+
+    pot = RotateAndTiltWrapperPotential(
+        pot=_MWLIKE, zvec=None, galaxy_pa=None, offset=[1.0, 1.0, 1.0]
+    )
+    R, Z, phi = 0.5, 10.0, 0.0
+    f = lambda x: pot._dens(R, x, phi=phi, t=0.0)  # noqa: E731
+    fv = lambda s: numpy.array(  # noqa: E731
+        [f(v) for v in numpy.atleast_1d(s).ravel()]
+    ).reshape(numpy.shape(s))
+    ref = integrate.quad(f, -Z, Z, limit=400)[0]
+
+    split = float(pot._vertical_quad_split(R, phi=phi))
+    got = bq.symmetric_quad(numpy, fv, Z, n=50, interior_point=split)
+    at_zero = bq.symmetric_quad(numpy, fv, Z, n=50, interior_point=0.0)
+
+    assert abs(got - ref) / abs(ref) < 1e-8, "split-at-mid-plane is not accurate"
+    assert abs(at_zero - ref) / abs(ref) > 1e-2, "split-at-0 was supposed to be bad"
+
+
+def test_composite_delegates_both_surfdens_routes():
+    """A composite integrates each component separately, on both routes.
+
+    Sigma of a sum is the sum of the Sigmas (and the Poisson integrand is
+    additive too), and only the per-component route lets each component split at
+    its own mid-plane -- integrating the summed density splits at the
+    composite's plane, which is 0 for every composite.
+
+    The structural assertions are the discriminating ones: a value comparison
+    alone passes vacuously, because on numpy (and on an untraced backend) both
+    routes go through the same adaptive scipy quadrature and agree regardless.
+    """
+    from galpy.potential import CompositePotential
+    from galpy.potential.Potential import Potential as _P
+
+    assert CompositePotential._surfdens is not _P._surfdens
+    assert CompositePotential._surfdens_poisson is not _P._surfdens_poisson
+
+    off = RotateAndTiltWrapperPotential(
+        pot=_MWLIKE, zvec=None, galaxy_pa=None, offset=[1.0, 1.0, 1.0]
+    )
+    comp = CompositePotential([off, HernquistPotential(amp=0.4, a=0.6)])
+    R, z, phi = 0.5, 2.0, 0.3
+    # numpy must keep the inherited single quadrature, so that path stays
+    # byte-identical; the delegation is a backend-only route.
+    numpy.testing.assert_allclose(
+        comp._surfdens(R, z, phi=phi, t=0.0),
+        _P._surfdens(comp, R, z, phi=phi, t=0.0),
+        rtol=1e-12,
+        atol=1e-14,
+    )

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -579,6 +579,10 @@ _SPLIT_CASES = [
         dict(zvec=[_S3, _S3, _S3], galaxy_pa=0.4, offset=[1.0, 1.0, 1.0]),
     ),
     ("edge-on", dict(zvec=[0.0, 1.0, 0.0], galaxy_pa=0.3, offset=None)),
+    # Degenerate but constructible: identity rotation and no offset, i.e. a
+    # wrapper that displaces nothing. Takes the early return, which must hand
+    # back a plain 0.0 -- callers use that to skip the xp.where entirely.
+    ("no-op", dict(zvec=[0.0, 0.0, 1.0], galaxy_pa=0.0, offset=None)),
 ]
 
 
@@ -590,12 +594,19 @@ def test_vertical_quad_split_is_the_mid_plane_crossing(case):
     would catch a sign error or a transposed rotation that a self-consistent
     re-derivation would not.
     """
-    _, kw = case
+    name, kw = case
     pot = RotateAndTiltWrapperPotential(pot=_MWLIKE, **kw)
     for R, phi in ((0.5, 0.0), (1.3, 0.9), (0.2, 2.7)):
-        c = float(pot._vertical_quad_split(R, phi=phi))
+        raw = pot._vertical_quad_split(R, phi=phi)
+        c = float(raw)
         zp = float(pot._rect_transformed(numpy, R, c, phi)[2])
-        if kw["zvec"] == [0.0, 1.0, 0.0]:
+        if name == "no-op":
+            # Nothing is displaced, so the mid-plane is z = 0 and the method
+            # must say so via the early return -- a plain float, not an array
+            # from the solve below, which is what lets callers skip the
+            # xp.where and keeps this off the traced path entirely.
+            assert type(raw) is float and raw == 0.0
+        elif kw["zvec"] == [0.0, 1.0, 0.0]:
             # Edge-on: the wrapped plane contains the line of integration, so
             # there is no unique crossing and the split must stay at 0.
             assert c == 0.0
@@ -661,4 +672,55 @@ def test_composite_delegates_both_surfdens_routes():
         _P._surfdens(comp, R, z, phi=phi, t=0.0),
         rtol=1e-12,
         atol=1e-14,
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_composite_surfdens_delegation_runs_on_a_backend(backend_name):
+    """Run both delegating branches, and pin what they must return.
+
+    The structural test above proves the overrides exist; nothing was executing
+    them, because ``get_namespace`` only resolves away from numpy once the
+    inputs are backend arrays. The contract both routes owe is the sum over the
+    NON-dissipative components, so a wrong component list, a missing
+    ``use_physical=False``, or a dropped ``isDissipative`` filter each move the
+    number; the friction term is here to make that last one bite.
+
+    The private methods are called directly with backend scalars rather than
+    through ``surfdens``: a composite holding a dissipative force is not
+    backend-compatible, so ``@backend_input`` skips the coercion and ``z``
+    would arrive as a float while ``get_namespace`` still resolves to the
+    forced backend. That mismatch is real but pre-existing (it reproduces on
+    develop without these overrides) and belongs to its own fix, not here.
+    """
+    from galpy import backend
+    from galpy.backend import as_numpy
+    from galpy.potential import (
+        ChandrasekharDynamicalFrictionForce,
+        CompositePotential,
+    )
+
+    off = RotateAndTiltWrapperPotential(
+        pot=_MWLIKE, zvec=None, galaxy_pa=None, offset=[1.0, 1.0, 1.0]
+    )
+    hern = HernquistPotential(amp=0.4, a=0.6)
+    comp = CompositePotential(
+        [off, hern, ChandrasekharDynamicalFrictionForce(GMs=0.01, rhm=0.1, dens=hern)]
+    )
+    R, z, phi = 0.5, 2.0, 0.3
+    parts = (off, hern)
+    # The density route delegates to the public surfdens, which applies each
+    # component's own _amp; the Poisson route delegates to _surfdens_poisson,
+    # which already carries it. Mirror both exactly.
+    want = sum(
+        float(p.surfdens(R, z, phi=phi, t=0.0, use_physical=False)) for p in parts
+    )
+    want_poisson = sum(float(p._surfdens_poisson(R, z, phi=phi, t=0.0)) for p in parts)
+    Rb, zb, phib = (_toscalar(backend_name, v) for v in (R, z, phi))
+    with backend.use(backend_name, force=True):
+        got = comp._surfdens(Rb, zb, phi=phib, t=0.0)
+        got_poisson = comp._surfdens_poisson(Rb, zb, phi=phib, t=0.0)
+    numpy.testing.assert_allclose(float(as_numpy(got)), want, rtol=1e-10, atol=0.0)
+    numpy.testing.assert_allclose(
+        float(as_numpy(got_poisson)), want_poisson, rtol=1e-8, atol=0.0
     )

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -614,6 +614,39 @@ def test_vertical_quad_split_is_the_mid_plane_crossing(case):
             assert abs(zp) < 1e-12, f"z' = {zp:e} at the split {c:e}"
 
 
+def test_vertical_quad_interior_falls_back_to_zero_outside_the_range():
+    """The clamp is a fall-back to 0, NOT a clamp to the boundary.
+
+    Both arms of the ``xp.where`` are asserted. Pinning the reject arm is the
+    point: clamping a runaway crossing to +/-|z| degenerates one panel to zero
+    width and measured 2-6x WORSE than splitting at 0, so "outside the range"
+    has to return 0.0 and not ``+/-absz``.
+    """
+    pot = RotateAndTiltWrapperPotential(
+        pot=_MWLIKE, zvec=None, galaxy_pa=None, offset=[1.0, 1.0, 1.0]
+    )
+    R, phi = 0.5, 0.0
+    c = float(pot._vertical_quad_split(R, phi=phi))
+    assert c != 0.0, "this case is supposed to displace the mid-plane"
+
+    # Crossing inside [-|z|, |z|]: used as-is, to full precision.
+    inside = pot._vertical_quad_interior(numpy, R, 10.0 * abs(c), phi, 0.0)
+    assert float(inside) == c
+
+    # Crossing outside: 0.0, and specifically not the nearer boundary.
+    outside = pot._vertical_quad_interior(numpy, R, 0.5 * abs(c), phi, 0.0)
+    assert float(outside) == 0.0
+
+    # The boundary itself is excluded (a split AT +/-|z| is the zero-width
+    # panel the fall-back exists to avoid).
+    edge = pot._vertical_quad_interior(numpy, R, abs(c), phi, 0.0)
+    assert float(edge) == 0.0
+
+    # An ordinary potential never gets here: it short-circuits to a plain
+    # float, which is what keeps its quadrature byte-identical.
+    assert type(_MWLIKE._vertical_quad_interior(numpy, R, 1.0, phi, 0.0)) is float
+
+
 def test_vertical_split_makes_the_density_quadrature_accurate():
     """The split is worth ~8 orders on a displaced disk, and z=0 is not enough.
 

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -12942,6 +12942,15 @@ class testMWPotential(Potential):
             self._potlist, R, z, phi=phi, t=t, forcepoisson=forcepoisson
         )
 
+    def _surfdens_poisson(self, R, z, phi=0.0, t=0.0):
+        # Completes the delegation: Potential.surfdens(forcepoisson=True) raises
+        # before it reaches _surfdens above, so without this the Poisson route
+        # would integrate at THIS object's mid-plane (0) instead of at each
+        # component's own -- wrong for a displaced or tilted component.
+        return evaluateSurfaceDensities(
+            self._potlist, R, z, phi=phi, t=t, forcepoisson=True
+        )
+
     def vcirc(self, R):
         return potential.vcirc(self._potlist, R)
 


### PR DESCRIPTION
Clears the **5 RotateAndTilt `poisson_surfdens` jax-jit ledger entries** that
gh#1283 diagnosed but deliberately left open.

## The defect

The traced surfdens quadratures split the vertical interval at `z=0` and cluster
their nodes there — correct only when the density sits at `z=0`. An offset or
tilted `RotateAndTiltWrapperPotential` puts its disk plane elsewhere, so the rule
samples a sharply-peaked integrand where it is flattest. At the failing point of
`mockOffsetMWP14WrapperPotential` (`offset=[1,1,1]`, plane at `z=-1`), that
reproduces the observed `tdens = 0.07209774` **to all 8 digits**.

Node count is not the lever: n=200 with the wrong split is still 6.2e-03, while
n=50 with the right split is 1.2e-10.

## The fix, in four links

1. **`RotateAndTiltWrapperPotential` broadcasts over a trailing node axis**
   (re-applies the change gh#1283 reverted — it is a prerequisite, the wrapper
   rejects the node array outright without it).
2. **`Potential._vertical_quad_split`** (0.0 by default) + the wrapper's override,
   solving where the wrapped mid-plane crosses the vertical line at `(R, phi)`.
   Falls back to 0 when the plane misses the interval — clamping to the boundary
   degenerates a panel and measured 2-6x *worse* than not trying.
3. **`CompositePotential` delegates both surfdens routes per component**, so each
   splits at its own mid-plane. Σ of a sum is the sum of the Σs, and the Poisson
   integrand is additive too. This was the blocker: `CompositePotential` defines
   `_dens` but *inherited* `_surfdens`, so the quadrature ran once over the
   summed density at the composite's plane, which is always 0.
4. **`testMWPotential` forwards `_surfdens_poisson`** — completing a delegation
   it already does for `_evaluate`, `_Rforce`, `_zforce`, `_R2deriv`, `_z2deriv`,
   `_dens`, `_surfdens` and `vcirc`. Its `_surfdens` even threads `forcepoisson`
   through, but `Potential.surfdens` raises *before* reaching it on that route,
   so the parameter was dead code.

Accuracy at the failing point, split vs the true density peak:

| mock | split | true peak | err(split 0) | err(split c) |
|---|---|---|---|---|
| RotatedAndTilted | -0.5000 | -0.4950 | 1.383e-02 | **1.070e-10** |
| ...wInclination | -1.0925 | -1.0850 | 4.736e-03 | **1.450e-06** |
| Offset | -1.0000 | -1.0000 | 6.366e-02 | **1.176e-10** |

## numpy is untouched

The delegation is backend-only; numpy keeps the inherited single scipy
quadrature. `test_potential.py` on numpy: **1283 passed, 0 failures, 0 errors**.

## Gates

| run | result |
|---|---|
| `test_potential.py`, numpy, whole file | 1283 passed, **0 failures** |
| `test_potential.py`, `--backend jax --jit`, whole file | 1278 passed, **0 failures**, 5 xfail, 102 skipped |

Re-measured at the current head `bcb2172e` (the table previously read
1276 / 7 xfail, taken before the last two commits and before gh#1283 landed in
the base).

The 5 remaining xfails are all expected, and were read out of the run's junitxml
rather than recalled: 3 AnyAxisym (the known 1-m cancellation, deliberately
**not** touched here) and 2 pickling. `McMillan17` and `Cautun20` are no longer
among them — **they now pass**, because gh#1283 merged and this branch's base
contains it. That is the whole of the 1276 -> 1278 / 7 -> 5 difference; nothing
in this PR changed to cause it.

## Tests

Six new tests in `test_backend_wrappers.py`, **A/B'd: 6 pass with the fix, 6 fail
without it.**

* the split is checked against `_rect_transformed` (does the wrapped `z'`
  actually vanish there, <1e-12) over 3 `(R, phi)` points and 4 geometries
  including the edge-on degenerate case — not against a re-derivation of the
  same formula, which would not catch a sign error;
* the quadrature test asserts **both** arms — accurate at the mid-plane (<1e-8)
  *and* visibly wrong at 0 (>1e-2) — so it cannot pass on an easy integrand;
* the composite test is structural. A value comparison passes **vacuously**:
  untraced, both routes go through the same adaptive scipy quadrature and agree
  whether or not the delegation exists. An earlier draft did exactly that.

## Ledger

**347 → 342**, exactly 5 removed, verified by set difference. The AnyAxisym
`poisson_surfdens` entry is deliberately kept — different root cause.

## Cross-backend

Verified on torch as well as jax — the same 5 nodeids pass under
`--backend torch --jit` (5 passed, 243 s). That matters because defects in this
area have repeatedly been per-backend, so a jax-only result would not have been
evidence for torch.

## Sequencing (after gh#1284)

gh#1284 ledgers these same 5 tests as **`torch-jit` xfails** (it originally
mis-typed 4 of them as `slow-skip`, corrected in `19832bb1` — the sweep that
produced those timings ran in a worktree carrying the then-unmerged broadcast
fix, so on a clean tree they fail fast rather than run slowly).

This branch fixes all 5 on torch too, so once rebased onto post-gh#1284 develop
it should additionally drop these five lines from `tests/backend_xfail.txt`:

    torch-jit ...::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
    torch-jit ...::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
    torch-jit ...::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
    torch-jit ...::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
    torch-jit ...::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]

**Keep** `torch-jit ...[AnyAxisymmetricRazorThinDiskPotential]` — different root
cause (the known 1-m cancellation), untouched here, exactly as its jax twin is
kept.

Checked with `git merge-tree`: this branch already merges onto gh#1284's head
cleanly, so the rebase is mechanical.

## What this PR's CI does and does not prove

Worth stating explicitly, because it is easy to read a green matrix as
validating the headline claim, and here it does not.

**Per-PR CI runs the backend shards EAGER.** `--jit` is set only by a
`workflow_dispatch` with `jit=true` (`JIT_FLAG` in `backend-tests.yml`), so the
5 cleared entries — all `jax-jit` — are not exercised by this PR's own checks.
Eagerly, `_quad_needs_backend` routes both surfdens routes to
`scipy.integrate.quad`, so those tests pass on develop already and would pass
here regardless of whether the fix works.

**What CI does prove** is the mechanism, because the 6 new tests in
`test_backend_wrappers.py` were deliberately written not to need `--jit`:

* the plane-crossing solve is checked against `_rect_transformed` directly;
* the quadrature accuracy is checked by calling `backend.quadrature.symmetric_quad`
  on numpy with each split point, asserting **both** arms (<1e-8 at the mid-plane,
  >1e-2 at zero);
* the composite delegation is checked structurally, since a value comparison
  passes vacuously on the eager path.

Those 6 fail without this change and pass with it (A/B'd), so a green CI here is
real evidence — for the mechanism, not for the traced end-to-end result.

**The traced result is local evidence**, and is stated as such:
`test_potential.py` under `--backend jax --jit` on this branch is
**1276 passed / 0 failures / 7 expected xfail**, and the 5 nodeids also pass
under `--backend torch --jit`. That is the standing "traced green is asserted by
me, not enforced by CI" caveat — and the reason the `--jit` CI dimension is an
open question for the maintainer.

