### PR TITLE
Two wrong tolerances: surfdens quadrature (epsabs) and the streamgapdf sample distance

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -668,6 +668,7 @@ class Potential(Force):
                         ),
                         -numpy.fabs(z),
                         numpy.fabs(z),
+                        epsabs=0.0,
                     )[0]
                 )
                 / 4.0
@@ -700,8 +701,18 @@ class Potential(Force):
         - 2021-04-19 - Adjusted for non-z-symmetric densities by Bovy (UofT).
 
         """
+        # epsabs=0 so the criterion is purely RELATIVE. quad's default
+        # epsabs=1.49e-8 is absolute, so a vertical integral whose own value is
+        # at or below ~1e-8 in internal units passes the absolute test on the
+        # first crude estimate and returns immediately, reporting success while
+        # being ~1e-5 wrong. That happens for truncated profiles and for any
+        # potential far from the plane -- MWPotential2014[0] at R=1, |z|=5
+        # integrates to 8.2e-9 and came back 9.6e-6 relative off.
         return integrate.quad(
-            lambda x: self._dens(R, x, phi=phi, t=t), -numpy.fabs(z), numpy.fabs(z)
+            lambda x: self._dens(R, x, phi=phi, t=t),
+            -numpy.fabs(z),
+            numpy.fabs(z),
+            epsabs=0.0,
         )[0]
 
     @potential_physical_input

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1670,6 +1670,41 @@ def test_poisson_potential(potname):
     return None
 
 
+# Test that the generic vertical surfdens quadrature stays accurate when the
+# integral itself is tiny. scipy.integrate.quad's default epsabs=1.49e-8 is an
+# ABSOLUTE criterion, so an integral of order 1e-8 or below is satisfied by the
+# first crude estimate and quad returns immediately, reporting success -- the
+# surface density was then ~1e-5 wrong with no warning. Fixed by epsabs=0.
+def test_surfdens_small_integral_is_not_truncated():
+    from scipy import integrate
+
+    # PowerSphericalPotentialwCutoff has rc = 1.9/8, so its density is already
+    # ~1e-31 at r=2: the vertical integral at R=1 is ~2.5e-10, well under the
+    # default absolute tolerance, which is exactly the regime that broke.
+    p = potential.MWPotential2014[0]
+    for R, Z in ((1.0, 2.0), (1.0, 5.0), (1.0, 8.0)):
+        # Reference: the same quadrature driven to its relative limit. Verified
+        # against mpmath at 30 dps to 1.2e-15 when this test was written.
+        ref = (
+            p._amp
+            * integrate.quad(
+                lambda x: p._dens(R, x, phi=0.0, t=0.0),
+                -Z,
+                Z,
+                epsabs=0.0,
+                epsrel=1e-13,
+                limit=2000,
+            )[0]
+        )
+        got = p.surfdens(R, Z, use_physical=False)
+        assert numpy.fabs(got / ref - 1.0) < 1e-12, (
+            f"surfdens(R={R}, z={Z}) = {got:e} differs from the converged "
+            f"quadrature {ref:e} by {numpy.fabs(got / ref - 1.0):e} relative; "
+            "the vertical integral is being truncated by an absolute tolerance"
+        )
+    return None
+
+
 # Test whether the (integrated) Poisson equation is satisfied if _surfdens and the relevant second derivatives are implemented
 @pytest.mark.parametrize("potname", _POISSON_SURFDENS_POTS)
 def test_poisson_surfdens_potential(potname):

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -18597,7 +18597,7 @@ def test_streamgapdf_sample():
     ), "streamgapdf sample lb does not return a correct Quantity"
     assert (
         numpy.fabs(lb[2].to(units.kpc).value - lbnou[2])
-        < _NUMPY_1_22 * 1e-5 + (1 - _NUMPY_1_22) * 1e-8
+        < _NUMPY_1_22 * 1e-4 + (1 - _NUMPY_1_22) * 1e-5
     ), "streamgapdf sample lb does not return a correct Quantity"
     assert (
         numpy.fabs(lb[3].to(units.km / units.s).value - lbnou[3])
@@ -18626,7 +18626,7 @@ def test_streamgapdf_sample():
     ), "streamgapdf sample lbdt does not return a correct Quantity"
     assert (
         numpy.fabs(lbdt[2].to(units.kpc).value - lbdtnou[2])
-        < _NUMPY_1_22 * 1e-5 + (1 - _NUMPY_1_22) * 1e-8
+        < _NUMPY_1_22 * 1e-4 + (1 - _NUMPY_1_22) * 1e-5
     ), "streamgapdf sample lbdt does not return a correct Quantity"
     assert (
         numpy.fabs(lbdt[3].to(units.km / units.s).value - lbdtnou[3])


### PR DESCRIPTION
Two independent places where a tolerance was wrong for the magnitude it was applied to. Files are disjoint.

## 1. `surfdens` integrates with an absolute tolerance — closes #1289

`scipy.integrate.quad`'s default `epsabs=1.49e-8` is **absolute**, so a vertical integral whose own value is at or below ~1e-8 in internal units is satisfied by the first crude estimate: quad returns immediately reporting success while the surface density is ~1e-5 wrong. Nothing warns.

`MWPotential2014[0]` has `rc = 1.9/8`, so its density is already ~1e-31 at r=2 and the R=1 vertical integral is ~2.5e-10 — squarely in that regime. Measured against mpmath at 30 dps, before → after:

| R | \|z\| | before | after |
|---|---|---|---|
| 1 | 2 | 2.8e-10 | 8.4e-16 |
| 1 | 5 | **9.5e-06** | 1.3e-15 |
| 1 | 8 | **2.2e-05** | 0 |

Both surfdens sites get `epsabs=0`. No new `IntegrationWarning` on either side.

`Potential.mass` was checked for the same defect and is **not** exposed — its Gauss'-theorem integrals are 1e-4 to 1e-2, far above the default absolute tolerance, agreeing with a tight reference to ≤1.4e-14. Left alone.

## 2. `test_streamgapdf_sample` distance bar — closes #1290

The sampled distance was compared with a **1e-8 absolute** bar on an 11.6 kpc value (~9e-10 relative), while every sibling component in the same block used 1e-5 absolute (~1e-7 relative on their magnitudes). The distance bar was two orders tighter than the rest — and tighter than two independently constructed `streamgapdf` objects can guarantee, since they agree to 8 significant figures and their agreement is limited by construction arithmetic, not by the unit round-trip the test exists to check. On windows-latest/py3.14 that tipped over intermittently (observed 4.39e-08 vs the 1e-08 bar).

Both distance sites (`lb` and `lbdt`) now use the sibling pair. The tight branch is selected on numpy 2.x, where `_NUMPY_1_22` is 0, which is why it only began flaking recently.

## Gates

* `test_potential.py` — 1328 tests, 0 failures. The new surfdens test A/B's: **fails** without the fix (2.75e-10 vs a 1e-12 bar).
* `test_quantity.py` — **242 tests, 0 failures**, run as the whole file (a single nodeid is not a valid context here — the module fixture never runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm