### PR TITLE
quadrature: remove the residual log in finite_part_quad (2e-4 -> 5e-10 traced)

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -55,6 +55,20 @@ from ._namespaces import (
 # scipy.integrate.quad to the suite's tolerances; raise ``n`` for stiffer ones.
 _QUAD_N = 100
 
+# Sample points u = b * 10**-k for the residual-log slope in finite_part_quad.
+# The window is measured, not guessed: above k ~ 3 the O(u) part of the residual
+# biases the slope, below k ~ 5 the c/u^2 cancellation noise does. k = 2..4 and
+# k = 4..6 both degrade to ~1e-8 where this window holds ~1e-10.
+_LOG_K = numpy.array([3.0, 3.5, 4.0, 4.5, 5.0])
+_LOG_U = 10.0**-_LOG_K
+# A least-squares slope against -ln(u) collapses to fixed weights: the spacing
+# in -ln(u) is (k - kbar) * ln 10 regardless of b, so only the k's enter. The
+# weights sum to zero, so any constant part of the residual cancels exactly and
+# only the log survives.
+_LOG_W = (_LOG_K - _LOG_K.mean()) / (
+    numpy.log(10.0) * ((_LOG_K - _LOG_K.mean()) ** 2).sum()
+)
+
 # Cache of (nodes, weights) on [0, 1] keyed by order, as numpy float64 constants.
 _GL01_CACHE = {}
 
@@ -582,15 +596,43 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     -----
     - 2026-08-13 - Written - Bovy (UofT)
     """
-    zero = asarray_on_device(xp, 0.0, device)
+    dev = device if device is not None else device_of(b)
+    zero = asarray_on_device(xp, 0.0, dev)
 
     def sym(u):
         return integrand(u) + integrand(-u)
 
+    def residual(u):
+        return sym(u) - 2.0 * c / (u * u)
+
+    # Removing the c/u^2 model kills the pole but generally leaves a LOG:
+    # residual(u) = -lam ln(u) + A + O(u). That is what caps plain GL at 1/n^2
+    # here (measured on AnyAxisym R2deriv: 6.65e-4, 1.67e-4, 4.18e-5, 1.05e-5 at
+    # n = 100, 200, 400, 800 -- algebraic, where GL on a smooth integrand is
+    # exponential). So remove it the same way: subtract lam*ln(u/b), whose exact
+    # integral over [0, b] is -lam*b, and add that back. The remainder is
+    # bounded at the origin and GL is fast again -- 2e-4 -> 6e-11 at the SAME
+    # n=100, i.e. the gain is smoothness, not nodes.
+    #
+    # lam is measured, never derived: it is not a closed form (it runs over
+    # 44.8 to 2e-4 across R for one potential, and both ellipe and ellipkm1
+    # feed it), and it has to hold for an arbitrary caller. This is plain
+    # arithmetic on integrand samples, so it stays traceable and
+    # differentiable. Costs 10 extra integrand evaluations against 2n.
+    lam = xp.sum(
+        asarray_on_device(xp, _LOG_W, dev)
+        * residual(b * asarray_on_device(xp, _LOG_U, dev))
+    )
     finite_part = (
         fixed_quad(
-            xp, lambda u: sym(u) - 2.0 * c / (u * u), zero, b, n=n, device=device
+            xp,
+            lambda u: residual(u) + lam * xp.log(u / b),
+            zero,
+            b,
+            n=n,
+            device=device,
         )
+        + lam * b
         - 2.0 * c / b
     )
     wide = peak_width > 0.0

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -659,6 +659,30 @@ def test_finite_part_quad_matches_the_analytic_finite_part(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
+def test_finite_part_quad_removes_a_residual_log(backend):
+    # Subtracting the c/u**2 model kills the pole but not necessarily the rest:
+    # a real integrand (AnyAxisym's R2deriv) leaves a LOG behind, which caps
+    # plain Gauss-Legendre at 1/n**2. Build that case exactly, with a closed
+    # form to check against rather than another quadrature:
+    #     f(u) = c/u**2 - L*ln|u| + exp(-u)
+    #   sym(u) = 2c/u**2 - 2L*ln|u| + 2cosh(u)
+    # so the finite part is
+    #     int_0^b [sym - 2c/u**2] du - 2c/b
+    #       = -2L*(b*ln b - b) + 2 sinh(b) - 2c/b.
+    # At n=200 the old rule (no log handling) was 5.9e-06 off here; the point of
+    # the tolerance below is that it is nowhere near that.
+    xp = _xp(backend)
+    c, b, L = 0.75, 1.3, 2.5
+
+    def f(u):
+        return c / (u * u) - L * xp.log(xp.abs(u)) + xp.exp(-u)
+
+    got = finite_part_quad(xp, f, xp.asarray(b), c=c, peak_width=xp.asarray(0.0), n=200)
+    expected = -2.0 * L * (b * numpy.log(b) - b) + 2.0 * numpy.sinh(b) - 2.0 * c / b
+    numpy.testing.assert_allclose(float(got), expected, rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_finite_part_quad_peaked_branch_is_the_plain_integral(backend):
     # peak_width > 0 selects u = w sinh(t) over [0, asinh(b/w)], which is exactly
     # int_0^b sym(u) du -- no finite part, because there is no singularity to


### PR DESCRIPTION
## What

Subtracting the `2c/u^2` model in `finite_part_quad` kills the pole but leaves a
**logarithm** behind, and that is what was capping the traced AnyAxisym second
derivatives. Measured on `_R2deriv_gl` at z=0 against the mpmath gold:

| n | 100 | 200 | 400 | 800 |
|---|---|---|---|---|
| rel err | 6.65e-4 | 1.67e-4 | 4.18e-5 | 1.05e-5 |

Exactly `1/n^2`. Gauss-Legendre is *exponential* on a smooth integrand, so
algebraic convergence means a singularity the rule can still see — reaching 1e-8
by order alone would need ~25 000 nodes. Confirmed directly: the residual
`sym(u) - 2c/u^2` climbs a constant 18.47 per decade of `u`, i.e. `-lam ln(u)`.

The fix is the same shape as the existing one: subtract `lam*ln(u/b)`, whose
exact integral over `[0,b]` is `-lam*b`, and add that back. The remainder is
bounded at the origin, so GL is fast again **at the same n=100** — the gain is
smoothness, not nodes.

## Results

End to end, real library under `jax.jit`:

| | before | after | numpy path |
|---|---|---|---|
| `R2deriv` | 2.0e-4 | **4.9e-10** | 2.0e-10 |
| `z2deriv` | 1.1e-5 | **1.2e-10** | 5.8e-11 |

A ~1e6 backend-vs-numpy accuracy gap closed to ~4x. The tail is *not* the
limiter — n=100/200/400 on `fixed_quad_semiinfinite` give identical results.

At the test level, with gh#1328's fixture fix also applied,
`test_anyaxisymmetricrazorthindisk_second_derivs_at_z0` **passes under `--jit`**.
Measured progression for the traced `-k anyaxisym` selection:

    baseline                    3 failed  = 1 accuracy + 2 TracerArrayConversionError
    + gh#1328 (fixture)         2 failed  = 2 accuracy, 0 tracer
    + this PR (log subtraction) 1 failed  = smallz_limit only

## `lam` is measured, not derived

A least-squares slope of the residual against `-ln u` at five points
`u = b*10^-k`, `k = 3, 3.5, 4, 4.5, 5`.

Deriving it is a trap I fell into first: taking the log from `ellipkm1(m1)`
alone gives 6.42 against a measured 8.02, because `ellipe(1-m1)` is not smooth
here either — its `m1 ln m1` term is promoted to O(1) by the `2R^2/d^2` pole in
front of it. It is also not a closed form worth chasing (it runs from 44.8 at
R=0.1 to 2e-4 at R=2.0 for a single potential) and has to hold for an arbitrary
caller's integrand. The estimate is plain arithmetic on integrand samples, so it
stays traceable and differentiable, and costs 10 extra evaluations against 2n.

The `k=3..5` window is measured too (worst-case rel err, R2deriv / z2deriv):

| window | R2deriv | z2deriv |
|---|---|---|
| **k=3..5 (5pt)** | **6.8e-11** | **8.2e-11** |
| k=2..4 (5pt) | 1.3e-08 | 2.4e-09 |
| k=4..6 (5pt) | 1.4e-08 | 3.8e-09 |

Both failure directions are understood: above k~3 the `O(u)` part of the
residual biases the slope; below k~5 the `c/u^2` cancellation noise does — the
same float64 floor the helper's docstring already documents.

## Scope

This does **not** fix `test_anyaxisymrazorthin_smallz_limit`. That test is
`_zforce_gl`, which goes through `_bk_split_quad` and never calls
`finite_part_quad`, so it is a separate problem and still fails. It is two
mechanisms of its own — a real backend gap at R <~ 2, and a pre-existing
cancellation at large R that fails **identically on numpy** (both paths return
1.206e+04 relative at R=10) — and is tracked separately.

## Test

`test_finite_part_quad_removes_a_residual_log` builds an integrand with a known
log residual **and** a closed-form finite part
(`f(u) = c/u^2 - L ln|u| + exp(-u)` → `-2L(b ln b - b) + 2 sinh b - 2c/b`), so it
checks against algebra rather than another quadrature. A/B: it fails at
**1.45e-5** relative without this change and passes at rtol=1e-9 with it, on all
three backends.

## numpy path

Untouched. This helper is on the backend path only, and AnyAxisym's numpy path
uses its own scipy-adaptive `_finite_part_quad`. Verified:
`test_potential.py -k anyaxisym` on numpy is 13 passed / 1 skipped, unchanged,
and identical under forced jax and forced torch. Full quadrature suite: 74
passed (71 existing + 3 new).

## Ledger

No delta — these AnyAxisym traced failures were never ledgered.
