### PR TITLE
slow-skip: un-defer 3 measured-stale MW mass-model entries (168 -> 165)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -142,10 +142,7 @@ jax tests/test_potential.py::test_MultipoleExpansion_deepcopy
 # slow-skip (correct-but-too-slow) until SCF/Multipole/wrapper eval is vectorized on
 # jax. torch fails these FAST at construction (0.0 s) -> they stay in the torch xfail-
 # ledger; numpy exercises all of them.
-jax tests/test_potential.py::test_Cautun20
 jax tests/test_potential.py::test_DehnenBinney98
-jax tests/test_potential.py::test_McMillan17
-jax tests/test_potential.py::test_diskscf_overflow
 jax tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]
 jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]
 jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]


### PR DESCRIPTION
**Ledger delta: 168 → 165.** No source change — ledger only.

Measured by un-skipping and running the whole `tests/test_potential.py` under
`--backend jax` with `--timeout=600 --timeout-method=thread`, so junitxml lands and
the numbers are per-entry rather than inferred from a constructor timing:

| entry | result | time |
|---|---|---|
| `test_diskscf_overflow` | PASSED | **5.8 s** |
| `test_McMillan17` | PASSED | **27.4 s** |
| `test_Cautun20` | PASSED | **34.6 s** |
| `test_DehnenBinney98` | PASSED | 276.8 s — **kept deferred** |

Run: `1281 passed, 109 skipped, 51:20`.

The three un-deferred sit at 6–35 s, comparable to ordinary running tests, so the
slow-skip reason ("unrunnable under the backend until the port is vectorized") no
longer describes them. `DehnenBinney98` still costs 4.6 minutes and stays deferred —
un-deferring it would put a single test at ~9% of a shard.

### Independent of gh#1316

These do **not** depend on that PR's `interpRZPotential` fix, so this is a separate
burndown rather than a follow-on:

- the MW mass-model modules contain **zero** `interpRZPotential` references;
- `_grid_eval` exists in **one** file, `interpRZPotential.py`;
- the measuring worktree's **only** source diff vs develop was that same file.

So the fix cannot reach these tests and the timings transfer to a clean develop.