### PR TITLE
backend: as_backend_constant must not name the default device (1.5x eager)

### DIFF
--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -160,6 +160,10 @@ def as_backend_constant(xp, value, ref):
         return value
     dtype = getattr(ref, "dtype", None)
     device = getattr(ref, "device", None)
+    if device is not None and device == default_device(xp):
+        # naming the default device commits the placement instead of letting the
+        # backend do it (~3x); same guard as coerce_coords -- see default_device.
+        device = None
     try:
         return xp.asarray(value, dtype=dtype, device=device)
     except TypeError:  # pragma: no cover - namespace without device= kwarg

--- a/galpy/backend/_coerce.py
+++ b/galpy/backend/_coerce.py
@@ -61,8 +61,8 @@ import numpy
 from ._namespaces import (
     _is_floating_dtype,
     asarray_on_device,
-    default_device,
     device_of,
+    effective_device,
     is_backend_array,
 )
 
@@ -100,13 +100,9 @@ def coerce_coords(xp, *coords, device=None):
     """
     if xp is numpy:
         return coords
-    dev = device_of(*coords) if device is None else device
-    if dev is not None and dev == default_device(xp):
-        # placing there is what asarray does anyway, and naming it explicitly
-        # costs ~3x (it commits instead of letting the backend place) -- see
-        # default_device. Only a NON-default anchor (a CUDA sibling on a
-        # CPU-default run) is worth paying for.
-        dev = None
+    # Only a NON-default anchor (a CUDA sibling on a CPU-default run) is worth
+    # naming; effective_device drops the rest.
+    dev = effective_device(xp, device_of(*coords) if device is None else device)
     out = []
     for c in coords:
         if c is None:
@@ -159,11 +155,7 @@ def as_backend_constant(xp, value, ref):
     if xp is numpy:
         return value
     dtype = getattr(ref, "dtype", None)
-    device = getattr(ref, "device", None)
-    if device is not None and device == default_device(xp):
-        # naming the default device commits the placement instead of letting the
-        # backend do it (~3x); same guard as coerce_coords -- see default_device.
-        device = None
+    device = effective_device(xp, getattr(ref, "device", None))
     try:
         return xp.asarray(value, dtype=dtype, device=device)
     except TypeError:  # pragma: no cover - namespace without device= kwarg

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -371,6 +371,21 @@ def _backend_dtype(xp, dtype):
     return getattr(xp, name, dtype)
 
 
+def effective_device(xp, device):
+    """``device``, or None when it is the backend's DEFAULT device.
+
+    Naming the default device COMMITS the placement instead of letting the
+    backend choose, which costs ~3x (see default_device). Every caller that
+    hands a device to ``asarray`` wants this, so the policy lives here once:
+    when it was open-coded per call site, ``as_backend_constant`` was simply
+    missed and paid the cost on all 144 of its call sites (galpy #1300 was the
+    same bug in ``coerce_coords``).
+    """
+    if device is not None and device == default_device(xp):
+        return None
+    return device
+
+
 def asarray_on_device(xp, a, device, dtype=None):
     """``xp.asarray(a, dtype=dtype)`` placed on ``device`` when one is given.
 

--- a/tests/test_backend_coerce.py
+++ b/tests/test_backend_coerce.py
@@ -13,7 +13,13 @@ import numpy
 import pytest
 
 from galpy import backend
-from galpy.backend import is_backend_array, promote_scalars
+from galpy.backend import (
+    as_backend_constant,
+    as_numpy,
+    is_backend_array,
+    promote_scalars,
+)
+from galpy.backend._namespaces import default_device
 
 # This module manages backends explicitly, so it is exempt from the global force.
 pytestmark = pytest.mark.backend_managed
@@ -86,3 +92,62 @@ def test_coords_transform_all_numpy_under_forced_backend(backend_name):
         for g, r in zip(got, ref):
             assert is_backend_array(g)
             numpy.testing.assert_allclose(float(g), float(r), rtol=1e-12, atol=1e-14)
+
+
+# --- as_backend_constant: do not name the default device (galpy #1300) --------
+# Asking asarray for an explicit device COMMITS the placement instead of letting
+# the backend choose, measured in default_device's docstring at 397.6 us vs
+# 134.6 us on jax CPU. coerce_coords already skips the keyword when the anchor
+# IS the default device; as_backend_constant did not, so every stored constant
+# (144 call sites: streamdf, streamgapdf, sphericaldf, NonInertialFrameForce,
+# RotateAndTilt, ...) paid it on every evaluation.
+
+
+def test_as_backend_constant_numpy_is_object_identical_passthrough():
+    # numpy backend: the stored constant is returned untouched (byte-identical).
+    value = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+    out = as_backend_constant(numpy, value, numpy.array(1.0))
+    assert out is value
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_as_backend_constant_does_not_name_the_default_device(backend_name):
+    # The fix: for a ref sitting on the backend's DEFAULT device, asarray must be
+    # called without a device= keyword. Asserted by spying on the namespace's
+    # asarray, so the test fails if the guard is removed.
+    value = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+    seen = []
+    with backend.use(backend_name, force=True) as xp:
+        ref = xp.asarray(1.0)
+        assert getattr(ref, "device", None) == default_device(xp), (
+            f"{backend_name}: ref is not on the default device, test is vacuous"
+        )
+        real = xp.asarray
+
+        def spy(*args, **kwargs):
+            seen.append(kwargs.get("device", "ABSENT"))
+            return real(*args, **kwargs)
+
+        try:
+            xp.asarray = spy
+            as_backend_constant(xp, value, ref)
+        finally:
+            xp.asarray = real
+    assert seen, f"{backend_name}: as_backend_constant did not call asarray"
+    assert all(d in ("ABSENT", None) for d in seen), (
+        f"{backend_name}: default device was named explicitly: {seen}"
+    )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_as_backend_constant_preserves_values_dtype_and_device(backend_name):
+    # Skipping the device keyword must not move the array or perturb a bit: the
+    # constant is compared EXACTLY (no tolerance) against the stored numpy value.
+    value = numpy.array([[1.0, -2.5], [3.25, 4.0e-17]])
+    with backend.use(backend_name, force=True) as xp:
+        ref = xp.asarray(numpy.float64(1.0))
+        out = as_backend_constant(xp, value, ref)
+        assert is_backend_array(out)
+        assert out.dtype == ref.dtype
+        assert getattr(out, "device", None) == getattr(ref, "device", None)
+        assert numpy.array_equal(as_numpy(out), value)


### PR DESCRIPTION
## What

`coerce_coords` skips the `device=` keyword when the anchor **is** the backend's
default device. Naming it commits the placement instead of letting the backend
choose — `default_device`'s own docstring prices this at **397.6 us vs 134.6 us**
on jax CPU and blames it for turning *"a 1.7 s dxdv test into a 300 s timeout"*
(galpy #1300).

`as_backend_constant`, 60 lines down the same file, never got that guard. It passes
`device=getattr(ref, "device", None)` unconditionally, and `ref` is always a real
backend array — so the default device is named on **every** call.

```python
 dtype = getattr(ref, "dtype", None)
 device = getattr(ref, "device", None)
+if device is not None and device == default_device(xp):
+    device = None
```

## How it was found

Patching `jax._src.pjit.with_sharding_constraint` and counting the innermost galpy
frame: **7.00 calls per `NonInertialFrameForce._force`, 100% of them from
`_coerce.py:164`**.

## Measured (develop worktree, jax CPU; A/B arms verified to differ)

| | before | after | |
|---|---|---|---|
| `_force` per call | 5069.7 us | 3064.0 us | **1.65x** |
| `test_arbitraryaxisrotation_omegafunc_nullpotential` (jax eager) | 414.5 s | 273.6 s | **1.51x** |

## Blast radius

Not a noninertial fix — **144 call sites**: streamdf 66, streamgapdf 20,
sphericaldf 11, NonInertialFrameForce 10, RotateAndTilt 9, streamspraydf 7,
EllipsoidalPotential 6, ... i.e. exactly the slow-skip clusters.

## Safety

* **numpy path untouched** — `if xp is numpy: return value` precedes the change,
  so it is byte-identical by construction.
* **GPU preserved** — a NON-default anchor (a CUDA `ref` on a CPU-default run)
  still names its device; only the redundant default naming is skipped. Same
  logic already blessed in `coerce_coords`.

## Ledger delta

**None.** The second measurement crosses the 300 s per-test CI cap, but
un-deferring requires all 17 noninertial entries measured — a separate ledger PR.
slow_skip 68, xfail 8, skip 68, all unchanged.

## Tests

Three tests added to `tests/test_backend_coerce.py` (its existing home; no new
file, no duplicated helper). A/B-verified — the two device tests **FAIL on both
jax and torch** with the guard reverted:

```
arm=BASE   2 failed, 10 passed
arm=FIXED  12 passed
```

Gate (this branch, all three arms green):

```
numpy  708 passed, 1 skipped     (incl. test_noninertial.py, test_streamgapdf_impulse.py)
jax    694 passed, 1 skipped     (forced)
torch  694 passed, 1 skipped     (forced)
```