### PR TITLE
hyp2f1: extend the backend fallback to 0 < z < 1 via Pfaff

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -103,12 +103,28 @@ def _pfaff_series(xp, a, b, c, z):
 
 
 def hyp2f1_fallback(xp, a, b, c, z):
-    r"""2F1(a, b; c; z) for real z <= 0.
+    r"""2F1(a, b; c; z) for real z < 1.
 
     a, b, c are scalars (galpy potential parameters); z is a backend array
-    (or scalar) with z <= 0.
+    (or scalar).
 
-    Three routes, in order of preference:
+    **0 < z < 1 is handled by Pfaff, entering at the top.** The routes below all
+    assume z <= 0, and before this they were simply applied to positive z as
+    well, which returned a silently wrong answer -- measured against scipy,
+    5.1e-03 at z=0.1 rising to 6.4e-01 at z=0.95 (the Gauss series is truncated
+    far too early there). galpy itself only ever passes z <= 0
+    (`TwoPowerSphericalPotential` spans -15.8 .. -0.06), so nothing in-tree was
+    affected, but the wrong answer was silent rather than an error.
+
+    Pfaff maps 0 < z < 1 to z/(z-1) in (-inf, 0], i.e. exactly onto the domain
+    the routes below are built for:
+
+        2F1(a,b;c;z) = (1-z)^{-a} 2F1(a, c-b; c; z/(z-1))
+
+    Verified over 36 (a,b,c,z) combinations with 0.05 <= z <= 0.999: worst
+    relative error 9.6e-07, and <= 1.4e-14 for five of the six parameter sets.
+
+    Three routes for z <= 0, in order of preference:
 
     1. the boundary-layer Euler integral, when the parameters admit it;
     2. Euler's transformation 2F1(a,b;c;z) = (1-z)^{c-a-b} 2F1(c-a,c-b;c;z),
@@ -120,9 +136,23 @@ def hyp2f1_fallback(xp, a, b, c, z):
        integral's range.
 
     Note a Pfaff transformation is NOT usable for route 2: it maps z <= 0 to
-    z/(z-1) in [0, 1), and the integral's substitutions assume z <= 0.
+    z/(z-1) in [0, 1), and the integral's substitutions assume z <= 0. (That is
+    the same identity used for entry above, in the opposite direction -- there it
+    moves positive z ONTO this domain, which is precisely what is wanted.)
     """
     z = xp.asarray(z) * 1.0
+    pos = z > 0.0
+    # Each branch is evaluated at a z that is valid FOR THAT BRANCH -- never the
+    # raw z -- so the dead side cannot produce a nan that a gradient would carry
+    # back (xp.where evaluates both sides eagerly).
+    safe = -xp.ones_like(z)
+    direct = _hyp2f1_nonpositive(xp, a, b, c, xp.where(pos, safe, z))
+    pfaff = _hyp2f1_nonpositive(xp, a, c - b, c, xp.where(pos, z / (z - 1.0), safe))
+    return xp.where(pos, (1.0 - z) ** (-a) * pfaff, direct)
+
+
+def _hyp2f1_nonpositive(xp, a, b, c, z):
+    """2F1(a, b; c; z) for real z <= 0 -- the three routes named above."""
     if not _in_regime(a, b, c):
         if _in_regime(c - a, c - b, c):
             return (1.0 - z) ** (c - a - b) * _euler_integral(xp, c - a, c - b, c, z)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1047,3 +1047,36 @@ def test_router_promotes_numpy_scalar_params_torch():
     p_py = PSPC(alpha=1.3, rc=2.0)
     p_np = PSPC(alpha=numpy.float64(1.3), rc=2.0)
     assert torch.allclose(p_py._rforce(r), p_np._rforce(r))
+
+
+# 0 < z < 1 was UNTESTED until 2026-08-11: every grid above uses z = -_HYP2F1_W,
+# i.e. z <= 0. The fallback is built for z <= 0 and, applied to positive z, was
+# returning the first-order Taylor series 1 + (ab/c)z -- 5.1e-03 wrong at z=0.1
+# rising to 6.4e-01 at z=0.95, silently. galpy itself only passes z <= 0
+# (TwoPowerSphericalPotential spans -15.8 .. -0.06) so nothing in-tree was
+# affected, which is exactly why no test caught it. It now enters via Pfaff,
+# 2F1(a,b;c;z) = (1-z)^{-a} 2F1(a, c-b; c; z/(z-1)), landing on the z <= 0 domain.
+_HYP2F1_ZPOS = numpy.array([1e-8, 0.05, 0.1, 0.4, 0.8, 0.95, 0.999])
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("a,b,c", _HYP2F1_CASES, ids=[str(x) for x in _HYP2F1_CASES])
+def test_hyp2f1_positive_z_matches_scipy(backend, a, b, c):
+    z = _HYP2F1_ZPOS
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    # Same bar as the z <= 0 parity test: Pfaff reuses that machinery, so the
+    # accuracy is the same modulo the (1-z)^{-a} prefactor. Measured worst case
+    # over this grid is 9.9e-07, on the one parameter set whose z <= 0 accuracy
+    # is itself ~4e-06 (a pre-existing floor, not introduced by the transform),
+    # so 1e-5 pins the transform without re-litigating that floor.
+    rtol = 0.0 if backend == "numpy" else 1e-5
+    numpy.testing.assert_allclose(got, ref, rtol=rtol, atol=1e-10)
+    # And pin the specific failure mode: the old code returned the 2-term series,
+    # so assert we are NOT that. Without this the test would still pass if a
+    # future change silently reverted to a low-order truncation at small z.
+    if backend != "numpy":
+        two_term = 1.0 + (a * b / c) * z
+        assert numpy.max(numpy.abs(got - two_term)) > 1e-3, (
+            "hyp2f1 looks like the first-order Taylor series again"
+        )


### PR DESCRIPTION
`galpy.backend.special.hyp2f1` returns a badly wrong answer for **every z > 0**
on both jax and torch. Measured against scipy:

| z | −2.0 | −0.5 | 0.1 | 0.4 | 0.8 | 0.95 |
|---|---|---|---|---|---|---|
| rel err | 7e-15 | 6e-15 | **5.1e-03** | **8.6e-02** | **3.9e-01** | **6.4e-01** |

Every z<0 point is exact; every z>0 point is wrong, and the value returned is
exactly `1 + (ab/c)z` — the first-order Taylor series.

## This is a domain violation, not broken code

The fallback's docstring says *"2F1(a, b; c; z) for real z <= 0"*, and the three
routes inside genuinely assume it. Positive z was simply being passed through to
them, returning garbage **silently** rather than raising.

## Why nothing caught it

galpy never leaves the domain: instrumenting `TwoPowerSphericalPotential` shows
it passes `z ∈ [−15.8, −0.06]`. And the existing parity tests use
`z = -_HYP2F1_W` — negative-only. So the gap is **latent**, which is exactly what
makes it a landmine for the next caller (and it is reachable from the public
`galpy.backend.special` API).

## Fix

Enter through Pfaff:

    2F1(a,b;c;z) = (1-z)^{-a} 2F1(a, c-b; c; z/(z-1))

which maps `0 < z < 1` onto `z <= 0` — precisely the domain the existing routes
are built for — so the accuracy is *theirs*, not a new approximation. Split into
`hyp2f1_fallback` (entry/selection) and `_hyp2f1_nonpositive` (the three routes).

Each branch is evaluated at a z valid **for that branch**, never the raw z, so
`xp.where`'s eagerly-evaluated dead side cannot feed a `nan` back through a
gradient.

## Measured

| domain | before | after |
|---|---|---|
| `0 < z < 1` | 5.1e-03 … 6.4e-01 | **6.7e-15 … 9.9e-07** |
| `z <= 0` | 4.17e-06 | **4.17e-06 (unchanged)** |

The `z <= 0` figure was A/B'd against the unmodified file on an *identical* grid.
That floor is pre-existing, at `(a,b,c,z) = (1.5, 0.5, 3.0, -15.0)`, and is not
touched here.

## Test

`test_hyp2f1_positive_z_matches_scipy`, mirroring the `z <= 0` parity test, plus
an explicit assertion that the result is **not** the 2-term series — so a future
silent reversion to a low-order truncation fails rather than passes.

A/B'd rather than assumed: **12 fail without the fix, 6 pass** (numpy, which
routes to scipy directly).

`tests/test_backend_special.py`: **197 passed**.

## No behaviour change in galpy itself

Since galpy only ever passes `z <= 0`, every in-tree result is bit-identical.
This strictly extends the usable domain.