### PR TITLE
slow-skip: re-defer torch FDM central_limit (gh#1284's un-defer was wrong)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -36,6 +36,14 @@ jax tests/test_orbits.py::test_SOS_3D  # 269s -- inside the cap, but within 20% 
 # integration that finishes under the timeout, so only central_limit is deferred.)
 jax tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
 jax tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
+# RE-DEFERRED 2026-08-09 (gh#1284 removed this line; that was wrong). The comment
+# above says torch central_limit "finishes under the timeout" -- measured, it does
+# not: >438 s on an IDLE 72-core box against the 300 s cap, and it timed out in CI
+# on gh#1286. gh#1284's un-defer rested on a run where the test crashed early on
+# the numpy-on-Tensor collision it was simultaneously fixing (6.47 s to raise
+# TypeError), so the "fast" reading measured a fail-fast, not the work. Torch is
+# the same un-vectorized dissipative path as jax above; it belongs here with them.
+torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
 
 # --- jax quasi-isothermal DF (Track F df migration) ---
 # quasiisothermaldf is not yet backend-migrated; this test does many nested


### PR DESCRIPTION
## What

Re-adds one line to `tests/backend_slow_skip.txt`:

```
torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
```

`slow_skip` 108 → 109. Verified by set difference: **+1 / −0**, no other line touched, no source change.

## Why — I removed it, and it was wrong

gh#1284 (merged earlier today) un-deferred this entry. It is now failing on gh#1286:

```
tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit
Failed: Timeout (>300.0s) from pytest-timeout
Backend torch: 19 passed, 1 deferred, 1 FAILED, 0 ERROR (NOT in ledger)
```

## The measurement that misled me, and the one that settles it

| tree | duration | outcome |
|---|---|---|
| without gh#1284's `as_numpy` fix | **6.47 s** | FAILED — `TypeError: max() received an invalid combination of arguments` |
| with the fix applied | **>438 s** | still running, idle 72-core box |

The 6.47 s is what this test costs **when it crashes early**. Without gh#1284's own `as_numpy(o.r(t))` change, the assertion hits the very numpy-on-Tensor collision that PR was fixing, and the integration never runs. *A test that fails fast is not a fast test* — I read a fail-fast as a speed measurement.

With the fix applied so the assertion actually works, the same test exceeds **438 s on a completely idle box** — 46 % past the 300 s cap with zero competing load. This is not load-marginal and not a flake; it is over the cap outright. gh#1284's CI passing once was a single sample of a test that sits past the limit.

## The comment that made it look safe

The block comment above the `jax` entries ends:

> *(torch `const_FDMfactor` is a shorter integration that finishes under the timeout, so only `central_limit` is deferred.)*

That sentence is about **`const_FDMfactor`**, and I read it as covering `central_limit`. Corrected in place, with both numbers, so the next person doesn't repeat either mistake.

Torch runs the same un-vectorized dissipative path as the two `jax` entries directly above it (scipy.sici + numpy.interp + per-call Python branching, evaluated thousands of times under a forced backend). It belongs with them, and it comes off the list the same way they do: when the dissipative forces are actually migrated, not by re-reading the comment.

## Effect

Unblocks **gh#1286**, whose own 24 un-defers are all CI-verified green and whose only red is this inherited failure (plus the `all-clear` that aggregates it).

Deliberately a separate one-line PR rather than a ride-along in gh#1286 — that PR is a jax-side burndown and has no business touching torch entries. This puts three PRs open against the usual two; it is remediation of a defect I merged, not new work.
