### PR TITLE
slow-skip: un-defer 24 measured-stale eager-jax entries (109 -> 85)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -209,18 +209,7 @@ jax tests/test_orbit.py::test_integrate_indiv_t_python_paths  # 300s (failed)
 # entry are slow-skipped together here to stop the recurring per-PR flake.
 jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz
 jax tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz
-jax tests/test_noninertial.py::test_accellsrframe_funcomegaz
-jax tests/test_noninertial.py::test_accellsrframe_funcomegaz_2d
-jax tests/test_noninertial.py::test_accellsrframe_vecfuncomegaz
-jax tests/test_noninertial.py::test_accellsrframe_vecfuncomegaz_2D
-jax tests/test_noninertial.py::test_accellsrframe_vecomegaz
-jax tests/test_noninertial.py::test_accellsrframe_vecomegaz_2d
-jax tests/test_noninertial.py::test_cinterp_funcomegaz
-jax tests/test_noninertial.py::test_cinterp_vecfuncomega
 jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz
-jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_vecomegaz
-jax tests/test_noninertial.py::test_lsrframe_vecomegaz
-jax tests/test_noninertial.py::test_lsrframe_vecomegaz_2d
 jax tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -151,7 +151,6 @@ jax tests/test_streamspraydf.py::test_center
 # steps per-force-call (~1 ms each) and exceeds the per-test budget. They validate
 # C-vs-Python STM numerics, which the numpy run already covers; the differentiable
 # in-backend (diffrax/torchdiffeq) STM is covered by tests/test_backend_orbit_stm.py.
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[OblateStaeckelWrapperPotential]  # 289s -- inside the cap, but within 20% of it
 jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_norot_offset]  # 300s (failed)
 jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_offset]  # 290s -- inside the cap, but within 20% of it
 jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]  # 300s (failed)
@@ -165,10 +164,6 @@ jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic  # 620s -- O
 # Python force eval) + a few integrate paths that step in Python under jax. Track A
 # force vectorization / Track D in-backend default will let these un-defer.
 jax tests/test_orbit.py::test_energy_jacobi_conservation[BurkertPotentialNoC--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[FerrersPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[RazorThinExponentialDiskPotential--10.0--9.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockSpecialRotatingFlatSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[nestedListPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_integrate_backwards  # 300s (failed)
 jax tests/test_orbit.py::test_integrate_negative_time  # 300s (failed)
 jax tests/test_orbit.py::test_zmax  # 300s (failed)
@@ -185,14 +180,6 @@ jax tests/test_orbit.py::test_zmax  # 300s (failed)
 # box (~2.4x on the CI runner); even 5-way duration-split, a group clustering several
 # overflows the 4500s shard cap (jax orbit group 3 timed out). Defer the heaviest
 # until Track D vectorization; the faster majority stays un-deferred. numpy runs all.
-jax tests/test_orbit.py::test_energy_jacobi_conservation[AnySphericalPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[DoubleExponentialDiskPotential--6.0--6.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatCorotatingRotationSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatSolidBodyRotationPlanarSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatSolidBodyRotationSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockFlatSpiralArmsPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockRotatedAndTiltedMWP14WrapperPotential--10.0--10.0-False]
-jax tests/test_orbit.py::test_energy_jacobi_conservation[mockRotatingFlatSpiralArmsPotential--10.0--10.0-False]
 jax tests/test_orbit.py::test_integrate_indiv_t_python_paths  # 300s (failed)
 
 # --- jax NonInertialFrameForce func/vec-omega (eager-XLA timeout) ---


### PR DESCRIPTION
Two eager-jax `backend_slow_skip.txt` burndowns, in one PR because they edit
the same file and would otherwise conflict.

Both lists were **inherited, never measured**. Re-measured whole-file on a clean
worktree at `9dc31569` under `--backend jax` with the candidate entries removed,
then classified by junitxml **duration** against the 240 s bar.

| file | measured | stale (dropped) | still slow (kept) |
|---|---|---|---|
| `test_noninertial.py` | 19 | **11** | 8 |
| `test_orbit.py` | 25 | **13** | 12 |
| **total** | **44** | **24 (55 %)** | 20 |

`slow_skip` non-comment rows: **109 -> 85** (this PR removes 24; the absolute
numbers moved twice as develop advanced -- gh#1284, then gh#1288 re-adding the
torch FDM entry -- but the -24 delta is unchanged and is the claim being made). Verified by set difference against
`origin/feat/backends-develop`: **-24 / +0**, no additions, no other file touched.

### Every dropped entry is fast *and* green

Un-deferring on speed alone would be half a check -- a `slow_skip` entry
*skips* the test, so a dropped entry that fails would turn a hidden skip into a
new red. Each of the 24 was matched back into the junitxml of the run that
measured it (noninertial rows from the **eager** run, not the traced one):

| test | s | result |
|---|---|---|
| `test_accellsrframe_funcomegaz` | 16.5 | pass |
| `test_accellsrframe_funcomegaz_2d` | 9.6 | pass |
| `test_accellsrframe_vecfuncomegaz` | 30.6 | pass |
| `test_accellsrframe_vecfuncomegaz_2D` | 18.5 | pass |
| `test_accellsrframe_vecomegaz` | 14.5 | pass |
| `test_accellsrframe_vecomegaz_2d` | 7.4 | pass |
| `test_cinterp_funcomegaz` | 0.7 | pass |
| `test_cinterp_vecfuncomega` | 0.2 | pass |
| `test_linacc_changingacc_xyz_accellsrframe_vecomegaz` | 235.8 | pass |
| `test_lsrframe_vecomegaz` | 16.6 | pass |
| `test_lsrframe_vecomegaz_2d` | 9.3 | pass |
| `test_dxdv_3d_c_vs_python[OblateStaeckelWrapperPotential]` | 237.9 | pass |
| `test_energy_jacobi_conservation[AnySphericalPotential--10.0--10.0-False]` | 127.5 | pass |
| `test_energy_jacobi_conservation[DoubleExponentialDiskPotential--6.0--6.0-False]` | 41.1 | pass |
| `test_energy_jacobi_conservation[FerrersPotential--10.0--10.0-False]` | 109.2 | pass |
| `test_energy_jacobi_conservation[RazorThinExponentialDiskPotential--10.0--9.0-False]` | 112.2 | pass |
| `test_energy_jacobi_conservation[mockFlatCorotatingRotationSpiralArmsPotential--10.0--10.0-False]` | 126.2 | pass |
| `test_energy_jacobi_conservation[mockFlatSolidBodyRotationPlanarSpiralArmsPotential--10.0--10.0-False]` | 38.6 | pass |
| `test_energy_jacobi_conservation[mockFlatSolidBodyRotationSpiralArmsPotential--10.0--10.0-False]` | 117.8 | pass |
| `test_energy_jacobi_conservation[mockFlatSpiralArmsPotential--10.0--10.0-False]` | 132.8 | pass |
| `test_energy_jacobi_conservation[mockRotatedAndTiltedMWP14WrapperPotential--10.0--10.0-False]` | 58.5 | pass |
| `test_energy_jacobi_conservation[mockRotatingFlatSpiralArmsPotential--10.0--10.0-False]` | 126.7 | pass |
| `test_energy_jacobi_conservation[mockSpecialRotatingFlatSpiralArmsPotential--10.0--10.0-False]` | 129.5 | pass |
| `test_energy_jacobi_conservation[nestedListPotential--10.0--10.0-False]` | 201.1 | pass |

**24/24 located, 24/24 pass**, slowest 237.9 s.

### Classification is by duration, not pass/fail

`test_orbit`'s two "failures" are `Failed: Timeout (>900.0s) from
pytest-timeout` -- cap-hits, i.e. *slow*, and both are **kept**.
`--timeout-method=signal` cannot interrupt a test inside a C extension, so a
slow test can surface as an `F` (or as a PASS that ran well past its cap).
Reading those two as defects would have deleted two entries that need to stay.

### One judgement call, named rather than buried

`test_dxdv_3d_c_vs_python[OblateStaeckelWrapperPotential...]` at **237.9 s**
sits 2.1 s under the bar. It is dropped, and it is the first entry to re-defer
if that shard ever runs long.

Durations come from an `xdist -n 8` run, which inflates them -- conservative for
everything dropped. Ten of the 13 `test_orbit` drops are
`test_energy_jacobi_conservation[...]` parametrisations.

### Cost: what this puts back into the jax shards

Un-deferring is not free — these tests start running again. Measured (xdist -n 8):

| file | entries | sum | slowest |
|---|---|---|---|
| `test_noninertial.py` | 11 | 359.7 s (6.0 min) | 235.8 s |
| `test_orbit.py` | 13 | 1559.3 s (26.0 min) | 237.9 s |
| **total** | **24** | **1919.0 s (32.0 min)** | |

CI runs ~0.71x this box, so ~23 min of added wall time, spread across the jax
`test_orbit`/`test_orbits` and `test_noninertial` shards (each of which is
already split into groups, so no single shard absorbs all of it).

Stating it because the failure mode if it is too much is a **session timeout on
a shard**, which reads as an unrelated red rather than as "this PR added
runtime". If a jax shard goes long on this PR, that is the cause, and the lever
is to re-defer the largest entries -- `test_dxdv_3d_c_vs_python[OblateStaeckel...]`
(237.9 s) and `test_linacc_changingacc_xyz_accellsrframe_vecomegaz` (235.8 s)
first.

