### PR TITLE
tests: read AnyAxisym small-|z| forces through as_numpy (torch red)

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -821,9 +821,9 @@ class Potential(Force):
             # first crude estimate and returns success while being ~1e-5 wrong --
             # MWPotential2014[0] at R=1, |z|=5 integrates to 8.2e-9 and came back
             # 9.6e-6 relative off.
-            inner = integrate.quad(
-                poisson_integrand(R, phi), -absz, absz, epsabs=0.0
-            )[0]
+            inner = integrate.quad(poisson_integrand(R, phi), -absz, absz, epsabs=0.0)[
+                0
+            ]
         else:
             # Fixed-order GL over the whole [-z, z] needs an order that grows
             # with the range (n=100 is only 3.7e-4 at |z|=10). Splitting at the

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -14184,17 +14184,23 @@ def test_anyaxisymrazorthin_smallz_limit():
     # NB an earlier version of this test asserted Fz/z was constant there. That
     # is the wrong physics and it passed *because* the values were garbage: a
     # correct implementation fails it.
+    # as_numpy at every readout: under a forced backend these return Tensors, and
+    # numpy.all/numpy.fabs on a Tensor raise (numpy forwards axis=/out=, which
+    # torch rejects). The assertions below are about VALUES, so cast once here
+    # rather than teaching each one about backends; as_numpy is a no-op on numpy.
     tp = potential.AnyAxisymmetricRazorThinDiskPotential(normalize=1.0)
     R = 0.5
-    limit = -2.0 * numpy.pi * tp.surfdens(R, 0.0, use_physical=False)
+    limit = float(as_numpy(-2.0 * numpy.pi * tp.surfdens(R, 0.0, use_physical=False)))
     zs = numpy.array([1e-5, 1e-6, 1e-8, 1e-12, 1e-20, 1e-30])
-    fz = numpy.array([tp.zforce(R, z, use_physical=False) for z in zs])
+    fz = numpy.array([float(as_numpy(tp.zforce(R, z, use_physical=False))) for z in zs])
     assert numpy.all(numpy.fabs(fz / limit - 1.0) < 3e-4), (
         f"zforce does not approach -2 pi Sigma(R) as z->0+: Fz/limit = {fz / limit}"
     )
     # Above the plane the disk pulls back toward it, and Fz is odd in z.
     assert numpy.all(fz < 0.0), f"zforce has the wrong sign above the plane: {fz}"
-    fz_neg = numpy.array([tp.zforce(R, -z, use_physical=False) for z in zs])
+    fz_neg = numpy.array(
+        [float(as_numpy(tp.zforce(R, -z, use_physical=False))) for z in zs]
+    )
     assert numpy.all(numpy.fabs(fz_neg + fz) < 3e-4 * numpy.fabs(limit)), (
         f"zforce is not odd in z: Fz(-z) = {fz_neg}, -Fz(z) = {-fz}"
     )
@@ -14206,7 +14212,7 @@ def test_anyaxisymrazorthin_smallz_limit():
     # contributes. Rforce and the second derivatives have no such prefactor and
     # a naive substitution overflows on their odd-part cancellation.
     for name in ("__call__", "Rforce"):
-        val = getattr(tp, name)(R, 1e-5, use_physical=False)
+        val = float(as_numpy(getattr(tp, name)(R, 1e-5, use_physical=False)))
         assert numpy.isfinite(val), f"{name} non-finite just below the peak scale"
     return None
 


### PR DESCRIPTION
`test_anyaxisymrazorthin_smallz_limit` fails under `--backend torch`:

```
TypeError: all() received an invalid combination of arguments -
           got (out=NoneType, axis=NoneType, ...)
```

It asserts with `numpy.all(numpy.fabs(fz / limit - 1.0) < 3e-4)`, and under a
forced backend `fz` is a **Tensor** — numpy then forwards `axis=`/`out=` kwargs
that torch does not accept. Same for `fz_neg`, `limit`, and the
`numpy.isfinite(val)` guard.

### Not a rebase defect

The test came from main (gh#1296), and main's tests were never written to be
backend-aware. The rebase onto main simply made it reachable from the
forced-backend harness for the first time. The identical nodeid fails on
`feat/backends` too, so this red is inherited rather than introduced.

### Scope was measured, not guessed

Main touched five test files:

| file | forced-torch |
|---|---|
| `test_potential.py` | **1 failed** (this one) |
| `test_orbits.py` + `test_SpiralArmsPotential.py` + `test_interp_potential.py` | 180 passed, 0 failed |
| `test_quantity.py` | the known astropy-units boundary — fails under any backend by design |

So this is a class of exactly one, which is why it is fixed here rather than
turned into a sweep.

### The fix

The established test-side pattern: `as_numpy` at the **readout**, once, instead
of teaching each assertion about backends. These assertions are about *values*,
not array types, so casting at the boundary keeps them readable. `as_numpy` is a
no-op on numpy, so that path is untouched. No source change.

Verified: the nodeid passes under **numpy, torch and jax**; before the change
torch failed on two separate trees.