### PR TITLE
ledger: un-xfail torch-jit test_eccentricity (measured stale after gh#1330/gh#1331)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -341,8 +341,6 @@ jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazo
 # torch-jit defects found by the 2026-08-09 torch sweep.
 # AnyAxisym traced GL forces ~1e-6; reproduces on jax too
 torch-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
-# same AnyAxisym root cause seen through an orbit (e=5.4e-6 vs 1e-8)
-torch-jit tests/test_orbit.py::test_eccentricity
 # torch-jit: the RotateAndTilt wrapper rejects the quadrature's node array, so
 # these FAIL fast (35.6 s for all four) -- they are defects, not slow tests. The
 # 2026-08-09 sweep measured them at 300-400 s because its worktree carried the


### PR DESCRIPTION
ledger: un-xfail torch-jit test_eccentricity (measured stale)

Dispatched a traced run on `feat/backends-develop` (`workflow_dispatch`,
`jit=true`, run 32025928130) and swept its JUnit artifacts for
(ledgered AND passed) entries. Of **91** ledger entries, **51** are not
evaluable in traced mode (they are eager entries), **39** are still correctly
ledgered, and exactly **one** is stale:

    torch-jit tests/test_orbit.py::test_eccentricity

Verified against the raw artifact rather than only the sweep's verdict:

    backend-junit-torch-...-test_orbit_test_orbits_main_g3
      testcase name=test_eccentricity time=2.951  children=[]        -> PASSED
    backend-junit-jax-...-test_orbit_test_orbits_main_g3
      testcase name=test_eccentricity time=0.781  children=[skipped]

Its own comment explains why it was ledgered: "same AnyAxisym root cause seen
through an orbit (e=5.4e-6 vs 1e-8)". That root cause is what gh#1330 (the
`finite_part_quad` log subtraction) and gh#1331 (the relative zforce floor)
fixed, so the orbit's eccentricity now lands inside tolerance under torch.

**The jax-jit entry is deliberately kept.** It still reports `skipped` in the
same run, so the shared root cause is NOT uniformly resolved and claiming
otherwise would be the tidy-story mistake. One line out, not two.

Ledger delta: xfail 15 -> 14; in-scope 91 -> 90.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm