### PR TITLE
AnyAxisym: resolve Phi's a=R log singularity at z=0 in the traced path (3e-5 -> 1e-12)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -394,7 +394,47 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             m1, aRz = self._bk_m1_aRz(a, R, z2, xp)
             return a * sdens(a) / xp.sqrt(aRz) * _bspecial.ellipkm1(m1)
 
-        return -4.0 * self._bk_split_quad(potint, R, xp, dev, z)
+        # NOT _bk_split_quad, unlike Rforce and zforce. Phi's peak at a=R is
+        # LOGARITHMIC (ellipkm1 ~ -ln(m1)/2), not the 1/((a-R)^2+z^2) pole those
+        # two carry, and _bk_split_quad switches its panel grading OFF at z == 0
+        # -- which leaves the log sitting on a plain panel edge, where GL
+        # converges only algebraically. Measured against scipy, at z = 0:
+        #
+        #     R        _bk_split_quad   transformed_quad
+        #     0.2      2.966e-05        4.425e-11
+        #     0.5      4.175e-05        6.072e-11
+        #     1.0      3.179e-05        4.541e-11
+        #
+        # (n=100 sharpens those to ~1e-12.) transformed_quad splits at a=R and
+        # clusters nodes into the boundary layer with X = xi^3, which resolves a
+        # log; for z > 0 it agrees with the ladder to the last digit at every z
+        # sampled (1e-8, 1e-4, 1e-2, 0.1, 1.0), so nothing regresses.
+        #
+        # It is NOT a drop-in for the other two: xi^3 clustering only reaches
+        # ~(1/n)^3 R ~ 5e-7 of the peak, so on zforce's pole it degrades to
+        # 1.1e-05 at z=1e-6 and 1.7e-02 at z=1e-8, where the geometric ladder --
+        # which marches panel edges to dmin = 4|z| exactly -- holds 8e-13 and
+        # 3.8e-10. Different singularity, different rule.
+        Rp = xp.where(xp.isfinite(R) & (R > 0), R, xp.ones_like(R))
+        inner = _bquad.transformed_quad(
+            xp,
+            potint,
+            xp.zeros_like(Rp),
+            2.0 * Rp,
+            n=_GLORDER,
+            interior_point=Rp,
+            device=dev,
+        )
+        out = xp.where(R > 0, inner, xp.zeros_like(inner)) + (
+            _bquad.fixed_quad_semiinfinite(
+                xp,
+                potint,
+                2.0 * xp.where(xp.isfinite(R), R, xp.ones_like(R)),
+                n=_GLORDER,
+                device=dev,
+            )
+        )
+        return -4.0 * xp.where(xp.isfinite(R), out, xp.zeros_like(out))
 
     # ------------------------------- Rforce --------------------------------
     @check_potential_inputs_not_arrays


### PR DESCRIPTION
`_evaluate_gl` went through `_bk_split_quad`, which switches its panel grading
**off at `z == 0`** — deliberately, because grading there makes an
R-finite-difference blow up. That leaves Phi's **logarithmic** peak at `a = R`
sitting on a plain panel edge, where fixed-order GL converges only
algebraically.

Traced Phi vs scipy, at `z = 0`:

| R | before | after |
|---|---|---|
| 0.2 | 2.97e-05 | **1.86e-12** |
| 0.5 | 4.18e-05 | **1.05e-12** |
| 1.0 | 3.18e-05 | **2.54e-14** |
| 2.0 | 6.66e-06 | **1.47e-12** |

`z > 0` is untouched — 1.9e-13 / 1.1e-13 / 1.4e-14 / 4.5e-15 at
`z = 1e-4, 1e-2, 0.1, 1.0`, i.e. exactly what the ladder already gave.

**This matters beyond the ledger.** `z = 0` is the midplane, which is where
planar orbits evaluate the potential under jit, so a 3e-5 error there is
user-facing rather than a test artifact.

## Why `transformed_quad` here and NOT in `_bk_split_quad`

`transformed_quad` splits at `a = R` and clusters nodes into the boundary layer
with `X = xi^3` — the right rule for a **log**. It is deliberately not applied
to `Rforce`/`zforce`, whose peak is a `1/((a-R)^2+z^2)` **pole** of width `~|z|`.
`xi^3` clustering only reaches `~(1/n)^3 R ~ 5e-7` of the peak. Measured on
`zforce` under `jax.jit`, against numpy:

| z | geometric ladder | transformed_quad |
|---|---|---|
| 1e-2 | 6.4e-15 | 7.7e-15 |
| 1e-4 | 1.3e-14 | 7.6e-12 |
| 1e-6 | 8.2e-13 | **1.1e-05** |
| 1e-8 | 3.8e-10 | **1.7e-02** |

The ladder marches panel edges to `dmin = 4|z|` **exactly**, which is what a
`|z|`-width feature needs. Different singularity, different rule — so
`_bk_split_quad` keeps both of those callers unchanged. (I had originally
intended to replace the ladder wholesale on the strength of the Phi numbers
alone; this measurement is why that did not happen.)

## Scope

* numpy path untouched — `_evaluate_numpy` is not in the diff, and
  `-k anyaxisym` on numpy is 13 passed / 0 failed.
* One function changed; no new helpers, no new module-level state.

## Ledger delta: NONE

`-k anyaxisym --backend jax --jit`: **11 passed, 1 skipped, 2 xfailed**, and
both xfails still report `x`, not `X` — no hidden XPASS.

* `test_forceAsDeriv_potential` cannot clear here. Fixing traced Phi moves its
  one-sided midplane FD from 8.3e3 to **-2.105**, which is the *physically
  correct* `-2*pi*Sigma(0.5) = -2.102952`; the assertion demands ~0 and still
  fails. That needs the centred-difference change in gh#1333 (numpy-visible,
  on main) to reach this branch first.
* `test_poisson_surfdens_potential` is a separate cause — the deliberate
  array-input opt-out (`TypeError: ... do not accept array inputs`), not a
  numerical error.

This PR is accuracy only.
