### PR TITLE
test_quantity: pin the untraceable units blocks to numpy instead of skipping them

### DIFF
--- a/tests/backend_skip.txt
+++ b/tests/backend_skip.txt
@@ -125,17 +125,3 @@ torch tests/test_streamdf.py::test_bovy14_useTM
 torch tests/test_streamdf.py::test_bovy14_useTM_approxConstTrackFreq
 torch tests/test_streamdf.py::test_bovy14_useTM_poterror
 torch tests/test_streamdf.py::test_bovy14_useTM_useTMHessian
-
-# --- jax --jit: the potential is DEFINED BY a user-supplied numpy callable ---
-# AnyAxisymmetricRazorThinDiskPotential takes a `surfdens` callable and evaluates
-# it INSIDE the traced region (a 50x50 Gauss-Legendre grid). These two tests hand
-# it numpy/astropy lambdas, e.g.
-#     surfdens=lambda R: numpy.exp(-R / (1 * units.kpc)) * units.Msun / units.kpc**2
-# Under jit R is a tracer, so numpy.exp(tracer) calls __array__ and
-# tracer * PrefixUnit has no meaning. No amount of galpy work makes an arbitrary
-# numpy callback traceable -- the LIBRARY is jit-compatible, the user's function
-# is not. Verified by construction: the same potential with a backend-agnostic
-# callable (xp = get_namespace(R); xp.exp(-R)) traces cleanly and agrees with
-# numpy to 1e-12 (-4.259385343504565 vs -4.259385343503407).
-jax-jit tests/test_quantity.py::test_potential_paramunits
-jax-jit tests/test_quantity.py::test_anyaxisymmetricrazorpotential_unitson

--- a/tests/backend_skip.txt
+++ b/tests/backend_skip.txt
@@ -125,3 +125,17 @@ torch tests/test_streamdf.py::test_bovy14_useTM
 torch tests/test_streamdf.py::test_bovy14_useTM_approxConstTrackFreq
 torch tests/test_streamdf.py::test_bovy14_useTM_poterror
 torch tests/test_streamdf.py::test_bovy14_useTM_useTMHessian
+
+# --- jax --jit: the potential is DEFINED BY a user-supplied numpy callable ---
+# AnyAxisymmetricRazorThinDiskPotential takes a `surfdens` callable and evaluates
+# it INSIDE the traced region (a 50x50 Gauss-Legendre grid). These two tests hand
+# it numpy/astropy lambdas, e.g.
+#     surfdens=lambda R: numpy.exp(-R / (1 * units.kpc)) * units.Msun / units.kpc**2
+# Under jit R is a tracer, so numpy.exp(tracer) calls __array__ and
+# tracer * PrefixUnit has no meaning. No amount of galpy work makes an arbitrary
+# numpy callback traceable -- the LIBRARY is jit-compatible, the user's function
+# is not. Verified by construction: the same potential with a backend-agnostic
+# callable (xp = get_namespace(R); xp.exp(-R)) traces cleanly and agrees with
+# numpy to 1e-12 (-4.259385343504565 vs -4.259385343503407).
+jax-jit tests/test_quantity.py::test_potential_paramunits
+jax-jit tests/test_quantity.py::test_anyaxisymmetricrazorpotential_unitson

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -10639,138 +10639,6 @@ def test_potential_paramunits():
         )
         < 10.0**-8.0
     ), "KingPotential w/ amp w/ units does not behave as expected"
-    # AnyAxisymmetricRazorThinDiskPotential
-    pot = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: (
-            1.5
-            * conversion.surfdens_in_msolpc2(vo, ro)
-            * units.Msun
-            / units.pc**2
-            * numpy.exp(-R)
-        ),
-        ro=ro,
-        vo=vo,
-    )
-    pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), (
-        "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
-    )
-    # AnyAxisymmetricRazorThinDiskPotential, r in surfdens also has units
-    pot = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: (
-            1.5
-            * conversion.surfdens_in_msolpc2(vo, ro)
-            * units.Msun
-            / units.pc**2
-            * numpy.exp(-R / ro / units.kpc)
-        ),
-        ro=ro,
-        vo=vo,
-    )
-    pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), (
-        "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
-    )
-    # AnyAxisymmetricRazorThinDiskPotential, r in surfdens only has units
-    pot = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: 1.5 * numpy.exp(-R / ro / units.kpc), ro=ro, vo=vo
-    )
-    pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), (
-        "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
-    )
-    # AnySphericalPotential
-    pot = potential.AnySphericalPotential(
-        dens=lambda r: (
-            0.64
-            / r
-            / (1 + r) ** 3
-            * conversion.dens_in_msolpc3(vo, ro)
-            * units.Msun
-            / units.pc**3
-        ),
-        ro=ro,
-        vo=vo,
-    )
-    pot_nounits = potential.AnySphericalPotential(
-        dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
-    # AnySphericalPotential, r in dens also has units
-    pot = potential.AnySphericalPotential(
-        dens=lambda r: (
-            0.64
-            / (r / ro / units.kpc)
-            / (1 + r / ro / units.kpc) ** 3
-            * conversion.dens_in_msolpc3(vo, ro)
-            * units.Msun
-            / units.pc**3
-        ),
-        ro=ro,
-        vo=vo,
-    )
-    pot_nounits = potential.AnySphericalPotential(
-        dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
-    # AnySphericalPotential, r in dens only has units
-    pot = potential.AnySphericalPotential(
-        dens=lambda r: 0.64 / (r / ro / units.kpc) / (1 + r / ro / units.kpc) ** 3,
-        ro=ro,
-        vo=vo,
-    )
-    pot_nounits = potential.AnySphericalPotential(
-        dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
-    )
-    # Check potential
-    assert (
-        numpy.fabs(
-            pot(4.0, 0.0, phi=1.0, use_physical=False)
-            - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
-        )
-        < 10.0**-8.0
-    ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
     # If you add one here, don't base it on ChandrasekharDynamicalFrictionForce!!
     # RotateAndTiltWrapperPotential, zvec, pa
     wrappot = potential.TriaxialNFWPotential(amp=1.0, a=3.0, b=0.7, c=0.5)
@@ -10973,6 +10841,155 @@ def test_potential_paramunits():
     )
     # If you add one here, don't base it on ChandrasekharDynamicalFrictionForce!!
     return None
+
+
+def test_potential_paramunits_user_callable():
+    # The Any*Potential family is DEFINED BY a user-supplied callable, which the
+    # potential evaluates internally. When that callable returns a Quantity (the
+    # point of these checks) it cannot run inside a jit trace: astropy needs a
+    # concrete array, and `Quantity * tracer` has no meaning. So this block is
+    # pinned to numpy rather than skipped -- the units contract is a numpy-path
+    # claim, and splitting it out keeps the other ~1100 lines of
+    # test_potential_paramunits running under a forced/traced backend instead of
+    # skipping all of it for these 12 constructions.
+    import galpy.backend
+    from galpy import potential
+    from galpy.util import conversion
+
+    ro, vo = 7.0, 230.0
+    with galpy.backend.use("numpy", force=True):
+        # AnyAxisymmetricRazorThinDiskPotential
+        pot = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: (
+                1.5
+                * conversion.surfdens_in_msolpc2(vo, ro)
+                * units.Msun
+                / units.pc**2
+                * numpy.exp(-R)
+            ),
+            ro=ro,
+            vo=vo,
+        )
+        pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
+        )
+        # AnyAxisymmetricRazorThinDiskPotential, r in surfdens also has units
+        pot = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: (
+                1.5
+                * conversion.surfdens_in_msolpc2(vo, ro)
+                * units.Msun
+                / units.pc**2
+                * numpy.exp(-R / ro / units.kpc)
+            ),
+            ro=ro,
+            vo=vo,
+        )
+        pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
+        )
+        # AnyAxisymmetricRazorThinDiskPotential, r in surfdens only has units
+        pot = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: 1.5 * numpy.exp(-R / ro / units.kpc), ro=ro, vo=vo
+        )
+        pot_nounits = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: 1.5 * numpy.exp(-R), ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "AnyAxisymmetricRazorThinDiskPotential w/ parameters w/ units does not behave as expected"
+        )
+        # AnySphericalPotential
+        pot = potential.AnySphericalPotential(
+            dens=lambda r: (
+                0.64
+                / r
+                / (1 + r) ** 3
+                * conversion.dens_in_msolpc3(vo, ro)
+                * units.Msun
+                / units.pc**3
+            ),
+            ro=ro,
+            vo=vo,
+        )
+        pot_nounits = potential.AnySphericalPotential(
+            dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
+        # AnySphericalPotential, r in dens also has units
+        pot = potential.AnySphericalPotential(
+            dens=lambda r: (
+                0.64
+                / (r / ro / units.kpc)
+                / (1 + r / ro / units.kpc) ** 3
+                * conversion.dens_in_msolpc3(vo, ro)
+                * units.Msun
+                / units.pc**3
+            ),
+            ro=ro,
+            vo=vo,
+        )
+        pot_nounits = potential.AnySphericalPotential(
+            dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
+        # AnySphericalPotential, r in dens only has units
+        pot = potential.AnySphericalPotential(
+            dens=lambda r: 0.64 / (r / ro / units.kpc) / (1 + r / ro / units.kpc) ** 3,
+            ro=ro,
+            vo=vo,
+        )
+        pot_nounits = potential.AnySphericalPotential(
+            dens=lambda r: 0.64 / r / (1 + r) ** 3, ro=ro, vo=vo
+        )
+        # Check potential
+        assert (
+            numpy.fabs(
+                pot(4.0, 0.0, phi=1.0, use_physical=False)
+                - pot_nounits(4.0, 0.0, phi=1.0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), "AnySphericalPotential w/ parameters w/ units does not behave as expected"
 
 
 def test_scfpotential_from_nbody_units():
@@ -11916,23 +11933,57 @@ def test_anyaxisymmetricrazorpotential_unitson():
     # Test that AnyAxisymmetricRazorPotential returns outputs with units when the
     # input surface density has units (this is the consistent behavior with other
     # potentials); see #724
+    import galpy.backend
     from galpy import potential
 
-    expdisk = potential.RazorThinExponentialDiskPotential(
-        amp=1e10 * units.Msun / units.kpc**2, hr=1 * units.kpc
-    )
-    diskpot = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: numpy.exp(-R / (1 * units.kpc)) * units.Msun / units.kpc**2,
-        amp=1e10,
-    )
-    assert isinstance(diskpot(6 * units.kpc, 100.0 * units.pc), units.Quantity), (
-        "AnyAxisymmetricRazorThinDiskPotential does not return outputs with units when the input surface density has units"
-    )
-    assert numpy.fabs(
-        (1.0 - expdisk.vcirc(6 * units.kpc) / diskpot.vcirc(6 * units.kpc)) < 1e-10
-    ), (
-        "AnyAxisymmetricRazorThinDiskPotential does not return outputs with units when the input surface density has units"
-    )
+    # A surfdens callable that returns a Quantity cannot run inside a jit trace:
+    # astropy needs a concrete array, and Quantity * tracer is undefined. The
+    # units claim is a numpy-path claim, so pin this arm to numpy rather than
+    # skipping the test on a backend.
+    with galpy.backend.use("numpy", force=True):
+        expdisk = potential.RazorThinExponentialDiskPotential(
+            amp=1e10 * units.Msun / units.kpc**2, hr=1 * units.kpc
+        )
+        diskpot = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: (
+                numpy.exp(-R / (1 * units.kpc)) * units.Msun / units.kpc**2
+            ),
+            amp=1e10,
+        )
+        pot = diskpot(6 * units.kpc, 100.0 * units.pc)
+        assert isinstance(pot, units.Quantity), (
+            "AnyAxisymmetricRazorThinDiskPotential does not return outputs with units when the input surface density has units"
+        )
+        assert pot.unit.is_equivalent(units.km**2 / units.s**2), (
+            "AnyAxisymmetricRazorThinDiskPotential returns outputs with the wrong unit when the input surface density has units"
+        )
+        # The same disk with the 1e10 in the callable rather than in amp. The two
+        # are equivalent in exact arithmetic, but the numpy force integral is
+        # scipy.integrate.quad, whose default epsabs=1.49e-8 is larger than the
+        # whole integral once amp carries the normalization (_sdens is then
+        # ~1e-12): quad stops early and vcirc comes out ~1e-5 off instead of
+        # ~1e-13. That is a pre-existing numpy-path defect, filed separately; use
+        # the O(1) _sdens form so this can be compared at the numerical limit.
+        diskpot_o1 = potential.AnyAxisymmetricRazorThinDiskPotential(
+            surfdens=lambda R: (
+                1e10 * numpy.exp(-R / (1 * units.kpc)) * units.Msun / units.kpc**2
+            ),
+            amp=1.0,
+        )
+        # fabs OUTSIDE the comparison: fabs(x < tol) is a bool, so it accepted
+        # every ratio above one and only the potential-too-large direction ever
+        # failed.
+        assert (
+            numpy.fabs(
+                1.0 - expdisk.vcirc(6 * units.kpc) / diskpot_o1.vcirc(6 * units.kpc)
+            )
+            < 1e-10
+        ), (
+            "AnyAxisymmetricRazorThinDiskPotential does not agree with the equivalent RazorThinExponentialDiskPotential when the input surface density has units"
+        )
+    # The potential's own backend/traced coverage lives in
+    # tests/test_backend_anyaxisymdisk.py, which drives it through a
+    # namespace-agnostic surfdens; nothing here needs to duplicate it.
     return None
 
 


### PR DESCRIPTION
Two `test_quantity.py` tests build `Any*Potential` from a `surfdens` callable that
returns an astropy `Quantity`. That cannot run inside a jit trace — astropy needs a
concrete array, and `Quantity * tracer` is undefined — so they fail under
`--backend jax --jit`.

My first version of this PR ledgered both tests as `jax-jit` skips. That was the
wrong shape: `test_potential_paramunits` is **1253 lines**, and only **12
user-callable constructions** (6 `AnyAxisymmetricRazorThinDiskPotential` + 6
`AnySphericalPotential`, lines 10643–10763, under 5% of the test) are untraceable.
The ledger entry quarantined ~1200 lines of unit coverage to protect 132.

Instead:

* extract those 12 constructions into `test_potential_paramunits_user_callable`
  and run it inside `use("numpy", force=True)`;
* pin `test_anyaxisymmetricrazorpotential_unitson` the same way.

Both are numpy-path claims, so pinning states what they actually test rather than
declaring them untestable on a backend.

**Ledger delta: 0.** The net diff of this PR touches only `tests/test_quantity.py`.

Gate: `tests/test_quantity.py` under `--backend jax --jit` is **245 passed, 0
failed, 0 skipped** (17m10s), i.e. the ~1100 previously-skipped lines now run
traced and pass. Plain numpy is green too.

### Two defects this surfaced

The unitson value check was

```python
assert numpy.fabs((1.0 - expdisk.vcirc(...) / diskpot.vcirc(...)) < 1e-10)
```

— `fabs` wrapping the **comparison**, so it evaluated `fabs(bool)`: every ratio
above one passed, and only the potential-too-large direction could ever fail. With
the parentheses fixed it reports a real 1.04e-5 disagreement.

That disagreement is a **pre-existing numpy-path defect**, not something this PR
introduces. Surface densities agree to 2e-16, so it is not normalization: with
`amp=1e10` carrying the normalization, `_sdens` returns ~1.8e-12 and
`scipy.integrate.quad`'s default `epsabs=1.49e-8` is four orders **larger than the
integral itself**, so quad returns early. Moving the 1e10 into the callable
(`amp=1.0`, `_sdens` ~0.018) restores 2e-13. So AnyAxisym's accuracy depends on how
the user splits normalization between `amp` and `surfdens`, silently. The test now
compares in the O(1) form at 1e-10 and says why, rather than loosening the
tolerance to accommodate a bug.

Separately, chasing a tolerance here turned up a traced-only defect (filed
internally, not fixed in this PR): at `z == 0` the traced AnyAxisym force is
~5.7e-5 off from numpy while eager is exact, because `dmin` collapses to `half`
there and all 24 graded panels become zero-width. `tests/test_backend_anyaxisymdisk.py`
asserts `z == 0` only in the **eager** test, which is why the eager suite cannot
see it.

The potential's own backend/traced coverage already lives in
`tests/test_backend_anyaxisymdisk.py`, so nothing here duplicates it.