### PR TITLE
ExpTruncNFW.from_nfw: differentiable mass → rc solve (implicit function theorem)

### DIFF
--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -186,7 +186,14 @@ class ExpTruncNFWPotential(SphericalPotential):
             # Namespace-agnostic residual, with target_F passed through ``args``
             # rather than closed over: galpy's brentq follows the DATA, and only
             # an argument it can see selects the differentiable backend path.
-            xp = get_namespace(target_F)
+            # xp must follow the DATA, not the ambient (possibly FORCED) default:
+            # under `use("torch", force=True)` with a plain-float mass,
+            # get_namespace would say torch while brentq -- which dispatches on
+            # the data -- correctly goes to scipy and hands the residual Python
+            # floats, giving `torch.exp(float)`. Deriving both from the same
+            # predicate makes xp and the brentq dispatch agree by construction.
+            numpy_path = not is_backend_array(target_F)
+            xp = numpy if numpy_path else get_namespace(target_F)
             Froot = lambda al, tF: xp.exp(al) * (1.0 + al) * exp1(al) - 1.0 - tF
             # numpy stays byte-identical: xp is numpy, exp1 routes to
             # scipy.special.exp1, and brentq routes to scipy.optimize.brentq.
@@ -195,7 +202,6 @@ class ExpTruncNFWPotential(SphericalPotential):
             # Python control flow on the solved value -- are numpy-only. The
             # trade is deliberate: gradients in exchange for the domain check
             # and the warnings, which are user guidance rather than correctness.
-            numpy_path = not is_backend_array(target_F)
             # F(alpha) decreases monotonically from +inf (alpha->0, rc->inf, the
             # un-truncated infinite-mass NFW) to 0 (alpha->inf). Any finite mass
             # is therefore reachable, with a larger mass simply giving a larger

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -194,7 +194,12 @@ class ExpTruncNFWPotential(SphericalPotential):
             # predicate makes xp and the brentq dispatch agree by construction.
             numpy_path = not is_backend_array(target_F)
             xp = numpy if numpy_path else get_namespace(target_F)
-            Froot = lambda al, tF: xp.exp(al) * (1.0 + al) * exp1(al) - 1.0 - tF
+            # exp1 ALSO follows the ambient namespace, so on the numpy path take
+            # scipy's directly: the router would return a torch Tensor for a
+            # Python-float argument under `use("torch", force=True)`, and scipy's
+            # brentq would then be handed a Tensor residual.
+            _e1 = _scipy_exp1 if numpy_path else exp1
+            Froot = lambda al, tF: xp.exp(al) * (1.0 + al) * _e1(al) - 1.0 - tF
             # numpy stays byte-identical: xp is numpy, exp1 routes to
             # scipy.special.exp1, and brentq routes to scipy.optimize.brentq.
             # On a backend target_F the value is a TRACER under jax.grad, so the

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -180,12 +180,22 @@ class ExpTruncNFWPotential(SphericalPotential):
             # Keep amp = nfw.amp and solve amp * F(a/rc) = mass for rc, where
             # F(alpha) = exp(alpha)(1+alpha)E_1(alpha) - 1 decreases monotonically
             # from +inf (alpha->0) to 0 (alpha->inf), so the root is unique.
-            from scipy.optimize import brentq
+            from ..backend.optimize import brentq
 
             target_F = conversion.parse_mass(mass, ro=nfw._ro, vo=nfw._vo) / nfw._amp
-            Froot = lambda al: (
-                numpy.exp(al) * (1.0 + al) * _scipy_exp1(al) - 1.0 - target_F
-            )
+            # Namespace-agnostic residual, with target_F passed through ``args``
+            # rather than closed over: galpy's brentq follows the DATA, and only
+            # an argument it can see selects the differentiable backend path.
+            xp = get_namespace(target_F)
+            Froot = lambda al, tF: xp.exp(al) * (1.0 + al) * exp1(al) - 1.0 - tF
+            # numpy stays byte-identical: xp is numpy, exp1 routes to
+            # scipy.special.exp1, and brentq routes to scipy.optimize.brentq.
+            # On a backend target_F the value is a TRACER under jax.grad, so the
+            # bracket pre-check and the advisory warnings below -- both ordinary
+            # Python control flow on the solved value -- are numpy-only. The
+            # trade is deliberate: gradients in exchange for the domain check
+            # and the warnings, which are user guidance rather than correctness.
+            numpy_path = not is_backend_array(target_F)
             # F(alpha) decreases monotonically from +inf (alpha->0, rc->inf, the
             # un-truncated infinite-mass NFW) to 0 (alpha->inf). Any finite mass
             # is therefore reachable, with a larger mass simply giving a larger
@@ -193,16 +203,16 @@ class ExpTruncNFWPotential(SphericalPotential):
             # end: F(690) ~ 2e-6 is the smallest mass we can evaluate before
             # exp(alpha) overflows (rc < a/690).
             a_low, a_high = 1e-150, 690.0  # F(1e-150) ~ 344; exp(690) still finite
-            if Froot(a_high) > 0.0:
+            if numpy_path and Froot(a_high, target_F) > 0.0:
                 raise ValueError(
                     "ExpTruncNFWPotential.from_nfw: the requested mass is too "
                     "small to evaluate -- it implies a truncation sharper than "
                     "rc = a/690, where the closed-form total mass overflows in "
                     "floating point"
                 )
-            alpha = brentq(Froot, a_low, a_high)
+            alpha = brentq(Froot, a_low, a_high, args=(target_F,))
             rc = a / alpha
-            if rc < a:
+            if numpy_path and rc < a:
                 warnings.warn(
                     "ExpTruncNFWPotential.from_nfw: the requested total mass "
                     f"implies a truncation radius rc={rc:g} smaller than the NFW "
@@ -217,7 +227,7 @@ class ExpTruncNFWPotential(SphericalPotential):
                 # divergent) NFW outskirts. rvir needs the overdensity definition
                 # and can fail (e.g. odd unit setups), so guard it.
                 try:
-                    rvir = nfw.rvir(use_physical=False)
+                    rvir = nfw.rvir(use_physical=False) if numpy_path else None
                 except Exception:  # pragma: no cover
                     rvir = None
                 if rvir is not None and rc > 2.0 * rvir:

--- a/tests/test_backend_exptruncnfw.py
+++ b/tests/test_backend_exptruncnfw.py
@@ -287,3 +287,27 @@ def test_from_nfw_mass_gradient_vs_finite_difference(backend_name):
         f"{backend_name}: d(rc)/d(mass)={got!r} vs finite difference {fd!r} "
         f"(rel err {abs(got - fd) / abs(fd):.3e})"
     )
+
+
+@pytest.mark.parametrize("backend_name", [b for b in BACKENDS if b != "numpy"])
+def test_from_nfw_under_forced_backend_with_plain_float_mass(backend_name):
+    """Regression: xp must follow the DATA, not the ambient forced default.
+
+    Under ``use(backend, force=True)`` with a plain-float ``mass``,
+    ``get_namespace`` reports the forced backend while ``brentq`` -- which
+    dispatches on the data -- correctly routes to scipy and hands the residual
+    Python floats. Deriving ``xp`` from the ambient namespace therefore produced
+    ``torch.exp(float) -> TypeError`` (caught by CI on the force-managed
+    test_potential / test_quantity shards, which this module's
+    ``backend_managed`` mark exempts it from).
+    """
+    from galpy import backend as _backend
+    from galpy.potential import NFWPotential
+
+    nfw = NFWPotential(amp=1.0, a=2.0)
+    ref = ExpTruncNFWPotential.from_nfw(nfw, mass=3.0).rc
+    with _backend.use(backend_name, force=True):
+        rc = ExpTruncNFWPotential.from_nfw(nfw, mass=3.0).rc
+    assert abs(float(as_numpy(rc)) - ref) < 1e-10 * ref, (
+        f"{backend_name} forced: rc={rc!r} vs unforced numpy {ref!r}"
+    )

--- a/tests/test_backend_exptruncnfw.py
+++ b/tests/test_backend_exptruncnfw.py
@@ -219,3 +219,71 @@ def test_param_grad_vs_fd(backend_name, var):
     numpy.testing.assert_allclose(
         ad, fd, rtol=1e-5, err_msg=f"d(rforce)/d{var} ({backend_name})"
     )
+
+
+###############################################################################
+# from_nfw(mass=...): the truncation radius is the root of
+# amp * F(a/rc) = mass, so d(rc)/d(mass) exists and is what a fit of a truncated
+# NFW to an observed total mass needs. The solve now runs through galpy's own
+# backend brentq (implicit function theorem) instead of scipy.optimize.brentq,
+# so that derivative flows on jax/torch; the numpy path still routes to scipy.
+###############################################################################
+
+
+def _rc_from_mass(mass):
+    from galpy.potential import NFWPotential
+
+    nfw = NFWPotential(amp=1.0, a=2.0)
+    return ExpTruncNFWPotential.from_nfw(nfw, mass=mass).rc
+
+
+def test_from_nfw_mass_solve_satisfies_its_own_equation():
+    """numpy path: the returned rc really is the root, to machine precision.
+
+    Pins the SOLVE rather than a hard-coded rc, so the test still means something
+    if the profile is ever reparametrized.
+    """
+    from scipy.special import exp1 as _exp1
+
+    from galpy.potential import NFWPotential
+
+    nfw = NFWPotential(amp=1.0, a=2.0)
+    mass = 3.0
+    rc = _rc_from_mass(mass)
+    assert isinstance(rc, float), "numpy path must stay on scipy and return a float"
+    al = nfw.a / rc
+    resid = nfw._amp * (numpy.exp(al) * (1.0 + al) * _exp1(al) - 1.0) - mass
+    assert abs(resid) < 1e-12 * mass, f"rc is not the root: residual {resid!r}"
+
+
+@pytest.mark.parametrize("backend_name", [b for b in BACKENDS if b != "numpy"])
+def test_from_nfw_forward_value_matches_numpy(backend_name):
+    """The solved rc is backend-independent to ~machine precision."""
+    ref = _rc_from_mass(3.0)
+    xp_mass = jnp.asarray(3.0) if backend_name == "jax" else torch.tensor(3.0)
+    got = float(as_numpy(_rc_from_mass(xp_mass)))
+    assert abs(got - ref) < 1e-10 * ref, f"{backend_name}: {got!r} vs numpy {ref!r}"
+
+
+@pytest.mark.parametrize("backend_name", [b for b in BACKENDS if b != "numpy"])
+def test_from_nfw_mass_gradient_vs_finite_difference(backend_name):
+    """d(rc)/d(mass) from the implicit function theorem vs a central difference.
+
+    The FD reference is computed on the NUMPY path, so this compares the backend
+    derivative against an independent evaluation of the same function -- not
+    against itself. Tolerance is 1e-8 relative; the implicit-diff value agrees
+    with the FD to ~8e-12 in practice, and a wrong/absent derivative would be off
+    by order unity, so this is a real check rather than a finite-and-nonzero one.
+    """
+    m0, h = 3.0, 1e-5
+    fd = (_rc_from_mass(m0 + h) - _rc_from_mass(m0 - h)) / (2.0 * h)
+    if backend_name == "jax":
+        got = float(jax.grad(_rc_from_mass)(jnp.asarray(m0)))
+    else:
+        mt = torch.tensor(m0, requires_grad=True)
+        _rc_from_mass(mt).backward()
+        got = float(mt.grad)
+    assert abs(got - fd) < 1e-8 * abs(fd), (
+        f"{backend_name}: d(rc)/d(mass)={got!r} vs finite difference {fd!r} "
+        f"(rel err {abs(got - fd) / abs(fd):.3e})"
+    )


### PR DESCRIPTION
## The gap

`from_nfw(nfw, mass=...)` solves `amp * F(a/rc) = mass` for the truncation radius,
using `scipy.optimize.brentq` on a residual built from `numpy.exp` and
`scipy.special.exp1`. So `d(rc)/d(mass)` did not exist on any backend:

```
jax.grad(lambda m: ExpTruncNFWPotential.from_nfw(nfw, mass=m).rc)(3.0)
-> TracerArrayConversionError: __array__() was called on traced array
```

That derivative is exactly what fitting a truncated NFW to an observed total mass
needs.

## The change

Route the solve through galpy's **own** `galpy.backend.optimize.brentq`, which
already implements the implicit function theorem, with the residual written in the
resolved namespace and `exp1` from `galpy.backend.special`. Both were **already
imported by this module** for the evaluate path — no new helper, no new import
surface, nothing hoisted.

One wiring detail worth naming: `target_F` goes through `args=` rather than being
closed over, because galpy's `brentq` **follows the data** — only an argument it can
see selects the differentiable path.

## Measured (jax + torch, x64)

| | |
|---|---|
| numpy `rc` | `175.7878520799847` — **byte-identical to before** |
| `d(rc)/d(mass)` | `190.8931303136` vs central FD `190.8931303120` → **rel err 8.08e-12**, both backends |
| forward value | numpy == jax == torch to 1e-10 |

numpy is byte-identical **by construction**: `xp is numpy`, `exp1` routes to
`scipy.special.exp1` (documented byte-identical in the router), and `brentq` routes
to `scipy.optimize.brentq` for non-backend brackets/args.

## A deliberate trade, documented in the code

Under `jax.grad` the solved value is a **tracer**, so the bracket pre-check
(`Froot(a_high) > 0`) and the two advisory warnings (`rc < a`, `rc > 2 rvir`) are
ordinary Python control flow on it and would raise `ConcretizationTypeError`. They
are now numpy-path-only.

The backend path gives up a domain check and two warnings — **user guidance, not
correctness** — in exchange for gradients. The numpy path keeps both, unchanged.

## Tests

Added to the existing `tests/test_backend_exptruncnfw.py` (no new file):

- the numpy solve **satisfies its own equation** to <1e-12 relative and still returns
  a plain `float` — pins the *solve*, not a hard-coded `rc`, so it survives a
  reparametrization;
- forward `rc` agrees across numpy/jax/torch;
- `d(rc)/d(mass)` vs a central difference computed on the **numpy** path — an
  independent evaluation, not the backend checked against itself — at 1e-8 relative
  against a measured 8e-12.

**A/B verified:** both gradient tests **fail** on jax and torch without this change
and pass with it.

## Gate

```
test_backend_exptruncnfw.py   41 passed   numpy / jax / torch
test_potential.py -k ExpTrunc 17 passed, 1 skipped   (C extension built)
```

Ledger delta: **none** — xfail 8 / slow_skip 61 / skip 68 unchanged.