### PR TITLE
test_potential: dispatch the AnyAxisym surfdens fixture on the namespace

### DIFF
--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     _PYNBODY_LOADED = False
 from galpy import orbit, potential
-from galpy.backend import as_numpy, get_namespace
+from galpy.backend import as_numpy, get_namespace, is_backend_array
 from galpy.util import _rotate_to_arbitrary_vector, coords
 from galpy.util._optional_deps import _APY_LOADED
 
@@ -14265,6 +14265,24 @@ def test_razorthinexponentialdisk_forces_at_the_closedform_handover():
     return None
 
 
+def _anyaxisym_surfdens(R):
+    """Sigma(R) = exp(-R/0.3), usable on every path AnyAxisym evaluates it on.
+
+    Dispatch on ``is_backend_array``, NOT on ``get_namespace``, copying
+    ``AnyAxisymmetricRazorThinDiskPotential._default_surfdens``, whose comment
+    spells out why: under a FORCED backend ``get_namespace`` returns that
+    backend's namespace even for a plain float, and ``torch.exp`` rejects a
+    float where ``jax.numpy.exp`` accepts one. The potential's concrete-scalar
+    branch hands ``_sdens`` a Python float (it reuses scipy's adaptive quad
+    there), so a bare ``get_namespace(R).exp`` raises
+    ``TypeError: exp(): argument 'input' must be Tensor, not float`` on torch --
+    measured, not hypothesised. Guarding this way keeps a numpy / float / Quantity
+    R on ``numpy.exp`` (byte-identical) and sends only a real backend array to
+    the namespace, which is what the traced run needs.
+    """
+    return (get_namespace(R) if is_backend_array(R) else numpy).exp(-R / 0.3)
+
+
 # AnyAxisymmetricRazorThinDiskPotential's second derivatives are Hadamard
 # finite-part integrals: the integrand diverges as C/(a-R)^2 with the SAME sign
 # on both sides of a=R, so the halves add rather than cancel. Evaluating them
@@ -14294,11 +14312,11 @@ def test_anyaxisymmetricrazorthindisk_second_derivs_at_z0():
         2.0: 9.7856791896e-02,
     }
     p = potential.AnyAxisymmetricRazorThinDiskPotential(
-        # get_namespace, not numpy: identical function, but numpy.exp on a
-        # tracer raises TracerArrayConversionError, so the --jit run failed here
-        # for a reason that had nothing to do with the potential. The mpmath gold
-        # values below are for exactly Sigma(R)=exp(-R/0.3) and are unaffected.
-        surfdens=lambda R: get_namespace(R).exp(-R / 0.3)
+        # Not bare numpy.exp: it raises TracerArrayConversionError on a tracer,
+        # so the --jit run failed here for a reason that had nothing to do with
+        # the potential. Same function either way, so the mpmath gold values
+        # below (for exactly Sigma(R)=exp(-R/0.3)) are unaffected.
+        surfdens=_anyaxisym_surfdens
     )
     for R, ref in gold_R2.items():
         got = p.R2deriv(R, 0.0, use_physical=False)
@@ -14346,11 +14364,11 @@ def test_anyaxisymmetricrazorthindisk_all_methods_reject_arrays():
     every other test stayed green -- exactly the blind spot this closes.
     """
     p = potential.AnyAxisymmetricRazorThinDiskPotential(
-        # get_namespace, not numpy: identical function, but numpy.exp on a
-        # tracer raises TracerArrayConversionError, so the --jit run failed here
-        # for a reason that had nothing to do with the potential. The mpmath gold
-        # values below are for exactly Sigma(R)=exp(-R/0.3) and are unaffected.
-        surfdens=lambda R: get_namespace(R).exp(-R / 0.3)
+        # Not bare numpy.exp: it raises TracerArrayConversionError on a tracer,
+        # so the --jit run failed here for a reason that had nothing to do with
+        # the potential. Same function either way, so the mpmath gold values
+        # below (for exactly Sigma(R)=exp(-R/0.3)) are unaffected.
+        surfdens=_anyaxisym_surfdens
     )
     arr = numpy.array([0.8, 1.2])
     for name in ("__call__", "Rforce", "zforce", "R2deriv", "z2deriv", "Rzderiv"):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -14294,7 +14294,11 @@ def test_anyaxisymmetricrazorthindisk_second_derivs_at_z0():
         2.0: 9.7856791896e-02,
     }
     p = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: numpy.exp(-R / 0.3)
+        # get_namespace, not numpy: identical function, but numpy.exp on a
+        # tracer raises TracerArrayConversionError, so the --jit run failed here
+        # for a reason that had nothing to do with the potential. The mpmath gold
+        # values below are for exactly Sigma(R)=exp(-R/0.3) and are unaffected.
+        surfdens=lambda R: get_namespace(R).exp(-R / 0.3)
     )
     for R, ref in gold_R2.items():
         got = p.R2deriv(R, 0.0, use_physical=False)
@@ -14342,7 +14346,11 @@ def test_anyaxisymmetricrazorthindisk_all_methods_reject_arrays():
     every other test stayed green -- exactly the blind spot this closes.
     """
     p = potential.AnyAxisymmetricRazorThinDiskPotential(
-        surfdens=lambda R: numpy.exp(-R / 0.3)
+        # get_namespace, not numpy: identical function, but numpy.exp on a
+        # tracer raises TracerArrayConversionError, so the --jit run failed here
+        # for a reason that had nothing to do with the potential. The mpmath gold
+        # values below are for exactly Sigma(R)=exp(-R/0.3) and are unaffected.
+        surfdens=lambda R: get_namespace(R).exp(-R / 0.3)
     )
     arr = numpy.array([0.8, 1.2])
     for name in ("__call__", "Rforce", "zforce", "R2deriv", "z2deriv", "Rzderiv"):


### PR DESCRIPTION
## What

Both `AnyAxisymmetricRazorThinDiskPotential` fixtures in `test_potential.py`
build the disk from `surfdens=lambda R: numpy.exp(-R / 0.3)`. `numpy.exp` on a
tracer raises `TracerArrayConversionError`, so under `--jit` those tests failed
inside the **test's own fixture**, not in the potential. They now dispatch on
`get_namespace(R)`.

`get_namespace(R).exp` is the same function for the same input, so the mpmath
gold values (computed for exactly `Sigma(R) = exp(-R/0.3)`) are untouched:
measured `5.588879573` against gold `5.5888795714e+00`.

## Measured effect, which is less than I first estimated

Under `--backend jax --jit`, `-k anyaxisym`:

|                          | before | after |
|--------------------------|--------|-------|
| `TracerArrayConversionError` | 2      | **0** |
| accuracy failures        | 1      | 2     |

So this fixes **one** test (`..._all_methods_reject_a`). The second tracer error
was *masking* a pre-existing accuracy failure: `..._second_derivs_at_z0` was
raising before it reached its own assertion, and now gets there and fails on
accuracy. That belongs to the known AnyAxisym z→0 singularity gap, not to
traceability.

I had earlier described this as fixing two tests. That was an estimate from the
mechanism rather than a measurement; when a fix removes an *exception*, the
count of tests it fixes is not knowable until they are re-run.

Landing it anyway, deliberately: a tracer error sitting in front of a numerical
error means the numerical one can never be seen. With the fixture fixed, the
singularity gap is now measurable — it is `1/n^2` in the finite-part
quadrature order, i.e. a residual non-smoothness, not a missing treatment.

## numpy path

Byte-unchanged. `test_potential.py -k anyaxisym` on numpy: 13 passed, 1 skipped
— identical to before.

## Ledger

No delta. `..._second_derivs_at_z0` is already carried; it changes which
assertion it fails on, not whether it fails.
