### PR TITLE
AnySphericalPotential: integrate element-wise for array r

### DIFF
--- a/galpy/potential/AnySphericalPotential.py
+++ b/galpy/potential/AnySphericalPotential.py
@@ -6,6 +6,7 @@ from scipy import integrate
 
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
+from ..util.quadpack import quad_over_limits
 from .SphericalPotential import SphericalPotential
 
 if _APY_LOADED:
@@ -79,12 +80,9 @@ class AnySphericalPotential(SphericalPotential):
                 )
         if not hasattr(self, "_rawdens"):  # unitless
             self._rawdens = dens
+
         self._rawmass = lambda r: (
-            4.0
-            * numpy.pi
-            * integrate.quad(
-                lambda a: a**2 * self._rawdens(a), 0, numpy.atleast_1d(r).flatten()[0]
-            )[0]
+            4.0 * numpy.pi * quad_over_limits(lambda a: a**2 * self._rawdens(a), 0, r)
         )
         # The potential at zero, try to figure out whether it's finite
         _zero_msg = integrate.quad(
@@ -115,20 +113,21 @@ class AnySphericalPotential(SphericalPotential):
 
     def _revaluate(self, r, t=0.0):
         """Potential as a function of r and time"""
+        # r == 0 / isinf(r) are per-element questions, so an array r has to be
+        # handled element by element; scipy's quad wants a scalar limit anyway.
+        if numpy.ndim(r) == 0:
+            return self._revaluate_scalar(r)
+        rr = numpy.asarray(r)
+        return numpy.reshape([self._revaluate_scalar(x) for x in rr.ravel()], rr.shape)
+
+    def _revaluate_scalar(self, r):
         if r == 0:
             return self._pot_zero
         elif numpy.isinf(r):
             return self._pot_inf
         else:
-            return (
-                -self._rawmass(r) / r
-                - 4.0
-                * numpy.pi
-                * integrate.quad(
-                    lambda a: self._rawdens(a) * a,
-                    numpy.atleast_1d(r).flatten()[0],
-                    numpy.inf,
-                )[0]
+            return -self._rawmass(r) / r - 4.0 * numpy.pi * quad_over_limits(
+                lambda a: self._rawdens(a) * a, r, numpy.inf
             )
 
     def _rforce(self, r, t=0.0):

--- a/galpy/potential/interpRZPotential.py
+++ b/galpy/potential/interpRZPotential.py
@@ -124,32 +124,37 @@ def _grid_eval(evaluator, pot, rgrid, zgrid):
     * the potential neither raises nor broadcasts correctly. This is the
       dangerous one, because a ``try/except`` sails straight past it and the
       whole interpolation grid is then built from wrong numbers. Measured
-      2026-08-10, ``AnySphericalPotential`` does exactly that: its array results
-      differ from the cell-by-cell ones in 95 % of cells, silently.
+      2026-08-10, ``AnySphericalPotential`` did exactly that: its array results
+      differed from the cell-by-cell ones in 95 % of cells, silently. That
+      potential has since been fixed, so this branch is now exercised only by
+      the synthetic mis-broadcaster in
+      ``test_grid_eval_falls_back_on_silent_misbroadcast`` -- deliberately, so
+      the guard keeps its own test rather than depending on some other
+      component staying buggy.
 
     **Composites are not a special case and do not need one.** A list or a
     ``CompositePotential`` broadcasts iff its components do, because the
     evaluator just sums them. Verified over all 56 pairwise composites (both
     spellings) of 8 individually-vectorisable potentials: **none** fell back.
-    Only a composite *containing* an array-unsafe component -- in practice
-    ``AnySphericalPotential`` -- falls back, which is the correct outcome, since
-    the sum is then as wrong as its worst term.
+    Only a composite *containing* an array-unsafe component falls back, which is
+    the correct outcome, since the sum is then as wrong as its worst term.
 
     So the vectorised result is accepted only after it reproduces the scalar
     path **bit for bit** on a spot-check sample (see `_spot_check_cells`).
     Bit-for-bit rather than within a tolerance is deliberate: the point of this
     is to be a pure speed-up, so anything that would move a shipped value falls
     back instead. Across a 19-potential zoo x the 7 sampled quantities, 94 of
-    108 combinations are bit-identical over the entire grid, 9 raise, and 5 (all
-    ``AnySphericalPotential``) differ and are caught here.
+    108 combinations were bit-identical over the entire grid, 9 raised, and 5
+    (all ``AnySphericalPotential``, before it was fixed) differed and were
+    caught here.
 
     The sample is ~19 cells rather than two whole rows. That is a deliberate
     trade: it costs 31x less on potentials where a scalar call is expensive
     (``DoubleExponentialDiskPotential``: 0.008 s vs 0.251 s), at the price of
     being probabilistic for a *sparse* disagreement. It is not probabilistic for
     the failure this actually guards against -- a broadcasting bug is a
-    whole-array phenomenon, and the one real instance disagrees in 95 % of
-    cells, which ~19 independent samples miss with probability 5e-25.
+    whole-array phenomenon, and the one real instance seen so far disagreed in
+    95 % of cells, which ~19 independent samples miss with probability 5e-25.
     """
     nR, nz = len(rgrid), len(zgrid)
 

--- a/galpy/util/quadpack.py
+++ b/galpy/util/quadpack.py
@@ -16,6 +16,37 @@ def _infunc(x, func, gfun, hfun, more_args, epsrel, epsabs):
     return retval[0]
 
 
+def quad_over_limits(func, a, b, **kwargs):
+    """``quad(func, a, b)[0]`` with either limit allowed to be an array.
+
+    scipy's ``quad`` accepts scalar limits only, and silently uses just the
+    first element if handed an array, so integrating over array coordinates has
+    to be done element by element.
+
+    Parameters
+    ----------
+    func : callable
+        Function to integrate, of one variable.
+    a, b : float or array
+        Limits of integration; broadcast against each other.
+    **kwargs
+        Passed through to ``scipy.integrate.quad``.
+
+    Returns
+    -------
+    float or array
+        The integral, of the broadcast shape of ``a`` and ``b``. A scalar in,
+        scalar out, evaluated by exactly the same ``quad`` call as before.
+    """
+    if numpy.ndim(a) == 0 and numpy.ndim(b) == 0:
+        return quad(func, a, b, **kwargs)[0]
+    aa, bb = numpy.broadcast_arrays(a, b)
+    out = numpy.empty(aa.shape)
+    for idx in numpy.ndindex(aa.shape):
+        out[idx] = quad(func, aa[idx], bb[idx], **kwargs)[0]
+    return out
+
+
 def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     return quad(
         _infunc,

--- a/tests/test_interp_potential.py
+++ b/tests/test_interp_potential.py
@@ -3,6 +3,61 @@ import numpy
 from galpy import potential
 
 
+class _MisBroadcastPotential(potential.Potential):
+    """A potential that silently returns the wrong thing for array input.
+
+    It neither raises nor returns the wrong shape, so a ``try/except`` around
+    the vectorised call sails straight past it -- which is precisely the failure
+    ``_grid_eval``'s bit-for-bit spot check exists to catch. Synthetic on
+    purpose: this branch used to be covered only incidentally, by a real
+    potential that happened to be buggy, so it silently lost its coverage the
+    moment that potential was fixed.
+    """
+
+    def __init__(self):
+        potential.Potential.__init__(self, amp=1.0)
+        self.hasC = False
+        self.hasC_dxdv = False
+
+    def _evaluate(self, R, z, phi=0.0, t=0.0):
+        base = -1.0 / numpy.sqrt(R**2.0 + z**2.0 + 1.0)
+        # array input gets a different answer than the same point scalar-wise
+        return base + 1.0 if numpy.ndim(R) > 0 else base
+
+
+def test_grid_eval_falls_back_on_silent_misbroadcast():
+    from galpy.potential.interpRZPotential import _grid_eval
+
+    pot = _MisBroadcastPotential()
+    rgrid = numpy.linspace(0.1, 2.0, 9)
+    zgrid = numpy.linspace(0.0, 0.5, 7)
+    got = _grid_eval(potential.evaluatePotentials, pot, rgrid, zgrid)
+    ref = numpy.array(
+        [
+            [
+                potential.evaluatePotentials(pot, r, zz, use_physical=False)
+                for zz in zgrid
+            ]
+            for r in rgrid
+        ]
+    )
+    # the guard must have rejected the vectorised answer and looped instead,
+    # so the +1.0 offset must NOT be present anywhere
+    assert numpy.array_equal(got, ref), (
+        "_grid_eval accepted a silently mis-broadcasting potential"
+    )
+    # and confirm the vectorised answer really was different, i.e. that this
+    # test would fail without the guard rather than passing vacuously
+    Rmesh, zmesh = numpy.meshgrid(rgrid, zgrid, indexing="ij")
+    vec = numpy.asarray(
+        potential.evaluatePotentials(pot, Rmesh, zmesh, use_physical=False)
+    )
+    assert vec.shape == ref.shape and not numpy.any(vec == ref), (
+        "the mis-broadcast fixture did not actually differ from the scalar path"
+    )
+    return None
+
+
 def test_errors():
     # Test that when we set up an interpRZPotential w/ another interpRZPotential, we get an error
     rzpot = potential.interpRZPotential(

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -773,7 +773,6 @@ def _make_pots_potential_array_input():
     rmpots.append("DoubleExponentialDiskPotential")
     rmpots.append("RazorThinExponentialDiskPotential")
     rmpots.append("AnyAxisymmetricRazorThinDiskPotential")
-    rmpots.append("AnySphericalPotential")
     rmpots.append("SphericalShellPotential")
     rmpots.append("HomogeneousSpherePotential")
     # These cannot be setup without arguments

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -101,3 +101,50 @@ def test_quadpack():
         "galpy.util.quadpack.dblquad did not work as expected"
     )
     return None
+
+
+def test_quad_over_limits():
+    from scipy.integrate import quad
+
+    from galpy.util.quadpack import quad_over_limits
+
+    f = lambda x: numpy.exp(-x) * x**2
+    # Scalar in, scalar out, and exactly the plain quad call
+    assert quad_over_limits(f, 0.0, 1.3) == quad(f, 0.0, 1.3)[0], (
+        "quad_over_limits does not reproduce quad exactly for scalar limits"
+    )
+    assert numpy.ndim(quad_over_limits(f, 0.0, 1.3)) == 0, (
+        "quad_over_limits does not return a scalar for scalar limits"
+    )
+    # Array upper limit: every element integrated to its own limit, which is
+    # exactly what a bare quad(f, 0, b) silently fails to do (it uses b[0])
+    b = numpy.array([0.3, 1.0, 2.5, 7.0])
+    got = quad_over_limits(f, 0.0, b)
+    ref = numpy.array([quad(f, 0.0, x)[0] for x in b])
+    assert got.shape == b.shape, "quad_over_limits did not preserve shape"
+    assert numpy.all(got == ref), (
+        "quad_over_limits does not match element-by-element quad"
+    )
+    assert not numpy.all(got == got[0]), "quad_over_limits collapsed to a single limit"
+    # Array lower limit, and both limits arrays (broadcast)
+    a = numpy.array([0.1, 0.5, 1.0, 2.0])
+    assert numpy.all(
+        quad_over_limits(f, a, numpy.inf)
+        == numpy.array([quad(f, x, numpy.inf)[0] for x in a])
+    ), "quad_over_limits does not handle an array lower limit"
+    assert numpy.all(
+        quad_over_limits(f, a, b)
+        == numpy.array([quad(f, x, y)[0] for x, y in zip(a, b)])
+    ), "quad_over_limits does not handle two array limits"
+    # 2D shape is preserved, with the limits deliberately not monotonic
+    b2 = numpy.array([[0.3, 1.0, 2.5], [4.0, 0.2, 6.0]])
+    got2 = quad_over_limits(f, 0.0, b2)
+    assert got2.shape == b2.shape, "quad_over_limits did not preserve a 2D shape"
+    assert numpy.all(
+        got2 == numpy.array([[quad(f, 0.0, x)[0] for x in row] for row in b2])
+    ), "quad_over_limits is wrong on a 2D grid of limits"
+    # kwargs reach scipy
+    assert (
+        quad_over_limits(f, 0.0, 1.3, epsabs=1e-3) == quad(f, 0.0, 1.3, epsabs=1e-3)[0]
+    ), "quad_over_limits does not pass kwargs through to quad"
+    return None


### PR DESCRIPTION
`scipy.integrate.quad` takes **scalar** limits. `AnySphericalPotential` handed it
`numpy.atleast_1d(r).flatten()[0]` at two sites, so an array `r` was integrated
only to `r[0]` and that single answer reused for every element:

* **`_rawmass`** — `_rforce` divides that one enclosed mass by an array `r**2`,
  so **forces away from `r[0]` are silently wrong**. No exception, no warning.
  Measured **87.7 % relative error** on the grid the existing test uses.
* **`_revaluate`** — the same collapse for the potential itself.

`_revaluate` also branches on `if r == 0` / `numpy.isinf(r)`, which raise
`ValueError: truth value of an array … is ambiguous` for array input — so the
potential was not merely wrong for arrays, it was unusable:

```python
>>> from galpy.potential import AnySphericalPotential
>>> import numpy
>>> p = AnySphericalPotential()
>>> R = numpy.linspace(0.1, 2.0, 11)
>>> p.Rforce(R, 0.0)          # before: silently wrong away from R[0]
>>> p(R, 0.0)                 # before: ValueError
```

## Fix

Both sites now integrate element by element, through a new
`galpy.util.quadpack.quad_over_limits`. That module is already "some variations
on scipy's quadpack/quad", so the helper lives there rather than inside the
potential.

**Scalar input is unchanged and bit-identical** — it takes the same single
`quad` call as before, verified bit-for-bit at six radii against the old
formulas. Only array input changes, and only from wrong to right.

## Testing — the check already existed, with this potential excluded

`test_potential_array_input` already asserts whole-array == cell-by-cell at
1e-10 for `__call__`, `Rforce`, `zforce`, `phitorque`, `R2deriv`, `z2deriv`,
`phi2deriv` and `Rzderiv`, across every discovered potential.
`AnySphericalPotential` sat on its **exclusion list** — which is exactly why
this survived. So this PR **deletes the exclusion** rather than adding new test
machinery; the potential now matches cell-by-cell to `0.000e+00` on all seven
methods.

Both failure halves are confirmed caught, not assumed:

* against the unmodified file the test fails (`ValueError`);
* with *only* the collapsing `_rawmass` reinstated — so the potential evaluates
  fine and the bug is silent — the force assertion still fires at 87.7 %.

`quad_over_limits` gets its own direct test in `tests/test_util.py` (exact
equality against per-element `scipy.quad`, array upper/lower/both limits, 2D
shape, kwargs passthrough, and an explicit anti-collapse assertion).

Local gate: `test_potential.py` + `test_interp_potential.py` + `test_util.py`
**1280 passed, 0 failed**; `test_quantity.py` (serial) **242 passed, 0 failed**.

## Follow-up, not in this PR

The other six potentials on that exclusion list — `FerrersPotential`,
`DoubleExponentialDiskPotential`, `RazorThinExponentialDiskPotential`,
`AnyAxisymmetricRazorThinDiskPotential`, `SphericalShellPotential`,
`HomogeneousSpherePotential` — are *all* genuinely broken for array input as
well (`ValueError`/`TypeError` out of scalar `if` branching). Measured, but out
of scope here.