### PR TITLE
in-backend ODE: nsteps (constant stepping) makes the batched reverse pass exact

### DIFF
--- a/galpy/backend/_jax/orbit_ode.py
+++ b/galpy/backend/_jax/orbit_ode.py
@@ -46,7 +46,9 @@ def _resolve_adjoint(diffrax, adjoint):
     )
 
 
-def integrate(pot, y0, ts, *, dim, rtol, atol, max_steps, solver=None, adjoint=None):
+def integrate(
+    pot, y0, ts, *, dim, rtol, atol, max_steps, solver=None, adjoint=None, nsteps=None
+):
     """Integrate the EOM with diffrax (Dopri8, adaptive). y0/ys in rectangular
     EOM variables [x, vx, y, vy, z, vz], shape (dim,) for one orbit or (N, dim) for
     a batch.
@@ -89,10 +91,14 @@ def integrate(pot, y0, ts, *, dim, rtol, atol, max_steps, solver=None, adjoint=N
             _solver,
             t0=tsi[0],
             t1=tsi[-1],
-            dt0=None,
+            dt0=None if nsteps is None else (tsi[-1] - tsi[0]) / nsteps,
             y0=y0i,
             saveat=diffrax.SaveAt(ts=tsi),
-            stepsize_controller=diffrax.PIDController(rtol=rtol, atol=atol),
+            stepsize_controller=(
+                diffrax.PIDController(rtol=rtol, atol=atol)
+                if nsteps is None
+                else diffrax.ConstantStepSize()
+            ),
             max_steps=max_steps,
             **_extra,
         ).ys

--- a/galpy/backend/_reference/inbackend_ode.py
+++ b/galpy/backend/_reference/inbackend_ode.py
@@ -146,7 +146,16 @@ def _from_eom(xp, ys, phasedim):
 
 
 def integrate_orbit(
-    pot, vxvv, ts, *, rtol=1e-12, atol=1e-12, max_steps=None, solver=None, adjoint=None
+    pot,
+    vxvv,
+    ts,
+    *,
+    rtol=1e-12,
+    atol=1e-12,
+    max_steps=None,
+    solver=None,
+    adjoint=None,
+    nsteps=None,
 ):
     """Differentiably integrate an orbit with the backend's ODE solver.
 
@@ -175,6 +184,9 @@ def integrate_orbit(
     adjoint : jax/diffrax adjoint (None -> RecursiveCheckpointAdjoint, reverse-mode
         FIRST order; 'direct' for SECOND derivatives -- jax.hessian / nested jacrev).
         Ignored on torch (torchdiffeq's plain odeint already double-backprops).
+    nsteps : constant-step count (jax only; None -> adaptive stepping). Needed when
+        the solve is differentiated under ``jax.vmap`` -- see the jax integrator's
+        docstring for why adaptive steps break the batched reverse pass.
 
     Returns
     -------
@@ -211,8 +223,14 @@ def integrate_orbit(
             max_steps=max_steps,
             solver=solver,
             adjoint=adjoint,
+            nsteps=nsteps,
         )
     elif "torch" in name:
+        if nsteps is not None:
+            raise NotImplementedError(
+                "nsteps (constant stepping) is a jax/diffrax option; torchdiffeq "
+                "selects its own steps"
+            )
         from .._torch.orbit_ode import integrate as _integrate_torch
 
         ys = _integrate_torch(

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -4873,8 +4873,10 @@ def _vmap_track_chunks(xp, single, xv0_all, thetasTrack):
     Passing ``nsteps`` (constant stepping) to the in-backend ODE removes the
     step-size dependence and makes the batched Jacobian exact to ~1e-11, so a
     vmap'd chunk loop becomes viable; see
-    ``test_inbackend_nsteps_makes_the_batched_reverse_pass_exact_jax``. torch: a Python stack of per-chunk calls (torch.func.vmap
-    cannot trace the torchdiffeq custom-autograd orbit). 6-tuple of stacked arrays.
+    ``test_inbackend_nsteps_makes_the_batched_reverse_pass_exact_jax``.
+
+    torch: a Python stack of per-chunk calls (torch.func.vmap cannot trace the
+    torchdiffeq custom-autograd orbit). Returns a 6-tuple of stacked arrays.
     """
     if name_of_namespace(xp) == "jax":
         import jax

--- a/galpy/df/streamdf.py
+++ b/galpy/df/streamdf.py
@@ -4855,14 +4855,25 @@ def _vmap_track_chunks(xp, single, xv0_all, thetasTrack):
     """Map the per-chunk backend track assembly over ``(xv0_all, thetasTrack)``.
 
     jax: ``jax.lax.map`` -- fork-free (no ``parallel_map``), jit-compatible, no
-    item-assignment, and CORRECTLY differentiable. NOT ``jax.vmap``: ``single``
-    calls ``calcaAJac`` = ``jax.jacrev`` of the AA map (over a diffrax/C-STM
-    integration with no vmap batching rule), and ``jax.vmap`` batches that inner
-    jacrev in a way that silently DROPS the outer d/d(parameter) gradient (the
-    forward value is correct, but jax.grad through the track leaks ~20%). lax.map
-    runs the chunks sequentially in the compiled graph, so the jacrev is never
-    batched and the gradient is exact (matches a finite-difference of the same
-    track to ~1e-4). torch: a Python stack of per-chunk calls (torch.func.vmap
+    item-assignment, and CORRECTLY differentiable. NOT ``jax.vmap``, but the
+    reason is NOT that jacrev cannot be batched -- it can (root-caused
+    2026-08-19; the earlier note here blamed jacrev batching and was wrong).
+
+    ``single`` calls ``calcaAJac`` = ``jax.jacrev`` of the AA map over a diffrax
+    integration, and the track's outer d/d(parameter) then differentiates THAT,
+    so the solve runs under diffrax's ``DirectAdjoint``, which differentiates the
+    solver's own operations. The default step-size controller is ADAPTIVE, so
+    under ``jax.vmap`` the batch elements choose different step sequences and the
+    batched reverse pass is wrong by 2-13% (growing with integration time) while
+    the forward value stays right to 1e-10 -- which is exactly why this looked
+    like a silent gradient drop. ``lax.map`` runs the chunks sequentially, so the
+    steps are never batched and the gradient is exact (matches a finite
+    difference of the same track to ~1e-4; measured 0.09% end-to-end).
+
+    Passing ``nsteps`` (constant stepping) to the in-backend ODE removes the
+    step-size dependence and makes the batched Jacobian exact to ~1e-11, so a
+    vmap'd chunk loop becomes viable; see
+    ``test_inbackend_nsteps_makes_the_batched_reverse_pass_exact_jax``. torch: a Python stack of per-chunk calls (torch.func.vmap
     cannot trace the torchdiffeq custom-autograd orbit). 6-tuple of stacked arrays.
     """
     if name_of_namespace(xp) == "jax":

--- a/tests/test_backend_inbackend_ode.py
+++ b/tests/test_backend_inbackend_ode.py
@@ -714,3 +714,21 @@ def test_inbackend_nsteps_makes_the_batched_reverse_pass_exact_jax():
         f"constant-step trajectory differs from adaptive: "
         f"max rel {numpy.max(numpy.fabs(ad - cs)) / numpy.max(numpy.fabs(ad)):.3e}"
     )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch/torchdiffeq not installed")
+def test_inbackend_nsteps_is_rejected_on_torch():
+    """``nsteps`` is a jax/diffrax option; torchdiffeq picks its own steps.
+
+    Passing it on torch must fail loudly rather than being silently ignored --
+    a silently-dropped nsteps would hand back an adaptively-stepped solve while
+    the caller believes the steps are fixed, which is exactly the confusion this
+    option exists to remove.
+    """
+    import torch
+
+    pot = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    vxvv = torch.tensor([1.0, 0.1, 1.1, 0.1, 0.2, 0.0], dtype=torch.float64)
+    ts = torch.linspace(0.0, 1.0, 5, dtype=torch.float64)
+    with pytest.raises(NotImplementedError, match="jax/diffrax option"):
+        integrate_orbit(pot, vxvv, ts, nsteps=100)

--- a/tests/test_backend_inbackend_ode.py
+++ b/tests/test_backend_inbackend_ode.py
@@ -648,3 +648,69 @@ def test_orbit_integrate_inbackend_kwargs_tolerance_jax():
     assert shared == {"rtol": 1e-5, "atol": 1e-5}, f"caller dict mutated: {shared}"
     numpy.testing.assert_allclose(second, first, rtol=1e-12, atol=1e-12)
     numpy.testing.assert_allclose(second, loose, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.skipif(not HAVE_JAX, reason="jax/diffrax not installed")
+def test_inbackend_nsteps_makes_the_batched_reverse_pass_exact_jax():
+    """``nsteps`` (constant stepping) fixes reverse-mode AD under ``jax.vmap``.
+
+    diffrax's ``DirectAdjoint`` -- the one needed for second-order AD, e.g. an
+    outer d/d(parameter) through an inner ``jacrev``, as the stream track does --
+    differentiates the solver's OWN operations. With the default adaptive
+    controller, ``jax.vmap`` batch elements choose different step sequences, so
+    the batched reverse pass disagrees with the unbatched one (measured here at
+    1e-3, and 2-13% through a full action-angle map, growing with integration
+    time) even though the FORWARD values agree to ~1e-10. That asymmetry is what
+    made it look like a jacrev-batching bug for a long time; it is not, and
+    plain ``vmap(jacrev)`` is exact in JAX.
+
+    Constant steps remove the step-size dependence entirely. Asserted two ways:
+    the batched Jacobian must match the unbatched one to near machine precision,
+    AND the constant-step trajectory must still agree with the adaptive one, so
+    the fix cannot be "pass by integrating badly".
+    """
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    from galpy.potential import LogarithmicHaloPotential
+
+    # an ARRAY-valued parameter is the differentiable configuration
+    lp = LogarithmicHaloPotential(normalize=1.0, q=jnp.asarray(0.9))
+    ts = jnp.linspace(0.0, 8.0, 60)
+    V = jnp.asarray(
+        [
+            [1.561, 0.351, -1.155, 0.887, -0.477, 0.120],
+            [1.500, 0.300, -1.100, 0.850, -0.450, 0.200],
+        ]
+    )
+
+    def _final(v, **extra):
+        return integrate_orbit(
+            lp,
+            v,
+            ts,
+            rtol=1e-10,
+            atol=1e-10,
+            max_steps=20000,
+            adjoint="direct",
+            **extra,
+        )[-1]
+
+    J = jax.jacrev(lambda v: _final(v, nsteps=2000))
+    seq = numpy.stack([numpy.asarray(J(V[i]), dtype=float) for i in range(V.shape[0])])
+    vm = numpy.asarray(jax.vmap(J)(V), dtype=float)
+    scale = numpy.max(numpy.fabs(seq))
+    assert numpy.all(numpy.fabs(seq - vm) < 1e-11 * scale), (
+        "constant-step batched Jacobian != unbatched: "
+        f"max rel {numpy.max(numpy.fabs(seq - vm)) / scale:.3e}"
+    )
+
+    # ... and the constant-step solve is still the right trajectory
+    ad = numpy.asarray(_final(V[0]), dtype=float)
+    cs = numpy.asarray(_final(V[0], nsteps=2000), dtype=float)
+    assert numpy.all(numpy.fabs(ad - cs) < 1e-8 * numpy.max(numpy.fabs(ad))), (
+        f"constant-step trajectory differs from adaptive: "
+        f"max rel {numpy.max(numpy.fabs(ad - cs)) / numpy.max(numpy.fabs(ad)):.3e}"
+    )

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -858,21 +858,10 @@ def _track_loss_fn(sdf, prog_vxvv, tintJ, W):
     # `direct` flag selecting the AA adjoint -- 'direct' (twice-diff, for jax.grad)
     # or the default recursive (smooth adaptive forward, for the finite difference).
     def _aA(lp, direct):
-        # nsteps (constant stepping) in BOTH arms. With the default adaptive
-        # controller the AD arm's DirectAdjoint differentiates the solver's own
-        # step-size decisions, so the gradient carries a spurious dependence on
-        # the step sequence -- which is environment-dependent. Measured on
-        # py3.14/jax 0.11.1, where this test fails: adaptive gives
-        # |AD-FD|/|AD| = 0.4191% against a 0.3% bar, constant steps give
-        # 0.0513%. (On py3.13/jax 0.10.1 both pass with an order of magnitude to
-        # spare, which is why this went unnoticed.) Verified NOT caused by any
-        # PR: the develop tree and the AnySpherical branch fail with bit-identical
-        # numbers (R0 AD=3.542997e-01, |AD-FD|=1.48e-03). Constant steps also
-        # make the two arms differ only in the adjoint, as a clean A/B should.
         ikw = (
-            {"adjoint": "direct", "max_steps": 20000, "nsteps": 3000}
+            {"adjoint": "direct", "max_steps": 20000}
             if direct
-            else {"max_steps": 200000, "nsteps": 3000}
+            else {"max_steps": 200000}
         )
         return actionAngleIsochroneApprox(
             pot=lp, b=0.8, tintJ=tintJ, integrate_method="diffrax", integrate_kwargs=ikw

--- a/tests/test_backend_streamdf.py
+++ b/tests/test_backend_streamdf.py
@@ -858,10 +858,21 @@ def _track_loss_fn(sdf, prog_vxvv, tintJ, W):
     # `direct` flag selecting the AA adjoint -- 'direct' (twice-diff, for jax.grad)
     # or the default recursive (smooth adaptive forward, for the finite difference).
     def _aA(lp, direct):
+        # nsteps (constant stepping) in BOTH arms. With the default adaptive
+        # controller the AD arm's DirectAdjoint differentiates the solver's own
+        # step-size decisions, so the gradient carries a spurious dependence on
+        # the step sequence -- which is environment-dependent. Measured on
+        # py3.14/jax 0.11.1, where this test fails: adaptive gives
+        # |AD-FD|/|AD| = 0.4191% against a 0.3% bar, constant steps give
+        # 0.0513%. (On py3.13/jax 0.10.1 both pass with an order of magnitude to
+        # spare, which is why this went unnoticed.) Verified NOT caused by any
+        # PR: the develop tree and the AnySpherical branch fail with bit-identical
+        # numbers (R0 AD=3.542997e-01, |AD-FD|=1.48e-03). Constant steps also
+        # make the two arms differ only in the adjoint, as a clean A/B should.
         ikw = (
-            {"adjoint": "direct", "max_steps": 20000}
+            {"adjoint": "direct", "max_steps": 20000, "nsteps": 3000}
             if direct
-            else {"max_steps": 200000}
+            else {"max_steps": 200000, "nsteps": 3000}
         )
         return actionAngleIsochroneApprox(
             pot=lp, b=0.8, tintJ=tintJ, integrate_method="diffrax", integrate_kwargs=ikw


### PR DESCRIPTION
in-backend ODE: nsteps (constant stepping) makes the batched reverse pass exact

Root-cause of the long-standing streamdf "vmap corrupts the gradient" defect,
which the code and my own notes had recorded as jax.vmap batching the inner
jacrev and silently dropping the outer d/d(parameter) term. That explanation is
wrong, and it sent several investigations down the wrong path.

Measured 2026-08-19:

    pure JAX vmap(jacrev) under an outer grad        1e-10    fine
    galpy AA map, q = python float                   4.5e-7   fine
    galpy AA map, q = jnp.asarray(0.9)  ADAPTIVE     1.9e-2 .. 1.3e-1  WRONG
    galpy AA map, q = jnp.asarray(0.9)  CONSTANT     3e-7 .. 8e-7      fine

jacrev batches fine. The real cause is the ODE solver: integrate() uses dt0=None
with a PIDController, i.e. ADAPTIVE steps. The second-order path the stream track
needs (an outer d/dq through an inner jacrev) requires diffrax's DirectAdjoint,
which differentiates the solver's OWN operations -- so under jax.vmap, where the
batch elements choose different step sequences, the batched reverse pass is wrong
while the forward stays right to 1e-10. The error grows with integration time
(1.9% -> 7.5% -> 13% across successive track chunks), and the trigger requires an
array-valued potential parameter, which is exactly the AD configuration.

This adds an opt-in `nsteps`: a constant step of (t1-t0)/nsteps. That removes the
step-size dependence, and the batched Jacobian matches the unbatched one to
~1e-14 on a plain orbit and ~7e-7 through a full action-angle map. Adaptive
stepping stays the default (more accurate per unit work, and fine unbatched).

Not a correctness fix for shipped code: streamdf's _vmap_track_chunks uses
lax.map, which never batches the steps, so galpy's stream-track gradients are and
were correct -- re-verified end to end at 0.09% against a finite difference of
the same track. What this unlocks is batching that loop, which lax.map costs us
today. The misleading docstring is corrected in the same commit.

The test asserts BOTH directions: the batched Jacobian must match the unbatched
one to 1e-11, and the constant-step trajectory must still match the adaptive one
to 1e-8 -- so the fix cannot pass by integrating badly.

Verified: tests/test_backend_inbackend_ode.py 85 passed locally (the C extension
must be built in the worktree; without it 15 of these fail for unrelated reasons).

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
