### PR TITLE
ledger: un-xfail jax-jit test_pickling_potential_unitful_dens (-1 xfail)

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -253,9 +253,13 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetric
 # node to numpy, so the density is inherently non-differentiable -- and anchors
 # the result back (see its docstring). That routes through as_numpy(), i.e.
 # numpy.asarray(), which a tracer cannot satisfy. Eager jax/torch are fine: a
-# concrete array converts. Un-ledger only if units handling ever becomes
-# backend-native; there is nothing to fix in the test.
-jax-jit tests/test_potential.py::test_pickling_potential_unitful_dens
+# concrete array converts.
+#
+# `test_pickling_potential_unitful_dens` was ALSO ledgered here on that
+# reasoning and is now MEASURED PASSING traced -- the 2026-08-18
+# workflow_dispatch(jit=true, regen=true) run (32141815273) does not list it.
+# So the blanket "there is nothing to fix" claim held for the wrapper case only;
+# only `drops_units_wrapper` still hits the untraceable as_numpy() boundary.
 jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
 
 # jax-jit: actionAngleStaeckelGrid, MEASURED 2026-08-07 on the first traced run of


### PR DESCRIPTION
**Measured, not inferred.** The 2026-08-18 `workflow_dispatch(jit=true, regen=true)`
run ([32141815273](https://github.com/jobovy/galpy/actions/runs/32141815273), 45/45
green) regenerates the traced ledger as an artifact instead of xfailing. Its
`backend-xfail-new-*` artifacts do **not** list this test — it now passes traced.

This contradicts the comment the entry sat under, which asserted that a units-based
density *"is NOT TRACEABLE ... by construction rather than a defect ... there is
nothing to fix in the test"*. That holds for its sibling but not for this one: only
`drops_units_wrapper` still hits the untraceable `as_numpy()` boundary. The comment
is corrected here rather than left to mislead.

**Ledger delta: −1 xfail** (14 → 13 real entries).

### How to check this, and how not to

The traced suite is only reachable via `workflow_dispatch(jit=true)`, so **this PR's
own CI does not exercise the entry** — a green run here is not evidence either way.
The regen artifact is the measurement. Flagging that explicitly so the evidence
isn't mistaken for "CI went green".

Same regen run also surfaced 4 traced failures that are in *no* list
(`energy_conservation_linear[AnyAxisym]`, `energy_jacobi_conservation[AnyAxisym]`,
`anyaxisymmetricrazorthindisk_second_derivs_at_z0`, `vcirc_vesc_special`, all
torch-jit, all pre-existing on develop). Those are tracked separately — not folded
into this one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm