### PR TITLE
actionAngle: stop masking an inner AttributeError as "method not implemented"

### DIFF
--- a/galpy/actionAngle/actionAngle.py
+++ b/galpy/actionAngle/actionAngle.py
@@ -198,12 +198,15 @@ class actionAngle(metaclass=MetaActionAngle):
         -----
         - 2014-01-03 - Written for top level - Bovy (IAS)
         """
+        # Only a MISSING method means "not implemented"; look the attribute up
+        # separately so an AttributeError raised INSIDE it keeps its own traceback.
         try:
-            return self._evaluate(*args, **kwargs)
-        except AttributeError:  # pragma: no cover
+            method = self._evaluate
+        except AttributeError:
             raise NotImplementedError(
                 "'__call__' method not implemented for this actionAngle module"
             )
+        return method(*args, **kwargs)
 
     @actionAngle_physical_input
     @physical_conversion_actionAngle("actionsFreqs", pop=True)
@@ -232,12 +235,15 @@ class actionAngle(metaclass=MetaActionAngle):
         - 2014-01-03 - Written for top level - Bovy (IAS)
 
         """
+        # Only a MISSING method means "not implemented"; look the attribute up
+        # separately so an AttributeError raised INSIDE it keeps its own traceback.
         try:
-            return self._actionsFreqs(*args, **kwargs)
-        except AttributeError:  # pragma: no cover
+            method = self._actionsFreqs
+        except AttributeError:
             raise NotImplementedError(
                 "'actionsFreqs' method not implemented for this actionAngle module"
             )
+        return method(*args, **kwargs)
 
     @actionAngle_physical_input
     @physical_conversion_actionAngle("actionsFreqsAngles", pop=True)
@@ -265,12 +271,15 @@ class actionAngle(metaclass=MetaActionAngle):
         -----
         - 2014-01-03 - Written for top level - Bovy (IAS)
         """
+        # Only a MISSING method means "not implemented"; look the attribute up
+        # separately so an AttributeError raised INSIDE it keeps its own traceback.
         try:
-            return self._actionsFreqsAngles(*args, **kwargs)
-        except AttributeError:  # pragma: no cover
+            method = self._actionsFreqsAngles
+        except AttributeError:
             raise NotImplementedError(
                 "'actionsFreqsAngles' method not implemented for this actionAngle module"
             )
+        return method(*args, **kwargs)
 
     @actionAngle_physical_input
     @physical_conversion_actionAngle("EccZmaxRperiRap", pop=True)
@@ -298,12 +307,15 @@ class actionAngle(metaclass=MetaActionAngle):
         -----
         - 2017-12-12 - Written - Bovy (UofT)
         """
+        # Only a MISSING method means "not implemented"; look the attribute up
+        # separately so an AttributeError raised INSIDE it keeps its own traceback.
         try:
-            return self._EccZmaxRperiRap(*args, **kwargs)
-        except AttributeError:  # pragma: no cover
+            method = self._EccZmaxRperiRap
+        except AttributeError:
             raise NotImplementedError(
                 "'EccZmaxRperiRap' method not implemented for this actionAngle module"
             )
+        return method(*args, **kwargs)
 
 
 class UnboundError(Exception):  # pragma: no cover

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8311,3 +8311,55 @@ def test_actionAngleStaeckel_python_freqsAngles_branches():
                 for o in out:
                     assert numpy.all(numpy.isfinite(numpy.atleast_1d(o)))
     return None
+
+
+# The four actionAngle entry points map a MISSING implementation method to
+# NotImplementedError. They must not also swallow an AttributeError raised from
+# INSIDE an implementation that does exist: that turned real failures (e.g. handing
+# backend arrays to the C code) into a misleading "method not implemented".
+_AA_ENTRY_POINTS = [
+    ("__call__", "_evaluate"),
+    ("actionsFreqs", "_actionsFreqs"),
+    ("actionsFreqsAngles", "_actionsFreqsAngles"),
+    ("EccZmaxRperiRap", "_EccZmaxRperiRap"),
+]
+
+
+@pytest.mark.parametrize("public,private", _AA_ENTRY_POINTS)
+def test_actionAngle_missing_method_raises_notimplemented(public, private):
+    from galpy.actionAngle import actionAngle
+
+    aA = actionAngle()  # base class implements none of them
+    assert not hasattr(aA, private), (
+        f"test assumes the base class has no {private}; it now does"
+    )
+    with pytest.raises(NotImplementedError) as excinfo:
+        getattr(aA, public)(1.0, 0.1, 1.1, 0.1, 0.1)
+    assert public.strip("_") in str(excinfo.value), (
+        f"NotImplementedError for {public} should name the method, got: {excinfo.value}"
+    )
+    return None
+
+
+@pytest.mark.parametrize("public,private", _AA_ENTRY_POINTS)
+def test_actionAngle_inner_attributeerror_is_not_masked(public, private):
+    """An AttributeError from inside the implementation must propagate unchanged."""
+    from galpy.actionAngle import actionAngle
+
+    sentinel = "inner attribute failure, not a missing method"
+
+    class _Boom(actionAngle):
+        def __init__(self):
+            actionAngle.__init__(self)
+
+    def _raise(*args, **kwargs):
+        raise AttributeError(sentinel)
+
+    setattr(_Boom, private, _raise)
+    aA = _Boom()
+    with pytest.raises(AttributeError) as excinfo:
+        getattr(aA, public)(1.0, 0.1, 1.1, 0.1, 0.1)
+    assert sentinel in str(excinfo.value), (
+        f"{public} masked the inner AttributeError; got: {excinfo.value}"
+    )
+    return None


### PR DESCRIPTION
The four public `actionAngle` entry points -- `__call__`, `actionsFreqs`,
`actionsFreqsAngles`, `EccZmaxRperiRap` -- wrapped the **call** to their implementation in

```python
try:
    return self._evaluate(*args, **kwargs)
except AttributeError:  # pragma: no cover
    raise NotImplementedError("'__call__' method not implemented for this actionAngle module")
```

The intent is to report a subclass that does not implement the method. But the `try` covers
the call as well as the lookup, so **any** `AttributeError` raised *inside* a method that does
exist gets relabelled `"'<name>' method not implemented for this actionAngle module"` and its
traceback is lost.

That is not hypothetical. It is what an `actionAngleAdiabaticGrid` off-grid fallback handing
backend (jax/torch) arrays to the C implementation reports, which made a concrete, ordinary
failure read as a missing method and cost real debugging time.

### Change

Look the attribute up separately, so only a genuinely absent method is reported as
`NotImplementedError` and everything else propagates unchanged:

```python
try:
    method = self._evaluate
except AttributeError:
    raise NotImplementedError(...)
return method(*args, **kwargs)
```

### Coverage

The four handlers were marked `# pragma: no cover`. They are now **covered** instead, by tests
asserting both halves of the contract for all four entry points:

- a missing method still raises `NotImplementedError` naming the method;
- an `AttributeError` raised inside an implementation reaches the caller intact.

### Verification

A/B against the same tests: **without** the source change the four "not masked" tests fail and
the four "missing method" tests still pass, so the tests measure exactly this fix and the
intended behaviour is genuinely preserved. Full `tests/test_actionAngle.py` is green
(223 passed), including `test_nullpotential_error`, whose `NotImplementedError` is raised
deliberately elsewhere and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm