### PR TITLE
xfail: collect the AnyAxisym 2ndDeriv entry gh#1307 already fixed

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -237,7 +237,6 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap
 # tolerance is ever made backend-aware.
 jax-jit tests/test_orbit.py::test_eccentricity
 torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
-jax-jit tests/test_potential.py::test_2ndDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 
 # --- torch --jit: parallel_map's fork is fixed for EAGER torch only ----------


### PR DESCRIPTION
**Ledger delta: 169 → 168** (xfail 16 → 15).

gh#1307 routed AnyAxisym's traced `R2deriv`/`z2deriv` through the Hadamard
finite-part rule, ~8 orders better at the midplane. The corresponding ledger entry
was never removed, because the ledger uses `xfail(strict=False)`: a landed fix flips
the entry XFAIL → **XPASS**, which is not a CI failure. Nothing goes red, so a
paid-for fix sits uncollected indefinitely.

### Measured, not assumed

`tests/test_potential.py` run **whole-file** under `--backend jax --jit`, junitxml
parsed for the exact nodeid (matched literally — the `[...]` in a nodeid is a grep
character class, and absence of a `<skipped>` element is *not* evidence of XPASS
unless the nodeid is actually ledgered for the backend being run):

| entry | result |
|---|---|
| `test_2ndDeriv_potential[AnyAxisym…]` | **PASSED → XPASS, removed** |
| `test_forceAsDeriv_potential[AnyAxisym…]` | still XFAIL, kept |
| `test_poisson_surfdens_potential[AnyAxisym…]` | still XFAIL, kept |

The two torch-jit siblings were measured in a separate `--backend torch --jit` run
and both still XFAIL, so they stay too.

That split is the expected one: gh#1307 fixed the second derivatives, not the
forces — consistent with the parked negative result that traced `Rforce` would need
~7e-11 absolute to pass. Removing all five AnyAxisym-mentioning entries would have
been wrong.

### Scope note

A whole-matrix sweep of the 44 `backend-junit-*` artifacts at `50dbf316` found **0
other stale xfail entries**, so this is the only one of its kind rather than the
first of many. slow-skip/skip entries (153 of the 169) cannot be validated from
artifacts at all — they are skipped, so junit records `skipped` regardless — and
need timed runs instead.