### PR TITLE
ledger: replace a censored bound and 4 stale times with measurements

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -147,7 +147,7 @@ jax tests/test_streamspraydf.py::test_center
 # steps per-force-call (~1 ms each) and exceeds the per-test budget. They validate
 # C-vs-Python STM numerics, which the numpy run already covers; the differentiable
 # in-backend (diffrax/torchdiffeq) STM is covered by tests/test_backend_orbit_stm.py.
-jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]  # >420s (measured 2026-08-15, timed out)
+jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]  # PASSES in 528.9s (CI~375s) -- re-measured 2026-08-22 post-#1364 in the real CI shard (--splits 5 --group 3); the old '>420s timed out' was a TIMEOUT BOUND, not a time
 jax tests/test_orbit.py::test_liouville_planar  # >420s (measured 2026-08-15, timed out)
 jax tests/test_orbit.py::test_lyapunov_spectrum_consistency  # PASSES in 662s (measured 2026-08-15) -- genuinely performance-gated
 jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic  # PASSES in 1535s (measured 2026-08-15) -- genuinely performance-gated
@@ -241,8 +241,16 @@ jax tests/test_streamdf.py  # 2026-08-21: DEADLOCKS, does not merely run slow --
 # timed out next run). Defer the whole file under jax (the numpy StreamTrack path
 # is covered by the numpy suite, the backend track/class by
 # test_backend_streamTrack.py). Un-skip when the pipeline is jit-vectorized.
-jax tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # measured 2026-08-21: 408.0s (CI~290s)
-jax tests/test_streamTrack.py::test_streamTrack_with_progpot  # measured 2026-08-21: 331.7s (CI~236s)
+#
+# WHY streamTrack IS NOT A BURNDOWN TARGET (measured 2026-08-22, both modes,
+# whole file, post-#1364): 0.96x-1.11x. gh#1364's as_backend_constant guard
+# removes a fixed cost PER as_backend_constant CALL, so it pays in proportion to
+# calls per EVALUATION: RotateAndTilt makes 15/force-eval -> 1.95x on the force
+# call, NonInertialFrameForce 7 -> 1.07x-1.64x on its tests, streamTrack ~0 per
+# evaluation (its stream-module calls are in TRACK SETUP, run a handful of times)
+# -> nothing. Do not re-run this sweep expecting a win from that guard.
+jax tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 427.2s (CI~303s) re-measured 2026-08-22 post-#1364 (was 408.0s; 0.96x -- the guard does NOT help here)
+jax tests/test_streamTrack.py::test_streamTrack_with_progpot  # 323.7s (CI~230s) re-measured 2026-08-22 post-#1364 (was 331.7s; 1.02x). STAYS: it straddles the 240s margin on a ~2% wobble, which is noise, not a change
 # jax-eager Staeckel Python-path freqs+angles is borderline >300s in the shard
 # (it passes in isolation and ran <300s in the regen, so it's a DROP from the
 # xfail-ledger, not a failure); skip it under jax to dodge the flaky pytest-timeout
@@ -327,8 +335,8 @@ jax-jit tests/test_noninertial.py::test_arbitraryaxisrotation_omegadot  # 454s
 # 498->452 and 348->314 s -- ~10% inflation, not the 6x that test_noninertial
 # saw, because this run had one competitor rather than four. Either way both
 # clear 240 s, so the split is unchanged.
-jax-jit tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 452s traced
-jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 314s traced
+jax-jit tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 406.7s traced (CI~289s) re-measured 2026-08-22 post-#1364 (was 452s; 1.11x)
+jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 326.8s traced (CI~232s) re-measured 2026-08-22 post-#1364 (was 314s; 0.96x). STAYS: straddles the margin on noise, same as its eager twin
 
 # --- jax-jit: measured by the 10-file traced sweep (2026-08-09) ---
 # gh#1279 stopped `-jit` inheriting the eager slow-skip list, which un-deferred


### PR DESCRIPTION
**Comment-only. Entry set byte-identical, 61 → 61** — verified by parsing the entry
field of every line and comparing sets, not by eyeballing the diff. Nothing is
deferred or un-deferred.

This banks measurements taken while evaluating gh#1364, so the next sweep doesn't
repeat ~3 h of runs to rediscover them.

## 1. A censored bound replaced by a number

`test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]` read
`>420s (measured 2026-08-15, timed out)`. That is a **timeout bound, not a time** —
it can't be compared against anything, and dividing by it manufactures whatever
ratio you want. Re-measured in the real CI shard (`--splits 5 --group 3`, post-#1364):

```
PASSES in 528.9 s  ->  CI~375 s
```

Still over the 300 s cap, still deferred — but now on a measurement.

## 2. Four streamTrack times refreshed post-guard

```
eager   408.0 -> 427.2 s (0.96x)     331.7 -> 323.7 s (1.02x)
jit     452.0 -> 406.7 s (1.11x)     314.0 -> 326.8 s (0.96x)
```

Both `with_progpot` rows now land at CI~230 (eager) / ~232 (jit), *inside* the 240 s
margin they used to sit outside. **That is a 2–4% wobble, not a change** — two
independent runs putting the same test on opposite sides of the line is the clearest
evidence the line isn't what moved. Annotated `STAYS` so a later reader doesn't
mistake the crossing for a burndown opportunity.

## 3. Why streamTrack isn't a target for that guard

Recorded in-file so it isn't re-derived: the guard removes a fixed cost **per
`as_backend_constant` call**, so it pays in proportion to calls per *evaluation* —

| | calls / evaluation | effect |
|---|---|---|
| RotateAndTilt | 15 | 1.95× on the force call |
| NonInertialFrameForce | 7 | 1.07–1.64× on its tests |
| streamTrack | ~0 (calls are in track *setup*) | none |

## Ledger delta

`xfail` 8, `slow_skip` 61, `skip` 68 — **all unchanged**.