### PR TITLE
AnyAxisym: Phi misses the midplane cusp for |z| << R (and the test that hid it)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -212,16 +212,25 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             return self._pot_zero
         elif numpy.isinf(R**2 + z**2):
             return 0.0
-        potint = lambda a: (
-            a
-            * self._sdens(a)
-            / numpy.sqrt((R + a) ** 2.0 + z**2.0)
-            * special.ellipk(4 * R * a / ((R + a) ** 2.0 + z**2.0))
-        )
-        return -4 * (
-            integrate.quad(potint, 0, 2 * R, points=[R])[0]
-            + integrate.quad(potint, 2 * R, numpy.inf)[0]
-        )
+
+        # Same a=R peak, and the same fix, as zforce and Rzderiv: see
+        # _quad_apeak. Phi's peak is only logarithmic rather than 1/((a-R)^2+z^2),
+        # so it is not wrong by orders of magnitude -- but for |z| << R quad
+        # still steps over the O(|z|)-wide region entirely and misses the
+        # 2*pi*Sigma(R)*|z| that Phi picks up off the midplane. That term IS the
+        # vertical force, so without this Phi and zforce disagree: at R=0.5,
+        # Phi(1e-8)-Phi(0) came back 4.4e-12 where zforce(0.5,1e-8) = -2.10295
+        # demands 2.10e-8.
+        #
+        # m1 = 1-m is taken from the exact d2 = (a-R)^2+z^2 that _quad_apeak
+        # supplies, never as 1 - 4aR/aRz: that subtraction rounds to 0 for
+        # |z| << R and sends ellipk to inf right at the peak, which is why the
+        # peak cannot simply be panelled with the old integrand.
+        def potint(a, u, d2):
+            aRz = (R + a) ** 2.0 + z**2.0
+            return a * self._sdens(a) / numpy.sqrt(aRz) * special.ellipkm1(d2 / aRz)
+
+        return -4 * _quad_apeak(potint, R, z)
 
     @check_potential_inputs_not_arrays
     def _Rforce(self, R, z, phi=0.0, t=0.0):

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1275,9 +1275,22 @@ def test_forceAsDeriv_potential(potname):
                 dz = 10.0**-8.0
                 newZ = Zs[jj] + dz
                 dz = newZ - Zs[jj]  # Representable number
-                mpotderivz = (
-                    tp(Rs[ii], Zs[jj], phi=1.0) - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
-                ) / dz
+                if Zs[jj] == 0.0:
+                    # At the midplane Phi may have a |z| KINK -- a razor-thin
+                    # disk's is exactly 2*pi*Sigma(R)*|z| -- and there the
+                    # one-sided difference measures the one-sided slope, which
+                    # is +2*pi*Sigma(R), not dPhi/dz. Phi is even in z about a
+                    # midplane where Fz vanishes, so the CENTRED difference is
+                    # the right probe: it is 0 for the kink and -Fz for a smooth
+                    # potential, and it is O(dz^2) rather than O(dz) accurate.
+                    mpotderivz = (
+                        tp(Rs[ii], Zs[jj] - dz, phi=1.0)
+                        - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
+                    ) / (2.0 * dz)
+                else:
+                    mpotderivz = (
+                        tp(Rs[ii], Zs[jj], phi=1.0) - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
+                    ) / dz
                 tzforce = potential.evaluatezforces(tp, Rs[ii], Zs[jj], phi=1.0)
                 if tzforce**2.0 < 10.0**ttol:
                     assert mpotderivz**2.0 < 10.0**ttol, (


### PR DESCRIPTION
`AnyAxisymmetricRazorThinDiskPotential._evaluate` integrated with plain
`points=[R]`. For `|z| << R` scipy's adaptive rule never places a node inside
the `O(|z|)`-wide peak at `a = R`, so its error estimate stays small, it stops
subdividing, and **Phi comes back flat off the midplane**.

The term it drops is exactly the vertical force. At `R = 0.5`, where
`2*pi*Sigma(0.5) = 2.102952` and galpy's own `zforce(0.5, 1e-8) = -2.102952`:

| `Phi(z) - Phi(0)` | before | after | expected |
|---|---|---|---|
| z = 1e-8 | +4.436e-12 | +1.876e-08 | +2.103e-08 |
| z = 1e-6 | -9.637e-11 | **+2.103e-06** | +2.103e-06 |
| z = 1e-4 | +2.1029e-04 | +2.1029e-04 | +2.1030e-04 |

So `Phi` and `zforce` contradicted each other for `|z| < ~1e-5`. Independently
arbitrated with scipy's *own* adaptive rule using the stable complement and the
peak forced into its own panel: **+2.096e-08**, i.e. the cusp is real and the
old value was the wrong one.

## Two explanations tested and rejected first

* **scipy tolerance.** `epsabs=1e-14` does not move `Phi(dz)` at all (-4.9e-12)
  and returns **NaN** at `z=0`. Not tolerance-limited.
* **`ellipk` rounding alone.** Switching to the exact complement + `ellipkm1`
  *without* resolving the peak still gives +8.2e-13 at z=1e-8. Necessary but not
  sufficient: it is what makes the peak *evaluable* (with `ellipk`, `m` rounds
  to exactly 1.0 at `a=R` and panelling the old integrand returns `nan`/`-inf`).

## The fix was already in the file

`_quad_apeak` does precisely this, via `a = R + |z| t`, and its own comment
describes the identical failure for `zforce` ("came back +1.9e-8 instead of
-1.86"). It was wired into `zforce` and `Rzderiv` and simply never into `Phi`.
No new machinery is added here.

**Not byte-identical on the numpy path** — that is the point of the fix.

## Why the test change is in the same commit

`test_forceAsDeriv_potential` probes the midplane with a **one-sided**
difference. `Phi` has a `|z|` kink there, so the one-sided slope is
`+2*pi*Sigma(R)`, not `dPhi/dz`; the assertion `Fz(R,0)=0 => dPhi/dz=0` was
passing only because `Phi` was flat — two errors cancelling. With `Phi` fixed it
reads -1.876 and the assertion fails.

`Phi` is even in `z` about a midplane where `Fz` vanishes, so the **centred**
difference is the correct probe: 0 for a kink, `-Fz` for a smooth potential, and
`O(dz^2)` rather than `O(dz)` accurate. Applied at `z == 0` only; every other
sample point is untouched.

## Gate

`tests/test_potential.py`, full file, same invocation both sides:

| | failed | passed | skipped |
|---|---|---|---|
| this branch | 8 | 1225 | 102 |
| pristine main | 8 | 1225 | 102 |

Identical failing sets, all 8 environmental in this worktree (no C extension, no
pynbody: the `*_c` tests, `dehnen_bar_python_c_consistency`, `InterpSnapshot*`,
`RotateAndTiltWrapper`). `-k forceAsDeriv` alone: 148 passed, 1 failed
(`mockInterpSnapshotRZPotential`, which fails identically on pristine main —
verified by direct A/B).

## Known limit

At `z = 1e-8` the recovered increment is ~11% low, because differencing 2.1e-8
out of `Phi ~ 2` is at the float64 floor. By `z = 1e-6` it is exact. Documented
rather than chased.
