### PR TITLE
sphericaldf: honour a per-call ro=/vo= when parsing Quantity inputs

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -30,6 +30,13 @@ v1.12.1 (expected around 2026-11-01)
   the particle sum is accumulated in batches so building from a very large number
   of particles stays memory-bounded.
 
+- Fixed ``vmomentdensity``, ``sigmar``, ``sigmat``, and ``beta`` of the
+  ``sphericaldf`` family to honour a per-call ``ro=`` when parsing ``Quantity``
+  input radii; previously the DF's own ``ro`` was always used, even though the
+  per-call value was already honoured for the output units. This is consistent
+  with potentials and with ``diskdf``/``quasiisothermaldf``. Calls that do not
+  pass ``ro=`` are unaffected.
+
 - Added translation between the ``SCFPotential`` and ``MultipoleExpansionPotential``
   representations: ``SCFPotential.from_multipole`` builds an SCF expansion from a
   multipole expansion, and ``MultipoleExpansionPotential.from_scf`` does the

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -30,12 +30,15 @@ v1.12.1 (expected around 2026-11-01)
   the particle sum is accumulated in batches so building from a very large number
   of particles stays memory-bounded.
 
-- Fixed ``vmomentdensity``, ``sigmar``, ``sigmat``, and ``beta`` of the
-  ``sphericaldf`` family to honour a per-call ``ro=`` when parsing ``Quantity``
-  input radii; previously the DF's own ``ro`` was always used, even though the
-  per-call value was already honoured for the output units. This is consistent
-  with potentials and with ``diskdf``/``quasiisothermaldf``. Calls that do not
-  pass ``ro=`` are unaffected.
+- Fixed the ``sphericaldf`` family to honour a per-call ``ro=``/``vo=`` when
+  parsing ``Quantity`` inputs: radii for ``vmomentdensity``, ``sigmar``,
+  ``sigmat``, and ``beta``, and energies, angular momenta, and phase-space
+  coordinates for ``__call__`` and ``dMdE``. Previously the DF's own ``ro`` and
+  ``vo`` were always used, even though the per-call values were already honoured
+  for the output units. This is consistent with how potentials treat ``ro=``.
+  Calls that do not pass ``ro=``/``vo=`` are unaffected. Also fixed a typo in
+  ``sphericaldf.__call__`` that parsed a ``Quantity`` ``Lz`` with ``ro=vo``
+  (harmless in practice, because no current DF uses ``Lz``).
 
 - Added translation between the ``SCFPotential`` and ``MultipoleExpansionPotential``
   representations: ``SCFPotential.from_multipole`` builds an SCF expansion from a

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -123,6 +123,17 @@ def _handle_rmin(rmin, pot, denspot, scale, ro, df_name):
     return 0.0
 
 
+def _input_scales(obj, kwargs):
+    """The ro and vo to use for parsing Quantity *inputs*: a per-call ro=/vo=
+    if one is given, the DF's own otherwise. Same precedence as
+    potential_physical_input, which is why the methods using this are decorated
+    with pop=False: ro= and vo= have to still be in kwargs when the body runs.
+    """
+    ro = conversion.parse_length_kpc(kwargs.get("ro", None))
+    vo = conversion.parse_velocity_kms(kwargs.get("vo", None))
+    return obj._ro if ro is None else ro, obj._vo if vo is None else vo
+
+
 class sphericaldf(df):
     """Superclass for spherical distribution functions"""
 
@@ -193,7 +204,7 @@ class sphericaldf(df):
             )
 
     ############################## EVALUATING THE DF###############################
-    @physical_conversion("massphasespacedensity", pop=True)
+    @physical_conversion("massphasespacedensity", pop=False)
     def __call__(self, *args, **kwargs):
         """
         Evaluate the DF
@@ -215,7 +226,9 @@ class sphericaldf(df):
         -----
         - 2020-07-22 - Written - Lane (UofT)
         - 2024-10-29 - Fixed to return mass/phase-space volume units for physical-unit output - Bovy (UofT)
+        - 2026-08-20 - A per-call ro=/vo= is now also used to parse Quantity inputs - Bovy (UofT)
         """
+        ro, vo = _input_scales(self, kwargs)
         # Get E,L,Lz
         if len(args) == 1:
             if not isinstance(args[0], Orbit):  # Assume tuple (E,L,Lz)
@@ -224,16 +237,16 @@ class sphericaldf(df):
                 E = args[0].E(pot=self._pot, use_physical=False)
                 L = numpy.sqrt(numpy.sum(args[0].L(use_physical=False) ** 2.0))
                 Lz = args[0].Lz(use_physical=False)
-            E = numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
-            L = numpy.atleast_1d(conversion.parse_angmom(L, ro=self._ro, vo=self._vo))
-            Lz = numpy.atleast_1d(conversion.parse_angmom(Lz, ro=self._vo, vo=self._vo))
+            E = numpy.atleast_1d(conversion.parse_energy(E, vo=vo))
+            L = numpy.atleast_1d(conversion.parse_angmom(L, ro=ro, vo=vo))
+            Lz = numpy.atleast_1d(conversion.parse_angmom(Lz, ro=ro, vo=vo))
         else:  # Assume R,vR,vT,z,vz,(phi)
             R, vR, vT, z, vz, phi = (args + (None,))[:6]
-            R = conversion.parse_length(R, ro=self._ro)
-            vR = conversion.parse_velocity(vR, vo=self._vo)
-            vT = conversion.parse_velocity(vT, vo=self._vo)
-            z = conversion.parse_length(z, ro=self._ro)
-            vz = conversion.parse_velocity(vz, vo=self._vo)
+            R = conversion.parse_length(R, ro=ro)
+            vR = conversion.parse_velocity(vR, vo=vo)
+            vT = conversion.parse_velocity(vT, vo=vo)
+            z = conversion.parse_length(z, ro=ro)
+            vz = conversion.parse_velocity(vz, vo=vo)
             vtotSq = vR**2.0 + vT**2.0 + vz**2.0
             E = numpy.atleast_1d(0.5 * vtotSq + _evaluatePotentials(self._pot, R, z))
             Lz = numpy.atleast_1d(R * vT)
@@ -252,8 +265,8 @@ class sphericaldf(df):
             )
         )
 
-    @physical_conversion("massenergydensity", pop=True)
-    def dMdE(self, E):
+    @physical_conversion("massenergydensity", pop=False)
+    def dMdE(self, E, **kwargs):
         """
         Compute the differential energy distribution dM/dE: the amount of mass per unit energy
 
@@ -270,11 +283,13 @@ class sphericaldf(df):
         Notes
         -----
         - 2023-05-23 - Written - Bovy (UofT)
+        - 2026-08-20 - A per-call vo= is now also used to parse a Quantity input - Bovy (UofT)
 
         """
-        return self._dMdE(
-            numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
-        ).reshape(E.shape if isinstance(E, numpy.ndarray) else ())
+        _, vo = _input_scales(self, kwargs)
+        return self._dMdE(numpy.atleast_1d(conversion.parse_energy(E, vo=vo))).reshape(
+            E.shape if isinstance(E, numpy.ndarray) else ()
+        )
 
     @potential_physical_input
     def vmomentdensity(self, r, n, m, **kwargs):

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -37,7 +37,7 @@ from ..potential.Potential import (
 )
 from ..potential.SCFPotential import _RToxi, _xiToR
 from ..util import _optional_deps, conversion, galpyWarning
-from ..util.conversion import physical_conversion
+from ..util.conversion import physical_conversion, potential_physical_input
 from .df import df
 
 # Use _APY_LOADED/_APY_UNITS like this to be able to change them in tests
@@ -276,6 +276,7 @@ class sphericaldf(df):
             numpy.atleast_1d(conversion.parse_energy(E, vo=self._vo))
         ).reshape(E.shape if isinstance(E, numpy.ndarray) else ())
 
+    @potential_physical_input
     def vmomentdensity(self, r, n, m, **kwargs):
         """
         Calculate an arbitrary moment of the velocity distribution at r times the density.
@@ -298,6 +299,7 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
+        # No-op once the decorator has converted r, but validates the input
         r = conversion.parse_length(r, ro=self._ro)
         use_physical = kwargs.pop("use_physical", True)
         ro = kwargs.pop("ro", None)
@@ -345,6 +347,7 @@ class sphericaldf(df):
             )[0]
         )
 
+    @potential_physical_input
     @physical_conversion("velocity", pop=True)
     def sigmar(self, r):
         """
@@ -364,9 +367,11 @@ class sphericaldf(df):
         -----
         - 2020-09-04 - Written - Bovy (UofT)
         """
+        # No-op once the decorator has converted r, but validates the input
         r = conversion.parse_length(r, ro=self._ro)
         return numpy.sqrt(self._vmomentdensity(r, 2, 0) / self._vmomentdensity(r, 0, 0))
 
+    @potential_physical_input
     @physical_conversion("velocity", pop=True)
     def sigmat(self, r):
         """
@@ -387,10 +392,12 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
+        # No-op once the decorator has converted r, but validates the input
         r = conversion.parse_length(r, ro=self._ro)
         return numpy.sqrt(self._vmomentdensity(r, 0, 2) / self._vmomentdensity(r, 0, 0))
 
-    def beta(self, r):
+    @potential_physical_input
+    def beta(self, r, ro=None, vo=None):
         """
         Calculate the anisotropy at radius r.
 
@@ -398,6 +405,12 @@ class sphericaldf(df):
         ----------
         r : float
             Spherical radius at which to calculate the anisotropy.
+        ro : float or Quantity, optional
+            Distance scale used to interpret r when it is a Quantity (default:
+            the DF's own ro).
+        vo : float or Quantity, optional
+            Velocity scale; not used here, accepted so that ro= and vo= can be
+            passed together as for the other methods.
 
         Returns
         -------
@@ -409,6 +422,7 @@ class sphericaldf(df):
         - 2020-09-04 - Written - Bovy (UofT)
 
         """
+        # No-op once the decorator has converted r, but validates the input
         r = conversion.parse_length(r, ro=self._ro)
         return 1.0 - self._vmomentdensity(r, 0, 2) / 2.0 / self._vmomentdensity(r, 2, 0)
 

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17456,6 +17456,143 @@ def test_sphericaldf_method_inputAsQuantity():
     return None
 
 
+def test_sphericaldf_method_inputAsQuantity_percall_ro():
+    # A per-call ro=/vo= has to be used to interpret Quantity inputs,
+    # rather than the DF's own ro/vo (#1198)
+    from galpy import potential
+    from galpy.df import isotropicHernquistdf, osipkovmerrittdf
+    from galpy.orbit import Orbit
+
+    ro, vo = 8.0, 220.0
+    pot = potential.HernquistPotential(amp=2.0, a=1.3)
+    dfh = isotropicHernquistdf(pot=pot, ro=ro, vo=vo)
+    # beta is identically zero for an isotropic DF, so use an anisotropic one
+    dfa = osipkovmerrittdf(pot=pot, ra=1.3, ro=ro, vo=vo)
+    # 1 pc is 0.001/ro in internal units, with ro the per-call one when given
+    for kwargs, r in [
+        ({}, 0.001 / ro),
+        ({"ro": 10.0}, 0.001 / 10.0),
+        ({"ro": 10.0 * units.kpc}, 0.001 / 10.0),
+    ]:
+        assert (
+            numpy.fabs(
+                dfh.sigmar(1.0 * units.pc, use_physical=False, **kwargs)
+                - dfh.sigmar(r, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method sigmar does not parse a Quantity radius with the per-call ro"
+        )
+        assert (
+            numpy.fabs(
+                dfh.sigmat(1.0 * units.pc, use_physical=False, **kwargs)
+                - dfh.sigmat(r, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method sigmat does not parse a Quantity radius with the per-call ro"
+        )
+        assert (
+            numpy.fabs(
+                dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False, **kwargs)
+                - dfh.vmomentdensity(r, 0, 0, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method vmomentdensity does not parse a Quantity radius with the per-call ro"
+        )
+        assert (
+            numpy.fabs(dfa.beta(1.0 * units.pc, **kwargs) - dfa.beta(r)) < 10.0**-8.0
+        ), (
+            "sphericaldf method beta does not parse a Quantity radius with the per-call ro"
+        )
+    # and the override has to actually make a difference
+    assert (
+        numpy.fabs(
+            dfh.sigmar(1.0 * units.pc, use_physical=False)
+            - dfh.sigmar(1.0 * units.pc, use_physical=False, ro=10.0)
+        )
+        > 10.0**-6.0
+    ), (
+        "sphericaldf method sigmar ignores the per-call ro when parsing a Quantity radius"
+    )
+    # Same for the energy input of dMdE and of __call__ in its (E,L,Lz) form,
+    # which are parsed with vo rather than ro
+    o = Orbit([0.5, 0.05, 0.3, 0.02, 0.05, 0.4], ro=ro, vo=vo)
+    Ei = o.E(pot=pot, use_physical=False)
+    Eq = Ei * vo**2.0 * units.km**2.0 / units.s**2.0
+    for kwargs, E in [({}, Ei), ({"vo": 300.0}, Ei * (vo / 300.0) ** 2.0)]:
+        assert (
+            numpy.fabs(
+                dfh.dMdE(Eq, use_physical=False, **kwargs)
+                - dfh.dMdE(E, use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method dMdE does not parse a Quantity energy with the per-call vo"
+        )
+        assert (
+            numpy.fabs(
+                dfh((Eq,), use_physical=False, **kwargs) - dfh((E,), use_physical=False)
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method __call__ does not parse a Quantity energy with the per-call vo"
+        )
+    assert (
+        numpy.fabs(
+            dfh.dMdE(Eq, use_physical=False)
+            - dfh.dMdE(Eq, use_physical=False, vo=300.0)
+        )
+        > 10.0**-6.0
+    ), "sphericaldf method dMdE ignores the per-call vo when parsing a Quantity energy"
+    # and for __call__ in its R,vR,vT,z,vz form, which uses both ro and vo
+    Ri, vRi, vTi, zi, vzi = (
+        o.R(use_physical=False),
+        o.vR(use_physical=False),
+        o.vT(use_physical=False),
+        o.z(use_physical=False),
+        o.vz(use_physical=False),
+    )
+    quant = (
+        Ri * ro * units.kpc,
+        vRi * vo * units.km / units.s,
+        vTi * vo * units.km / units.s,
+        zi * ro * units.kpc,
+        vzi * vo * units.km / units.s,
+    )
+    for kwargs, (tro, tvo) in [
+        ({}, (ro, vo)),
+        ({"ro": 10.0, "vo": 300.0}, (10.0, 300.0)),
+    ]:
+        assert (
+            numpy.fabs(
+                dfh(*quant, use_physical=False, **kwargs)
+                - dfh(
+                    Ri * ro / tro,
+                    vRi * vo / tvo,
+                    vTi * vo / tvo,
+                    zi * ro / tro,
+                    vzi * vo / tvo,
+                    use_physical=False,
+                )
+            )
+            < 10.0**-8.0
+        ), (
+            "sphericaldf method __call__ does not parse Quantity coordinates with the per-call ro/vo"
+        )
+    assert (
+        numpy.fabs(
+            dfh(*quant, use_physical=False)
+            - dfh(*quant, use_physical=False, ro=10.0, vo=300.0)
+        )
+        > 10.0**-6.0
+    ), (
+        "sphericaldf method __call__ ignores the per-call ro/vo when parsing Quantity coordinates"
+    )
+    return None
+
+
 def test_sphericaldf_sample():
     from galpy import potential
     from galpy.df import isotropicHernquistdf

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -3952,59 +3952,6 @@ def test_eddington_sample_negative_df_regions_no_crash():
     return None
 
 
-def test_sphericaldf_percall_ro_override():
-    # A per-call ro= must be used when parsing a Quantity input radius,
-    # like for potentials and diskdf/quasiisothermaldf (#1198)
-    from galpy.util._optional_deps import _APY_LOADED
-
-    if not _APY_LOADED:
-        return None
-    from astropy import units
-
-    pot = potential.HernquistPotential(amp=2.0, a=1.0)
-    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
-    # Without ro=, 1 pc is parsed with the DF's own ro of 8 kpc
-    assert (
-        numpy.fabs(
-            dfh.sigmar(1.0 * units.pc, use_physical=False)
-            - dfh.sigmar(0.001 / 8.0, use_physical=False)
-        )
-        < 1e-12
-    ), "sigmar does not parse a Quantity radius with the DF's ro"
-    # With ro=10., it is parsed with the per-call value instead
-    assert (
-        numpy.fabs(
-            dfh.sigmar(1.0 * units.pc, use_physical=False, ro=10.0)
-            - dfh.sigmar(0.001 / 10.0, use_physical=False)
-        )
-        < 1e-12
-    ), "sigmar does not parse a Quantity radius with the per-call ro"
-    # Same for sigmat and vmomentdensity
-    assert (
-        numpy.fabs(
-            dfh.sigmat(1.0 * units.pc, use_physical=False, ro=10.0)
-            - dfh.sigmat(0.001 / 10.0, use_physical=False)
-        )
-        < 1e-12
-    ), "sigmat does not parse a Quantity radius with the per-call ro"
-    assert (
-        numpy.fabs(
-            dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False, ro=10.0)
-            - dfh.vmomentdensity(0.001 / 10.0, 0, 0, use_physical=False)
-        )
-        < 1e-12
-    ), "vmomentdensity does not parse a Quantity radius with the per-call ro"
-    # beta needs an anisotropic DF, because the isotropic one is zero
-    # everywhere; beta(r) = r^2/(r^2+ra^2) for the Osipkov-Merritt DF
-    dfa = osipkovmerrittdf(pot=pot, ra=1.0, ro=8.0, vo=220.0)
-    for ro, r in zip([None, 10.0], [0.001 / 8.0, 0.001 / 10.0]):
-        assert (
-            numpy.fabs(dfa.beta(1.0 * units.pc, ro=ro) - r**2.0 / (r**2.0 + 1.0))
-            < 1e-12
-        ), "beta does not parse a Quantity radius with the per-call ro"
-    return None
-
-
 def test_sphericaldf_bad_radius_error():
     # Non-numeric input should still give the standard clear error, which
     # comes from the in-body parse_length, not from the input decorator

--- a/tests/test_sphericaldf.py
+++ b/tests/test_sphericaldf.py
@@ -3950,3 +3950,69 @@ def test_eddington_sample_negative_df_regions_no_crash():
         "Sampled speeds exceed the escape speed of the truncated DF"
     )
     return None
+
+
+def test_sphericaldf_percall_ro_override():
+    # A per-call ro= must be used when parsing a Quantity input radius,
+    # like for potentials and diskdf/quasiisothermaldf (#1198)
+    from galpy.util._optional_deps import _APY_LOADED
+
+    if not _APY_LOADED:
+        return None
+    from astropy import units
+
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    # Without ro=, 1 pc is parsed with the DF's own ro of 8 kpc
+    assert (
+        numpy.fabs(
+            dfh.sigmar(1.0 * units.pc, use_physical=False)
+            - dfh.sigmar(0.001 / 8.0, use_physical=False)
+        )
+        < 1e-12
+    ), "sigmar does not parse a Quantity radius with the DF's ro"
+    # With ro=10., it is parsed with the per-call value instead
+    assert (
+        numpy.fabs(
+            dfh.sigmar(1.0 * units.pc, use_physical=False, ro=10.0)
+            - dfh.sigmar(0.001 / 10.0, use_physical=False)
+        )
+        < 1e-12
+    ), "sigmar does not parse a Quantity radius with the per-call ro"
+    # Same for sigmat and vmomentdensity
+    assert (
+        numpy.fabs(
+            dfh.sigmat(1.0 * units.pc, use_physical=False, ro=10.0)
+            - dfh.sigmat(0.001 / 10.0, use_physical=False)
+        )
+        < 1e-12
+    ), "sigmat does not parse a Quantity radius with the per-call ro"
+    assert (
+        numpy.fabs(
+            dfh.vmomentdensity(1.0 * units.pc, 0, 0, use_physical=False, ro=10.0)
+            - dfh.vmomentdensity(0.001 / 10.0, 0, 0, use_physical=False)
+        )
+        < 1e-12
+    ), "vmomentdensity does not parse a Quantity radius with the per-call ro"
+    # beta needs an anisotropic DF, because the isotropic one is zero
+    # everywhere; beta(r) = r^2/(r^2+ra^2) for the Osipkov-Merritt DF
+    dfa = osipkovmerrittdf(pot=pot, ra=1.0, ro=8.0, vo=220.0)
+    for ro, r in zip([None, 10.0], [0.001 / 8.0, 0.001 / 10.0]):
+        assert (
+            numpy.fabs(dfa.beta(1.0 * units.pc, ro=ro) - r**2.0 / (r**2.0 + 1.0))
+            < 1e-12
+        ), "beta does not parse a Quantity radius with the per-call ro"
+    return None
+
+
+def test_sphericaldf_bad_radius_error():
+    # Non-numeric input should still give the standard clear error, which
+    # comes from the in-body parse_length, not from the input decorator
+    pot = potential.HernquistPotential(amp=2.0, a=1.0)
+    dfh = isotropicHernquistdf(pot=pot, ro=8.0, vo=220.0)
+    for method in [dfh.sigmar, dfh.sigmat, dfh.beta]:
+        with pytest.raises(RuntimeError, match="not understood"):
+            method("foo")
+    with pytest.raises(RuntimeError, match="not understood"):
+        dfh.vmomentdensity("foo", 0, 0)
+    return None


### PR DESCRIPTION
Fixes #1198, replacing #1345.

## Problem

Methods of the `sphericaldf` family converted `Quantity` inputs with the DF's own `_ro`/`_vo`, ignoring a per-call `ro=`/`vo=` — even though the same `ro=`/`vo=` was already honoured for the *output* units. Potentials route input conversion through `@potential_physical_input`, which reads `kwargs["ro"]` first and falls back to the object's `_ro`, so the two disagreed about what `ro=` means on a method call.

## Fix

**Radius inputs** — `vmomentdensity`, `sigmar`, `sigmat`, `beta` are decorated with `@potential_physical_input`.

`beta` gains explicit `ro=`/`vo=` parameters so it accepts the same overrides as the others without a catch-all `**kwargs`. It keeps returning a plain float — no output decorator, since `test_quantity.py` asserts it is not a `Quantity`.

The in-body `conversion.parse_length(r, ro=self._ro)` calls are **kept**. Once the decorator has run they are the identity, but they still do two useful things, so they are retained with a comment rather than removed:

- they validate the input type, so `sigmar("foo")` keeps raising the standard `RuntimeError: Input 'foo' not understood; should either be a number or an astropy Quantity` instead of failing deep inside the integrand;
- `potential_physical_input` only converts *positional* arguments, so they leave `sigmar(r=1*u.pc)` behaving exactly as it does on `main`.

**Energy, angular momentum, and phase-space inputs** — `__call__` and `dMdE` cannot use `potential_physical_input`, whose arguments are all lengths. Their `physical_conversion` switches to `pop=False` so that `ro=`/`vo=` are still in `kwargs` when the body runs, and a small `_input_scales` helper resolves them with the same precedence (per-call value if given, the DF's own otherwise). All output conversion stays in `physical_conversion`, so `use_physical=`, `quantity=`, and the internal-units warning are untouched.

The fallback is `_ro`/`_vo` unconditionally rather than gated on `_roSet`/`_voSet`: parsing a `Quantity` always needs *some* scale, and gating would pass `ro=None` into `parse_length` for a DF built without units.

Also fixes a typo that parsed a `Quantity` `Lz` with `ro=vo`. It has no effect today, since every `_call_internal` in the family takes only `(E,L)`.

## Scope

Every genuinely affected entry point in the family is covered. The other in-body `parse_*` calls counted in #1198 are not bugs: `sphericaldf.__init__`/`_handle_rmin`, `sphericaldf.sample` (which has no `ro=`/`vo=` parameter at all), `kingdf.__init__`, and `osipkovmerrittdf.__init__` all parse at construction time or with no per-call override available, where the DF's own scale is the only correct one.

## Verification

| | `main` | this PR |
|---|---|---|
| `sigmar(1 pc, use_physical=False)` | `0.02938340917273438` | `0.02938340917273438` |
| `sigmar(1 pc, use_physical=False, ro=10.)` | `0.02938340917273438` | `0.02670139589892777` |
| `sigmar(..., ro=10.*u.kpc)` | `0.02938340917273438` | `0.02670139589892777` |
| `dMdE(E_q, vo=300.)` | value at `vo=220` | `1.5386267984795907` = `dMdE(E_i*(220/300)^2)` |
| `df((E_q,), vo=300.)` | value at `vo=220` | `0.00716953862146177` = `df((E_i*(220/300)^2,))` |
| `df(R,vR,vT,z,vz as Quantity, ro=10., vo=300.)` | value at `ro=8,vo=220` | `0.20644904181884122` = rescaled internal call |
| `beta(1.1)` return type | `float64` | `float64` |
| `quantity=True` on `sigmar`/`dMdE`/`__call__` | `Quantity` | `Quantity` |
| `sigmar(r=1*u.pc)`, `vmomentdensity(r=1*u.pc, …)` | ok | unchanged |
| warnings on a df with `ro`/`vo` unset | none | none |

`0.026701396` is the value predicted in #1198. Calls that do not pass `ro=`/`vo=` are unaffected.

The `Quantity` regression test lives in `tests/test_quantity.py`, not `tests/test_sphericaldf.py`: that file's CI matrix entry has `REQUIRES_ASTROPY: false`, so an `_APY_LOADED`-guarded test there never actually runs. It covers all four radius methods, both `__call__` input forms, and `dMdE`, and fails against `main`. `test_sphericaldf_bad_radius_error` stays in `tests/test_sphericaldf.py`, since it needs no astropy.

`tests/test_sphericaldf.py`: 223 passed. `tests/test_quantity.py`: 243 passed.

## Credit

The original patch and the shape of the regression test come from @sdoygb in #1345; thanks for spotting and reporting this.
