### PR TITLE
RazorThinExponentialDisk: substitute out the k=R endpoint singularity

### DIFF
--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -67,6 +67,28 @@ class RazorThinExponentialDiskPotential(Potential):
         ):  # pragma: no cover
             self.normalize(normalize)
 
+    def _inner_nodes(self, R):
+        """Substituted Gauss-Legendre nodes/weights for the inner panel [0, R].
+
+        As ``|z| -> 0`` the force integrands carry a factor
+        ``1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm)`` with a square-root singularity
+        exactly at the panel edge ``k=R``, against which fixed-order
+        Gauss-Legendre converges only algebraically -- n=3000 still leaves 1e-4.
+        Substituting ``k = R(1-v^2)`` puts the Jacobian's zero (``2Rv``)
+        precisely where that factor blows up, so the product is smooth and the
+        same 100 nodes reach ~5e-5 instead of ~5e-3: better than n=3000, at no
+        extra integrand evaluations. Weights follow this module's convention of
+        carrying the full panel width rather than half of it.
+        """
+        v = 0.5 * (self._glx + 1.0)
+        return R * (1.0 - v**2.0), 2.0 * R * v * self._glw
+
+    def _outer_nodes(self, R, kmax):
+        """The same, for the outer panel [R, kmax], via ``k = R + u^2``."""
+        umax = numpy.sqrt(kmax - R)
+        u = umax * 0.5 * (self._glx + 1.0)
+        return R + u**2.0, 2.0 * umax * u * self._glw
+
     def _evaluate(self, R, z, phi=0.0, t=0.0):
         if self._new:
             if numpy.fabs(z) < 10.0**-6.0:
@@ -103,16 +125,7 @@ class RazorThinExponentialDiskPotential(Potential):
                     * (special.i0(y) * special.k0(y) - special.i1(y) * special.k1(y))
                 )
             kalphamax1 = R
-            # k = R(1-v^2). As z->0 the 1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm) factor
-            # below has a square-root singularity exactly at the panel edge k=R,
-            # against which fixed-order Gauss-Legendre converges only
-            # algebraically (n=3000 still leaves 1e-4). This substitution's
-            # Jacobian 2Rv vanishes precisely where that factor blows up, so the
-            # product is smooth and the same 100 nodes reach ~5e-5 instead of
-            # ~5e-3 -- better than n=3000, at no extra integrand evaluations.
-            v1 = 0.5 * (self._glx + 1.0)
-            ks1 = kalphamax1 * (1.0 - v1**2.0)
-            weights1 = 2.0 * kalphamax1 * v1 * self._glw
+            ks1, weights1 = self._inner_nodes(R)
             sqrtp = numpy.sqrt(z**2.0 + (ks1 + R) ** 2.0)
             sqrtm = numpy.sqrt(z**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
@@ -124,11 +137,7 @@ class RazorThinExponentialDiskPotential(Potential):
             )
             if R < 10.0:
                 kalphamax2 = 10.0
-                # k = R + u^2: the same singularity seen from the right panel.
-                umax = numpy.sqrt(kalphamax2 - kalphamax1)
-                u2 = umax * 0.5 * (self._glx + 1.0)
-                ks2 = kalphamax1 + u2**2.0
-                weights2 = 2.0 * umax * u2 * self._glw
+                ks2, weights2 = self._outer_nodes(R, kalphamax2)
                 sqrtp = numpy.sqrt(z**2.0 + (ks2 + R) ** 2.0)
                 sqrtm = numpy.sqrt(z**2.0 + (ks2 - R) ** 2.0)
                 evalInt2 = (
@@ -161,16 +170,7 @@ class RazorThinExponentialDiskPotential(Potential):
             if numpy.fabs(z) < 10.0**-6.0:
                 return 0.0
             kalphamax1 = R
-            # k = R(1-v^2). As z->0 the 1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm) factor
-            # below has a square-root singularity exactly at the panel edge k=R,
-            # against which fixed-order Gauss-Legendre converges only
-            # algebraically (n=3000 still leaves 1e-4). This substitution's
-            # Jacobian 2Rv vanishes precisely where that factor blows up, so the
-            # product is smooth and the same 100 nodes reach ~5e-5 instead of
-            # ~5e-3 -- better than n=3000, at no extra integrand evaluations.
-            v1 = 0.5 * (self._glx + 1.0)
-            ks1 = kalphamax1 * (1.0 - v1**2.0)
-            weights1 = 2.0 * kalphamax1 * v1 * self._glw
+            ks1, weights1 = self._inner_nodes(R)
             sqrtp = numpy.sqrt(z**2.0 + (ks1 + R) ** 2.0)
             sqrtm = numpy.sqrt(z**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
@@ -182,11 +182,7 @@ class RazorThinExponentialDiskPotential(Potential):
             )
             if R < 10.0:
                 kalphamax2 = 10.0
-                # k = R + u^2: the same singularity seen from the right panel.
-                umax = numpy.sqrt(kalphamax2 - kalphamax1)
-                u2 = umax * 0.5 * (self._glx + 1.0)
-                ks2 = kalphamax1 + u2**2.0
-                weights2 = 2.0 * umax * u2 * self._glw
+                ks2, weights2 = self._outer_nodes(R, kalphamax2)
                 sqrtp = numpy.sqrt(z**2.0 + (ks2 + R) ** 2.0)
                 sqrtm = numpy.sqrt(z**2.0 + (ks2 - R) ** 2.0)
                 evalInt2 = (

--- a/galpy/potential/RazorThinExponentialDiskPotential.py
+++ b/galpy/potential/RazorThinExponentialDiskPotential.py
@@ -103,8 +103,16 @@ class RazorThinExponentialDiskPotential(Potential):
                     * (special.i0(y) * special.k0(y) - special.i1(y) * special.k1(y))
                 )
             kalphamax1 = R
-            ks1 = kalphamax1 * 0.5 * (self._glx + 1.0)
-            weights1 = kalphamax1 * self._glw
+            # k = R(1-v^2). As z->0 the 1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm) factor
+            # below has a square-root singularity exactly at the panel edge k=R,
+            # against which fixed-order Gauss-Legendre converges only
+            # algebraically (n=3000 still leaves 1e-4). This substitution's
+            # Jacobian 2Rv vanishes precisely where that factor blows up, so the
+            # product is smooth and the same 100 nodes reach ~5e-5 instead of
+            # ~5e-3 -- better than n=3000, at no extra integrand evaluations.
+            v1 = 0.5 * (self._glx + 1.0)
+            ks1 = kalphamax1 * (1.0 - v1**2.0)
+            weights1 = 2.0 * kalphamax1 * v1 * self._glw
             sqrtp = numpy.sqrt(z**2.0 + (ks1 + R) ** 2.0)
             sqrtm = numpy.sqrt(z**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
@@ -116,8 +124,11 @@ class RazorThinExponentialDiskPotential(Potential):
             )
             if R < 10.0:
                 kalphamax2 = 10.0
-                ks2 = (kalphamax2 - kalphamax1) * 0.5 * (self._glx + 1.0) + kalphamax1
-                weights2 = (kalphamax2 - kalphamax1) * self._glw
+                # k = R + u^2: the same singularity seen from the right panel.
+                umax = numpy.sqrt(kalphamax2 - kalphamax1)
+                u2 = umax * 0.5 * (self._glx + 1.0)
+                ks2 = kalphamax1 + u2**2.0
+                weights2 = 2.0 * umax * u2 * self._glw
                 sqrtp = numpy.sqrt(z**2.0 + (ks2 + R) ** 2.0)
                 sqrtm = numpy.sqrt(z**2.0 + (ks2 - R) ** 2.0)
                 evalInt2 = (
@@ -150,8 +161,16 @@ class RazorThinExponentialDiskPotential(Potential):
             if numpy.fabs(z) < 10.0**-6.0:
                 return 0.0
             kalphamax1 = R
-            ks1 = kalphamax1 * 0.5 * (self._glx + 1.0)
-            weights1 = kalphamax1 * self._glw
+            # k = R(1-v^2). As z->0 the 1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm) factor
+            # below has a square-root singularity exactly at the panel edge k=R,
+            # against which fixed-order Gauss-Legendre converges only
+            # algebraically (n=3000 still leaves 1e-4). This substitution's
+            # Jacobian 2Rv vanishes precisely where that factor blows up, so the
+            # product is smooth and the same 100 nodes reach ~5e-5 instead of
+            # ~5e-3 -- better than n=3000, at no extra integrand evaluations.
+            v1 = 0.5 * (self._glx + 1.0)
+            ks1 = kalphamax1 * (1.0 - v1**2.0)
+            weights1 = 2.0 * kalphamax1 * v1 * self._glw
             sqrtp = numpy.sqrt(z**2.0 + (ks1 + R) ** 2.0)
             sqrtm = numpy.sqrt(z**2.0 + (ks1 - R) ** 2.0)
             evalInt1 = (
@@ -163,8 +182,11 @@ class RazorThinExponentialDiskPotential(Potential):
             )
             if R < 10.0:
                 kalphamax2 = 10.0
-                ks2 = (kalphamax2 - kalphamax1) * 0.5 * (self._glx + 1.0) + kalphamax1
-                weights2 = (kalphamax2 - kalphamax1) * self._glw
+                # k = R + u^2: the same singularity seen from the right panel.
+                umax = numpy.sqrt(kalphamax2 - kalphamax1)
+                u2 = umax * 0.5 * (self._glx + 1.0)
+                ks2 = kalphamax1 + u2**2.0
+                weights2 = 2.0 * umax * u2 * self._glw
                 sqrtp = numpy.sqrt(z**2.0 + (ks2 + R) ** 2.0)
                 sqrtm = numpy.sqrt(z**2.0 + (ks2 - R) ** 2.0)
                 evalInt2 = (

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -13737,3 +13737,51 @@ def test_anyaxisymrazorthin_smallz_limit():
         val = getattr(tp, name)(R, 1e-5, use_physical=False)
         assert numpy.isfinite(val), f"{name} non-finite just below the peak scale"
     return None
+
+
+# The RazorThinExponentialDiskPotential force quadrature has a square-root
+# singularity at the panel edge k=R as |z| -> 0 (the 1/sqrt(R^2+z^2-k^2+...)
+# factor), against which fixed-order Gauss-Legendre converges only
+# algebraically. Just above the |z|=1e-6 handover -- where the exact Bessel
+# closed form is given up -- that cost ~3 significant digits. The nodes are
+# substituted so the Jacobian cancels the singularity; this pins the result.
+def test_razorthinexponentialdisk_forces_at_the_closedform_handover():
+    from scipy import special
+
+    hr = 1.0 / 3.0
+    alpha = 1.0 / hr
+    p = potential.RazorThinExponentialDiskPotential(amp=1.0, hr=hr)
+
+    def exact_Rforce(R):
+        # The z=0 limit in closed form; verified against an mpmath quadrature of
+        # the same integral at 40 dps to <= 2.8e-9 when this test was written.
+        y = 0.5 * alpha * R
+        return (
+            -2.0
+            * numpy.pi
+            * y
+            * (special.i0(y) * special.k0(y) - special.i1(y) * special.k1(y))
+        )
+
+    # |z| <= 1e-5 so the true vertical dependence (which is what the closed form
+    # does NOT capture) stays far below the quadrature error being pinned.
+    for R in (0.5, 1.0, 2.0, 4.0):
+        ref = exact_Rforce(R)
+        for z in (1e-6, 1e-5):
+            got = p.Rforce(R, z, use_physical=False)
+            rel = numpy.fabs(got / ref - 1.0)
+            assert rel < 2e-4, (
+                f"RazorThinExponentialDiskPotential.Rforce({R}, {z}) is {rel:e} "
+                f"relative from the exact z->0 limit; the endpoint singularity at "
+                "k=R is not being resolved (this was 5.2e-03 before the node "
+                "substitution)"
+            )
+    # The two branches must also join smoothly across the handover.
+    for R in (0.5, 1.0, 2.0):
+        lo = p.Rforce(R, 9.99e-7, use_physical=False)  # closed-form branch
+        hi = p.Rforce(R, 1.001e-6, use_physical=False)  # quadrature branch
+        assert numpy.fabs(hi / lo - 1.0) < 2e-4, (
+            f"RazorThinExponentialDiskPotential.Rforce jumps by "
+            f"{numpy.fabs(hi / lo - 1.0):e} across the |z|=1e-6 handover at R={R}"
+        )
+    return None


### PR DESCRIPTION
Closes #1276.

The force quadrature integrand carries `1/sqrt(R^2+z^2-k^2+sqrtp*sqrtm)`, which goes to zero at `k=R` as `|z| -> 0`: a square-root singularity sitting **exactly on the panel boundary**. Fixed-order Gauss-Legendre converges only algebraically against that, so just above the `|z|=1e-6` handover — where the exact Bessel closed form is given up — the forces lost ~3 significant digits.

## Raising `glorder` is the wrong lever

Relative error at `|z|=1e-6`:

| R | n=100 (ships) | n=300 | n=1000 | n=3000 | **sub, n=100** |
|---|---|---|---|---|---|
| 0.5 | 5.21e-03 | 1.67e-03 | 7.54e-04 | 1.03e-04 | **5.38e-05** |
| 1.0 | 3.38e-03 | 1.08e-03 | 3.13e-04 | 4.02e-05 | **3.14e-05** |
| 2.0 | 8.94e-04 | 2.89e-04 | 6.43e-05 | 5.28e-06 | **3.89e-06** |
| 4.0 | 1.42e-05 | 4.63e-06 | 9.78e-07 | 9.81e-09 | **6.90e-08** |

Order buys about one digit per 10x nodes. Substituting `k = R(1-v^2)` on `[0,R]` and `k = R+u^2` on `[R,10]` puts a Jacobian zero exactly where the integrand blows up: **at the same 100 nodes it beats n=3000**, with no extra integrand evaluations and the node tables still built once at construction.

Applied to `_Rforce` and `_zforce`, the two methods carrying the singular factor. `_evaluate` uses the arcsin form — a kink, not a singularity — and is unaffected.

## Arbiter

The exact z=0 closed form, validated against an mpmath quadrature of the same integral at 40 dps (agreeing to 2.8e-9 / 1.3e-9 / 2.3e-10), and independently cross-checked by a second mpmath run at each z. Two things this caught in my own harness, worth stating because either would have given a confident wrong answer: a first adaptive reference returned `nan` at z=1e-9 (so "nothing converges" meant the *reference* was broken), and an mpmath rebuild came out exactly 2x off because **galpy's weights are `(hi-lo)*glw`, twice the standard GL weights**, with the factor absorbed into the `-2*sqrt(2)` prefactor.

## Effect and residual

This moves numpy values for `|z| >= 1e-6` — toward the truth. The discontinuity across the handover falls with the error: at R=0.5 the two branches disagreed by 5.2e-03 and now agree to 5.4e-05.

**Residual, stated not buried:** 5.4e-05 at R=0.5 is a two-digit improvement, not a cure. At `z -> 0` the integrand also has a jump in `(k-R)/sqrtm` that a square substitution does not absorb; `glorder=300` with the substitution reaches 3.1e-06 for callers who need it.

## Gate

`test_potential.py`: **1226 passed, 102 skipped, 0 failures.** The new test A/B's — it fails without the fix (5.21e-03 against a 2e-04 bar) and pins the handover continuity too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm