### PR TITLE
AnyAxisym: floor |z| relative to R in the traced zforce (last traced failure)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -37,6 +37,10 @@ from .Potential import Potential, check_potential_inputs_not_arrays
 # 5.937e-11 at z = 1e-9, 1e-10 and 1e-12. Both derivatives use this constant, and
 # z2deriv moves LESS across the floor than R2deriv does.
 _R2DERIV_ZFLOOR = 1e-9
+# Relative floor on |z|/R for the traced zforce; see _zforce_gl for why it is
+# relative and where 1e-8 comes from (6 orders above the measured ~1e-14 onset,
+# 4 orders inside the 3e-4 the small-z limit test asks for).
+_ZFORCE_ZFLOOR_REL = 1e-8
 
 if _APY_LOADED:
     from astropy import units
@@ -478,8 +482,32 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     def _zforce_gl(self, R, z, xp, dev):
         # z==0 is the disk plane (zforce=0 by symmetry) but the integrand has a
         # non-integrable 1/(a-R)^2 pole there; guard the dead branch with z_safe.
+        #
+        # |z| is also floored RELATIVE to R. The peak at a=R has width ~|z|, and
+        # _bk_split_quad grades its panels to it by forming edges R +/- d and,
+        # in the integrand, a - R -- both by subtraction. Once |z|/R falls to a
+        # few tens of machine epsilon those stop being representable, the
+        # innermost panels collapse to zero width and the 1/((a-R)^2+z^2) pole
+        # is sampled at a == R. Measured onset (traced, vs -2 pi Sigma(R)):
+        #
+        #     R       0.05      0.2       0.5       2.0
+        #     z/R     3.2e-15   3.2e-15   1.0e-14   1.0e-14      (~14-45 eps)
+        #
+        # i.e. SCALE-FREE in z/R, which is why the floor is relative -- an
+        # absolute one would be wrong at small R. Flooring is not an
+        # approximation being smuggled in: Fz(z->0+) is exactly -2 pi Sigma(R)
+        # for a razor-thin disk, the integral goes as 1/|z|, so -4 |z| I(|z|)
+        # evaluated AT the floor already is that limit. The floor sits 6 orders
+        # above the 1e-14 onset, so the quadrature is only ever used where it is
+        # accurate, and the limit's own error at the floor is O(z/R) ~ 1e-8.
+        # numpy needs none of this: _quad_apeak splits on scipy's points=[R],
+        # which stays finite, and it saturates INSIDE tolerance instead.
+        az = xp.maximum(xp.abs(z), _ZFORCE_ZFLOOR_REL * xp.abs(R))
+        # R == 0 (with z == 0) would leave az == 0 and put the pole back; that
+        # branch is dead, but keep it finite so it cannot poison a gradient.
+        az = xp.where(az > 0, az, xp.ones_like(az))
         z_safe = xp.where(z == 0, xp.ones_like(z), z)
-        z2 = z_safe**2
+        z2 = az**2
         sdens = self._sdens
 
         def zforceint(a):
@@ -492,8 +520,13 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
                 / xp.sqrt(aRz)
             )
 
-        integral = self._bk_split_quad(zforceint, R, xp, dev, z)
-        return xp.where(z == 0, xp.zeros_like(z), -4.0 * z * integral)
+        # az, not z, on BOTH sides: the panel grading must see the floored width
+        # it was integrated at, and -4 |z| I(|z|) is what tends to the limit. Fz
+        # is odd in z, so the sign is reapplied here rather than carried through.
+        integral = self._bk_split_quad(zforceint, R, xp, dev, az)
+        return xp.where(
+            z == 0, xp.zeros_like(z), -4.0 * xp.sign(z_safe) * az * integral
+        )
 
     # ------------------------------ R2deriv --------------------------------
     @check_potential_inputs_not_arrays


### PR DESCRIPTION
## What

`test_anyaxisymrazorthin_smallz_limit` was the last traced AnyAxisym failure
that is a genuine backend gap. It checks `Fz -> -2 pi Sigma(R)` as `z -> 0+`, a
constant; the traced path returned `Fz/limit` of **2.65e3** and **2.68e13** at
the two smallest z.

## Cause

`_bk_split_quad` grades panels toward the `a=R` peak (width `~|z|`) by forming
edges `Rp +/- d`, and the integrand forms `a - R` — both by subtraction. Once
`|z|/R` reaches a few tens of machine epsilon neither is representable: the
innermost panels collapse to zero width and the `1/((a-R)^2+z^2)` pole is
sampled at `a == R`.

Measured onset, traced, against the limit:

| R | 0.05 | 0.2 | 0.5 | 2.0 |
|---|---|---|---|---|
| onset z/R | 3.2e-15 | 3.2e-15 | 1.0e-14 | 1.0e-14 |

Those are adjacent half-decade grid points, so within resolution the onset is
**constant in z/R across a 40× range of R** — a relative-precision effect. That
is why the floor is relative; an absolute one (as `_R2DERIV_ZFLOOR` is) would be
wrong at small R for exactly this reason.

## Fix

Clamp `|z|` up to `1e-8 * R` and evaluate there.

This is not an approximation being smuggled in: `Fz(z->0+)` is **exactly**
`-2 pi Sigma(R)` for a razor-thin disk and the integral goes as `1/|z|`, so
`-4 |z| I(|z|)` evaluated at the floor already *is* that limit. The floor sits 6
orders above the 1e-14 onset, so the quadrature is only ever used where it is
accurate, and the limit's own error at the floor is `O(z/R) ~ 1e-8` — four
orders inside the 3e-4 the test asks for. Above the floor nothing changes.

Clamping rather than branching also removes a hazard instead of adding one:
there is no second `xp.where` arm holding a divergent integral that could
NaN-poison a reverse-mode gradient.

## Result

With this and gh#1330 (already merged), traced AnyAxisym reaches **zero**
failures:

    baseline                        3 failed  (1 accuracy + 2 tracer errors)
    + gh#1328 (fixture)             2 failed
    + gh#1330 (log subtraction)     1 failed
    + this PR                       0 failed

Measured on the synced branch: `-k anyaxisym --backend jax --jit` →
**11 passed, 1 skipped, 2 xfailed, 0 FAILED**. The 2 xfails report `x`, not `X`,
so there is no hidden XPASS and no ledger delta to claim.

## Scope

This does **not** address the large-R arm of the same family, where `Sigma(R)`
is exponentially small and the quadrature cancels away the answer. That fails
**identically on numpy** — both paths give 1.206e+04 relative at R=10, z/R=1e-6
— so it is the formulation, not the migration, and no floor reaches it.

## Test

No new test: the existing `smallz_limit` **is** the forcing test, and it flips —
it fails without this change and passes with it.

## numpy

Untouched (`_zforce_numpy` is a separate scipy path). `-k anyaxisym` on numpy is
13 passed / 1 skipped, unchanged, and identical under forced torch **and**
forced jax.
