### PR TITLE
backend: ask name_of_namespace, do not re-derive the backend from __name__

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -24,6 +24,7 @@ from ..backend import (
     coerce_coords,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
     promote_scalars,
 )
 from ..backend.optimize import brentq as _backend_brentq
@@ -1252,7 +1253,11 @@ def estimateBIsochrone(pot, R, z, phi=None):
             bs = bs[~xp.isnan(bs)]
             # array-api-compat torch's median returns the lower central order
             # statistic for even counts; quantile(.,0.5) matches numpy.median.
-            bmed = xp.quantile(bs, 0.5) if "torch" in xp.__name__ else xp.median(bs)
+            bmed = (
+                xp.quantile(bs, 0.5)
+                if name_of_namespace(xp) == "torch"
+                else xp.median(bs)
+            )
             return xp.stack([xp.amin(bs), bmed, xp.amax(bs)])
         if phi is None:
             phi = [None for r in R]

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -20,6 +20,7 @@ from ..backend import (
     device_of,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
     promote_scalars,
 )
 from ..backend._namespaces import (
@@ -79,7 +80,7 @@ def _nanmedian(xp, a):
     (not their average), so torch is handled via ``quantile(.,0.5)`` on the
     NaN-filtered values to match numpy's convention (eager-only; the median
     is a non-differentiable selection)."""
-    if "torch" in getattr(xp, "__name__", ""):
+    if name_of_namespace(xp) == "torch":
         return xp.quantile(a[~xp.isnan(a)], 0.5)
     return xp.nanmedian(a)
 
@@ -658,12 +659,12 @@ def _staeckel_c_grad_actions(pot, delta, R, vR, vT, z, vz, u0, order, useu0=Fals
         )
         return jr, jz, jac
 
-    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
-    if "jax" in name:
+    name = name_of_namespace(get_namespace(R, vR, vT, z, vz))
+    if name == "jax":
         from ..backend._jax.staeckel_c import actions_with_jac
 
         return actions_with_jac(host_jac, (R, vR, vT, z, vz))
-    if "torch" in name:
+    if name == "torch":
         from ..backend._torch.staeckel_c import actions_with_jac
 
         return actions_with_jac(host_jac, R, vR, vT, z, vz)
@@ -702,12 +703,12 @@ def _staeckel_c_grad_ecczmax(pot, delta, R, vR, vT, z, vz, u0, useu0=False):
         )
         return e, zm, rp, ra, jac
 
-    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
-    if "jax" in name:
+    name = name_of_namespace(get_namespace(R, vR, vT, z, vz))
+    if name == "jax":
         from ..backend._jax.staeckel_c import ecczmax_with_jac
 
         return ecczmax_with_jac(host_jac, (R, vR, vT, z, vz))
-    if "torch" in name:
+    if name == "torch":
         from ..backend._torch.staeckel_c import ecczmax_with_jac
 
         return ecczmax_with_jac(host_jac, R, vR, vT, z, vz)
@@ -745,12 +746,12 @@ def _staeckel_c_grad_actionsfreqs(pot, delta, R, vR, vT, z, vz, u0, order, useu0
         Or, Op, Oz = _staeckel_c_freq_circ_fix(pot, Rn, jr, jz, Or, Op, Oz)
         return jr, jz, Or, Op, Oz, jac
 
-    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
-    if "jax" in name:
+    name = name_of_namespace(get_namespace(R, vR, vT, z, vz))
+    if name == "jax":
         from ..backend._jax.staeckel_c import actionsfreqs_with_jac
 
         return actionsfreqs_with_jac(host_jac, (R, vR, vT, z, vz))
-    if "torch" in name:
+    if name == "torch":
         from ..backend._torch.staeckel_c import actionsfreqs_with_jac
 
         return actionsfreqs_with_jac(host_jac, R, vR, vT, z, vz)
@@ -791,12 +792,12 @@ def _staeckel_c_grad_actionsfreqsangles(
         jac = numpy.concatenate((ojac, ajac), axis=1)  # (N,8,5): ojac(5,5) + ajac(3,5)
         return jr, jz, Or, Op, Oz, angler, anglephi, anglez, jac
 
-    name = getattr(get_namespace(R, vR, vT, z, vz), "__name__", "")
-    if "jax" in name:
+    name = name_of_namespace(get_namespace(R, vR, vT, z, vz))
+    if name == "jax":
         from ..backend._jax.staeckel_c import actionsfreqsangles_with_jac
 
         return actionsfreqsangles_with_jac(host_jac, (R, vR, vT, z, vz), phi)
-    if "torch" in name:
+    if name == "torch":
         from ..backend._torch.staeckel_c import actionsfreqsangles_with_jac
 
         return actionsfreqsangles_with_jac(host_jac, R, vR, vT, z, vz, phi)

--- a/galpy/df/constantbetadf.py
+++ b/galpy/df/constantbetadf.py
@@ -551,7 +551,7 @@ class constantbetadf(_constantbetadf):
         construction: a DF built with jax autodiff may be evaluated under a
         forced-torch run, so the grad operator must match the eval backend.
         """
-        name = "torch" if "torch" in getattr(xp, "__name__", "") else "jax"
+        name = name_of_namespace(xp)
         cache = self.__dict__.setdefault("_gradfunc_cache", {})
         if name not in cache:
             grad, vmap = autodiff_ops(xp)

--- a/galpy/df/evolveddiskdf.py
+++ b/galpy/df/evolveddiskdf.py
@@ -21,7 +21,7 @@ import warnings
 import numpy
 from scipy import integrate
 
-from ..backend import device_of, get_namespace, is_backend_array
+from ..backend import device_of, get_namespace, is_backend_array, name_of_namespace
 from ..backend import quadrature as _bquad
 from ..orbit import Orbit
 from ..potential import calcRotcurve, planarCompositePotential, planarForce
@@ -3146,7 +3146,7 @@ class evolveddiskdf(df):
         # backend orbits integrate with the backend's own solver; a C-method NAME
         # would route there anyway, but pick it explicitly so a non-C
         # integrate_method (odeint/leapfrog) works too.
-        bmethod = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+        bmethod = "diffrax" if name_of_namespace(xp) == "jax" else "torchdiffeq"
         if isinstance(t, (list, numpy.ndarray)):
             t = numpy.atleast_1d(numpy.asarray(t))
             nt = len(t)

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -22,6 +22,7 @@ from ..backend import (
     as_numpy,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
     promote_scalars,
 )
 from ..backend import special as _bspecial
@@ -1472,7 +1473,7 @@ class streamdf(df):
             )
         xv0_prog = self._progenitor._ic_backend  # (6,) backend IC, grad-connected
         xp = get_namespace(xv0_prog)
-        method = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+        method = "diffrax" if name_of_namespace(xp) == "jax" else "torchdiffeq"
         # Recompute the progenitor's freqs/angles from the (backend) progenitor so the
         # offsets carry the potential/IC gradient (the numpy body reads the stored
         # constants). The track offset is (track AA - progenitor AA); with both AAs
@@ -4864,7 +4865,7 @@ def _vmap_track_chunks(xp, single, xv0_all, thetasTrack):
     track to ~1e-4). torch: a Python stack of per-chunk calls (torch.func.vmap
     cannot trace the torchdiffeq custom-autograd orbit). 6-tuple of stacked arrays.
     """
-    if "jax" in xp.__name__:
+    if name_of_namespace(xp) == "jax":
         import jax
 
         return jax.lax.map(lambda a: single(a[0], a[1]), (xv0_all, thetasTrack))

--- a/galpy/df/streamgapdf.py
+++ b/galpy/df/streamgapdf.py
@@ -15,6 +15,7 @@ from ..backend import (
     device_of,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
 )
 from ..backend import special as _bspecial
 from ..backend import use
@@ -2068,7 +2069,7 @@ def _impulse_deltav_general_orbitintegration_backend(
     # galpot's forces to return backend arrays (a real Potential does; a test
     # double whose force returns a bare Python scalar does not -> numpy path).
     xp = get_namespace(v, x, w)
-    method = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+    method = "diffrax" if name_of_namespace(xp) == "jax" else "torchdiffeq"
     v, x, w, x0, v0 = coerce_coords(xp, v, x, w, x0, v0)
     if v.ndim == 1:
         v = xp.reshape(v, (1, 3))

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -10,6 +10,7 @@ from ..backend import (
     as_numpy,
     get_namespace,
     is_backend_array,
+    name_of_namespace,
     use,
 )
 from ..df.df import df
@@ -763,7 +764,7 @@ class basestreamspraydf(df):
             self._progenitor.integrate(self._progenitor_times, self._pot)
             self._bsamp = None
             return
-        inbackend = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+        inbackend = "diffrax" if name_of_namespace(xp) == "jax" else "torchdiffeq"
         if ic_backend:
             ic = prog_ic
         else:
@@ -855,7 +856,7 @@ class basestreamspraydf(df):
             xp, _, prog_method = bsamp
         else:
             xp = get_namespace(cic_backend) if ic_backend else get_namespace(_cf)
-        inbackend = "diffrax" if "jax" in xp.__name__ else "torchdiffeq"
+        inbackend = "diffrax" if name_of_namespace(xp) == "jax" else "torchdiffeq"
         if bsamp is None:
             self._promote_progenitor_backend(xp, inbackend)
             _, _, prog_method = self._bsamp

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -23,7 +23,13 @@ elif _SCIPY_VERSION < parse_version("0.19"):  # pragma: no cover
 else:
     from scipy.special import logsumexp
 
-from ..backend import as_numpy, coerce_coords, get_namespace, is_backend_array
+from ..backend import (
+    as_numpy,
+    coerce_coords,
+    get_namespace,
+    is_backend_array,
+    name_of_namespace,
+)
 from ..potential import (
     _INF,
     CompositePotential,
@@ -1763,7 +1769,7 @@ class Orbit:
                 _potl = _check_potential_list_and_deprecate(pot)
                 _inbk = (
                     "diffrax"
-                    if "jax" in get_namespace(ic_backend).__name__
+                    if name_of_namespace(get_namespace(ic_backend)) == "jax"
                     else "torchdiffeq"
                 )
                 # C-STM eligibility by phase-space dim: 6D needs the full C 3D
@@ -2234,7 +2240,7 @@ class Orbit:
         else:
             t = numpy.atleast_1d(numpy.asarray(t, dtype=float))
             ts = xp.asarray(t)
-        if "jax" in xp.__name__:
+        if name_of_namespace(xp) == "jax":
             from ..backend._jax import orbit_stm
         else:
             from ..backend._torch import orbit_stm

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -553,3 +553,51 @@ def test_units_decorator_is_outside_the_jit_boundary(module_path):
         "the jit trace and raise TracerArrayConversionError; put "
         "@physical_conversion above @backend_input."
     )
+
+
+def test_no_module_hand_rolls_namespace_detection():
+    """Backend identity is asked via name_of_namespace, not by inspecting __name__.
+
+    galpy.backend.name_of_namespace maps a resolved namespace to "numpy"/"jax"/
+    "torch". Modules that re-derive that from ``xp.__name__`` are re-implementing
+    it, and the re-implementation is only accidentally correct: ``"torch" in
+    xp.__name__`` works, ``xp.__name__.startswith("torch")`` does NOT, because the
+    torch namespace is ``array_api_compat.torch``. That exact slip disabled torch
+    tracing everywhere in galpy/backend/_jit.py and no test noticed -- an untraced
+    call returns the same values a traced one does, so only a coverage delta
+    caught it.
+
+    Asking through the helper makes the invariant structural instead of a
+    convention every author has to remember.
+    """
+    import ast
+    import pathlib
+
+    import galpy
+
+    root = pathlib.Path(galpy.__file__).parent
+    # _namespaces.py DEFINES the mapping, so it is the one place that may look at
+    # __name__ directly.
+    allowed = {"_namespaces.py"}
+    offenders = []
+    for path in sorted(root.rglob("*.py")):
+        if path.name in allowed:
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - galpy always parses
+            continue
+        for node in ast.walk(tree):
+            # `<something>.__name__` compared against, or searched for, a backend
+            # name -- in either argument order.
+            if not isinstance(node, ast.Compare):
+                continue
+            src = ast.unparse(node)
+            if "__name__" not in src:
+                continue
+            if any(f'"{b}"' in src or f"'{b}'" in src for b in ("jax", "torch")):
+                offenders.append(f"{path.relative_to(root)}:{node.lineno}: {src}")
+    assert not offenders, (
+        "modules deriving the backend name from __name__ instead of calling "
+        "galpy.backend.name_of_namespace:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
`galpy.backend.name_of_namespace` maps a resolved namespace to `"numpy"`/`"jax"`/
`"torch"`. Twelve sites re-derived that from `xp.__name__` instead:

| module | sites |
|---|---|
| `df/constantbetadf.py` | 1 |
| `df/streamspraydf.py` | 2 |
| `df/streamgapdf.py` | 1 |
| `df/evolveddiskdf.py` | 1 |
| `df/streamdf.py` | 2 |
| `orbit/Orbits.py` | 2 |
| `actionAngle/actionAngleIsochroneApprox.py` | 1 |
| `actionAngle/actionAngleStaeckel.py` | 6 |

### Why this is not a cosmetic DRY pass

All twelve were **correct** — but only *accidentally*. Each happened to use `in`:

* `"torch" in xp.__name__` — works.
* `xp.__name__.startswith("torch")` — does **not**, because the torch namespace is
  `array_api_compat.torch`.

I reached for `startswith` in `galpy/backend/_jit.py` and it matched nothing,
**disabling torch tracing everywhere**. No test noticed, and structurally none
could: an untraced call returns exactly the values a traced one does, so
`--backend torch --jit` stayed green while tracing nothing. Only a coverage delta
caught it — 11 newly-dead lines (fixed in #1303).

So this removes twelve further chances to repeat that, by giving the question one
answer instead of twelve spellings.

### Enforcement

`test_no_module_hand_rolls_namespace_detection` walks every module's AST and fails
on any comparison mentioning `__name__` together with a backend name, exempting
only `_namespaces.py`, which **defines** the mapping.

Negative control, so it is demonstrably not vacuous — reintroducing one site
reports the exact location:

```
E   df/streamdf.py:4868: 'jax' in xp.__name__
```

and it passes again on restore.

### No behaviour change

`name_of_namespace` returns exactly what the substring tests returned for every
namespace galpy supports; it is a pure refactor.

### Gate

| arm | result |
|---|---|
| `test_backend_conventions` + `test_backend_staeckel_grad` + `test_backend_input`, numpy | 205 passed |
| same, `--backend jax` | 205 passed |
| same, `--backend torch` | 205 passed |
| `test_streamgapdf` + `test_evolveddiskdf`, numpy | 66 passed |

The last arm is there deliberately: it is the only one exercising the
`streamgapdf`/`evolveddiskdf` sites, which the first three never execute.