### PR TITLE
AnyAxisymmetricRazorThinDisk: evaluate the second derivatives as finite-part integrals

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -77,6 +77,43 @@ def _quad_apeak(f, R, z):
     )
 
 
+def _finite_part_quad(integrand_d, R, az, C):
+    """Integrate ``integrand_d(d)`` over the disc, as a Hadamard finite part.
+
+    ``integrand_d`` is parameterised by the OFFSET ``d = a - R`` so the offset is
+    never formed by subtraction: at R=0.2 the float64 spacing is 2.8e-17, so
+    recovering d=1e-10 from ``a - R`` carries 8e-8 relative error, which the
+    ``1/(d^2+z^2)^2`` factor then amplifies.
+
+    Near d=0 the integrand behaves as ``C/d^2 + B/d + integrable``. Symmetrising
+    about d=0 cancels the odd ``B/d`` term exactly, so only ``C`` is needed --
+    and ``C`` never involves a derivative of the surface density.
+
+    At z=0 the integral exists only as a finite part: the integrand diverges as
+    ``C/d^2`` with the SAME sign either side, so the halves add rather than
+    cancel. Subtract the singular model and add back its finite part, ``-2C/R``.
+    For z>0 there is a peak of width ~z instead; ``d = z*sinh(t)`` gives
+    log-spaced coverage from z out to R with no endpoint crowding.
+    (``d = z*tan(t)`` fails -- ``arctan(R/z)`` lands within ~5e-10 of pi/2, where
+    tan is quantised: the same representability trap one level up.)
+    """
+
+    def sym(u):
+        return integrand_d(u) + integrand_d(-u)
+
+    if az == 0.0:
+        inner = (
+            integrate.quad(lambda u: sym(u) - 2.0 * C / (u * u), 0.0, R)[0]
+            - 2.0 * C / R
+        )
+    else:
+        tmax = numpy.arcsinh(R / az)
+        inner = integrate.quad(
+            lambda t: sym(az * numpy.sinh(t)) * az * numpy.cosh(t), 0.0, tmax
+        )[0]
+    return -4 * (inner + integrate.quad(integrand_d, R, numpy.inf)[0])
+
+
 class AnyAxisymmetricRazorThinDiskPotential(Potential):
     """Class that implements the potential of an arbitrary axisymmetric, razor-thin disk with surface density :math:`\\Sigma(R)`"""
 
@@ -267,98 +304,41 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / (2.0 * R2 * dz**2 * aRz**1.5)
             )
 
-        # Symmetrise about d=0. The integrand behaves as C/d^2 + B/d + integrable
-        # with C = Sigma(R)/2; pairing +-d cancels the odd B/d term exactly, so
-        # only C has to be handled -- and C needs no derivative of Sigma.
-        def sym(u):
-            return r2derivint(u) + r2derivint(-u)
-
-        C = self._sdens(R) / 2.0
-        if z2 == 0.0:
-            # At z=0 the integral exists only as a Hadamard finite part: the
-            # integrand diverges as C/d^2 with the SAME sign either side, so the
-            # two halves add rather than cancel. Subtract the singular model and
-            # add back its finite part, -2C/R over the symmetric panel.
-            inner = (
-                integrate.quad(lambda u: sym(u) - 2.0 * C / (u * u), 0.0, R)[0]
-                - 2.0 * C / R
-            )
-        else:
-            # d = z*sinh(t) gives log-spaced coverage from z out to R with no
-            # endpoint crowding, so the width-z peak is resolved at any z.
-            # (d = z*tan(t) fails: arctan(R/z) lands within ~5e-10 of pi/2, where
-            # tan is quantised -- the same representability trap one level up.)
-            tmax = numpy.arcsinh(R / az)
-            inner = integrate.quad(
-                lambda t: sym(az * numpy.sinh(t)) * az * numpy.cosh(t), 0.0, tmax
-            )[0]
-        return -4 * (inner + integrate.quad(r2derivint, R, numpy.inf)[0])
+        return _finite_part_quad(r2derivint, R, az, self._sdens(R) / 2.0)
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
         R2 = R**2
-        z2 = z**2
+        az = numpy.fabs(z)
+        if az < _R2DERIV_ZFLOOR:
+            az = 0.0
+        z2 = az**2
 
-        def z2derivint(a):
-            a2 = a**2
-            aRz = (a + R) ** 2.0 + z2
-            # m = 4aR/((a+R)^2+z^2), and 1-m = ((a-R)^2+z^2)/((a+R)^2+z^2) exactly.
-            # Taking K from that complement never forms 1-m by subtraction, which
-            # rounds to 0 for tiny |z| and sends ellipk to inf. E is bounded, so
-            # clamping m only guards the >1 rounding artifact there.
-            m = numpy.minimum(4 * a * R / aRz, 1.0)
-            km1 = ((a - R) ** 2.0 + z2) / aRz
+        def z2derivint(d):
+            """As for R2deriv: parameterised by the offset d = a - R."""
+            a = R + d
+            a2 = R2 + 2.0 * R * d + d * d
+            dz = d * d + z2  # (a-R)^2 + z^2, exactly
+            a2mR2 = d * (2.0 * R + d)  # a^2 - R^2, exactly
+            aRz = (2.0 * R + d) ** 2.0 + z2
+            m = numpy.minimum(4.0 * a * R / aRz, 1.0)
             return (
                 a
                 * self._sdens(a)
                 * (
                     -(
-                        ((a2 - R2) ** 2 - 2.0 * (a2 + R2) * z2 - 3.0 * z**4)
+                        (a2mR2**2 - 2.0 * (a2 + R2) * z2 - 3.0 * z2**2)
                         * special.ellipe(m)
                     )
-                    - z2 * ((a - R) ** 2 + z2) * special.ellipkm1(km1)
+                    - z2 * dz * special.ellipkm1(dz / aRz)
                 )
-                / (((a - R) ** 2 + z2) ** 2 * ((a + R) ** 2 + z2) ** 1.5)
+                / (dz**2 * aRz**1.5)
             )
 
-        return -4 * (
-            integrate.quad(z2derivint, 0, 2 * R, points=[R])[0]
-            + integrate.quad(z2derivint, 2 * R, numpy.inf)[0]
-        )
-
-    @check_potential_inputs_not_arrays
-    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        R2 = R**2
-        z2 = z**2
-
-        def rzderivint(a, u, d2):
-            aRz = (a + R) ** 2.0 + z2
-            # m = 4aR/((a+R)^2+z^2), and 1-m = d2/aRz exactly. Taking K from that
-            # complement never forms 1-m by subtraction, which rounds to 0 for
-            # tiny |z| and sends ellipk to inf. E is bounded, so clamping m only
-            # guards the >1 rounding artifact there.
-            m = numpy.minimum(4 * a * R / aRz, 1.0)
-            # Both coefficients are written in u = a-R, the point they are built
-            # about: the E one vanishes at (a=R, z=0) and the K one factors
-            # through d2. Forming either from a and R cancels away for |z| << R.
-            ecoeff = (
-                u * (16.0 * R2 * R + 4.0 * R * z2 + 4.0 * R * u * u)
-                + u * u * (12.0 * R2 + 2.0 * z2)
-                + u**4
-                - 4.0 * R2 * z2
-                + z2 * z2
-            )
-            kcoeff = d2 * (2.0 * R * u + d2)
-            return (
-                a
-                * self._sdens(a)
-                * (-ecoeff * special.ellipe(m) + kcoeff * special.ellipkm1(d2 / aRz))
-                / R
-                / d2**2
-                / aRz**1.5
-            )
-
-        return -2 * z * _quad_apeak(rzderivint, R, z)
+        # At z=0 the K term carries a z^2 factor and drops out entirely, leaving
+        # -a Sigma(a) E(m) / (d^2 (a+R)), so the singular coefficient is
+        # -Sigma(R)/2 -- exactly minus R2deriv's. Verified to 5e-10.
+        return _finite_part_quad(z2derivint, R, az, -self._sdens(R) / 2.0)
 
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         return self._sdens(R)

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -340,5 +340,38 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         # -Sigma(R)/2 -- exactly minus R2deriv's. Verified to 5e-10.
         return _finite_part_quad(z2derivint, R, az, -self._sdens(R) / 2.0)
 
+    def _Rzderiv(self, R, z, phi=0.0, t=0.0):
+        R2 = R**2
+        z2 = z**2
+
+        def rzderivint(a, u, d2):
+            aRz = (a + R) ** 2.0 + z2
+            # m = 4aR/((a+R)^2+z^2), and 1-m = d2/aRz exactly. Taking K from that
+            # complement never forms 1-m by subtraction, which rounds to 0 for
+            # tiny |z| and sends ellipk to inf. E is bounded, so clamping m only
+            # guards the >1 rounding artifact there.
+            m = numpy.minimum(4 * a * R / aRz, 1.0)
+            # Both coefficients are written in u = a-R, the point they are built
+            # about: the E one vanishes at (a=R, z=0) and the K one factors
+            # through d2. Forming either from a and R cancels away for |z| << R.
+            ecoeff = (
+                u * (16.0 * R2 * R + 4.0 * R * z2 + 4.0 * R * u * u)
+                + u * u * (12.0 * R2 + 2.0 * z2)
+                + u**4
+                - 4.0 * R2 * z2
+                + z2 * z2
+            )
+            kcoeff = d2 * (2.0 * R * u + d2)
+            return (
+                a
+                * self._sdens(a)
+                * (-ecoeff * special.ellipe(m) + kcoeff * special.ellipkm1(d2 / aRz))
+                / R
+                / d2**2
+                / aRz**1.5
+            )
+
+        return -2 * z * _quad_apeak(rzderivint, R, z)
+
     def _surfdens(self, R, z, phi=0.0, t=0.0):
         return self._sdens(R)

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -340,6 +340,7 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
         # -Sigma(R)/2 -- exactly minus R2deriv's. Verified to 5e-10.
         return _finite_part_quad(z2derivint, R, az, -self._sdens(R) / 2.0)
 
+    @check_potential_inputs_not_arrays
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
         R2 = R**2
         z2 = z**2

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -10,6 +10,13 @@ from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .Potential import Potential, check_potential_inputs_not_arrays
 
+# Below this |z|, R2deriv is indistinguishable from its z=0 limit: measured
+# against an mpmath Hankel reference the true value moves by only 5.9e-09 between
+# z=0 and z=1e-10 (and ~1e-11 by z=1e-12), while the finite-|z| quadrature branch
+# degrades there. Snapping costs ~6e-9 and avoids a decade in which neither
+# branch is accurate.
+_R2DERIV_ZFLOOR = 1e-9
+
 if _APY_LOADED:
     from astropy import units
 
@@ -220,41 +227,72 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     @check_potential_inputs_not_arrays
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
         R2 = R**2
-        z2 = z**2
+        az = numpy.fabs(z)
+        if az < _R2DERIV_ZFLOOR:
+            az = 0.0
+        z2 = az**2
 
-        def r2derivint(a):
-            a2 = a**2
-            aRz = (a + R) ** 2.0 + z2
-            # m = 4aR/((a+R)^2+z^2), and 1-m = ((a-R)^2+z^2)/((a+R)^2+z^2) exactly.
-            # Taking K from that complement never forms 1-m by subtraction, which
-            # rounds to 0 for tiny |z| and sends ellipk to inf. E is bounded, so
-            # clamping m only guards the >1 rounding artifact there.
-            m = numpy.minimum(4 * a * R / aRz, 1.0)
-            km1 = ((a - R) ** 2.0 + z2) / aRz
+        def r2derivint(d):
+            """The integrand as a function of the OFFSET d = a - R.
+
+            Parameterised by d, never by a, so the offset is never formed by
+            subtraction: at R=0.2 the float64 spacing is 2.8e-17, so recovering
+            d=1e-10 from ``a - R`` carries 8e-8 relative error, which
+            ``1/(d^2+z^2)^2`` then amplifies. Every ingredient is exact in d:
+            ``a^2-R^2 = d(2R+d)`` and ``(a-R)^2+z^2 = d^2+z^2``.
+            """
+            a = R + d
+            a2 = R2 + 2.0 * R * d + d * d
+            dz = d * d + z2  # (a-R)^2 + z^2, exactly
+            a2mR2 = d * (2.0 * R + d)  # a^2 - R^2, exactly
+            aRz = (2.0 * R + d) ** 2.0 + z2
+            m = numpy.minimum(4.0 * a * R / aRz, 1.0)
             return (
                 a
                 * self._sdens(a)
                 * (
                     -(
                         (
-                            (a2 - 3.0 * R2) * (a2 - R2) ** 2
+                            (a2 - 3.0 * R2) * a2mR2**2
                             + (3.0 * a2**2 + 2.0 * a2 * R2 + 3.0 * R2**2) * z2
-                            + (3.0 * a2 + 7.0 * R2) * z**4
-                            + z**6
+                            + (3.0 * a2 + 7.0 * R2) * z2**2
+                            + z2**3
                         )
                         * special.ellipe(m)
                     )
-                    + ((a - R) ** 2 + z2)
-                    * ((a2 - R2) ** 2 + 2.0 * (a2 + 2.0 * R2) * z2 + z**4)
-                    * special.ellipkm1(km1)
+                    + dz
+                    * (a2mR2**2 + 2.0 * (a2 + 2.0 * R2) * z2 + z2**2)
+                    * special.ellipkm1(dz / aRz)
                 )
-                / (2.0 * R2 * ((a - R) ** 2 + z2) ** 2 * ((a + R) ** 2 + z2) ** 1.5)
+                / (2.0 * R2 * dz**2 * aRz**1.5)
             )
 
-        return -4 * (
-            integrate.quad(r2derivint, 0, 2 * R, points=[R])[0]
-            + integrate.quad(r2derivint, 2 * R, numpy.inf)[0]
-        )
+        # Symmetrise about d=0. The integrand behaves as C/d^2 + B/d + integrable
+        # with C = Sigma(R)/2; pairing +-d cancels the odd B/d term exactly, so
+        # only C has to be handled -- and C needs no derivative of Sigma.
+        def sym(u):
+            return r2derivint(u) + r2derivint(-u)
+
+        C = self._sdens(R) / 2.0
+        if z2 == 0.0:
+            # At z=0 the integral exists only as a Hadamard finite part: the
+            # integrand diverges as C/d^2 with the SAME sign either side, so the
+            # two halves add rather than cancel. Subtract the singular model and
+            # add back its finite part, -2C/R over the symmetric panel.
+            inner = (
+                integrate.quad(lambda u: sym(u) - 2.0 * C / (u * u), 0.0, R)[0]
+                - 2.0 * C / R
+            )
+        else:
+            # d = z*sinh(t) gives log-spaced coverage from z out to R with no
+            # endpoint crowding, so the width-z peak is resolved at any z.
+            # (d = z*tan(t) fails: arctan(R/z) lands within ~5e-10 of pi/2, where
+            # tan is quantised -- the same representability trap one level up.)
+            tmax = numpy.arcsinh(R / az)
+            inner = integrate.quad(
+                lambda t: sym(az * numpy.sinh(t)) * az * numpy.cosh(t), 0.0, tmax
+            )[0]
+        return -4 * (inner + integrate.quad(r2derivint, R, numpy.inf)[0])
 
     @check_potential_inputs_not_arrays
     def _z2deriv(self, R, z, phi=0.0, t=0.0):

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -22,9 +22,10 @@ from .Potential import Potential, check_potential_inputs_not_arrays
 #     0.2    5.9e-08    1.9e-09
 #     1.0    2.4e-09    4.5e-09
 #
-# i.e. up to ~6e-8, falling ~linearly in z (5.9e-09 by z=1e-10, ~1e-11 by
-# z=1e-12). Both derivatives use this constant, and z2deriv moves LESS across the
-# floor than R2deriv does, so the bound is set by R2deriv at small R.
+# i.e. up to ~6e-8, set by R2deriv at small R. The movement is exactly linear in
+# z -- measured, not extrapolated: R=0.2 R2deriv gives 5.937e-08, 5.937e-09 and
+# 5.937e-11 at z = 1e-9, 1e-10 and 1e-12. Both derivatives use this constant, and
+# z2deriv moves LESS across the floor than R2deriv does.
 _R2DERIV_ZFLOOR = 1e-9
 
 if _APY_LOADED:

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -10,11 +10,21 @@ from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .Potential import Potential, check_potential_inputs_not_arrays
 
-# Below this |z|, R2deriv is indistinguishable from its z=0 limit: measured
-# against an mpmath Hankel reference the true value moves by only 5.9e-09 between
-# z=0 and z=1e-10 (and ~1e-11 by z=1e-12), while the finite-|z| quadrature branch
-# degrades there. Snapping costs ~6e-9 and avoids a decade in which neither
-# branch is accurate.
+# Below this |z| both second derivatives are indistinguishable from their z=0
+# limits, so we evaluate the z=0 branch: the finite-|z| branch degrades here (the
+# offset d is not representable relative to R), and this avoids a decade in which
+# neither branch is accurate.
+#
+# Worst case is at the floor itself. Relative movement of the TRUE value between
+# z=0 and z=1e-9, vs an mpmath Hankel reference:
+#
+#     R      R2deriv    z2deriv
+#     0.2    5.9e-08    1.9e-09
+#     1.0    2.4e-09    4.5e-09
+#
+# i.e. up to ~6e-8, falling ~linearly in z (5.9e-09 by z=1e-10, ~1e-11 by
+# z=1e-12). Both derivatives use this constant, and z2deriv moves LESS across the
+# floor than R2deriv does, so the bound is set by R2deriv at small R.
 _R2DERIV_ZFLOOR = 1e-9
 
 if _APY_LOADED:

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -13820,3 +13820,52 @@ def test_razorthinexponentialdisk_forces_at_the_closedform_handover():
             f"{numpy.fabs(hi / lo - 1.0):e} across the |z|=1e-6 handover at R={R}"
         )
     return None
+
+
+# AnyAxisymmetricRazorThinDiskPotential's second derivatives are Hadamard
+# finite-part integrals: the integrand diverges as C/(a-R)^2 with the SAME sign
+# on both sides of a=R, so the halves add rather than cancel. Evaluating them
+# with a rule built for integrable singularities (QUADPACK's QAGP, via
+# points=[R]) returned an extrapolation artifact -- ~1e-5 for R2deriv and ~5e-7
+# for z2deriv at small R, improving outward as the singularity weakens.
+def test_anyaxisymmetricrazorthindisk_second_derivs_at_z0():
+    # Gold values: the Hankel-transform form of each derivative, evaluated with
+    #   mpmath.quadosc at 25 dps over the Bessel zeros, for Sigma(R)=exp(-R/0.3):
+    #     R2deriv = -2pi Int k^2 (J1(kR)/(kR) - J0(kR)) Sigmatilde(k) dk
+    #     z2deriv = -2pi Int k^2 J0(kR) Sigmatilde(k) dk
+    #   with Sigmatilde(k) = hr^2 (1+(k hr)^2)^(-3/2), hr = 0.3.
+    gold_R2 = {
+        0.1: 5.5888795714e00,
+        0.2: 6.0373468138e-01,
+        0.3: -1.1823292800e00,
+        0.5: -1.9316472211e00,
+        1.0: -1.0271497109e00,
+        2.0: -1.7859053254e-01,
+    }
+    gold_z2 = {
+        0.1: -2.0840815646e01,
+        0.2: -9.5528281577e00,
+        0.3: -4.6392259813e00,
+        0.5: -8.7079146148e-01,
+        1.0: 3.8734081084e-01,
+        2.0: 9.7856791896e-02,
+    }
+    p = potential.AnyAxisymmetricRazorThinDiskPotential(
+        surfdens=lambda R: numpy.exp(-R / 0.3)
+    )
+    for R, ref in gold_R2.items():
+        got = p.R2deriv(R, 0.0, use_physical=False)
+        assert numpy.fabs(got / ref - 1.0) < 1e-8, (
+            f"AnyAxisym R2deriv({R}, 0) = {got:e} is "
+            f"{numpy.fabs(got / ref - 1.0):e} relative from the Hankel reference "
+            f"{ref:e}; the finite part at a=R is not being taken (this was "
+            "9.9e-06 at R=0.2 before the fix)"
+        )
+    for R, ref in gold_z2.items():
+        got = p.z2deriv(R, 0.0, use_physical=False)
+        assert numpy.fabs(got / ref - 1.0) < 1e-8, (
+            f"AnyAxisym z2deriv({R}, 0) = {got:e} is "
+            f"{numpy.fabs(got / ref - 1.0):e} relative from the Hankel reference "
+            f"{ref:e} (this was 5.1e-07 at R=0.2 before the fix)"
+        )
+    return None

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -13883,3 +13883,34 @@ def test_anyaxisymmetricrazorthindisk_second_derivs_at_z0():
             f"{ref:e} (this was 5.1e-07 at R=0.2 before the fix)"
         )
     return None
+
+
+def test_anyaxisymmetricrazorthindisk_all_methods_reject_arrays():
+    """Every evaluation method must keep @check_potential_inputs_not_arrays.
+
+    This potential integrates with scipy.quad, which needs scalars; the decorator
+    is what turns an array call into a clean TypeError instead of a wrong number
+    or an opaque failure deep in the integrand.
+
+    Pinning the SET, not one method, and pinning the CONTRACT rather than the
+    decorator's presence: the gold-value test above calls Rzderiv with scalars,
+    so it passes whether or not the decorator is attached. A rewrite of these
+    methods dropped `@check_potential_inputs_not_arrays` from `_Rzderiv` while
+    every other test stayed green -- exactly the blind spot this closes.
+    """
+    p = potential.AnyAxisymmetricRazorThinDiskPotential(
+        surfdens=lambda R: numpy.exp(-R / 0.3)
+    )
+    arr = numpy.array([0.8, 1.2])
+    for name in ("__call__", "Rforce", "zforce", "R2deriv", "z2deriv", "Rzderiv"):
+        meth = getattr(p, name)
+        # scalar still works -- proves the method is live, so a NameError or a
+        # deleted method cannot masquerade as the TypeError we want below
+        assert numpy.isfinite(meth(1.0, 0.1, use_physical=False)), (
+            f"{name} is not usable on scalars"
+        )
+        with pytest.raises(TypeError):
+            meth(arr, 0.1, use_physical=False)
+        with pytest.raises(TypeError):
+            meth(1.0, arr, use_physical=False)
+    return None

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -13861,6 +13861,20 @@ def test_anyaxisymmetricrazorthindisk_second_derivs_at_z0():
             f"{ref:e}; the finite part at a=R is not being taken (this was "
             "9.9e-06 at R=0.2 before the fix)"
         )
+    # _Rzderiv is NOT touched by this change, but the R2deriv/z2deriv edits sit
+    # directly around it in the file, so pin that it still exists and is right --
+    # a splice that silently dropped it would otherwise pass every other test.
+    gold_Rz = {  # -2pi Int k^2 J1(kR) exp(-kz) Sigmatilde(k) dk, at z=1e-3
+        0.2: -1.0683375594e01,
+        0.5: -3.9465142998e00,
+        1.0: -7.4727577704e-01,
+    }
+    for R, ref in gold_Rz.items():
+        got = p.Rzderiv(R, 1e-3, use_physical=False)
+        assert numpy.fabs(got / ref - 1.0) < 1e-8, (
+            f"AnyAxisym Rzderiv({R}, 1e-3) = {got:e} differs from the Hankel "
+            f"reference {ref:e} by {numpy.fabs(got / ref - 1.0):e}"
+        )
     for R, ref in gold_z2.items():
         got = p.z2deriv(R, 0.0, use_physical=False)
         assert numpy.fabs(got / ref - 1.0) < 1e-8, (


### PR DESCRIPTION
Closes #1277.

`AnyAxisymmetricRazorThinDiskPotential.R2deriv` and `.z2deriv` are **Hadamard
finite-part** integrals, and were being evaluated with a rule built for
*integrable* singularities. The result was finite and plausible but wrong in the
5th–7th digit.

## The defect

Both integrands diverge as `C/(a-R)^2` near the ring radius, **with the same sign
on both sides** (measured 2.5656e+07 vs 2.5686e+07 at `a-R = 1e-4`), so the two
halves *add* rather than cancel. The integral exists only as a finite part.

The shipped code reached for `integrate.quad(..., points=[R])`, which selects
QUADPACK's QAGP — the singularity-aware routine for *integrable* singularities.
Its answer here is an extrapolation artifact: ~1e-5 relative for `R2deriv`, ~5e-7
for `z2deriv`, improving outward as the singularity weakens relative to `R`. That
R-dependence is exactly what #1277 reports.

## The fix

Four changes, each doing one job:

1. **Reparameterise the integrand in the offset `d = a - R`.** The offset is then
   never formed by subtraction. At R=0.2 the float64 spacing is 2.8e-17, so
   recovering `d = 1e-10` from `a - R` carries 8e-8 relative error, which the
   `1/(d^2+z^2)^2` factor amplifies. Every ingredient is exact in `d`:
   `a^2-R^2 = d(2R+d)` and `(a-R)^2+z^2 = d^2+z^2`.
2. **Symmetrise about `d = 0`.** Near the singularity the integrand is
   `C/d^2 + B/d + integrable`; symmetrising cancels the odd `B/d` term exactly, so
   **no derivative of the surface density is ever needed** — only `C`.
3. **Subtract the singular model and add back its finite part** (`-2C/R`) on the
   `z = 0` branch. `C = Sigma(R)/2` for `R2deriv`, and exactly `-Sigma(R)/2` for
   `z2deriv` (at z=0 its K term carries a `z^2` factor and drops out, leaving
   `-a Sigma(a) E(m) / (d^2 (a+R))`; verified to 5e-10).
4. **Substitute `d = z*sinh(t)` for `z > 0`**, giving log-spaced coverage from `z`
   out to `R` with no endpoint crowding. (`d = z*tan(t)` fails: `arctan(R/z)`
   lands within ~5e-10 of pi/2, where `tan` is quantised — the same
   representability trap one level up.)

Both derivatives share one helper, `_finite_part_quad(integrand_d, R, az, C)`,
differing only in the sign of `C`.

**Below `|z| = 1e-9` the z=0 branch is used** (module constant
`_R2DERIV_ZFLOOR`, which gates *both* derivatives). That regime is under the
representability floor for `d`, so no quadrature recovers it, and snapping avoids
a decade in which neither branch is accurate.

Cost of the floor, worst case being at the floor itself — relative movement of the
true value between z=0 and z=1e-9, vs the mpmath Hankel reference:

| R | `R2deriv` | `z2deriv` |
|---|---|---|
| 0.2 | 5.9e-08 | 1.9e-09 |
| 1.0 | 2.4e-09 | 4.5e-09 |

so **up to ~6e-8**, set by `R2deriv` at small R. The movement is exactly linear in
z — measured, not extrapolated: R=0.2 `R2deriv` gives 5.937e-08, 5.937e-09 and
5.937e-11 at z = 1e-9, 1e-10, 1e-12. `z2deriv` moves *less* across the floor
than `R2deriv` does, so sharing the constant is at least as safe there — worth
measuring rather than assuming, since `z2deriv`'s first-order correction integral
`∫k³J₀Σ̃dk` does not converge, so its z-dependence is not linear a priori.

## Measured

Relative error vs a Hankel-transform reference (`mpmath.quadosc`, 25 dps, over the
Bessel zeros), for `Sigma(R) = exp(-R/0.3)`:

| quantity | shipped | this PR |
|---|---|---|
| `R2deriv` | 9.90e-06 | **4.29e-10** |
| `z2deriv` | 5.06e-07 | **2.97e-11** |

and it is better at **every** `|z|` in the band, not only at `z = 0` — worth
stating because the shipped `z2deriv` is in fact *worse* off-plane (9.0e-07 at
`|z| = 1e-12`) than the `z = 0` figure suggests.

## Tests

`test_anyaxisymmetricrazorthindisk_second_derivs_at_z0` pins `R2deriv` and
`z2deriv` against that Hankel reference at 1e-8 relative across six radii each.

`test_anyaxisymmetricrazorthindisk_all_methods_reject_arrays` pins that all six
evaluation methods keep `@check_potential_inputs_not_arrays`, by asserting the
**contract** (scalar works, array raises `TypeError`) rather than the decorator's
presence — see below.

## Note on `_Rzderiv`

`_Rzderiv` is **not** touched by this change, but it sits between the two edited
methods and a `def`-to-`def` splice deleted it during development; a later commit
restored it but dropped its `@check_potential_inputs_not_arrays`. Both are fixed
here, and both are now pinned.

Neither was caught by the existing suite, which is worth recording: the generic
`Rzderiv` checks in `test_potential.py` are guarded by `hasattr(tp, "_Rzderiv")`
so a deleted method becomes a silent *skip*, and `test_orbit.py` excludes this
potential outright. Measured: with the decorator removed the gold-value test still
PASSES while an array call dies as `ValueError: The truth value of an array with
more than one element is ambiguous` from inside the integrand — precisely the
opaque failure the decorator converts into a clean `TypeError`.

## numpy path

This **deliberately changes numpy results** — it is an accuracy fix on `main`, so
that is the point rather than a side effect. Sizes are the table above.

Full `tests/test_potential.py`: **1329 tests, 0 failures, 0 errors, 102 skipped.**
