### PR TITLE
backend quadrature: one GL order for symmetric_quad, matching quad's

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -474,7 +474,7 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None, device=N
     return match_input_dtype(result, a, b, c)
 
 
-def symmetric_quad(xp, integrand, b, *, n=50, interior_point=0.0, device=None):
+def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=None):
     r"""``int_{-|b|}^{|b|} integrand(s) ds``, for finite **or infinite** ``b``.
 
     A finite ``b`` is handed to `transformed_quad`, which splits at
@@ -502,7 +502,10 @@ def symmetric_quad(xp, integrand, b, *, n=50, interior_point=0.0, device=None):
         limit, not one already mapped through the namespace: the finite/infinite
         choice is made from it and a namespace op would have made it a tracer.
     n : int, optional
-        Gauss-Legendre order (default 50).
+        Gauss-Legendre order (default ``_QUAD_N``, as for `quad`). 50 is not
+        enough for the vertical surface-density integrals: measured against
+        mpmath, it degrades to 1.4e-08 at |z|=20 and 2.6e-05 at (R=0.01,
+        |z|=50), where ``_QUAD_N`` stays at machine precision.
     interior_point : float, optional
         Split point for the finite branch (default 0.0).
     device : optional

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -787,7 +787,6 @@ class Potential(Force):
                     _bquad.node_axis(R), x, phi=_bquad.node_axis(phi), t=t
                 ),
                 numpy.inf,  # a local constant, so concrete even inside a trace
-                n=50,
             )
         try:
             if forcepoisson:
@@ -829,7 +828,6 @@ class Potential(Force):
                 xp,
                 poisson_integrand(_bquad.node_axis(R), _bquad.node_axis(phi)),
                 absz,
-                n=50,
                 interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
             )
         return (
@@ -915,7 +913,6 @@ class Potential(Force):
                 _bquad.node_axis(R), x, phi=_bquad.node_axis(phi), t=t
             ),
             absz,
-            n=50,
             interior_point=self._vertical_quad_interior(xp, R, absz, phi, t),
         )
 

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -15,6 +15,7 @@ from galpy.backend.quadrature import (
     gauss_legendre_nodes,
     nested_quad,
     quad,
+    symmetric_quad,
     transformed_quad,
 )
 
@@ -584,3 +585,55 @@ def test_device_hint_cuda():
         txp, lambda s: sc * torch.exp(-s), 0.0, 5.0, n=60, device=cuda
     ).backward()
     numpy.testing.assert_allclose(float(sc.grad.cpu()), e5 / 2.0, rtol=1e-6)
+
+
+def test_symmetric_quad_default_order_resolves_extreme_aspect_ratio():
+    """The default order must handle R << |z| on a real galpy integrand.
+
+    This is the case the vertical surface-density quadrature actually ships:
+    ``Potential._surfdens``/``_surfdens_poisson`` integrate the density over
+    ``[-|z|, |z|]`` with this rule, and under a trace there is no scipy to fall
+    back to. At R=0.01, |z|=50 the integrand has structure on scale ~R across a
+    5000:1 range, which is where a fixed-order rule runs out first.
+
+    All three arms are asserted, because the pass alone would not show the bar
+    discriminates:
+
+    * n=200 vs the reference -- validates the ARBITER. scipy is the reference
+      here, so it has to be shown converging to the same value the rule does;
+      otherwise a disagreement could be scipy's fault, not the rule's.
+    * the default order -- the actual contract.
+    * n=50 -- must FAIL the bar. Without this the test would still pass if the
+      default were lowered back to 50, which is exactly the regression it
+      exists to catch.
+    """
+    from scipy import integrate
+
+    from galpy.potential import MWPotential2014
+
+    p = MWPotential2014[0]  # PowerSphericalPotentialwCutoff: cusped and truncated
+    R, Z = 0.01, 50.0
+    f = lambda x: p._dens(R, float(x), phi=0.0, t=0.0)  # noqa: E731
+    fv = lambda s: numpy.array(  # noqa: E731
+        [f(v) for v in numpy.atleast_1d(s).ravel()]
+    ).reshape(numpy.shape(s))
+
+    # epsabs=0 -- a pure RELATIVE criterion. scipy's default epsabs=1.49e-8 is
+    # absolute and silently truncates integrals whose value is near it (galpy
+    # gh#1289); it does not bite at this R, but the reference must not depend on
+    # that luck.
+    ref = integrate.quad(f, -Z, Z, epsabs=0, epsrel=1e-13, limit=2000)[0]
+
+    def rel(**kw):
+        got = float(symmetric_quad(numpy, fv, Z, interior_point=0.0, **kw))
+        return abs(got - ref) / abs(ref)
+
+    assert rel(n=200) < 1e-12, "reference and the rule disagree -- arbiter suspect"
+    # No n= : this asserts on the DEFAULT, which is the thing that can regress.
+    # Passing n=_QUAD_N here instead would still pass if someone lowered the
+    # default, since it would be pinning the constant rather than the default.
+    assert rel() < 1e-9, f"symmetric_quad's DEFAULT order is too low here: {rel():.2e}"
+    assert rel(n=50) > 1e-7, (
+        f"n=50 was supposed to be visibly wrong here ({rel(n=50):.2e}); if it is "
+        "not, this test no longer discriminates and the bar needs re-deriving"
+    )


### PR DESCRIPTION
## What

`galpy/backend/quadrature.py` already owns `_QUAD_N = 100`, documented for exactly this class of integrand ("smooth galpy integrands (mass/surface-density profiles)"), and `quad` already defaults to it. Only `symmetric_quad` disagreed, at 50 — and all three of its callers *also* passed `n=50` explicitly. So the magic number appeared four times and the two defaults contradicted each other.

This makes `symmetric_quad` default to `_QUAD_N` and **deletes** the three now-redundant overrides. Net **+5/−5 lines in source, no new constant.**

## Why 50 is not enough

Measured against mpmath at 30 dps, both branches of the rule, relative error:

```
                  finite clustered, worst corner        infinite branch (mass)
                       (R=0.01, |z|=50)
                    n=50       n=100                    n=50       n=100
MWPotential2014[0]  3.41e-06   7.29e-12                 2.20e-14   1.81e-15
MiyamotoNagai       2.94e-08   1.10e-15                 6.78e-13   9.86e-16
NFW                 8.05e-07   1.41e-12                 7.85e-16   5.23e-16
```

The clustered-node design is sound — at `R >= 0.1, |z| <= 5` even n=50 is 1e-12 or better. It breaks only when **R ≪ |z|**: structure on scale ~R across a 5000:1 range. `_QUAD_N` fixes it with margin, and costs nothing on the infinite branch.

## Numpy is byte-identical

All three call sites return through `scipy.integrate.quad` before they can reach `symmetric_quad` — site 1 via an explicit `if xp is numpy`, sites 2 and 3 via `_quad_needs_backend`, which is False for numpy. The default only moves values on **traced** backends, which is where the error above was actually shipping.

## Gate

* **Traced jax `test_potential.py`, before vs after**: 1385 shared nodeids, **0 outcome flips**, +0.2 % wall clock. This is the gate that matters — the 12 jax `test_potential` ledger entries all live on this code path, and any tolerance near 1e-5 could have moved. None did.
* Committed state: `test_backend_quadrature.py` 62 passed, `test_backend_wrappers.py` 530 passed.

## Test

`test_symmetric_quad_default_order_resolves_extreme_aspect_ratio` pins the **default**, not a passed-in order — the earlier draft passed `n=_QUAD_N` explicitly, which would have kept passing if someone reverted the default. Three arms against a `scipy.integrate.quad` reference at `epsrel=1e-13`:

```python
assert rel(n=200) < 1e-12   # validates the ARBITER first
assert rel()      < 1e-9    # the DEFAULT -- the actual contract
assert rel(n=50)  > 1e-7    # must FAIL, or the bar doesn't discriminate
```

A/B'd both ways: with the default at `_QUAD_N` it passes; with the default put back to 50 it fails.
