### PR TITLE
Unit support for actionAngleVerticalInverse

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,11 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
+- ``actionAngleVerticalInverse`` now supports physical units: it accepts
+  ``ro`` and ``vo``, parses the energies of its tori and the actions and
+  angles at which it is evaluated when these are given as Quantities, and
+  returns its outputs in physical units.
+
 - Added an exact, ODE-based point transformation to
   ``actionAngleVerticalInverse`` (``use_pointtransform="exact"``): instead of
   fitting a polynomial approximation, solve the ordinary differential equation

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -18,12 +18,29 @@ from scipy import integrate, interpolate, ndimage, optimize
 
 from ..potential import evaluatelinearForces, evaluatelinearPotentials
 from ..potential.Potential import _check_potential_list_and_deprecate
-from ..util import galpyWarning
+from ..util import conversion, galpyWarning
+
+if conversion._APY_LOADED:
+    from astropy import units
 from ..util import plot as plot
 from .actionAngleHarmonic import actionAngleHarmonic
 from .actionAngleHarmonicInverse import actionAngleHarmonicInverse
 from .actionAngleInverse import actionAngleInverse
 from .actionAngleVertical import actionAngleVertical
+
+
+def _parse_energies(Es, vo):
+    """Convert the energies of the tori to internal units; Es can be a
+    number, a sequence or array of numbers, a Quantity, or a sequence of
+    Quantities (the natural way to give a single torus is Es=[E])"""
+    if (
+        conversion._APY_LOADED
+        and isinstance(Es, (list, tuple))
+        and len(Es) > 0
+        and isinstance(Es[0], units.Quantity)
+    ):
+        Es = units.Quantity(list(Es))
+    return conversion.parse_energy(numpy.atleast_1d(Es), vo=vo)
 
 
 class actionAngleVerticalInverse(actionAngleInverse):
@@ -44,6 +61,7 @@ class actionAngleVerticalInverse(actionAngleInverse):
         maxiter=100,
         angle_tol=1e-12,
         bisect=False,
+        **kwargs,
     ):
         """
         Initialize an actionAngleVerticalInverse object
@@ -81,24 +99,33 @@ class actionAngleVerticalInverse(actionAngleInverse):
         -----
         - 2018-04-11 - Started - Bovy (UofT)
         """
-        # actionAngleInverse.__init__(self,*args,**kwargs)
+        actionAngleInverse.__init__(self, **kwargs)
         if pot is None:  # pragma: no cover
             raise OSError("Must specify pot= for actionAngleVerticalInverse")
         self._pot = _check_potential_list_and_deprecate(pot)
         self._aAV = actionAngleVertical(pot=self._pot)
         # Compute action, frequency, and xmax for each energy
-        self._nE = len(Es)
+        self._Es = numpy.sort(_parse_energies(Es, self._vo))
+        self._nE = len(self._Es)
         js = numpy.empty(self._nE)
         Omegas = numpy.empty(self._nE)
         xmaxs = numpy.empty(self._nE)
-        self._Es = numpy.sort(numpy.array(Es))
-        for ii, E in enumerate(Es):
-            if (E - evaluatelinearPotentials(self._pot, 0.0)) < 1e-14:
+        for ii, E in enumerate(self._Es):
+            if (
+                E - evaluatelinearPotentials(self._pot, 0.0, use_physical=False)
+            ) < 1e-14:
                 # J=0, should be using vertical freq. from 2nd deriv.
                 tJ, tO = self._aAV.actionsFreqs(
                     0.0,
                     numpy.sqrt(
-                        2.0 * (E + 1e-5 - evaluatelinearPotentials(self._pot, 0.0))
+                        2.0
+                        * (
+                            E
+                            + 1e-5
+                            - evaluatelinearPotentials(
+                                self._pot, 0.0, use_physical=False
+                            )
+                        )
                     ),
                 )
                 js[ii] = 0.0
@@ -106,13 +133,20 @@ class actionAngleVerticalInverse(actionAngleInverse):
                 xmaxs[ii] = 0.0
                 continue
             tJ, tO = self._aAV.actionsFreqs(
-                0.0, numpy.sqrt(2.0 * (E - evaluatelinearPotentials(self._pot, 0.0)))
+                0.0,
+                numpy.sqrt(
+                    2.0
+                    * (E - evaluatelinearPotentials(self._pot, 0.0, use_physical=False))
+                ),
             )
             js[ii] = tJ[0]
             Omegas[ii] = tO[0]
             xmaxs[ii] = self._aAV.calcxmax(
                 0.0,
-                numpy.sqrt(2.0 * (E - evaluatelinearPotentials(self._pot, 0.0))),
+                numpy.sqrt(
+                    2.0
+                    * (E - evaluatelinearPotentials(self._pot, 0.0, use_physical=False))
+                ),
                 E=E,
             )
         self._js = js
@@ -261,6 +295,8 @@ class actionAngleVerticalInverse(actionAngleInverse):
                     ),
                     galpyWarning,
                 )
+        # Check the units
+        self._check_consistent_units()
         # Setup interpolation if requested
         if setup_interp:
             self._interp = True
@@ -302,7 +338,8 @@ class actionAngleVerticalInverse(actionAngleInverse):
                 xmesh = pt(xamesh) * self._xmaxs[ii]
                 # Compute v from (E,xmesh)
                 v2mesh = 2.0 * (
-                    self._Es[ii] - evaluatelinearPotentials(self._pot, xmesh)
+                    self._Es[ii]
+                    - evaluatelinearPotentials(self._pot, xmesh, use_physical=False)
                 )
                 v2mesh[v2mesh < 0.0] = 0.0
                 vmesh = numpy.sqrt(v2mesh)
@@ -392,11 +429,14 @@ class actionAngleVerticalInverse(actionAngleInverse):
             # equation dchi/dthetaa = sqrt(Q)/(omega xmax), with
             # Q = v^2/(1-y^2), is regular over the whole quarter period,
             # including at the turning point, where Q -> -F(xmax) xmax
-            Qmax = -evaluatelinearForces(self._pot, xmaxs) * xmaxs
+            Qmax = -evaluatelinearForces(self._pot, xmaxs, use_physical=False) * xmaxs
 
             def deriv_thetaa(thetaa, chi):
                 y = numpy.sin(chi)
-                v2 = 2.0 * (Es - evaluatelinearPotentials(self._pot, xmaxs * y))
+                v2 = 2.0 * (
+                    Es
+                    - evaluatelinearPotentials(self._pot, xmaxs * y, use_physical=False)
+                )
                 v2[v2 < 0.0] = 0.0
                 omy2 = 1.0 - y**2.0
                 Q = numpy.empty(ng)
@@ -983,7 +1023,9 @@ class actionAngleVerticalInverse(actionAngleInverse):
         )
         # Then plot energy
         pyplot.subplot(1, 2, 2)
-        Eorbit = (v**2.0 / 2.0 + evaluatelinearPotentials(self._pot, x)) / E - 1.0
+        Eorbit = (
+            v**2.0 / 2.0 + evaluatelinearPotentials(self._pot, x, use_physical=False)
+        ) / E - 1.0
         ymin, ymax = numpy.amin(Eorbit), numpy.amax(Eorbit)
         plot.plot(
             ta,
@@ -1206,9 +1248,13 @@ class actionAngleVerticalInverse(actionAngleInverse):
         pyplot.subplot(2, 3, 3)
         ta = numpy.linspace(0.0, 2.0 * numpy.pi, 1001)
         x, v = truthaAV(truthaAV._js, ta)
-        Edirect = v**2.0 / 2.0 + evaluatelinearPotentials(self._pot, x)
+        Edirect = v**2.0 / 2.0 + evaluatelinearPotentials(
+            self._pot, x, use_physical=False
+        )
         x, v = self(self.J(E), ta)
-        Einterp = v**2.0 / 2.0 + evaluatelinearPotentials(self._pot, x)
+        Einterp = v**2.0 / 2.0 + evaluatelinearPotentials(
+            self._pot, x, use_physical=False
+        )
         ymin, ymax = numpy.amin([Edirect, Einterp]), numpy.amax([Edirect, Einterp])
 
         plot.plot(
@@ -1613,7 +1659,7 @@ def _anglea(
         )
     else:
         x = xmax * polynomial.polyval((xa / ptxmax).T, ptcoeffs.T, tensor=False).T
-    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x))
+    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x, use_physical=False))
     v2[v2 < 0] = 0.0
     v2[numpy.fabs(xa) == ptxmax] = 0.0  # just in case the pt mapping has small issues
     if pt_exact:
@@ -1730,7 +1776,7 @@ def _danglea(
             / ptxmax**2.0
             * polynomial.polyval((xa / ptxmax).T, ptderiv2coeffs.T, tensor=False).T
         )
-    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x))
+    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x, use_physical=False))
     v2[v2 < 1e-15] = 1e-15
     anglea = numpy.arctan2(omega * xa * piprime, vsign * numpy.sqrt(v2))
     return (
@@ -1739,7 +1785,7 @@ def _danglea(
         * v2**-1.5
         * (
             v2 * (piprime + xa * piprime2)
-            - xa * evaluatelinearForces(pot, x) * piprime**2.0
+            - xa * evaluatelinearForces(pot, x, use_physical=False) * piprime**2.0
         )
     )
 
@@ -1807,7 +1853,7 @@ def _ja(
             / ptxmax
             * polynomial.polyval((xa / ptxmax).T, ptderivcoeffs.T, tensor=False).T
         )
-    v2over2 = E - evaluatelinearPotentials(pot, x)
+    v2over2 = E - evaluatelinearPotentials(pot, x, use_physical=False)
     v2over2[v2over2 < 0.0] = 0.0
     out = numpy.empty_like(xa)
     gIndx = True ^ ((xmax == 0.0) * (ptxmax == xmax + 1e-10))
@@ -1895,7 +1941,7 @@ def _djadj(
             / ptxmax**2.0
             * polynomial.polyval((xa / ptxmax).T, ptderiv2coeffs.T, tensor=False).T
         )
-    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x))
+    v2 = 2.0 * (E - evaluatelinearPotentials(pot, x, use_physical=False))
     # J=0 special case:
     zindx = (xmax == 0.0) * (ptxmax == xmax + 1e-10)
     if numpy.any(zindx):
@@ -1922,14 +1968,16 @@ def _djadj(
         * piprime[gIndx] ** 2.0
         / (
             v2[gIndx] * (1.0 + piprime2[gIndx] / piprime[gIndx] * xa[gIndx])
-            - xa[gIndx] * evaluatelinearForces(pot, x[gIndx]) * piprime[gIndx]
+            - xa[gIndx]
+            * evaluatelinearForces(pot, x[gIndx], use_physical=False)
+            * piprime[gIndx]
         )
     )
     dxAdE[(xmax == 0.0) * (ptxmax == xmax + 1e-10)] = 1.0
     return (
         1.0
         + (
-            evaluatelinearForces(pot, x) / piprime
+            evaluatelinearForces(pot, x, use_physical=False) / piprime
             + omega**2.0 * xa
             - piprime**-3.0 * piprime2 * v2
         )

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -13073,6 +13073,64 @@ def test_actionAngle_method_turnphysicaloff():
     return None
 
 
+def test_actionAngleVerticalInverse_units():
+    # Unit support of actionAngleVerticalInverse: Quantity energies for the
+    # tori of the instance, Quantity actions and angles for its evaluation,
+    # and physical outputs
+    import warnings
+
+    from galpy.actionAngle import actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+    from galpy.util import conversion
+
+    ro, vo = 9.0, 230.0
+    E = 0.5
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        aAVI = actionAngleVerticalInverse(
+            pot=IsothermalDiskPotential(amp=1.0, sigma=0.5, ro=ro, vo=vo),
+            Es=[E * (vo * units.km / units.s) ** 2.0],
+            nta=128,
+            ro=ro,
+            vo=vo,
+        )
+        aAVI_int = actionAngleVerticalInverse(
+            pot=IsothermalDiskPotential(amp=1.0, sigma=0.5), Es=[E], nta=128
+        )
+    assert numpy.fabs(aAVI._Es[0] - E) < 1e-10, (
+        "actionAngleVerticalInverse does not parse an energy given as a Quantity"
+    )
+    assert numpy.fabs(aAVI._js[0] - aAVI_int._js[0]) < 1e-10, (
+        "actionAngleVerticalInverse with a potential with ro and vo set does not give the same torus as one in internal units"
+    )
+
+    def _value(x, unit):
+        x = numpy.atleast_1d(x)[0]
+        return x.to(unit).value if isinstance(x, units.Quantity) else x
+
+    J = aAVI_int._js[0]
+    Jq = ro * vo * units.kpc * units.km / units.s
+    out = aAVI(J * Jq, 1.1 * units.rad)
+    out_int = aAVI_int(J, 1.1)
+    for ii, (fac, unit) in enumerate([(ro, units.kpc), (vo, units.km / units.s)]):
+        assert (
+            numpy.fabs(_value(out[ii], unit) / fac - numpy.atleast_1d(out_int[ii])[0])
+            < 1e-10
+        ), (
+            "actionAngleVerticalInverse method __call__ does not return the physical version of the internal-unit coordinates"
+        )
+    assert (
+        numpy.fabs(
+            _value(aAVI.Freqs(J * Jq), 1.0 / units.Gyr) / conversion.freq_in_Gyr(vo, ro)
+            - numpy.atleast_1d(aAVI_int.Freqs(J))[0]
+        )
+        < 1e-10
+    ), (
+        "actionAngleVerticalInverse method Freqs does not return the physical version of the internal-unit frequency"
+    )
+    return None
+
+
 def test_actionAngleHarmonic_setup_omega_units():
     from galpy.actionAngle import actionAngleHarmonic
     from galpy.util import conversion


### PR DESCRIPTION
`actionAngleVerticalInverse` never called `actionAngleInverse.__init__` (the call was commented out), so it rejected `ro=`/`vo=` with a `TypeError`, never set `_roSet`/`_voSet` — which the base class's decorators need to convert the outputs of `__call__`, `xvFreqs`, and `Freqs` — and parsed none of its inputs.

This calls the parent constructor, checks units against the potential, parses the energies of the tori (including a sequence of Quantities, since `Es=[E]` is the natural way to give a single torus), and evaluates the potential in internal units throughout the setup — without which a potential constructed with `ro`/`vo` returns Quantities into the internal computations and the setup fails. Actions, angles, and outputs are then handled by the base class's decorators. Tests in `test_quantity.py` check that Quantity inputs give the same torus as internal units and that outputs come back scaled by ro, vo, and 1/Gyr.

Companion to #1339, which does the same for `actionAngleSphericalInverse` on the spherical development branch; the small energy-parsing helper is duplicated between the two for now and should be unified in `actionAngleInverse` once that branch is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ