### PR TITLE
Full test coverage of actionAngleSphericalInverse

### DIFF
--- a/galpy/actionAngle/actionAngleIsochrone.py
+++ b/galpy/actionAngle/actionAngleIsochrone.py
@@ -453,21 +453,11 @@ class _actionAngleIsochroneHelper:
         c = -self.amp / 2.0 / E - self.b
         e2 = 1.0 - L * L / self.amp / c * (1.0 + self.b / c)
         e = numpy.sqrt(e2)
-        if isinstance(self.b, numpy.ndarray):
-            s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-            coseta = 1 / e * (1.0 - self.b / c * (s - 2.0))
-            pindx = self.b == 0.0
-            coseta[pindx] = 1 / e[pindx] * (1.0 - r[pindx] / c[pindx])
-        else:
-            if self.b == 0.0:
-                coseta = 1 / e * (1.0 - r / c)
-            else:
-                s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-                coseta = 1 / e * (1.0 - self.b / c * (s - 2.0))
-        pindx = coseta > 1.0
-        coseta[pindx] = 1.0
-        pindx = coseta < -1.0
-        coseta[pindx] = -1.0
+        # Using b (s-2) = sqrt(b^2+r^2) - b, which needs no special case for
+        # the Kepler limit b = 0 and does not divide by b
+        coseta = numpy.clip(
+            (1.0 - (numpy.sqrt(self.b**2.0 + r**2.0) - self.b) / c) / e, -1.0, 1.0
+        )
         eta = numpy.arccos(coseta)
         if vrneg:
             eta = 2.0 * numpy.pi - eta
@@ -483,21 +473,11 @@ class _actionAngleIsochroneHelper:
         L2overampc = L2 / self.amp / self._c
         e2 = 1.0 - L2overampc * (1.0 + self.b / self._c)
         self._e = numpy.sqrt(e2)
-        if isinstance(self.b, numpy.ndarray):
-            s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-            coseta = 1 / self._e * (1.0 - self.b / self._c * (s - 2.0))
-            pindx = self.b == 0.0
-            coseta[pindx] = 1 / self._e[pindx] * (1.0 - r[pindx] / self._c[pindx])
-        else:
-            if self.b == 0.0:
-                coseta = 1 / self._e * (1.0 - r / self._c)
-            else:
-                s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-                coseta = 1 / self._e * (1.0 - self.b / self._c * (s - 2.0))
-        pindx = coseta > 1.0
-        coseta[pindx] = 1.0
-        pindx = coseta < -1.0
-        coseta[pindx] = -1.0
+        coseta = numpy.clip(
+            (1.0 - (numpy.sqrt(self.b**2.0 + r**2.0) - self.b) / self._c) / self._e,
+            -1.0,
+            1.0,
+        )
         self._eta = numpy.arccos(coseta)
         if vrneg:
             self._eta = 2.0 * numpy.pi - self._eta
@@ -565,21 +545,11 @@ class _actionAngleIsochroneHelper:
         c = -self.amp / 2.0 / E - self.b
         e2 = 1.0 - L2 / self.amp / c * (1.0 + self.b / c)
         e = numpy.sqrt(e2)
-        if isinstance(self.b, numpy.ndarray):
-            s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-            coseta = 1 / e * (1.0 - self.b / c * (s - 2.0))
-            pindx = self.b == 0.0
-            coseta[pindx] = 1 / e[pindx] * (1.0 - r[pindx] / c[pindx])
-        else:
-            if self.b == 0.0:
-                coseta = 1 / e * (1.0 - r / c)
-            else:
-                s = 1.0 + numpy.sqrt(1.0 + r * r / self.b**2.0)
-                coseta = 1 / e * (1.0 - self.b / c * (s - 2.0))
-        pindx = coseta > 1.0
-        coseta[pindx] = 1.0
-        pindx = coseta < -1.0
-        coseta[pindx] = -1.0
+        # Using b (s-2) = sqrt(b^2+r^2) - b, which needs no special case for
+        # the Kepler limit b = 0 and does not divide by b
+        coseta = numpy.clip(
+            (1.0 - (numpy.sqrt(self.b**2.0 + r**2.0) - self.b) / c) / e, -1.0, 1.0
+        )
         eta = numpy.arccos(coseta)
         if vrneg:
             eta = 2.0 * numpy.pi - eta
@@ -598,7 +568,8 @@ class _actionAngleIsochroneHelper:
             + dedLfac * L2 / 4.0 / c** 2.0 / E** 2 * (1.0 + 2.0 * self.b / c)
         )
         return (
-            numfordrdE / (r / self.b**2.0 / (s - 1.0) - numfordrdE * dEdr),
+            numfordrdE
+            / (r / self.b / numpy.sqrt(self.b**2.0 + r**2.0) - numfordrdE * dEdr),
             (
                 -dedLfac
                 * (
@@ -608,7 +579,7 @@ class _actionAngleIsochroneHelper:
                 + dcdLfac * dcdLoverdEdL * dEdL
             )
             / (
-                r / self.b**2.0 / (s - 1.0)
+                r / self.b / numpy.sqrt(self.b**2.0 + r**2.0)
                 - dcdLfac * dcdLoverdrdL
                 - dedLfac * L2o2GMc2etc * dcdLoverdrdL
             ),

--- a/galpy/actionAngle/actionAngleSphericalInverse.py
+++ b/galpy/actionAngle/actionAngleSphericalInverse.py
@@ -33,12 +33,6 @@ from .actionAngleIsochrone import _actionAngleIsochroneHelper, actionAngleIsochr
 from .actionAngleIsochroneInverse import actionAngleIsochroneInverse
 from .actionAngleSpherical import actionAngleSpherical
 
-_APY_LOADED = True
-try:
-    from astropy import units
-except ImportError:
-    _APY_LOADED = False
-
 
 def _grid_pad_weights(pad, npts):
     """Lagrange weights that extrapolate a function sampled at
@@ -343,6 +337,8 @@ class actionAngleSphericalInverse(actionAngleInverse):
             / (2.0 * self._Omegaz - self._Omegar) ** 2.0
         )
         if numpy.any(ampb < 0.0):
+            # Realistic spherical potentials have Omegar/2 < Omegaz < Omegar
+            # strictly, with equality only in the Kepler and harmonic limits
             raise NotImplementedError(
                 "actionAngleSphericalInverse not implemented for the case where Omegaz > Omegar or Omegaz < Omegar/2"
             )
@@ -1201,7 +1197,7 @@ class actionAngleSphericalInverse(actionAngleInverse):
             shift_action = self._pt_deg > 1
         # First find the torus for this energy and angular momentum
         indx = numpy.nanargmin(
-            numpy.fabs(E - self._internal_Es) * numpy.fabs(L - self._internal_Ls)
+            numpy.fabs(E - self._internal_Es) + numpy.fabs(L - self._internal_Ls)
         )
         if (
             numpy.fabs(E - self._Es[indx]) > 1e-10
@@ -1407,7 +1403,7 @@ class actionAngleSphericalInverse(actionAngleInverse):
                 gs = overplot  # confusingly, we overload the meaning of overplot
         else:
             if not overplot:
-                outer = gridspec.GridSpec(1, 3, width_ratios=[2.0, 0.05], wspace=0.05)
+                outer = gridspec.GridSpec(1, 2, width_ratios=[2.0, 0.05], wspace=0.05)
                 gs = gridspec.GridSpecFromSubplotSpec(
                     1, 3, subplot_spec=outer[0], wspace=0.35
                 )
@@ -1418,7 +1414,7 @@ class actionAngleSphericalInverse(actionAngleInverse):
         for ii, (E, L) in enumerate(zip(Es, Ls)):
             # First find the torus for this energy and angular momentum
             indx = numpy.nanargmin(
-                numpy.fabs(E - self._internal_Es) * numpy.fabs(L - self._internal_Ls)
+                numpy.fabs(E - self._internal_Es) + numpy.fabs(L - self._internal_Ls)
             )
             if (
                 numpy.fabs(E - self._Es[indx]) > 1e-10
@@ -1569,7 +1565,7 @@ class actionAngleSphericalInverse(actionAngleInverse):
         if not self._interp:
             # First find the torus for this energy and angular momentum
             indx = numpy.nanargmin(
-                numpy.fabs(E - self._internal_Es) * numpy.fabs(L - self._internal_Ls)
+                numpy.fabs(E - self._internal_Es) + numpy.fabs(L - self._internal_Ls)
             )
             if (
                 numpy.fabs(E - self._Es[indx]) > 1e-10
@@ -1580,7 +1576,17 @@ class actionAngleSphericalInverse(actionAngleInverse):
                 )
             tJr = self._jr[indx]
         else:
-            tJr = self.Jr(E)
+            # Look up the torus by (E,L): invert the interpolated E(iL,ix)
+            # for ix at fixed L, like the Jr inversion in _gridcoords
+            iL = float((L - self._Lmin) / (self._Lmax - self._Lmin) * (self._nL - 1.0))
+            ix = 0.5 * (self._nE - 1.0)
+            for _ in range(100):
+                dEdix = _evs(self._EInterp, iL, ix, dy=1)
+                dix = -(_evs(self._EInterp, iL, ix) - E) / dEdix
+                ix = float(numpy.clip(ix + dix, 0.0, self._nE - 1.0))
+                if numpy.fabs(dix) < 1e-12:
+                    break
+            tJr = _evs(self._jrInterp, iL, ix)
         r, vr, _, _, _, _ = self(
             tJr, L, 0.0, tar, numpy.zeros_like(tar), numpy.zeros_like(tar), point=point
         )

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8258,6 +8258,108 @@ def test_actionAngleSphericalInverse_wrtSpherical_bisect():
     return None
 
 
+# Test the remaining error paths, warning paths, and plotting options of
+# actionAngleSphericalInverse, for full coverage of the module
+def test_actionAngleSphericalInverse_errors_and_plotting_options():
+    from matplotlib import pyplot
+
+    from galpy.actionAngle import actionAngleSpherical, actionAngleSphericalInverse
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+
+    logpot = LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    # Es/Ls length mismatch
+    with pytest.raises(ValueError):
+        actionAngleSphericalInverse(pot=logpot, Es=[1.0, 2.0], Ls=[1.0])
+    aAS = actionAngleSpherical(pot=logpot)
+    o = Orbit([1.0, 0.4, 1.0, 0.2, 0.3, 0.0])
+    E = o.E(pot=logpot)
+    L = numpy.sqrt(numpy.sum(numpy.array(o.L()) ** 2.0))
+    jr, jphi, jz, _, _, _, ar, ap, az = aAS.actionsFreqsAngles(
+        o.R(), o.vR(), o.vT(), o.z(), o.vz(), o.phi()
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        aASI = actionAngleSphericalInverse(pot=logpot, nta=128, Es=[E], Ls=[L])
+    # Evaluating and Freqs for a torus that is not in the instance
+    with pytest.raises(ValueError):
+        aASI(2.0 * aASI._jr[0] + 0.1, jphi[0], jz[0], ar[0], ap[0], az[0])
+    with pytest.raises(ValueError):
+        aASI.Freqs(2.0 * aASI._jr[0] + 0.1, jphi[0], jz[0])
+    # Plotting for a torus that is not in the instance
+    with pytest.raises(ValueError):
+        aASI.plot_convergence(E + 1.0, L + 1.0)
+    with pytest.raises(ValueError):
+        aASI.plot_power(E + 1.0, L + 1.0)
+    # Overplotting a second power spectrum (few-tori version)
+    gs = aASI.plot_power(E, L, return_gridspec=True)
+    aASI.plot_power(E, L, overplot=gs, ls="--")
+    pyplot.close("all")
+    with pytest.raises(ValueError):
+        aASI.plot_orbit(E + 1.0, L + 1.0)
+    # Plotting options not exercised elsewhere: explicit ranges, auxiliary
+    # isochrone tori, orbit-only, and the auxiliary-plane (point=False) view
+    aASI.plot_orbit(E, L, xrange=[0.0, 3.0], yrange=[-1.0, 1.0])
+    pyplot.close("all")
+    aASI.plot_orbit(E, L, include_isochrone_tori=True)
+    pyplot.close("all")
+    aASI.plot_orbit(E, L, orbit_only=True)
+    pyplot.close("all")
+    aASI.plot_orbit(E, L, point=False)
+    pyplot.close("all")
+    # Newton-Raphson non-convergence warning of the radial-angle solve (falls
+    # back onto bisection)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        aASIn = actionAngleSphericalInverse(
+            pot=logpot, nta=128, Es=[E], Ls=[L], maxiter=1
+        )
+    with pytest.warns(galpyWarning, match="Newton-Raphson did not converge"):
+        aASIn(aASIn._jr[0], jphi[0], jz[0], ar[0], ap[0], az[0])
+    return None
+
+
+# Test the multi-torus (colormapped) version of the power plot and its
+# restrictions
+def test_actionAngleSphericalInverse_plotting_manytori():
+    from matplotlib import pyplot
+
+    from galpy.actionAngle import actionAngleSphericalInverse
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+
+    logpot = LogarithmicHaloPotential(normalize=1.0, q=1.0)
+    L = 1.1
+    Es = [0.7, 0.9, 1.1, 1.3]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        aASI = actionAngleSphericalInverse(pot=logpot, nta=128, Es=Es, Ls=[L, L, L, L])
+    gs = aASI.plot_power(Es, [L, L, L, L], return_gridspec=True)
+    pyplot.close("all")
+    # overplotting with >= 4 energies is not supported
+    with pytest.raises(RuntimeError):
+        aASI.plot_power(Es, [L, L, L, L], overplot=gs)
+    pyplot.close("all")
+    return None
+
+
+# Test that plot_orbit also works for an interpolated instance
+def test_actionAngleSphericalInverse_interpolation_plot_orbit(
+    setup_actionAngleSphericalInverse_interpolated_exactpointtransform,
+):
+    from matplotlib import pyplot
+
+    aASI, logpot = setup_actionAngleSphericalInverse_interpolated_exactpointtransform
+    from galpy.orbit import Orbit
+
+    o = Orbit([1.0, 0.4, 1.0, 0.2, 0.3, 0.0])
+    E = o.E(pot=logpot)
+    L = numpy.sqrt(numpy.sum(numpy.array(o.L()) ** 2.0))
+    aASI.plot_orbit(E, L)
+    pyplot.close("all")
+    return None
+
+
 # Test that the bisection angle solve of actionAngleSphericalInverse warns
 # when it does not converge
 def test_actionAngleSphericalInverse_convergence_warnings():
@@ -8631,6 +8733,77 @@ def test_actionAngleSphericalInverse_orbit_interpolation(
     assert numpy.nanmax(numpy.fabs(Ei - E) / numpy.fabs(E)) < 1e-7, (
         "Energy is not conserved along the torus of the interpolated actionAngleSphericalInverse"
     )
+    return None
+
+
+# Test the isochrone helper's radial angle for negative radial velocities and
+# its reuse path, and check its analytic radius derivatives against finite
+# differences (the helper is used by actionAngleSphericalInverse to solve for
+# the radii of a regular grid in the auxiliary angle)
+def test_actionAngleIsochroneHelper_angler_and_derivatives():
+    from galpy.actionAngle.actionAngleIsochrone import _actionAngleIsochroneHelper
+    from galpy.potential import IsochronePotential
+
+    ip = IsochronePotential(amp=2.0, b=0.8)
+    helper = _actionAngleIsochroneHelper(ip=ip)
+    L = 0.9
+    E = -0.4
+    r = numpy.array([0.9, 1.3, 1.8])
+    vr2 = 2.0 * (E - ip(r, 0.0)) - L**2.0 / r**2.0
+    assert numpy.all(vr2 > 0.0), "Test setup does not have a radial velocity"
+    ar = helper.angler(r, vr2, L)
+    arneg = helper.angler(r, vr2, L, vrneg=True)
+    # The angle of the incoming branch is 2 pi minus that of the outgoing one
+    dsum = (ar + arneg + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+    assert numpy.amax(numpy.fabs(dsum)) < 1e-10, (
+        "Radial angle of the isochrone helper for vr < 0 is not 2 pi minus that for vr > 0"
+    )
+    # d angler / d r at constant E and L, against finite differences
+    for vrneg in [False, True]:
+        dardr = helper.danglerdr_constant_L(r, vr2, L, numpy.zeros_like(r), vrneg=vrneg)
+        # The reuse path recomputes the angle from the stored quantities
+        assert (
+            numpy.amax(
+                numpy.fabs(
+                    helper.angler(r, vr2, L, reuse=True)
+                    - helper.angler(r, vr2, L, vrneg=vrneg)
+                )
+            )
+            < 1e-10
+        ), (
+            "Reuse path of the isochrone helper's angler does not agree with a direct computation"
+        )
+        dr = 1e-6
+        vr2p = 2.0 * (E - ip(r + dr, 0.0)) - L**2.0 / (r + dr) ** 2.0
+        vr2m = 2.0 * (E - ip(r - dr, 0.0)) - L**2.0 / (r - dr) ** 2.0
+        dardr_fd = (
+            helper.angler(r + dr, vr2p, L, vrneg=vrneg)
+            - helper.angler(r - dr, vr2m, L, vrneg=vrneg)
+        ) / (2.0 * dr)
+        assert numpy.amax(numpy.fabs(dardr / dardr_fd - 1.0)) < 1e-6, (
+            "Analytic d angler / d r of the isochrone helper does not agree with finite differences"
+        )
+    # dr/dE at constant angler, against finite differences: moving the energy
+    # and the radius together in this way has to keep the angle fixed
+    for vrneg in [False, True]:
+        drdE, drdL = helper.drdEL_constant_angler(
+            r, vr2, E, L, numpy.zeros_like(r), numpy.zeros_like(r), vrneg=vrneg
+        )
+        dE = 1e-6
+        for sgn in [1.0, -1.0]:
+            rp = r + sgn * dE * drdE
+            vr2p = 2.0 * (E + sgn * dE - ip(rp, 0.0)) - L**2.0 / rp**2.0
+            assert (
+                numpy.amax(
+                    numpy.fabs(
+                        helper.angler(rp, vr2p, L, vrneg=vrneg)
+                        - helper.angler(r, vr2, L, vrneg=vrneg)
+                    )
+                )
+                < 1e-9
+            ), (
+                "Analytic dr/dE at constant radial angle of the isochrone helper does not keep the angle constant"
+            )
     return None
 
 


### PR DESCRIPTION
Fifth layer of stack #1315 (base: `aainv-spherical-interp`, #1318), bringing the module to 100% line coverage per the phase-2 coverage goal (repo misses back to the main baseline).

Covers all remaining error paths, the Newton-non-convergence warning, and every plotting option — and fixes three latent bugs the uncovered paths were hiding: the ≥4-tori power plot's colorbar gridspec always raised (3 columns, 2 width ratios); the (E,L) torus lookup in the plotting methods minimized the *product* |ΔE|·|ΔL|, degenerate whenever tori share an L (always returned the first torus) — now the sum; and `plot_orbit` on an interpolated instance called a non-existent `Jr` method — now inverts the interpolated E(iL, ix) at fixed L. Also drops an unused astropy import guard.

Note: the stack below was rebased once to fix the #1313 test-placement review comment (spherical tests had split `test_nullpotential_error` from its comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ