### PR TITLE
xfail: un-defer the 5 torch-jit poisson_surfdens wrapper entries (21 -> 16)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -348,8 +348,3 @@ torch-jit tests/test_orbit.py::test_eccentricity
 # these FAIL fast (35.6 s for all four) -- they are defects, not slow tests. The
 # 2026-08-09 sweep measured them at 300-400 s because its worktree carried the
 # then-unmerged broadcast fix; on a clean tree they never get that far.
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
-torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]


### PR DESCRIPTION
## What

Drops the 5 **torch-jit** `poisson_surfdens` wrapper entries from `tests/backend_xfail.txt`:

```
torch-jit tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
torch-jit ...[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]
torch-jit ...[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]
torch-jit ...[mockRotatedTiltedOffsetMWP14WrapperPotential]
torch-jit ...[mockOffsetMWP14WrapperPotential]
```

`backend_xfail.txt` **21 → 16**. No source change; ledger only.

## Why they pass now

They pass **because of gh#1285**, which splits the vertical surfdens quadrature at each potential's own mid-plane instead of at z=0. These wrappers displace or tilt their structure, so splitting at 0 put every node on one side of the peak. That is the whole reason they were xfailed.

The claim is therefore **coupled to gh#1285** and this PR must land after it. Verified two ways:

**Two-sided A/B under `torch --jit`**, with a control:

| side | result |
|---|---|
| BASE (clean develop) | **5 failed**, 1 xfailed |
| FIX (gh#1285) | **5 passed**, 1 xfailed |

The 1 xfailed on both sides is `AnyAxisymmetricRazorThinDiskPotential`, held deliberately as a control — it stays xfailed on both sides, so the flip is attributable to the fix and not to the run.

**Re-confirmed on gh#1285's current head** (it has moved since that A/B — a coverage commit and a base merge):

```
5 passed, 1380 deselected, 19 warnings in 242.53s
```

## Why this is a separate PR from gh#1285

gh#1285 cleared the **jax-jit** rows for the same tests; this clears the **torch-jit** rows. Same tests, different mode prefix, so the two edits are disjoint despite touching the same file. gh#1285 has since merged (`fb159ff7`), taking the ledger 26 → 21, and this PR rebased onto it cleanly: 21 → 16, with **both** `AnyAxisymmetricRazorThinDiskPotential` entries (torch-jit and jax-jit) surviving — which is the property that has to hold, since that potential deliberately opts out of array input and genuinely cannot pass.

Splitting them also means the torch-jit drop carries its own `torch --jit` evidence. gh#1285 only gated eager torch, so folding these rows into it would have un-deferred them on the strength of a run that never exercised the traced torch path.
