### PR TITLE
ledger: un-defer 8 noninertial entries measured under the #1364 guard (69 → 61)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -207,11 +207,8 @@ jax tests/test_orbit.py::test_integrate_indiv_t_python_paths  # >420s (measured 
 # funcomega); all func/vec-omega tests that are torch-xfail-ledgered but had no jax
 # entry are slow-skipped together here to stop the recurring per-PR flake.
 jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz
-jax tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz
 jax tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz
-jax tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega
 jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot
-jax tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential
 # Re-homed from backend_xfail.txt 2026-08-05: same class as the block above, and
 # the two slowest members of it. Timed under `--backend jax --runxfail` (nothing
 # masked), whole -k arbitraryaxisrotation family:
@@ -296,15 +293,33 @@ torch tests/test_dynamfric.py::test_dynamfric_c  # measured 2026-08-21: >700s TI
 # was never eager-ledgered at all -- tracing made it SLOWER -- which inheritance
 # could not have surfaced.
 jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation  # 616s traced
+#
+# RE-MEASURED 2026-08-22 as CONTROLLED A/Bs, after the as_backend_constant
+# default-device guard (gh#1364). Whole file, serial, C extension active; the
+# BASE arm is develop without the guard, everything else identical. BASE
+# reproduces this ledger's own historical numbers to 0.85-1.02, so the arms are
+# comparable. CI estimated at the measured CI/local factor 0.71; entries are
+# kept unless they clear the 240 s CI margin.
+#
+#   jax --jit          BASE   FIXED     x     CI~
+#     test_arbitraryaxisrotation          525.6  490.7  1.07  348.4   stays
+#     ..._omegafunc                       523.9  400.5  1.31  284.4   stays
+#     ..._accellsrframe_funcomegaz        502.6  351.9  1.43  249.9   stays
+#     ..._omegadot                        387.3  352.3  1.10  250.1   stays
+#     test_python_vs_c_..._vecomegaz      486.7  297.5  1.64  211.2   un-deferred
+#     ..._accellsrframe_scalarfuncomegaz  399.1  307.1  1.30  218.0   un-deferred
+#     ..._omegafunc_nullpotential         372.8  247.2  1.51  175.5   un-deferred
+#     test_python_vs_c_...funcomega       383.1  243.3  1.57  172.8   un-deferred
+#     test_python_vs_c_..._scalarfunc     340.1  235.3  1.45  167.0   un-deferred
+#
+# The speedup is HETEROGENEOUS (1.07x-1.64x): the two slowest tests barely move,
+# so they stay deferred on their own merits, not on an averaged figure.
+# jax eager (same treatment): 8 -> 5, un-deferring the three at CI~213.7 /
+# 199.1 / 176.7 s.
 jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc  # 573s
 jax-jit tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_funcomegaz  # 529s
-jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_vecomegaz  # 477s
 jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot  # 454s
-jax-jit tests/test_noninertial.py::test_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz  # 437s
-jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegafunc_nullpotential  # 386s
-jax-jit tests/test_noninertial.py::test_python_vs_c_arbitraryaxisrotation_funcomega  # 381s
 # NOT in the eager jax list: fast eager, 354 s traced. Tracing made it slower.
-jax-jit tests/test_noninertial.py::test_python_vs_c_linacc_changingacc_xyz_accellsrframe_scalarfuncomegaz  # 354s
 # tests/test_streamTrack.py, whole file, serial: 45 cases -> 45 PASSED,
 # total 1215 s, median 8.7 s, 2 over the 240 s margin. The eager `jax` entry is
 # the WHOLE FILE (per-track eager XLA dispatch blows the shard); traced, 43 of


### PR DESCRIPTION
## What

gh#1364 (`as_backend_constant` no longer names the default device) speeds the
noninertial force path by **1.07×–1.64×**. Eight of the 17 noninertial entries now
clear the ledger's **240 s CI margin** and go back into CI.

| | before | after |
|---|---|---|
| `jax` eager | 8 | **5** |
| `jax --jit` | 9 | **4** |
| **slow_skip total** | 69 | **61** |

`backend_xfail` 8 and `backend_skip` 68 unchanged. Ledger-only diff — one file.

## Measurement: controlled A/Bs, not before/after against old annotations

Whole file, serial, C extension active, same box, same command. The BASE arm is
develop **without** the guard, so the two trees differ only in `_coerce.py` +
`_namespaces.py`. **53 passed / 0 failed on every arm.**

| `jax --jit` | BASE | FIXED | × | CI~ | verdict |
|---|---|---|---|---|---|
| `test_arbitraryaxisrotation` | 525.6 | 490.7 | 1.07 | 348.4 | stays |
| `..._omegafunc` | 523.9 | 400.5 | 1.31 | 284.4 | stays |
| `..._accellsrframe_funcomegaz` | 502.6 | 351.9 | 1.43 | 249.9 | stays |
| `..._omegadot` | 387.3 | 352.3 | 1.10 | 250.1 | stays |
| `test_python_vs_c_..._vecomegaz` | 486.7 | 297.5 | 1.64 | 211.2 | **un-defer** |
| `..._accellsrframe_scalarfuncomegaz` | 399.1 | 307.1 | 1.30 | 218.0 | **un-defer** |
| `..._omegafunc_nullpotential` | 372.8 | 247.2 | 1.51 | 175.5 | **un-defer** |
| `test_python_vs_c_...funcomega` | 383.1 | 243.3 | 1.57 | 172.8 | **un-defer** |
| `test_python_vs_c_..._scalarfunc` | 340.1 | 235.3 | 1.45 | 167.0 | **un-defer** |

CI estimated at the measured CI/local factor **0.71**.

## Why this is a real burndown, not a fast-box artefact

Three independent checks:

1. **The BASE arm reproduces this ledger's own historical numbers to 0.85–1.02.**
   The recorded values were sound and today's box is not systematically fast — the
   thing that would otherwise explain the whole effect.
2. **The speedup is heterogeneous (1.07×–1.64×).** The two slowest tests barely
   move; they stay deferred on their own merits, not on an averaged figure. A
   uniform shift would have been the suspicious result.
3. **Eager cross-check:** `..._omegafunc_nullpotential` measures 273.6 s alone and
   280.4 s inside the full 53-test file (2.5% apart) against 414.5 s pre-guard — so
   the number is not a single-test-context artefact.

An earlier *uncontrolled* comparison of the same jit run against the old
annotations suggested a flat "20–38% everywhere". That was too strong, and only
the BASE arm separated it — recorded in the log rather than quietly dropped.

## What is retained, and why

Everything kept is kept on a measurement: one over the 300 s cap (CI~348) and
three inside the 240 s margin (CI~284/250/250). The in-file annotation records all
nine jit numbers so the next sweep can tell stale from genuinely slow.