### PR TITLE
backend: one device anchor per call, not per coordinate

### DIFF
--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -61,6 +61,7 @@ import numpy
 from ._namespaces import (
     _is_floating_dtype,
     asarray_on_device,
+    default_device,
     device_of,
     is_backend_array,
 )
@@ -100,6 +101,12 @@ def coerce_coords(xp, *coords, device=None):
     if xp is numpy:
         return coords
     dev = device_of(*coords) if device is None else device
+    if dev is not None and dev == default_device(xp):
+        # placing there is what asarray does anyway, and naming it explicitly
+        # costs ~3x (it commits instead of letting the backend place) -- see
+        # default_device. Only a NON-default anchor (a CUDA sibling on a
+        # CPU-default run) is worth paying for.
+        dev = None
     out = []
     for c in coords:
         if c is None:

--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -66,7 +66,7 @@ from ._namespaces import (
 )
 
 
-def coerce_coords(xp, *coords):
+def coerce_coords(xp, *coords, device=None):
     """Bring coordinate inputs onto the active backend's array type.
 
     The dominant non-numpy failure mode is "the namespace resolved to a backend
@@ -86,12 +86,20 @@ def coerce_coords(xp, *coords):
         the backend's float64 -- galpy's interior precision; a bare ``asarray``
         of a Python float would give torch float32 and miss the tolerances.
 
+    ``device`` overrides the device the coerced coordinates land on. Without it
+    the anchor is derived from ``coords`` alone, which is only right when the
+    caller passes every coordinate of a call at once: coercing them one at a
+    time gives each its own anchor, so a numpy coordinate anchors to None (the
+    backend default device, i.e. CPU for torch) while its CUDA siblings stay on
+    the GPU, and the evaluator is handed a split-device coordinate set. Callers
+    that coerce coordinate-by-coordinate pass the shared anchor explicitly.
+
     The numpy backend is a strict pass-through (``coords`` returned object-
     identical) -> the numpy path stays byte-identical.
     """
     if xp is numpy:
         return coords
-    dev = device_of(*coords)
+    dev = device_of(*coords) if device is None else device
     out = []
     for c in coords:
         if c is None:

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -41,7 +41,7 @@ import numpy
 from ._coerce import coerce_coords
 from ._compat import is_backend_compatible
 from ._jit import NOT_TRACED, traced_call
-from ._namespaces import is_backend_array
+from ._namespaces import device_of, is_backend_array
 from ._resolver import get_namespace
 
 _EMPTY = inspect.Parameter.empty
@@ -72,7 +72,7 @@ def _backend_ready(target):
     return is_backend_compatible(target)
 
 
-def _coerce_one(xp, val):
+def _coerce_one(xp, val, device=None):
     """Coerce a single declared coordinate, preserving a sequence as a sequence.
 
     A coordinate may be a sequence -- the ``[vR,vT,vz]`` velocity of the
@@ -89,8 +89,8 @@ def _coerce_one(xp, val):
     if hasattr(val, "unit"):
         return val
     if isinstance(val, (list, tuple)):
-        return type(val)(coerce_coords(xp, *val))
-    (out,) = coerce_coords(xp, val)
+        return type(val)(coerce_coords(xp, *val, device=device))
+    (out,) = coerce_coords(xp, val, device=device)
     return out
 
 
@@ -177,19 +177,26 @@ def backend_input(*coords):
             on_backend = [val for val in probe if is_backend_array(val)]
             xp = get_namespace(*(on_backend or probe))
             if xp is not numpy and _backend_ready(args[0]):
+                # ONE device anchor for the whole call. Coercing each coordinate
+                # on its own would let each derive its own: a numpy/python
+                # coordinate anchors to None -> the backend default device (CPU
+                # for torch) while its CUDA siblings stay on the GPU, and the
+                # evaluator gets a split-device coordinate set -- a mixed-device
+                # error in some potentials, a silent GPU->CPU transfer in others.
+                dev = device_of(*probe)
                 newargs = None
                 for c, ii in slots:
                     if ii is not None and ii < nargs:
                         if newargs is None:
                             newargs = list(args)
-                        newargs[ii] = _coerce_one(xp, newargs[ii])
+                        newargs[ii] = _coerce_one(xp, newargs[ii], dev)
                     elif c in kwargs:
-                        kwargs[c] = _coerce_one(xp, kwargs[c])
+                        kwargs[c] = _coerce_one(xp, kwargs[c], dev)
                 if newargs is not None:
                     args = tuple(newargs)
                 for c, ii, dflt in defaults:
                     if ii >= nargs and c not in kwargs:
-                        kwargs[c] = _coerce_one(xp, dflt)
+                        kwargs[c] = _coerce_one(xp, dflt, dev)
                 # Under an opt-in trace mode this boundary is also where the
                 # jit/compile happens: the declared coordinates are the traced
                 # arguments and everything else is static. Off by default.

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -320,6 +320,29 @@ def device_of(*coords):
     return None
 
 
+_DEFAULT_DEVICE = {}
+
+
+def default_device(xp):
+    """Device ``xp`` places a new array on when none is requested.
+
+    Asking an explicit device of ``asarray`` is not free -- it commits the array
+    rather than letting the backend place it, measured at 397.6 us/call against
+    134.6 us/call for ``device=None`` on jax CPU. The coordinate boundary is
+    crossed in a tight loop during an orbit integration, so paying that on every
+    coercion turned a 1.7 s dxdv test into a 300 s timeout (galpy #1300). Callers
+    compare against this to skip the device keyword when it cannot change
+    placement anyway. Cached because asking costs an allocation.
+    """
+    key = getattr(xp, "__name__", None) or repr(xp)
+    if key not in _DEFAULT_DEVICE:
+        try:
+            _DEFAULT_DEVICE[key] = getattr(xp.asarray(0.0), "device", None)
+        except Exception:  # pragma: no cover - namespace without asarray/device
+            _DEFAULT_DEVICE[key] = None
+    return _DEFAULT_DEVICE[key]
+
+
 def _backend_dtype(xp, dtype):
     """Map a numpy dtype to the active backend's dtype.
 

--- a/tests/backend_jit_helpers.py
+++ b/tests/backend_jit_helpers.py
@@ -82,10 +82,13 @@ def count_boundary_crossings(fn, backend):
     real = _bi.coerce_coords
     n = [0]
 
-    def spy(xp, *coords):
+    def spy(xp, *coords, **kwargs):
+        # **kwargs so the spy keeps matching coerce_coords' signature: it grew a
+        # device= anchor, and a positional-only spy turns that into a TypeError
+        # in every test that counts crossings.
         if xp is not numpy:
             n[0] += 1
-        return real(xp, *coords)
+        return real(xp, *coords, **kwargs)
 
     _bi.coerce_coords = spy
     try:

--- a/tests/test_backend_device.py
+++ b/tests/test_backend_device.py
@@ -156,3 +156,41 @@ def test_mixed_coords_cross_device_cuda():
     zc = torch.tensor([0.3, 0.6], device="cuda")
     de = DEDP()(1.5, zc)
     assert de.device.type == "cuda"
+    # A numpy ARRAY sibling, not a scalar. The scalar cases above pass even with
+    # a per-coordinate device anchor, because torch accepts a 0-dim CPU tensor
+    # in a binary op with a CUDA one -- only a non-0-dim numpy sibling exposes a
+    # split anchor. Both orders, since the anchor must not depend on which
+    # coordinate happens to be the backend array.
+    for R, z in (
+        (torch.tensor([1.2, 1.3], device="cuda"), numpy.array([0.1, 0.2])),
+        (numpy.array([1.2, 1.3]), torch.tensor([0.1, 0.2], device="cuda")),
+    ):
+        out = evaluateRforces(_scf(), R, z, phi=0.0)
+        assert out.device.type == "cuda"
+
+
+@pytest.mark.skipif(torch is None, reason="needs torch")
+def test_backend_input_anchors_all_coords_on_one_device():
+    """Every declared coordinate of a call must land on ONE device.
+
+    Coercing them one at a time gives each its own anchor, so a numpy sibling
+    anchors to None -> the backend default device while a CUDA coordinate stays
+    on the GPU. Uses torch's ``meta`` device as a second device so this runs on
+    every runner: without a shared anchor the numpy coordinate lands on ``cpu``
+    and the assertion below fails, exactly as it would on a real GPU.
+    """
+    from galpy.backend._input import backend_input
+
+    class _Target:
+        _backend_compatible = True
+
+        @backend_input("R", "z", "phi")
+        def evaluate(self, R, z, phi=0.0):
+            return R, z, phi
+
+    R, z, phi = _Target().evaluate(
+        torch.tensor([1.2, 1.3], device="meta"), numpy.array([0.1, 0.2]), phi=0.3
+    )
+    assert {R.device.type, z.device.type, phi.device.type} == {"meta"}, (
+        f"split anchor: R={R.device}, z={z.device}, phi={phi.device}"
+    )

--- a/tests/test_backend_diskdf.py
+++ b/tests/test_backend_diskdf.py
@@ -105,9 +105,11 @@ def test_ssp_plain_scalar_stays_on_numpy(backend, fn, monkeypatch):
 
     real, entered = _bi.coerce_coords, []
 
-    def spy(xp, *coords):
+    def spy(xp, *coords, **kwargs):
+        # **kwargs: coerce_coords grew a device= anchor; a positional-only spy
+        # turns every call through it into a TypeError.
         entered.append(getattr(xp, "__name__", str(xp)))
-        return real(xp, *coords)
+        return real(xp, *coords, **kwargs)
 
     monkeypatch.setattr(_bi, "coerce_coords", spy)
 


### PR DESCRIPTION
`@backend_input` coerced each declared coordinate on its own, so each derived its own device anchor **from itself alone**. A numpy/python coordinate has no device, so it anchored to `None` → the backend default device (CPU for torch), while a CUDA sibling stayed on the GPU. The evaluator was then handed a coordinate set split across devices.

Reproduced on a TITAN Xp with a spy on `MiyamotoNagaiPotential._Rforce`:

| call | evaluator sees | result |
|---|---|---|
| `R` numpy 1-D + `z` cuda 1-D | `R=cpu`, `z=cuda:0` | **cpu** |
| `R` cuda 1-D + `z` numpy 1-D | `R=cuda:0`, `z=cpu` | cuda:0 |

Whether that is fatal depends on the potential's arithmetic: a mixed-device error in some, a **silent GPU→CPU transfer** in others — the first row hands back a CPU result for a CUDA input, losing the GPU without saying so.

## Fix

Compute the anchor **once** over all declared coordinates — the wrapper already collects them in `probe` — and thread it into `coerce_coords` through a new `device=` keyword. Both orders now put every coordinate on `cuda:0`.

The numpy path cannot reach any of this: `device_of` is called only inside the `xp is not numpy` branch, and `coerce_coords` returns before consulting `device` on numpy. Byte-identical by construction.

## Tests

Both were verified to **fail without the source change**:

- `test_backend_input_anchors_all_coords_on_one_device` uses torch's **`meta`** device as a second device, so the property is checked on every runner rather than only where a GPU exists. Without a shared anchor: `split anchor: R=meta, z=cpu, phi=cpu`.
- the existing CUDA test gains a numpy-**array** sibling in both orders. Without the fix: `assert 'cpu' == 'cuda'`.

That second one is the gap worth naming. `test_mixed_coords_cross_device_cuda` already covered "mixed scalar/array coords" — but with **scalar** `R,z`, and torch accepts a 0-dim CPU tensor in a binary op with a CUDA one, so a per-coordinate anchor sails straight through. Only a non-0-dim numpy sibling exposes it.

## Gates (from finished runs)

| | |
|---|---|
| numpy `test_potential.py` | 1324 passed |
| forced torch `test_potential.py` | 1288 passed |
| forced jax `test_potential.py` | 1276 passed (57 min) |
| CUDA device test (TITAN Xp) | passed |
| device/input/conventions/coerce suites, rebased | 138 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm