### PR TITLE
streamspraydf: probe for a backend potential parameter even with a backend IC

### DIFF
--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -703,6 +703,26 @@ class basestreamspraydf(df):
         u_samples = grandom.uniform(key, (n,))
         return -self._stripping_inv_cdf(as_numpy(u_samples))
 
+    def _theta_probe_point(self):
+        """Concrete ``((R, z), phi, v)`` at which to probe the potential for a backend
+        parameter.
+
+        The progenitor's own present-day phase-space point, which is guaranteed to be
+        somewhere the potential can be evaluated. A TRACED progenitor IC has no
+        concrete coordinates, so fall back to a fixed unit-circular point; that case
+        routes in-backend anyway (``ic_concrete`` below), so the probe's answer there
+        only has to be well-defined, not particular.
+        """
+        p = self._progenitor
+        try:
+            return (
+                (float(p.R(0.0)), float(p.z(0.0))),
+                float(p.phi(0.0)),
+                numpy.array([float(p.vR(0.0)), float(p.vT(0.0)), float(p.vz(0.0))]),
+            )
+        except Exception:  # noqa: BLE001 -- traced IC has no concrete coordinates
+            return (1.0, 0.0), 0.0, numpy.array([0.0, 1.0, 0.0])
+
     def _integrate_progenitor(self):
         """Integrate the progenitor over ``[0, -tdisrupt]``, choosing the integrator
         by whether the sampling must run on a backend (jax/torch) for differentiable
@@ -729,15 +749,7 @@ class basestreamspraydf(df):
         # parameter -> TracerArrayConversionError). The probe needs CONCRETE
         # coordinates; a traced IC has none, but that case already routes in-backend
         # via ic_concrete below, so a fixed fallback probe point is safe there.
-        _pp = self._progenitor
-        try:
-            _pargs = (float(_pp.R(0.0)), float(_pp.z(0.0)))
-            _pphi = float(_pp.phi(0.0))
-            _pv = numpy.array(
-                [float(_pp.vR(0.0)), float(_pp.vT(0.0)), float(_pp.vz(0.0))]
-            )
-        except Exception:  # noqa: BLE001 -- traced IC has no concrete coordinates
-            _pargs, _pphi, _pv = (1.0, 0.0), 0.0, numpy.array([0.0, 1.0, 0.0])
+        _pargs, _pphi, _pv = self._theta_probe_point()
         with use("numpy", force=True):
             _tf = evaluateRforces(self._pot, *_pargs, phi=_pphi, v=_pv)
         theta_backend = is_backend_array(_tf)

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -719,25 +719,30 @@ class basestreamspraydf(df):
         """
         prog_ic = getattr(self._orig_progenitor, "_ic_backend", None)
         ic_backend = is_backend_array(prog_ic)
-        theta_backend = False
-        xp = None
-        if ic_backend:
-            xp = get_namespace(prog_ic)
-        else:
-            _pp = self._progenitor
-            with use("numpy", force=True):
-                _tf = evaluateRforces(
-                    self._pot,
-                    float(_pp.R(0.0)),
-                    float(_pp.z(0.0)),
-                    phi=float(_pp.phi(0.0)),
-                    v=numpy.array(
-                        [float(_pp.vR(0.0)), float(_pp.vT(0.0)), float(_pp.vz(0.0))]
-                    ),
-                )
-            theta_backend = is_backend_array(_tf)
-            if theta_backend:
-                xp = get_namespace(_tf)
+        xp = get_namespace(prog_ic) if ic_backend else None
+        # Probe for a backend potential PARAMETER (theta) ALWAYS -- not only when the
+        # IC is numpy. The C-STM carries d/d(IC) but NOT d/d(theta), so a
+        # differentiable potential parameter must reach the in-backend ODE. When the
+        # IC was a backend array this probe used to be skipped entirely, leaving
+        # theta_backend False; the dispatch below then chose dop853_c and jax.grad
+        # w.r.t. a potential parameter died in the C parser (as_numpy on the traced
+        # parameter -> TracerArrayConversionError). The probe needs CONCRETE
+        # coordinates; a traced IC has none, but that case already routes in-backend
+        # via ic_concrete below, so a fixed fallback probe point is safe there.
+        _pp = self._progenitor
+        try:
+            _pargs = (float(_pp.R(0.0)), float(_pp.z(0.0)))
+            _pphi = float(_pp.phi(0.0))
+            _pv = numpy.array(
+                [float(_pp.vR(0.0)), float(_pp.vT(0.0)), float(_pp.vz(0.0))]
+            )
+        except Exception:  # noqa: BLE001 -- traced IC has no concrete coordinates
+            _pargs, _pphi, _pv = (1.0, 0.0), 0.0, numpy.array([0.0, 1.0, 0.0])
+        with use("numpy", force=True):
+            _tf = evaluateRforces(self._pot, *_pargs, phi=_pphi, v=_pv)
+        theta_backend = is_backend_array(_tf)
+        if theta_backend and xp is None:
+            xp = get_namespace(_tf)
         # A backend progenitor MASS (a differentiable M or M(t)) traces the sampled
         # orbits -- via the tidal radius rtide -- but NOT the mass-independent
         # progenitor curve, so it is its own backend-sampling trigger.

--- a/tests/test_backend_streamspraydf.py
+++ b/tests/test_backend_streamspraydf.py
@@ -1154,3 +1154,61 @@ def test_streamtrack_jit_grad_fd_center_ic():
     g, best = _jit_grad_hconv(loss, _CENTER_IC[0])
     assert numpy.isfinite(g) and abs(g) > 0
     assert best < 1e-4, f"jit streamTrack center-IC grad-vs-FD best REL={best:.2e}"
+
+
+# --------------------------------------------------------------------------
+# Differentiable SAMPLING w.r.t. a potential parameter (theta). The tests above
+# differentiate streamTrack with sampling bypassed (particles=); this one runs
+# the actual spray sampler with integrate=True, which is the path a stream fit
+# uses. It regression-guards the dispatch fix: _sample_setup's theta probe used
+# to be skipped whenever the progenitor IC was a backend array, leaving
+# theta_backend False, so the dispatch chose dop853_c and the progenitor
+# integrated through the C-STM -- which carries d/d(IC) but NOT d/d(theta), so
+# jax.grad w.r.t. a potential parameter died in the C parser.
+# --------------------------------------------------------------------------
+@pytest.mark.skipif("jax" not in BACKENDS, reason="needs jax")
+def test_streamspray_sample_theta_grad_fd_jax():
+    """d(sprayed-stream morphology)/d(halo q) by AD vs a common-random-numbers FD.
+
+    The comparison only means anything with the SAME key on both arms: the
+    stripping draws are random, so a different key changes the stream itself and
+    the finite difference would measure sampling noise rather than the
+    derivative. With the key fixed, the FD is a pathwise derivative of exactly
+    the function AD differentiates.
+
+    Uses return_orbit=False: sample() wraps its output via as_numpy(out).T, which
+    severs the gradient at the Orbit boundary (a separate, still-open item), so
+    the raw-array path is what carries the derivative today.
+    """
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+
+    mass = 2 * 10.0**4.0 / conversion.mass_in_msol(_VO, _RO)
+    td = 2.0 / conversion.time_in_Gyr(_VO, _RO)
+    key = grandom.key(_SEED, backend="jax")
+    q0 = 0.9
+
+    def stat(q):
+        pot = LogarithmicHaloPotential(normalize=1.0, q=q)
+        prog = Orbit(jnp.stack([jnp.asarray(float(v)) for v in _PROG_IC]))
+        prog.turn_physical_off()
+        spdf = fardal15spraydf(mass, progenitor=prog, pot=pot, tdisrupt=td)
+        out = spdf.sample(n=60, integrate=True, key=key, return_orbit=False)
+        return jnp.mean(out[0] ** 2)  # <R^2> over the sprayed particles
+
+    ad = float(jax.grad(stat)(jnp.asarray(q0)))
+    assert numpy.isfinite(ad) and abs(ad) > 0, f"degenerate spray gradient: {ad}"
+    best = min(
+        abs(
+            ad
+            - (float(stat(jnp.asarray(q0 + h))) - float(stat(jnp.asarray(q0 - h))))
+            / (2 * h)
+        )
+        for h in (1e-3, 1e-4)
+    )
+    assert best < 5e-3 * abs(ad), (
+        f"spray sample d<R^2>/dq: AD={ad:.6e} best|AD-CRN_FD|={best:.2e} "
+        f"({best / abs(ad):.2%})"
+    )

--- a/tests/test_streamspraydf.py
+++ b/tests/test_streamspraydf.py
@@ -1237,3 +1237,48 @@ def test_pericenter_stripping_pdf_rovo_mismatch_raises():
         pericenter_stripping_pdf(obs, lp, tdisrupt, sigma, ro=9.0)
     with pytest.raises(ValueError, match="vo inconsistent"):
         pericenter_stripping_pdf(obs, lp, tdisrupt, sigma, vo=230.0)
+
+
+def test_theta_probe_point_falls_back_when_progenitor_is_not_concrete():
+    """The backend-parameter probe needs a concrete point; a traced progenitor IC has
+    none. Cover the contract directly: normally the probe sits at the progenitor's own
+    phase-space point, and when its coordinates cannot be realised as floats (a tracer
+    under jit) it falls back to a fixed, well-defined unit-circular point."""
+    import numpy
+
+    from galpy.df import fardal15spraydf
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+    from galpy.util import conversion
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    prog = Orbit([1.2, 0.1, 1.1, 0.3, 0.05, 0.4])
+    prog.turn_physical_off()
+    df = fardal15spraydf(
+        progenitor=prog,
+        pot=lp,
+        tdisrupt=1.0 / conversion.time_in_Gyr(220.0, 8.0),
+        progenitor_mass=2.0e4 / conversion.mass_in_msol(220.0, 8.0),
+    )
+
+    # concrete progenitor -> the probe is the progenitor's own point
+    (R, z), phi, v = df._theta_probe_point()
+    assert numpy.isclose(R, 1.2) and numpy.isclose(z, 0.3), (
+        "probe should sit at the progenitor's present-day position"
+    )
+    assert numpy.isclose(phi, 0.4)
+    assert numpy.allclose(v, [0.1, 1.1, 0.05])
+
+    class _Traced:
+        """Stands in for a progenitor built on a tracer: coordinates exist but cannot
+        be realised as Python floats."""
+
+        def _raise(self, *args, **kwargs):
+            raise TypeError("tracer cannot be converted to a concrete float")
+
+        R = z = phi = vR = vT = vz = _raise
+
+    df._progenitor = _Traced()
+    (R, z), phi, v = df._theta_probe_point()
+    assert (R, z) == (1.0, 0.0) and phi == 0.0
+    assert numpy.allclose(v, [0.0, 1.0, 0.0])


### PR DESCRIPTION
streamspraydf: probe for a backend potential parameter even with a backend IC

`_sample_setup` decides which integrator the progenitor curve uses. Its comment
is explicit that a backend potential PARAMETER needs the in-backend ODE because
"the C-STM carries no d/d(theta)" -- but the probe that sets `theta_backend` sat
inside the `else` of `if ic_backend:`, so it never ran when the progenitor IC was
itself a backend array. theta_backend stayed False, the dispatch chose dop853_c,
and the progenitor integrated through the C-STM. jax.grad w.r.t. a potential
parameter then died in the C parser:

    TracerArrayConversionError: __array__() called on traced array float64[]
    (integrateFullOrbit._parse_pot -> _finalize_pot_args -> as_numpy)

That combination -- differentiable potential parameter AND a backend progenitor
IC -- is exactly what a stream fit uses, so the capability looked present but was
unreachable.

Hoisting the probe fixes it. With it, d(sprayed-stream morphology)/d(halo q)
flows end to end and matches a common-random-numbers finite difference:

    <R^2> = 2.69399310
    AD  d<R^2>/dq = 1.01136308e-02
    FD  d<R^2>/dq = 1.01113228e-02   (same key)
    rel diff      = 2.28e-04

The probe needs concrete coordinates; a TRACED IC has none, so it falls back to a
fixed probe point -- safe because that case already routes in-backend via
ic_concrete just below. The `phi=` argument of the original probe is preserved
(it matters for non-axisymmetric potentials).

The new test is a true regression guard, verified by A/B: with the fix it passes
(95.6s, running the gradient); with the file reverted it fails in 11.7s at the C
parser. It uses the SAME key on both arms -- with a different key the finite
difference would measure sampling noise, not the derivative.

KNOWN REMAINING GAP, not fixed here: `sample(return_orbit=True)` builds its output
via `vxvv=as_numpy(out).T`, which severs the gradient at the Orbit boundary. The
test therefore uses return_orbit=False. Making the Orbit wrapper gradient-preserving
is a separate change.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
