### PR TITLE
streamspraydf: thread integrate_kwargs so forward-mode AD works through a spray stream

### DIFF
--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -39,6 +39,7 @@ class basestreamspraydf(df):
         center=None,
         centerpot=None,
         progpot=None,
+        integrate_kwargs=None,
         ro=None,
         vo=None,
     ):
@@ -137,6 +138,11 @@ class basestreamspraydf(df):
         assert conversion.physical_compatible(self, progenitor), (
             "Physical conversion for the progenitor Orbit object is not consistent with that of the basestreamspraydf object being initialized"
         )
+        # Extra options for the in-backend ODE solves (progenitor, center, sampled
+        # orbits, track curve). Only reach jax/torch integrators -- the numpy/C paths
+        # take none. `adjoint="direct"` is what makes forward-mode and higher-order
+        # AD work: the default checkpointed adjoint is a custom_vjp, i.e. reverse-only.
+        self._integrate_kwargs = integrate_kwargs
         self._orig_progenitor = progenitor  # Store so we can use its ro/vo/etc.
         self._progenitor = progenitor()
         self._progenitor.turn_physical_off()
@@ -465,10 +471,10 @@ class basestreamspraydf(df):
             # backend track_prog_cart (torch has no negative-step slice -> xp.flip).
             o_f = Orbit(ic)
             o_f.turn_physical_off()
-            o_f.integrate(t_fwd, _track_pot, method=method)
+            o_f.integrate(t_fwd, _track_pot, method=method, **self._ikw(method))
             o_b = Orbit(ic)
             o_b.turn_physical_off()
-            o_b.integrate(t_back, _track_pot, method=method)
+            o_b.integrate(t_back, _track_pot, method=method, **self._ikw(method))
 
             def _cart(o):
                 # Read the integrated states directly (o.orbit at the integration grid)
@@ -825,7 +831,7 @@ class basestreamspraydf(df):
         bgrid = numpy.linspace(0.0, -self._tdisrupt, 2001)
         self._progenitor = Orbit(ic)
         self._progenitor.turn_physical_off()
-        self._progenitor.integrate(bgrid, self._pot, method=method)
+        self._progenitor.integrate(bgrid, self._pot, method=method, **self._ikw(method))
         self._bsamp = (xp, self._progenitor, method)
 
     def _integrate_center(self):
@@ -905,7 +911,9 @@ class basestreamspraydf(df):
         bgrid = numpy.linspace(0.0, -self._tdisrupt, 2001)  # match the progenitor grid
         self._center = Orbit(ic)
         self._center.turn_physical_off()
-        self._center.integrate(bgrid, self._centerpot, method=method)
+        self._center.integrate(
+            bgrid, self._centerpot, method=method, **self._ikw(method)
+        )
 
     def _promote_progenitor_backend(self, xp, inbackend):
         """Re-integrate a pure-numpy progenitor as a backend orbit (theta/mass-independent
@@ -929,8 +937,20 @@ class basestreamspraydf(df):
         bgrid = numpy.linspace(0.0, -self._tdisrupt, 2001)
         self._progenitor = Orbit(ic)
         self._progenitor.turn_physical_off()
-        self._progenitor.integrate(bgrid, self._pot, method=inbackend)
+        self._progenitor.integrate(
+            bgrid, self._pot, method=inbackend, **self._ikw(inbackend)
+        )
         self._bsamp = (xp, self._progenitor, inbackend)
+
+    def _ikw(self, method):
+        """``inbackend_kwargs`` for an in-backend ODE ``method``, else ``{}``.
+
+        The C and numpy integrators take no solver options, so the extra kwargs are
+        handed only to the jax/torch paths.
+        """
+        if not self._integrate_kwargs or method not in ("diffrax", "torchdiffeq"):
+            return {}
+        return {"inbackend_kwargs": dict(self._integrate_kwargs)}
 
     def _backend_sampling(self):
         """``(xp, backend_progenitor, sample_method)`` when the sampling runs on a
@@ -1080,7 +1100,8 @@ class basestreamspraydf(df):
                 # per-orbit 2-point grid [-dt_i, 0] (not the 10001-point fixed-step
                 # grid the numpy path needs).
                 ts = xp.stack([-xp.asarray(dt), xp.zeros(n)], axis=-1)
-                o.integrate(ts, self._pot, method=sample_method or "dop853_c")
+                _m = sample_method or "dop853_c"
+                o.integrate(ts, self._pot, method=_m, **self._ikw(_m))
             else:
                 ts = xp.linspace(-as_numpy(dt), xp.zeros(n), 10001, axis=-1)
                 o.integrate(ts, self._pot)  # byte-identical numpy default
@@ -1351,6 +1372,7 @@ class chen24spraydf(basestreamspraydf):
         progpot=None,
         mean=None,
         cov=None,
+        integrate_kwargs=None,
         ro=None,
         vo=None,
     ):
@@ -1407,6 +1429,7 @@ class chen24spraydf(basestreamspraydf):
             center=center,
             centerpot=centerpot,
             progpot=progpot,
+            integrate_kwargs=integrate_kwargs,
             ro=ro,
             vo=vo,
         )
@@ -1510,6 +1533,7 @@ class fardal15spraydf(basestreamspraydf):
         progpot=None,
         meankvec=[2.0, 0.0, 0.3, 0.0, 0.0, 0.0],
         sigkvec=[0.4, 0.0, 0.4, 0.5, 0.5, 0.0],
+        integrate_kwargs=None,
         ro=None,
         vo=None,
     ):
@@ -1567,6 +1591,7 @@ class fardal15spraydf(basestreamspraydf):
             center=center,
             centerpot=centerpot,
             progpot=progpot,
+            integrate_kwargs=integrate_kwargs,
             ro=ro,
             vo=vo,
         )

--- a/galpy/df/streamspraydf.py
+++ b/galpy/df/streamspraydf.py
@@ -709,6 +709,22 @@ class basestreamspraydf(df):
         u_samples = grandom.uniform(key, (n,))
         return -self._stripping_inv_cdf(as_numpy(u_samples))
 
+    def _progenitor_now(self):
+        """The progenitor's present-day ``(R, vR, vT, z, vz, phi)`` as concrete floats.
+
+        Raises when they cannot be realised as floats (a traced IC) -- callers that
+        have a defined answer in that case catch it; callers that do not should fail.
+        """
+        p = self._progenitor
+        return (
+            float(p.R(0.0)),
+            float(p.vR(0.0)),
+            float(p.vT(0.0)),
+            float(p.z(0.0)),
+            float(p.vz(0.0)),
+            float(p.phi(0.0)),
+        )
+
     def _theta_probe_point(self):
         """Concrete ``((R, z), phi, v)`` at which to probe the potential for a backend
         parameter.
@@ -719,15 +735,11 @@ class basestreamspraydf(df):
         routes in-backend anyway (``ic_concrete`` below), so the probe's answer there
         only has to be well-defined, not particular.
         """
-        p = self._progenitor
         try:
-            return (
-                (float(p.R(0.0)), float(p.z(0.0))),
-                float(p.phi(0.0)),
-                numpy.array([float(p.vR(0.0)), float(p.vT(0.0)), float(p.vz(0.0))]),
-            )
+            R, vR, vT, z, vz, phi = self._progenitor_now()
         except Exception:  # noqa: BLE001 -- traced IC has no concrete coordinates
             return (1.0, 0.0), 0.0, numpy.array([0.0, 1.0, 0.0])
+        return (R, z), phi, numpy.array([vR, vT, vz])
 
     def _integrate_progenitor(self):
         """Integrate the progenitor over ``[0, -tdisrupt]``, choosing the integrator
@@ -921,19 +933,7 @@ class basestreamspraydf(df):
         a center-only backend trigger (centerpot theta / center IC) drives differentiable
         center= sampling while ``self._pot`` carries no backend parameter. Sets ``_bsamp``.
         """
-        p = self._progenitor
-        ic = xp.asarray(
-            numpy.array(
-                [
-                    float(p.R(0.0)),
-                    float(p.vR(0.0)),
-                    float(p.vT(0.0)),
-                    float(p.z(0.0)),
-                    float(p.vz(0.0)),
-                    float(p.phi(0.0)),
-                ]
-            )
-        )
+        ic = xp.asarray(numpy.array(self._progenitor_now()))
         bgrid = numpy.linspace(0.0, -self._tdisrupt, 2001)
         self._progenitor = Orbit(ic)
         self._progenitor.turn_physical_off()

--- a/tests/test_streamspraydf.py
+++ b/tests/test_streamspraydf.py
@@ -1282,3 +1282,44 @@ def test_theta_probe_point_falls_back_when_progenitor_is_not_concrete():
     (R, z), phi, v = df._theta_probe_point()
     assert (R, z) == (1.0, 0.0) and phi == 0.0
     assert numpy.allclose(v, [0.0, 1.0, 0.0])
+
+
+def test_integrate_kwargs_reach_only_the_in_backend_integrators():
+    """`integrate_kwargs` are solver options for the jax/torch ODE paths; the C and
+    numpy integrators take none. Cover the contract directly -- the options are
+    handed over for `diffrax`/`torchdiffeq` and withheld from everything else --
+    since the suite that exercises the enabled path uploads no coverage."""
+    import numpy
+
+    from galpy.df import fardal15spraydf
+    from galpy.orbit import Orbit
+    from galpy.potential import LogarithmicHaloPotential
+    from galpy.util import conversion
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    prog = Orbit([1.2, 0.1, 1.1, 0.3, 0.05, 0.4])
+    prog.turn_physical_off()
+    kw = {"adjoint": "direct", "max_steps": 4096}
+    common = dict(
+        progenitor=prog,
+        pot=lp,
+        tdisrupt=1.0 / conversion.time_in_Gyr(220.0, 8.0),
+        progenitor_mass=2.0e4 / conversion.mass_in_msol(220.0, 8.0),
+    )
+
+    df = fardal15spraydf(integrate_kwargs=kw, **common)
+    for method in ("diffrax", "torchdiffeq"):
+        assert df._ikw(method) == {"inbackend_kwargs": kw}, (
+            f"{method} is an in-backend ODE and must receive the solver options"
+        )
+    for method in ("dop853_c", "symplec4_c", "odeint"):
+        assert df._ikw(method) == {}, (
+            f"{method} takes no solver options and must receive none"
+        )
+    # a copy, so a caller mutating its dict cannot reach into the df afterwards
+    assert df._ikw("diffrax")["inbackend_kwargs"] is not kw
+
+    # default (None) withholds them everywhere, so nothing changes for existing users
+    df_default = fardal15spraydf(**common)
+    for method in ("diffrax", "torchdiffeq", "dop853_c"):
+        assert df_default._ikw(method) == {}


### PR DESCRIPTION
## Why

Forward-mode AD through a spray stream was impossible:

```
TypeError: can't apply forward-mode autodiff (jvp) to a custom_vjp function
```

Every in-backend solve in `streamspraydf` (the progenitor at construction, the
center, the sampled orbits, the `streamTrack` curve) ran with diffrax's default
checkpointed adjoint, which is implemented as a `custom_vjp` and is therefore
reverse-only, and there was no way to ask for a different one.

That matters because a potential parameter is a **scalar**: reverse mode needs one
pass per output — i.e. per particle — while forward mode returns the whole
`(6, N)` tangent in a single pass. It is the difference between "a gradient exists"
and "you can predict a 1500-particle stream".

## What

`Orbit.integrate` already accepts `inbackend_kwargs`, so this only threads a new
`integrate_kwargs=` constructor option through to it. `_ikw()` hands the options to
`diffrax`/`torchdiffeq` only — the C and numpy integrators take no solver options —
so the numpy path is untouched and the default (`None`) changes nothing anywhere.

Second commit removes a duplication found while auditing #1346: the probe point and
the promoted backend IC extracted the same six progenitor accessors. One
`_progenitor_now()` now does it. The fallback deliberately stays only on the probe —
giving `_promote_progenitor_backend` a fallback would silently substitute a fixed
unit-circular IC for the real progenitor.

## Measured

Tangent from one `jvp` vs a common-random-number central difference of the same
sampler (120 particles), i.e. second-order convergence onto the AD value rather
than a finiteness check:

| h | max\|FD−AD\| / max\|AD\| |
|---|---|
| 1e-2 | 5.9e-02 |
| 1e-3 | 6.0e-04 |
| 1e-4 | 1.6e-05 |

- `tests/test_streamspraydf.py` — 39 passed (numpy path unchanged)
- `tests/test_backend_streamspraydf.py` — 58 passed under jax (12m38s)

Ledger delta: none.

Enables the gS3 talk figure (one AD pass predicting the `streamTrack` across
q = 0.7–1.1 against a direct re-run).