### PR TITLE
tests: adopt assert_jit_matches_eager at six jit-vs-eager sites

### DIFF
--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -38,6 +38,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.actionAngle import (
     actionAngleAdiabatic,
     actionAngleAdiabaticGrid,
@@ -2095,9 +2097,7 @@ def test_staeckelgrid_native_setup_differentiable(backend):
             grad = jax.grad(loss)(baseL)
             dd = float(jnp.sum(grad * jnp.asarray(V)))
             # jit-safe: jax.jit == eager
-            numpy.testing.assert_allclose(
-                float(jax.jit(loss)(baseL)), float(loss(baseL)), rtol=1e-11, atol=1e-11
-            )
+            assert_jit_matches_eager(loss, baseL, rtol=1e-11, atol=1e-11)
 
             def _l(a):
                 return float(loss(jnp.asarray(a)))

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -28,6 +28,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import get_namespace, is_backend_array
 from galpy.potential import (
@@ -168,10 +169,11 @@ def test_default_surfdens_jit_safe():
     R0, z0 = 1.1, 0.3
     ref = float(evaluateRforces(pot, numpy.float64(R0), numpy.float64(z0)))
     rf = lambda R: evaluateRforces(pot, R, jnp.asarray(z0))
-    jR = float(jax.jit(rf)(jnp.asarray(R0)))
+    # ref= compares the traced array call against the plain-float numpy value;
+    # the helper additionally rejects a trace that folded R away to a constant.
+    assert_jit_matches_eager(rf, jnp.asarray(R0), rtol=1e-10, atol=1e-12, ref=ref)
     gR = float(jax.jacfwd(rf)(jnp.asarray(R0)))
-    assert numpy.isfinite(jR) and numpy.isfinite(gR)
-    numpy.testing.assert_allclose(jR, ref, rtol=1e-10, atol=1e-12)
+    assert numpy.isfinite(gR)
 
 
 @pytest.mark.parametrize("backend_name", AD_BACKENDS)

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -34,6 +34,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 import galpy.backend
 from galpy.backend import as_numpy
 from galpy.df import constantbetadf, constantbetaHernquistdf, constantbetaPowerLawdf
@@ -341,10 +343,10 @@ def test_generic_fE_jit_traceable():
                     [pinf + 1.0, Emin - 1.0],  # out of bounds -> exactly zero
                 ]
             )
-            eager = as_numpy(df.fE(jnp.asarray(Es)))
-            traced = as_numpy(jax.jit(df.fE)(jnp.asarray(Es)))
-        # tracing must not perturb the value: same kernel, same GL nodes
-        numpy.testing.assert_allclose(traced, eager, rtol=1e-12, atol=0.0)
+            # tracing must not perturb the value: same kernel, same GL nodes
+            traced = assert_jit_matches_eager(
+                df.fE, jnp.asarray(Es), rtol=1e-12, atol=0.0
+            )
         assert numpy.all(traced[-2:] == 0.0)
 
 

--- a/tests/test_backend_dynamfric.py
+++ b/tests/test_backend_dynamfric.py
@@ -53,6 +53,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.backend import as_numpy
 from galpy.potential import (
     ChandrasekharDynamicalFrictionForce,
@@ -219,14 +221,18 @@ def test_dynamfric_jax_jit_jacfwd_finite(label, obj):
             use_physical=False,
         )
 
-    jitted = float(jax.jit(fR)(jnp.asarray(_R0)))
-    jac = float(jax.jacfwd(fR)(jnp.asarray(_R0)))
-    assert numpy.isfinite(jitted), f"{label}: jit not finite"
-    assert numpy.isfinite(jac), f"{label}: jacfwd not finite"
-    # jit value must equal the eager numpy Rforce
-    numpy.testing.assert_allclose(
-        jitted, _np_forces(obj, _R0)[0], rtol=1e-10, atol=1e-13
+    # jit value must equal the eager numpy Rforce, supplied via ref=; the helper
+    # additionally rejects a trace that folded R0 away into a constant.
+    assert_jit_matches_eager(
+        fR,
+        jnp.asarray(_R0),
+        rtol=1e-10,
+        atol=1e-13,
+        ref=_np_forces(obj, _R0)[0],
+        err_msg=label,
     )
+    jac = float(jax.jacfwd(fR)(jnp.asarray(_R0)))
+    assert numpy.isfinite(jac), f"{label}: jacfwd not finite"
 
 
 @pytest.mark.filterwarnings("error::DeprecationWarning")

--- a/tests/test_backend_evolveddiskdf.py
+++ b/tests/test_backend_evolveddiskdf.py
@@ -46,6 +46,8 @@ try:
 except ImportError:  # pragma: no cover
     torch = None
 
+from backend_jit_helpers import assert_jit_matches_eager
+
 from galpy.backend import as_numpy, is_backend_array, use
 from galpy.df import dehnendf, evolveddiskdf
 from galpy.potential import (
@@ -369,6 +371,7 @@ def test_direct_moment_jit_matches_eager():
         ).reshape(())
 
     with use("jax", force=True):
-        eager = float(call(jnp.asarray(_R)))
-        jitted = float(jax.jit(call)(jnp.asarray(_R)))
-    numpy.testing.assert_allclose(jitted, eager, rtol=1e-12, atol=1e-14)
+        # assert_jit_matches_eager also checks the jaxpr CONSUMES its argument: a
+        # trace that folded it away returns a constant and would match eager
+        # vacuously, which a bare allclose cannot see.
+        assert_jit_matches_eager(call, jnp.asarray(_R), rtol=1e-12, atol=1e-14)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -9,6 +9,7 @@ import numpy
 import pytest
 import scipy.interpolate as si
 import scipy.ndimage as sndi
+from backend_jit_helpers import assert_jit_matches_eager
 
 from galpy.backend import as_numpy
 from galpy.backend.interpolate import (
@@ -382,9 +383,7 @@ def test_interp_bilinear_jit_equals_eager(backend):
     def f(x, y):
         return interp_bilinear(jnp, bx, by, bz, x, y, extrapolate="clip")
 
-    eager = numpy.asarray(f(X, Y))
-    jitted = numpy.asarray(jax.jit(f)(X, Y))
-    numpy.testing.assert_allclose(jitted, eager, rtol=0.0, atol=1e-14)
+    assert_jit_matches_eager(f, X, Y, rtol=0.0, atol=1e-14)
 
 
 def test_interp_bilinear_bad_extrapolate():


### PR DESCRIPTION
Six `test_backend_*` modules each hand-rolled the same comparison:

```python
eager  = as_numpy(fn(*args))
jitted = as_numpy(jax.jit(fn)(*args))
assert_allclose(jitted, eager, ...)
```

That checks jitting does not change the value, but says nothing about whether the
trace actually **consumed its arguments**. A trace that folds them away returns a
constant and still compares equal, so the value check alone cannot see it — the
same blind spot that let the torch-tracing bug (a `startswith` test against
`array_api_compat.torch`, whose `__name__` does not begin with `"torch"`) disable
torch tracing everywhere until codecov flagged the dead lines.

`assert_jit_matches_eager` already existed and does both: compares against eager,
and inspects the jaxpr to confirm the output really is a function of the traced
arguments. This adopts it at the six sites that are genuinely `jit(f)(x)` vs
`f(x)`, **preserving each site's existing tolerances exactly**.
`anyaxisymdisk` and `dynamfric` pass their numpy reference through `ref=`, since
there the eager side is deliberately a plain-float numpy call.

### Scoped by classification, not by grep count

Of the 67 raw `jax.jit` sites in `tests/test_backend_*.py`:

| shape | count | adoptable |
|---|---|---|
| direct `jit(f)(x)` call | 17 | yes |
| bound to a name (reused/cached) | 17 | case by case |
| AD compile (`grad`/`jacfwd`) | 9 | **no** |
| other | 21 | no |

`test_backend_trace.py:58` was inspected and deliberately left alone — it asserts
that `under_trace` fired, not a value match, so this helper would be the wrong
assertion there.

### Gate

Whole files, three arms, all from finished runs (`### DONE` marker):

| arm | result |
|---|---|
| numpy | 655 passed (32:22) |
| `--backend jax` | 655 passed (32:18) |
| `--backend torch` | 655 passed (33:17) |

Test-only change; no `galpy/` source is touched, so the numpy path is
byte-identical by construction.