### PR TITLE
in-backend ODE: accept rtol/atol through inbackend_kwargs

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -67,8 +67,9 @@ class actionAngleIsochroneApprox(actionAngle):
             which supports GPU and higher-order autodiff of the actions.
         integrate_kwargs : dict, optional
             Extra options forwarded to the in-backend solver when
-            integrate_method='diffrax'/'torchdiffeq' ('max_steps', 'solver', and
-            (jax) 'adjoint'); e.g. {'adjoint': 'direct', 'max_steps': 4096} enables
+            integrate_method='diffrax'/'torchdiffeq' ('rtol', 'atol', 'max_steps',
+            'solver', and (jax) 'adjoint'); 'rtol'/'atol' (default 1e-12 each) are
+            the only way to set the solver tolerance here; e.g. {'adjoint': 'direct', 'max_steps': 4096} enables
             jax SECOND derivatives (jax.hessian / nested jacrev) of the actions w.r.t.
             the input phase-space coordinates. Ignored for the C/numpy path.
         dt : float, optional

--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2178,7 +2178,14 @@ class Orbit:
 
         _rtol = 1e-12 if rtol is None else rtol
         _atol = 1e-12 if atol is None else atol
-        _ibk = inbackend_kwargs or {}
+        # rtol/atol are in-backend solver options like max_steps/solver/adjoint, so
+        # accept them through inbackend_kwargs too (they are the only route callers
+        # that expose just that dict -- e.g. actionAngleIsochroneApprox's
+        # integrate_kwargs -- have to the tolerance). Pop rather than splat: they
+        # are also passed explicitly below, and duplicating a keyword raises.
+        _ibk = dict(inbackend_kwargs or {})
+        _rtol = _ibk.pop("rtol", _rtol)
+        _atol = _ibk.pop("atol", _atol)
         # ts is either the shared 1-D output grid (nt,) -- all orbits integrated in
         # ONE solve -- or a PER-ORBIT grid of shape self.shape + (nt,): each orbit
         # its own times (same length nt), as the C integrators' indiv_t (used by
@@ -2341,7 +2348,7 @@ class Orbit:
         atol : float, optional
             Absolute tolerance. Default is None.
         inbackend_kwargs : dict, optional
-            Extra options for the in-backend differentiable ODE solver (only used by method='diffrax'/'torchdiffeq', or a jax/torch initial condition that falls back to it): 'max_steps', 'solver', and (jax) 'adjoint'. Pass inbackend_kwargs={'adjoint': 'direct', 'max_steps': 4096} to enable jax SECOND derivatives (jax.hessian / nested jacrev) through the integration; the default 'recursive' adjoint is reverse-mode first-order only. Ignored by all other (C/scipy) methods.
+            Extra options for the in-backend differentiable ODE solver (only used by method='diffrax'/'torchdiffeq', or a jax/torch initial condition that falls back to it): 'rtol', 'atol', 'max_steps', 'solver', and (jax) 'adjoint'. 'rtol'/'atol' here override the rtol/atol arguments. Pass inbackend_kwargs={'adjoint': 'direct', 'max_steps': 4096} to enable jax SECOND derivatives (jax.hessian / nested jacrev) through the integration; the default 'recursive' adjoint is reverse-mode first-order only. Ignored by all other (C/scipy) methods.
 
         Returns
         -------

--- a/tests/test_backend_inbackend_ode.py
+++ b/tests/test_backend_inbackend_ode.py
@@ -595,3 +595,56 @@ def test_inbackend_1d_batch_jax():
     out = numpy.asarray(integrate_orbit(pot, jnp.asarray(ics), jnp.asarray(_TS)))
     assert out.shape == (len(_TS), 3, 2)
     numpy.testing.assert_allclose(out[-1], ref, rtol=1e-6, atol=1e-7)
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_orbit_integrate_inbackend_kwargs_tolerance_jax():
+    # rtol/atol are reachable through inbackend_kwargs, not just as integrate()
+    # arguments. They used to collide with the explicitly-forwarded pair and raise
+    # "got multiple values for keyword argument 'rtol'" -- which made the tolerance
+    # UNREACHABLE for callers that expose only the dict (actionAngleIsochroneApprox's
+    # integrate_kwargs is the motivating one: it has no rtol/atol parameters).
+    pot = PlummerPotential(amp=1.0, b=0.6)
+
+    def final_state(**kw):
+        o = Orbit(jnp.asarray(_IC))
+        o.integrate(jnp.asarray(_TS), pot, method="diffrax", **kw)
+        return numpy.asarray(o.getOrbit()).reshape(-1, len(_IC))[-1]
+
+    tight = final_state()  # default rtol=atol=1e-12
+    loose = final_state(inbackend_kwargs={"rtol": 1e-5, "atol": 1e-5})
+    d_loose = numpy.max(numpy.fabs(loose - tight))
+
+    # Two-sided: the knob must actually REACH the solver (a silently-dropped
+    # rtol would give a bit-identical trajectory), and it must behave like a
+    # tolerance rather than garbage.
+    assert d_loose > 1e-9, f"loose tolerance changed nothing: max|d|={d_loose:.3e}"
+    assert d_loose < 1e-2, f"loose tolerance diverged: max|d|={d_loose:.3e}"
+
+    # Passing the SAME loose tolerance the documented way must agree closely with
+    # passing it through the dict -- same knob, two spellings. Both are adaptive
+    # solves with the same controller, so require them to track to 1e-12.
+    via_args = final_state(rtol=1e-5, atol=1e-5)
+    numpy.testing.assert_allclose(loose, via_args, rtol=1e-12, atol=1e-12)
+
+    # Precedence is documented as "inbackend_kwargs overrides": with a tight
+    # explicit pair AND a loose dict, the loose one must win. This is the
+    # discriminating assertion -- if precedence were reversed the result would
+    # equal `tight` instead.
+    override = final_state(
+        rtol=1e-12, atol=1e-12, inbackend_kwargs={"rtol": 1e-5, "atol": 1e-5}
+    )
+    numpy.testing.assert_allclose(override, loose, rtol=1e-12, atol=1e-12)
+    assert numpy.max(numpy.fabs(override - tight)) == pytest.approx(d_loose, rel=1e-9)
+
+    # The dict must be REUSABLE: callers that store it and pass it on every call
+    # (actionAngleIsochroneApprox keeps self._integrate_kwargs) would otherwise get
+    # the tolerance honoured once and silently dropped afterwards. This is why the
+    # implementation pops from a COPY; popping from the caller's dict passes every
+    # assertion above and still breaks here on the second integration.
+    shared = {"rtol": 1e-5, "atol": 1e-5}
+    first = final_state(inbackend_kwargs=shared)
+    second = final_state(inbackend_kwargs=shared)
+    assert shared == {"rtol": 1e-5, "atol": 1e-5}, f"caller dict mutated: {shared}"
+    numpy.testing.assert_allclose(second, first, rtol=1e-12, atol=1e-12)
+    numpy.testing.assert_allclose(second, loose, rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
`Orbit._integrate_inbackend` forwards `rtol`/`atol` explicitly **and** splats
`inbackend_kwargs`, so any caller passing either through the dict hit:

```
TypeError: galpy.backend._reference.inbackend_ode.integrate_orbit()
           got multiple values for keyword argument 'rtol'
```

Scoped honestly: the docstrings only ever promised `max_steps`, `solver` and
(jax) `adjoint`, so this is not a broken documented feature. The real gap is
that **`actionAngleIsochroneApprox` exposes no `rtol`/`atol` parameters at all**
and forwards `integrate_kwargs` verbatim as `inbackend_kwargs` — so there was no
route whatsoever for an AA caller to set the solver tolerance.

Fix: pop `rtol`/`atol` from a **copy** of the dict. The copy is load-bearing —
AA stores the dict (`self._integrate_kwargs`) and passes it on *every* call, so
popping from the caller's dict would honour the tolerance once and silently drop
it afterwards. Both docstrings now list the accepted keys.

### Test is two-sided, not finite-and-nonzero

* the loose tolerance must **change** the trajectory (a silently-dropped `rtol`
  gives a bit-identical result) and must still behave like a tolerance;
* the same value passed both spellings must agree to 1e-12;
* with a tight explicit pair **and** a loose dict, the loose one must win —
  reversed precedence would return the tight result;
* the dict must survive **reuse** across two integrations.

### Verified by A/B, both directions

```
without the fix    TypeError ... multiple values for 'rtol'   FAILED
with the fix       2 passed
without dict()     AssertionError: caller dict mutated: {}
                   (only the reuse assertion catches it — every other
                    assertion in the test still passes)
```

Full-file gate, same worktree, one difference:

```
patched     15 failed, 69 passed
unpatched   15 failed, 68 passed, 1 deselected
IDENTICAL failing sets
```

The 15 are pre-existing in that worktree: it has no built C extension, so
`_c_reference`'s `dop853_c` falls back to a Python integrator and the `rtol=1e-6`
comparisons fail. None of them is caused by this change.

**Ledger delta: none.** numpy path untouched (`_integrate_inbackend` is the
backend-only path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm