### PR TITLE
AnyAxisym: traced R2deriv/z2deriv through the Hadamard finite part (~8 orders at the midplane)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -544,33 +544,56 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
 
     def _R2deriv_gl(self, R, z, xp, dev):
         R2 = R**2
-        z2 = z**2
+        # Mirror the numpy floor: below it the finite-|z| branch cannot resolve
+        # the peak, and numpy evaluates the z=0 limit instead. Without it the
+        # sinh branch of finite_part_quad is entered at a width where the
+        # substitution cannot work.
+        az = xp.abs(z)
+        az = xp.where(az < _R2DERIV_ZFLOOR, xp.zeros_like(az), az)
+        z2 = az**2
         sdens = self._sdens
 
-        def r2derivint(a):
-            a2 = a**2
-            m1, aRz = self._bk_m1_aRz(a, R, z2, xp)
+        def r2derivint(d):
+            # Parameterised by the OFFSET d = a - R, never by a: a^2-R^2 =
+            # d(2R+d) and (a-R)^2+z^2 = d^2+z^2 are exact in d, whereas
+            # recovering d from a-R loses the digits that 1/(d^2+z^2)^2 then
+            # amplifies. m1 = dz/aRz is 1-m exactly, since aRz - dz = 4 R a.
+            a = R + d
+            a2 = R2 + 2.0 * R * d + d * d
+            dz = d * d + z2
+            a2mR2 = d * (2.0 * R + d)
+            aRz = (2.0 * R + d) ** 2.0 + z2
+            m1 = dz / aRz
             return (
                 a
                 * sdens(a)
                 * (
                     -(
                         (
-                            (a2 - 3.0 * R2) * (a2 - R2) ** 2
+                            (a2 - 3.0 * R2) * a2mR2**2
                             + (3.0 * a2**2 + 2.0 * a2 * R2 + 3.0 * R2**2) * z2
-                            + (3.0 * a2 + 7.0 * R2) * z**4
-                            + z**6
+                            + (3.0 * a2 + 7.0 * R2) * z2**2
+                            + z2**3
                         )
                         * _bspecial.ellipe(1.0 - m1)
                     )
-                    + ((a - R) ** 2 + z2)
-                    * ((a2 - R2) ** 2 + 2.0 * (a2 + 2.0 * R2) * z2 + z**4)
+                    + dz
+                    * (a2mR2**2 + 2.0 * (a2 + 2.0 * R2) * z2 + z2**2)
                     * _bspecial.ellipkm1(m1)
                 )
-                / (2.0 * R2 * ((a - R) ** 2 + z2) ** 2 * aRz**1.5)
+                / (2.0 * R2 * dz**2 * aRz**1.5)
             )
 
-        return -4.0 * self._bk_split_quad(r2derivint, R, xp, dev, z)
+        # Hadamard finite part, as the numpy path does: the a=R singularity is
+        # a non-integrable c/d^2 divergence, so no amount of panel grading
+        # converges it -- the generic split_quad rule used here before was ~1e4
+        # off at the midplane.
+        return -4.0 * (
+            _bquad.finite_part_quad(
+                xp, r2derivint, R, c=sdens(R) / 2.0, peak_width=az, device=dev
+            )
+            + _bquad.fixed_quad_semiinfinite(xp, r2derivint, R, device=dev)
+        )
 
     # ------------------------------ z2deriv --------------------------------
     @check_potential_inputs_not_arrays
@@ -614,26 +637,48 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
 
     def _z2deriv_gl(self, R, z, xp, dev):
         R2 = R**2
-        z2 = z**2
+        # Mirror the numpy floor: below it the finite-|z| branch cannot resolve
+        # the peak, and numpy evaluates the z=0 limit instead. Without it the
+        # sinh branch of finite_part_quad is entered at a width where the
+        # substitution cannot work.
+        az = xp.abs(z)
+        az = xp.where(az < _R2DERIV_ZFLOOR, xp.zeros_like(az), az)
+        z2 = az**2
         sdens = self._sdens
 
-        def z2derivint(a):
-            a2 = a**2
-            m1, aRz = self._bk_m1_aRz(a, R, z2, xp)
+        def z2derivint(d):
+            # Parameterised by the OFFSET d = a - R, never by a: a^2-R^2 =
+            # d(2R+d) and (a-R)^2+z^2 = d^2+z^2 are exact in d, whereas
+            # recovering d from a-R loses the digits that 1/(d^2+z^2)^2 then
+            # amplifies. m1 = dz/aRz is 1-m exactly, since aRz - dz = 4 R a.
+            a = R + d
+            a2 = R2 + 2.0 * R * d + d * d
+            dz = d * d + z2
+            a2mR2 = d * (2.0 * R + d)
+            aRz = (2.0 * R + d) ** 2.0 + z2
+            m1 = dz / aRz
             return (
                 a
                 * sdens(a)
                 * (
                     -(
-                        ((a2 - R2) ** 2 - 2.0 * (a2 + R2) * z2 - 3.0 * z**4)
+                        (a2mR2**2 - 2.0 * (a2 + R2) * z2 - 3.0 * z2**2)
                         * _bspecial.ellipe(1.0 - m1)
                     )
-                    - z2 * ((a - R) ** 2 + z2) * _bspecial.ellipkm1(m1)
+                    - z2 * dz * _bspecial.ellipkm1(m1)
                 )
-                / (((a - R) ** 2 + z2) ** 2 * aRz**1.5)
+                / (dz**2 * aRz**1.5)
             )
 
-        return -4.0 * self._bk_split_quad(z2derivint, R, xp, dev, z)
+        # At z=0 the K term carries a z^2 factor and drops out, leaving
+        # -a Sigma(a) E(m) / (d^2 (a+R)), so the singular coefficient is
+        # -Sigma(R)/2 -- exactly minus R2deriv's.
+        return -4.0 * (
+            _bquad.finite_part_quad(
+                xp, z2derivint, R, c=-sdens(R) / 2.0, peak_width=az, device=dev
+            )
+            + _bquad.fixed_quad_semiinfinite(xp, z2derivint, R, device=dev)
+        )
 
     # ------------------------------ Rzderiv --------------------------------
     @check_potential_inputs_not_arrays

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -515,3 +515,61 @@ def test_zforce_at_tiny_z_reaches_sheet_limit(backend_name, R, z, tol):
         f"sheet limit {limit:.8e} (rel {rel:.2e}) -- the a=R peak is not "
         "resolved, so the graded panels are not reaching dmin"
     )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_traced_second_derivs_match_numpy_through_the_midplane(backend_name):
+    # MUST be traced. _bk_dispatch deliberately routes concrete eager input back
+    # to scipy, so an eager version of this test would compare scipy against
+    # scipy and pass no matter how wrong the GL path is -- which is exactly why
+    # the defect below survived: the suite asserted z == 0 only in the eager
+    # test.
+    #
+    # The backend path used to run ONE generic graded-panel rule for all six
+    # methods, while numpy handles the a=R singularity analytically. At z == 0
+    # that integral is a non-integrable c/d^2 divergence, so no amount of panel
+    # grading converges it and traced R2deriv came out ~3.8e+03 relative error --
+    # four orders of magnitude wrong, and reachable from user code, since traced
+    # epifreq() evaluates R2deriv at z=0. Both second derivatives now go through
+    # the same Hadamard finite part numpy uses.
+    #
+    # The tolerances are MEASURED accuracy with modest headroom, not round
+    # numbers: at z == 0 the finite-part integrand is a difference of two
+    # ~1/u**2 quantities, so ~1e-5 is its floor there, tightening rapidly as |z|
+    # lifts off the plane.
+    import warnings
+
+    import galpy.backend
+
+    grid = ((0.0, 1e-4), (1e-10, 1e-4), (1e-8, 1e-6), (1e-6, 1e-8), (1e-4, 1e-10))
+    for fn in (evaluateR2derivs, evaluatez2derivs):
+        for R in (0.5, 1.0, 2.0):
+            # numpy references OUTSIDE the forced context: taken inside, the
+            # boundary coerces them onto the traced path and the comparison
+            # becomes traced-vs-itself.
+            refs = [
+                float(fn(_POT, numpy.float64(R), numpy.float64(z))) for z, _ in grid
+            ]
+            # torch emits its own script_method DeprecationWarning the first
+            # time torch.compile runs in a process. Under the numpy-default run
+            # this test is that first use, and the suite turns warnings into
+            # errors -- so filter that one warning narrowly rather than losing
+            # the torch arm of the assertion.
+            with (
+                warnings.catch_warnings(),
+                galpy.backend.use(backend_name, force=True),
+                galpy.backend.jit(backend_name),
+            ):
+                warnings.filterwarnings(
+                    "ignore", message=".*script_method.*", category=DeprecationWarning
+                )
+                for (z, tol), ref in zip(grid, refs):
+                    got = fn(_POT, _scalar(backend_name, R), _scalar(backend_name, z))
+                    assert is_backend_array(got), (
+                        f"{fn.__name__} fell back off the backend at R={R}, z={z}"
+                    )
+                    rel = abs(1.0 - float(got) / ref)
+                    assert rel < tol, (
+                        f"{backend_name} traced {fn.__name__} at R={R}, z={z}: "
+                        f"rel err {rel:.2e} exceeds {tol:.0e} (numpy {ref:.6e})"
+                    )


### PR DESCRIPTION
Consumes `finite_part_quad` from #1306.

### The defect

The backend path ran **one generic graded-panel rule** (`_bk_split_quad`) for all
six methods, while numpy handles the `a=R` singularity analytically — `_quad_apeak`
for zforce/Rzderiv, `_finite_part_quad` for the second derivatives, plus a
`_R2DERIV_ZFLOOR` snap that the backend lacked entirely.

At `z == 0` the second-derivative integral is a **non-integrable `c/d²` divergence**.
Grading panels toward it cannot converge — it diverges — so traced `R2deriv` came out
at **~1.06e+04 relative error**, four orders of magnitude wrong. It is reachable from
user code: traced `epifreq()` evaluates `R2deriv` at z=0.

### The fix

Both second derivatives now go through `finite_part_quad`, with the caller keeping
its own `-4` prefactor and `[R, ∞)` tail, and numpy's `ZFLOOR` mirrored — without
that snap the sinh branch is entered at a width where the substitution cannot work.

The integrands are re-parameterised by the **offset** `d = a - R`, like their numpy
twins: `a²-R² = d(2R+d)` and `(a-R)²+z² = d²+z²` are exact in `d`, whereas recovering
`d` from `a-R` loses the digits that `1/(d²+z²)²` then amplifies. That also makes
`m1 = dz/aRz` exactly `1-m` (since `aRz - dz = 4Ra`), so numpy's `min(4aR/aRz, 1)`
clamp is unnecessary here.

### Measured (traced vs numpy, R2deriv at R=0.5)

| z | 0 | 1e-10 | 1e-8 | 1e-6 | 1e-4 | 0.1 |
|---|---|---|---|---|---|---|
| **before** | 3.8e+03 | 2.0e+02 | 5.0e-02 | — | ~1e-10 | ~4e-14 |
| **jax** | 4.1e-05 | 4.1e-05 | 9.0e-08 | 4.0e-10 | 4.7e-12 | 4.4e-15 |
| **torch** | 4.1e-05 | 4.1e-05 | 9.9e-08 | 5.2e-10 | 3.7e-12 | 6.6e-15 |

`z2deriv` behaves the same (1.1e-05 at z=0, R=0.5). ~8 orders at the midplane, a
further 1–2 orders where it was already fine, no regression anywhere.

### The test, and why it must be traced

`_bk_dispatch` deliberately routes concrete **eager** input back to scipy. An eager
version of this assertion would therefore compare scipy against scipy and pass no
matter how wrong the GL path is — which is exactly why this survived: the suite
asserted `z == 0` only in the eager test.

A/B'd against the unfixed source to prove it is not vacuous: it reports
**1.06e+04 vs its 1e-04 tolerance** on both backends. Tolerances are measured
accuracy with modest headroom, not round numbers.

### Gates

* `tests/test_backend_anyaxisymdisk.py`: **49 passed** on numpy, `--backend jax`,
  `--backend torch`, `--backend jax --jit`, `--backend torch --jit`; +2 new tests.
* **numpy path byte-identical**, verified by A/B (stash, re-run, identical digits) —
  `finite_part_quad` is backend-only.

### Scope honesty

This does **not** flip either ledgered AnyAxisym xfail. Those need traced `Rforce`
accurate to ~7e-11 absolute, which this decomposition cannot reach in float64 — the
finite-part integrand is a difference of two `~1/u²` quantities and is noise below
`u ~ 1e-7`. It is a correctness fix on its own merits, not a ledger burn.