### PR TITLE
ledger: un-defer the nine stale test_interp_potential slow-skips (79 → 70)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -83,12 +83,6 @@ jax tests/test_qdf.py::test_sampleV_interpolate
 # under 300 s is in neither list. Bookkeeping, not burndown: xfail -2, deferred +2;
 # skipping them also returns ~38 min of jax shard time per run.
 # Defer all until interpRZ is backend-vectorized (group d); numpy runs them, values correct.
-jax tests/test_interp_potential.py::test_interpolation_potential_force_c
-jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs
-jax tests/test_interp_potential.py::test_interpolation_potential_dens
-jax tests/test_interp_potential.py::test_interpolation_potential_force
-jax tests/test_interp_potential.py::test_interpolation_potential_c
-jax tests/test_interp_potential.py::test_interpolation_potential_secondderivs_c
 
 # (2026-08-08) The two jax actionAngleAdiabatic timeouts that lived here are
 # un-deferred: they were deferred because the vertical path dispatched eager-jax
@@ -286,8 +280,6 @@ torch tests/test_dynamfric.py::test_dynamfric_c
 # today only because backend-tests' normal runs carry no --jit dimension; they
 # are listed here so a workflow_dispatch(jit=true) run does not surface them as
 # a surprise red. Un-defer when the per-force-call overhead work lands.
-torch-jit tests/test_interp_potential.py::test_interpolation_potential_force_c  # 300s (timeout)
-torch-jit tests/test_interp_potential.py::test_interpolation_potential_secondderivs  # 300s (timeout)
 
 # --- jax-jit: measured under `--backend jax --jit`, 2026-08-09 ---
 # These exist because the slow-skip list no longer inherits eager entries (see
@@ -338,7 +330,6 @@ jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 314s traced
 jax-jit tests/test_dynamfric.py::test_dynamfric_c  # 300s cap traced
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap
-jax-jit tests/test_interp_potential.py::test_interpolation_potential_force_c  # 300s cap
 jax-jit tests/test_qdf.py::test_sampleV_interpolate  # 300s cap
 jax-jit tests/test_orbits.py::test_SOS_3D  # 300s cap (269s eager -> SLOWER traced)
 # NOT an eager entry: tracing alone makes these slow, so inheritance could never
@@ -371,3 +362,21 @@ torch-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfa
 torch-jit tests/test_orbit.py::test_interprz_dxdv_3d
 torch-jit tests/test_orbit.py::test_analytic_zmax
 torch-jit tests/test_orbit.py::test_liouville_planar
+#
+# UN-DEFER (2026-08-21): the nine tests/test_interp_potential.py entries are
+# STALE -- the interpRZPotential grid-build vectorisation made them fast and they
+# were never re-timed. Measured whole-file with the C extension verified ACTIVE
+# (libgalpy loaded AND interpRZPotential(enable_c=True)), per-test durations from
+# junitxml, all 46 tests PASSING in every arm:
+#
+#     --backend jax          46 passed, 242.9s   entries 3.8s .. 43.7s
+#     --backend jax --jit    46 passed,  47.7s   entries 2.6s, 3.0s
+#     --backend torch --jit  46 passed, 144.0s   entries 0.4s, 1.7s
+#
+# Against the 300 s per-test CI cap that is a 10-100x margin; even at a 5x
+# adverse CI/local factor (measured factor is ~0.71 for jax shards, i.e. CI is
+# FASTER) none of them approaches the cap, so the conclusion does not rest on the
+# scaling. test_interp_potential.py is NOT pytest-split and does not appear in
+# .test_orbit_durations, so this is a ledger-only edit (the two-file un-defer rule
+# applies to the split test_orbit.py).
+#


### PR DESCRIPTION
All nine `tests/test_interp_potential.py` slow-skip entries predate the interpRZPotential grid-build vectorisation and were **never re-timed**. They are stale by a wide margin.

### Measured, not assumed

Whole-file runs (not hand-picked nodeids — those don't carry their fixtures), per-test durations read from **junitxml**, with the C extension verified **active first** (`libgalpy` loaded **and** `interpRZPotential(enable_c=True)` constructed) so C-gated tests couldn't fake a pass by skipping:

| arm | whole file | the ledgered entries |
|---|---|---|
| `--backend jax` | 46 passed, 242.9s | 3.8 – 43.7s |
| `--backend jax --jit` | 46 passed, **47.7s** | 3.0s, 2.6s |
| `--backend torch --jit` | 46 passed, 144.0s | 1.7s, 0.4s |

Per entry (jax eager): `_potential_c` 43.7s · `_force` 16.5s · `_dens` 12.5s · `_force_c` 8.6s · `_secondderivs_c` 5.3s · `_secondderivs` 3.8s.

Against the **300 s per-test CI cap** that is a 10–100× margin. The measured CI/local factor for jax shards is ~0.71 (CI is *faster*), but the margin is large enough that even a **5× adverse** factor keeps every entry clear of the cap — so the conclusion does not rest on that scaling. Worth noting the traced arms come in *faster* than eager.

### Why this is a ledger-only edit

`test_interp_potential.py` is **not** pytest-split and does **not** appear in `.test_orbit_durations`, so the two-file un-defer rule doesn't apply. (That rule exists for the split `test_orbit.py`, where pytest-split records 0.05 s for a skipped test and would otherwise mis-balance the shards.) Checked rather than assumed.

Verified by loading the edited file through **conftest's own parser**: zero `test_interp_potential` nodeids remain under `jax` / `jax-jit` / `torch` / `torch-jit`, and the rest of the file still parses.

### Ledger delta

**slow_skip 79 → 70.** xfail 8 and skip 68 unchanged. No source files touched.