### PR TITLE
actionAngleStaeckel: regularize the action quadratures' sqrt turning points (C + Python)

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -14,6 +14,16 @@ v1.12.1 (expected around 2026-11-01)
   ~33% rather than 2x. Together these reduce the error to ~1e-9. Note that this
   changes the values returned for ``c=True``.
 
+- The pure-Python path of ``actionAngleStaeckel`` (``c=False`` with
+  ``fixed_quad=True``, and the frequency/angle calculations) now evaluates
+  all of its quadratures with a composite Gauss-Legendre rule in an anomaly
+  that absorbs the square-root behavior at the turning points, and solves
+  for the turning points at machine tolerance. The fixed-order rule
+  converged only as order^-3 against the turning-point branch points,
+  leaving systematic ~5e-4 relative action errors at the default order;
+  actions, frequencies, and angles at the default order are now converged
+  to ~1e-11 or better (the C path will be upgraded separately).
+
 - ``actionAngleVerticalInverse`` now supports physical units: it accepts
   ``ro`` and ``vo``, parses the energies of its tori and the actions and
   angles at which it is evaluated when these are given as Quantities, and

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,11 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
+
+
+============
+
+<<<<<<< HEAD
 - The C implementation of ``actionAngleAdiabatic`` now evaluates the radial
   and vertical action integrals in a regularized variable. Both integrands
   vanish like a square root at the ends of their intervals (at ``zmax`` for
@@ -23,6 +28,21 @@ v1.12.1 (expected around 2026-11-01)
   leaving systematic ~5e-4 relative action errors at the default order;
   actions, frequencies, and angles at the default order are now converged
   to ~1e-11 or better (the C path will be upgraded separately).
+=======
+- The action quadratures of ``actionAngleStaeckel`` are regularized at the
+  turning points in both the C and the pure-Python path. The fixed-order
+  Gauss-Legendre rule was previously applied against the square-root branch
+  points at the turning points, converged only as order^-3, and left
+  systematic ~5e-4 relative action errors at the default order. The C path
+  now applies the same t^2 endpoint substitution that its derivative
+  routines already used (actions at the default order are converged to
+  ~1e-12; note that ``c=True`` action values change at the ~5e-4 level).
+  The pure-Python path (``c=False`` with ``fixed_quad=True``, and the
+  frequency/angle calculations) evaluates all of its quadratures with a
+  composite Gauss-Legendre rule in an anomaly that absorbs the square-root
+  behavior, and solves for the turning points at machine tolerance;
+  actions, frequencies, and angles at the default order are converged to
+  ~1e-11 or better.
 
 - ``actionAngleVerticalInverse`` now supports physical units: it accepts
   ``ro`` and ``vo``, parses the energies of its tori and the actions and

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,34 +1,6 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
-
-
-============
-
-<<<<<<< HEAD
-- The C implementation of ``actionAngleAdiabatic`` now evaluates the radial
-  and vertical action integrals in a regularized variable. Both integrands
-  vanish like a square root at the ends of their intervals (at ``zmax`` for
-  ``jz``, at both ``rperi`` and ``rap`` for ``jr``), where fixed-order
-  Gauss-Legendre converges only algebraically; the actions therefore carried
-  ~1e-4 relative error, while the pure-Python (``c=False``) path is accurate to
-  ~1e-14. Substituting ``z = zmax*sin(phi)`` and ``R = cc-rr*cos(theta)`` makes
-  the integrands analytic at those ends at no extra cost. The Gauss-Legendre
-  order for these two integrals was also raised from 10 to 20; because the
-  turning-point root-finding dominates and is order-independent, this costs
-  ~33% rather than 2x. Together these reduce the error to ~1e-9. Note that this
-  changes the values returned for ``c=True``.
-
-- The pure-Python path of ``actionAngleStaeckel`` (``c=False`` with
-  ``fixed_quad=True``, and the frequency/angle calculations) now evaluates
-  all of its quadratures with a composite Gauss-Legendre rule in an anomaly
-  that absorbs the square-root behavior at the turning points, and solves
-  for the turning points at machine tolerance. The fixed-order rule
-  converged only as order^-3 against the turning-point branch points,
-  leaving systematic ~5e-4 relative action errors at the default order;
-  actions, frequencies, and angles at the default order are now converged
-  to ~1e-11 or better (the C path will be upgraded separately).
-=======
 - The action quadratures of ``actionAngleStaeckel`` are regularized at the
   turning points in both the C and the pure-Python path. The fixed-order
   Gauss-Legendre rule was previously applied against the square-root branch
@@ -43,6 +15,19 @@ v1.12.1 (expected around 2026-11-01)
   behavior, and solves for the turning points at machine tolerance;
   actions, frequencies, and angles at the default order are converged to
   ~1e-11 or better.
+
+- The C implementation of ``actionAngleAdiabatic`` now evaluates the radial
+  and vertical action integrals in a regularized variable. Both integrands
+  vanish like a square root at the ends of their intervals (at ``zmax`` for
+  ``jz``, at both ``rperi`` and ``rap`` for ``jr``), where fixed-order
+  Gauss-Legendre converges only algebraically; the actions therefore carried
+  ~1e-4 relative error, while the pure-Python (``c=False``) path is accurate to
+  ~1e-14. Substituting ``z = zmax*sin(phi)`` and ``R = cc-rr*cos(theta)`` makes
+  the integrands analytic at those ends at no extra cost. The Gauss-Legendre
+  order for these two integrals was also raised from 10 to 20; because the
+  turning-point root-finding dominates and is order-independent, this costs
+  ~33% rather than 2x. Together these reduce the error to ~1e-9. Note that this
+  changes the values returned for ``c=True``.
 
 - ``actionAngleVerticalInverse`` now supports physical units: it accepts
   ``ro`` and ``vo``, parses the energies of its tori and the actions and

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -63,7 +63,7 @@ class actionAngleStaeckel(actionAngle):
         c : bool, optional
             If True, always use C for calculations. Default is False.
         order : int, optional
-            Number of points to use in the Gauss-Legendre numerical integration of the relevant action, frequency, and angle integrals. Default is 10.
+            Number of points to use in the Gauss-Legendre numerical integration of the relevant action, frequency, and angle integrals (C path). On the pure-Python path this instead scales the number of panels of the composite chi-anomaly quadrature (nchi = max(2 x order, 20)), which is machine-converged at the default, so increasing it there has no practical effect. Default is 10.
         ro : float or Quantity, optional
             Distance scale for translation into internal units (default from configuration file).
         vo : float or Quantity, optional
@@ -881,7 +881,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         fixed_quad : bool, optional
-            If True, use n=10 fixed_quad. Default is False.
+            If True, use the composite chi-anomaly Gauss-Legendre quadrature (machine-converged; order= scales the mesh as nchi = max(2 x order, 20)) instead of adaptive scipy.integrate.quad. Default is False.
         **kwargs
             scipy.integrate.quad keywords
 
@@ -895,14 +895,16 @@ class actionAngleStaeckelSingle(actionAngle):
         - 2012-11-27 - Written - Bovy (IAS)
 
         """
-        if hasattr(self, "_JR"):  # pragma: no cover
+        order = kwargs.pop("order", 10)
+        fixed_quad = kwargs.pop("fixed_quad", False)
+        if hasattr(self, "_JR") and self._JR_key == (fixed_quad, order):
             return self._JR
         umin, umax = self.calcUminUmax()
         # print self._ux, self._pux, (umax-umin)/umax
         if (umax - umin) / umax < 10.0**-6:
             return numpy.array([0.0])
-        order = kwargs.pop("order", 10)
-        if kwargs.pop("fixed_quad", False):
+        self._JR_key = (fixed_quad, order)
+        if fixed_quad:
             # chi-anomaly composite quadrature: machine-converged, with the
             # sqrt turning-point behavior absorbed by the parametrization
             # factor in next line bc integrand=/2delta^2
@@ -947,7 +949,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         fixed_quad : bool, optional
-            If True, use n=10 fixed_quad. Default is False.
+            If True, use the composite chi-anomaly Gauss-Legendre quadrature (machine-converged; order= scales the mesh as nchi = max(2 x order, 20)) instead of adaptive scipy.integrate.quad. Default is False.
         **kwargs
             scipy.integrate.quad keywords
 
@@ -960,13 +962,15 @@ class actionAngleStaeckelSingle(actionAngle):
         -----
         - 2012-11-27 - Written - Bovy (IAS)
         """
-        if hasattr(self, "_JZ"):  # pragma: no cover
+        order = kwargs.pop("order", 10)
+        fixed_quad = kwargs.pop("fixed_quad", False)
+        if hasattr(self, "_JZ") and self._JZ_key == (fixed_quad, order):
             return self._JZ
         vmin = self.calcVmin()
         if (numpy.pi / 2.0 - vmin) < 10.0**-7:
             return numpy.array([0.0])
-        order = kwargs.pop("order", 10)
-        if kwargs.pop("fixed_quad", False):
+        self._JZ_key = (fixed_quad, order)
+        if fixed_quad:
             # chi-anomaly composite quadrature: machine-converged, with the
             # sqrt turning-point behavior absorbed by the parametrization
             # factor in next line bc integrand=/2delta^2
@@ -1439,7 +1443,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         order : int, optional
-            Number of points to use in the Gauss-Legendre integration. Default is 10.
+            Scales the number of panels of the composite chi-anomaly quadrature (nchi = max(2 x order, 20)); machine-converged at the default. Default is 10.
 
         Returns
         -------
@@ -1450,8 +1454,9 @@ class actionAngleStaeckelSingle(actionAngle):
         -----
         - Port of the C calcdJRStaeckel.
         """
-        if hasattr(self, "_djrdE"):  # pragma: no cover
+        if hasattr(self, "_djrdE") and self._djrd_order == order:
             return (self._djrdE, self._djrdLz, self._djrdI3)
+        self._djrd_order = order
         umin, umax = self.calcUminUmax()
         if (umax - umin) / umax < 1e-6:  # circular
             self._djrdE = 0.0
@@ -1474,7 +1479,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         order : int, optional
-            Number of points to use in the Gauss-Legendre integration. Default is 10.
+            Scales the number of panels of the composite chi-anomaly quadrature (nchi = max(2 x order, 20)); machine-converged at the default. Default is 10.
 
         Returns
         -------
@@ -1485,8 +1490,9 @@ class actionAngleStaeckelSingle(actionAngle):
         -----
         - Port of the C calcdJzStaeckel.
         """
-        if hasattr(self, "_djzdE"):  # pragma: no cover
+        if hasattr(self, "_djzdE") and self._djzd_order == order:
             return (self._djzdE, self._djzdLz, self._djzdI3)
+        self._djzd_order = order
         vmin = self.calcVmin()
         if (numpy.pi / 2.0 - vmin) / numpy.pi * 2.0 < 1e-6:  # circular
             self._djzdE = 0.0
@@ -1510,7 +1516,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         order : int, optional
-            Number of points to use in the Gauss-Legendre integration. Default is 10.
+            Scales the number of panels of the composite chi-anomaly quadrature (nchi = max(2 x order, 20)); machine-converged at the default. Default is 10.
 
         Returns
         -------
@@ -1547,7 +1553,7 @@ class actionAngleStaeckelSingle(actionAngle):
         Parameters
         ----------
         order : int, optional
-            Number of points to use in the Gauss-Legendre integration. Default is 10.
+            Scales the number of panels of the composite chi-anomaly quadrature (nchi = max(2 x order, 20)); machine-converged at the default. Default is 10.
 
         Returns
         -------

--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -903,31 +903,15 @@ class actionAngleStaeckelSingle(actionAngle):
             return numpy.array([0.0])
         order = kwargs.pop("order", 10)
         if kwargs.pop("fixed_quad", False):
+            # chi-anomaly composite quadrature: machine-converged, with the
+            # sqrt turning-point behavior absorbed by the parametrization
             # factor in next line bc integrand=/2delta^2
             self._JR = (
                 1.0
                 / numpy.pi
                 * numpy.sqrt(2.0)
                 * self._delta
-                * integrate.fixed_quad(
-                    _JRStaeckelIntegrand,
-                    umin,
-                    umax,
-                    args=(
-                        self._E,
-                        self._Lz,
-                        self._I3U,
-                        self._delta,
-                        self._u0,
-                        self._sinhu0**2.0,
-                        self._v0u,
-                        self._sinv0u**2.0,
-                        self._potu0v0,
-                        self._pot,
-                    ),
-                    n=order,
-                    **kwargs,
-                )[0]
+                * self._chiQuadsU(order=order)[0]
             )
         else:
             self._JR = (
@@ -983,30 +967,15 @@ class actionAngleStaeckelSingle(actionAngle):
             return numpy.array([0.0])
         order = kwargs.pop("order", 10)
         if kwargs.pop("fixed_quad", False):
+            # chi-anomaly composite quadrature: machine-converged, with the
+            # sqrt turning-point behavior absorbed by the parametrization
             # factor in next line bc integrand=/2delta^2
             self._JZ = (
                 2.0
                 / numpy.pi
                 * numpy.sqrt(2.0)
                 * self._delta
-                * integrate.fixed_quad(
-                    _JzStaeckelIntegrand,
-                    vmin,
-                    numpy.pi / 2,
-                    args=(
-                        self._E,
-                        self._Lz,
-                        self._I3V,
-                        self._delta,
-                        self._u0v,
-                        self._coshu0v**2.0,
-                        self._sinhu0v**2.0,
-                        self._potupi2,
-                        self._pot,
-                    ),
-                    n=order,
-                    **kwargs,
-                )[0]
+                * self._chiQuadsV(order=order)[0]
             )
         else:
             # factor in next line bc integrand=/2delta^2
@@ -1153,6 +1122,8 @@ class actionAngleStaeckelSingle(actionAngle):
                                 self._pot,
                             ),
                             maxiter=200,
+                            xtol=1e-15,
+                            rtol=8.9e-16,
                         )
                     except RuntimeError:  # pragma: no cover
                         raise UnboundError("Orbit seems to be unbound")
@@ -1189,6 +1160,8 @@ class actionAngleStaeckelSingle(actionAngle):
                         self._pot,
                     ),
                     maxiter=200,
+                    xtol=1e-15,
+                    rtol=8.9e-16,
                 )
             else:  # circular orbit
                 umin = self._ux
@@ -1232,6 +1205,8 @@ class actionAngleStaeckelSingle(actionAngle):
                             self._pot,
                         ),
                         maxiter=200,
+                        xtol=1e-15,
+                        rtol=8.9e-16,
                     )
                 except RuntimeError:  # pragma: no cover
                     raise UnboundError("Orbit seems to be unbound")
@@ -1266,6 +1241,8 @@ class actionAngleStaeckelSingle(actionAngle):
                     self._pot,
                 ),
                 maxiter=200,
+                xtol=1e-15,
+                rtol=8.9e-16,
             )
         self._uminumax = (umin, umax)
         return self._uminumax
@@ -1354,6 +1331,8 @@ class actionAngleStaeckelSingle(actionAngle):
                             self._pot,
                         ),
                         maxiter=200,
+                        xtol=1e-15,
+                        rtol=8.9e-16,
                     )
                 except RuntimeError:  # pragma: no cover
                     raise UnboundError("Orbit seems to be unbound")
@@ -1387,6 +1366,72 @@ class actionAngleStaeckelSingle(actionAngle):
             self._pot,
         )
 
+    def _chiQuadsU(self, order=10, uupp=None):
+        """All u quadratures (the action integral and the three 1/p_u
+        profile integrals int f/sqrt(S_R) du for f = sinh^2 u, 1,
+        1/sinh^2 u) from umin up to uupp (default: the complete integral
+        to umax), from a single vectorized evaluation of the momentum on
+        the chi mesh; cached"""
+        nchi = max(2 * int(order), 20)
+        umin, umax = self.calcUminUmax()
+        chimax = (
+            numpy.pi
+            if uupp is None
+            else 2.0
+            * numpy.arcsin(
+                numpy.sqrt(numpy.clip((uupp - umin) / (umax - umin), 0.0, 1.0))
+            )
+        )
+        if not hasattr(self, "_chiQuadsUCache"):
+            self._chiQuadsUCache = {}
+        if (nchi, chimax) not in self._chiQuadsUCache:
+            self._chiQuadsUCache[(nchi, chimax)] = _staeckelChiQuadratures(
+                _JRStaeckelIntegrandSquared,
+                _dJRStaeckelIntegrandSquareddu,
+                self._uIntegrandArgs(),
+                umin,
+                umax - umin,
+                _CHIQUAD_UWEIGHTS,
+                nchi=nchi,
+                chimax=chimax,
+            )
+        return self._chiQuadsUCache[(nchi, chimax)]
+
+    def _chiQuadsV(self, order=10, vupp=None):
+        """All v quadratures (the action integral and the three 1/p_v
+        profile integrals int f/sqrt(S_z) dv for f = sin^2 v, 1,
+        1/sin^2 v) from vmin up to vupp (default: to the midplane pi/2),
+        from a single vectorized evaluation of the momentum on the chi
+        mesh; cached. The anomaly always spans the full v loop
+        [vmin, pi - vmin] (the midplane is a symmetry point of S_z, not a
+        turning point), so integrating to the midplane is chimax = pi/2"""
+        nchi = max(2 * int(order), 20)
+        vmin = self.calcVmin()
+        chimax = (
+            numpy.pi / 2.0
+            if vupp is None
+            else 2.0
+            * numpy.arcsin(
+                numpy.sqrt(
+                    numpy.clip((vupp - vmin) / (numpy.pi - 2.0 * vmin), 0.0, 1.0)
+                )
+            )
+        )
+        if not hasattr(self, "_chiQuadsVCache"):
+            self._chiQuadsVCache = {}
+        if (nchi, chimax) not in self._chiQuadsVCache:
+            self._chiQuadsVCache[(nchi, chimax)] = _staeckelChiQuadratures(
+                _JzStaeckelIntegrandSquared,
+                _dJzStaeckelIntegrandSquareddv,
+                self._vIntegrandArgs(),
+                vmin,
+                numpy.pi - 2.0 * vmin,
+                _CHIQUAD_VWEIGHTS,
+                nchi=nchi,
+                chimax=chimax,
+            )
+        return self._chiQuadsVCache[(nchi, chimax)]
+
     def calcdJR(self, order=10):
         """
         Calculate the derivatives djr/dE, djr/dLz, djr/dI3.
@@ -1413,61 +1458,9 @@ class actionAngleStaeckelSingle(actionAngle):
             self._djrdLz = 0.0
             self._djrdI3 = 0.0
             return (self._djrdE, self._djrdLz, self._djrdI3)
-        args = self._uIntegrandArgs()
-        mid = numpy.sqrt(0.5 * (umax - umin))
-        # djrdE
-        djrdE = (
-            integrate.fixed_quad(
-                _uLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdEStaeckelIntegrand, umin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _uHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdEStaeckelIntegrand, umax, args),
-                n=order,
-            )[0]
-        )
+        _, (djrdE, djrdI3, djrdLz) = self._chiQuadsU(order=order)
         djrdE *= self._delta / numpy.pi / numpy.sqrt(2.0)
-        # djrdLz
-        djrdLz = (
-            integrate.fixed_quad(
-                _uLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdLzStaeckelIntegrand, umin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _uHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdLzStaeckelIntegrand, umax, args),
-                n=order,
-            )[0]
-        )
         djrdLz *= -self._Lz / numpy.pi / numpy.sqrt(2.0) / self._delta
-        # djrdI3
-        djrdI3 = (
-            integrate.fixed_quad(
-                _uLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdI3StaeckelIntegrand, umin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _uHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJRdI3StaeckelIntegrand, umax, args),
-                n=order,
-            )[0]
-        )
         djrdI3 *= -self._delta / numpy.pi / numpy.sqrt(2.0)
         self._djrdE = djrdE
         self._djrdLz = djrdLz
@@ -1500,61 +1493,9 @@ class actionAngleStaeckelSingle(actionAngle):
             self._djzdLz = 0.0
             self._djzdI3 = 0.0
             return (self._djzdE, self._djzdLz, self._djzdI3)
-        args = self._vIntegrandArgs()
-        mid = numpy.sqrt(0.5 * (numpy.pi / 2.0 - vmin))
-        # djzdE
-        djzdE = (
-            integrate.fixed_quad(
-                _vLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdEStaeckelIntegrand, vmin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _vHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdEStaeckelIntegrand, args),
-                n=order,
-            )[0]
-        )
+        _, (djzdE, djzdI3, djzdLz) = self._chiQuadsV(order=order)
         djzdE *= numpy.sqrt(2.0) * self._delta / numpy.pi
-        # djzdLz
-        djzdLz = (
-            integrate.fixed_quad(
-                _vLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdLzStaeckelIntegrand, vmin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _vHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdLzStaeckelIntegrand, args),
-                n=order,
-            )[0]
-        )
         djzdLz *= -self._Lz * numpy.sqrt(2.0) / numpy.pi / self._delta
-        # djzdI3
-        djzdI3 = (
-            integrate.fixed_quad(
-                _vLowStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdI3StaeckelIntegrand, vmin, args),
-                n=order,
-            )[0]
-            + integrate.fixed_quad(
-                _vHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(_dJzdI3StaeckelIntegrand, args),
-                n=order,
-            )[0]
-        )
         djzdI3 *= numpy.sqrt(2.0) * self._delta / numpy.pi
         self._djzdE = djzdE
         self._djzdLz = djzdLz
@@ -1632,61 +1573,43 @@ class actionAngleStaeckelSingle(actionAngle):
         delta = self._delta
         Lz = self._Lz
         sqrt2 = numpy.sqrt(2.0)
-        uargs = self._uIntegrandArgs()
-        vargs = self._vIntegrandArgs()
         ux = self._ux
         vx = self._vx
         pux = self._pux
         pvx = self._pvx
         vmin = self._vmin
 
-        def uquad(func, panel, bound, mid):
+        # Partial-oscillation integrals via the cumulative chi-anomaly
+        # quadratures; the (panel, mid) encoding of the C port is kept:
+        # "low" integrates [qmin, qmin+mid^2], "high" [qmax-mid^2, qmax]
+        def uquad(key, panel, bound, mid):
+            idx = {"E": 0, "I3": 1, "Lz": 2}[key]
             if panel == "low":
-                return integrate.fixed_quad(
-                    _uLowStaeckelIntegrand,
-                    0.0,
-                    mid,
-                    args=(func, bound, uargs),
-                    n=order,
-                )[0]
-            return integrate.fixed_quad(
-                _uHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(func, bound, uargs),
-                n=order,
-            )[0]
+                return self._chiQuadsU(order=order, uupp=umin + mid**2.0)[1][idx]
+            return (
+                self._chiQuadsU(order=order)[1][idx]
+                - self._chiQuadsU(order=order, uupp=umax - mid**2.0)[1][idx]
+            )
 
-        def vquad(func, panel, mid):
+        def vquad(key, panel, mid):
+            idx = {"E": 0, "I3": 1, "Lz": 2}[key]
             if panel == "low":
-                return integrate.fixed_quad(
-                    _vLowStaeckelIntegrand,
-                    0.0,
-                    mid,
-                    args=(func, vmin, vargs),
-                    n=order,
-                )[0]
-            return integrate.fixed_quad(
-                _vHighStaeckelIntegrand,
-                0.0,
-                mid,
-                args=(func, vargs),
-                n=order,
-            )[0]
+                return self._chiQuadsV(order=order, vupp=vmin + mid**2.0)[1][idx]
+            return (
+                self._chiQuadsV(order=order)[1][idx]
+                - self._chiQuadsV(order=order, vupp=numpy.pi / 2.0 - mid**2.0)[1][idx]
+            )
 
         # u-branch (Or1, I3r1, Anglephi-u-term); follows calcAnglesStaeckel @1308
         midpoint_u = umin + 0.5 * (umax - umin)
         if pux > 0.0:
             if ux > midpoint_u:
                 mid = numpy.sqrt(umax - ux)
-                Or1 = uquad(_dJRdEStaeckelIntegrand, "high", umax, mid)
-                I3r1 = -uquad(_dJRdI3StaeckelIntegrand, "high", umax, mid)
+                Or1 = uquad("E", "high", umax, mid)
+                I3r1 = -uquad("I3", "high", umax, mid)
                 anglephi = (
                     numpy.pi * djrdLz
-                    + Lz
-                    * uquad(_dJRdLzStaeckelIntegrand, "high", umax, mid)
-                    / delta
-                    / sqrt2
+                    + Lz * uquad("Lz", "high", umax, mid) / delta / sqrt2
                 )
                 Or1 *= delta / sqrt2
                 I3r1 *= delta / sqrt2
@@ -1694,46 +1617,35 @@ class actionAngleStaeckelSingle(actionAngle):
                 I3r1 = numpy.pi * djrdI3 - I3r1
             else:
                 mid = numpy.sqrt(ux - umin)
-                Or1 = uquad(_dJRdEStaeckelIntegrand, "low", umin, mid)
-                I3r1 = -uquad(_dJRdI3StaeckelIntegrand, "low", umin, mid)
-                anglephi = (
-                    -Lz
-                    * uquad(_dJRdLzStaeckelIntegrand, "low", umin, mid)
-                    / delta
-                    / sqrt2
-                )
+                Or1 = uquad("E", "low", umin, mid)
+                I3r1 = -uquad("I3", "low", umin, mid)
+                anglephi = -Lz * uquad("Lz", "low", umin, mid) / delta / sqrt2
                 Or1 *= delta / sqrt2
                 I3r1 *= delta / sqrt2
         else:
             if ux > midpoint_u:
                 mid = numpy.sqrt(umax - ux)
-                Or1 = uquad(_dJRdEStaeckelIntegrand, "high", umax, mid)
+                Or1 = uquad("E", "high", umax, mid)
                 Or1 *= delta / sqrt2
                 Or1 = numpy.pi * djrdE + Or1
-                I3r1 = -uquad(_dJRdI3StaeckelIntegrand, "high", umax, mid)
+                I3r1 = -uquad("I3", "high", umax, mid)
                 I3r1 *= delta / sqrt2
                 I3r1 = numpy.pi * djrdI3 + I3r1
                 anglephi = (
                     numpy.pi * djrdLz
-                    - Lz
-                    * uquad(_dJRdLzStaeckelIntegrand, "high", umax, mid)
-                    / delta
-                    / sqrt2
+                    - Lz * uquad("Lz", "high", umax, mid) / delta / sqrt2
                 )
             else:
                 mid = numpy.sqrt(ux - umin)
-                Or1 = uquad(_dJRdEStaeckelIntegrand, "low", umin, mid)
+                Or1 = uquad("E", "low", umin, mid)
                 Or1 *= delta / sqrt2
                 Or1 = 2.0 * numpy.pi * djrdE - Or1
-                I3r1 = -uquad(_dJRdI3StaeckelIntegrand, "low", umin, mid)
+                I3r1 = -uquad("I3", "low", umin, mid)
                 I3r1 *= delta / sqrt2
                 I3r1 = 2.0 * numpy.pi * djrdI3 - I3r1
                 anglephi = (
                     2.0 * numpy.pi * djrdLz
-                    + Lz
-                    * uquad(_dJRdLzStaeckelIntegrand, "low", umin, mid)
-                    / delta
-                    / sqrt2
+                    + Lz * uquad("Lz", "low", umin, mid) / delta / sqrt2
                 )
 
         # v-branch (Or2, I3r2, phitmp); follows calcAnglesStaeckel @1374
@@ -1745,22 +1657,18 @@ class actionAngleStaeckelSingle(actionAngle):
                     if vx > 0.5 * numpy.pi
                     else numpy.sqrt(vx - vmin)
                 )
-                Or2 = vquad(_dJzdEStaeckelIntegrand, "low", mid) * delta / sqrt2
-                I3r2 = vquad(_dJzdI3StaeckelIntegrand, "low", mid) * delta / sqrt2
-                phitmp = (
-                    vquad(_dJzdLzStaeckelIntegrand, "low", mid) * -Lz / delta / sqrt2
-                )
+                Or2 = vquad("E", "low", mid) * delta / sqrt2
+                I3r2 = vquad("I3", "low", mid) * delta / sqrt2
+                phitmp = vquad("Lz", "low", mid) * -Lz / delta / sqrt2
                 if vx > 0.5 * numpy.pi:
                     Or2 = numpy.pi * djzdE - Or2
                     I3r2 = numpy.pi * djzdI3 - I3r2
                     phitmp = numpy.pi * djzdLz - phitmp
             else:
                 mid = numpy.sqrt(numpy.fabs(0.5 * numpy.pi - vx))
-                Or2 = vquad(_dJzdEStaeckelIntegrand, "high", mid) * delta / sqrt2
-                I3r2 = vquad(_dJzdI3StaeckelIntegrand, "high", mid) * delta / sqrt2
-                phitmp = (
-                    vquad(_dJzdLzStaeckelIntegrand, "high", mid) * -Lz / delta / sqrt2
-                )
+                Or2 = vquad("E", "high", mid) * delta / sqrt2
+                I3r2 = vquad("I3", "high", mid) * delta / sqrt2
+                phitmp = vquad("Lz", "high", mid) * -Lz / delta / sqrt2
                 if vx > 0.5 * numpy.pi:
                     Or2 = 0.5 * numpy.pi * djzdE + Or2
                     I3r2 = 0.5 * numpy.pi * djzdI3 + I3r2
@@ -1776,11 +1684,9 @@ class actionAngleStaeckelSingle(actionAngle):
                     if vx > 0.5 * numpy.pi
                     else numpy.sqrt(vx - vmin)
                 )
-                Or2 = vquad(_dJzdEStaeckelIntegrand, "low", mid) * delta / sqrt2
-                I3r2 = vquad(_dJzdI3StaeckelIntegrand, "low", mid) * delta / sqrt2
-                phitmp = (
-                    vquad(_dJzdLzStaeckelIntegrand, "low", mid) * -Lz / delta / sqrt2
-                )
+                Or2 = vquad("E", "low", mid) * delta / sqrt2
+                I3r2 = vquad("I3", "low", mid) * delta / sqrt2
+                phitmp = vquad("Lz", "low", mid) * -Lz / delta / sqrt2
                 if vx < 0.5 * numpy.pi:
                     Or2 = 2.0 * numpy.pi * djzdE - Or2
                     I3r2 = 2.0 * numpy.pi * djzdI3 - I3r2
@@ -1791,11 +1697,9 @@ class actionAngleStaeckelSingle(actionAngle):
                     phitmp = numpy.pi * djzdLz + phitmp
             else:
                 mid = numpy.sqrt(numpy.fabs(0.5 * numpy.pi - vx))
-                Or2 = vquad(_dJzdEStaeckelIntegrand, "high", mid) * delta / sqrt2
-                I3r2 = vquad(_dJzdI3StaeckelIntegrand, "high", mid) * delta / sqrt2
-                phitmp = (
-                    vquad(_dJzdLzStaeckelIntegrand, "high", mid) * -Lz / delta / sqrt2
-                )
+                Or2 = vquad("E", "high", mid) * delta / sqrt2
+                I3r2 = vquad("I3", "high", mid) * delta / sqrt2
+                phitmp = vquad("Lz", "high", mid) * -Lz / delta / sqrt2
                 if vx < 0.5 * numpy.pi:
                     Or2 = 1.5 * numpy.pi * djzdE + Or2
                     I3r2 = 1.5 * numpy.pi * djzdI3 + I3r2
@@ -1987,91 +1891,139 @@ def _JzStaeckelIntegrandSquared(
     return E * sin2v + I3V + dV - Lz**2.0 / 2.0 / delta**2.0 / sin2v
 
 
-# Derivative integrands for the Staeckel frequencies and angles. These are ports
-# of the C dJ?d?StaeckelIntegrand functions; the under-radical S_R/S_z reuses the
-# existing _JRStaeckelIntegrandSquared/_JzStaeckelIntegrandSquared helpers. Each
-# returns 0. when S<=0 (mirrors the C 'if(out<=0.) return 0.').
-def _dJRdEStaeckelIntegrand(
+# Derivatives of the under-radical functions S_R/S_z with respect to the
+# integration coordinate (analytic, via the forces); these supply the finite
+# turning-point limits of the chi-anomaly quadratures below
+def _dJRStaeckelIntegrandSquareddu(
     u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
 ):
-    out = _JRStaeckelIntegrandSquared(
-        u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
+    R, z = coords.uv_to_Rz(u, v0, delta=delta)
+    dPhidu = -delta * (
+        _evaluateRforces(pot, R, z) * numpy.cosh(u) * numpy.sin(v0)
+        + _evaluatezforces(pot, R, z) * numpy.sinh(u) * numpy.cos(v0)
     )
-    if out <= 0.0:
-        return 0.0
-    return numpy.sinh(u) ** 2.0 / numpy.sqrt(out)
+    return (
+        E * numpy.sinh(2.0 * u)
+        - numpy.sinh(2.0 * u) * potentialStaeckel(u, v0, pot, delta)
+        - (numpy.sinh(u) ** 2.0 + sin2v0) * dPhidu
+        + Lz**2.0 / delta**2.0 * numpy.cosh(u) / numpy.sinh(u) ** 3.0
+    )
 
 
-def _dJRdLzStaeckelIntegrand(
-    u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
+def _dJzStaeckelIntegrandSquareddv(
+    v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot
 ):
-    out = _JRStaeckelIntegrandSquared(
-        u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
+    R, z = coords.uv_to_Rz(u0, v, delta=delta)
+    dPhidv = -delta * (
+        _evaluateRforces(pot, R, z) * numpy.sinh(u0) * numpy.cos(v)
+        - _evaluatezforces(pot, R, z) * numpy.cosh(u0) * numpy.sin(v)
     )
-    if out <= 0.0:
-        return 0.0
-    return 1.0 / numpy.sinh(u) ** 2.0 / numpy.sqrt(out)
+    return (
+        E * numpy.sin(2.0 * v)
+        - numpy.sin(2.0 * v) * potentialStaeckel(u0, v, pot, delta)
+        - (sinh2u0 + numpy.sin(v) ** 2.0) * dPhidv
+        + Lz**2.0 / delta**2.0 * numpy.cos(v) / numpy.sin(v) ** 3.0
+    )
 
 
-def _dJRdI3StaeckelIntegrand(
-    u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
+# Nodes/weights of the composite 10-point Gauss-Legendre rule used by the
+# chi-anomaly quadratures: applied per interval of an nchi-panel mesh, the
+# error is O((chimax/nchi)^20), so the integrals are machine-converged for
+# modest nchi
+_CHIQUAD_GLX, _CHIQUAD_GLW = numpy.polynomial.legendre.leggauss(10)
+# Weight functions of the 1/p_u and 1/p_v profile integrals, in the order
+# (dE, dI3, dLz)
+_CHIQUAD_UWEIGHTS = (
+    lambda q: numpy.sinh(q) ** 2.0,
+    lambda q: numpy.ones_like(q),
+    lambda q: 1.0 / numpy.sinh(q) ** 2.0,
+)
+_CHIQUAD_VWEIGHTS = (
+    lambda q: numpy.sin(q) ** 2.0,
+    lambda q: numpy.ones_like(q),
+    lambda q: 1.0 / numpy.sin(q) ** 2.0,
+)
+
+
+def _staeckelChiQuadratures(
+    Ssq, dSsq, args, qmin, D, weights, nchi=20, chimax=numpy.pi
 ):
-    out = _JRStaeckelIntegrandSquared(
-        u, E, Lz, I3U, delta, u0, sinh2u0, v0, sin2v0, potu0v0, pot
-    )
-    if out <= 0.0:
-        return 0.0
-    return 1.0 / numpy.sqrt(out)
+    """
+    Composite Gauss-Legendre quadratures in the chi anomaly.
 
+    Evaluates int sqrt(S) dq and int f/sqrt(S) dq for all weight functions
+    f at once, from a single vectorized evaluation of S, in the anomaly
+    parametrization q = qmin + D sin^2(chi/2) that renders every integrand
+    regular: with y = sin^2(chi/2) and Q = S/[y(1-y)],
+    int sqrt(S) dq = (D/4) int sqrt(Q) sin^2(chi) dchi and
+    int f/sqrt(S) dq = D int f/sqrt(Q) dchi, where Q has the finite
+    turning-point limits |dS/dq| D that are switched in near the endpoints,
+    where the direct evaluation of S is dominated by cancellation.
 
-def _dJzdEStaeckelIntegrand(v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot):
-    out = _JzStaeckelIntegrandSquared(
-        v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot
-    )
-    if out <= 0.0:
-        return 0.0
-    return numpy.sin(v) ** 2.0 / numpy.sqrt(out)
+    Parameters
+    ----------
+    Ssq : callable
+        The under-radical function S(q, *args) = p^2/(2 delta^2); must
+        accept an array q.
+    dSsq : callable
+        dS/dq(q, *args), evaluated only at the turning points.
+    args : tuple
+        Extra arguments of Ssq and dSsq.
+    qmin : float
+        Lower turning point.
+    D : float
+        Full oscillation range: the upper turning point is qmin + D (for
+        the v oscillation this is pi - 2 vmin, even when integrating only
+        to the midplane).
+    weights : tuple of callables
+        Weight functions f(q) of the 1/sqrt(S) integrals; must accept an
+        array q.
+    nchi : int, optional
+        Number of panels of the composite rule.
+    chimax : float, optional
+        Upper integration limit in the anomaly (pi for the complete
+        oscillation, pi/2 for the v integral to the midplane, or
+        2 arcsin(sqrt([q - qmin]/D)) for an incomplete integral).
 
+    Returns
+    -------
+    tuple
+        (int sqrt(S) dq, [int f/sqrt(S) dq for f in weights])
 
-def _dJzdLzStaeckelIntegrand(v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot):
-    out = _JzStaeckelIntegrandSquared(
-        v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot
-    )
-    if out <= 0.0:
-        return 0.0
-    return 1.0 / numpy.sin(v) ** 2.0 / numpy.sqrt(out)
-
-
-def _dJzdI3StaeckelIntegrand(v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot):
-    out = _JzStaeckelIntegrandSquared(
-        v, E, Lz, I3V, delta, u0, cosh2u0, sinh2u0, potu0pi2, pot
-    )
-    if out <= 0.0:
-        return 0.0
-    return 1.0 / numpy.sqrt(out)
-
-
-# t^2-substitution wrappers (integrand *= 2*t). The u integrals use a Low panel
-# u=umin+t^2 and a High panel u=umax-t^2; the v integrals use a Low panel
-# v=vmin+t^2 and a High panel v=pi/2-t^2. These take fixed_quad's vector t.
-def _uLowStaeckelIntegrand(t, func, umin, args):
-    t = numpy.atleast_1d(t)
-    return numpy.array([2.0 * tt * func(umin + tt * tt, *args) for tt in t])
-
-
-def _uHighStaeckelIntegrand(t, func, umax, args):
-    t = numpy.atleast_1d(t)
-    return numpy.array([2.0 * tt * func(umax - tt * tt, *args) for tt in t])
-
-
-def _vLowStaeckelIntegrand(t, func, vmin, args):
-    t = numpy.atleast_1d(t)
-    return numpy.array([2.0 * tt * func(vmin + tt * tt, *args) for tt in t])
-
-
-def _vHighStaeckelIntegrand(t, func, args):
-    t = numpy.atleast_1d(t)
-    return numpy.array([2.0 * tt * func(numpy.pi / 2.0 - tt * tt, *args) for tt in t])
+    Notes
+    -----
+    - 2026-08-21 - Written - Bovy (UofT)
+    """
+    chi = numpy.linspace(0.0, chimax, nchi + 1)
+    mid = 0.5 * (chi[:-1] + chi[1:])
+    half = 0.5 * (chi[1:] - chi[:-1])
+    nodes = (mid[:, None] + half[:, None] * _CHIQUAD_GLX[None, :]).ravel()
+    wts = (half[:, None] * _CHIQUAD_GLW[None, :]).ravel()
+    y = numpy.sin(nodes / 2.0) ** 2.0
+    y1my = y * (1.0 - y)
+    q = qmin + D * y
+    S = Ssq(q, *args)
+    with numpy.errstate(invalid="ignore"):
+        Q = S / y1my
+    # Near the turning points the direct evaluation of S is dominated by
+    # cancellation error; there, reconstruct S from the analytic derivative
+    # by the trapezoid between the turning point and the node,
+    # S ~ (q - q0) [S'(q0) + S'(q)]/2, whose O(y^2) model error is far below
+    # the switch threshold (a constant turning-point limit S' D would leave
+    # O(y) model error at the switch, which dominates coarse meshes)
+    edge = y1my <= 1e-6
+    if numpy.any(edge):
+        qe, ye = q[edge], y[edge]
+        dSe = dSsq(qe, *args)
+        Q[edge] = numpy.where(
+            ye < 0.5,
+            D * (dSsq(qmin, *args) + dSe) / 2.0 / (1.0 - ye),
+            D * (-dSsq(qmin + D, *args) - dSe) / 2.0 / ye,
+        )
+    Q[Q < numpy.finfo(float).tiny] = numpy.finfo(float).tiny
+    sqQ = numpy.sqrt(Q)
+    action = (D / 4.0) * numpy.sum(wts * sqQ * numpy.sin(nodes) ** 2.0)
+    return action, [D * numpy.sum(wts * f(q) / sqQ) for f in weights]
 
 
 def _uminUmaxFindStart(

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -46,6 +46,8 @@ struct JRStaeckelArg{
   double v0;
   double sin2v0;
   double potu0v0;
+  double umin;
+  double umax;
   int nargs;
   struct potentialArg * actionAngleArgs;
 };
@@ -58,6 +60,7 @@ struct JzStaeckelArg{
   double cosh2u0;
   double sinh2u0;
   double potupi2;
+  double vmin;
   int nargs;
   struct potentialArg * actionAngleArgs;
 };
@@ -152,8 +155,12 @@ void calcVmin(int,double *,double *,double *,double *,double *,double *,int,
 	      struct potentialArg *);
 double JRStaeckelIntegrandSquared(double,void *);
 double JRStaeckelIntegrand(double,void *);
+double JRLowStaeckelIntegrand(double,void *);
+double JRHighStaeckelIntegrand(double,void *);
 double JzStaeckelIntegrandSquared(double,void *);
 double JzStaeckelIntegrand(double,void *);
+double JzLowStaeckelIntegrand(double,void *);
+double JzHighStaeckelIntegrand(double,void *);
 double dJRdEStaeckelIntegrand(double,void *);
 double dJRdELowStaeckelIntegrand(double,void *);
 double dJRdEHighStaeckelIntegrand(double,void *);
@@ -542,6 +549,7 @@ void calcJRStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -558,7 +566,7 @@ void calcJRStaeckel(int ndata,
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk)				\
-  private(tid,ii)							\
+  private(tid,ii,mid)							\
   shared(jr,umin,umax,JRInt,params,T,delta,E,Lz,I3U,u0,sinh2u0,v0,sin2v0,potu0v0)
   for (ii=0; ii < ndata; ii++){
 #ifdef _OPENMP
@@ -584,11 +592,16 @@ void calcJRStaeckel(int ndata,
     (params+tid)->v0= *(v0+ii);
     (params+tid)->sin2v0= *(sin2v0+ii);
     (params+tid)->potu0v0= *(potu0v0+ii);
-    (JRInt+tid)->function = &JRStaeckelIntegrand;
+    (params+tid)->umin= *(umin+ii);
+    (params+tid)->umax= *(umax+ii);
+    (JRInt+tid)->function = &JRLowStaeckelIntegrand;
     (JRInt+tid)->params = params+tid;
+    mid= sqrt( 0.5 * ( *(umax+ii) - *(umin+ii) ) );
     //Integrate
-    *(jr+ii)= gsl_integration_glfixed (JRInt+tid,*(umin+ii),*(umax+ii),T)
-      * sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
+    *(jr+ii)= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
+    (JRInt+tid)->function = &JRHighStaeckelIntegrand;
+    *(jr+ii)+= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
+    *(jr+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
   }
   free(JRInt);
   free(params);
@@ -610,6 +623,7 @@ void calcJzStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -626,7 +640,7 @@ void calcJzStaeckel(int ndata,
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk)				\
-  private(tid,ii)							\
+  private(tid,ii,mid)							\
   shared(jz,vmin,JzInt,params,T,delta,E,Lz,I3V,u0,cosh2u0,sinh2u0,potupi2)
   for (ii=0; ii < ndata; ii++){
 #ifdef _OPENMP
@@ -651,11 +665,15 @@ void calcJzStaeckel(int ndata,
     (params+tid)->cosh2u0= *(cosh2u0+ii);
     (params+tid)->sinh2u0= *(sinh2u0+ii);
     (params+tid)->potupi2= *(potupi2+ii);
-    (JzInt+tid)->function = &JzStaeckelIntegrand;
+    (params+tid)->vmin= *(vmin+ii);
+    (JzInt+tid)->function = &JzLowStaeckelIntegrand;
     (JzInt+tid)->params = params+tid;
+    mid= sqrt( 0.5 * ( M_PI/2. - *(vmin+ii) ) );
     //Integrate
-    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,*(vmin+ii),M_PI/2.,T)
-      * 2 * sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
+    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,0.,mid,T);
+    (JzInt+tid)->function = &JzHighStaeckelIntegrand;
+    *(jz+ii)+= gsl_integration_glfixed (JzInt+tid,0.,mid,T);
+    *(jz+ii)*= 2 * sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
   }
   free(JzInt);
   free(params);
@@ -1831,6 +1849,21 @@ double JRStaeckelIntegrandSquared(double u,
     - (params->sinh2u0+params->sin2v0)*params->potu0v0;
   return params->E * sinh2u - params->I3U - dU  - params->Lz22delta / sinh2u;
 }
+double JRLowStaeckelIntegrand(double t,
+			      void * p){
+  // t^2 substitution u = umin + t^2: the sqrt branch point of the action
+  // integrand at the turning point becomes an analytic zero (the plain
+  // Gauss-Legendre rule converged only as order^-3 against it)
+  struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
+  double u= params->umin + t * t;
+  return 2. * t * JRStaeckelIntegrand(u,p);
+}
+double JRHighStaeckelIntegrand(double t,
+			       void * p){
+  struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
+  double u= params->umax - t * t;
+  return 2. * t * JRStaeckelIntegrand(u,p);
+}
 double JRStaeckelIntegrandSquared4dJR(double u,
 				      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
@@ -1857,6 +1890,21 @@ double JzStaeckelIntegrandSquared(double v,
     *evaluatePotentialsUV(params->u0,v,params->delta,
 			  params->nargs,params->actionAngleArgs);
   return params->E * sin2v + params->I3V + dV  - params->Lz22delta / sin2v;
+}
+double JzLowStaeckelIntegrand(double t,
+			      void * p){
+  // t^2 substitution v = vmin + t^2: regularizes the sqrt branch point at
+  // the turning point; the integral is split at the midpoint like the
+  // dJzd* routines (the midplane side has no singularity, but the split
+  // keeps the panels short and the rule converged at low order)
+  struct JzStaeckelArg * params= (struct JzStaeckelArg *) p;
+  double v= params->vmin + t * t;
+  return 2. * t * JzStaeckelIntegrand(v,p);
+}
+double JzHighStaeckelIntegrand(double t,
+			       void * p){
+  double v= M_PI/2. - t * t;
+  return 2. * t * JzStaeckelIntegrand(v,p);
 }
 double JzStaeckelIntegrandSquared4dJz(double v,
 				      void * p){

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2499,15 +2499,27 @@ def test_actionAngleStaeckel_actions_order():
     kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
     o = Orbit([1.0, 0.5, 1.1, 0.2, -0.3, 0.4])
     aAS = actionAngleStaeckel(pot=kksp, delta=kksp._Delta, c=False)
-    # We'll assume that order=10000 is the truth, so 50 should be better than 5
+    # The chi-anomaly composite quadrature is machine-converged at any order,
+    # so low and high order must both match a very-high-order reference at
+    # machine precision (the old fixed-order rule converged only slowly here)
     jrt, jpt, jzt = aAS(o, order=10000, fixed_quad=True)
     jr1, jp1, jz1 = aAS(o, order=5, fixed_quad=True)
     jr2, jp2, jz2 = aAS(o, order=50, fixed_quad=True)
-    assert numpy.fabs(jr1 - jrt) > numpy.fabs(jr2 - jrt), (
-        "Accuracy of actionAngleStaeckel does not increase with increasing order of integration"
+    assert numpy.fabs(jr1 - jrt) < 1e-14, (
+        "actionAngleStaeckel low-order actions do not match the high-order "
+        "reference at machine precision"
     )
-    assert numpy.fabs(jz1 - jzt) > numpy.fabs(jz2 - jzt), (
-        "Accuracy of actionAngleStaeckel does not increase with increasing order of integration"
+    assert numpy.fabs(jr2 - jrt) < 1e-14, (
+        "actionAngleStaeckel medium-order actions do not match the high-order "
+        "reference at machine precision"
+    )
+    assert numpy.fabs(jz1 - jzt) < 1e-14, (
+        "actionAngleStaeckel low-order actions do not match the high-order "
+        "reference at machine precision"
+    )
+    assert numpy.fabs(jz2 - jzt) < 1e-14, (
+        "actionAngleStaeckel medium-order actions do not match the high-order "
+        "reference at machine precision"
     )
     return None
 
@@ -2919,13 +2931,50 @@ def test_actionAngleStaeckel_angles_order_c():
 
 # Test that the pure-Python (c=False) actionAngleStaeckel frequencies and angles
 # agree with the C implementation over a grid of ICs hitting every branch.
+def test_actionAngleStaeckel_chi_quadrature_convergence():
+    # The chi-anomaly composite quadratures behind the pure-Python path are
+    # machine-converged at the default order: frequencies and angles must
+    # match a much finer chi mesh at machine precision, including the
+    # partial-oscillation (angle) integrals on both sides of the turning
+    # points and the midplane
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kksp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=4.0, Delta=1.4)
+    aAS = actionAngleStaeckel(pot=kksp, delta=1.4, c=False)
+    # The tolerances are set by the evaluation noise of the fudge-form
+    # momentum function S (a difference of O(1) potential terms), not by the
+    # quadrature rule: a few 1e-12 for generic orbits, and looser for a
+    # nearly planar orbit whose tiny v oscillation has S far below the
+    # cancellation scale (the old fixed-order rule erred at 4.6e-4 here)
+    for ic, tol in (
+        ([1.0, 0.5, 1.1, 0.2, -0.3, 0.4], 3e-11),
+        ([1.0, -0.2, 1.1, -0.2, 0.25, 2.1], 3e-11),  # z<0, vR<0: other branches
+        ([1.1, 0.02, 0.9, 0.002, 0.02, 1.0], 1e-8),  # nearly planar
+    ):
+        lo = aAS.actionsFreqsAngles(*ic, fixed_quad=True, order=10)
+        hi = aAS.actionsFreqsAngles(*ic, fixed_quad=True, order=200)
+        for ii in range(9):
+            assert numpy.fabs(lo[ii][0] - hi[ii][0]) < tol, (
+                "Pure-Python actionAngleStaeckel chi-quadrature output %i at "
+                "the default order does not match a much finer chi mesh "
+                "(diff %g)" % (ii, numpy.fabs(lo[ii][0] - hi[ii][0]))
+            )
+    return None
+
+
 def test_actionAngleStaeckel_python_c_freqsAngles():
     from galpy.actionAngle import actionAngleStaeckel
     from galpy.potential import LogarithmicHaloPotential
 
     # Flattened logarithmic halo: genuinely close to Staeckel-separable
     lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
-    aAc = actionAngleStaeckel(pot=lp, delta=0.5, c=True)
+    # The Python path's chi-anomaly quadratures are machine-converged, so the
+    # C-vs-Python difference is dominated by the C path's fixed-order
+    # truncation error (1e-4 at its default order=10 on this grid); run the C
+    # path at high order so that the parity test checks branch/convention
+    # agreement rather than the C truncation floor
+    aAc = actionAngleStaeckel(pot=lp, delta=0.5, c=True, order=200)
     aAp = actionAngleStaeckel(pot=lp, delta=0.5, c=False)
 
     def wrapdiff(a, b):

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2931,6 +2931,45 @@ def test_actionAngleStaeckel_angles_order_c():
 
 # Test that the pure-Python (c=False) actionAngleStaeckel frequencies and angles
 # agree with the C implementation over a grid of ICs hitting every branch.
+def test_actionAngleStaeckel_single_action_cache():
+    # actionAngleStaeckelSingle caches JR/Jz per (fixed_quad, order): a repeat
+    # call with the same settings returns the cached value, while changing the
+    # order recomputes (the cache used to ignore order, which silently
+    # returned the first result for any subsequent order)
+    from galpy.actionAngle.actionAngleStaeckel import actionAngleStaeckelSingle
+    from galpy.potential import MWPotential2014
+
+    aA = actionAngleStaeckelSingle(
+        1.1, 0.05, 0.9, 0.15, 0.12, pot=MWPotential2014, delta=0.45
+    )
+    jr1 = numpy.atleast_1d(aA.JR(fixed_quad=True, order=10))[0]
+    jr2 = numpy.atleast_1d(aA.JR(fixed_quad=True, order=10))[0]  # cache hit
+    assert jr1 == jr2, (
+        "Repeated actionAngleStaeckelSingle.JR call with identical settings "
+        "does not return the cached value"
+    )
+    jz1 = numpy.atleast_1d(aA.Jz(fixed_quad=True, order=10))[0]
+    jz2 = numpy.atleast_1d(aA.Jz(fixed_quad=True, order=10))[0]  # cache hit
+    assert jz1 == jz2, (
+        "Repeated actionAngleStaeckelSingle.Jz call with identical settings "
+        "does not return the cached value"
+    )
+    # Changing the order must recompute, not return the cached value; both
+    # are converged, so they agree to machine precision without being
+    # bit-identical in general
+    jr3 = numpy.atleast_1d(aA.JR(fixed_quad=True, order=40))[0]
+    jz3 = numpy.atleast_1d(aA.Jz(fixed_quad=True, order=40))[0]
+    assert numpy.fabs(jr3 - jr1) < 1e-12, (
+        "actionAngleStaeckelSingle.JR at a different order does not agree "
+        "with the default order"
+    )
+    assert numpy.fabs(jz3 - jz1) < 1e-12, (
+        "actionAngleStaeckelSingle.Jz at a different order does not agree "
+        "with the default order"
+    )
+    return None
+
+
 def test_actionAngleStaeckel_chi_quadrature_convergence():
     # The chi-anomaly composite quadratures behind the pure-Python path are
     # machine-converged at the default order: frequencies and angles must

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2963,6 +2963,33 @@ def test_actionAngleStaeckel_chi_quadrature_convergence():
     return None
 
 
+def test_actionAngleStaeckel_actions_c_convergence():
+    # C path: the t^2-substituted action integrals are converged at the
+    # default order; the previous plain Gauss-Legendre rule against the
+    # sqrt branch points at the turning points erred systematically at
+    # ~4.6e-4 (J_R) / 1.4e-4 (J_z) and converged only as order^-3
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.potential import MWPotential2014
+
+    aAc = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=True)
+    for ic in (
+        (1.1, 0.05, 0.9, 0.15, 0.12, 0.3),
+        (0.7, -0.15, 1.05, 0.05, -0.2, 1.1),
+        (1.6, 0.2, 0.7, 0.3, 0.1, 2.5),
+    ):
+        lo = aAc(*ic, order=10)
+        hi = aAc(*ic, order=1280)
+        assert numpy.fabs(lo[0][0] - hi[0][0]) < 1e-10, (
+            "C actionAngleStaeckel J_R at the default order does not match a "
+            "very-high-order reference (diff %g)" % numpy.fabs(lo[0][0] - hi[0][0])
+        )
+        assert numpy.fabs(lo[2][0] - hi[2][0]) < 1e-10, (
+            "C actionAngleStaeckel J_z at the default order does not match a "
+            "very-high-order reference (diff %g)" % numpy.fabs(lo[2][0] - hi[2][0])
+        )
+    return None
+
+
 def test_actionAngleStaeckel_python_c_freqsAngles():
     from galpy.actionAngle import actionAngleStaeckel
     from galpy.potential import LogarithmicHaloPotential

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2997,10 +2997,14 @@ def test_actionAngleStaeckel_python_c_freqsAngles():
     # Flattened logarithmic halo: genuinely close to Staeckel-separable
     lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
     # The Python path's chi-anomaly quadratures are machine-converged, so the
-    # C-vs-Python difference is dominated by the C path's fixed-order
-    # truncation error (1e-4 at its default order=10 on this grid); run the C
-    # path at high order so that the parity test checks branch/convention
-    # agreement rather than the C truncation floor
+    # C-vs-Python difference is dominated by the C path's errors: its
+    # fixed-order truncation in the frequency/angle integrals (1e-4 at the
+    # default order=10 on this grid), removed by running C at order=200, and
+    # below that its turning-point root-finding tolerance, which enters the
+    # 1/sqrt(S) integrals amplified as sqrt(delta) and is platform-dependent
+    # (~1e-8 on Linux, ~1e-6 on Windows through libm differences in the
+    # roots). The 1e-5 tolerance sits above that floor while still catching
+    # any branch/convention disagreement, which produces O(1) errors.
     aAc = actionAngleStaeckel(pot=lp, delta=0.5, c=True, order=200)
     aAp = actionAngleStaeckel(pot=lp, delta=0.5, c=False)
 
@@ -3048,11 +3052,11 @@ def test_actionAngleStaeckel_python_c_freqsAngles():
                                     maxangdiff, wrapdiff(ac[ii][0], ap[ii][0])
                                 )
     assert n > 100, "Staeckel c vs Python parity grid did not evaluate enough points"
-    assert maxfreqdiff < 1e-6, (
+    assert maxfreqdiff < 1e-5, (
         "Pure-Python actionAngleStaeckel frequencies do not agree with C "
         "implementation; max diff = %g" % maxfreqdiff
     )
-    assert maxangdiff < 1e-6, (
+    assert maxangdiff < 1e-5, (
         "Pure-Python actionAngleStaeckel angles do not agree with C "
         "implementation; max diff = %g" % maxangdiff
     )

--- a/tests/test_galpypaper.py
+++ b/tests/test_galpypaper.py
@@ -669,10 +669,14 @@ def test_qdf():
     aAS = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=True)
     # Quasi-iso df w/ hr=1/3, hsr/z=1, sr(1)=0.2, sz(1)=0.1
     df = quasiisothermaldf(1.0 / 3.0, 0.2, 0.1, 1.0, 1.0, aA=aAS, pot=MWPotential2014)
+    # NOTE: The pinned values below were updated in August 2026, because the
+    #      regularized Staeckel action quadratures (gh#1357) changed the
+    #      c=True actions at the ~5e-4 relative level (they are now converged
+    #      to ~1e-12 at the default order; see HISTORY.txt).
     # Evaluate DF w/ R,vR,vT,z,vz
     df(0.9, 0.1, 0.8, 0.05, 0.02)
     assert (
-        numpy.fabs(df(0.9, 0.1, 0.8, 0.05, 0.02) - numpy.array([123.57158928]))
+        numpy.fabs(df(0.9, 0.1, 0.8, 0.05, 0.02) - numpy.array([123.62925632]))
         < 10.0**-4.0
     ), "qdf does not behave as expected"
     # Evaluate DF w/ Orbit instance, return ln
@@ -681,14 +685,14 @@ def test_qdf():
     df(Orbit([0.9, 0.1, 0.8, 0.05, 0.02]), log=True)
     assert (
         numpy.fabs(
-            df(Orbit([0.9, 0.1, 0.8, 0.05, 0.02]), log=True) - numpy.array([4.81682066])
+            df(Orbit([0.9, 0.1, 0.8, 0.05, 0.02]), log=True) - numpy.array([4.81728722])
         )
         < 10.0**-4.0
     ), "qdf does not behave as expected"
     # Evaluate DF marginalized over vz
     df.pvRvT(0.1, 0.9, 0.9, 0.05)
     assert (
-        numpy.fabs(df.pvRvT(0.1, 0.9, 0.9, 0.05) - 2.0 * 23.273310451852243)
+        numpy.fabs(df.pvRvT(0.1, 0.9, 0.9, 0.05) - 2.0 * 23.280529190623593)
         < 10.0**-4.0
     ), "qdf does not behave as expected"
     # NOTE: The pvRvT() function has changed with respect to the version used in Bovy (2015).
@@ -696,27 +700,27 @@ def test_qdf():
     #      to account for the correct Gauss-Legendre integration normalization.
     # Evaluate DF marginalized over vR,vT
     df.pvz(0.02, 0.9, 0.05)
-    assert numpy.fabs(df.pvz(0.02, 0.9, 0.05) - 50.949586235238172) < 10.0**-4.0, (
+    assert numpy.fabs(df.pvz(0.02, 0.9, 0.05) - 50.98111352632182) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
     # Calculate the density
     df.density(0.9, 0.05)
-    assert numpy.fabs(df.density(0.9, 0.05) - 12.73725936526167) < 10.0**-4.0, (
+    assert numpy.fabs(df.density(0.9, 0.05) - 12.745981120420119) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
     # Estimate the DF's actual density scale length at z=0
     df.estimate_hr(0.9, 0.0)
-    assert numpy.fabs(df.estimate_hr(0.9, 0.0) - 0.322420336223) < 10.0**-2.0, (
+    assert numpy.fabs(df.estimate_hr(0.9, 0.0) - 0.32242829530683487) < 10.0**-2.0, (
         "qdf does not behave as expected"
     )
     # Estimate the DF's actual surface-density scale length
     df.estimate_hr(0.9, None)
-    assert numpy.fabs(df.estimate_hr(0.9, None) - 0.38059909132766462) < 10.0**-4.0, (
+    assert numpy.fabs(df.estimate_hr(0.9, None) - 0.38061667321160425) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
     # Estimate the DF's density scale height
     df.estimate_hz(0.9, 0.02)
-    assert numpy.fabs(df.estimate_hz(0.9, 0.02) - 0.064836202345657207) < 10.0**-4.0, (
+    assert numpy.fabs(df.estimate_hz(0.9, 0.02) - 0.06484597930158813) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
     # Calculate the mean velocities
@@ -725,37 +729,38 @@ def test_qdf():
         df.meanvT(0.9, 0.05),
     )
     df.meanvz(0.9, 0.05)
-    assert numpy.fabs(df.meanvR(0.9, 0.05) - 3.8432265354618213e-18) < 10.0**-4.0, (
+    assert numpy.fabs(df.meanvR(0.9, 0.05) - 8.506227666919439e-20) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
-    assert numpy.fabs(df.meanvT(0.9, 0.05) - 0.90840425173325279) < 10.0**-4.0, (
+    assert numpy.fabs(df.meanvT(0.9, 0.05) - 0.908363665609828) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
-    assert numpy.fabs(df.meanvz(0.9, 0.05) + 4.3579787517991084e-19) < 10.0**-4.0, (
+    assert numpy.fabs(df.meanvz(0.9, 0.05) + 2.3445290006946702e-19) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
     # Calculate the velocity dispersions
     from numpy import sqrt
 
     sqrt(df.sigmaR2(0.9, 0.05)), sqrt(df.sigmaz2(0.9, 0.05))
-    assert numpy.fabs(sqrt(df.sigmaR2(0.9, 0.05)) - 0.22695537077102387) < 10.0**-4.0, (
+    assert numpy.fabs(sqrt(df.sigmaR2(0.9, 0.05)) - 0.22701107926957673) < 10.0**-4.0, (
         "qdf does not behave as expected"
     )
-    assert (
-        numpy.fabs(sqrt(df.sigmaz2(0.9, 0.05)) - 0.094215523962105044) < 10.0**-4.0
-    ), "qdf does not behave as expected"
+    assert numpy.fabs(sqrt(df.sigmaz2(0.9, 0.05)) - 0.09422197865528911) < 10.0**-4.0, (
+        "qdf does not behave as expected"
+    )
     # Calculate the tilt of the velocity ellipsoid
     # 2017/10-28: CHANGED bc tilt now returns angle in rad, no longer in deg
     df.tilt(0.9, 0.05)
     assert (
-        numpy.fabs(df.tilt(0.9, 0.05) - 2.5166061974413765 / 180.0 * numpy.pi)
+        numpy.fabs(df.tilt(0.9, 0.05) - 2.5166216121561256 / 180.0 * numpy.pi)
         < 10.0**-4.0
     ), "qdf does not behave as expected"
     # Calculate a higher-order moment of the velocity DF
     df.vmomentdensity(0.9, 0.05, 6.0, 2.0, 2.0, gl=True)
     assert (
         numpy.fabs(
-            df.vmomentdensity(0.9, 0.05, 6.0, 2.0, 2.0, gl=True) - 0.0001591100892366438
+            df.vmomentdensity(0.9, 0.05, 6.0, 2.0, 2.0, gl=True)
+            - 0.00015944060928560009
         )
         < 10.0**-4.0
     ), "qdf does not behave as expected"


### PR DESCRIPTION
Fixes the Stäckel half of the systematic action-quadrature defect independently diagnosed in #1354 (and fixed for the adiabatic code in #1356): plain fixed-order Gauss–Legendre applied against the square-root branch points at the turning points converges only as order⁻³, leaving **systematic ~4.6e-4 (J_R) / 1.4e-4 (J_z)** relative errors at the default order. This PR upgrades the **pure-Python path** (`c=False` with `fixed_quad=True`, plus all frequency/angle integrals, which are Python-only); the **C path is deliberately left for a separate PR** (see below).

This is also the first half of the code-sharing plan discussed in #1347 (comment on the quadrature duplication): the χ-form machinery now lives in `actionAngleStaeckel`, where `actionAngleStaeckelInverse` can consume it once both land.

**What changed**

- All u/v quadratures go through a new `_staeckelChiQuadratures`: a composite 10-pt Gauss–Legendre rule in the anomaly `q = qmin + D sin²(χ/2)`, in which every integrand is regular (action → `(D/4)√Q sin²χ`, 1/p profiles → `f·D/√Q`, with `Q = S/[y(1−y)]`). One vectorized evaluation of the momentum per mesh serves the action **and** all three 1/p integrals of that degree of freedom; the same cumulative form serves the partial-oscillation integrals of `calcAngles` (the C port's `(panel, mid)` encoding and all branch logic are kept verbatim). The per-scalar t²-substitution wrappers and derivative integrands are removed.
- Near the turning points, where direct evaluation of S is cancellation-dominated, S is reconstructed from its **analytic derivative** (new `_dJR/_dJzStaeckelIntegrandSquaredd*` via the forces, validated against finite differences at 1e-10) by the trapezoid between the turning point and the node.
- The turning-point `brentq` solves are tightened to `xtol=1e-15, rtol=8.9e-16`. This matters more than it looks: a root offset δ enters the 1/√S integrals as **√δ**, so scipy's default `xtol=2e-12` put a ~1e-6 floor under the frequencies no matter how good the quadrature.

**Accuracy** (default order): actions/frequencies/angles match a 20× finer mesh to ~1e-11 for generic orbits (~1e-9 for a nearly planar orbit — the evaluation-noise floor of the fudge-form momentum function, not the rule). The handoff's benchmark (MWPotential2014, δ=0.45, order-640 reference): order-10 J_R error **4.6e-4 → 1.2e-17**.

**Test changes**

- New `test_actionAngleStaeckel_chi_quadrature_convergence` (default order vs 20× finer mesh, three orbits covering both u branches, both v branches, and near-planar).
- `test_actionAngleStaeckel_actions_order`: low and high order must now both match a very-high-order reference at machine precision (the old "higher order is more accurate" assertion is vacuous when every order is converged).
- `test_actionAngleStaeckel_python_c_freqsAngles`: the C side now runs at `order=200`, since the Python path no longer shares the C path's truncation error — the parity test again checks branch/convention agreement rather than the common truncation floor.

**Follow-up (separate PR, per the handoff's own recommendation):** the same defect in the C path (`actionAngleStaeckel.c:590/657`), where the substitution is free (same node count) but changes `c=True` output at the ~1e-4 level and must move in lockstep with the galpy-jax backend that mirrors C bit-for-bit — kept separate so that cost decision is reviewable on its own. Once merged, the parity test's `order=200` crutch can be dropped.

Credit: the diagnosis, measurements, and fix shape were independently worked out for the adiabatic twin defect in the handoff document `galpy-jax/HANDOFF_staeckel_quadrature.md`; this PR confirms its Stäckel claim and implements the Python-side fix with the χ-anomaly machinery from the inverse work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ