### PR TITLE
df/jit: parse input units outside the traced boundary (stacked on #1301)

### DIFF
--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -193,7 +193,7 @@ def backend_input(*coords):
                 # Under an opt-in trace mode this boundary is also where the
                 # jit/compile happens: the declared coordinates are the traced
                 # arguments and everything else is static. Off by default.
-                out = traced_call(method, args, kwargs, slots, nargs)
+                out = traced_call(method, args, kwargs, slots, nargs, xp)
                 if out is not NOT_TRACED:
                     return out
             return method(*args, **kwargs)

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -23,6 +23,8 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
 
+from ._namespaces import name_of_namespace
+
 # "off" | "jax" | "torch". Process-wide, like the backend selection itself.
 _JIT_CTX = ContextVar("galpy_jit_mode", default="off")
 # Set while a traced call is on the stack. Entry points call each other
@@ -193,7 +195,13 @@ def traced_call(method, args, kwargs, slots, nargs, xp=None):
     # harness runs --backend jax --jit gets torch-coerced coordinates handed to
     # a jax.jit, which raises "Error interpreting argument ... as an abstract
     # array". Trace only what this mode can actually trace; run the rest eager.
-    if xp is not None and not getattr(xp, "__name__", "").startswith(mode):
+    #
+    # Compare through name_of_namespace, NOT a startswith on __name__: the torch
+    # namespace is array_api_compat.torch, whose __name__ does not begin with
+    # "torch", so a prefix test silently disables torch tracing everywhere.
+    # numpy coordinates stay traceable -- both jax.jit and torch.compile accept
+    # them, and only a different BACKEND framework has to stay eager.
+    if xp is not None and name_of_namespace(xp) not in (mode, "numpy"):
         return NOT_TRACED
     if mode == "torch":
         compiled = _JITTED.get((method, "torch"))

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -178,7 +178,7 @@ def _torch_compiled(method):
     return torch.compile(call, fullgraph=False, dynamic=False)
 
 
-def traced_call(method, args, kwargs, slots, nargs):
+def traced_call(method, args, kwargs, slots, nargs, xp=None):
     """Run ``method`` under the active trace mode, or return ``NOT_TRACED``.
 
     ``slots`` is ``@backend_input``'s precomputed (name, positional index) list:
@@ -187,6 +187,13 @@ def traced_call(method, args, kwargs, slots, nargs):
     """
     mode = _JIT_CTX.get()
     if mode == "off" or _TRACING.get():
+        return NOT_TRACED
+    # The trace mode names ONE framework, but the caller can be on a DIFFERENT
+    # one inside it: a test that enters use("torch", force=True) while the
+    # harness runs --backend jax --jit gets torch-coerced coordinates handed to
+    # a jax.jit, which raises "Error interpreting argument ... as an abstract
+    # array". Trace only what this mode can actually trace; run the rest eager.
+    if xp is not None and not getattr(xp, "__name__", "").startswith(mode):
         return NOT_TRACED
     if mode == "torch":
         compiled = _JITTED.get((method, "torch"))

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -461,7 +461,6 @@ class sphericaldf(df):
             Ei,
         )
 
-    @backend_input("r")
     def vmomentdensity(self, r, n, m, **kwargs):
         """
         Calculate an arbitrary moment of the velocity distribution at r times the density.
@@ -494,18 +493,29 @@ class sphericaldf(df):
         if vo is None and hasattr(self, "_voSet") and self._voSet:
             vo = self._vo
         vo = conversion.parse_velocity_kms(vo)
+        # The @backend_input boundary wraps only the compute below, so the
+        # Quantity is built out here rather than inside the trace -- astropy
+        # calls __array__, which a tracer refuses. Same principle as the
+        # physical_conversion/backend_input decorator order enforced by
+        # test_backend_conventions; this method carries no units decorator to
+        # reorder, so the split is done by hand.
+        out = self._vmomentdensity_backend(r, n, m)
         if use_physical and vo is not None and ro is not None:
             fac = conversion.mass_in_msol(vo, ro) * vo ** (n + m) / ro**3
-            out = self._vmomentdensity(r, n, m)
             if _optional_deps._APY_UNITS:
                 u = units.Msun / units.kpc**3 * (units.km / units.s) ** (n + m)
                 # a Quantity is a consumption boundary: astropy can't hold a
                 # backend array (#1052), so cast unconditionally
                 return units.Quantity(as_numpy(out) * fac, unit=u)
             else:
-                return exit_cast(out, r) * fac
+                return out * fac
         else:
-            return exit_cast(self._vmomentdensity(r, n, m), r)
+            return out
+
+    @backend_input("r")
+    def _vmomentdensity_backend(self, r, n, m):
+        """Traced half of ``vmomentdensity``: no units may be built in here."""
+        return exit_cast(self._vmomentdensity(r, n, m), r)
 
     def _vmomentdensity(self, r, n, m):
         xp = resolve_namespace(r)
@@ -563,7 +573,6 @@ class sphericaldf(df):
         )
 
     @physical_conversion("velocity", pop=True)
-    @backend_input("r")
     def sigmar(self, r):
         """
         Calculate the radial velocity dispersion at radius r.
@@ -582,14 +591,23 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
-        r = conversion.parse_length(r, ro=self._ro)
+        # Parse input units OUT HERE, before the @backend_input boundary on the
+        # helper. A Quantity handed to the boundary is converted by jit through
+        # __array__, which yields the bare VALUE and silently drops the unit --
+        # sigmar(1 * u.pc) would then compute at r = 1 in INTERNAL units.
+        # Potentials avoid this because @potential_physical_input strips input
+        # units outside the boundary; these df methods parse inline, so the
+        # parse is hoisted and only the compute is traced.
+        return self._sigmar_backend(conversion.parse_length(r, ro=self._ro))
+
+    @backend_input("r")
+    def _sigmar_backend(self, r):
         xp = resolve_namespace(r)  # numpy path: xp.sqrt == numpy.sqrt (byte-identical)
         return exit_cast(
             xp.sqrt(self._vmomentdensity(r, 2, 0) / self._vmomentdensity(r, 0, 0)), r
         )
 
     @physical_conversion("velocity", pop=True)
-    @backend_input("r")
     def sigmat(self, r):
         """
         Calculate the tangential velocity dispersion at radius r.
@@ -609,13 +627,16 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
-        r = conversion.parse_length(r, ro=self._ro)
+        # units parsed outside the boundary -- see sigmar
+        return self._sigmat_backend(conversion.parse_length(r, ro=self._ro))
+
+    @backend_input("r")
+    def _sigmat_backend(self, r):
         xp = resolve_namespace(r)  # numpy path: xp.sqrt == numpy.sqrt (byte-identical)
         return exit_cast(
             xp.sqrt(self._vmomentdensity(r, 0, 2) / self._vmomentdensity(r, 0, 0)), r
         )
 
-    @backend_input("r")
     def beta(self, r):
         """
         Calculate the anisotropy at radius r.
@@ -635,7 +656,11 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
-        r = conversion.parse_length(r, ro=self._ro)
+        # units parsed outside the boundary -- see sigmar
+        return self._beta_backend(conversion.parse_length(r, ro=self._ro))
+
+    @backend_input("r")
+    def _beta_backend(self, r):
         return exit_cast(
             1.0 - self._vmomentdensity(r, 0, 2) / 2.0 / self._vmomentdensity(r, 2, 0), r
         )

--- a/tests/test_backend_input.py
+++ b/tests/test_backend_input.py
@@ -370,23 +370,66 @@ def test_coordinate_entry_points_are_decorated_or_listed():
 
     import galpy
 
+    def _decorators(node):
+        return {
+            (
+                d.func.id
+                if isinstance(d, ast.Call) and isinstance(d.func, ast.Name)
+                else getattr(d, "id", None)
+            )
+            for d in node.decorator_list
+        }
+
     stray = []
     for path in sorted(pathlib.Path(galpy.__file__).parent.rglob("*.py")):
         try:
             tree = ast.parse(path.read_text())
         except SyntaxError:  # pragma: no cover - galpy always parses
             continue
+        # Names in this module that DO coerce. A public entry point may parse its
+        # input units and then hand the bare coordinate to one of these -- that is
+        # the shape required to keep astropy outside the trace boundary, since
+        # @backend_input has to sit inside the unit parsing, not around it. Such a
+        # method still coerces; it just does it one call down.
+        coercing = {
+            n.name
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and "backend_input" in _decorators(n)
+        }
+
+        def _delegates_to_coercing(node, coords):
+            """True if ``node`` hands one of ``coords`` to a coercing function.
+
+            Requiring the coordinate to actually reach the call is what keeps this
+            from becoming a loophole: merely mentioning a decorated helper
+            somewhere in the body would excuse an entry point whose own arguments
+            never get coerced at all.
+            """
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                fn = call.func
+                name = (
+                    fn.attr
+                    if isinstance(fn, ast.Attribute)
+                    else getattr(fn, "id", None)
+                )
+                if name not in coercing:
+                    continue
+                passed = {
+                    sub.id
+                    for arg in list(call.args) + [k.value for k in call.keywords]
+                    for sub in ast.walk(arg)
+                    if isinstance(sub, ast.Name)
+                }
+                if passed & coords:
+                    return True
+            return False
+
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
                 continue
-            names = {
-                (
-                    d.func.id
-                    if isinstance(d, ast.Call) and isinstance(d.func, ast.Name)
-                    else getattr(d, "id", None)
-                )
-                for d in node.decorator_list
-            }
+            names = _decorators(node)
             if "physical_conversion" not in names or "backend_input" in names:
                 continue
             named = [a.arg for a in node.args.posonlyargs + node.args.args][1:]
@@ -394,6 +437,7 @@ def test_coordinate_entry_points_are_decorated_or_listed():
                 set(named) & _COORD_NAMES
                 and (path.name, node.name) not in _UNDECORATED_BY_DESIGN
                 and path.name not in _UNDECORATED_MODULES
+                and not _delegates_to_coercing(node, set(named) & _COORD_NAMES)
             ):
                 stray.append(f"{path.name}::{node.name}({', '.join(named)})")
     assert not stray, (

--- a/tests/test_backend_input.py
+++ b/tests/test_backend_input.py
@@ -445,3 +445,58 @@ def test_coordinate_entry_points_are_decorated_or_listed():
         "in _UNDECORATED_BY_DESIGN / _UNDECORATED_MODULES:\n  "
         + "\n  ".join(sorted(set(stray)))
     )
+
+
+@pytest.mark.parametrize("mode", ["jax", "torch"])
+def test_traced_call_traces_exactly_the_matching_namespace(mode):
+    # The guard in traced_call decides which calls a given trace mode may
+    # actually trace. It is invisible to every value-based test: an untraced call
+    # returns the same numbers as a traced one, so a mis-scoped guard silently
+    # turns tracing off and the suite stays green. That is not hypothetical --
+    # comparing xp.__name__ with startswith("torch") matched NOTHING, because the
+    # torch namespace is array_api_compat.torch, and it disabled torch tracing
+    # everywhere while every torch --jit test still passed.
+    #
+    # So assert the routing itself, not a value: NOT_TRACED or not, per namespace.
+    if mode not in _NS:
+        pytest.skip(f"{mode} not installed")
+    from galpy.backend._jit import NOT_TRACED, traced_call
+
+    def probe(x):
+        return x * 2.0
+
+    def _ns_module(name):
+        if name == "numpy":
+            return numpy
+        if name == "jax":
+            import jax.numpy
+
+            return jax.numpy
+        import array_api_compat.torch
+
+        return array_api_compat.torch
+
+    wrong = []
+    with backend.jit(mode):
+        for name in ["numpy"] + AD_BACKENDS:
+            xp = _ns_module(name)
+            got = traced_call(probe, (_asarray_for(name, 1.5),), {}, (("x", 0),), 1, xp)
+            traced = got is not NOT_TRACED
+            # numpy data is traceable by either framework; only a DIFFERENT
+            # backend framework has to stay eager.
+            expected = name in (mode, "numpy")
+            if traced is not expected:
+                wrong.append(
+                    f"{name}: {'traced' if traced else 'eager'} "
+                    f"(expected {'traced' if expected else 'eager'})"
+                )
+    # Report the WHOLE routing table rather than failing on the first mismatch:
+    # the torch entry is the one a __name__ prefix test gets wrong, and stopping
+    # at an earlier namespace would hide it.
+    assert not wrong, f"jit({mode}) routed the wrong namespaces -- " + "; ".join(wrong)
+
+
+def _asarray_for(name, x):
+    if name == "numpy":
+        return numpy.float64(x)
+    return _asarray(name, x)

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17803,7 +17803,14 @@ def test_sphericaldf_quantity_radius_is_not_coerced_on_a_backend(backend_name):
         jax.config.update("jax_enable_x64", True)
     pot = potential.HernquistPotential(amp=2.0, a=1.3)
     dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
-    ref = float(dfh.sigmar(100.0 * units.pc, use_physical=False))
+    # Pin the reference to numpy. Under the all-backend harness's --jit mode the
+    # WHOLE test runs inside a forced backend + jit context, so an unpinned
+    # reference is computed on the same path as `got` -- if that path drops the
+    # Quantity's unit, both sides are wrong by the same factor and the assertion
+    # passes vacuously. It did: traced sigmar(100 pc) returned the value for
+    # r = 100 in INTERNAL units, 0.685 relative off, and this test still passed.
+    with galpy.backend.use("numpy", force=True):
+        ref = float(dfh.sigmar(100.0 * units.pc, use_physical=False))
     with galpy.backend.use(backend_name, force=True):
         got = float(as_numpy(dfh.sigmar(100.0 * units.pc, use_physical=False)))
     assert numpy.isfinite(got), "Quantity radius produced a non-finite result"

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17801,18 +17801,28 @@ def test_sphericaldf_quantity_radius_is_not_coerced_on_a_backend(backend_name):
         import jax
 
         jax.config.update("jax_enable_x64", True)
-    pot = potential.HernquistPotential(amp=2.0, a=1.3)
-    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
-    # Pin the reference to numpy. Under the all-backend harness's --jit mode the
-    # WHOLE test runs inside a forced backend + jit context, so an unpinned
-    # reference is computed on the same path as `got` -- if that path drops the
-    # Quantity's unit, both sides are wrong by the same factor and the assertion
-    # passes vacuously. It did: traced sigmar(100 pc) returned the value for
-    # r = 100 in INTERNAL units, 0.685 relative off, and this test still passed.
+
+    def _sigmar():
+        pot = potential.HernquistPotential(amp=2.0, a=1.3)
+        return isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0).sigmar(
+            100.0 * units.pc, use_physical=False
+        )
+
+    # Build AND evaluate each df under one backend. Two reasons:
+    #  * the reference must be pinned to numpy -- under the harness's --jit mode
+    #    the whole test runs inside a forced backend, so an unpinned reference
+    #    is computed on the same path as `got`, and if that path drops the
+    #    Quantity's unit both sides are wrong by the same factor and this
+    #    assertion passes VACUOUSLY. It did: traced sigmar(100 pc) returned the
+    #    value for r = 100 in INTERNAL units, 0.685 relative off, still "passing".
+    #  * a df CONSTRUCTED under one backend caches arrays of that backend, and
+    #    meeting them from another raises (Tensor / jaxlib ArrayImpl). Reusing
+    #    one object across backends is a separate hazard from the units contract
+    #    under test here, so each arm gets its own.
     with galpy.backend.use("numpy", force=True):
-        ref = float(dfh.sigmar(100.0 * units.pc, use_physical=False))
+        ref = float(_sigmar())
     with galpy.backend.use(backend_name, force=True):
-        got = float(as_numpy(dfh.sigmar(100.0 * units.pc, use_physical=False)))
+        got = float(as_numpy(_sigmar()))
     assert numpy.isfinite(got), "Quantity radius produced a non-finite result"
     numpy.testing.assert_allclose(got, ref, rtol=1e-7)
 


### PR DESCRIPTION
**Stacked on gh#1301** (`backend-jit/units-jit-boundary`) — review that one first; this PR's diff is only the commit on top.

`sphericaldf`'s `sigmar`/`sigmat`/`beta`/`vmomentdensity` parse their input units **inside** the body (`conversion.parse_length`), so a `Quantity` reaches the `@backend_input` boundary and `jax.jit` converts it through `__array__`, taking the bare value and **dropping the unit**:

```
numpy (correct)     sigmar(100 pc) = 0.14090842477103016
forced jax + jit    sigmar(100 pc) = 0.04438549032202838   ← 68.5% wrong, silently
```

**Pre-existing on develop** (measured at `d76d683b`) — not introduced by the decorator swap this is stacked on. Potentials are unaffected because `@potential_physical_input` strips input units outside the boundary; these four methods carry no such decorator, so the parse is hoisted by hand: the public method parses, a `@backend_input` helper computes.

Verified: traced `sigmar(1.0 pc)` then matches `sigmar(1/8000 internal)` to 2e-15, and the jax `--jit` sphericaldf group goes **5 failed → 1 failed / 8 passed**.

Two supporting fixes:

- **`traced_call` declines to trace when the active namespace isn't the jit mode's framework.** A test entering `use("torch", force=True)` while the harness runs `--backend jax --jit` was handing torch Tensors to a `jax.jit` (*"Error interpreting argument … as an abstract array"*).
- **`test_sphericaldf_quantity_radius_is_not_coerced_on_a_backend` pins its reference to numpy.** Under `--jit` the whole test runs inside the forced-backend context, so the unpinned reference was computed on the same wrong path as the result — both wrong by the same factor, so the assertion **passed vacuously** while the value was 68% off.

## Draft: what's left

The torch parametrization of that test now fails differently — `Tensor / jaxlib._jax.ArrayImpl` inside `_vmomentdensity`. A df **constructed** under one backend caches arrays that a second forced backend then meets. That is cross-backend cached state, a distinct hazard from the units boundary, and it is what remains before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm