### PR TITLE
backend: make galpy's context variables readable inside a torch.compile trace

### DIFF
--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -21,17 +21,17 @@
 #   numpy behaviour changes.
 ###############################################################################
 from contextlib import contextmanager
-from contextvars import ContextVar
 
 from ._namespaces import name_of_namespace
+from ._tracectx import TracedContextVar
 
 # "off" | "jax" | "torch". Process-wide, like the backend selection itself.
-_JIT_CTX = ContextVar("galpy_jit_mode", default="off")
+_JIT_CTX = TracedContextVar("galpy_jit_mode", default="off")
 # Set while a traced call is on the stack. Entry points call each other
 # (Potential.__call__ -> evaluatePotentials -> ...), and re-tracing at every
 # nested boundary multiplies compile time for no benefit -- the outermost trace
 # already inlines the inner calls.
-_TRACING = ContextVar("galpy_jit_tracing", default=False)
+_TRACING = TracedContextVar("galpy_jit_tracing", default=False)
 
 _VALID = ("off", "jax", "torch")
 

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -167,17 +167,27 @@ def _jax_shim(method):
 
 def _torch_compiled(method):
     """``torch.compile``-ed method. dynamo derives its own guards, so unlike jax
-    it needs no static/traced split -- the declaration is only used by jax."""
+    it needs no static/traced split -- the declaration is only used by jax.
+
+    ``method`` is what gets compiled; the re-entrancy bookkeeping stays OUTSIDE
+    the compiled region. Wrapping it the other way round put
+    ``_TRACING.set(True)`` inside the very region it exists to guard, which is
+    both backwards and invisible: once the ContextVar stopped breaking the graph,
+    dynamo compiled that frame end-to-end, so those lines never executed as
+    Python and coverage.py could not see them (galpy #1358, 4 lines).
+    """
     import torch
+
+    compiled = torch.compile(method, fullgraph=False, dynamic=False)
 
     def call(*args, **kwargs):
         token = _TRACING.set(True)
         try:
-            return method(*args, **kwargs)
+            return compiled(*args, **kwargs)
         finally:
             _TRACING.reset(token)
 
-    return torch.compile(call, fullgraph=False, dynamic=False)
+    return call
 
 
 def traced_call(method, args, kwargs, slots, nargs, xp=None):

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -114,9 +114,9 @@ def under_trace(*xs):
         return False
     import torch
 
-    return torch.compiler.is_compiling() and any(
-        isinstance(x, torch.Tensor) for x in xs
-    )
+    from ._tracectx import is_compiling
+
+    return is_compiling() and any(isinstance(x, torch.Tensor) for x in xs)
 
 
 def untraceable_setup(method):

--- a/galpy/backend/_resolver.py
+++ b/galpy/backend/_resolver.py
@@ -14,14 +14,15 @@
 #   no array to dispatch on, so production autodiff (data-first) is unaffected.
 ###############################################################################
 import contextlib
-import contextvars
 
 import numpy
 
 from ._namespaces import namespace_for_name, namespace_from_arrays
+from ._tracectx import TracedContextVar
 
-# Thread-/async-safe default backend; stores (name, force) or None.
-_BACKEND_CTX = contextvars.ContextVar("galpy_backend", default=None)
+# Thread-/async-safe default backend; stores (name, force) or None. Traced so a
+# forced backend is still readable inside a torch.compile region.
+_BACKEND_CTX = TracedContextVar("galpy_backend", default=None)
 
 
 def get_namespace(*arrays, xp=None):

--- a/galpy/backend/_tracectx.py
+++ b/galpy/backend/_tracectx.py
@@ -6,6 +6,10 @@ import contextvars
 import sys
 import threading
 
+# Marks a token whose ``set`` happened while tracing, so it touched the mirror
+# only and ``reset`` must not hand a foreign token to the ContextVar.
+_TRACE_ONLY = object()
+
 
 def _is_compiling():
     """True while dynamo is tracing (cheap, and never imports torch itself)."""
@@ -50,9 +54,18 @@ class TracedContextVar:
     def set(self, value):
         previous = getattr(self._mirror, "value", self._default)
         self._mirror.value = value
+        if _is_compiling():
+            # Leave the ContextVar alone while dynamo is tracing: `ContextVar.set`
+            # is opaque to it exactly as `.get` is, and galpy sets one INSIDE the
+            # compiled region (_jit.py's tracing flag). A trace is a compile-time
+            # artifact, so its writes must not outlive it -- and reads taken
+            # during the trace hit the mirror anyway, so nothing observes a
+            # difference.
+            return (_TRACE_ONLY, previous)
         return (self._var.set(value), previous)
 
     def reset(self, token):
         var_token, previous = token
-        self._var.reset(var_token)
+        if var_token is not _TRACE_ONLY:
+            self._var.reset(var_token)
         self._mirror.value = previous

--- a/galpy/backend/_tracectx.py
+++ b/galpy/backend/_tracectx.py
@@ -1,0 +1,58 @@
+###############################################################################
+#   galpy.backend._tracectx: context variables that survive a torch.compile
+#   trace.
+###############################################################################
+import contextvars
+import sys
+import threading
+
+
+def _is_compiling():
+    """True while dynamo is tracing (cheap, and never imports torch itself)."""
+    torch = sys.modules.get("torch")
+    return torch is not None and torch.compiler.is_compiling()
+
+
+class TracedContextVar:
+    """A ``ContextVar`` that is also readable from inside a ``torch.compile`` trace.
+
+    ``ContextVar.get()`` is opaque to dynamo: every read severs the graph, so a
+    single one on a hot dispatch path breaks the whole compiled region, and
+    ``fullgraph=True`` refuses to compile at all. Inside a trace the value is
+    fixed by construction -- the backend and jit mode cannot change while dynamo
+    walks the bytecode -- so a mirror of the value is read instead.
+
+    The mirror is a ``threading.local``, NOT a module global: two threads that
+    force different backends must not observe each other's value, and that
+    isolation is the whole reason these are ContextVars rather than globals. A
+    plain thread starts with an empty context, so ``ContextVar`` and the mirror
+    agree there by construction.
+
+    Known limit, and it is narrow: they can disagree when a context is carried
+    somewhere the ``set`` did not happen -- ``copy_context().run(...)`` or an
+    asyncio task -- because the mirror follows the thread rather than the
+    context. Only a read taken WHILE COMPILING consults the mirror, so eager
+    galpy is unaffected, and galpy compiles on the thread that entered ``use``.
+    """
+
+    __slots__ = ("_var", "_mirror", "_default")
+
+    def __init__(self, name, default=None):
+        self._var = contextvars.ContextVar(name, default=default)
+        self._mirror = threading.local()
+        self._default = default
+
+    def get(self):
+        if _is_compiling():
+            return getattr(self._mirror, "value", self._default)
+        return self._var.get()
+
+    def set(self, value):
+        previous = getattr(self._mirror, "value", self._default)
+        self._mirror.value = value
+        return (self._var.set(value), previous)
+
+    def reset(self, token):
+        var_token, previous = token
+        self._var.reset(var_token)
+        self._mirror.value = previous

--- a/galpy/backend/_tracectx.py
+++ b/galpy/backend/_tracectx.py
@@ -11,8 +11,15 @@ import threading
 _TRACE_ONLY = object()
 
 
-def _is_compiling():
-    """True while dynamo is tracing (cheap, and never imports torch itself)."""
+def is_compiling():
+    """True while torch dynamo is tracing.
+
+    The shared "am I inside a torch.compile trace?" primitive. Cheap, and it
+    never imports torch itself -- a numpy-only run must not pay that import, so
+    the ``sys.modules`` lookup IS the contract rather than an optimisation.
+    ``_namespaces.under_trace`` composes this with an is-it-a-tensor test; a
+    ContextVar read has no array to test, so it needs the bare predicate.
+    """
     torch = sys.modules.get("torch")
     return torch is not None and torch.compiler.is_compiling()
 
@@ -47,14 +54,14 @@ class TracedContextVar:
         self._default = default
 
     def get(self):
-        if _is_compiling():
+        if is_compiling():
             return getattr(self._mirror, "value", self._default)
         return self._var.get()
 
     def set(self, value):
         previous = getattr(self._mirror, "value", self._default)
         self._mirror.value = value
-        if _is_compiling():
+        if is_compiling():
             # Leave the ContextVar alone while dynamo is tracing: `ContextVar.set`
             # is opaque to it exactly as `.get` is, and galpy sets one INSIDE the
             # compiled region (_jit.py's tracing flag). A trace is a compile-time

--- a/tests/backend_jit_helpers.py
+++ b/tests/backend_jit_helpers.py
@@ -97,3 +97,24 @@ def count_boundary_crossings(fn, backend):
     finally:
         _bi.coerce_coords = real
     return n[0]
+
+
+def no_torch_compile_deprecations():
+    """Suppress torch's own import-time DeprecationWarnings during a compile.
+
+    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
+    warns on ``torch.jit.script_method`` at class-definition time. A per-test
+    ``filterwarnings`` mark cannot suppress it (a module-level
+    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
+    filter it here, around the call itself.
+    """
+    import contextlib
+    import warnings
+
+    @contextlib.contextmanager
+    def _ctx():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            yield
+
+    return _ctx()

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -28,7 +28,7 @@
 ###############################################################################
 import numpy
 import pytest
-from backend_jit_helpers import assert_jit_matches_eager
+from backend_jit_helpers import assert_jit_matches_eager, no_torch_compile_deprecations
 
 from galpy.backend import get_namespace, is_backend_array
 from galpy.potential import (
@@ -240,27 +240,6 @@ def test_vcirc_no_longer_crashes(backend_name):
     numpy.testing.assert_allclose(got, ref, rtol=1e-10)
 
 
-def _no_torch_compile_deprecations():
-    """Suppress torch's own import-time DeprecationWarnings during a compile.
-
-    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
-    warns on ``torch.jit.script_method`` at class-definition time. A per-test
-    ``filterwarnings`` mark cannot suppress it (a module-level
-    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
-    filter it here, around the call itself.
-    """
-    import contextlib
-    import warnings
-
-    @contextlib.contextmanager
-    def _ctx():
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            yield
-
-    return _ctx()
-
-
 @pytest.mark.skipif(torch is None, reason="torch not installed")
 def test_torch_compile_takes_the_backend_gl_path():
     # Regression: under torch.compile the dispatch must pick the in-backend GL
@@ -279,7 +258,7 @@ def test_torch_compile_takes_the_backend_gl_path():
     z0 = torch.tensor(0.2, dtype=torch.float64)
     ref = float(evaluatePotentials(_POT, R0, z0))  # eager (scipy) value
     torch._dynamo.reset()
-    with _no_torch_compile_deprecations():
+    with no_torch_compile_deprecations():
         got = float(
             torch.compile(
                 lambda R, z: evaluatePotentials(_POT, R, z),

--- a/tests/test_backend_multipole.py
+++ b/tests/test_backend_multipole.py
@@ -37,7 +37,7 @@
 ###############################################################################
 import numpy
 import pytest
-from backend_jit_helpers import assert_jit_matches_eager
+from backend_jit_helpers import assert_jit_matches_eager, no_torch_compile_deprecations
 
 from galpy.backend import as_numpy
 from galpy.potential import MiyamotoNagaiPotential, MultipoleExpansionPotential
@@ -624,27 +624,6 @@ def test_from_density_backend_amp_closure(backend_name, symmetry):
     numpy.testing.assert_allclose(got, ref, rtol=1e-11, atol=1e-13)
 
 
-def _no_torch_compile_deprecations():
-    """Suppress torch's own import-time DeprecationWarnings during a compile.
-
-    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
-    warns on ``torch.jit.script_method`` at class-definition time. A per-test
-    ``filterwarnings`` mark cannot suppress it (a module-level
-    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
-    filter it here, around the call itself.
-    """
-    import contextlib
-    import warnings
-
-    @contextlib.contextmanager
-    def _ctx():
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            yield
-
-    return _ctx()
-
-
 @pytest.mark.skipif(torch is None, reason="torch not installed")
 def test_torch_compile_cold_lazy_table_build():
     # Regression: the backend constant tables are built lazily and memoized, so
@@ -671,7 +650,7 @@ def test_torch_compile_cold_lazy_table_build():
     ref = float(build().Rforce(R0, z0))  # warm/eager reference
     cold = build()  # never evaluated outside the trace
     torch._dynamo.reset()
-    with _no_torch_compile_deprecations():
+    with no_torch_compile_deprecations():
         got = float(
             torch.compile(
                 lambda R, z: cold.Rforce(R, z), fullgraph=False, dynamic=False

--- a/tests/test_backend_trace.py
+++ b/tests/test_backend_trace.py
@@ -20,6 +20,7 @@
 ###############################################################################
 import numpy
 import pytest
+from backend_jit_helpers import no_torch_compile_deprecations
 
 from galpy.backend._namespaces import under_trace, untraceable_setup
 
@@ -59,27 +60,6 @@ def test_under_trace_jax():
     assert seen == [True]
 
 
-def _no_torch_compile_deprecations():
-    """Suppress torch's own import-time DeprecationWarnings during a compile.
-
-    ``torch.compile`` lazily imports ``torch._inductor``, whose mkldnn module
-    warns on ``torch.jit.script_method`` at class-definition time. A per-test
-    ``filterwarnings`` mark cannot suppress it (a module-level
-    ``error::DeprecationWarning`` pytestmark is applied last and wins), so
-    filter it here, around the call itself.
-    """
-    import contextlib
-    import warnings
-
-    @contextlib.contextmanager
-    def _ctx():
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            yield
-
-    return _ctx()
-
-
 @pytest.mark.skipif(torch is None, reason="torch not installed")
 def test_under_trace_torch():
     # A concrete tensor -- even one carrying grad -- is not traced; only a
@@ -93,7 +73,7 @@ def test_under_trace_torch():
         return x * 2.0
 
     torch._dynamo.reset()
-    with _no_torch_compile_deprecations():
+    with no_torch_compile_deprecations():
         torch.compile(probe, fullgraph=False, dynamic=False, backend="eager")(
             torch.tensor(1.1, dtype=torch.float64)
         )
@@ -127,7 +107,7 @@ def test_untraceable_setup_runs_scipy_setup_under_compile():
         return x * _decorated_builder()
 
     torch._dynamo.reset()
-    with _no_torch_compile_deprecations():
+    with no_torch_compile_deprecations():
         got = torch.compile(use_builder, fullgraph=False, dynamic=False)(
             torch.tensor(2.0, dtype=torch.float64)
         )

--- a/tests/test_backend_tracectx.py
+++ b/tests/test_backend_tracectx.py
@@ -150,3 +150,44 @@ def test_jit_mode_contextvars_are_readable_inside_a_trace():
     finally:
         _JIT_CTX.reset(token)
     assert seen == {"mode": "torch", "tracing": False}
+
+
+def test_a_set_while_tracing_touches_the_mirror_only():
+    # `ContextVar.set` is opaque to dynamo exactly as `.get` is, and galpy sets
+    # one INSIDE the compiled region (_jit.py's tracing flag), so `.set` has to
+    # be traceable too. It stays off the ContextVar while tracing: a trace is a
+    # compile-time artifact and its writes must not outlive it. Assert the
+    # ContextVar is genuinely untouched, not merely that the call succeeded.
+    var = TracedContextVar("scoped", default="default")
+    var.set("eager")
+    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+        token = var.set("traced")
+        assert var.get() == "traced"  # reads during the trace see it
+        assert var._var.get() == "eager"  # the ContextVar does not
+        var.reset(token)
+        assert var.get() == "eager"
+    assert var.get() == "eager"
+    assert var._var.get() == "eager"
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_set_and_reset_survive_a_fullgraph_compile():
+    # The regression test for the `.set` half. `_jit.py`'s compiled `call` does
+    # `_TRACING.set(True) ... _TRACING.reset(token)` around the method, so a
+    # non-traceable `.set` would break the graph inside galpy's own jit path.
+    var = TracedContextVar("in_trace", default=False)
+
+    def f(x):
+        token = var.set(True)
+        try:
+            return x * 2.0 if var.get() else x
+        finally:
+            var.reset(token)
+
+    torch._dynamo.reset()
+    with no_torch_compile_deprecations():
+        got = torch.compile(f, fullgraph=True, dynamic=False)(
+            torch.tensor(1.5, dtype=torch.float64)
+        )
+    assert float(got) == 3.0  # the True branch ran, i.e. .get() saw the .set()
+    assert var.get() is False  # and the trace left no residue behind

--- a/tests/test_backend_tracectx.py
+++ b/tests/test_backend_tracectx.py
@@ -24,7 +24,7 @@ import pytest
 from backend_jit_helpers import no_torch_compile_deprecations
 
 from galpy.backend import _tracectx
-from galpy.backend._tracectx import TracedContextVar, _is_compiling
+from galpy.backend._tracectx import TracedContextVar, is_compiling
 
 pytestmark = pytest.mark.backend_managed
 
@@ -63,7 +63,7 @@ def test_get_reads_the_mirror_only_while_compiling():
     var.set("through-set")
     var._var.set("contextvar-only")
     assert var.get() == "contextvar-only"
-    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+    with mock.patch.object(_tracectx, "is_compiling", return_value=True):
         assert var.get() == "through-set"
 
 
@@ -76,10 +76,10 @@ def test_threads_do_not_share_the_mirror():
     seen = {}
 
     def worker():
-        with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+        with mock.patch.object(_tracectx, "is_compiling", return_value=True):
             seen["before"] = var.get()
         var.set("worker")
-        with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+        with mock.patch.object(_tracectx, "is_compiling", return_value=True):
             seen["after"] = var.get()
 
     thread = threading.Thread(target=worker)
@@ -87,7 +87,7 @@ def test_threads_do_not_share_the_mirror():
     thread.join()
     assert seen["before"] == "unset"  # the main thread's value is not visible
     assert seen["after"] == "worker"
-    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+    with mock.patch.object(_tracectx, "is_compiling", return_value=True):
         assert var.get() == "main"  # and the worker's did not leak back
 
 
@@ -96,12 +96,12 @@ def test_is_compiling_is_false_when_torch_is_not_imported():
     # run never pays the import. That guard IS the contract; the coverage shard
     # always has torch imported, so it is only reachable by hiding it.
     with mock.patch.dict(sys.modules, {"torch": None}):
-        assert _is_compiling() is False
+        assert is_compiling() is False
 
 
 @pytest.mark.skipif(torch is None, reason="torch not installed")
 def test_is_compiling_is_false_outside_a_trace():
-    assert _is_compiling() is False
+    assert is_compiling() is False
 
 
 @pytest.mark.skipif(torch is None, reason="torch not installed")
@@ -160,7 +160,7 @@ def test_a_set_while_tracing_touches_the_mirror_only():
     # ContextVar is genuinely untouched, not merely that the call succeeded.
     var = TracedContextVar("scoped", default="default")
     var.set("eager")
-    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+    with mock.patch.object(_tracectx, "is_compiling", return_value=True):
         token = var.set("traced")
         assert var.get() == "traced"  # reads during the trace see it
         assert var._var.get() == "eager"  # the ContextVar does not

--- a/tests/test_backend_tracectx.py
+++ b/tests/test_backend_tracectx.py
@@ -1,0 +1,152 @@
+###############################################################################
+# test_backend_tracectx.py: coverage for galpy.backend._tracectx.
+#
+# galpy resolves its backend, and its jit mode, through context variables. A
+# plain ``ContextVar.get()`` is opaque to torch dynamo: it severs the graph at
+# every read, and under ``fullgraph=True`` it refuses to compile at all. Since
+# get_namespace() reads one on every dispatch, that single call made the whole
+# of galpy uncompilable -- not because the potentials were untraceable, but
+# because of the lookup in front of them.
+#
+# ``TracedContextVar`` keeps the ContextVar (that isolation is the point) and
+# adds a thread-local mirror consulted ONLY while dynamo is tracing, where the
+# value is fixed by construction.
+#
+# The backend-tests CI job uploads no coverage, so the compiling branch is
+# exercised here explicitly. Backends that are not installed self-skip.
+###############################################################################
+import contextvars
+import sys
+import threading
+from unittest import mock
+
+import pytest
+from backend_jit_helpers import no_torch_compile_deprecations
+
+from galpy.backend import _tracectx
+from galpy.backend._tracectx import TracedContextVar, _is_compiling
+
+pytestmark = pytest.mark.backend_managed
+
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+except ImportError:  # pragma: no cover
+    torch = None
+
+
+@pytest.mark.parametrize("default", [None, "off", 0, False])
+def test_matches_a_contextvar_through_nested_set_and_reset(default):
+    # The eager contract is "indistinguishable from contextvars.ContextVar",
+    # so assert that against a real one step for step rather than spot-checking
+    # a single set/get.
+    ref = contextvars.ContextVar(f"ref_{default}", default=default)
+    got = TracedContextVar(f"got_{default}", default=default)
+    assert got.get() == ref.get() == default
+    ref_a, got_a = ref.set("a"), got.set("a")
+    assert got.get() == ref.get() == "a"
+    ref_b, got_b = ref.set("b"), got.set("b")
+    assert got.get() == ref.get() == "b"
+    ref.reset(ref_b), got.reset(got_b)
+    assert got.get() == ref.get() == "a"
+    ref.reset(ref_a), got.reset(got_a)
+    assert got.get() == ref.get() == default
+
+
+def test_get_reads_the_mirror_only_while_compiling():
+    # Drive the two sources of truth APART -- set the underlying ContextVar
+    # without going through .set(), so the mirror keeps the older value -- and
+    # check each branch returns its own. Setting both to the same value would
+    # pass no matter which branch ran.
+    var = TracedContextVar("which", default="default")
+    var.set("through-set")
+    var._var.set("contextvar-only")
+    assert var.get() == "contextvar-only"
+    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+        assert var.get() == "through-set"
+
+
+def test_threads_do_not_share_the_mirror():
+    # A module global would make two threads forcing different backends observe
+    # each other; that isolation is the whole reason these are ContextVars, so
+    # the mirror has to be thread-local. Assert BOTH directions.
+    var = TracedContextVar("iso", default="unset")
+    var.set("main")
+    seen = {}
+
+    def worker():
+        with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+            seen["before"] = var.get()
+        var.set("worker")
+        with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+            seen["after"] = var.get()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+    assert seen["before"] == "unset"  # the main thread's value is not visible
+    assert seen["after"] == "worker"
+    with mock.patch.object(_tracectx, "_is_compiling", return_value=True):
+        assert var.get() == "main"  # and the worker's did not leak back
+
+
+def test_is_compiling_is_false_when_torch_is_not_imported():
+    # The guard reads sys.modules rather than importing torch, so a numpy-only
+    # run never pays the import. That guard IS the contract; the coverage shard
+    # always has torch imported, so it is only reachable by hiding it.
+    with mock.patch.dict(sys.modules, {"torch": None}):
+        assert _is_compiling() is False
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_is_compiling_is_false_outside_a_trace():
+    assert _is_compiling() is False
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_forced_backend_survives_a_fullgraph_compile():
+    # The regression test. Before TracedContextVar this raised
+    #   Unsupported: Dynamo does not know how to trace method `get` of ContextVar
+    # for every potential and every method. fullgraph=True errors on ANY graph
+    # break, so reaching the assert at all is the no-break assertion; the
+    # comparison then pins that tracing did not change the value.
+    from galpy.backend import use
+    from galpy.potential import MiyamotoNagaiPotential
+
+    mp = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.05)
+    R = torch.tensor([1.0, 1.2, 0.8], dtype=torch.float64)
+    z = torch.tensor([0.1, 0.05, 0.2], dtype=torch.float64)
+    with use("torch", force=True):
+        eager = mp.Rforce(R, z)
+        torch._dynamo.reset()
+        with no_torch_compile_deprecations():
+            compiled = torch.compile(
+                lambda a, b: mp.Rforce(a, b), fullgraph=True, dynamic=False
+            )(R, z)
+    assert torch.equal(compiled, eager)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_jit_mode_contextvars_are_readable_inside_a_trace():
+    # _JIT_CTX/_TRACING are read by traced_call, i.e. inside the region
+    # torch.compile is walking -- the second break site, on the same mechanism.
+    from galpy.backend._jit import _JIT_CTX, _TRACING
+
+    seen = {}
+
+    def probe(x):
+        seen["mode"] = _JIT_CTX.get()
+        seen["tracing"] = _TRACING.get()
+        return x * 2.0
+
+    token = _JIT_CTX.set("torch")
+    try:
+        torch._dynamo.reset()
+        with no_torch_compile_deprecations():
+            torch.compile(probe, fullgraph=True, dynamic=False)(
+                torch.tensor(1.5, dtype=torch.float64)
+            )
+    finally:
+        _JIT_CTX.reset(token)
+    assert seen == {"mode": "torch", "tracing": False}


### PR DESCRIPTION
`get_namespace()` reads a `ContextVar` on every dispatch to find the active backend. `ContextVar.get()` is opaque to torch dynamo: it severs the graph at every read, and under `fullgraph=True` it refuses to compile at all. **That one lookup — not the potentials behind it — is what made galpy uncompilable under torch.** `_jit.py`'s `_JIT_CTX`/`_TRACING` are touched inside the compiled region for the same reason, so this is one mechanism at several sites rather than several problems.

### What this adds

`galpy.backend._tracectx.TracedContextVar`: the ContextVar, plus a mirror consulted **only** while `torch.compiler.is_compiling()`. Inside a trace the value is fixed by construction — the backend and jit mode cannot change while dynamo walks the bytecode — so the mirror is exact there. All three of galpy's context variables (`_BACKEND_CTX`, `_JIT_CTX`, `_TRACING`) move onto it.

Both halves of the API are traceable, and that took two passes:

* **`.get`** reads the mirror while tracing.
* **`.set`** *also* had to be handled: `_jit.py`'s compiled `call` does `_TRACING.set(True)` **inside** the region torch.compile walks, and `ContextVar.set` is opaque to dynamo for the same reason `.get` is. While tracing, `set` updates the mirror and leaves the ContextVar alone — the correct semantics, not a dodge: a trace is a compile-time artifact whose writes must not outlive it, and reads during the trace hit the mirror anyway. `reset` recognises such a token by a module-level sentinel.

The mirror is a **`threading.local`, not a module global**: two threads forcing different backends must not observe each other, and that isolation is the whole reason these are ContextVars. A plain thread starts with an empty context, so the ContextVar and the mirror agree there by construction. The docstring states the one narrow case where they *can* disagree — `copy_context().run(...)` or an asyncio task, where the context moves but the thread does not — rather than implying it is airtight.

### Measured, A/B against the base commit `a7cf6ed3`

**galpy's own `jit("torch")` path** (MiyamotoNagai.Rforce) — the path the `_jit.py` claim actually rests on:

| | result |
|---|---|
| baseline | 18 graph-break lines — `_resolver.py:45` ×5, **`_jit.py:174` ×1** |
| with fix | **0** galpy break sites, value bit-identical to eager |

`_jit.py:174` *is* `_TRACING.set(True)`, so without the `.set` half that site survives.

**Direct `torch.compile`, 3 potentials × 3 methods:**

| | result |
|---|---|
| baseline | 9/9 `fullgraph=FAIL` — *"Dynamo does not know how to trace method `get` of ContextVar"* |
| with fix | 9/9 `fullgraph=OK`, output **bit-identical** to eager |

### The tests are A/B-verified, not assumed

Each integration test was re-run with its own change reverted and **fails**; the unit tests of the class pass either way, since they exercise the class directly:

```
test_forced_backend_survives_a_fullgraph_compile        fails without the .get fix
test_jit_mode_contextvars_are_readable_inside_a_trace   fails without the .get fix
test_a_set_while_tracing_touches_the_mirror_only        fails without the .set fix
test_set_and_reset_survive_a_fullgraph_compile          fails without the .set fix
```

`fullgraph=True` *is* the no-graph-break assertion — it hard-errors on any break — so reaching the value comparison is the proof. The equivalence test deliberately drives the ContextVar and the mirror apart so each branch is discriminated; the scoped-set test asserts the ContextVar is **genuinely untouched**, not merely that the call succeeded.

### numpy is untouched

Off a trace, `TracedContextVar.get/set/reset` *are* the ContextVar's, and the guard reads `sys.modules` so a numpy-only run never pays a torch import.

### Also: a duplication fix

`_no_torch_compile_deprecations` existed as **three byte-identical copies** (same md5) in `test_backend_{trace,multipole,anyaxisymdisk}.py`; hoisted into `tests/backend_jit_helpers.py`.

### Local gate

```
touched test files, 155 tests each:  --backend torch 155 | --backend jax 155 | numpy 155
test_backend_tracectx.py, 12 tests:  torch 12 | jax 12 | numpy 12
py3.14 + -W error (the coverage shard's config):  8 passed, 4 torch-skips
```

### Scope note

This does **not** claim a suite-wide traced-pass improvement — sizing that needs the full torch `--jit` suite, which is a separate measurement. No ledger entries are changed here. `galpy314` has no torch locally, so the four torch tests are unverified on 3.14 outside CI.