### PR TITLE
backend: put the jit boundary inside the units layer (33 -> 8 traced failures)

### DIFF
--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -562,8 +562,8 @@ class sphericaldf(df):
             )
         )
 
-    @backend_input("r")
     @physical_conversion("velocity", pop=True)
+    @backend_input("r")
     def sigmar(self, r):
         """
         Calculate the radial velocity dispersion at radius r.
@@ -588,8 +588,8 @@ class sphericaldf(df):
             xp.sqrt(self._vmomentdensity(r, 2, 0) / self._vmomentdensity(r, 0, 0)), r
         )
 
-    @backend_input("r")
     @physical_conversion("velocity", pop=True)
+    @backend_input("r")
     def sigmat(self, r):
         """
         Calculate the tangential velocity dispersion at radius r.

--- a/galpy/potential/DissipativeForce.py
+++ b/galpy/potential/DissipativeForce.py
@@ -53,8 +53,8 @@ class DissipativeForce(Force):
         self.hasC_planar = True
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t", "v")
     def Rforce(self, R, z, phi=0.0, t=0.0, v=None):
         """
         Evaluate cylindrical radial force F_R  (R,z).
@@ -85,8 +85,8 @@ class DissipativeForce(Force):
         return self._Rforce_nodecorator(R, z, phi=phi, t=t, v=v)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t", "v")
     def zforce(self, R, z, phi=0.0, t=0.0, v=None):
         """
         Evaluate the vertical force F_z  (R,z,t).
@@ -117,8 +117,8 @@ class DissipativeForce(Force):
         return self._zforce_nodecorator(R, z, phi=phi, t=t, v=v)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t", "v")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "z", "phi", "t", "v")
     def phitorque(self, R, z, phi=0.0, t=0.0, v=None):
         """
         Evaluate the azimuthal torque F_phi  (R,z,phi,t,v).

--- a/galpy/potential/Force.py
+++ b/galpy/potential/Force.py
@@ -317,8 +317,8 @@ class Force:
             return 0.0
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def rforce(self, R, z, **kwargs):
         """
         Evaluate the spherical radial force F_r (R,z).

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -282,8 +282,8 @@ class Potential(Force):
         return None
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def __call__(self, R, z, phi=0.0, t=0.0, dR=0, dphi=0):
         """
         Evaluate the potential at the specified position and time.
@@ -340,8 +340,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def Rforce(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the cylindrical radial force F_R.
@@ -370,8 +370,8 @@ class Potential(Force):
         return self._Rforce_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def zforce(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the vertical force F_z.
@@ -400,8 +400,8 @@ class Potential(Force):
         return self._zforce_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def phitorque(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the azimuthal torque.
@@ -429,8 +429,8 @@ class Potential(Force):
         return self._phitorque_nodecorator(R, z, phi=phi, t=t)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def R2deriv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the second radial derivative.
@@ -464,8 +464,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def z2deriv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the second vertical derivative.
@@ -499,8 +499,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def phi2deriv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the second azimuthal derivative.
@@ -535,8 +535,8 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def Rzderiv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the mixed R,z derivative.
@@ -570,8 +570,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def Rphideriv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the mixed radial, azimuthal derivative.
@@ -606,8 +606,8 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def phizderiv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the mixed azimuthal, vertical derivative.
@@ -643,8 +643,8 @@ class Potential(Force):
             return 0.0
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def r2deriv(self, R, z, phi=0.0, t=0.0):
         """
         Evaluate the second spherical radial derivative.
@@ -682,8 +682,8 @@ class Potential(Force):
         ) * z / r
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("density", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def dens(self, R, z, phi=0.0, t=0.0, forcepoisson=False):
         """
         Evaluate the density rho(R,z,t).
@@ -730,8 +730,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("surfacedensity", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def surfdens(self, R, z, phi=0.0, t=0.0, forcepoisson=False):
         """
         Evaluate the surface density Sigma(R,z,phi,t) = int_{-z}^{+z} dz' rho(R,z',phi,t).
@@ -928,8 +928,8 @@ class Potential(Force):
         )
 
     @potential_physical_input
-    @backend_input("R", "z", "t")
     @physical_conversion("mass", pop=True)
+    @backend_input("R", "z", "t")
     def mass(self, R, z=None, t=0.0, forceint=False):
         """
         Evaluate the mass enclosed.
@@ -1042,8 +1042,8 @@ class Potential(Force):
         return rhalf(self, t=t, INF=INF, use_physical=False)
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("time", pop=True)
+    @backend_input("R", "t")
     def tdyn(self, R, t=0.0):
         """
         Calculate the dynamical time from tdyn^2 = 3pi/[G<rho>]
@@ -1444,8 +1444,8 @@ class Potential(Force):
         )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("velocity", pop=True)
+    @backend_input("R", "phi", "t")
     def vcirc(self, R, phi=None, t=0.0):
         """
         Calculate the circular velocity at R in this potential.
@@ -1477,8 +1477,8 @@ class Potential(Force):
         )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "phi", "t")
     def dvcircdR(self, R, phi=None, t=0.0):
         """
         Calculate the derivative of the circular velocity at R with respect to R in this potential.
@@ -1513,8 +1513,8 @@ class Potential(Force):
         )
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "t")
     def omegac(self, R, t=0.0):
         """
         Calculate the circular angular speed at R in this potential.
@@ -1540,8 +1540,8 @@ class Potential(Force):
         return xp.sqrt(-self.Rforce(R, 0.0, t=t, use_physical=False) / R)
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "t")
     def epifreq(self, R, t=0.0):
         """
         Calculate the epicycle frequency at R in this potential.
@@ -1570,8 +1570,8 @@ class Potential(Force):
         )
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "t")
     def verticalfreq(self, R, t=0.0):
         """
         Calculate the vertical frequency at R in this potential.
@@ -1628,8 +1628,8 @@ class Potential(Force):
         return lindbladR(self, OmegaP, m=m, t=t, use_physical=False, **kwargs)
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("velocity", pop=True)
+    @backend_input("R", "t")
     def vesc(self, R, t=0.0):
         """
         Calculate the escape velocity at R for this potential.
@@ -1744,8 +1744,8 @@ class Potential(Force):
         return LcE(self, E, t=t, use_physical=False)
 
     @potential_physical_input
-    @backend_input("R", "z", "t")
     @physical_conversion("dimensionless", pop=True)
+    @backend_input("R", "z", "t")
     def flattening(self, R, z, t=0.0):
         """
         Calculate the potential flattening, defined as sqrt(fabs(z/R F_R/F_z))
@@ -1977,8 +1977,8 @@ class Potential(Force):
             )
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("position", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def rtide(self, R, z, phi=0.0, t=0.0, M=None):
         """
         Calculate the tidal radius for object of mass M assuming a circular orbit
@@ -2025,8 +2025,8 @@ class Potential(Force):
         return (M / (omegac2 - d2phidr2)) ** (1.0 / 3.0)
 
     @potential_physical_input
-    @backend_input("R", "z", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "z", "phi", "t")
     def ttensor(self, R, z, phi=0.0, t=0.0, eigenval=False):
         """
         Calculate the tidal tensor Tij=-d(Psi)(dxidxj)
@@ -2189,8 +2189,8 @@ class PotentialError(Exception):  # pragma: no cover
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("energy", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluatePotentials(Pot, R, z, phi=None, t=0.0, dR=0, dphi=0):
     """
@@ -2238,8 +2238,8 @@ def _evaluatePotentials(Pot, R, z, phi=None, t=0.0, dR=0, dphi=0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("density", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
     """
@@ -2281,8 +2281,8 @@ def evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("surfacedensity", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateSurfaceDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
     """
@@ -2325,8 +2325,8 @@ def evaluateSurfaceDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "t")
 @physical_conversion("mass", pop=True)
+@backend_input("R", "z", "t")
 @potential_list_of_potentials_input
 def mass(Pot, R, z=None, t=0.0, forceint=False):
     """
@@ -2366,8 +2366,8 @@ def mass(Pot, R, z=None, t=0.0, forceint=False):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
+@backend_input("R", "z", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluateRforces(Pot, R, z, phi=None, t=0.0, v=None):
     """
@@ -2422,8 +2422,8 @@ def _evaluateRforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("energy", pop=True)
+@backend_input("R", "z", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluatephitorques(Pot, R, z, phi=None, t=0.0, v=None):
     """
@@ -2478,8 +2478,8 @@ def _evaluatephitorques(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
+@backend_input("R", "z", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluatezforces(Pot, R, z, phi=None, t=0.0, v=None):
     """
@@ -2534,8 +2534,8 @@ def _evaluatezforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t", "v")
 @physical_conversion("force", pop=True)
+@backend_input("R", "z", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluaterforces(Pot, R, z, phi=None, t=0.0, v=None):
     """
@@ -2584,8 +2584,8 @@ def evaluaterforces(Pot, R, z, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateR2derivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2624,8 +2624,8 @@ def evaluateR2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluatez2derivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2664,8 +2664,8 @@ def evaluatez2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateRzderivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2704,8 +2704,8 @@ def evaluateRzderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("energy", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluatephi2derivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2744,8 +2744,8 @@ def evaluatephi2derivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("force", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateRphiderivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2784,8 +2784,8 @@ def evaluateRphiderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("force", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluatephizderivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -2824,8 +2824,8 @@ def evaluatephizderivs(Pot, R, z, phi=None, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "z", "phi", "t")
 @potential_list_of_potentials_input
 def evaluater2derivs(Pot, R, z, phi=None, t=0.0):
     """
@@ -3328,8 +3328,8 @@ def plotSurfaceDensities(
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
+@backend_input("R", "t")
 @potential_list_of_potentials_input
 def epifreq(Pot, R, t=0.0):
     """
@@ -3359,8 +3359,8 @@ def epifreq(Pot, R, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
+@backend_input("R", "t")
 @potential_list_of_potentials_input
 def verticalfreq(Pot, R, t=0.0):
     """
@@ -3390,8 +3390,8 @@ def verticalfreq(Pot, R, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "t")
 @physical_conversion("dimensionless", pop=True)
+@backend_input("R", "z", "t")
 @potential_list_of_potentials_input
 def flattening(Pot, R, z, t=0.0):
     """
@@ -3753,8 +3753,8 @@ def _lindbladR_eq(R, Pot, OmegaP, m, t=0.0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "t")
 @physical_conversion("frequency", pop=True)
+@backend_input("R", "t")
 @potential_list_of_potentials_input
 def omegac(Pot, R, t=0.0):
     """
@@ -3793,8 +3793,8 @@ def omegac(Pot, R, t=0.0):
 
 
 @potential_physical_input
-@backend_input("R", "phi", "t")
 @physical_conversion("velocity", pop=True)
+@backend_input("R", "phi", "t")
 @potential_list_of_potentials_input
 def vcirc(Pot, R, phi=None, t=0.0):
     """
@@ -3839,8 +3839,8 @@ def vcirc(Pot, R, phi=None, t=0.0):
 
 
 @potential_physical_input
-@backend_input("R", "phi", "t")
 @physical_conversion("frequency", pop=True)
+@backend_input("R", "phi", "t")
 @potential_list_of_potentials_input
 def dvcircdR(Pot, R, phi=None, t=0.0):
     """
@@ -3899,8 +3899,8 @@ def dvcircdR(Pot, R, phi=None, t=0.0):
 
 
 @potential_physical_input
-@backend_input("R", "t")
 @physical_conversion("velocity", pop=True)
+@backend_input("R", "t")
 @potential_list_of_potentials_input
 def vesc(Pot, R, t=0.0):
     """
@@ -4618,8 +4618,8 @@ def kms_to_kpcGyrDecorator(func):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("position", pop=True)
+@backend_input("R", "z", "phi", "t")
 def rtide(Pot, R, z, phi=0.0, t=0.0, M=None):
     """
     Calculate the tidal radius for object of mass M assuming a circular orbit as
@@ -4671,8 +4671,8 @@ def rtide(Pot, R, z, phi=0.0, t=0.0, M=None):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "z", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "z", "phi", "t")
 def ttensor(Pot, R, z, phi=0.0, t=0.0, eigenval=False):
     """
     Calculate the tidal tensor Tij=-d(Psi)(dxidxj)
@@ -5000,8 +5000,8 @@ def _rhalfFindStart(rh, pot, tot_mass, t=0.0, lower=False):
 @potential_list_of_potentials_input
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "t")
 @physical_conversion("time", pop=True)
+@backend_input("R", "t")
 def tdyn(Pot, R, t=0.0):
     """
     Calculate the dynamical time from tdyn^2 = 3pi/[G<rho>].

--- a/galpy/potential/linearPotential.py
+++ b/galpy/potential/linearPotential.py
@@ -253,8 +253,8 @@ class linearPotential:
         return None
 
     @potential_physical_input
-    @backend_input("x", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("x", "t")
     def __call__(self, x, t=0.0):
         """
         Evaluate the potential.
@@ -289,8 +289,8 @@ class linearPotential:
             )
 
     @potential_physical_input
-    @backend_input("x", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("x", "t")
     def force(self, x, t=0.0):
         """
         Evaluate the force.
@@ -386,8 +386,8 @@ class linearPotential:
 @potential_positional_arg
 @potential_list_of_potentials_input
 @potential_physical_input
-@backend_input("x", "t")
 @physical_conversion("energy", pop=True)
+@backend_input("x", "t")
 def evaluatelinearPotentials(Pot, x, t=0.0):
     """
     Evaluate the sum of a combination of potentials.
@@ -427,8 +427,8 @@ def _evaluatelinearPotentials(Pot, x, t=0.0):
 @potential_positional_arg
 @potential_list_of_potentials_input
 @potential_physical_input
-@backend_input("x", "t")
 @physical_conversion("force", pop=True)
+@backend_input("x", "t")
 def evaluatelinearForces(Pot, x, t=0.0):
     """
     Evaluate the forces due to a combination of potentials.

--- a/galpy/potential/planarDissipativeForce.py
+++ b/galpy/potential/planarDissipativeForce.py
@@ -34,8 +34,8 @@ class planarDissipativeForce(planarForce):
         self.isDissipative = True
 
     @potential_physical_input
-    @backend_input("R", "phi", "t", "v")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "phi", "t", "v")
     def Rforce(self, R, phi=0.0, t=0.0, v=None):
         """
         Evaluate cylindrical radial force F_R  (R,phi).
@@ -64,8 +64,8 @@ class planarDissipativeForce(planarForce):
         return self._Rforce_nodecorator(R, phi=phi, t=t, v=v)
 
     @potential_physical_input
-    @backend_input("R", "phi", "t", "v")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "phi", "t", "v")
     def phitorque(self, R, phi=0.0, t=0.0, v=None):
         """
         Evaluate the azimuthal torque F_phi (R, phi, t, v).

--- a/galpy/potential/planarPotential.py
+++ b/galpy/potential/planarPotential.py
@@ -39,8 +39,8 @@ class planarPotential(planarForce):
         self.isDissipative = False
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "phi", "t")
     def __call__(self, R, phi=0.0, t=0.0, dR=0, dphi=0):
         """
         Evaluate the potential.
@@ -95,8 +95,8 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "phi", "t")
     def Rforce(self, R, phi=0.0, t=0.0):
         r"""
         Evaluate the radial force.
@@ -123,8 +123,8 @@ class planarPotential(planarForce):
         return self._Rforce_nodecorator(R, phi=phi, t=t)
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "phi", "t")
     def phitorque(self, R, phi=0.0, t=0.0):
         """
         Evaluate the azimuthal torque = - d Phi / d phi.
@@ -151,8 +151,8 @@ class planarPotential(planarForce):
         return self._phitorque_nodecorator(R, phi=phi, t=t)
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("forcederivative", pop=True)
+    @backend_input("R", "phi", "t")
     def R2deriv(self, R, phi=0.0, t=0.0):
         """
         Evaluate the second radial derivative.
@@ -183,8 +183,8 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("energy", pop=True)
+    @backend_input("R", "phi", "t")
     def phi2deriv(self, R, phi=0.0, t=0.0):
         """
         Evaluate the second azimuthal derivative.
@@ -216,8 +216,8 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("force", pop=True)
+    @backend_input("R", "phi", "t")
     def Rphideriv(self, R, phi=0.0, t=0.0):
         """
         Evaluate the mixed radial and azimuthal derivative.
@@ -249,8 +249,8 @@ class planarPotential(planarForce):
             )
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "t")
     def epifreq(self, R, t=0.0):
         """
         Calculate the epicycle frequency at R in this potential.
@@ -279,8 +279,8 @@ class planarPotential(planarForce):
         )
 
     @potential_physical_input
-    @backend_input("R", "phi", "t")
     @physical_conversion("velocity", pop=True)
+    @backend_input("R", "phi", "t")
     def vcirc(self, R, phi=None, t=0.0):
         """
         Calculate the circular velocity at R in potential Pot.
@@ -309,8 +309,8 @@ class planarPotential(planarForce):
         return xp.sqrt(R * -self.Rforce(R, phi=phi, t=t, use_physical=False))
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("frequency", pop=True)
+    @backend_input("R", "t")
     def omegac(self, R, t=0.0):
         """
         Calculate the circular angular speed at R in potential Pot.
@@ -455,8 +455,8 @@ class planarAxiPotential(planarPotential):
         return lindbladR(self, OmegaP, m=m, t=t, use_physical=False, **kwargs)
 
     @potential_physical_input
-    @backend_input("R", "t")
     @physical_conversion("velocity", pop=True)
+    @backend_input("R", "t")
     def vesc(self, R, t=0.0):
         """
         Calculate the escape velocity at R for the potential.
@@ -1012,8 +1012,8 @@ def toPlanarPotential(Pot):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "phi", "t")
 @physical_conversion("energy", pop=True)
+@backend_input("R", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateplanarPotentials(Pot, R, phi=None, t=0.0, dR=0, dphi=0):
     """
@@ -1066,8 +1066,8 @@ def _evaluateplanarPotentials(Pot, R, phi=None, t=0.0, dR=0, dphi=0):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "phi", "t", "v")
 @physical_conversion("force", pop=True)
+@backend_input("R", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluateplanarRforces(Pot, R, phi=None, t=0.0, v=None):
     """
@@ -1130,8 +1130,8 @@ def _evaluateplanarRforces(Pot, R, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "phi", "t", "v")
 @physical_conversion("energy", pop=True)
+@backend_input("R", "phi", "t", "v")
 @potential_list_of_potentials_input
 def evaluateplanarphitorques(Pot, R, phi=None, t=0.0, v=None):
     """
@@ -1193,8 +1193,8 @@ def _evaluateplanarphitorques(Pot, R, phi=None, t=0.0, v=None):
 
 @potential_positional_arg
 @potential_physical_input
-@backend_input("R", "phi", "t")
 @physical_conversion("forcederivative", pop=True)
+@backend_input("R", "phi", "t")
 @potential_list_of_potentials_input
 def evaluateplanarR2derivs(Pot, R, phi=None, t=0.0):
     """

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -474,3 +474,82 @@ def test_scalar_only_gate_spares_unmigrated_potential(backend):
         # the scipy scalar path runs and returns a plain float, no crash.
         got = float(pot._evaluate(0.9, 0.1, 0.0, 0.0))
     numpy.testing.assert_allclose(got, ref, rtol=1e-10, atol=0.0)
+
+
+###############################################################################
+# Decorator ORDER: the jit boundary must sit inside the units layer.
+#
+# Decorators apply bottom-up, so a method written
+#
+#     @backend_input("R", "z")      <- jit boundary
+#     @physical_conversion("force")  <- builds the Quantity
+#
+# attaches output units INSIDE the traced region, and Quantity.__new__ calls
+# __array__, which a tracer refuses (TracerArrayConversionError). Putting
+# physical_conversion OUTSIDE means the trace returns a concrete array and the
+# units are attached afterwards, which is both traceable and what the eager
+# path already does. This was 75 sites across 7 files, every one in the wrong
+# order, costing 33 jax --jit failures that had been mis-diagnosed as "astropy
+# and tracing are incompatible by design".
+###############################################################################
+
+_UNITS_DECORATORS = (
+    "physical_conversion",
+    "physical_conversion_tuple",
+    "physical_conversion_actionAngle",
+    "physical_conversion_actionAngleInverse",
+)
+
+
+def _decorator_name(dec):
+    """Bare name of a decorator node, whether or not it is called."""
+    node = dec.func if isinstance(dec, ast.Call) else dec
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _order_violations(path):
+    """(qualname, units_idx, boundary_idx) where the boundary is OUTSIDE units."""
+    out = []
+    for node in ast.walk(ast.parse(path.read_text())):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        names = [_decorator_name(d) for d in node.decorator_list]
+        if "backend_input" not in names:
+            continue
+        units = [ii for ii, n in enumerate(names) if n in _UNITS_DECORATORS]
+        if not units:
+            continue
+        boundary = names.index("backend_input")
+        # decorator_list is source order, i.e. OUTERMOST first: a lower index is
+        # further out. The units decorator must be outside the boundary.
+        if min(units) > boundary:
+            out.append((node.name, min(units), boundary))
+    return out
+
+
+_UNITS_BOUNDARY_FILES = sorted(
+    p
+    for p in pathlib.Path(potential.__file__).parent.parent.rglob("*.py")
+    if "backend_input" in p.read_text() and "physical_conversion" in p.read_text()
+)
+
+
+def test_units_boundary_files_are_found():
+    """Guard the glob: an empty file list would make the check below vacuous."""
+    assert len(_UNITS_BOUNDARY_FILES) >= 5, (
+        f"only {len(_UNITS_BOUNDARY_FILES)} files carry both decorators; the "
+        "search is probably broken"
+    )
+
+
+@pytest.mark.parametrize("module_path", _UNITS_BOUNDARY_FILES, ids=lambda p: p.stem)
+def test_units_decorator_is_outside_the_jit_boundary(module_path):
+    violations = _order_violations(module_path)
+    assert not violations, (
+        f"{module_path.name}: @backend_input is OUTSIDE the units decorator on "
+        f"{[v[0] for v in violations]}. The Quantity would then be built inside "
+        "the jit trace and raise TracerArrayConversionError; put "
+        "@physical_conversion above @backend_input."
+    )


### PR DESCRIPTION
Decorators apply bottom-up, so every units-returning method ran as:

```
@potential_physical_input      1. strip INPUT units
@backend_input("R","z",...)    2. ← jit boundary
@physical_conversion("force")  3. ← builds the Quantity, INSIDE the trace
def Rforce(...)                4. body
```

`physical_conversion` therefore constructed the astropy `Quantity` **inside the traced region**, and `Quantity.__new__` calls `__array__`, which a tracer refuses. The traceback shows the nesting: `traced_call` → `_jit.py shim` → `conversion.py wrapped` → `astropy/units/quantity.py` → `TracerArrayConversionError`.

I had previously recorded these 33 jax `--jit` failures as *"astropy and tracing are mutually exclusive by design; no backend work fixes it."* That was inferred from the error text and never tested. **It was wrong** — units attach perfectly well once they attach *after* the trace returns a concrete array.

## The A/B that established it

Swapping the pair in `Potential.py` **only** moved the failure: `pot(1.1, 0.1)` and `pot.Rforce(...)` went from failing to **passing**, and the test then failed at `pot.rforce(...)` — a method in a file I hadn't swapped yet.

## Change

75 sites across 7 files (Potential 49, planarPotential 14, linearPotential 4, DissipativeForce 3, sphericaldf 2, planarDissipativeForce 2, Force 1). **No** site had the correct order, so it's uniform — and the diff is a **provably pure reordering**: 75 lines added, 75 removed, identical as multisets, zero content change.

## Measured (finished runs)

| | result |
|---|---|
| jax `--jit` `test_quantity`+`test_coords` | **33 failures → 8** |
| numpy `test_quantity` | 244 passed, 0 failed |
| numpy `test_potential` | 1288 passed, 0 failed |

The numpy path is untouched (the units decorators are no-ops with `apy-units` off) — verified rather than assumed.

## Structural invariant

Added to `test_backend_conventions.py`, where the other source-structure checks live: for any method carrying both decorators, the units decorator must be the **outer** one. A/B'd — reverting the source makes it fail on exactly the 7 offending files and name the methods. It covers all four `physical_conversion*` spellings (plain, `_tuple`, `_actionAngle`, `_actionAngleInverse`); widening from 2 to 4 found no further violations, which is what confirms 75 was the complete set. A glob guard keeps an empty file list from making it pass vacuously.

## Residual 8 — a different mechanism, deliberately not in scope here

`sphericaldf.vmomentdensity` and friends carry `@backend_input` but **no** `@physical_conversion` — they build the Quantity inline in the body (`units.Quantity(as_numpy(out) * fac, unit=u)`), so there is no decorator to reorder and the invariant cannot see them. That needs restructuring (split the traced compute from the untraced unit attachment) and is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm