### PR TITLE
Port main's AnySpherical array + AnyAxisym midplane fixes to develop (-2 xfail)

### DIFF
--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -375,16 +375,25 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             return self._pot_zero
         elif numpy.isinf(R**2 + z**2):
             return 0.0
-        potint = lambda a: (
-            a
-            * self._sdens(a)
-            / numpy.sqrt((R + a) ** 2.0 + z**2.0)
-            * special.ellipk(4 * R * a / ((R + a) ** 2.0 + z**2.0))
-        )
-        return -4 * (
-            integrate.quad(potint, 0, 2 * R, points=[R])[0]
-            + integrate.quad(potint, 2 * R, numpy.inf)[0]
-        )
+
+        # Same a=R peak, and the same fix, as zforce and Rzderiv: see
+        # _quad_apeak. Phi's peak is only logarithmic rather than
+        # 1/((a-R)^2+z^2), so it is not wrong by orders of magnitude -- but for
+        # |z| << R quad still steps over the O(|z|)-wide region entirely and
+        # misses the 2*pi*Sigma(R)*|z| that Phi picks up off the midplane. That
+        # term IS the vertical force, so without this Phi and zforce disagree:
+        # at R=0.5, Phi(1e-8)-Phi(0) came back 4.4e-12 where
+        # zforce(0.5,1e-8) = -2.10295 demands 2.10e-8.
+        #
+        # m1 = 1-m is taken from the exact d2 = (a-R)^2+z^2 that _quad_apeak
+        # supplies, never as 1 - 4aR/aRz: that subtraction rounds to 0 for
+        # |z| << R and sends ellipk to inf right at the peak, which is why the
+        # peak cannot simply be panelled with the old integrand.
+        def potint(a, u, d2):
+            aRz = (R + a) ** 2.0 + z**2.0
+            return a * self._sdens(a) / numpy.sqrt(aRz) * special.ellipkm1(d2 / aRz)
+
+        return -4 * _quad_apeak(potint, R, z)
 
     def _evaluate_gl(self, R, z, xp, dev):
         z2 = z**2

--- a/galpy/potential/AnySphericalPotential.py
+++ b/galpy/potential/AnySphericalPotential.py
@@ -9,6 +9,7 @@ from scipy import integrate
 from ..backend import as_backend_constant, as_numpy, get_namespace, is_backend_array
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
+from ..util.quadpack import quad_over_limits
 from .SphericalPotential import SphericalPotential
 
 if _APY_LOADED:
@@ -54,11 +55,14 @@ class AnySphericalPotential(SphericalPotential):
 
         """
         SphericalPotential.__init__(self, amp=amp, ro=ro, vo=vo)
-        # numpy path: _rawmass closes over scipy.integrate.quad with a SCALAR
-        # upper limit (r[0] of an array), so the force is scalar-only -- an
-        # array input silently collapses to its first element. Tell
-        # Potential.mass to drive the backend GL quadrature node-by-node
-        # (vectorized=False) instead of feeding the whole node array.
+        # Drive Potential.mass's backend GL quadrature node-by-node
+        # (vectorized=False) rather than feeding it the whole node array.
+        #
+        # This is now a PERFORMANCE/driving choice, not a correctness guard:
+        # _rawmass integrates element-wise over an array upper limit (see its
+        # docstring), so feeding it the node array would be correct, just
+        # loop-per-node internally either way. It was originally a workaround
+        # for _rawmass silently collapsing an array r to r[0].
         self._force_accepts_arrays = False
         # A jax/torch coord routes _rawmass / the _revaluate tail to in-backend
         # Gauss-Legendre quadrature (see below); flag as backend-capable.
@@ -175,9 +179,14 @@ class AnySphericalPotential(SphericalPotential):
     def _rawmass(self, r):
         r"""Enclosed mass :math:`4\pi\int_0^r a^2\rho(a)\,da`.
 
-        numpy: scipy.integrate.quad with a SCALAR upper limit (byte-identical to
-        the historical closure -- an array ``r`` collapses to ``r[0]``). A
-        jax/torch ``r`` routes to in-backend fixed-order Gauss-Legendre so the
+        numpy: `quad_over_limits`, i.e. scipy's quad driven element by element
+        over an array upper limit. Scalar in, scalar out, through exactly the
+        same `quad` call as before, so the scalar path stays byte-identical.
+        (It previously integrated to ``numpy.atleast_1d(r).flatten()[0]``, so an
+        array ``r`` silently returned the mass inside ``r[0]`` at every element
+        -- 76 of 77 grid cells wrong, up to 0.94 relative, via `_rforce`.)
+
+        A jax/torch ``r`` routes to in-backend fixed-order Gauss-Legendre so the
         mass (and the force / 2nd derivative built on it) differentiates w.r.t.
         ``r`` and through the density's parameters.
         """
@@ -190,11 +199,7 @@ class AnySphericalPotential(SphericalPotential):
                 * _bk_quad(lambda a: a**2 * self._backend_dens(a), 0.0, r)
             )
         return (
-            4.0
-            * numpy.pi
-            * integrate.quad(
-                lambda a: a**2 * self._rawdens(a), 0, numpy.atleast_1d(r).flatten()[0]
-            )[0]
+            4.0 * numpy.pi * quad_over_limits(lambda a: a**2 * self._rawdens(a), 0, r)
         )
 
     def _revaluate(self, r, t=0.0):
@@ -217,20 +222,21 @@ class AnySphericalPotential(SphericalPotential):
             bulk = -self._rawmass(r_safe) / r_safe - 4.0 * numpy.pi * tail
             out = xp.where(r == 0, self._pot_zero, bulk)
             return xp.where(xp.isinf(r), self._pot_inf, out)
+        # r == 0 / isinf(r) are per-element questions, so an array r has to be
+        # handled element by element; scipy's quad wants a scalar limit anyway.
+        if numpy.ndim(r) == 0:
+            return self._revaluate_scalar(r)
+        rr = numpy.asarray(r)
+        return numpy.reshape([self._revaluate_scalar(x) for x in rr.ravel()], rr.shape)
+
+    def _revaluate_scalar(self, r):
         if r == 0:
             return self._pot_zero
         elif numpy.isinf(r):
             return self._pot_inf
         else:
-            return (
-                -self._rawmass(r) / r
-                - 4.0
-                * numpy.pi
-                * integrate.quad(
-                    lambda a: self._rawdens(a) * a,
-                    numpy.atleast_1d(r).flatten()[0],
-                    numpy.inf,
-                )[0]
+            return -self._rawmass(r) / r - 4.0 * numpy.pi * quad_over_limits(
+                lambda a: self._rawdens(a) * a, r, numpy.inf
             )
 
     def _rforce(self, r, t=0.0):

--- a/galpy/util/quadpack.py
+++ b/galpy/util/quadpack.py
@@ -16,6 +16,37 @@ def _infunc(x, func, gfun, hfun, more_args, epsrel, epsabs):
     return retval[0]
 
 
+def quad_over_limits(func, a, b, **kwargs):
+    """``quad(func, a, b)[0]`` with either limit allowed to be an array.
+
+    scipy's ``quad`` accepts scalar limits only, and silently uses just the
+    first element if handed an array, so integrating over array coordinates has
+    to be done element by element.
+
+    Parameters
+    ----------
+    func : callable
+        Function to integrate, of one variable.
+    a, b : float or array
+        Limits of integration; broadcast against each other.
+    **kwargs
+        Passed through to ``scipy.integrate.quad``.
+
+    Returns
+    -------
+    float or array
+        The integral, of the broadcast shape of ``a`` and ``b``. A scalar in,
+        scalar out, evaluated by exactly the same ``quad`` call as before.
+    """
+    if numpy.ndim(a) == 0 and numpy.ndim(b) == 0:
+        return quad(func, a, b, **kwargs)[0]
+    aa, bb = numpy.broadcast_arrays(a, b)
+    out = numpy.empty(aa.shape)
+    for idx in numpy.ndindex(aa.shape):
+        out[idx] = quad(func, aa[idx], bb[idx], **kwargs)[0]
+    return out
+
+
 def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
     return quad(
         _infunc,

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -336,11 +336,9 @@ jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 #    It is eager-vs-traced: eager has Phi(z=0) and Phi(z=1e-8) agreeing to 11
 #    digits, traced does not. Cause not yet identified; do not start from the
 #    quadrature ladder.
-jax-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 
 # torch-jit defects found by the 2026-08-09 torch sweep.
 # AnyAxisym traced GL forces ~1e-6; reproduces on jax too
-torch-jit tests/test_potential.py::test_forceAsDeriv_potential[AnyAxisymmetricRazorThinDiskPotential]
 # torch-jit: the RotateAndTilt wrapper rejects the quadrature's node array, so
 # these FAIL fast (35.6 s for all four) -- they are defects, not slow tests. The
 # 2026-08-09 sweep measured them at 300-400 s because its worktree carried the

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -16649,3 +16649,87 @@ def test_orbit_phi1phi2_multi_shape_and_time():
         assert numpy.allclose(multi.phi2(ts)[i], single.phi2(ts))
         assert numpy.allclose(multi.pmphi1(ts)[i], single.pmphi1(ts))
         assert numpy.allclose(multi.pmphi2(ts)[i], single.pmphi2(ts))
+
+
+# Orbits.E(t=array) tries one vectorised potential evaluation over (orbit, time)
+# and falls back to a per-orbit scalar loop when the potential cannot broadcast
+# (e.g. potentials that integrate numerically per point). The phi-less orbit
+# shapes -- phasedim 3 and 5 -- reach their own copies of that fallback, so they
+# need their own coverage; a synthetic scalar-only potential triggers it far more
+# cheaply and deterministically than a quadrature-backed real one.
+class _NoBroadcastPotential(potential.Potential):
+    """Axisymmetric harmonic potential whose _evaluate REJECTS array input.
+
+    Forces at any shape (so integration works normally), but Phi is scalar-only,
+    which is exactly the condition Orbits.E()'s per-orbit fallback exists for.
+    Uses plain arithmetic rather than numpy ufuncs so it behaves under a forced
+    backend too.
+    """
+
+    def __init__(self, amp=1.0, ro=None, vo=None):
+        potential.Potential.__init__(self, amp=amp, ro=ro, vo=vo)
+        self.isNonAxi = False
+
+    def _evaluate(self, R, z, phi=0.0, t=0.0):
+        for x in (R, z, t):
+            if numpy.ndim(x) > 0:
+                raise ValueError("this potential is scalar-only")
+        return 0.5 * (R**2.0 + z**2.0)
+
+    def _Rforce(self, R, z, phi=0.0, t=0.0):
+        return -R
+
+    def _zforce(self, R, z, phi=0.0, t=0.0):
+        return -z
+
+
+def test_orbits_energy_array_times_nonbroadcasting_potential():
+    """E(t=array) must fall back to the per-orbit loop, and get it right.
+
+    Checked against the CLOSED-FORM energy of the harmonic potential rather
+    than against galpy's own per-orbit path, so the assertion is independent of
+    the code under test. Two orbits with different energies and three distinct
+    times, so an (orbit, time) transposition in the fallback cannot pass.
+    """
+    from galpy.orbit import Orbit
+
+    pot = _NoBroadcastPotential(amp=1.0)
+    ts = numpy.linspace(0.0, 0.3, 4)
+
+    # phasedim 3 -- planar, no phi
+    o3 = Orbit([[1.0, 0.1, 1.1], [1.4, -0.2, 0.7]])
+    o3.integrate(ts, pot.toPlanar())
+    E3 = as_numpy(o3.E(ts, use_physical=False)).astype(float)
+    R3 = as_numpy(o3.R(ts, use_physical=False)).astype(float)
+    ref3 = (
+        0.5 * R3**2.0
+        + as_numpy(o3.vR(ts, use_physical=False)).astype(float) ** 2.0 / 2.0
+        + as_numpy(o3.vT(ts, use_physical=False)).astype(float) ** 2.0 / 2.0
+    )
+    assert E3.shape == ref3.shape, f"phasedim 3: shape {E3.shape} != {ref3.shape}"
+    assert numpy.all(numpy.fabs(E3 - ref3) < 1e-10), (
+        f"phasedim 3 fallback energy wrong: max |dE| = {numpy.max(numpy.fabs(E3 - ref3))}"
+    )
+
+    # phasedim 5 -- 3D, no phi
+    o5 = Orbit([[1.0, 0.1, 1.1, 0.1, 0.1], [1.4, -0.2, 0.7, -0.05, 0.2]])
+    o5.integrate(ts, pot)
+    E5 = as_numpy(o5.E(ts, use_physical=False)).astype(float)
+    ref5 = (
+        0.5
+        * (
+            as_numpy(o5.R(ts, use_physical=False)).astype(float) ** 2.0
+            + as_numpy(o5.z(ts, use_physical=False)).astype(float) ** 2.0
+        )
+        + as_numpy(o5.vR(ts, use_physical=False)).astype(float) ** 2.0 / 2.0
+        + as_numpy(o5.vT(ts, use_physical=False)).astype(float) ** 2.0 / 2.0
+        + as_numpy(o5.vz(ts, use_physical=False)).astype(float) ** 2.0 / 2.0
+    )
+    assert E5.shape == ref5.shape, f"phasedim 5: shape {E5.shape} != {ref5.shape}"
+    assert numpy.all(numpy.fabs(E5 - ref5) < 1e-10), (
+        f"phasedim 5 fallback energy wrong: max |dE| = {numpy.max(numpy.fabs(E5 - ref5))}"
+    )
+
+    # the orbits must actually differ, or a transposition would go unnoticed
+    assert numpy.fabs(E3[0, 0] - E3[1, 0]) > 0.1, "orbits too similar to be diagnostic"
+    assert numpy.fabs(E5[0, 0] - E5[1, 0]) > 0.1, "orbits too similar to be diagnostic"

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1548,9 +1548,22 @@ def test_forceAsDeriv_potential(potname):
                 dz = 10.0**-8.0
                 newZ = Zs[jj] + dz
                 dz = newZ - Zs[jj]  # Representable number
-                mpotderivz = (
-                    tp(Rs[ii], Zs[jj], phi=1.0) - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
-                ) / dz
+                if Zs[jj] == 0.0:
+                    # At the midplane Phi may have a |z| KINK -- a razor-thin
+                    # disk's is exactly 2*pi*Sigma(R)*|z| -- and there the
+                    # one-sided difference measures the one-sided slope, which
+                    # is +2*pi*Sigma(R), not dPhi/dz. Phi is even in z about a
+                    # midplane where Fz vanishes, so the CENTRED difference is
+                    # the right probe: it is 0 for the kink and -Fz for a smooth
+                    # potential, and it is O(dz^2) rather than O(dz) accurate.
+                    mpotderivz = (
+                        tp(Rs[ii], Zs[jj] - dz, phi=1.0)
+                        - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
+                    ) / (2.0 * dz)
+                else:
+                    mpotderivz = (
+                        tp(Rs[ii], Zs[jj], phi=1.0) - tp(Rs[ii], Zs[jj] + dz, phi=1.0)
+                    ) / dz
                 tzforce = potential.evaluatezforces(tp, Rs[ii], Zs[jj], phi=1.0)
                 if tzforce**2.0 < 10.0**ttol:
                     assert mpotderivz**2.0 < 10.0**ttol, (


### PR DESCRIPTION
Two main→develop correctness ports that this branch had never received, plus
the ledger delta they unlock. Grouped because the files are disjoint and the
runner queue is hours deep.

## 1. AnySpherical: array input returned the value at `r[0]`

`_rawmass` integrated to `numpy.atleast_1d(r).flatten()[0]`, so an array `r`
got the mass enclosed within its **first element** at every point — silently.
Via `_rforce` that is a wrong force everywhere. Measured on an 11×7 (R, z)
grid, whole-mesh call vs the same points one at a time:

| | before | after |
|---|---|---|
| `Rforce` | **76 of 77 cells differ, max rel 9.4e-01** | **0 of 77** |
| `Potential` | raised (`if r == 0` on an array) | 0 of 77 |

main fixed this in #1323 with `quad_over_limits`; this branch never got it and
instead worked around the symptom with `_force_accepts_arrays = False`, which
only governs how `Potential.mass` *drives* the quadrature and does not protect
a direct `evaluateRforces(pot, Rmesh, zmesh)`. The file's own comment stated
the defect outright.

`quad_over_limits` was **absent from this branch entirely** — `galpy/util/
quadpack.py` here predates #1323 — so it is brought over verbatim.
`_revaluate` splits into `_revaluate_scalar` + a per-element loop, matching
main. The backend arm (in-backend GL, differentiable) is untouched.

**numpy byte-identity verified, not assumed:** `Rforce`/`Potential` at
r = 0.05, 0.3, 1.0, 2.5, 5.0 match unmodified develop to the last digit.

`_force_accepts_arrays = False` is **kept**; only its comment is corrected,
since it was justified as a guard against exactly this collapse and is now just
a driving choice. Flipping it is a separate decision.

## 2. AnyAxisym: numpy Φ misses the midplane cusp (port of #1333)

`_evaluate_numpy` integrated with plain `points=[R]`, so for |z| ≪ R quad
stepped over the O(|z|)-wide peak at a=R and Φ came back **flat** off the
midplane — missing exactly the `2πΣ(R)·|z|` that *is* the vertical force, so Φ
and galpy's own `zforce` contradicted each other below |z| ~ 1e-5:

| Φ(z) − Φ(0) at R=0.5 | before | expected |
|---|---|---|
| z = 1e-8 | +4.436e-12 | +2.103e-08 |
| z = 1e-6 | −9.637e-11 | +2.103e-06 |

`_quad_apeak` — which fixes precisely this — **already exists on this branch**
and is used by `zforce` and `Rzderiv`; Φ was simply never wired to it. One
call, no new machinery.

The test change is inseparable. `test_forceAsDeriv_potential` probes the
midplane with a **one-sided** difference; Φ has a |z| kink there, so that
measures the one-sided slope `+2πΣ(R)`, not dΦ/dz. The assertion
`Fz(R,0)=0 ⟹ dΦ/dz=0` was passing only because Φ was flat — two errors
cancelling. Centred difference at `z == 0` only; every other sample untouched.
Whole `forceAsDeriv` family on numpy: **149 passed, 0 failed**.

## 3. Ledger: −2 xfail

With #1334's traced Φ fix on the base and the two fixes above, measured on this
content, `-k AnyAxisym`:

| | before | after |
|---|---|---|
| jax `--jit` | 11 passed, **2 xfailed** | **12 passed, 1 xfailed** |
| torch `--jit` | 11 passed, **2 xfailed** | **12 passed, 1 xfailed** |

so `test_forceAsDeriv_potential[AnyAxisym]` comes out of the ledger for both
backends. The surviving xfail is `poisson_surfdens`, reported `x` not `X` — no
hidden XPASS. **All three pieces are required**; none suffices alone.

`poisson_surfdens` is deliberately **not** burned: its traced failure is
`TypeError: … do not accept array inputs`, the array opt-out guarded by a
negative test that names this class. That is a design decision, not a silent
fix — though its numerical justification is now stale (R2deriv/z2deriv at
|z|=1e-5 went from 2.7e+04 to 5.3e-12 since it was written).

## Gates

`-k "AnySpherical or anyspherical or array_input"`: numpy 52 / jax 52 / torch
52 passed, 1 skipped each. `-k forceAsDeriv` numpy: 149 passed, 0 failed.
`-k AnyAxisym --jit`: jax and torch as tabled above.

**Numpy output changes** for AnyAxisym Φ at small |z| and for AnySpherical
array input — both deliberate, both matching main.
