### PR TITLE
actionAngleStaeckelInverse: direct single-torus inverse for Staeckel potentials

### DIFF
--- a/galpy/actionAngle/__init__.py
+++ b/galpy/actionAngle/__init__.py
@@ -11,6 +11,7 @@ from . import (
     actionAngleSpherical,
     actionAngleStaeckel,
     actionAngleStaeckelGrid,
+    actionAngleStaeckelInverse,
     actionAngleTorus,
     actionAngleVertical,
     actionAngleVerticalInverse,
@@ -36,6 +37,7 @@ actionAngleAdiabatic = actionAngleAdiabatic.actionAngleAdiabatic
 actionAngleAdiabaticGrid = actionAngleAdiabaticGrid.actionAngleAdiabaticGrid
 actionAngleStaeckelSingle = actionAngleStaeckel.actionAngleStaeckelSingle
 actionAngleStaeckel = actionAngleStaeckel.actionAngleStaeckel
+actionAngleStaeckelInverse = actionAngleStaeckelInverse.actionAngleStaeckelInverse
 actionAngleStaeckelGrid = actionAngleStaeckelGrid.actionAngleStaeckelGrid
 actionAngleIsochrone = actionAngleIsochrone.actionAngleIsochrone
 actionAngleIsochroneApprox = actionAngleIsochroneApprox.actionAngleIsochroneApprox

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -13,14 +13,18 @@ from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.optimize import brentq
 
 from ..potential import OblateStaeckelWrapperPotential
-from ..util import conversion, coords
+from ..util import coords
 from .actionAngleInverse import actionAngleInverse
 
-# Nodes/weights for composite 10-point Gauss-Legendre quadrature: applied per
-# interval of the nchi-point chi mesh, the error per panel is
+# Nodes/weights for composite 10-point Gauss-Legendre quadrature: applied
+# per interval of the nchi-point chi mesh, the error per panel is
 # O((pi/nchi)^20), so every stored integral is at machine precision for any
 # reasonable nchi; there is no accuracy knob to tune
 _GLX, _GLW = numpy.polynomial.legendre.leggauss(10)
+# Reference u of the internal Staeckel splitting for potentials that are not
+# already wrapped; its value is irrelevant for an exactly Staeckel potential
+# (any choice gives the same U, V up to the fixed gauge)
+_U0INTERNAL = 1.15
 
 
 class actionAngleStaeckelInverse(actionAngleInverse):
@@ -39,8 +43,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
     def __init__(
         self,
         pot=None,
-        delta=None,
-        u0=None,
         Es=[0.5],
         Lzs=[0.5],
         I3s=[0.1],
@@ -55,22 +57,11 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         Parameters
         ----------
         pot : Potential or list thereof
-            The potential; must be of exact Staeckel form in prolate
-            spheroidal coordinates with focal distance delta. Pass an
-            OblateStaeckelWrapperPotential to work with the Staeckel
-            approximation of a general axisymmetric potential (support for
-            torus-dependent delta in that case is planned).
-        delta : float or Quantity, optional
-            Focal distance of the prolate spheroidal coordinate system;
-            derived from the potential when possible (e.g., from a
-            KuzminKutuzovStaeckelPotential or an
-            OblateStaeckelWrapperPotential), otherwise required.
-        u0 : float, optional
-            Reference u of the Staeckel splitting (as in
-            OblateStaeckelWrapperPotential); irrelevant for an exactly
-            Staeckel potential (any value gives the same U, V up to the
-            fixed gauge), taken from the potential when passing an
-            OblateStaeckelWrapperPotential.
+            The potential; must be of exact Staeckel form and supply its own
+            focal distance: either an OblateStaeckelWrapperPotential (also
+            the route for the Staeckel approximation of a general
+            axisymmetric potential) or a potential with a _delta attribute
+            such as KuzminKutuzovStaeckelPotential.
         Es : list of float
             Energies of the tori to set up.
         Lzs : list of float
@@ -92,32 +83,32 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         - Angle conventions match those of the forward actionAngleStaeckel.
         - 2026-08-19 - Started - Bovy (UofT)
         """
+        if "delta" in kwargs or "u0" in kwargs:
+            raise TypeError(
+                "actionAngleStaeckelInverse does not accept delta= or u0=: "
+                "the potential itself supplies the focal distance (pass an "
+                "OblateStaeckelWrapperPotential or a potential with a "
+                "_delta attribute)"
+            )
         actionAngleInverse.__init__(self, **kwargs)
         if pot is None:  # pragma: no cover
             raise OSError("Must specify pot= for actionAngleStaeckelInverse")
         self._pot = pot
         if isinstance(pot, OblateStaeckelWrapperPotential):
-            if delta is not None or u0 is not None:
-                raise ValueError(
-                    "When pot is an OblateStaeckelWrapperPotential, delta and "
-                    "u0 are taken from the potential and cannot be specified"
-                )
             self._staeckelwrap = pot
-            self._delta = pot._delta
-            self._u0 = pot._u0
         else:
-            if delta is None:
-                delta = getattr(pot, "_Delta", None)
+            delta = getattr(pot, "_delta", None)
             if delta is None:
                 raise OSError(
-                    "Must specify delta= for actionAngleStaeckelInverse when "
-                    "it cannot be derived from the potential"
+                    "actionAngleStaeckelInverse requires a potential of "
+                    "Staeckel form that supplies its focal distance (e.g., "
+                    "KuzminKutuzovStaeckelPotential); wrap a general "
+                    "axisymmetric potential in OblateStaeckelWrapperPotential"
                 )
-            self._delta = conversion.parse_length(delta, ro=self._ro)
-            self._u0 = 1.15 if u0 is None else u0
             self._staeckelwrap = OblateStaeckelWrapperPotential(
-                pot=pot, delta=self._delta, u0=self._u0
+                pot=pot, delta=delta, u0=_U0INTERNAL
             )
+        self._delta = self._staeckelwrap._delta
         self._Es = numpy.atleast_1d(numpy.array(Es, dtype="float"))
         self._Lzs = numpy.atleast_1d(numpy.array(Lzs, dtype="float"))
         self._I3s = numpy.atleast_1d(numpy.array(I3s, dtype="float"))
@@ -130,161 +121,203 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # actionAngleStaeckel (the natural profile zero point is the northern
         # turning point, a quarter v-period earlier)
         self._anglez0 = numpy.pi / 2.0
-        # Per-torus setup
-        self._umins = numpy.empty(self._ntori)
-        self._umaxs = numpy.empty(self._ntori)
-        self._vmins = numpy.empty(self._ntori)
-        self._jr = numpy.empty(self._ntori)
-        self._jz = numpy.empty(self._ntori)
-        self._OmegaR = numpy.empty(self._ntori)
-        self._Omegaz = numpy.empty(self._ntori)
-        self._Omegaphi = numpy.empty(self._ntori)
-        self._dEI3Lz_dJ = numpy.empty((self._ntori, 3, 3))
-        self._Aprof = []  # per torus: 3 u-profile splines A_i(chi_u)
-        self._Bprof = []  # per torus: 3 v-profile splines B_i(chi_v)
-        self._dAprof = []
-        self._dBprof = []
-        for ii in range(self._ntori):
-            self._setup_torus(ii)
+        # Setup in three logical stages
+        self._find_turning_points()
+        self._compute_actions_frequencies_profiles()
+        self._build_angle_profile_splines()
 
-    ############################ STAECKEL SPLITTING ###########################
-    # U(u) and V(v) in the gauge V(pi/2) = 0, delegated to
-    # OblateStaeckelWrapperPotential (exact when the potential is Staeckel)
-    def _Uofu(self, u):
-        return self._staeckelwrap._U(u)
-
-    def _Vofv(self, v):
-        return self._staeckelwrap._V(v)
-
+    ############################ MOMENTA ######################################
     def _Wu(self, u, E, Lz, I3):
+        """p_u^2 on the torus (E, Lz, I3); u may be an array"""
         return (
-            2.0 * self._delta**2.0 * (E * numpy.sinh(u) ** 2.0 - self._Uofu(u) - I3)
+            2.0
+            * self._delta**2.0
+            * (E * numpy.sinh(u) ** 2.0 - self._staeckelwrap._U(u) - I3)
             - Lz**2.0 / numpy.sinh(u) ** 2.0
         )
 
     def _Wv(self, v, E, Lz, I3):
+        """p_v^2 on the torus (E, Lz, I3); v may be an array"""
         return (
-            2.0 * self._delta**2.0 * (E * numpy.sin(v) ** 2.0 + self._Vofv(v) + I3)
+            2.0
+            * self._delta**2.0
+            * (E * numpy.sin(v) ** 2.0 + self._staeckelwrap._V(v) + I3)
             - Lz**2.0 / numpy.sin(v) ** 2.0
         )
 
-    ############################ PER-TORUS SETUP ##############################
-    def _setup_torus(self, ii):
-        E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
-        Wu = lambda u: self._Wu(u, E, Lz, I3)
-        Wv = lambda v: self._Wv(v, E, Lz, I3)
-        # turning points from a single dense, vectorized bracketing scan
-        # (cheap: one vectorized potential evaluation); the u range covers
-        # any realistic bound torus and near-shell oscillations down to
-        # widths of a few times 1e-3
-        us = numpy.linspace(1e-3, 40.0, 16000)
-        pos = numpy.where(Wu(us) > 0.0)[0]
-        if len(pos) == 0:
-            raise ValueError(
-                f"No bound u oscillation found for torus {ii} (E={E}, Lz={Lz}, I3={I3})"
-            )
-        if pos[-1] == len(us) - 1:
-            raise ValueError(
-                f"u oscillation not enclosed for torus {ii} "
-                f"(E={E}, Lz={Lz}, I3={I3}); the torus is likely unbound"
-            )
-        ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
-        umin = brentq(Wu, ulo, us[pos[0]], xtol=1e-15, rtol=8.9e-16)
-        umaxx = brentq(Wu, us[pos[-1]], us[pos[-1] + 1], xtol=1e-15, rtol=8.9e-16)
-        vs = numpy.linspace(1e-3, numpy.pi / 2.0, 4000)
-        if Wv(numpy.pi / 2.0) <= 0.0:
-            raise ValueError(
-                f"Midplane not reached for torus {ii}; no valid torus for "
-                f"(E={E}, Lz={Lz}, I3={I3})"
-            )
-        neg = numpy.where(Wv(vs) < 0.0)[0]
-        vmin = (
-            brentq(Wv, vs[neg[-1]], numpy.pi / 2.0, xtol=1e-15, rtol=8.9e-16)
-            if len(neg) > 0
-            else 1e-8
-        )
-        self._umins[ii], self._umaxs[ii], self._vmins[ii] = umin, umaxx, vmin
-        Du, Dv = umaxx - umin, numpy.pi - 2.0 * vmin
-        u_of_chi = lambda c: umin + Du * numpy.sin(c / 2.0) ** 2.0
-        v_of_chi = lambda c: vmin + Dv * numpy.sin(c / 2.0) ** 2.0
+    ############################ SETUP: TURNING POINTS ########################
+    def _find_turning_points(self):
+        """Bracket and refine the turning points of all tori: a single
+        vectorized scan over a dense mesh (one potential evaluation for all
+        tori, because U and V are shared), refined per torus with brentq"""
         d2 = self._delta**2.0
-        # actions: J = (1/pi) int p dq over the half (u) / full-half (v) loop
-        self._jr[ii] = self._action_quad(Wu, u_of_chi, Du) / numpy.pi
-        self._jz[ii] = self._action_quad(Wv, v_of_chi, Dv) / numpy.pi
-        # 1/p profiles: cumulative int f(q)/p dq for f = delta^2 sinh^2/sin^2,
-        # delta^2, and Lz/sinh^2 / Lz/sin^2
-        PEu = self._cumprof(Wu, u_of_chi, Du, lambda q: d2 * numpy.sinh(q) ** 2.0)
-        PIu = self._cumprof(Wu, u_of_chi, Du, lambda q: d2 * numpy.ones_like(q))
-        PLu = self._cumprof(Wu, u_of_chi, Du, lambda q: Lz / numpy.sinh(q) ** 2.0)
-        PEv = self._cumprof(Wv, v_of_chi, Dv, lambda q: d2 * numpy.sin(q) ** 2.0)
-        PIv = self._cumprof(Wv, v_of_chi, Dv, lambda q: d2 * numpy.ones_like(q))
-        PLv = self._cumprof(Wv, v_of_chi, Dv, lambda q: Lz / numpy.sin(q) ** 2.0)
-        # period matrix: pi dJ_R = totEu dE - totIu dI3 - totLu dLz;
-        #                pi dJ_z = totEv dE + totIv dI3 - totLv dLz; dJ_phi = dLz
-        totEu, totIu, totLu = PEu[-1], PIu[-1], PLu[-1]
-        totEv, totIv, totLv = PEv[-1], PIv[-1], PLv[-1]
-        M = numpy.array(
-            [
-                [totEu / numpy.pi, -totIu / numpy.pi, -totLu / numpy.pi],
-                [totEv / numpy.pi, totIv / numpy.pi, -totLv / numpy.pi],
-                [0.0, 0.0, 1.0],
+        us = numpy.linspace(1e-3, 40.0, 16000)
+        Uu = self._staeckelwrap._U(us)
+        shu2 = numpy.sinh(us) ** 2.0
+        Wu_all = (
+            2.0 * d2 * (self._Es[:, None] * shu2 - Uu - self._I3s[:, None])
+            - self._Lzs[:, None] ** 2.0 / shu2
+        )
+        vs = numpy.linspace(1e-3, numpy.pi / 2.0, 4000)
+        Vv = self._staeckelwrap._V(vs)
+        snv2 = numpy.sin(vs) ** 2.0
+        Wv_all = (
+            2.0 * d2 * (self._Es[:, None] * snv2 + Vv + self._I3s[:, None])
+            - self._Lzs[:, None] ** 2.0 / snv2
+        )
+        self._umins = numpy.empty(self._ntori)
+        self._umaxs = numpy.empty(self._ntori)
+        self._vmins = numpy.empty(self._ntori)
+        for ii in range(self._ntori):
+            E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
+            pos = numpy.where(Wu_all[ii] > 0.0)[0]
+            if len(pos) == 0:
+                raise ValueError(
+                    f"No bound u oscillation found for torus {ii} "
+                    f"(E={E}, Lz={Lz}, I3={I3})"
+                )
+            if pos[-1] == len(us) - 1:
+                raise ValueError(
+                    f"u oscillation not enclosed for torus {ii} "
+                    f"(E={E}, Lz={Lz}, I3={I3}); the torus is likely unbound"
+                )
+            Wu = lambda u: self._Wu(u, E, Lz, I3)
+            ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
+            self._umins[ii] = brentq(Wu, ulo, us[pos[0]], xtol=1e-15, rtol=8.9e-16)
+            self._umaxs[ii] = brentq(
+                Wu, us[pos[-1]], us[pos[-1] + 1], xtol=1e-15, rtol=8.9e-16
+            )
+            if Wv_all[ii, -1] <= 0.0:
+                raise ValueError(
+                    f"Midplane not reached for torus {ii}; no valid torus "
+                    f"for (E={E}, Lz={Lz}, I3={I3})"
+                )
+            Wv = lambda v: self._Wv(v, E, Lz, I3)
+            neg = numpy.where(Wv_all[ii] < 0.0)[0]
+            self._vmins[ii] = (
+                brentq(
+                    Wv,
+                    vs[neg[-1]],
+                    numpy.pi / 2.0,
+                    xtol=1e-15,
+                    rtol=8.9e-16,
+                )
+                if len(neg) > 0
+                else 1e-8
+            )
+
+    ############################ SETUP: QUADRATURES ###########################
+    def _compute_actions_frequencies_profiles(self):
+        """Actions, the 3x3 period matrices, frequencies, and the cumulative
+        angle profiles of all tori, all from two vectorized potential
+        evaluations (one per degree of freedom): the momenta at the
+        composite Gauss-Legendre nodes of the shared chi mesh give both the
+        action integrands sqrt(W) sin(chi) and the 1/p profile integrands
+        f(q) sin(chi)/sqrt(W)"""
+        d2 = self._delta**2.0
+        mid = 0.5 * (self._chi[:-1] + self._chi[1:])
+        half = 0.5 * (self._chi[1:] - self._chi[:-1])
+        nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
+        sin_nodes = numpy.sin(nodes)
+        y_nodes = numpy.sin(nodes / 2.0) ** 2.0
+        npan, ngl = len(half), len(_GLX)
+
+        def profiles(qmin, D, W_of_q, fEs, fIs, fLs):
+            # q(chi) at the nodes for all tori: (ntori, nnodes)
+            q = qmin[:, None] + D[:, None] * y_nodes[None, :]
+            W = W_of_q(q)
+            W[W < numpy.finfo(float).tiny] = numpy.finfo(float).tiny
+            sqW = numpy.sqrt(W)
+            # action: (D/2) int sqrt(W) sin(chi) dchi
+            act_vals = sqW * (D[:, None] / 2.0) * sin_nodes[None, :]
+            action = (
+                (half[None, :, None] * _GLW[None, None, :])
+                * act_vals.reshape(self._ntori, npan, ngl)
+            ).sum(axis=(-1, -2))
+            # cumulative 1/p profiles: int f(q) (D/2) sin(chi)/sqrt(W) dchi
+            base = (D[:, None] / 2.0) * sin_nodes[None, :] / sqW
+            cums = []
+            for f in (fEs, fIs, fLs):
+                vals = f(q) * base
+                pans = (
+                    (half[None, :, None] * _GLW[None, None, :])
+                    * vals.reshape(self._ntori, npan, ngl)
+                ).sum(axis=-1)
+                cums.append(
+                    numpy.hstack(
+                        (
+                            numpy.zeros((self._ntori, 1)),
+                            numpy.cumsum(pans, axis=1),
+                        )
+                    )
+                )
+            return action, cums
+
+        Es, Lzs, I3s = self._Es, self._Lzs, self._I3s
+        actu, (PEu, PIu, PLu) = profiles(
+            self._umins,
+            self._umaxs - self._umins,
+            lambda q: self._Wu(q, Es[:, None], Lzs[:, None], I3s[:, None]),
+            lambda q: d2 * numpy.sinh(q) ** 2.0,
+            lambda q: d2 * numpy.ones_like(q),
+            lambda q: Lzs[:, None] / numpy.sinh(q) ** 2.0,
+        )
+        actv, (PEv, PIv, PLv) = profiles(
+            self._vmins,
+            numpy.pi - 2.0 * self._vmins,
+            lambda q: self._Wv(q, Es[:, None], Lzs[:, None], I3s[:, None]),
+            lambda q: d2 * numpy.sin(q) ** 2.0,
+            lambda q: d2 * numpy.ones_like(q),
+            lambda q: Lzs[:, None] / numpy.sin(q) ** 2.0,
+        )
+        self._jr = actu / numpy.pi
+        self._jz = actv / numpy.pi
+        # period matrices: pi dJ_R = PEu[-1] dE - PIu[-1] dI3 - PLu[-1] dLz;
+        #                  pi dJ_z = PEv[-1] dE + PIv[-1] dI3 - PLv[-1] dLz
+        M = numpy.zeros((self._ntori, 3, 3))
+        M[:, 0, 0] = PEu[:, -1] / numpy.pi
+        M[:, 0, 1] = -PIu[:, -1] / numpy.pi
+        M[:, 0, 2] = -PLu[:, -1] / numpy.pi
+        M[:, 1, 0] = PEv[:, -1] / numpy.pi
+        M[:, 1, 1] = PIv[:, -1] / numpy.pi
+        M[:, 1, 2] = -PLv[:, -1] / numpy.pi
+        M[:, 2, 2] = 1.0
+        self._dEI3Lz_dJ = numpy.linalg.inv(M)  # d(E,I3,Lz)/d(J_R,J_z,J_phi)
+        self._OmegaR = self._dEI3Lz_dJ[:, 0, 0]
+        self._Omegaz = self._dEI3Lz_dJ[:, 0, 1]
+        self._Omegaphi = self._dEI3Lz_dJ[:, 0, 2]
+        self._Pu = (PEu, PIu, PLu)
+        self._Pv = (PEv, PIv, PLv)
+
+    def _build_angle_profile_splines(self):
+        """The six per-torus angle-profile splines A_i(chi_u), B_i(chi_v):
+        theta_i = sum_X dX/dJ_i dW/dX with dW/dE = PEu + PEv,
+        dW/dI3 = -PIu + PIv, and dW/dLz = -PLu - PLv (+ phi)"""
+        PEu, PIu, PLu = self._Pu
+        PEv, PIv, PLv = self._Pv
+        self._Aprof, self._Bprof, self._dAprof, self._dBprof = [], [], [], []
+        for ii in range(self._ntori):
+            Minv = self._dEI3Lz_dJ[ii]
+            A = [
+                InterpolatedUnivariateSpline(
+                    self._chi,
+                    Minv[0, i] * PEu[ii] - Minv[1, i] * PIu[ii] - Minv[2, i] * PLu[ii],
+                    k=5,
+                )
+                for i in range(3)
             ]
-        )
-        Minv = numpy.linalg.inv(M)  # d(E,I3,Lz)/d(J_R,J_z,J_phi)
-        self._dEI3Lz_dJ[ii] = Minv
-        self._OmegaR[ii], self._Omegaz[ii], self._Omegaphi[ii] = Minv[0]
-        # angle profiles: theta_i = sum_X dX/dJ_i dW/dX with
-        # dW/dE = PEu + PEv, dW/dI3 = -PIu + PIv, dW/dLz = -PLu - PLv (+phi)
-        A = [
-            InterpolatedUnivariateSpline(
-                self._chi,
-                Minv[0, i] * PEu - Minv[1, i] * PIu - Minv[2, i] * PLu,
-                k=5,
-            )
-            for i in range(3)
-        ]
-        B = [
-            InterpolatedUnivariateSpline(
-                self._chi,
-                Minv[0, i] * PEv + Minv[1, i] * PIv - Minv[2, i] * PLv,
-                k=5,
-            )
-            for i in range(3)
-        ]
-        self._Aprof.append(A)
-        self._Bprof.append(B)
-        self._dAprof.append([a.derivative() for a in A])
-        self._dBprof.append([b.derivative() for b in B])
-
-    def _action_quad(self, W, q_of_chi, D):
-        """int p dq over the loop as (D/2) int sqrt(W) sin chi dchi (regular)."""
-        a, b = self._chi[:-1], self._chi[1:]
-        mid, half = 0.5 * (a + b), 0.5 * (b - a)
-        nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
-        vals = (
-            numpy.sqrt(numpy.clip(W(q_of_chi(nodes)), 0.0, None))
-            * 0.5
-            * D
-            * numpy.sin(nodes)
-        )
-        return float(numpy.sum((half[:, None] * _GLW[None, :]).ravel() * vals))
-
-    def _cumprof(self, W, q_of_chi, D, f):
-        """Cumulative int f(q)/p dq = int f (D/2) sin chi / sqrt(W) dchi on the
-        chi mesh; the integrand is regular including at the turning points."""
-        a, b = self._chi[:-1], self._chi[1:]
-        mid, half = 0.5 * (a + b), 0.5 * (b - a)
-        nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
-        q = q_of_chi(nodes)
-        w = W(q)
-        vals = numpy.empty_like(nodes)
-        good = w > 0.0
-        vals[good] = (
-            f(q[good]) * (D / 2.0) * numpy.sin(nodes[good]) / numpy.sqrt(w[good])
-        )
-        vals[~good] = 0.0  # only possible through rounding exactly at the ends
-        panels = (half[:, None] * _GLW[None, :] * vals.reshape(len(a), -1)).sum(axis=1)
-        return numpy.concatenate([[0.0], numpy.cumsum(panels)])
+            B = [
+                InterpolatedUnivariateSpline(
+                    self._chi,
+                    Minv[0, i] * PEv[ii] + Minv[1, i] * PIv[ii] - Minv[2, i] * PLv[ii],
+                    k=5,
+                )
+                for i in range(3)
+            ]
+            self._Aprof.append(A)
+            self._Bprof.append(B)
+            self._dAprof.append([a.derivative() for a in A])
+            self._dBprof.append([b.derivative() for b in B])
 
     ############################ EVALUATION ###################################
     def _torus_index(self, jr, jphi, jz):

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -340,15 +340,28 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._jz = actv / numpy.pi
         # period matrices: pi dJ_R = PEu[-1] dE - PIu[-1] dI3 - PLu[-1] dLz;
         #                  pi dJ_z = PEv[-1] dE + PIv[-1] dI3 - PLv[-1] dLz
-        M = numpy.zeros((self._ntori, 3, 3))
-        M[:, 0, 0] = PEu[:, -1] / numpy.pi
-        M[:, 0, 1] = -PIu[:, -1] / numpy.pi
-        M[:, 0, 2] = -PLu[:, -1] / numpy.pi
-        M[:, 1, 0] = PEv[:, -1] / numpy.pi
-        M[:, 1, 1] = PIv[:, -1] / numpy.pi
-        M[:, 1, 2] = -PLv[:, -1] / numpy.pi
-        M[:, 2, 2] = 1.0
-        self._dEI3Lz_dJ = numpy.linalg.inv(M)  # d(E,I3,Lz)/d(J_R,J_z,J_phi)
+        # Because J_phi = L_z identically, the third row of M is (0,0,1) and
+        # M is block-triangular: its inverse follows in closed form from the
+        # 2x2 (E,I3) block, with no general matrix inversion needed (the same
+        # 2x2 structure the forward actionAngleStaeckel uses for its
+        # frequencies)
+        a11 = PEu[:, -1] / numpy.pi
+        a12 = -PIu[:, -1] / numpy.pi
+        a13 = -PLu[:, -1] / numpy.pi
+        a21 = PEv[:, -1] / numpy.pi
+        a22 = PIv[:, -1] / numpy.pi
+        a23 = -PLv[:, -1] / numpy.pi
+        det = a11 * a22 - a12 * a21
+        self._dEI3Lz_dJ = numpy.zeros((self._ntori, 3, 3))
+        # d(E,I3)/d(J_R,J_z) from the inverse of the 2x2 block
+        self._dEI3Lz_dJ[:, 0, 0] = a22 / det
+        self._dEI3Lz_dJ[:, 0, 1] = -a12 / det
+        self._dEI3Lz_dJ[:, 1, 0] = -a21 / det
+        self._dEI3Lz_dJ[:, 1, 1] = a11 / det
+        # d(E,I3)/dJ_phi = -[2x2 inverse] . (dJ_R/dLz, dJ_z/dLz)
+        self._dEI3Lz_dJ[:, 0, 2] = -(a22 * a13 - a12 * a23) / det
+        self._dEI3Lz_dJ[:, 1, 2] = -(-a21 * a13 + a11 * a23) / det
+        self._dEI3Lz_dJ[:, 2, 2] = 1.0
         self._OmegaR = self._dEI3Lz_dJ[:, 0, 0]
         self._Omegaz = self._dEI3Lz_dJ[:, 0, 1]
         self._Omegaphi = self._dEI3Lz_dJ[:, 0, 2]

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -12,10 +12,14 @@ import numpy
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.optimize import brentq
 
-from ..potential import evaluatePotentials
-from ..util import conversion
+from ..potential import OblateStaeckelWrapperPotential
+from ..util import conversion, coords
 from .actionAngleInverse import actionAngleInverse
 
+# Nodes/weights for composite 10-point Gauss-Legendre quadrature: applied per
+# interval of the nchi-point chi mesh, the error per panel is
+# O((pi/nchi)^20), so every stored integral is at machine precision for any
+# reasonable nchi; there is no accuracy knob to tune
 _GLX, _GLW = numpy.polynomial.legendre.leggauss(10)
 
 
@@ -36,13 +40,11 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self,
         pot=None,
         delta=None,
+        u0=None,
         Es=[0.5],
         Lzs=[0.5],
         I3s=[0.1],
         nchi=2001,
-        uref=1.15,
-        umax=10.0,
-        nscan=800,
         maxiter=60,
         angle_tol=1e-13,
         **kwargs,
@@ -54,10 +56,21 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         ----------
         pot : Potential or list thereof
             The potential; must be of exact Staeckel form in prolate
-            spheroidal coordinates with focal distance delta (e.g.,
-            KuzminKutuzovStaeckelPotential).
-        delta : float
-            Focal distance of the prolate spheroidal coordinate system.
+            spheroidal coordinates with focal distance delta. Pass an
+            OblateStaeckelWrapperPotential to work with the Staeckel
+            approximation of a general axisymmetric potential (support for
+            torus-dependent delta in that case is planned).
+        delta : float or Quantity, optional
+            Focal distance of the prolate spheroidal coordinate system;
+            derived from the potential when possible (e.g., from a
+            KuzminKutuzovStaeckelPotential or an
+            OblateStaeckelWrapperPotential), otherwise required.
+        u0 : float, optional
+            Reference u of the Staeckel splitting (as in
+            OblateStaeckelWrapperPotential); irrelevant for an exactly
+            Staeckel potential (any value gives the same U, V up to the
+            fixed gauge), taken from the potential when passing an
+            OblateStaeckelWrapperPotential.
         Es : list of float
             Energies of the tori to set up.
         Lzs : list of float
@@ -69,12 +82,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         nchi : int, optional
             Number of grid points in the chi anomaly for the stored
             profiles.
-        uref : float, optional
-            Reference u used in the Staeckel splitting of the potential.
-        umax : float, optional
-            Maximum u scanned for the u turning points.
-        nscan : int, optional
-            Number of points in the turning-point bracketing scans.
         maxiter : int, optional
             Maximum number of Newton iterations in the angle inversion.
         angle_tol : float, optional
@@ -82,31 +89,47 @@ class actionAngleStaeckelInverse(actionAngleInverse):
 
         Notes
         -----
-        - Angle conventions: theta_R = 0 at u = u_- moving outward;
-          theta_z = 0 at v = v_- (the northern turning point) moving toward
-          the midplane; theta_phi follows from dW/dL_z.
+        - Angle conventions match those of the forward actionAngleStaeckel.
         - 2026-08-19 - Started - Bovy (UofT)
         """
-        actionAngleInverse.__init__(self, *[], **kwargs)
+        actionAngleInverse.__init__(self, **kwargs)
         if pot is None:  # pragma: no cover
             raise OSError("Must specify pot= for actionAngleStaeckelInverse")
-        if delta is None:  # pragma: no cover
-            raise OSError("Must specify delta= for actionAngleStaeckelInverse")
         self._pot = pot
-        self._delta = conversion.parse_length(delta, ro=self._ro)
+        if isinstance(pot, OblateStaeckelWrapperPotential):
+            if delta is not None or u0 is not None:
+                raise ValueError(
+                    "When pot is an OblateStaeckelWrapperPotential, delta and "
+                    "u0 are taken from the potential and cannot be specified"
+                )
+            self._staeckelwrap = pot
+            self._delta = pot._delta
+            self._u0 = pot._u0
+        else:
+            if delta is None:
+                delta = getattr(pot, "_Delta", None)
+            if delta is None:
+                raise OSError(
+                    "Must specify delta= for actionAngleStaeckelInverse when "
+                    "it cannot be derived from the potential"
+                )
+            self._delta = conversion.parse_length(delta, ro=self._ro)
+            self._u0 = 1.15 if u0 is None else u0
+            self._staeckelwrap = OblateStaeckelWrapperPotential(
+                pot=pot, delta=self._delta, u0=self._u0
+            )
         self._Es = numpy.atleast_1d(numpy.array(Es, dtype="float"))
         self._Lzs = numpy.atleast_1d(numpy.array(Lzs, dtype="float"))
         self._I3s = numpy.atleast_1d(numpy.array(I3s, dtype="float"))
         self._ntori = len(self._Es)
         self._nchi = nchi
-        self._uref = uref
-        self._umax = umax
-        self._nscan = nscan
         self._maxiter = maxiter
         self._angle_tol = angle_tol
         self._chi = numpy.linspace(0.0, numpy.pi, nchi)
-        # Staeckel splitting with the gauge V(pi/2) = 0
-        self._Vref = self._Uofu(uref)
+        # theta_z = 0 at the upward midplane crossing, matching the forward
+        # actionAngleStaeckel (the natural profile zero point is the northern
+        # turning point, a quarter v-period earlier)
+        self._anglez0 = numpy.pi / 2.0
         # Per-torus setup
         self._umins = numpy.empty(self._ntori)
         self._umaxs = numpy.empty(self._ntori)
@@ -125,18 +148,13 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             self._setup_torus(ii)
 
     ############################ STAECKEL SPLITTING ###########################
-    def _phi_uv(self, u, v):
-        R = self._delta * numpy.sinh(u) * numpy.sin(v)
-        z = self._delta * numpy.cosh(u) * numpy.cos(v)
-        return evaluatePotentials(self._pot, R, z, use_physical=False)
-
+    # U(u) and V(v) in the gauge V(pi/2) = 0, delegated to
+    # OblateStaeckelWrapperPotential (exact when the potential is Staeckel)
     def _Uofu(self, u):
-        return self._phi_uv(u, numpy.pi / 2.0) * (numpy.sinh(u) ** 2.0 + 1.0)
+        return self._staeckelwrap._U(u)
 
     def _Vofv(self, v):
-        return self._Vref - self._phi_uv(self._uref, v) * (
-            numpy.sinh(self._uref) ** 2.0 + numpy.sin(v) ** 2.0
-        )
+        return self._staeckelwrap._V(v)
 
     def _Wu(self, u, E, Lz, I3):
         return (
@@ -155,23 +173,29 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
         Wu = lambda u: self._Wu(u, E, Lz, I3)
         Wv = lambda v: self._Wv(v, E, Lz, I3)
-        # turning points from bracketing scans
-        us = numpy.linspace(1e-3, self._umax, self._nscan)
+        # turning points from a single dense, vectorized bracketing scan
+        # (cheap: one vectorized potential evaluation); the u range covers
+        # any realistic bound torus and near-shell oscillations down to
+        # widths of a few times 1e-3
+        us = numpy.linspace(1e-3, 40.0, 16000)
         pos = numpy.where(Wu(us) > 0.0)[0]
         if len(pos) == 0:
             raise ValueError(
-                f"No bound u oscillation found for torus {ii} "
-                "(E={E}, Lz={Lz}, I3={I3})"
+                f"No bound u oscillation found for torus {ii} (E={E}, Lz={Lz}, I3={I3})"
+            )
+        if pos[-1] == len(us) - 1:
+            raise ValueError(
+                f"u oscillation not enclosed for torus {ii} "
+                f"(E={E}, Lz={Lz}, I3={I3}); the torus is likely unbound"
             )
         ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
-        uhi = us[pos[-1] + 1] if pos[-1] < self._nscan - 1 else self._umax
         umin = brentq(Wu, ulo, us[pos[0]], xtol=1e-15, rtol=8.9e-16)
-        umaxx = brentq(Wu, us[pos[-1]], uhi, xtol=1e-15, rtol=8.9e-16)
-        vs = numpy.linspace(1e-3, numpy.pi / 2.0, self._nscan)
+        umaxx = brentq(Wu, us[pos[-1]], us[pos[-1] + 1], xtol=1e-15, rtol=8.9e-16)
+        vs = numpy.linspace(1e-3, numpy.pi / 2.0, 4000)
         if Wv(numpy.pi / 2.0) <= 0.0:
             raise ValueError(
                 f"Midplane not reached for torus {ii}; no valid torus for "
-                "(E={E}, Lz={Lz}, I3={I3})"
+                f"(E={E}, Lz={Lz}, I3={I3})"
             )
         neg = numpy.where(Wv(vs) < 0.0)[0]
         vmin = (
@@ -305,7 +329,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         wu, wv = numpy.copy(thR), numpy.copy(thz)
         for _ in range(self._maxiter):
             f0 = self._fold(A[0], wu) + self._fold(B[0], wv) - thR
-            f1 = self._fold(A[1], wu) + self._fold(B[1], wv) - thz
+            f1 = self._fold(A[1], wu) + self._fold(B[1], wv) + self._anglez0 - thz
             f0 = (f0 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             f1 = (f1 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             J00, J01 = self._dfold(dA[0], wu), self._dfold(dB[0], wv)
@@ -336,8 +360,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # (u, v, p_u, p_v) -> (R, z, vR, vz)
         sh, ch = numpy.sinh(u), numpy.cosh(u)
         sn, cs = numpy.sin(v), numpy.cos(v)
-        R = self._delta * sh * sn
-        z = self._delta * ch * cs
+        R, z = coords.uv_to_Rz(u, v, delta=self._delta)
         den = self._delta * (sh**2.0 + sn**2.0)
         vR = (pu * ch * sn + pv * sh * cs) / den
         vz = (pu * sh * cs - pv * ch * sn) / den
@@ -357,31 +380,3 @@ class actionAngleStaeckelInverse(actionAngleInverse):
     def _Freqs(self, jr, jphi, jz, **kwargs):
         ii = self._torus_index(jr, jphi, jz)
         return (self._OmegaR[ii], self._Omegaphi[ii], self._Omegaz[ii])
-
-    ############################ FORWARD (for tests) ##########################
-    def _point_to_angles(self, R, vR, vT, z, vz, phi, indx):
-        """Angles of a phase-space point on torus indx (internal, used to
-        anchor traversal tests); returns (theta_R, theta_phi, theta_z)."""
-        ii = indx
-        d = self._delta
-        d1 = numpy.sqrt(R**2.0 + (z + d) ** 2.0)
-        d2 = numpy.sqrt(R**2.0 + (z - d) ** 2.0)
-        u = numpy.arccosh(numpy.clip((d1 + d2) / (2.0 * d), 1.0, None))
-        v = numpy.arccos(numpy.clip((d1 - d2) / (2.0 * d), -1.0, 1.0))
-        pu = d * (vR * numpy.cosh(u) * numpy.sin(v) + vz * numpy.sinh(u) * numpy.cos(v))
-        pv = d * (vR * numpy.sinh(u) * numpy.cos(v) - vz * numpy.cosh(u) * numpy.sin(v))
-        umin, umaxx, vmin = self._umins[ii], self._umaxs[ii], self._vmins[ii]
-        Du, Dv = umaxx - umin, numpy.pi - 2.0 * vmin
-        chiu = 2.0 * numpy.arcsin(numpy.sqrt(numpy.clip((u - umin) / Du, 0.0, 1.0)))
-        chiv = 2.0 * numpy.arcsin(numpy.sqrt(numpy.clip((v - vmin) / Dv, 0.0, 1.0)))
-        wu = numpy.where(pu >= 0.0, chiu, 2.0 * numpy.pi - chiu)
-        wv = numpy.where(pv >= 0.0, chiv, 2.0 * numpy.pi - chiv)
-        A, B = self._Aprof[ii], self._Bprof[ii]
-        thR = self._fold(A[0], wu) + self._fold(B[0], wv)
-        thz = self._fold(A[1], wu) + self._fold(B[1], wv)
-        thphi = phi + self._fold(A[2], wu) + self._fold(B[2], wv)
-        return (
-            thR % (2.0 * numpy.pi),
-            thphi % (2.0 * numpy.pi),
-            thz % (2.0 * numpy.pi),
-        )

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -437,23 +437,35 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         thR = numpy.atleast_1d(numpy.array(angler, dtype="float"))
         thz = numpy.atleast_1d(numpy.array(anglez, dtype="float"))
         thphi = numpy.atleast_1d(numpy.array(anglephi, dtype="float"))
-        # solve the additively separable 2x2 system for the extended phases
+        # Solve the additively separable 2x2 system for the extended phases,
+        # iterating only on the angles that have not yet converged (as in the
+        # 1D and spherical inverses): the Newton iteration is quadratically
+        # convergent, so most angles are done in a few steps while a few
+        # near-degenerate ones take longer
         wu, wv = numpy.copy(thR), numpy.copy(thz)
+        unconv = numpy.ones(wu.shape, dtype="bool")
         for _ in range(self._maxiter):
-            f0 = self._fold(A[0], wu) + self._fold(B[0], wv) - thR
-            f1 = self._fold(A[1], wu) + self._fold(B[1], wv) + self._anglez0 - thz
+            twu, twv = wu[unconv], wv[unconv]
+            f0 = self._fold(A[0], twu) + self._fold(B[0], twv) - thR[unconv]
+            f1 = (
+                self._fold(A[1], twu)
+                + self._fold(B[1], twv)
+                + self._anglez0
+                - thz[unconv]
+            )
             f0 = (f0 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             f1 = (f1 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
-            J00, J01 = self._dfold(dA[0], wu), self._dfold(dB[0], wv)
-            J10, J11 = self._dfold(dA[1], wu), self._dfold(dB[1], wv)
+            J00, J01 = self._dfold(dA[0], twu), self._dfold(dB[0], twv)
+            J10, J11 = self._dfold(dA[1], twu), self._dfold(dB[1], twv)
             det = J00 * J11 - J01 * J10
             dwu = (J11 * f0 - J01 * f1) / det
             dwv = (-J10 * f0 + J00 * f1) / det
             step = numpy.maximum(numpy.fabs(dwu), numpy.fabs(dwv))
             lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
-            wu -= dwu * lim
-            wv -= dwv * lim
-            if numpy.max(step) < self._angle_tol:
+            wu[unconv] -= dwu * lim
+            wv[unconv] -= dwv * lim
+            unconv[unconv] = step >= self._angle_tol
+            if not numpy.any(unconv):
                 break
         # phases -> (u, v, p_u, p_v)
         E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -10,7 +10,7 @@
 ###############################################################################
 import numpy
 from scipy.interpolate import InterpolatedUnivariateSpline
-from scipy.optimize import brentq
+from scipy.optimize import brentq, minimize_scalar
 
 from ..potential import OblateStaeckelWrapperPotential
 from ..util import coords
@@ -147,9 +147,15 @@ class actionAngleStaeckelInverse(actionAngleInverse):
 
     ############################ SETUP: TURNING POINTS ########################
     def _find_turning_points(self):
-        """Bracket and refine the turning points of all tori: a single
-        vectorized scan over a dense mesh (one potential evaluation for all
-        tori, because U and V are shared), refined per torus with brentq"""
+        """Bracket and refine the turning points of all tori. A single
+        vectorized scan over a shared mesh (one potential evaluation for all
+        tori, because U and V are shared) seeds the brackets; neither the
+        range nor the resolution of the scan is a hard limit, because the
+        brackets are extended by geometric stepping beyond the mesh (like
+        the rperi/rap search in actionAngleSpherical) and an oscillation
+        narrower than the mesh spacing is recovered by refining the maximum
+        of W_u before declaring it absent. Roots are polished with brentq
+        at machine tolerance."""
         d2 = self._delta**2.0
         us = numpy.linspace(1e-3, 40.0, 16000)
         Uu = self._staeckelwrap._U(us)
@@ -170,23 +176,49 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._vmins = numpy.empty(self._ntori)
         for ii in range(self._ntori):
             E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
-            pos = numpy.where(Wu_all[ii] > 0.0)[0]
-            if len(pos) == 0:
-                raise ValueError(
-                    f"No bound u oscillation found for torus {ii} "
-                    f"(E={E}, Lz={Lz}, I3={I3})"
-                )
-            if pos[-1] == len(us) - 1:
-                raise ValueError(
-                    f"u oscillation not enclosed for torus {ii} "
-                    f"(E={E}, Lz={Lz}, I3={I3}); the torus is likely unbound"
-                )
             Wu = lambda u: self._Wu(u, E, Lz, I3)
-            ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
-            self._umins[ii] = brentq(Wu, ulo, us[pos[0]], xtol=1e-15, rtol=8.9e-16)
-            self._umaxs[ii] = brentq(
-                Wu, us[pos[-1]], us[pos[-1] + 1], xtol=1e-15, rtol=8.9e-16
-            )
+            pos = numpy.where(Wu_all[ii] > 0.0)[0]
+            if len(pos) > 0:
+                ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
+                uin, uout = us[pos[0]], us[pos[-1]]
+                uhi = us[pos[-1] + 1] if pos[-1] < len(us) - 1 else None
+            else:
+                # No positive sample: the oscillation may simply be narrower
+                # than the mesh spacing (a near-shell torus); refine the
+                # maximum of W_u around the largest sample before declaring
+                # that there is no bound oscillation (guarding against NaNs
+                # from potential evaluations at extreme coordinates)
+                jmax = numpy.nanargmax(Wu_all[ii])
+                res = minimize_scalar(
+                    lambda u: -self._Wu(u, E, Lz, I3),
+                    bounds=(us[max(jmax - 1, 0)], us[min(jmax + 1, len(us) - 1)]),
+                    method="bounded",
+                    options={"xatol": 1e-14},
+                )
+                if -res.fun <= 0.0:
+                    raise ValueError(
+                        f"No bound u oscillation found for torus {ii} "
+                        f"(E={E}, Lz={Lz}, I3={I3})"
+                    )
+                uin = uout = res.x
+                ulo, uhi = uin / 2.0, 2.0 * uout
+            if uhi is None:
+                # The oscillation extends beyond the scan: step out
+                # geometrically until W_u turns properly negative (the
+                # not-< comparison keeps stepping through NaNs from
+                # potential evaluations at extreme coordinates)
+                uhi = 2.0 * uout
+                while not Wu(uhi) < 0.0:
+                    if uhi > 200.0:
+                        raise ValueError(
+                            f"u oscillation of torus {ii} extends beyond "
+                            f"u=200 (E={E}, Lz={Lz}, I3={I3}); the torus is "
+                            "likely unbound"
+                        )
+                    uout = uhi
+                    uhi *= 2.0
+            self._umins[ii] = brentq(Wu, ulo, uin, xtol=1e-15, rtol=8.9e-16)
+            self._umaxs[ii] = brentq(Wu, uout, uhi, xtol=1e-15, rtol=8.9e-16)
             if Wv_all[ii, -1] <= 0.0:
                 raise ValueError(
                     f"Midplane not reached for torus {ii}; no valid torus "
@@ -207,35 +239,67 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             )
 
     ############################ SETUP: QUADRATURES ###########################
+    def _dWu(self, u, E, Lz):
+        """dW_u/du (independent of I3); u may be an array"""
+        return (
+            2.0
+            * self._delta**2.0
+            * (E * numpy.sinh(2.0 * u) - self._staeckelwrap._dUdu(u))
+            + 2.0 * Lz**2.0 * numpy.cosh(u) / numpy.sinh(u) ** 3.0
+        )
+
+    def _dWv(self, v, E, Lz):
+        """dW_v/dv (independent of I3); v may be an array"""
+        return (
+            2.0
+            * self._delta**2.0
+            * (E * numpy.sin(2.0 * v) + self._staeckelwrap._dVdv(v))
+            + 2.0 * Lz**2.0 * numpy.cos(v) / numpy.sin(v) ** 3.0
+        )
+
     def _compute_actions_frequencies_profiles(self):
         """Actions, the 3x3 period matrices, frequencies, and the cumulative
         angle profiles of all tori, all from two vectorized potential
-        evaluations (one per degree of freedom): the momenta at the
-        composite Gauss-Legendre nodes of the shared chi mesh give both the
-        action integrands sqrt(W) sin(chi) and the 1/p profile integrands
-        f(q) sin(chi)/sqrt(W)"""
+        evaluations (one per degree of freedom). All integrands are written
+        in terms of the regular ratio Q = W/[y(1-y)] (y = sin^2 chi/2), so
+        that the action integrand is (D/4) sqrt(Q) sin^2(chi) and the 1/p
+        profile integrands are f(q) D/sqrt(Q); near the turning points,
+        where the direct evaluation of W is dominated by cancellation
+        error, Q is replaced by its finite limits |W'(q_-+)| D computed
+        from the analytic derivative of the momentum (the same masking as
+        in the 1D and spherical quadratures)"""
         d2 = self._delta**2.0
         mid = 0.5 * (self._chi[:-1] + self._chi[1:])
         half = 0.5 * (self._chi[1:] - self._chi[:-1])
         nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
         sin_nodes = numpy.sin(nodes)
         y_nodes = numpy.sin(nodes / 2.0) ** 2.0
+        y1my = y_nodes * (1.0 - y_nodes)
         npan, ngl = len(half), len(_GLX)
 
-        def profiles(qmin, D, W_of_q, fEs, fIs, fLs):
+        def profiles(qmin, qmax, W_of_q, dW_of_q, fEs, fIs, fLs):
+            D = qmax - qmin
             # q(chi) at the nodes for all tori: (ntori, nnodes)
             q = qmin[:, None] + D[:, None] * y_nodes[None, :]
-            W = W_of_q(q)
-            W[W < numpy.finfo(float).tiny] = numpy.finfo(float).tiny
-            sqW = numpy.sqrt(W)
-            # action: (D/2) int sqrt(W) sin(chi) dchi
-            act_vals = sqW * (D[:, None] / 2.0) * sin_nodes[None, :]
+            Q = W_of_q(q) / y1my[None, :]
+            # turning-point limits Q -> |W'| D, switched in where the direct
+            # evaluation is unreliable
+            Qlim = numpy.where(
+                y_nodes[None, :] < 0.5,
+                (dW_of_q(qmin) * D)[:, None],
+                (-dW_of_q(qmax) * D)[:, None],
+            )
+            Q = numpy.where(y1my[None, :] > 1e-6, Q, Qlim)
+            Q[Q < numpy.finfo(float).tiny] = numpy.finfo(float).tiny
+            sqQ = numpy.sqrt(Q)
+            # action: (D/4) int sqrt(Q) sin^2(chi) dchi
+            act_vals = sqQ * (D[:, None] / 4.0) * sin_nodes[None, :] ** 2.0
             action = (
                 (half[None, :, None] * _GLW[None, None, :])
                 * act_vals.reshape(self._ntori, npan, ngl)
             ).sum(axis=(-1, -2))
-            # cumulative 1/p profiles: int f(q) (D/2) sin(chi)/sqrt(W) dchi
-            base = (D[:, None] / 2.0) * sin_nodes[None, :] / sqW
+            # cumulative 1/p profiles: int f(q) D/sqrt(Q) dchi
+            base = D[:, None] / sqQ
             cums = []
             for f in (fEs, fIs, fLs):
                 vals = f(q) * base
@@ -256,16 +320,18 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         Es, Lzs, I3s = self._Es, self._Lzs, self._I3s
         actu, (PEu, PIu, PLu) = profiles(
             self._umins,
-            self._umaxs - self._umins,
+            self._umaxs,
             lambda q: self._Wu(q, Es[:, None], Lzs[:, None], I3s[:, None]),
+            lambda q: self._dWu(q, Es, Lzs),
             lambda q: d2 * numpy.sinh(q) ** 2.0,
             lambda q: d2 * numpy.ones_like(q),
             lambda q: Lzs[:, None] / numpy.sinh(q) ** 2.0,
         )
         actv, (PEv, PIv, PLv) = profiles(
             self._vmins,
-            numpy.pi - 2.0 * self._vmins,
+            numpy.pi - self._vmins,
             lambda q: self._Wv(q, Es[:, None], Lzs[:, None], I3s[:, None]),
+            lambda q: self._dWv(q, Es, Lzs),
             lambda q: d2 * numpy.sin(q) ** 2.0,
             lambda q: d2 * numpy.ones_like(q),
             lambda q: Lzs[:, None] / numpy.sin(q) ** 2.0,

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1,0 +1,387 @@
+###############################################################################
+#   actionAngleStaeckelInverse.py: inverse action-angle transformation for
+#   axisymmetric Staeckel potentials, computed directly from the separable
+#   structure: each angle is the sum of a u-profile and a v-profile
+#   (theta_i = dW/dJ_i with W = int p_u du + int p_v dv + L_z phi), with all
+#   profiles evaluated as regular quadratures in the chi anomaly and the
+#   (J,theta) -> (x,v) direction solved by an additively-separable 2x2
+#   Newton iteration. No auxiliary torus, generating function, or Fourier
+#   lattice is involved; placement on the torus is exact by construction.
+###############################################################################
+import numpy
+from scipy.interpolate import InterpolatedUnivariateSpline
+from scipy.optimize import brentq
+
+from ..potential import evaluatePotentials
+from ..util import conversion
+from .actionAngleInverse import actionAngleInverse
+
+_GLX, _GLW = numpy.polynomial.legendre.leggauss(10)
+
+
+class actionAngleStaeckelInverse(actionAngleInverse):
+    """Inverse action-angle formalism for axisymmetric Staeckel potentials
+
+    The angles of a separable potential are additively separable in the
+    per-degree-of-freedom phases: theta_i = dW/dJ_i with
+    W = int p_u du + int p_v dv + L_z phi, so each angle is the sum of a
+    u-profile and a v-profile, both regular quadratures in the chi anomaly
+    (u = u_- + [u_+ - u_-] sin^2 chi_u/2 and similarly for the full v loop).
+    Evaluating (J,theta) -> (x,v) requires only inverting the additively
+    separable 2x2 angle system, followed by closed-form coordinate
+    transformations. Placement on the torus is exact by construction.
+    """
+
+    def __init__(
+        self,
+        pot=None,
+        delta=None,
+        Es=[0.5],
+        Lzs=[0.5],
+        I3s=[0.1],
+        nchi=2001,
+        uref=1.15,
+        umax=10.0,
+        nscan=800,
+        maxiter=60,
+        angle_tol=1e-13,
+        **kwargs,
+    ):
+        """
+        Initialize an actionAngleStaeckelInverse object.
+
+        Parameters
+        ----------
+        pot : Potential or list thereof
+            The potential; must be of exact Staeckel form in prolate
+            spheroidal coordinates with focal distance delta (e.g.,
+            KuzminKutuzovStaeckelPotential).
+        delta : float
+            Focal distance of the prolate spheroidal coordinate system.
+        Es : list of float
+            Energies of the tori to set up.
+        Lzs : list of float
+            z-components of the angular momentum of the tori.
+        I3s : list of float
+            Third integrals of the tori (in the convention
+            p_u^2 = 2 delta^2 [E sinh^2 u - U(u) - I_3] - L_z^2/sinh^2 u
+            with the gauge V(pi/2) = 0).
+        nchi : int, optional
+            Number of grid points in the chi anomaly for the stored
+            profiles.
+        uref : float, optional
+            Reference u used in the Staeckel splitting of the potential.
+        umax : float, optional
+            Maximum u scanned for the u turning points.
+        nscan : int, optional
+            Number of points in the turning-point bracketing scans.
+        maxiter : int, optional
+            Maximum number of Newton iterations in the angle inversion.
+        angle_tol : float, optional
+            Convergence tolerance of the angle inversion.
+
+        Notes
+        -----
+        - Angle conventions: theta_R = 0 at u = u_- moving outward;
+          theta_z = 0 at v = v_- (the northern turning point) moving toward
+          the midplane; theta_phi follows from dW/dL_z.
+        - 2026-08-19 - Started - Bovy (UofT)
+        """
+        actionAngleInverse.__init__(self, *[], **kwargs)
+        if pot is None:  # pragma: no cover
+            raise OSError("Must specify pot= for actionAngleStaeckelInverse")
+        if delta is None:  # pragma: no cover
+            raise OSError("Must specify delta= for actionAngleStaeckelInverse")
+        self._pot = pot
+        self._delta = conversion.parse_length(delta, ro=self._ro)
+        self._Es = numpy.atleast_1d(numpy.array(Es, dtype="float"))
+        self._Lzs = numpy.atleast_1d(numpy.array(Lzs, dtype="float"))
+        self._I3s = numpy.atleast_1d(numpy.array(I3s, dtype="float"))
+        self._ntori = len(self._Es)
+        self._nchi = nchi
+        self._uref = uref
+        self._umax = umax
+        self._nscan = nscan
+        self._maxiter = maxiter
+        self._angle_tol = angle_tol
+        self._chi = numpy.linspace(0.0, numpy.pi, nchi)
+        # Staeckel splitting with the gauge V(pi/2) = 0
+        self._Vref = self._Uofu(uref)
+        # Per-torus setup
+        self._umins = numpy.empty(self._ntori)
+        self._umaxs = numpy.empty(self._ntori)
+        self._vmins = numpy.empty(self._ntori)
+        self._jr = numpy.empty(self._ntori)
+        self._jz = numpy.empty(self._ntori)
+        self._OmegaR = numpy.empty(self._ntori)
+        self._Omegaz = numpy.empty(self._ntori)
+        self._Omegaphi = numpy.empty(self._ntori)
+        self._dEI3Lz_dJ = numpy.empty((self._ntori, 3, 3))
+        self._Aprof = []  # per torus: 3 u-profile splines A_i(chi_u)
+        self._Bprof = []  # per torus: 3 v-profile splines B_i(chi_v)
+        self._dAprof = []
+        self._dBprof = []
+        for ii in range(self._ntori):
+            self._setup_torus(ii)
+
+    ############################ STAECKEL SPLITTING ###########################
+    def _phi_uv(self, u, v):
+        R = self._delta * numpy.sinh(u) * numpy.sin(v)
+        z = self._delta * numpy.cosh(u) * numpy.cos(v)
+        return evaluatePotentials(self._pot, R, z, use_physical=False)
+
+    def _Uofu(self, u):
+        return self._phi_uv(u, numpy.pi / 2.0) * (numpy.sinh(u) ** 2.0 + 1.0)
+
+    def _Vofv(self, v):
+        return self._Vref - self._phi_uv(self._uref, v) * (
+            numpy.sinh(self._uref) ** 2.0 + numpy.sin(v) ** 2.0
+        )
+
+    def _Wu(self, u, E, Lz, I3):
+        return (
+            2.0 * self._delta**2.0 * (E * numpy.sinh(u) ** 2.0 - self._Uofu(u) - I3)
+            - Lz**2.0 / numpy.sinh(u) ** 2.0
+        )
+
+    def _Wv(self, v, E, Lz, I3):
+        return (
+            2.0 * self._delta**2.0 * (E * numpy.sin(v) ** 2.0 + self._Vofv(v) + I3)
+            - Lz**2.0 / numpy.sin(v) ** 2.0
+        )
+
+    ############################ PER-TORUS SETUP ##############################
+    def _setup_torus(self, ii):
+        E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
+        Wu = lambda u: self._Wu(u, E, Lz, I3)
+        Wv = lambda v: self._Wv(v, E, Lz, I3)
+        # turning points from bracketing scans
+        us = numpy.linspace(1e-3, self._umax, self._nscan)
+        pos = numpy.where(Wu(us) > 0.0)[0]
+        if len(pos) == 0:
+            raise ValueError(
+                f"No bound u oscillation found for torus {ii} "
+                "(E={E}, Lz={Lz}, I3={I3})"
+            )
+        ulo = us[pos[0] - 1] if pos[0] > 0 else 1e-8
+        uhi = us[pos[-1] + 1] if pos[-1] < self._nscan - 1 else self._umax
+        umin = brentq(Wu, ulo, us[pos[0]], xtol=1e-15, rtol=8.9e-16)
+        umaxx = brentq(Wu, us[pos[-1]], uhi, xtol=1e-15, rtol=8.9e-16)
+        vs = numpy.linspace(1e-3, numpy.pi / 2.0, self._nscan)
+        if Wv(numpy.pi / 2.0) <= 0.0:
+            raise ValueError(
+                f"Midplane not reached for torus {ii}; no valid torus for "
+                "(E={E}, Lz={Lz}, I3={I3})"
+            )
+        neg = numpy.where(Wv(vs) < 0.0)[0]
+        vmin = (
+            brentq(Wv, vs[neg[-1]], numpy.pi / 2.0, xtol=1e-15, rtol=8.9e-16)
+            if len(neg) > 0
+            else 1e-8
+        )
+        self._umins[ii], self._umaxs[ii], self._vmins[ii] = umin, umaxx, vmin
+        Du, Dv = umaxx - umin, numpy.pi - 2.0 * vmin
+        u_of_chi = lambda c: umin + Du * numpy.sin(c / 2.0) ** 2.0
+        v_of_chi = lambda c: vmin + Dv * numpy.sin(c / 2.0) ** 2.0
+        d2 = self._delta**2.0
+        # actions: J = (1/pi) int p dq over the half (u) / full-half (v) loop
+        self._jr[ii] = self._action_quad(Wu, u_of_chi, Du) / numpy.pi
+        self._jz[ii] = self._action_quad(Wv, v_of_chi, Dv) / numpy.pi
+        # 1/p profiles: cumulative int f(q)/p dq for f = delta^2 sinh^2/sin^2,
+        # delta^2, and Lz/sinh^2 / Lz/sin^2
+        PEu = self._cumprof(Wu, u_of_chi, Du, lambda q: d2 * numpy.sinh(q) ** 2.0)
+        PIu = self._cumprof(Wu, u_of_chi, Du, lambda q: d2 * numpy.ones_like(q))
+        PLu = self._cumprof(Wu, u_of_chi, Du, lambda q: Lz / numpy.sinh(q) ** 2.0)
+        PEv = self._cumprof(Wv, v_of_chi, Dv, lambda q: d2 * numpy.sin(q) ** 2.0)
+        PIv = self._cumprof(Wv, v_of_chi, Dv, lambda q: d2 * numpy.ones_like(q))
+        PLv = self._cumprof(Wv, v_of_chi, Dv, lambda q: Lz / numpy.sin(q) ** 2.0)
+        # period matrix: pi dJ_R = totEu dE - totIu dI3 - totLu dLz;
+        #                pi dJ_z = totEv dE + totIv dI3 - totLv dLz; dJ_phi = dLz
+        totEu, totIu, totLu = PEu[-1], PIu[-1], PLu[-1]
+        totEv, totIv, totLv = PEv[-1], PIv[-1], PLv[-1]
+        M = numpy.array(
+            [
+                [totEu / numpy.pi, -totIu / numpy.pi, -totLu / numpy.pi],
+                [totEv / numpy.pi, totIv / numpy.pi, -totLv / numpy.pi],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        Minv = numpy.linalg.inv(M)  # d(E,I3,Lz)/d(J_R,J_z,J_phi)
+        self._dEI3Lz_dJ[ii] = Minv
+        self._OmegaR[ii], self._Omegaz[ii], self._Omegaphi[ii] = Minv[0]
+        # angle profiles: theta_i = sum_X dX/dJ_i dW/dX with
+        # dW/dE = PEu + PEv, dW/dI3 = -PIu + PIv, dW/dLz = -PLu - PLv (+phi)
+        A = [
+            InterpolatedUnivariateSpline(
+                self._chi,
+                Minv[0, i] * PEu - Minv[1, i] * PIu - Minv[2, i] * PLu,
+                k=5,
+            )
+            for i in range(3)
+        ]
+        B = [
+            InterpolatedUnivariateSpline(
+                self._chi,
+                Minv[0, i] * PEv + Minv[1, i] * PIv - Minv[2, i] * PLv,
+                k=5,
+            )
+            for i in range(3)
+        ]
+        self._Aprof.append(A)
+        self._Bprof.append(B)
+        self._dAprof.append([a.derivative() for a in A])
+        self._dBprof.append([b.derivative() for b in B])
+
+    def _action_quad(self, W, q_of_chi, D):
+        """int p dq over the loop as (D/2) int sqrt(W) sin chi dchi (regular)."""
+        a, b = self._chi[:-1], self._chi[1:]
+        mid, half = 0.5 * (a + b), 0.5 * (b - a)
+        nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
+        vals = (
+            numpy.sqrt(numpy.clip(W(q_of_chi(nodes)), 0.0, None))
+            * 0.5
+            * D
+            * numpy.sin(nodes)
+        )
+        return float(numpy.sum((half[:, None] * _GLW[None, :]).ravel() * vals))
+
+    def _cumprof(self, W, q_of_chi, D, f):
+        """Cumulative int f(q)/p dq = int f (D/2) sin chi / sqrt(W) dchi on the
+        chi mesh; the integrand is regular including at the turning points."""
+        a, b = self._chi[:-1], self._chi[1:]
+        mid, half = 0.5 * (a + b), 0.5 * (b - a)
+        nodes = (mid[:, None] + half[:, None] * _GLX[None, :]).ravel()
+        q = q_of_chi(nodes)
+        w = W(q)
+        vals = numpy.empty_like(nodes)
+        good = w > 0.0
+        vals[good] = (
+            f(q[good]) * (D / 2.0) * numpy.sin(nodes[good]) / numpy.sqrt(w[good])
+        )
+        vals[~good] = 0.0  # only possible through rounding exactly at the ends
+        panels = (half[:, None] * _GLW[None, :] * vals.reshape(len(a), -1)).sum(axis=1)
+        return numpy.concatenate([[0.0], numpy.cumsum(panels)])
+
+    ############################ EVALUATION ###################################
+    def _torus_index(self, jr, jphi, jz):
+        indx = numpy.nanargmin(
+            numpy.fabs(jr - self._jr)
+            + numpy.fabs(jphi - self._Lzs)
+            + numpy.fabs(jz - self._jz)
+        )
+        if (
+            numpy.fabs(jr - self._jr[indx]) > 1e-8
+            or numpy.fabs(jphi - self._Lzs[indx]) > 1e-8
+            or numpy.fabs(jz - self._jz[indx]) > 1e-8
+        ):
+            raise ValueError(
+                "Given actions not found among the actions of the tori set up "
+                "in this actionAngleStaeckelInverse instance"
+            )
+        return indx
+
+    def _fold(self, P, w):
+        """P on [0,pi] extended over the full loop, w in [0,2pi)."""
+        w = numpy.mod(w, 2.0 * numpy.pi)
+        return numpy.where(
+            w <= numpy.pi, P(w), 2.0 * P(numpy.pi) - P(2.0 * numpy.pi - w)
+        )
+
+    def _dfold(self, dP, w):
+        w = numpy.mod(w, 2.0 * numpy.pi)
+        return numpy.where(w <= numpy.pi, dP(w), dP(2.0 * numpy.pi - w))
+
+    def _evaluate(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
+        return self._xvFreqs(jr, jphi, jz, angler, anglephi, anglez, **kwargs)[:6]
+
+    def _xvFreqs(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
+        ii = self._torus_index(jr, jphi, jz)
+        A, B = self._Aprof[ii], self._Bprof[ii]
+        dA, dB = self._dAprof[ii], self._dBprof[ii]
+        thR = numpy.atleast_1d(numpy.array(angler, dtype="float"))
+        thz = numpy.atleast_1d(numpy.array(anglez, dtype="float"))
+        thphi = numpy.atleast_1d(numpy.array(anglephi, dtype="float"))
+        # solve the additively separable 2x2 system for the extended phases
+        wu, wv = numpy.copy(thR), numpy.copy(thz)
+        for _ in range(self._maxiter):
+            f0 = self._fold(A[0], wu) + self._fold(B[0], wv) - thR
+            f1 = self._fold(A[1], wu) + self._fold(B[1], wv) - thz
+            f0 = (f0 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            f1 = (f1 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            J00, J01 = self._dfold(dA[0], wu), self._dfold(dB[0], wv)
+            J10, J11 = self._dfold(dA[1], wu), self._dfold(dB[1], wv)
+            det = J00 * J11 - J01 * J10
+            dwu = (J11 * f0 - J01 * f1) / det
+            dwv = (-J10 * f0 + J00 * f1) / det
+            step = numpy.maximum(numpy.fabs(dwu), numpy.fabs(dwv))
+            lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
+            wu -= dwu * lim
+            wv -= dwv * lim
+            if numpy.max(step) < self._angle_tol:
+                break
+        # phases -> (u, v, p_u, p_v)
+        E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
+        umin, umaxx, vmin = self._umins[ii], self._umaxs[ii], self._vmins[ii]
+        Du, Dv = umaxx - umin, numpy.pi - 2.0 * vmin
+        wum, wvm = numpy.mod(wu, 2.0 * numpy.pi), numpy.mod(wv, 2.0 * numpy.pi)
+        chiu = numpy.where(wum <= numpy.pi, wum, 2.0 * numpy.pi - wum)
+        chiv = numpy.where(wvm <= numpy.pi, wvm, 2.0 * numpy.pi - wvm)
+        su = numpy.where(wum <= numpy.pi, 1.0, -1.0)
+        sv = numpy.where(wvm <= numpy.pi, 1.0, -1.0)
+        u = umin + Du * numpy.sin(chiu / 2.0) ** 2.0
+        v = vmin + Dv * numpy.sin(chiv / 2.0) ** 2.0
+        pu = su * numpy.sqrt(numpy.clip(self._Wu(u, E, Lz, I3), 0.0, None))
+        pv = sv * numpy.sqrt(numpy.clip(self._Wv(v, E, Lz, I3), 0.0, None))
+        phi = thphi - self._fold(A[2], wu) - self._fold(B[2], wv)
+        # (u, v, p_u, p_v) -> (R, z, vR, vz)
+        sh, ch = numpy.sinh(u), numpy.cosh(u)
+        sn, cs = numpy.sin(v), numpy.cos(v)
+        R = self._delta * sh * sn
+        z = self._delta * ch * cs
+        den = self._delta * (sh**2.0 + sn**2.0)
+        vR = (pu * ch * sn + pv * sh * cs) / den
+        vz = (pu * sh * cs - pv * ch * sn) / den
+        vT = Lz / R
+        return (
+            R,
+            vR,
+            vT,
+            z,
+            vz,
+            phi % (2.0 * numpy.pi),
+            self._OmegaR[ii],
+            self._Omegaphi[ii],
+            self._Omegaz[ii],
+        )
+
+    def _Freqs(self, jr, jphi, jz, **kwargs):
+        ii = self._torus_index(jr, jphi, jz)
+        return (self._OmegaR[ii], self._Omegaphi[ii], self._Omegaz[ii])
+
+    ############################ FORWARD (for tests) ##########################
+    def _point_to_angles(self, R, vR, vT, z, vz, phi, indx):
+        """Angles of a phase-space point on torus indx (internal, used to
+        anchor traversal tests); returns (theta_R, theta_phi, theta_z)."""
+        ii = indx
+        d = self._delta
+        d1 = numpy.sqrt(R**2.0 + (z + d) ** 2.0)
+        d2 = numpy.sqrt(R**2.0 + (z - d) ** 2.0)
+        u = numpy.arccosh(numpy.clip((d1 + d2) / (2.0 * d), 1.0, None))
+        v = numpy.arccos(numpy.clip((d1 - d2) / (2.0 * d), -1.0, 1.0))
+        pu = d * (vR * numpy.cosh(u) * numpy.sin(v) + vz * numpy.sinh(u) * numpy.cos(v))
+        pv = d * (vR * numpy.sinh(u) * numpy.cos(v) - vz * numpy.cosh(u) * numpy.sin(v))
+        umin, umaxx, vmin = self._umins[ii], self._umaxs[ii], self._vmins[ii]
+        Du, Dv = umaxx - umin, numpy.pi - 2.0 * vmin
+        chiu = 2.0 * numpy.arcsin(numpy.sqrt(numpy.clip((u - umin) / Du, 0.0, 1.0)))
+        chiv = 2.0 * numpy.arcsin(numpy.sqrt(numpy.clip((v - vmin) / Dv, 0.0, 1.0)))
+        wu = numpy.where(pu >= 0.0, chiu, 2.0 * numpy.pi - chiu)
+        wv = numpy.where(pv >= 0.0, chiv, 2.0 * numpy.pi - chiv)
+        A, B = self._Aprof[ii], self._Bprof[ii]
+        thR = self._fold(A[0], wu) + self._fold(B[0], wv)
+        thz = self._fold(A[1], wu) + self._fold(B[1], wv)
+        thphi = phi + self._fold(A[2], wu) + self._fold(B[2], wv)
+        return (
+            thR % (2.0 * numpy.pi),
+            thphi % (2.0 * numpy.pi),
+            thz % (2.0 * numpy.pi),
+        )

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -198,7 +198,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
             )
         elif isinstance(p, potential.KuzminKutuzovStaeckelPotential):
             pot_type.append(16)
-            pot_args.extend([p._amp, p._ac, p._Delta])
+            pot_args.extend([p._amp, p._ac, p._delta])
         elif isinstance(p, potential.PlummerPotential):
             pot_type.append(17)
             pot_args.extend([p._amp, p._b])

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -217,7 +217,7 @@ def _parse_pot(pot, t=None):
             p._Pot, potential.KuzminKutuzovStaeckelPotential
         ):
             pot_type.append(16)
-            pot_args.extend([p._Pot._amp, p._Pot._ac, p._Pot._Delta])
+            pot_args.extend([p._Pot._amp, p._Pot._ac, p._Pot._delta])
         elif isinstance(p, planarPotentialFromRZPotential) and isinstance(
             p._Pot, potential.PlummerPotential
         ):

--- a/galpy/potential/KuzminKutuzovStaeckelPotential.py
+++ b/galpy/potential/KuzminKutuzovStaeckelPotential.py
@@ -50,9 +50,9 @@ class KuzminKutuzovStaeckelPotential(Potential):
         Potential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units="mass")
         Delta = conversion.parse_length(Delta, ro=self._ro)
         self._ac = ac
-        self._Delta = Delta
-        self._gamma = self._Delta**2 / (1.0 - self._ac**2)
-        self._alpha = self._gamma - self._Delta**2
+        self._delta = Delta
+        self._gamma = self._delta**2 / (1.0 - self._ac**2)
+        self._alpha = self._gamma - self._delta**2
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):
@@ -62,27 +62,27 @@ class KuzminKutuzovStaeckelPotential(Potential):
         self.hasC_dxdv3d = True  # full 3D Hessian (R2deriv/z2deriv/Rzderiv) in C
 
     def _evaluate(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
         return -1.0 / (numpy.sqrt(l) + numpy.sqrt(n))
 
     def _Rforce(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
-        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
+        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._delta)
         dldR = jac[0, 0]
         dndR = jac[1, 0]
         return -(dldR * self._lderiv(l, n) + dndR * self._nderiv(l, n))
 
     def _zforce(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
-        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
+        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._delta)
         dldz = jac[0, 1]
         dndz = jac[1, 1]
         return -(dldz * self._lderiv(l, n) + dndz * self._nderiv(l, n))
 
     def _R2deriv(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
-        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
-        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
+        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._delta)
+        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._delta)
         dldR = jac[0, 0]
         dndR = jac[1, 0]
         d2ldR2 = hess[0, 0, 0]
@@ -96,9 +96,9 @@ class KuzminKutuzovStaeckelPotential(Potential):
         )
 
     def _z2deriv(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
-        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
-        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
+        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._delta)
+        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._delta)
         dldz = jac[0, 1]
         dndz = jac[1, 1]
         d2ldz2 = hess[0, 1, 1]
@@ -112,9 +112,9 @@ class KuzminKutuzovStaeckelPotential(Potential):
         )
 
     def _Rzderiv(self, R, z, phi=0.0, t=0.0):
-        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._Delta)
-        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._Delta)
-        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._Delta)
+        l, n = coords.Rz_to_lambdanu(R, z, ac=self._ac, Delta=self._delta)
+        jac = coords.Rz_to_lambdanu_jac(R, z, Delta=self._delta)
+        hess = coords.Rz_to_lambdanu_hess(R, z, Delta=self._delta)
         dldR = jac[0, 0]
         dndR = jac[1, 0]
         dldz = jac[0, 1]

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -7915,6 +7915,206 @@ def test_actionAngleVerticalInverse_notE_errors():
     return None
 
 
+# ---------------- actionAngleStaeckelInverse tests ----------------
+def _kk_torus_labels(kkp, delta, ic):
+    """(E, Lz, I3) of an orbit IC in a Staeckel potential, computed
+    independently of actionAngleStaeckelInverse's internals"""
+    from galpy.orbit import Orbit
+    from galpy.potential import evaluatePotentials
+
+    o = Orbit(ic)
+    E = float(o.E(pot=kkp))
+    Lz = float(o.R() * o.vT())
+    R, z, vR, vz = float(o.R()), float(o.z()), float(o.vR()), float(o.vz())
+    d1 = numpy.sqrt(R**2.0 + (z + delta) ** 2.0)
+    d2 = numpy.sqrt(R**2.0 + (z - delta) ** 2.0)
+    u = numpy.arccosh((d1 + d2) / 2.0 / delta)
+    v = numpy.arccos((d1 - d2) / 2.0 / delta)
+    pu = delta * (vR * numpy.cosh(u) * numpy.sin(v) + vz * numpy.sinh(u) * numpy.cos(v))
+    Uu = evaluatePotentials(kkp, delta * numpy.sinh(u), 0.0) * (
+        numpy.sinh(u) ** 2.0 + 1.0
+    )
+    I3 = (
+        E * numpy.sinh(u) ** 2.0
+        - Uu
+        - (pu**2.0 + Lz**2.0 / numpy.sinh(u) ** 2.0) / 2.0 / delta**2.0
+    )
+    return E, Lz, float(I3)
+
+
+def test_actionAngleStaeckelInverse_actionsFreqs_vs_forward():
+    # Actions and frequencies of the inverse setup agree with the forward
+    # actionAngleStaeckel code run at high quadrature order
+    from galpy.actionAngle import actionAngleStaeckel, actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    aAS = actionAngleStaeckel(pot=kkp, delta=delta, c=True, order=200)
+    jr, _, jz = (float(numpy.asarray(x).ravel()[0]) for x in aAS(*ic))
+    assert numpy.fabs(aASI._jr[0] - jr) < 1e-6, (
+        "actionAngleStaeckelInverse J_R does not agree with the forward actionAngleStaeckel"
+    )
+    assert numpy.fabs(aASI._jz[0] - jz) < 1e-6, (
+        "actionAngleStaeckelInverse J_z does not agree with the forward actionAngleStaeckel"
+    )
+    out = aAS.actionsFreqs(*ic)
+    OmR, Omphi, Omz = (float(numpy.asarray(out[i]).ravel()[0]) for i in (3, 4, 5))
+    OmiR, Omiphi, Omiz = aASI.Freqs(aASI._jr[0], Lz, aASI._jz[0])
+    assert numpy.fabs(OmiR - OmR) < 1e-8, (
+        "actionAngleStaeckelInverse Omega_R does not agree with the forward code"
+    )
+    assert numpy.fabs(Omiz - Omz) < 1e-8, (
+        "actionAngleStaeckelInverse Omega_z does not agree with the forward code"
+    )
+    assert numpy.fabs(Omiphi - Omphi) < 1e-8, (
+        "actionAngleStaeckelInverse Omega_phi does not agree with the forward code"
+    )
+    return None
+
+
+def test_actionAngleStaeckelInverse_orbit():
+    # Evaluating the torus along theta(t) = theta0 + Omega t reproduces the
+    # integrated orbit over many periods and both branches, and the
+    # Hamiltonian is constant along the reconstructed torus at machine
+    # precision
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.orbit import Orbit
+    from galpy.potential import KuzminKutuzovStaeckelPotential, evaluatePotentials
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    for ic, postol in (
+        ([1.1, 0.3, 0.9, 0.25, 0.2, 0.0], 1e-6),  # benign
+        ([1.1, 0.9, 0.35, 0.15, 0.1, 0.0], 1e-6),  # eccentric
+        ([1.1, 0.001, 0.9418239, 0.15, 0.25, 0.0], 1e-6),  # near-shell J_R->0
+        ([1.1, 0.4, 0.9, 0.002, 0.002, 0.0], 1e-5),  # near-planar J_z->0
+    ):
+        E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+        aASI = actionAngleStaeckelInverse(
+            pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3]
+        )
+        jr, jz = aASI._jr[0], aASI._jz[0]
+        o = Orbit(ic)
+        ts = numpy.linspace(0.0, 60.0, 501)
+        o.integrate(ts, kkp, method="dop853_c")
+        th0 = aASI._point_to_angles(
+            numpy.array([ic[0]]),
+            numpy.array([ic[1]]),
+            numpy.array([ic[2]]),
+            numpy.array([ic[3]]),
+            numpy.array([ic[4]]),
+            numpy.array([ic[5]]),
+            0,
+        )
+        OmR, Omphi, Omz = aASI.Freqs(jr, Lz, jz)
+        R, vR, vT, z, vz, phi = aASI(
+            jr,
+            Lz,
+            jz,
+            th0[0] + OmR * ts,
+            th0[1] + Omphi * ts,
+            th0[2] + Omz * ts,
+        )
+        assert numpy.amax(numpy.fabs(R - o.R(ts))) < postol, (
+            "actionAngleStaeckelInverse orbit traversal does not agree with "
+            "direct orbit integration in R"
+        )
+        assert numpy.amax(numpy.fabs(z - o.z(ts))) < postol, (
+            "actionAngleStaeckelInverse orbit traversal does not agree with "
+            "direct orbit integration in z"
+        )
+        dphi = numpy.fabs((phi - o.phi(ts) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi)
+        assert numpy.amax(dphi) < postol, (
+            "actionAngleStaeckelInverse orbit traversal does not agree with "
+            "direct orbit integration in phi"
+        )
+        # Hamiltonian constancy along the reconstructed torus
+        H = 0.5 * (vR**2.0 + vz**2.0 + vT**2.0) + evaluatePotentials(kkp, R, z)
+        assert numpy.amax(numpy.fabs(H - E)) / numpy.fabs(E) < 1e-13, (
+            "Hamiltonian is not constant at machine precision along the "
+            "reconstructed actionAngleStaeckelInverse torus"
+        )
+    return None
+
+
+def test_actionAngleStaeckelInverse_xvFreqs_consistency():
+    # xvFreqs returns the same (x,v) as __call__ plus the frequencies
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    jr, jz = aASI._jr[0], aASI._jz[0]
+    ang = (numpy.array([0.1, 2.0]), numpy.array([0.3, 1.0]), numpy.array([0.2, 4.0]))
+    out1 = aASI(jr, Lz, jz, *ang)
+    out2 = aASI.xvFreqs(jr, Lz, jz, *ang)
+    for o1, o2 in zip(out1, out2[:6]):
+        assert numpy.all(numpy.fabs(numpy.array(o1) - numpy.array(o2)) < 1e-14), (
+            "actionAngleStaeckelInverse xvFreqs phase-space output does not "
+            "agree with __call__"
+        )
+    assert numpy.all(
+        numpy.fabs(numpy.array(out2[6:]) - numpy.array(aASI.Freqs(jr, Lz, jz))) < 1e-14
+    ), "actionAngleStaeckelInverse xvFreqs frequencies do not agree with Freqs"
+    return None
+
+
+def test_actionAngleStaeckelInverse_wrongactions_error():
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    with pytest.raises(ValueError) as excinfo:
+        aASI(0.2, 0.5, 0.1, 0.0, 0.0, 0.0)
+        pytest.fail(
+            "Evaluating actionAngleStaeckelInverse with actions not set up "
+            "should have raised a ValueError, but did not"
+        )
+    with pytest.raises(ValueError) as excinfo:
+        aASI.Freqs(0.2, 0.5, 0.1)
+        pytest.fail(
+            "Freqs with actions not set up should have raised a ValueError, but did not"
+        )
+    return None
+
+
+def test_actionAngleStaeckelInverse_notorus_errors():
+    # Unbound / invalid torus labels raise errors
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleStaeckelInverse(
+            pot=kkp, delta=delta, Es=[10.0], Lzs=[0.99], I3s=[1.9]
+        )
+        pytest.fail(
+            "Setting up an unbound actionAngleStaeckelInverse torus should "
+            "have raised a ValueError, but did not"
+        )
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleStaeckelInverse(
+            pot=kkp, delta=delta, Es=[0.78], Lzs=[0.99], I3s=[-50.0]
+        )
+        pytest.fail(
+            "Setting up an actionAngleStaeckelInverse torus that does not "
+            "reach the midplane should have raised a ValueError, but did not"
+        )
+    return None
+
+
 # Test that computing actionAngle coordinates in C for a NullPotential leads to an error
 def test_nullpotential_error():
     from galpy.actionAngle import actionAngleStaeckel

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8151,6 +8151,61 @@ def test_actionAngleStaeckelInverse_wrongactions_error():
     return None
 
 
+def test_actionAngleStaeckelInverse_thinshell():
+    # A u oscillation narrower than the turning-point scan spacing is
+    # recovered by refining the maximum of W_u, and its profiles are
+    # computed stably through the turning-point limits of Q = W/[y(1-y)]
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential, evaluatePotentials
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+
+    def Uofu(u):
+        return evaluatePotentials(kkp, delta * numpy.sinh(u), 0.0) * (
+            numpy.sinh(u) ** 2.0 + 1.0
+        )
+
+    # Labels of an exact shell torus (double root of W_u at ustar):
+    # W_u'(ustar) = 0 and W_u(ustar) = 0 solved for (E, I3) at fixed Lz
+    ustar, Lz = 1.0, 0.99
+    du = 1e-6
+    Up = (Uofu(ustar + du) - Uofu(ustar - du)) / (2.0 * du)
+    sh, ch = numpy.sinh(ustar), numpy.cosh(ustar)
+    Estar = (Up - Lz**2.0 * ch / (delta**2.0 * sh**3.0)) / numpy.sinh(2.0 * ustar)
+    I3star = Estar * sh**2.0 - Uofu(ustar) - Lz**2.0 / (2.0 * delta**2.0 * sh**2.0)
+    # Slightly above the shell energy: a genuine, ultra-thin oscillation
+    aASI = actionAngleStaeckelInverse(
+        pot=kkp, Es=[Estar + 1e-9], Lzs=[Lz], I3s=[I3star]
+    )
+    assert aASI._umaxs[0] - aASI._umins[0] < 1e-4, (
+        "Ultra-thin shell torus was not recovered by the turning-point "
+        "refinement (the u oscillation should be narrower than the scan "
+        "spacing)"
+    )
+    assert 0.0 < aASI._jr[0] < 1e-8, (
+        "Ultra-thin shell torus does not have the expected tiny radial action"
+    )
+    # The frequencies must connect continuously to those of a nearby,
+    # normally-resolved torus
+    aASI_ref = actionAngleStaeckelInverse(
+        pot=kkp, Es=[Estar + 1e-4], Lzs=[Lz], I3s=[I3star]
+    )
+    assert numpy.fabs(aASI._OmegaR[0] - aASI_ref._OmegaR[0]) < 1e-3, (
+        "Radial frequency of the ultra-thin shell torus does not connect "
+        "to that of a nearby resolved torus"
+    )
+    assert numpy.fabs(aASI._Omegaz[0] - aASI_ref._Omegaz[0]) < 1e-4, (
+        "Vertical frequency of the ultra-thin shell torus does not connect "
+        "to that of a nearby resolved torus"
+    )
+    assert numpy.fabs(aASI._Omegaphi[0] - aASI_ref._Omegaphi[0]) < 1e-4, (
+        "Azimuthal frequency of the ultra-thin shell torus does not connect "
+        "to that of a nearby resolved torus"
+    )
+    return None
+
+
 def test_actionAngleStaeckelInverse_notorus_errors():
     # Unbound / invalid torus labels raise errors
     from galpy.actionAngle import actionAngleStaeckelInverse

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2459,7 +2459,7 @@ def test_actionAngleStaeckel_actions_order():
 
     kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
     o = Orbit([1.0, 0.5, 1.1, 0.2, -0.3, 0.4])
-    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._Delta, c=False)
+    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._delta, c=False)
     # We'll assume that order=10000 is the truth, so 50 should be better than 5
     jrt, jpt, jzt = aAS(o, order=10000, fixed_quad=True)
     jr1, jp1, jz1 = aAS(o, order=5, fixed_quad=True)
@@ -2480,7 +2480,7 @@ def test_actionAngleStaeckel_actions_order_c():
 
     kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
     o = Orbit([1.0, 0.5, 1.1, 0.2, -0.3, 0.4])
-    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._Delta, c=True)
+    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._delta, c=True)
     # We'll assume that order=10000 is the truth, so 50 should be better than 5
     jrt, jpt, jzt = aAS(o, order=10000)
     jr1, jp1, jz1 = aAS(o, order=5)
@@ -2777,7 +2777,7 @@ def test_actionAngleStaeckel_freqs_order_c():
 
     kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
     o = Orbit([1.0, 0.5, 1.1, 0.2, -0.3, 0.4])
-    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._Delta, c=True)
+    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._delta, c=True)
     # We'll assume that order=10000 is the truth, so 50 should be better than 5
     jrt, jpt, jzt, ort, opt, ozt = aAS.actionsFreqs(o, order=10000)
     jr1, jp1, jz1, or1, op1, oz1 = aAS.actionsFreqs(o, order=5)
@@ -2846,7 +2846,7 @@ def test_actionAngleStaeckel_angles_order_c():
 
     kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
     o = Orbit([1.0, 0.5, 1.1, 0.2, -0.3, 0.4])
-    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._Delta, c=True)
+    aAS = actionAngleStaeckel(pot=kksp, delta=kksp._delta, c=True)
     # We'll assume that order=10000 is the truth, so 50 should be better than 5
     jrt, jpt, jzt, ort, opt, ozt, art, apt, azt = aAS.actionsFreqsAngles(o, order=10000)
     jr1, jp1, jz1, or1, op1, oz1, ar1, ap1, az1 = aAS.actionsFreqsAngles(o, order=5)
@@ -8005,12 +8005,9 @@ def test_actionAngleStaeckelInverse_wrapper():
         "actionAngleStaeckelInverse with a wrapped Staeckel potential does "
         "not agree with the unwrapped potential"
     )
-    with pytest.raises(ValueError) as excinfo:
-        actionAngleStaeckelInverse(pot=swp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
-        pytest.fail(
-            "Specifying delta= together with an OblateStaeckelWrapperPotential "
-            "should have raised a ValueError, but did not"
-        )
+    with pytest.raises(TypeError):
+        # delta and u0 are no longer accepted: the potential supplies them
+        actionAngleStaeckelInverse(pot=swp, delta=1.3, Es=[E], Lzs=[Lz], I3s=[I3])
     return None
 
 
@@ -8163,18 +8160,14 @@ def test_actionAngleStaeckelInverse_notorus_errors():
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
     with pytest.raises(ValueError) as excinfo:
         # E > 0: the u oscillation is not enclosed (unbound)
-        actionAngleStaeckelInverse(
-            pot=kkp, delta=delta, Es=[10.0], Lzs=[0.99], I3s=[1.9]
-        )
+        actionAngleStaeckelInverse(pot=kkp, Es=[10.0], Lzs=[0.99], I3s=[1.9])
         pytest.fail(
             "Setting up an unbound actionAngleStaeckelInverse torus should "
             "have raised a ValueError, but did not"
         )
     with pytest.raises(ValueError) as excinfo:
         # deeply negative E with large I3: W_u < 0 everywhere
-        actionAngleStaeckelInverse(
-            pot=kkp, delta=delta, Es=[-3.0], Lzs=[0.99], I3s=[5.0]
-        )
+        actionAngleStaeckelInverse(pot=kkp, Es=[-3.0], Lzs=[0.99], I3s=[5.0])
         pytest.fail(
             "Setting up an actionAngleStaeckelInverse torus with no bound u "
             "oscillation should have raised a ValueError, but did not"
@@ -8183,9 +8176,7 @@ def test_actionAngleStaeckelInverse_notorus_errors():
     ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
     E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
     with pytest.raises(ValueError) as excinfo:
-        actionAngleStaeckelInverse(
-            pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3 - 0.3]
-        )
+        actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3 - 0.3])
         pytest.fail(
             "Setting up an actionAngleStaeckelInverse torus that does not "
             "reach the midplane should have raised a ValueError, but did not"

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -7944,7 +7944,8 @@ def _kk_torus_labels(kkp, delta, ic):
 
 def test_actionAngleStaeckelInverse_actionsFreqs_vs_forward():
     # Actions and frequencies of the inverse setup agree with the forward
-    # actionAngleStaeckel code run at high quadrature order
+    # actionAngleStaeckel code run at high quadrature order; delta is
+    # derived from the potential automatically
     from galpy.actionAngle import actionAngleStaeckel, actionAngleStaeckelInverse
     from galpy.potential import KuzminKutuzovStaeckelPotential
 
@@ -7952,7 +7953,11 @@ def test_actionAngleStaeckelInverse_actionsFreqs_vs_forward():
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
     ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
     E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
-    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    # No delta= given: derived from the KuzminKutuzov potential
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
+    assert numpy.fabs(aASI._delta - delta) < 1e-15, (
+        "actionAngleStaeckelInverse did not derive delta from the potential"
+    )
     aAS = actionAngleStaeckel(pot=kkp, delta=delta, c=True, order=200)
     jr, _, jz = (float(numpy.asarray(x).ravel()[0]) for x in aAS(*ic))
     assert numpy.fabs(aASI._jr[0] - jr) < 1e-6, (
@@ -7976,17 +7981,87 @@ def test_actionAngleStaeckelInverse_actionsFreqs_vs_forward():
     return None
 
 
+def test_actionAngleStaeckelInverse_wrapper():
+    # An OblateStaeckelWrapperPotential can be passed directly, providing
+    # delta and u0; specifying them as well is an error
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import (
+        KuzminKutuzovStaeckelPotential,
+        OblateStaeckelWrapperPotential,
+    )
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    swp = OblateStaeckelWrapperPotential(pot=kkp, delta=delta, u0=1.15)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
+    aASIw = actionAngleStaeckelInverse(pot=swp, Es=[E], Lzs=[Lz], I3s=[I3])
+    assert numpy.fabs(aASI._jr[0] - aASIw._jr[0]) < 1e-12, (
+        "actionAngleStaeckelInverse with a wrapped Staeckel potential does "
+        "not agree with the unwrapped potential"
+    )
+    assert numpy.fabs(aASI._jz[0] - aASIw._jz[0]) < 1e-12, (
+        "actionAngleStaeckelInverse with a wrapped Staeckel potential does "
+        "not agree with the unwrapped potential"
+    )
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleStaeckelInverse(pot=swp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+        pytest.fail(
+            "Specifying delta= together with an OblateStaeckelWrapperPotential "
+            "should have raised a ValueError, but did not"
+        )
+    return None
+
+
+def test_actionAngleStaeckelInverse_angleconventions():
+    # Round trip through both codes: the forward actionAngleStaeckel angles
+    # of a point, fed to the inverse, return the same point (this requires
+    # matching angle conventions)
+    from galpy.actionAngle import actionAngleStaeckel, actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
+    aAS = actionAngleStaeckel(pot=kkp, delta=delta, c=True, order=200)
+    out = aAS.actionsFreqsAngles(*ic)
+    ar, ap, az = (numpy.asarray(out[i]).ravel() for i in (6, 7, 8))
+    R, vR, vT, z, vz, phi = aASI(aASI._jr[0], Lz, aASI._jz[0], ar, ap, az)
+    rec = numpy.array(
+        [
+            float(R[0]),
+            float(vR[0]),
+            float(vT[0]),
+            float(z[0]),
+            float(vz[0]),
+            float(phi[0]),
+        ]
+    )
+    diff = rec - numpy.array(ic)
+    diff[5] = (diff[5] + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+    assert numpy.amax(numpy.fabs(diff)) < 1e-6, (
+        "Feeding the forward actionAngleStaeckel angles to "
+        "actionAngleStaeckelInverse does not return the original point; "
+        "angle conventions do not match"
+    )
+    return None
+
+
 def test_actionAngleStaeckelInverse_orbit():
     # Evaluating the torus along theta(t) = theta0 + Omega t reproduces the
     # integrated orbit over many periods and both branches, and the
     # Hamiltonian is constant along the reconstructed torus at machine
     # precision
-    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.actionAngle import actionAngleStaeckel, actionAngleStaeckelInverse
     from galpy.orbit import Orbit
     from galpy.potential import KuzminKutuzovStaeckelPotential, evaluatePotentials
 
     delta = 1.3
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    aAS = actionAngleStaeckel(pot=kkp, delta=delta, c=True, order=200)
     for ic, postol in (
         ([1.1, 0.3, 0.9, 0.25, 0.2, 0.0], 1e-6),  # benign
         ([1.1, 0.9, 0.35, 0.15, 0.1, 0.0], 1e-6),  # eccentric
@@ -7994,22 +8069,13 @@ def test_actionAngleStaeckelInverse_orbit():
         ([1.1, 0.4, 0.9, 0.002, 0.002, 0.0], 1e-5),  # near-planar J_z->0
     ):
         E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
-        aASI = actionAngleStaeckelInverse(
-            pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3]
-        )
+        aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
         jr, jz = aASI._jr[0], aASI._jz[0]
         o = Orbit(ic)
         ts = numpy.linspace(0.0, 60.0, 501)
         o.integrate(ts, kkp, method="dop853_c")
-        th0 = aASI._point_to_angles(
-            numpy.array([ic[0]]),
-            numpy.array([ic[1]]),
-            numpy.array([ic[2]]),
-            numpy.array([ic[3]]),
-            numpy.array([ic[4]]),
-            numpy.array([ic[5]]),
-            0,
-        )
+        out = aAS.actionsFreqsAngles(*ic)
+        th0 = [float(numpy.asarray(out[i]).ravel()[0]) for i in (6, 7, 8)]
         OmR, Omphi, Omz = aASI.Freqs(jr, Lz, jz)
         R, vR, vT, z, vz, phi = aASI(
             jr,
@@ -8032,7 +8098,6 @@ def test_actionAngleStaeckelInverse_orbit():
             "actionAngleStaeckelInverse orbit traversal does not agree with "
             "direct orbit integration in phi"
         )
-        # Hamiltonian constancy along the reconstructed torus
         H = 0.5 * (vR**2.0 + vz**2.0 + vT**2.0) + evaluatePotentials(kkp, R, z)
         assert numpy.amax(numpy.fabs(H - E)) / numpy.fabs(E) < 1e-13, (
             "Hamiltonian is not constant at machine precision along the "
@@ -8050,7 +8115,7 @@ def test_actionAngleStaeckelInverse_xvFreqs_consistency():
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
     ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
     E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
-    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
     jr, jz = aASI._jr[0], aASI._jz[0]
     ang = (numpy.array([0.1, 2.0]), numpy.array([0.3, 1.0]), numpy.array([0.2, 4.0]))
     out1 = aASI(jr, Lz, jz, *ang)
@@ -8074,7 +8139,7 @@ def test_actionAngleStaeckelInverse_wrongactions_error():
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
     ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
     E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
-    aASI = actionAngleStaeckelInverse(pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3])
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
     with pytest.raises(ValueError) as excinfo:
         aASI(0.2, 0.5, 0.1, 0.0, 0.0, 0.0)
         pytest.fail(
@@ -8097,6 +8162,7 @@ def test_actionAngleStaeckelInverse_notorus_errors():
     delta = 1.3
     kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
     with pytest.raises(ValueError) as excinfo:
+        # E > 0: the u oscillation is not enclosed (unbound)
         actionAngleStaeckelInverse(
             pot=kkp, delta=delta, Es=[10.0], Lzs=[0.99], I3s=[1.9]
         )
@@ -8105,12 +8171,38 @@ def test_actionAngleStaeckelInverse_notorus_errors():
             "have raised a ValueError, but did not"
         )
     with pytest.raises(ValueError) as excinfo:
+        # deeply negative E with large I3: W_u < 0 everywhere
         actionAngleStaeckelInverse(
-            pot=kkp, delta=delta, Es=[0.78], Lzs=[0.99], I3s=[-50.0]
+            pot=kkp, delta=delta, Es=[-3.0], Lzs=[0.99], I3s=[5.0]
+        )
+        pytest.fail(
+            "Setting up an actionAngleStaeckelInverse torus with no bound u "
+            "oscillation should have raised a ValueError, but did not"
+        )
+    # valid u oscillation, but the v oscillation does not reach the midplane
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleStaeckelInverse(
+            pot=kkp, delta=delta, Es=[E], Lzs=[Lz], I3s=[I3 - 0.3]
         )
         pytest.fail(
             "Setting up an actionAngleStaeckelInverse torus that does not "
             "reach the midplane should have raised a ValueError, but did not"
+        )
+    with pytest.raises(OSError) as excinfo:
+        from galpy.potential import LogarithmicHaloPotential
+
+        actionAngleStaeckelInverse(
+            pot=LogarithmicHaloPotential(normalize=1.0),
+            Es=[0.78],
+            Lzs=[0.99],
+            I3s=[0.1],
+        )
+        pytest.fail(
+            "Setting up actionAngleStaeckelInverse without delta for a "
+            "potential it cannot be derived from should have raised an "
+            "OSError, but did not"
         )
     return None
 

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8151,6 +8151,55 @@ def test_actionAngleStaeckelInverse_wrongactions_error():
     return None
 
 
+def test_actionAngleStaeckelInverse_periodmatrix_finitediff():
+    # Self-consistency of the six complete profile integrals: the period
+    # matrix d(J_R,J_z)/d(E,I3,Lz), which is what builds the frequencies and
+    # the angle-profile coefficients, must agree with finite differences of
+    # the actions across neighbouring tori. This is a test-suite check only:
+    # computing it at setup would cost ~5x the setup of a torus, and the
+    # construction has no fitted ingredient that could silently drift
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    delta = 1.3
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=delta)
+    ic = [1.1, 0.3, 0.9, 0.25, 0.2, 0.0]
+    E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)
+    aASI = actionAngleStaeckelInverse(pot=kkp, Es=[E], Lzs=[Lz], I3s=[I3])
+    # Rows of M from the stored complete profiles (see the class docstring)
+    PEu, PIu, PLu = (p[0, -1] for p in aASI._Pu)
+    PEv, PIv, PLv = (p[0, -1] for p in aASI._Pv)
+    M = (
+        numpy.array(
+            [
+                [PEu, -PIu, -PLu],
+                [PEv, PIv, -PLv],
+            ]
+        )
+        / numpy.pi
+    )
+    h = 1e-6
+    for jj, (dE, dI3, dLz) in enumerate(((h, 0.0, 0.0), (0.0, h, 0.0), (0.0, 0.0, h))):
+        up = actionAngleStaeckelInverse(
+            pot=kkp, Es=[E + dE], Lzs=[Lz + dLz], I3s=[I3 + dI3]
+        )
+        dw = actionAngleStaeckelInverse(
+            pot=kkp, Es=[E - dE], Lzs=[Lz - dLz], I3s=[I3 - dI3]
+        )
+        fd = numpy.array(
+            [
+                (up._jr[0] - dw._jr[0]) / 2.0 / h,
+                (up._jz[0] - dw._jz[0]) / 2.0 / h,
+            ]
+        )
+        assert numpy.all(numpy.fabs((fd - M[:, jj]) / M[:, jj]) < 1e-8), (
+            "Period matrix of actionAngleStaeckelInverse does not agree with "
+            "finite differences of the actions across neighbouring tori "
+            "(column %i): %s vs %s" % (jj, M[:, jj], fd)
+        )
+    return None
+
+
 def test_actionAngleStaeckelInverse_thinshell():
     # A u oscillation narrower than the turning-point scan spacing is
     # recovered by refining the maximum of W_u, and its profiles are

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8065,7 +8065,7 @@ def test_actionAngleStaeckelInverse_orbit():
     for ic, postol in (
         ([1.1, 0.3, 0.9, 0.25, 0.2, 0.0], 1e-6),  # benign
         ([1.1, 0.9, 0.35, 0.15, 0.1, 0.0], 1e-6),  # eccentric
-        ([1.1, 0.001, 0.9418239, 0.15, 0.25, 0.0], 1e-6),  # near-shell J_R->0
+        ([1.1, 0.001, 0.8425895627614183, 0.15, 0.25, 0.0], 1e-6),  # near-shell J_R->0
         ([1.1, 0.4, 0.9, 0.002, 0.002, 0.0], 1e-5),  # near-planar J_z->0
     ):
         E, Lz, I3 = _kk_torus_labels(kkp, delta, ic)


### PR DESCRIPTION
First layer of the phase-3 stack (base: `aainv-staeckel-dev`, branched from main — independent of the in-prep spherical branch per the plan). Implements the direct separable-angle construction worked out and verified in fast-orbits (STAECKEL_MATH.md §12; Step-0 notebook, fast-orbits #9):

- Each angle is the sum of a u-profile and a v-profile (θᵢ = ∂W/∂Jᵢ), all six profiles computed as regular quadratures in the χ anomaly with analytic turning-point limits; actions and the 3×3 period matrix from the same machinery; evaluation inverts the additively separable 2×2 angle system by a damped, vectorized Newton iteration. No auxiliary torus, no generating function, no Fourier lattice; placement is exact by construction.
- Tori labeled by (E, L_z, I₃) with the Stäckel splitting extracted from the potential in the V(π/2) = 0 gauge (Step 0.1 conventions).
- Tests (all fast, ~5 s): actions/frequencies vs the forward `actionAngleStaeckel` at order=200 (1e-6/1e-8), 10-period two-branch traversal vs direct integration for benign / eccentric / near-shell (J_R/J_z ≈ 0.01, no special casing) / near-planar tori, δH/|E| < 1e-13 along the reconstructed torus, xvFreqs/Freqs consistency, wrong-action and invalid-torus error paths.

Next layers: actions → (E, I₃) inversion, Stäckel-ized targets (N2), interpolation (N3), units/docs (N4). The forward-code χ-form quadrature improvement goes to main separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ