### PR TITLE
quadrature: traceable Hadamard finite-part rule (finite_part_quad)

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -529,6 +529,83 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
     )
 
 
+def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None):
+    r"""``int_0^b [f(u) + f(-u)] du`` for ``f`` singular as ``c/u^2`` at ``u = 0``.
+
+    The symmetrised integrand is what makes this well posed: an odd ``B/u`` term
+    cancels exactly between ``f(u)`` and ``f(-u)``, so only the even ``c/u^2``
+    part needs handling and ``c`` never involves a derivative of ``f``.
+
+    ``peak_width`` is the scale over which ``f`` varies near the origin (for a
+    razor-thin disk, ``|z|``), and it selects between two regimes:
+
+    * ``peak_width == 0`` -- the integral exists only as a Hadamard finite part:
+      the halves add rather than cancel, so the singular model is subtracted and
+      its finite part ``-2c/b`` added back.
+    * ``peak_width > 0`` -- there is a peak of width ``~peak_width`` instead, and
+      ``u = peak_width * sinh(t)`` gives log-spaced coverage from ``peak_width``
+      out to ``b`` with no endpoint crowding.
+
+    Both branches are evaluated (a traced ``peak_width`` cannot be branched on),
+    so the sinh branch is computed at a guarded width -- ``asinh(b/0)`` would be
+    ``inf`` and would poison the gradient of the branch that is actually taken.
+
+    NOTE ON NODE PLACEMENT. ``f(u) + f(-u) - 2c/u^2`` is a difference of two
+    ``~1/u^2`` quantities, so it loses roughly two digits per decade of ``u`` and
+    is pure noise below ``u ~ 1e-7 b``. Fixed-order Gauss-Legendre is used
+    precisely because its smallest node sits at ``~b/n^2``, just above that
+    floor. Do NOT substitute a rule that clusters harder at the endpoint:
+    tanh-sinh reaches ``u ~ 1e-20 b`` and DIVERGES here (measured: 1e6 relative
+    error at n=200, 1e21 at n=400, nan at n=800). The limit is floating-point
+    cancellation, not the quadrature order.
+
+    Parameters
+    ----------
+    xp : module
+        Array namespace.
+    integrand : callable
+        ``f(u)``, called with the quadrature nodes (vectorised over a trailing
+        node axis). It is called at both ``+u`` and ``-u``.
+    b : array
+        Upper limit; the interval is ``[0, b]``.
+    c : array
+        Coefficient of the ``1/u^2`` singularity in ``f(u) + f(-u)``, i.e. the
+        symmetrised integrand behaves as ``2c/u^2`` near the origin.
+    peak_width : array
+        Width of the near-origin structure; ``0`` selects the finite part.
+    n : int, optional
+        Gauss-Legendre order.
+    device : optional
+        Device to anchor the nodes on.
+
+    Notes
+    -----
+    - 2026-08-13 - Written - Bovy (UofT)
+    """
+    zero = asarray_on_device(xp, 0.0, device)
+
+    def sym(u):
+        return integrand(u) + integrand(-u)
+
+    finite_part = (
+        fixed_quad(
+            xp, lambda u: sym(u) - 2.0 * c / (u * u), zero, b, n=n, device=device
+        )
+        - 2.0 * c / b
+    )
+    wide = peak_width > 0.0
+    w = xp.where(wide, peak_width, xp.ones_like(peak_width))
+    peaked = fixed_quad(
+        xp,
+        lambda t: sym(w * xp.sinh(t)) * w * xp.cosh(t),
+        zero,
+        xp.asinh(b / w),
+        n=n,
+        device=device,
+    )
+    return xp.where(wide, peaked, finite_part)
+
+
 def nested_quad(xp, integrand, bounds, *, n=50, device=None):
     r"""Tensor-product fixed-order GL over a hyper-rectangle.
 

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 from galpy.backend.quadrature import (
+    finite_part_quad,
     fixed_quad,
     fixed_quad_semiinfinite,
     gauss_legendre,
@@ -636,4 +637,64 @@ def test_symmetric_quad_default_order_resolves_extreme_aspect_ratio():
     assert rel(n=50) > 1e-7, (
         f"n=50 was supposed to be visibly wrong here ({rel(n=50):.2e}); if it is "
         "not, this test no longer discriminates and the bar needs re-deriving"
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_finite_part_quad_matches_the_analytic_finite_part(backend):
+    # Construct an integrand whose finite part is known in closed form, rather
+    # than comparing against another quadrature: f(u) = c/u**2 + exp(-u) gives
+    # sym(u) = 2c/u**2 + (exp(-u) + exp(u)), so the rule's subtraction removes
+    # the singular model exactly and
+    #     int_0^b [sym(u) - 2c/u**2] du - 2c/b = 2 sinh(b) - 2c/b.
+    xp = _xp(backend)
+    c, b = 0.75, 1.3
+
+    def f(u):
+        return c / (u * u) + xp.exp(-u)
+
+    got = finite_part_quad(xp, f, xp.asarray(b), c=c, peak_width=xp.asarray(0.0), n=200)
+    expected = 2.0 * numpy.sinh(b) - 2.0 * c / b
+    numpy.testing.assert_allclose(float(got), expected, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_finite_part_quad_peaked_branch_is_the_plain_integral(backend):
+    # peak_width > 0 selects u = w sinh(t) over [0, asinh(b/w)], which is exactly
+    # int_0^b sym(u) du -- no finite part, because there is no singularity to
+    # subtract. With a smooth f that integral is 2 sinh(b) again, and the answer
+    # must not depend on w: the substitution only redistributes the nodes.
+    xp = _xp(backend)
+    b = 1.3
+
+    def f(u):
+        return xp.exp(-u)
+
+    expected = 2.0 * numpy.sinh(b)
+    for w in (1e-6, 1e-3, 0.5):
+        got = finite_part_quad(
+            xp, f, xp.asarray(b), c=0.0, peak_width=xp.asarray(w), n=200
+        )
+        numpy.testing.assert_allclose(
+            float(got), expected, rtol=1e-9, atol=1e-11, err_msg=f"peak_width={w}"
+        )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_finite_part_quad_branches_on_a_traced_peak_width(backend):
+    # peak_width is data, so the branch cannot be a python if. Both arms are
+    # evaluated; the guarded width is what keeps asinh(b/0) from poisoning the
+    # taken arm. Check the selection is right at w == 0 AND that no nan leaks.
+    xp = _xp(backend)
+    c, b = 0.75, 1.3
+
+    def f(u):
+        return c / (u * u) + xp.exp(-u)
+
+    at_zero = float(
+        finite_part_quad(xp, f, xp.asarray(b), c=c, peak_width=xp.asarray(0.0), n=200)
+    )
+    assert numpy.isfinite(at_zero)
+    numpy.testing.assert_allclose(
+        at_zero, 2.0 * numpy.sinh(b) - 2.0 * c / b, rtol=1e-10, atol=1e-12
     )


### PR DESCRIPTION
Adds `finite_part_quad` to `galpy/backend/quadrature.py`: the backend counterpart
to `AnyAxisymmetricRazorThinDiskPotential`'s numpy `_finite_part_quad`, i.e.
`int_0^b [f(u)+f(-u)] du` for an `f` singular as `c/u^2` at the origin.

Symmetrising is what makes it well posed — the odd `B/u` term cancels exactly
between `f(u)` and `f(-u)`, so only `c` is needed and `c` never involves a
derivative of `f` (which matters: for a user-supplied surface density that
derivative is not available).

`peak_width` selects the regime and may be traced, so both branches are evaluated
and the sinh branch runs at a guarded width — `asinh(b/0)` would be `inf` and
would poison the gradient of the branch actually taken.

The rule returns the **inner** integral only. The `-4` prefactor and the
`[R, inf)` tail are AnyAxisym conventions, not part of a general rule.

### Why it is being added

Traced `R2deriv`/`z2deriv` for AnyAxisym at the midplane are currently wrong by
**four orders of magnitude** (traced `-2.7e+04` vs numpy `-2.5788` at R=0.75),
because the backend path runs one generic graded-panel rule for all six methods
while numpy has two analytic singularity treatments the backend lacks. That is
reachable from user code — traced `epifreq()` evaluates `R2deriv` at z=0.

This PR is the rule alone; wiring `_R2deriv_gl`/`_z2deriv_gl` onto it is the
follow-up. **It will not flip either ledgered AnyAxisym xfail** — those are
blocked on a separate requirement (traced `Rforce` to ~7e-11 absolute, which the
current decomposition cannot reach in float64) — so this is a correctness fix on
its own merits, not a ledger burn.

### Validation

Against scipy's adaptive `_finite_part_quad` on the real AnyAxisym R2deriv
integrand (`surfdens=1.5exp(-3R)`):

| R | z | rel-err n=100 | rel-err n=400 |
|---|---|---|---|
| 0.5 | 0 | 4.06e-05 | 2.55e-06 |
| 0.5 | 1e-8 | 1.39e-07 | 1.23e-05 |
| 0.5 | 1e-4 | 2.47e-12 | 6.32e-10 |
| 1.0 | 0 | 7.10e-06 | 4.47e-07 |
| 2.0 | 0.1 | 3.66e-14 | 8.64e-14 |

Two properties are recorded in the docstring, because both are easy to "improve"
into a regression:

* **use n=100, do not raise it.** At z=1e-8 the error *grows* with n
  (1.4e-7 -> 1.2e-5): more nodes reach where `sym(u) - 2c/u^2` is cancellation
  noise. The integrand is a difference of two `~1/u^2` quantities and loses ~2
  digits per decade, so it is unusable below `u ~ 1e-7 b`.
* **do not swap in a rule that clusters harder at the endpoint.** tanh-sinh —
  the rule normally reached for at an endpoint singularity — reaches `u ~ 1e-20 b`
  and diverges outright here: 1e6 relative error at n=200, 1e21 at n=400, nan at
  n=800. The limit is floating-point cancellation, not quadrature order.

### Tests

New tests check both branches against **closed-form** values rather than another
quadrature, so they cannot agree with the rule for the wrong reason:

* finite-part branch: `f(u) = c/u^2 + exp(-u)` gives exactly `2 sinh(b) - 2c/b`;
* peaked branch: the sinh substitution *is* `int_0^b sym(u) du`, so a smooth `f`
  must give `2 sinh(b)` independent of `w` — swept `w = 1e-6, 1e-3, 0.5`;
* a third test pins the traced-branch behaviour and asserts finiteness at `w == 0`
  (the guarded-width case).

`tests/test_backend_quadrature.py`: 70 passed / 1 skipped on numpy, and green
under `--backend jax` and `--backend torch`.

numpy path untouched — the rule is backend-only and has no consumer yet.