### PR TITLE
Fix per-call ro= override ignored in sphericaldf input parsing

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -30,6 +30,16 @@ v1.12.1 (expected around 2026-11-01)
   the particle sum is accumulated in batches so building from a very large number
   of particles stays memory-bounded.
 
+- Fixed ``sphericaldf`` methods (``vmomentdensity``, ``sigmar``, ``sigmat``,
+  ``beta``, ``dMdE``, and ``__call__``) to honour per-call ``ro=``/``vo=``
+  overrides when parsing ``Quantity`` inputs, consistent with potentials and
+  the disk DF classes; previously the per-call scale(s) were ignored and the
+  instance's own ``_ro``/``_vo`` were used. ``beta`` now uses the standard
+  ``@physical_conversion`` decorator (it is dimensionless and can return
+  physical units), and ``dMdE``/``__call__`` return physical units when
+  ``ro``/``vo`` are set. ``__call__`` also fixes a bug where the ``Lz`` input
+  was parsed with ``ro=vo`` instead of ``ro=ro``.
+
 - Added translation between the ``SCFPotential`` and ``MultipoleExpansionPotential``
   representations: ``SCFPotential.from_multipole`` builds an SCF expansion from a
   multipole expansion, and ``MultipoleExpansionPotential.from_scf`` does the

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -30,6 +30,14 @@ v1.12.1 (expected around 2026-11-01)
   the particle sum is accumulated in batches so building from a very large number
   of particles stays memory-bounded.
 
+- Fixed ``diskdf.__call__`` and ``quasiisothermaldf.__call__`` to honour
+  per-call ``ro=``/``vo=`` overrides when parsing ``Quantity`` inputs
+  (``E,L`` for ``diskdf``, ``(jr,lz,jz)`` for ``quasiisothermaldf``),
+  completing the ``sphericaldf`` fix below; previously these inputs were
+  parsed with the instance's own ``_ro``/``_vo`` even when per-call scales
+  were given. Both ``__call__`` methods now return physical units when
+  ``ro``/``vo`` are set.
+
 - Fixed ``sphericaldf`` methods (``vmomentdensity``, ``sigmar``, ``sigmat``,
   ``beta``, ``dMdE``, and ``__call__``) to honour per-call ``ro=``/``vo=``
   overrides when parsing ``Quantity`` inputs, consistent with potentials and

--- a/galpy/df/diskdf.py
+++ b/galpy/df/diskdf.py
@@ -20,6 +20,7 @@ import copy
 import os
 import os.path
 import pickle
+import warnings
 
 import numpy
 import scipy
@@ -30,11 +31,15 @@ from scipy import integrate, interpolate, optimize, stats
 from ..actionAngle import actionAngleAdiabatic
 from ..orbit import Orbit
 from ..potential import PowerSphericalPotential
-from ..util import conversion, quadpack, save_pickles
+from ..util import conversion, galpyWarning, quadpack, save_pickles
 from ..util.ars import ars
 from ..util.conversion import (
     _APY_LOADED,
     _APY_UNITS,
+    parse_angmom,
+    parse_energy,
+    parse_length_kpc,
+    parse_velocity_kms,
     physical_conversion,
     potential_physical_input,
     surfdens_in_msolpc2,
@@ -138,7 +143,6 @@ class diskdf(df):
         self._aA = actionAngleAdiabatic(pot=self._psp, gamma=0.0)
         return None
 
-    @physical_conversion("phasespacedensity2d", pop=True)
     def __call__(self, *args, **kwargs):
         """
         Evaluate the distribution function
@@ -152,6 +156,15 @@ class diskdf(df):
                     b) Orbit instance + t: call the Orbit instance (for list, each instance is called at t)
                 2) E,L - energy (/vo^2; or can be Quantity) and angular momentun (/ro/vo; or can be Quantity)
                 3) array vxvv [3/4,nt] [must be in natural units /vo,/ro; use Orbit interface for physical-unit input]
+        ro : float or Quantity, optional
+            Length scale used to convert Quantity inputs and to return
+            physical-unit output.
+        vo : float or Quantity, optional
+            Velocity scale used to convert Quantity inputs and to return
+            physical-unit output.
+        use_physical : bool, optional
+            If True (default), return the DF in physical units
+            (1/phase-space volume) when ro and vo are set.
         marginalizeVperp : bool, optional
             marginalize over perpendicular velocity (only supported with 1a) for single orbits above)
         marginalizeVlos : bool, optional
@@ -169,7 +182,38 @@ class diskdf(df):
         Notes
         -----
         - 2010-07-10 - Written - Bovy (NYU)
+        - 2026-08-20 - Per-call ro=/vo= overrides now also apply to input parsing - Bovy (UofT)
         """
+        # Parse physical-unit overrides
+        use_physical = kwargs.pop("use_physical", True)
+        ro = kwargs.pop("ro", None)
+        if ro is None and hasattr(self, "_roSet") and self._roSet:
+            ro = self._ro
+        ro = conversion.parse_length_kpc(ro)
+        vo = kwargs.pop("vo", None)
+        if vo is None and hasattr(self, "_voSet") and self._voSet:
+            vo = self._vo
+        vo = conversion.parse_velocity_kms(vo)
+
+        def _physical_output(out):
+            # Convert to physical units
+            if use_physical and vo is not None and ro is not None:
+                fac = 1.0 / vo**2.0 / ro**2.0
+                if _APY_UNITS:
+                    u = 1 / (units.km / units.s) ** 2 / units.kpc**2
+                out = out * fac
+                if _APY_UNITS:
+                    return units.Quantity(out, unit=u)
+                else:
+                    return out
+            else:
+                if use_physical and (vo is None or ro is None):
+                    warnings.warn(
+                        "Returning output(s) in internal units even though use_physical=True, because ro and/or vo not set",
+                        galpyWarning,
+                    )
+                return out
+
         if isinstance(args[0], Orbit):
             if len(args[0]) > 1:
                 raise RuntimeError(
@@ -177,31 +221,39 @@ class diskdf(df):
                 )  # pragma: no cover
             if len(args) == 1:
                 if kwargs.pop("marginalizeVperp", False):
-                    return self._call_marginalizevperp(args[0], **kwargs)
+                    return _physical_output(
+                        self._call_marginalizevperp(args[0], **kwargs)
+                    )
                 elif kwargs.pop("marginalizeVlos", False):
-                    return self._call_marginalizevlos(args[0], **kwargs)
+                    return _physical_output(
+                        self._call_marginalizevlos(args[0], **kwargs)
+                    )
                 else:
-                    return numpy.real(
-                        self.eval(
-                            *vRvTRToEL(
-                                args[0].vR(use_physical=False),
-                                args[0].vT(use_physical=False),
-                                args[0].R(use_physical=False),
-                                self._beta,
-                                self._dftype,
+                    return _physical_output(
+                        numpy.real(
+                            self.eval(
+                                *vRvTRToEL(
+                                    args[0].vR(use_physical=False),
+                                    args[0].vT(use_physical=False),
+                                    args[0].R(use_physical=False),
+                                    self._beta,
+                                    self._dftype,
+                                )
                             )
                         )
                     )
             else:
                 no = args[0](args[1])
-                return numpy.real(
-                    self.eval(
-                        *vRvTRToEL(
-                            no.vR(use_physical=False),
-                            no.vT(use_physical=False),
-                            no.R(use_physical=False),
-                            self._beta,
-                            self._dftype,
+                return _physical_output(
+                    numpy.real(
+                        self.eval(
+                            *vRvTRToEL(
+                                no.vR(use_physical=False),
+                                no.vT(use_physical=False),
+                                no.R(use_physical=False),
+                                self._beta,
+                                self._dftype,
+                            )
                         )
                     )
                 )
@@ -214,8 +266,8 @@ class diskdf(df):
             vR = numpy.array([o.vR(use_physical=False) for o in args[0]])
             vT = numpy.array([o.vT(use_physical=False) for o in args[0]])
             R = numpy.array([o.R(use_physical=False) for o in args[0]])
-            return numpy.real(
-                self.eval(*vRvTRToEL(vR, vT, R, self._beta, self._dftype))
+            return _physical_output(
+                numpy.real(self.eval(*vRvTRToEL(vR, vT, R, self._beta, self._dftype)))
             )
         elif isinstance(args[0], numpy.ndarray) and not (
             hasattr(args[0], "isscalar") and args[0].isscalar
@@ -224,11 +276,18 @@ class diskdf(df):
             vR = args[0][1]
             vT = args[0][2]
             R = args[0][0]
-            return numpy.real(
-                self.eval(*vRvTRToEL(vR, vT, R, self._beta, self._dftype))
+            return _physical_output(
+                numpy.real(self.eval(*vRvTRToEL(vR, vT, R, self._beta, self._dftype)))
             )
         else:
-            return numpy.real(self.eval(*args))
+            # Parse E, L with the per-call ro/vo when they are Quantities
+            E = conversion.parse_energy(args[0], vo=vo)
+            L = (
+                conversion.parse_angmom(args[1], ro=ro, vo=vo)
+                if len(args) > 1
+                else None
+            )
+            return _physical_output(numpy.real(self.eval(E, L, *args[2:])))
 
     def _call_marginalizevperp(self, o, **kwargs):
         """Call the DF, marginalizing over perpendicular velocity"""

--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -161,7 +161,6 @@ class quasiisothermaldf(df):
         )
         return None
 
-    @physical_conversion("phasespacedensity", pop=True)
     def __call__(self, *args, **kwargs):
         """
         Evaluate the DF
@@ -179,6 +178,15 @@ class quasiisothermaldf(df):
                 c) Orbit instance: initial condition used if that's it, orbit(t) if there is a time given as well
         log: bool, optional
             If True, return the natural log.
+        ro : float or Quantity, optional
+            Length scale used to convert Quantity inputs and to return
+            physical-unit output.
+        vo : float or Quantity, optional
+            Velocity scale used to convert Quantity inputs and to return
+            physical-unit output.
+        use_physical : bool, optional
+            If True (default), return the DF in physical units
+            (1/phase-space volume) when ro and vo are set.
         func: function of (jr,lz,jz), optional
             Function of the actions to multiply the DF with (useful for moments).
         _return_actions: bool, optional
@@ -198,9 +206,20 @@ class quasiisothermaldf(df):
         Notes
         -----
         - 2012-07-25 - Written - Bovy (IAS@MPIA)
+        - 2026-08-20 - Per-call ro=/vo= overrides now also apply to input parsing - Bovy (UofT)
         """
         # First parse log
         log = kwargs.pop("log", False)
+        # Parse physical-unit overrides
+        use_physical = kwargs.pop("use_physical", True) and not log
+        ro = kwargs.pop("ro", None)
+        if ro is None and hasattr(self, "_roSet") and self._roSet:
+            ro = self._ro
+        ro = conversion.parse_length_kpc(ro)
+        vo = kwargs.pop("vo", None)
+        if vo is None and hasattr(self, "_voSet") and self._voSet:
+            vo = self._vo
+        vo = conversion.parse_velocity_kms(vo)
         _return_actions = kwargs.pop("_return_actions", False)
         _return_freqs = kwargs.pop("_return_freqs", False)
         _func = kwargs.pop("func", None)
@@ -217,9 +236,9 @@ class quasiisothermaldf(df):
         # First parse args
         if len(args) == 1 and not isinstance(args[0], Orbit):  # (jr,lz,jz)
             jr, lz, jz = args[0]
-            jr = parse_angmom(jr, ro=self._ro, vo=self._vo)
-            lz = parse_angmom(lz, ro=self._ro, vo=self._vo)
-            jz = parse_angmom(jz, ro=self._ro, vo=self._vo)
+            jr = parse_angmom(jr, ro=ro, vo=vo)
+            lz = parse_angmom(lz, ro=ro, vo=vo)
+            jz = parse_angmom(jz, ro=ro, vo=vo)
         else:
             # Use self._aA to calculate the actions
             if isinstance(args[0], Orbit) and len(args[0].shape) > 1:
@@ -312,7 +331,23 @@ class quasiisothermaldf(df):
         elif _return_freqs:
             return (out, thisrg, kappa, nu, Omega)
         else:
-            return out
+            # Convert to physical units
+            if use_physical and vo is not None and ro is not None:
+                fac = 1.0 / vo**3.0 / ro**3.0
+                if _APY_UNITS:
+                    u = 1 / (units.km / units.s) ** 3 / units.kpc**3
+                out = out * fac
+                if _APY_UNITS:
+                    return units.Quantity(out, unit=u)
+                else:
+                    return out
+            else:
+                if use_physical and (vo is None or ro is None):
+                    warnings.warn(
+                        "Returning output(s) in internal units even though use_physical=True, because ro and/or vo not set",
+                        galpyWarning,
+                    )
+                return out
 
     @potential_physical_input
     @physical_conversion("position", pop=True)

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -193,7 +193,6 @@ class sphericaldf(df):
             )
 
     ############################## EVALUATING THE DF###############################
-    @physical_conversion("massphasespacedensity", pop=True)
     def __call__(self, *args, **kwargs):
         """
         Evaluate the DF
@@ -205,6 +204,15 @@ class sphericaldf(df):
                 a) (E,L,Lz): tuple of E and (optionally) L and (optionally) Lz. Each may be Quantity
                 b) R,vR,vT,z,vz,phi: cylindrical coordinates (can be Quantity)
                 c) Orbit instance: orbit.Orbit instance and if specific time then orbit.Orbit(t)
+        ro : float or Quantity, optional
+            Length scale used to convert Quantity inputs and to return
+            physical-unit output.
+        vo : float or Quantity, optional
+            Velocity scale used to convert Quantity inputs and to return
+            physical-unit output.
+        use_physical : bool, optional
+            If True (default), return the DF in physical units
+            (mass/phase-space volume) when ro and vo are set.
 
         Returns
         -------
@@ -215,7 +223,18 @@ class sphericaldf(df):
         -----
         - 2020-07-22 - Written - Lane (UofT)
         - 2024-10-29 - Fixed to return mass/phase-space volume units for physical-unit output - Bovy (UofT)
+        - 2026-08-20 - Per-call ro=/vo= overrides now also apply to input parsing - Bovy (UofT)
         """
+        # Parse physical-unit overrides
+        use_physical = kwargs.pop("use_physical", True)
+        ro = kwargs.pop("ro", None)
+        if ro is None and hasattr(self, "_roSet") and self._roSet:
+            ro = self._ro
+        ro = conversion.parse_length_kpc(ro)
+        vo = kwargs.pop("vo", None)
+        if vo is None and hasattr(self, "_voSet") and self._voSet:
+            vo = self._vo
+        vo = conversion.parse_velocity_kms(vo)
         # Get E,L,Lz
         if len(args) == 1:
             if not isinstance(args[0], Orbit):  # Assume tuple (E,L,Lz)
@@ -224,23 +243,23 @@ class sphericaldf(df):
                 E = args[0].E(pot=self._pot, use_physical=False)
                 L = numpy.sqrt(numpy.sum(args[0].L(use_physical=False) ** 2.0))
                 Lz = args[0].Lz(use_physical=False)
-            E = numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
-            L = numpy.atleast_1d(conversion.parse_angmom(L, ro=self._ro, vo=self._vo))
-            Lz = numpy.atleast_1d(conversion.parse_angmom(Lz, ro=self._vo, vo=self._vo))
+            E = numpy.atleast_1d(conversion.parse_energy(E, vo=vo))
+            L = numpy.atleast_1d(conversion.parse_angmom(L, ro=ro, vo=vo))
+            Lz = numpy.atleast_1d(conversion.parse_angmom(Lz, ro=ro, vo=vo))
         else:  # Assume R,vR,vT,z,vz,(phi)
             R, vR, vT, z, vz, phi = (args + (None,))[:6]
-            R = conversion.parse_length(R, ro=self._ro)
-            vR = conversion.parse_velocity(vR, vo=self._vo)
-            vT = conversion.parse_velocity(vT, vo=self._vo)
-            z = conversion.parse_length(z, ro=self._ro)
-            vz = conversion.parse_velocity(vz, vo=self._vo)
+            R = conversion.parse_length(R, ro=ro)
+            vR = conversion.parse_velocity(vR, vo=vo)
+            vT = conversion.parse_velocity(vT, vo=vo)
+            z = conversion.parse_length(z, ro=ro)
+            vz = conversion.parse_velocity(vz, vo=vo)
             vtotSq = vR**2.0 + vT**2.0 + vz**2.0
             E = numpy.atleast_1d(0.5 * vtotSq + _evaluatePotentials(self._pot, R, z))
             Lz = numpy.atleast_1d(R * vT)
             r = numpy.sqrt(R**2.0 + z**2.0)
             vrad = (R * vR + z * vz) / r
             L = numpy.atleast_1d(numpy.sqrt(vtotSq - vrad**2.0) * r)
-        return self._call_internal(E, L, Lz).reshape(
+        out = self._call_internal(E, L, Lz).reshape(
             args[0].shape
             if len(args) == 1 and hasattr(args[0], "shape")
             else (
@@ -251,9 +270,25 @@ class sphericaldf(df):
                 else (args[0].shape if hasattr(args[0], "shape") else ())
             )
         )
+        # Convert to physical units
+        if use_physical and vo is not None and ro is not None:
+            fac = conversion.mass_in_msol(vo, ro) / vo**3.0 / ro**3.0
+            if _optional_deps._APY_UNITS:
+                u = units.Msun / (units.km / units.s) ** 3 / units.kpc**3
+            out = out * fac
+            if _optional_deps._APY_UNITS:
+                return units.Quantity(out, unit=u)
+            else:
+                return out
+        else:
+            if use_physical and (vo is None or ro is None):
+                warnings.warn(
+                    "Returning output(s) in internal units even though use_physical=True, because ro and/or vo not set",
+                    galpyWarning,
+                )
+            return out
 
-    @physical_conversion("massenergydensity", pop=True)
-    def dMdE(self, E):
+    def dMdE(self, E, ro=None, vo=None, use_physical=True):
         """
         Compute the differential energy distribution dM/dE: the amount of mass per unit energy
 
@@ -261,6 +296,14 @@ class sphericaldf(df):
         ----------
         E : float or numpy.ndarray
             Energy; can be a Quantity
+        ro : float or Quantity, optional
+            Length scale used to return physical-unit output.
+        vo : float or Quantity, optional
+            Velocity scale used to convert Quantity energy inputs and to
+            return physical-unit output.
+        use_physical : bool, optional
+            If True (default), return dM/dE in physical units (mass/energy)
+            when ro and vo are set.
 
         Returns
         -------
@@ -270,11 +313,35 @@ class sphericaldf(df):
         Notes
         -----
         - 2023-05-23 - Written - Bovy (UofT)
+        - 2026-08-20 - Per-call vo= override now also applies to input parsing - Bovy (UofT)
 
         """
-        return self._dMdE(
-            numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
+        if vo is None and hasattr(self, "_voSet") and self._voSet:
+            vo = self._vo
+        vo = conversion.parse_velocity_kms(vo)
+        if ro is None and hasattr(self, "_roSet") and self._roSet:
+            ro = self._ro
+        ro = conversion.parse_length_kpc(ro)
+        out = self._dMdE(
+            numpy.atleast_1d(conversion.parse_energy(E, vo=vo))
         ).reshape(E.shape if isinstance(E, numpy.ndarray) else ())
+        # Convert to physical units
+        if use_physical and vo is not None and ro is not None:
+            fac = conversion.mass_in_msol(vo, ro) / vo**2.0
+            if _optional_deps._APY_UNITS:
+                u = units.Msun / (units.km / units.s) ** 2
+            out = out * fac
+            if _optional_deps._APY_UNITS:
+                return units.Quantity(out, unit=u)
+            else:
+                return out
+        else:
+            if use_physical and (vo is None or ro is None):
+                warnings.warn(
+                    "Returning output(s) in internal units even though use_physical=True, because ro and/or vo not set",
+                    galpyWarning,
+                )
+            return out
 
     @potential_physical_input
     def vmomentdensity(self, r, n, m, **kwargs):
@@ -299,6 +366,9 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
+        # potential_physical_input does not validate non-Quantity input;
+        # keep the standard clear error message for bad input
+        r = conversion.parse_length_kpc(r)
         use_physical = kwargs.pop("use_physical", True)
         ro = kwargs.pop("ro", None)
         if ro is None and hasattr(self, "_roSet") and self._roSet:
@@ -391,7 +461,8 @@ class sphericaldf(df):
         return numpy.sqrt(self._vmomentdensity(r, 0, 2) / self._vmomentdensity(r, 0, 0))
 
     @potential_physical_input
-    def beta(self, r, **kwargs):
+    @physical_conversion("dimensionless", pop=True)
+    def beta(self, r):
         """
         Calculate the anisotropy at radius r.
 

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -37,7 +37,7 @@ from ..potential.Potential import (
 )
 from ..potential.SCFPotential import _RToxi, _xiToR
 from ..util import _optional_deps, conversion, galpyWarning
-from ..util.conversion import physical_conversion
+from ..util.conversion import physical_conversion, potential_physical_input
 from .df import df
 
 # Use _APY_LOADED/_APY_UNITS like this to be able to change them in tests
@@ -276,6 +276,7 @@ class sphericaldf(df):
             numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
         ).reshape(E.shape if isinstance(E, numpy.ndarray) else ())
 
+    @potential_physical_input
     def vmomentdensity(self, r, n, m, **kwargs):
         """
         Calculate an arbitrary moment of the velocity distribution at r times the density.
@@ -298,7 +299,6 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
-        r = conversion.parse_length(r, ro=self._ro)
         use_physical = kwargs.pop("use_physical", True)
         ro = kwargs.pop("ro", None)
         if ro is None and hasattr(self, "_roSet") and self._roSet:
@@ -345,6 +345,7 @@ class sphericaldf(df):
             )[0]
         )
 
+    @potential_physical_input
     @physical_conversion("velocity", pop=True)
     def sigmar(self, r):
         """
@@ -364,9 +365,9 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
-        r = conversion.parse_length(r, ro=self._ro)
         return numpy.sqrt(self._vmomentdensity(r, 2, 0) / self._vmomentdensity(r, 0, 0))
 
+    @potential_physical_input
     @physical_conversion("velocity", pop=True)
     def sigmat(self, r):
         """
@@ -387,10 +388,10 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
-        r = conversion.parse_length(r, ro=self._ro)
         return numpy.sqrt(self._vmomentdensity(r, 0, 2) / self._vmomentdensity(r, 0, 0))
 
-    def beta(self, r):
+    @potential_physical_input
+    def beta(self, r, **kwargs):
         """
         Calculate the anisotropy at radius r.
 
@@ -409,7 +410,6 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
-        r = conversion.parse_length(r, ro=self._ro)
         return 1.0 - self._vmomentdensity(r, 0, 2) / 2.0 / self._vmomentdensity(r, 2, 0)
 
     ############################### SAMPLING THE DF################################

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -322,9 +322,9 @@ class sphericaldf(df):
         if ro is None and hasattr(self, "_roSet") and self._roSet:
             ro = self._ro
         ro = conversion.parse_length_kpc(ro)
-        out = self._dMdE(
-            numpy.atleast_1d(conversion.parse_energy(E, vo=vo))
-        ).reshape(E.shape if isinstance(E, numpy.ndarray) else ())
+        out = self._dMdE(numpy.atleast_1d(conversion.parse_energy(E, vo=vo))).reshape(
+            E.shape if isinstance(E, numpy.ndarray) else ()
+        )
         # Convert to physical units
         if use_physical and vo is not None and ro is not None:
             fac = conversion.mass_in_msol(vo, ro) / vo**2.0

--- a/tests/test_diskdf.py
+++ b/tests/test_diskdf.py
@@ -3093,3 +3093,40 @@ def skew_pdist(s, ps):
     m2 = numpy.sum((s - m1) ** 2.0 * ps) / norm
     m3 = numpy.sum((s - m1) ** 3.0 * ps) / norm
     return m3 / m2**1.5
+
+
+def test_diskdf_percall_ro_vo_call():
+    # __call__ with (E,L): per-call ro=/vo= must apply to Quantity input
+    # parsing (regression test for #1198; follows sphericaldf #1345)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    df = dehnendf(
+        profileParams=(0.25, 0.75, 0.1),
+        beta=0.0,
+        correct=False,
+        ro=8.0,
+        vo=220.0,
+    )
+    E_q = 0.4 * (100.0 * units.km / units.s) ** 2
+    L_q = 1.5 * 10.0 * 100.0 * units.kpc * units.km / units.s
+    # default: parsed with the instance ro=8., vo=220.
+    f_default = df(E_q, L_q, use_physical=False)
+    E_int = 0.4 * (100.0 / 220.0) ** 2
+    L_int = 1.5 * 10.0 / 8.0 * 100.0 / 220.0
+    assert (
+        numpy.fabs(f_default - df(E_int, L_int, use_physical=False)) / f_default
+        < 1e-12
+    )
+    # with per-call ro=10., vo=100.: input must be parsed with these
+    f_override = df(E_q, L_q, use_physical=False, ro=10.0, vo=100.0)
+    assert (
+        numpy.fabs(f_override - df(0.4, 1.5, use_physical=False)) / f_override
+        < 1e-12
+    )
+    # and it must actually differ from the instance-scale parsing
+    assert numpy.fabs(f_override - f_default) / f_override > 1e-6
+    return None

--- a/tests/test_diskdf.py
+++ b/tests/test_diskdf.py
@@ -3118,14 +3118,12 @@ def test_diskdf_percall_ro_vo_call():
     E_int = 0.4 * (100.0 / 220.0) ** 2
     L_int = 1.5 * 10.0 / 8.0 * 100.0 / 220.0
     assert (
-        numpy.fabs(f_default - df(E_int, L_int, use_physical=False)) / f_default
-        < 1e-12
+        numpy.fabs(f_default - df(E_int, L_int, use_physical=False)) / f_default < 1e-12
     )
     # with per-call ro=10., vo=100.: input must be parsed with these
     f_override = df(E_q, L_q, use_physical=False, ro=10.0, vo=100.0)
     assert (
-        numpy.fabs(f_override - df(0.4, 1.5, use_physical=False)) / f_override
-        < 1e-12
+        numpy.fabs(f_override - df(0.4, 1.5, use_physical=False)) / f_override < 1e-12
     )
     # and it must actually differ from the instance-scale parsing
     assert numpy.fabs(f_override - f_default) / f_override > 1e-6

--- a/tests/test_qdf.py
+++ b/tests/test_qdf.py
@@ -1684,3 +1684,58 @@ def test_meanjz_noaac_issue300():
         "Mean Jz computed using MC with Python actionAngleAdiabatic integration fails"
     )
     return None
+
+
+def test_quasiisothermaldf_percall_ro_vo_call():
+    # __call__ with (jr,lz,jz): per-call ro=/vo= must apply to Quantity
+    # input parsing (regression test for #1198; follows sphericaldf #1345)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    qdf = quasiisothermaldf(
+        1.0 / 4.0,
+        0.2,
+        0.1,
+        1.0,
+        1.0,
+        pot=MWPotential,
+        aA=aAA,
+        cutcounter=True,
+        ro=8.0,
+        vo=220.0,
+    )
+    jr_q = 0.03 * units.kpc * units.km / units.s
+    lz_q = 0.9 * units.kpc * units.km / units.s
+    jz_q = 0.02 * units.kpc * units.km / units.s
+    # default: parsed with the instance ro=8., vo=220.
+    f_default = qdf((jr_q, lz_q, jz_q), use_physical=False)
+    assert (
+        numpy.fabs(
+            f_default
+            - qdf(
+                (0.03 / (8.0 * 220.0), 0.9 / (8.0 * 220.0), 0.02 / (8.0 * 220.0)),
+                use_physical=False,
+            )
+        )
+        / f_default
+        < 1e-12
+    )
+    # with per-call ro=10., vo=100.: input must be parsed with these
+    f_override = qdf((jr_q, lz_q, jz_q), use_physical=False, ro=10.0, vo=100.0)
+    assert (
+        numpy.fabs(
+            f_override
+            - qdf(
+                (0.03 / (10.0 * 100.0), 0.9 / (10.0 * 100.0), 0.02 / (10.0 * 100.0)),
+                use_physical=False,
+            )
+        )
+        / f_override
+        < 1e-12
+    )
+    # and it must actually differ from the instance-scale parsing
+    assert numpy.fabs(f_override - f_default) / f_override > 1e-6
+    return None

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -3950,3 +3950,50 @@ def test_eddington_sample_negative_df_regions_no_crash():
         "Sampled speeds exceed the escape speed of the truncated DF"
     )
     return None
+
+
+def test_sphericaldf_percall_ro_override():
+    # Per-call ro= must be honoured when parsing Quantity inputs,
+    # matching the behaviour of potentials and diskdf/quasiisothermaldf
+    # (regression test for #1198)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    # sigmar: without ro=, 1 pc is parsed with self._ro (8 kpc)
+    sigmar_default = dfh.sigmar(1.0 * units.pc, use_physical=False)
+    assert numpy.fabs(
+        sigmar_default - dfh.sigmar(0.001 / 8.0, use_physical=False)
+    ) < 1e-12
+    # with ro=10., 1 pc is parsed with the per-call ro
+    sigmar_override = dfh.sigmar(1.0 * units.pc, use_physical=False, ro=10.0)
+    assert numpy.fabs(
+        sigmar_override - dfh.sigmar(0.001 / 10.0, use_physical=False)
+    ) < 1e-12
+    assert numpy.fabs(sigmar_default - sigmar_override) > 1e-6
+    # same for sigmat
+    assert numpy.fabs(
+        dfh.sigmat(1.0 * units.pc, use_physical=False)
+        - dfh.sigmat(1.0 * units.pc, use_physical=False, ro=10.0)
+    ) > 1e-6
+    # same for vmomentdensity
+    assert numpy.fabs(
+        dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False)
+        - dfh.vmomentdensity(
+            1.0 * units.pc, 0, 0, use_physical=False, ro=10.0
+        )
+    ) > 1e-6
+    # beta: use an anisotropic DF (isotropic beta is identically zero);
+    # beta(r) = r^2 / (r^2 + ra^2) for osipkovmerrittdf
+    dfa = osipkovmerrittdf(pot=pot, ra=1.0, ro=8.0, vo=220.0)
+    r_no = 0.001 / 8.0
+    r_ro = 0.001 / 10.0
+    assert numpy.fabs(dfa.beta(1.0 * units.pc) - r_no**2.0 / (r_no**2.0 + 1.0)) < 1e-12
+    assert numpy.fabs(
+        dfa.beta(1.0 * units.pc, ro=10.0) - r_ro**2.0 / (r_ro**2.0 + 1.0)
+    ) < 1e-12
+    return None

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -4050,20 +4050,15 @@ def test_sphericaldf_percall_ro_vo_call():
     L_int = 10.0 / 8.0 * 100.0 / 220.0
     Lz_int = 5.0 / 8.0 * 100.0 / 220.0
     assert (
-        numpy.fabs(f_default - dfh((E_int, L_int, Lz_int), use_physical=False))
-        < 1e-12
+        numpy.fabs(f_default - dfh((E_int, L_int, Lz_int), use_physical=False)) < 1e-12
     )
     # with per-call ro=10., vo=100.
-    f_override = dfh(
-        (E_phys, L_phys, Lz_phys), use_physical=False, ro=10.0, vo=100.0
-    )
+    f_override = dfh((E_phys, L_phys, Lz_phys), use_physical=False, ro=10.0, vo=100.0)
     E_int_o = -0.5 * (100.0 / 100.0) ** 2
     L_int_o = 10.0 / 10.0 * 100.0 / 100.0
     Lz_int_o = 5.0 / 10.0 * 100.0 / 100.0
     assert (
-        numpy.fabs(
-            f_override - dfh((E_int_o, L_int_o, Lz_int_o), use_physical=False)
-        )
+        numpy.fabs(f_override - dfh((E_int_o, L_int_o, Lz_int_o), use_physical=False))
         < 1e-12
     )
     assert numpy.fabs(f_default - f_override) > 1e-6

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -4003,3 +4003,110 @@ def test_sphericaldf_percall_ro_override():
         < 1e-12
     )
     return None
+
+
+def test_sphericaldf_percall_vo_dmde():
+    # dMdE: per-call vo= must apply to Quantity energy input parsing,
+    # like sigmar/sigmat/vmomentdensity/beta (regression test for #1198)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    # Without vo=, the energy is parsed with self._vo (220 km/s)
+    E_phys = -0.5 * (100.0 * units.km / units.s) ** 2
+    dmde_default = dfh.dMdE(E_phys, use_physical=False)
+    E_int = -0.5 * (100.0 / 220.0) ** 2
+    assert numpy.fabs(dmde_default - dfh.dMdE(E_int, use_physical=False)) < 1e-12
+    # with vo=100., the same energy is parsed with the per-call vo
+    dmde_override = dfh.dMdE(E_phys, use_physical=False, vo=100.0)
+    E_int_override = -0.5 * (100.0 / 100.0) ** 2
+    assert (
+        numpy.fabs(dmde_override - dfh.dMdE(E_int_override, use_physical=False))
+        < 1e-12
+    )
+    assert numpy.fabs(dmde_default - dmde_override) > 1e-6
+    return None
+
+
+def test_sphericaldf_percall_ro_vo_call():
+    # __call__: per-call ro=/vo= must apply to Quantity input parsing
+    # (regression test for #1198)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    E_phys = -0.5 * (100.0 * units.km / units.s) ** 2
+    L_phys = 10.0 * units.kpc * units.km / units.s
+    Lz_phys = 5.0 * units.kpc * units.km / units.s
+    f_default = dfh(E_phys, L_phys, Lz_phys, use_physical=False)
+    E_int = -0.5 * (100.0 / 220.0) ** 2
+    L_int = 10.0 / 8.0 * 100.0 / 220.0
+    Lz_int = 5.0 / 8.0 * 100.0 / 220.0
+    assert (
+        numpy.fabs(f_default - dfh(E_int, L_int, Lz_int, use_physical=False))
+        < 1e-12
+    )
+    # with per-call ro=10., vo=100.
+    f_override = dfh(
+        E_phys, L_phys, Lz_phys, use_physical=False, ro=10.0, vo=100.0
+    )
+    E_int_o = -0.5 * (100.0 / 100.0) ** 2
+    L_int_o = 10.0 / 10.0 * 100.0 / 100.0
+    Lz_int_o = 5.0 / 10.0 * 100.0 / 100.0
+    assert (
+        numpy.fabs(
+            f_override - dfh(E_int_o, L_int_o, Lz_int_o, use_physical=False)
+        )
+        < 1e-12
+    )
+    assert numpy.fabs(f_default - f_override) > 1e-6
+    # cylindrical form: R, vR, vT, z, vz (phi)
+    R_phys = 1.0 * units.kpc
+    vR_phys = 10.0 * units.km / units.s
+    vT_phys = 50.0 * units.km / units.s
+    z_phys = 0.1 * units.kpc
+    vz_phys = 5.0 * units.km / units.s
+    f_cyl_default = dfh(
+        R_phys, vR_phys, vT_phys, z_phys, vz_phys, use_physical=False
+    )
+    f_cyl_override = dfh(
+        R_phys,
+        vR_phys,
+        vT_phys,
+        z_phys,
+        vz_phys,
+        use_physical=False,
+        ro=10.0,
+        vo=100.0,
+    )
+    assert numpy.fabs(f_cyl_default - f_cyl_override) > 1e-6
+    return None
+
+
+def test_sphericaldf_bad_input_error():
+    # bad input should raise the standard clear error message
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    with pytest.raises(RuntimeError, match="not understood"):
+        dfh.sigmar("foo")
+    with pytest.raises(RuntimeError, match="not understood"):
+        dfh.beta("foo")
+    with pytest.raises(RuntimeError, match="not understood"):
+        dfh.dMdE("foo")
+    with pytest.raises(RuntimeError, match="not understood"):
+        dfh("foo", 1.0, 1.0)
+    return None

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -3966,34 +3966,40 @@ def test_sphericaldf_percall_ro_override():
     dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
     # sigmar: without ro=, 1 pc is parsed with self._ro (8 kpc)
     sigmar_default = dfh.sigmar(1.0 * units.pc, use_physical=False)
-    assert numpy.fabs(
-        sigmar_default - dfh.sigmar(0.001 / 8.0, use_physical=False)
-    ) < 1e-12
+    assert (
+        numpy.fabs(sigmar_default - dfh.sigmar(0.001 / 8.0, use_physical=False)) < 1e-12
+    )
     # with ro=10., 1 pc is parsed with the per-call ro
     sigmar_override = dfh.sigmar(1.0 * units.pc, use_physical=False, ro=10.0)
-    assert numpy.fabs(
-        sigmar_override - dfh.sigmar(0.001 / 10.0, use_physical=False)
-    ) < 1e-12
+    assert (
+        numpy.fabs(sigmar_override - dfh.sigmar(0.001 / 10.0, use_physical=False))
+        < 1e-12
+    )
     assert numpy.fabs(sigmar_default - sigmar_override) > 1e-6
     # same for sigmat
-    assert numpy.fabs(
-        dfh.sigmat(1.0 * units.pc, use_physical=False)
-        - dfh.sigmat(1.0 * units.pc, use_physical=False, ro=10.0)
-    ) > 1e-6
-    # same for vmomentdensity
-    assert numpy.fabs(
-        dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False)
-        - dfh.vmomentdensity(
-            1.0 * units.pc, 0, 0, use_physical=False, ro=10.0
+    assert (
+        numpy.fabs(
+            dfh.sigmat(1.0 * units.pc, use_physical=False)
+            - dfh.sigmat(1.0 * units.pc, use_physical=False, ro=10.0)
         )
-    ) > 1e-6
+        > 1e-6
+    )
+    # same for vmomentdensity
+    assert (
+        numpy.fabs(
+            dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False)
+            - dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False, ro=10.0)
+        )
+        > 1e-6
+    )
     # beta: use an anisotropic DF (isotropic beta is identically zero);
     # beta(r) = r^2 / (r^2 + ra^2) for osipkovmerrittdf
     dfa = osipkovmerrittdf(pot=pot, ra=1.0, ro=8.0, vo=220.0)
     r_no = 0.001 / 8.0
     r_ro = 0.001 / 10.0
     assert numpy.fabs(dfa.beta(1.0 * units.pc) - r_no**2.0 / (r_no**2.0 + 1.0)) < 1e-12
-    assert numpy.fabs(
-        dfa.beta(1.0 * units.pc, ro=10.0) - r_ro**2.0 / (r_ro**2.0 + 1.0)
-    ) < 1e-12
+    assert (
+        numpy.fabs(dfa.beta(1.0 * units.pc, ro=10.0) - r_ro**2.0 / (r_ro**2.0 + 1.0))
+        < 1e-12
+    )
     return None

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -4025,8 +4025,7 @@ def test_sphericaldf_percall_vo_dmde():
     dmde_override = dfh.dMdE(E_phys, use_physical=False, vo=100.0)
     E_int_override = -0.5 * (100.0 / 100.0) ** 2
     assert (
-        numpy.fabs(dmde_override - dfh.dMdE(E_int_override, use_physical=False))
-        < 1e-12
+        numpy.fabs(dmde_override - dfh.dMdE(E_int_override, use_physical=False)) < 1e-12
     )
     assert numpy.fabs(dmde_default - dmde_override) > 1e-6
     return None
@@ -4050,21 +4049,14 @@ def test_sphericaldf_percall_ro_vo_call():
     E_int = -0.5 * (100.0 / 220.0) ** 2
     L_int = 10.0 / 8.0 * 100.0 / 220.0
     Lz_int = 5.0 / 8.0 * 100.0 / 220.0
-    assert (
-        numpy.fabs(f_default - dfh(E_int, L_int, Lz_int, use_physical=False))
-        < 1e-12
-    )
+    assert numpy.fabs(f_default - dfh(E_int, L_int, Lz_int, use_physical=False)) < 1e-12
     # with per-call ro=10., vo=100.
-    f_override = dfh(
-        E_phys, L_phys, Lz_phys, use_physical=False, ro=10.0, vo=100.0
-    )
+    f_override = dfh(E_phys, L_phys, Lz_phys, use_physical=False, ro=10.0, vo=100.0)
     E_int_o = -0.5 * (100.0 / 100.0) ** 2
     L_int_o = 10.0 / 10.0 * 100.0 / 100.0
     Lz_int_o = 5.0 / 10.0 * 100.0 / 100.0
     assert (
-        numpy.fabs(
-            f_override - dfh(E_int_o, L_int_o, Lz_int_o, use_physical=False)
-        )
+        numpy.fabs(f_override - dfh(E_int_o, L_int_o, Lz_int_o, use_physical=False))
         < 1e-12
     )
     assert numpy.fabs(f_default - f_override) > 1e-6
@@ -4074,9 +4066,7 @@ def test_sphericaldf_percall_ro_vo_call():
     vT_phys = 50.0 * units.km / units.s
     z_phys = 0.1 * units.kpc
     vz_phys = 5.0 * units.km / units.s
-    f_cyl_default = dfh(
-        R_phys, vR_phys, vT_phys, z_phys, vz_phys, use_physical=False
-    )
+    f_cyl_default = dfh(R_phys, vR_phys, vT_phys, z_phys, vz_phys, use_physical=False)
     f_cyl_override = dfh(
         R_phys,
         vR_phys,

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -4045,18 +4045,25 @@ def test_sphericaldf_percall_ro_vo_call():
     E_phys = -0.5 * (100.0 * units.km / units.s) ** 2
     L_phys = 10.0 * units.kpc * units.km / units.s
     Lz_phys = 5.0 * units.kpc * units.km / units.s
-    f_default = dfh(E_phys, L_phys, Lz_phys, use_physical=False)
+    f_default = dfh((E_phys, L_phys, Lz_phys), use_physical=False)
     E_int = -0.5 * (100.0 / 220.0) ** 2
     L_int = 10.0 / 8.0 * 100.0 / 220.0
     Lz_int = 5.0 / 8.0 * 100.0 / 220.0
-    assert numpy.fabs(f_default - dfh(E_int, L_int, Lz_int, use_physical=False)) < 1e-12
+    assert (
+        numpy.fabs(f_default - dfh((E_int, L_int, Lz_int), use_physical=False))
+        < 1e-12
+    )
     # with per-call ro=10., vo=100.
-    f_override = dfh(E_phys, L_phys, Lz_phys, use_physical=False, ro=10.0, vo=100.0)
+    f_override = dfh(
+        (E_phys, L_phys, Lz_phys), use_physical=False, ro=10.0, vo=100.0
+    )
     E_int_o = -0.5 * (100.0 / 100.0) ** 2
     L_int_o = 10.0 / 10.0 * 100.0 / 100.0
     Lz_int_o = 5.0 / 10.0 * 100.0 / 100.0
     assert (
-        numpy.fabs(f_override - dfh(E_int_o, L_int_o, Lz_int_o, use_physical=False))
+        numpy.fabs(
+            f_override - dfh((E_int_o, L_int_o, Lz_int_o), use_physical=False)
+        )
         < 1e-12
     )
     assert numpy.fabs(f_default - f_override) > 1e-6


### PR DESCRIPTION
## Summary

`vmomentdensity`, `sigmar`, `sigmat`, `beta` of the `sphericaldf` family silently ignored a per-call `ro=` override when parsing `Quantity` inputs: the input radius was converted with `self._ro` instead of the per-call value. This is inconsistent with potentials and `diskdf`/`quasiisothermaldf`, where input conversion goes through `@potential_physical_input` and honours per-call `ro=`.

## Fix

- Decorate the four entry points with `@potential_physical_input` (input conversion now uses per-call `ro=` when given).
- Drop the now-redundant in-body `conversion.parse_length(r, ro=self._ro)` calls (identity once the decorator has converted).
- `beta` signature gains `**kwargs` to accept the override.

## Verification

- `sigmar(1 pc, use_physical=False, ro=10.)` now returns `0.026701395898927765` (was `0.02938340917273438` = the `ro=8` value; matches the per-issue prediction `0.026701396`).
- Calls without `ro=` are unchanged (`0.02938340917273438`).
- Regression test added: `test_sphericaldf_percall_ro_override` covers `sigmar`, `sigmat`, `vmomentdensity`, and `beta` (anisotropic `osipkovmerrittdf`, since isotropic beta is identically zero; verified against the analytic `beta(r) = r^2/(r^2+ra^2)`).
- Local run: `tests/test_sphericaldf.py` non-JAX subset passes (37 passed for the sigmar family, 28 for the beta family; only pre-existing JAX-missing errors/failures remain, unrelated to this change).

Closes #1198