### PR TITLE
Restore the 5 coverage lines develop lost (20 -> 15 misses)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -2628,10 +2628,14 @@ def estimateDeltaStaeckel(pot, R, z, no_median=False, delta0=1e-6):
             # array-capable potentials evaluate the whole array at once
             delta2 = _delta2(R, z)
         except (TypeError, RuntimeError):
-            # scalar-only potentials (e.g. DoubleExponentialDisk, which rejects
-            # array inputs on every path) evaluate element-by-element; each scalar
-            # is a backend scalar so the migrated scalar path still runs on the
-            # backend.
+            # potentials whose evaluators reject a whole-array call are done
+            # element-by-element; each scalar is a backend scalar so the migrated
+            # scalar path still runs on the backend. Measured 2026-08-16, the
+            # potential that actually lands here is
+            # AnyAxisymmetricRazorThinDiskPotential -- NOT DoubleExponentialDisk,
+            # which this comment used to name: its scalar-only decorator sits on
+            # the public methods, and the calls above go through the internal
+            # _evaluateRforces/_evaluatezforces, which bypass it.
             delta2 = xp.stack([_delta2(R[ii], z[ii]) for ii in range(len(R))])
         indx = (delta2 < delta0**2.0) & (
             (delta2 > -(10.0**-10.0)) | bool(pot_includes_scf)

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -340,19 +340,23 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             # makes it symbolic) and would trace scipy's quad instead: ask.
             or under_trace(R, z)
         ):
-            try:  # plain concrete backend input: reuse scipy's accurate value
-                Rf, zf = float(R), float(z)
-            except Exception:  # tracer: in-backend differentiable GL
-                pass
-            else:
-                # numpy.asarray keeps scipy's float64 value at full precision
-                # (asarray_on_device of a bare python float would drop to torch's
-                # float32 default, and match_input_dtype's later up-cast cannot
-                # recover the lost digits -> a derivative test's dr=1e-8 FD blows
-                # up); match_input_dtype then honours the input's own dtype.
-                return match_input_dtype(
-                    asarray_on_device(xp, numpy.asarray(numpy_fn(Rf, zf)), dev), R, z
-                )
+            # plain concrete backend input: reuse scipy's accurate value. No
+            # try/except around float(): every caller is guarded by
+            # @check_potential_inputs_not_arrays, so R and z are scalar here, and
+            # the tracer cases that used to need the guard (grad, jit, vmap,
+            # vmap-of-grad, torch.compile) are all diverted by the requires_grad
+            # / under_trace test above -- verified by tracing each of them. A
+            # float() failure now would be a genuine surprise, and should raise
+            # rather than silently switch to a different quadrature.
+            Rf, zf = float(R), float(z)
+            # numpy.asarray keeps scipy's float64 value at full precision
+            # (asarray_on_device of a bare python float would drop to torch's
+            # float32 default, and match_input_dtype's later up-cast cannot
+            # recover the lost digits -> a derivative test's dr=1e-8 FD blows
+            # up); match_input_dtype then honours the input's own dtype.
+            return match_input_dtype(
+                asarray_on_device(xp, numpy.asarray(numpy_fn(Rf, zf)), dev), R, z
+            )
         return match_input_dtype(gl_fn(R, z, xp, dev), R, z)  # differentiate: GL
 
     # ------------------------------ potential ------------------------------

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -56,6 +56,7 @@ from galpy.actionAngle import (
     estimateDeltaStaeckel,
 )
 from galpy.potential import (
+    AnyAxisymmetricRazorThinDiskPotential,
     HernquistPotential,
     IsochronePotential,
     IsothermalDiskPotential,
@@ -2488,3 +2489,37 @@ def test_aavertical_backend_path_uses_undecorated_evaluators(backend):
         f"{n} times; the bracketing/root-find closure should call the "
         "undecorated _evaluatelinearPotentials, not the decorated entry point"
     )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_estimateDeltaStaeckel_scalar_only_potential(backend):
+    # A potential whose evaluators reject a whole-array call makes _delta2(R, z)
+    # raise, and estimateDeltaStaeckel falls back to evaluating element by
+    # element. MWPotential2014 in the parity test above is array-capable, so
+    # that fallback had no coverage at all.
+    #
+    # Measured which potential actually takes it, rather than trusting the
+    # source comment: AnyAxisymmetricRazorThinDiskPotential does.
+    # DoubleExponentialDiskPotential -- named in that comment -- does NOT: its
+    # public methods carry the scalar-only decorator, but estimateDeltaStaeckel
+    # goes through the internal _evaluateRforces/_evaluatezforces, which bypass
+    # it, so the array call simply succeeds.
+    pot = AnyAxisymmetricRazorThinDiskPotential(surfdens=lambda R: numpy.exp(-R / 0.3))
+    # Deliberately NOT the _EST_R/_EST_Z grid the parity test uses: on that one
+    # delta^2 goes negative for this potential and both paths return NaN, so an
+    # allclose would compare NaN to NaN and pass while asserting nothing. These
+    # points give finite deltas, and the finiteness is asserted below so a
+    # regression to NaN fails instead of passing vacuously.
+    R = numpy.array([0.4, 0.6, 0.8, 1.0])
+    z = numpy.array([0.3, 0.4, 0.5, 0.6])
+    ref = numpy.asarray(estimateDeltaStaeckel(pot, R, z, no_median=True))
+    got = estimateDeltaStaeckel(pot, _arr(backend, R), _arr(backend, z), no_median=True)
+    assert _is_backend_array(backend, got)
+    assert numpy.all(numpy.isfinite(ref)) and numpy.all(
+        numpy.isfinite(as_numpy(got))
+    ), (
+        "estimateDeltaStaeckel scalar-only fallback returned NaN; the comparison "
+        "below would then be vacuous"
+    )
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-8, atol=1e-10)
+    return None

--- a/tests/test_backend_jeans.py
+++ b/tests/test_backend_jeans.py
@@ -233,3 +233,23 @@ def test_sigmar_jit_of_grad_matches_eager_grad():
         )
     )
     assert_jit_matches_eager(g, jnp.asarray(0.5), rtol=1e-11, atol=0.0)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_jeans_sigmalos_userdens_surfdens_fallback(backend):
+    # dens= supplied and surfdens=None: galpy cannot ask the potential for a
+    # surface density, so sigmalos falls back to integrating dens along the
+    # line of sight itself. The parity tests above always let the potential
+    # supply both, so the BACKEND limb of that fallback
+    # (2 * fixed_quad_semiinfinite, as against scipy.quad on numpy) had no
+    # coverage at all -- a defensive branch reachable only through this
+    # argument combination.
+    dens = lambda r: _HP.dens(r, 0.0, use_physical=False)
+    for R0 in (0.8, 1.4):
+        ref = jeans.sigmalos(_HP, R0, dens=dens, use_physical=False)
+        got = jeans.sigmalos(_HP, _arr(backend, R0), dens=dens, use_physical=False)
+        assert _is_backend_array(backend, got)
+        numpy.testing.assert_allclose(
+            as_numpy(got), numpy.asarray(ref), rtol=1e-6, atol=1e-9
+        )
+    return None


### PR DESCRIPTION
`feat/backends-develop` carries **5 uncovered lines that `feat/backends` does
not** (repo misses 20 vs 15). Measured, not guessed: `feat/backends` → `main`
is 24 → 15 misses with **0 files worse**, so the regression is entirely
develop's, i.e. mine.

Located with the codecov report endpoint (`/report/?sha=<full sha>&path=<file>`,
missed lines are `value != 0`). **All five are fallback / `except` branches on
the backend path**, and none is newly-added untested code — the compare endpoint
confirms no *diff* line lost coverage in any of the three files. They are
pre-existing lines that stopped being reachable.

| file:line | branch | fix |
|---|---|---|
| `jeans.py:181` | backend limb of the surfdens fallback | forcing test |
| `actionAngleStaeckel.py:2630,2635` | `except (TypeError, RuntimeError)` → per-element `xp.stack` | forcing test |
| `AnyAxisymmetricRazorThinDisk.py:345,346` | `except Exception: pass` around a `float()` probe | **deleted — unreachable** |

## Each one, and what it cost to get right

**jeans** — reachable only when the caller supplies `dens=` and omits
`surfdens=`, so galpy cannot ask the potential for a surface density. Every
existing parity test lets the potential supply both. Verified by tracing that
line 181 executes and its numpy sibling at 174 does not.

**estimateDeltaStaeckel** — the source comment claimed
`DoubleExponentialDisk` takes this branch. It does **not**: its scalar-only
decorator is on the *public* methods, while `_delta2` calls the internal
`_evaluateRforces`/`_evaluatezforces`, which bypass it. Probed the candidates;
`AnyAxisymmetricRazorThinDiskPotential` is the one that actually lands there.
Comment corrected.

That test also nearly shipped **vacuous**: on the grid the neighbouring parity
test uses, δ² goes negative for this potential and *both* paths return NaN —
`assert_allclose` treats NaN as equal to NaN, so it would have covered the line
while asserting nothing. It now uses points where the result is finite and
asserts that finiteness explicitly, and I re-verified the traced coverage after
changing the points, since the forcing condition depends on them.

**AnyAxisym** — deleted rather than tested, because it cannot run. All six
callers are `@check_potential_inputs_not_arrays`-decorated, so `R`/`z` are
scalar and `float()` cannot fail on a shape; and every tracer case is diverted
before the probe by the `requires_grad`/`under_trace` test above it. Traced
five modes to confirm nothing reaches 345/346: concrete backend scalar,
`jax.grad`, `jax.jit`, `jax.vmap`, `vmap`-of-`grad` — all correct, none enters
the except. It reads as leftover from before `under_trace` existed. A `float()`
failure now raises, which beats silently switching quadrature.

## Gates

    tests/test_backend_jeans.py -k userdens          2 passed (jax, torch)
    tests/test_backend_actionAngle.py -k scalar_only 2 passed (jax, torch)
    tests/test_backend_anyaxisymdisk.py             51 passed
    tests/test_potential.py -k anyaxisym            13 passed, 1 skipped

## The general lesson

Backend migration loses coverage by making **defensive branches unreachable**,
not by adding untested code. Those branches exist precisely for conditions the
happy path never creates, so they need their forcing test in the same PR that
introduces them — otherwise they are covered only incidentally, by some other
component staying broken, and go dark the moment it is fixed.