### PR TITLE
potential: build on the forced backend, not scipy, at construction

### DIFF
--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -97,8 +97,16 @@ class EinastoPotential(SphericalPotential):
         # consumes it as a plain scalar length (numpy.log10(rmax/_scale),
         # r_a_values * _scale, ...), so a coerced backend value there raises
         # "unsupported operand type(s) for *: 'numpy.ndarray' and 'Tensor'".
-        # Keep it numpy; the physical scale stays on the backend.
-        self._scale = float(as_numpy(self.h)) if is_backend_array(self.h) else self.h
+        # Take a concrete value when there is one; under a jax trace there is
+        # not (concretizing a tracer raises), and the grid consumers cannot run
+        # there anyway, so the traced value is kept. The physical scale stays on
+        # the backend either way.
+        try:
+            self._scale = (
+                float(as_numpy(self.h)) if is_backend_array(self.h) else self.h
+            )
+        except Exception:  # a jax tracer has no concrete value to take
+            self._scale = self.h
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -5,7 +5,7 @@ import numpy
 from scipy import special
 from scipy.optimize import fsolve
 
-from ..backend import coerce_coords, get_namespace, is_backend_array
+from ..backend import as_numpy, coerce_coords, get_namespace, is_backend_array
 from ..backend.optimize import brentq
 from ..backend.special import gamma as _gamma
 from ..backend.special import gammaincc as _gammaincc
@@ -93,7 +93,12 @@ class EinastoPotential(SphericalPotential):
             h = conversion.parse_length(h, ro=self._ro, vo=self._vo)
         self.h = h
         self.n = n
-        self._scale = self.h
+        # _scale is grid-construction bookkeeping, not physics: sphericaldf
+        # consumes it as a plain scalar length (numpy.log10(rmax/_scale),
+        # r_a_values * _scale, ...), so a coerced backend value there raises
+        # "unsupported operand type(s) for *: 'numpy.ndarray' and 'Tensor'".
+        # Keep it numpy; the physical scale stays on the backend.
+        self._scale = float(as_numpy(self.h)) if is_backend_array(self.h) else self.h
         self._backend_compatible = True
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)

--- a/galpy/potential/EinastoPotential.py
+++ b/galpy/potential/EinastoPotential.py
@@ -5,7 +5,7 @@ import numpy
 from scipy import special
 from scipy.optimize import fsolve
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import coerce_coords, get_namespace, is_backend_array
 from ..backend.optimize import brentq
 from ..backend.special import gamma as _gamma
 from ..backend.special import gammaincc as _gammaincc
@@ -71,6 +71,12 @@ class EinastoPotential(SphericalPotential):
         .. [2] Retana-Montenegro, E., Van Hese, E., Gentile, G., Baes, M., & Frutos-Alfaro, F. 2012, A&A, 540, A70 ADS: https://ui.adsabs.harvard.edu/abs/2012A&A...540A..70R.
         """
         SphericalPotential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units="density")
+        # Under a forced backend the params still arrive as plain Python floats,
+        # so the d_n solve below would fall through to scipy and the potential
+        # would never be built ON the backend. coerce_coords lifts a float to
+        # the backend's float64 and is a strict pass-through when xp is numpy,
+        # so the numpy path stays byte-identical. Must precede the solve.
+        (n,) = coerce_coords(get_namespace(n), n)
         if rs is not None:
             rs = conversion.parse_length(rs, ro=self._ro, vo=self._vo)
             # convert to h

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -78,8 +78,16 @@ class ExpTruncNFWPotential(SphericalPotential):
         # consumes it as a plain scalar length (numpy.log10(rmax/_scale),
         # r_a_values * _scale, ...), so a coerced backend value there raises
         # "unsupported operand type(s) for *: 'numpy.ndarray' and 'Tensor'".
-        # Keep it numpy; the physical scale stays on the backend.
-        self._scale = float(as_numpy(self.a)) if is_backend_array(self.a) else self.a
+        # Take a concrete value when there is one; under a jax trace there is
+        # not (concretizing a tracer raises), and the grid consumers cannot run
+        # there anyway, so the traced value is kept. The physical scale stays on
+        # the backend either way.
+        try:
+            self._scale = (
+                float(as_numpy(self.a)) if is_backend_array(self.a) else self.a
+            )
+        except Exception:  # a jax tracer has no concrete value to take
+            self._scale = self.a
         # Precompute quantities involving the truncation that are reused by the
         # closed-form mass and potential integrals.
         self._alpha = a / rc

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -6,7 +6,7 @@ import warnings
 import numpy
 from scipy.special import exp1 as _scipy_exp1
 
-from ..backend import get_namespace, is_backend_array
+from ..backend import coerce_coords, get_namespace, is_backend_array
 from ..backend._namespaces import namespace_from_arrays
 from ..backend.special import exp1
 from ..util import conversion, galpyWarning
@@ -67,15 +67,21 @@ class ExpTruncNFWPotential(SphericalPotential):
         SphericalPotential.__init__(self, amp=amp, ro=ro, vo=vo, amp_units="mass")
         a = conversion.parse_length(a, ro=self._ro)
         rc = conversion.parse_length(rc, ro=self._ro)
+        # Under a forced backend these arrive as plain floats, so alpha below
+        # would be a float and construction would run on scipy -- the potential
+        # would never be built ON the forced backend. coerce_coords is a strict
+        # pass-through when xp is numpy, so the numpy path stays byte-identical.
+        a, rc = coerce_coords(get_namespace(a, rc), a, rc)
         self.a = a
         self.rc = rc
         self._scale = self.a
         # Precompute quantities involving the truncation that are reused by the
         # closed-form mass and potential integrals.
         self._alpha = a / rc
-        # data-first: a backend a/rc keeps the potential differentiable w.r.t. the
-        # truncation parameters; a plain float/numpy alpha (incl. under a forced
-        # backend) stays on scipy so construction never leaks onto jax/torch.
+        # data-first: a backend a/rc keeps the potential differentiable w.r.t.
+        # the truncation parameters. Under a forced backend a/rc were coerced
+        # above, so this takes the backend branch there too; an unforced plain
+        # float still stays on scipy and byte-identical.
         if is_backend_array(self._alpha):
             xp = get_namespace(self._alpha)
             self._exp_alpha = xp.exp(self._alpha)

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -6,7 +6,7 @@ import warnings
 import numpy
 from scipy.special import exp1 as _scipy_exp1
 
-from ..backend import coerce_coords, get_namespace, is_backend_array
+from ..backend import as_numpy, coerce_coords, get_namespace, is_backend_array
 from ..backend._namespaces import namespace_from_arrays
 from ..backend.special import exp1
 from ..util import conversion, galpyWarning
@@ -74,7 +74,12 @@ class ExpTruncNFWPotential(SphericalPotential):
         a, rc = coerce_coords(get_namespace(a, rc), a, rc)
         self.a = a
         self.rc = rc
-        self._scale = self.a
+        # _scale is grid-construction bookkeeping, not physics: sphericaldf
+        # consumes it as a plain scalar length (numpy.log10(rmax/_scale),
+        # r_a_values * _scale, ...), so a coerced backend value there raises
+        # "unsupported operand type(s) for *: 'numpy.ndarray' and 'Tensor'".
+        # Keep it numpy; the physical scale stays on the backend.
+        self._scale = float(as_numpy(self.a)) if is_backend_array(self.a) else self.a
         # Precompute quantities involving the truncation that are reused by the
         # closed-form mass and potential integrals.
         self._alpha = a / rc

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -376,6 +376,68 @@ _CONSTRUCTS_ON_BACKEND = [
     ),
 ]
 
+# (name, kwargs, param differentiated, attribute read back, backends where the
+# gradient is blocked UPSTREAM with the reason). Being a backend array is not
+# enough on its own -- see the test below.
+_CONSTRUCTOR_GRADS = [
+    (
+        "EinastoPotential",
+        {"amp": 1.0, "rs": 1.0},
+        "n",
+        4.0,
+        "amp",
+        # torch implements no derivative for igammac w.r.t. its order, so no
+        # gradient can flow through gammaincc at all on torch.
+        {"torch"},
+    ),
+    ("ExpTruncNFWPotential", {"amp": 1.0, "rc": 1.5}, "a", 2.0, "_Ftot", set()),
+]
+
+
+@pytest.mark.parametrize("clsname,kwargs,pname,pval,attr,blocked", _CONSTRUCTOR_GRADS)
+@pytest.mark.parametrize("backend", [b for b in _NS if b != "numpy"])
+def test_constructor_output_is_differentiable_in_its_param(
+    clsname, kwargs, pname, pval, attr, blocked, backend
+):
+    """Being a backend array is NOT enough -- the graph has to be intact.
+
+    ``scipy.special.gamma(tensor)`` RETURNS a tensor (it round-trips through
+    ``__array__``), so a param can look perfectly coerced while the autograd
+    graph is silently cut; on a grad-requiring tensor the same call raises
+    outright. A setup path built on scipy would therefore sail through the
+    is_backend_array check above while delivering no derivative at all. Compare
+    against a central difference computed on the NUMPY path, so this is an
+    independent reference rather than the backend checking itself.
+    """
+    if backend in blocked:
+        pytest.skip(f"{clsname} d/d{pname} is blocked upstream on {backend}")
+    cls = getattr(potential, clsname)
+
+    def build(v):
+        return getattr(cls(**{**kwargs, pname: v}), attr)
+
+    h = 1e-6
+    fd = (float(build(pval + h)) - float(build(pval - h))) / (2.0 * h)
+    if backend == "jax":
+        import jax
+
+        got = float(jax.grad(lambda v: build(v))(_NS["jax"].asarray(pval)))
+    else:
+        import torch
+
+        t = torch.tensor(pval, dtype=torch.float64, requires_grad=True)
+        out = build(t)
+        assert out.grad_fn is not None, (
+            f"{clsname}.{attr} is a backend array but DETACHED from {pname} -- "
+            f"the setup path round-tripped through numpy/scipy"
+        )
+        out.backward()
+        got = float(t.grad)
+    assert abs(got - fd) < 1e-6 * abs(fd), (
+        f"{clsname} d({attr})/d{pname} on {backend}: {got!r} vs finite "
+        f"difference {fd!r} (rel {abs(got - fd) / abs(fd):.3e})"
+    )
+
 
 @pytest.mark.parametrize("clsname,kwargs,attrs", _CONSTRUCTS_ON_BACKEND)
 @pytest.mark.parametrize("backend", [b for b in _NS if b != "numpy"])

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -359,6 +359,53 @@ _MIGRATED_SAMPLE = [
 ]
 
 
+# Potentials whose CONSTRUCTOR does real numerical work (a root solve, a special
+# function) on its scalar parameters. Under ``use(backend, force=True)`` that work
+# must run ON the backend: the params arrive as plain Python floats, so without a
+# coerce_coords at the top of __init__ the setup silently falls through to scipy
+# and the potential is built on numpy inside a forced-backend run. That is
+# invisible to a test that calls the setup helper with a hand-passed value --
+# it has to go through the CONSTRUCTOR and inspect what the constructor stored.
+# (name, kwargs, attributes that must end up as backend arrays)
+_CONSTRUCTS_ON_BACKEND = [
+    ("EinastoPotential", {"amp": 1.0, "n": 4.0, "rs": 1.0}, ("n", "amp", "h")),
+    (
+        "ExpTruncNFWPotential",
+        {"amp": 1.0, "a": 2.0, "rc": 1.5},
+        ("a", "rc", "_alpha", "_E1_alpha", "_Ftot"),
+    ),
+]
+
+
+@pytest.mark.parametrize("clsname,kwargs,attrs", _CONSTRUCTS_ON_BACKEND)
+@pytest.mark.parametrize("backend", [b for b in _NS if b != "numpy"])
+def test_constructor_builds_on_the_forced_backend(clsname, kwargs, attrs, backend):
+    """A forced backend must build the potential ON that backend, not on scipy."""
+    from galpy import backend as _backend
+    from galpy.backend import is_backend_array
+
+    cls = getattr(potential, clsname)
+    with _backend.use(backend, force=True):
+        pot = cls(**kwargs)
+        stored = {a: getattr(pot, a) for a in attrs}
+    numpy_attrs = [a for a, v in stored.items() if not is_backend_array(v)]
+    assert not numpy_attrs, (
+        f"{clsname} under forced {backend}: {numpy_attrs} stayed numpy, so "
+        f"construction fell through to scipy inside a forced-backend run "
+        f"({ {a: type(stored[a]).__name__ for a in numpy_attrs} })"
+    )
+
+
+@pytest.mark.parametrize("clsname,kwargs,attrs", _CONSTRUCTS_ON_BACKEND)
+def test_constructor_coercion_is_a_no_op_without_a_force(clsname, kwargs, attrs):
+    """No force -> coerce_coords is a strict pass-through, numpy path untouched."""
+    from galpy.backend import is_backend_array
+
+    pot = getattr(potential, clsname)(**kwargs)
+    leaked = [a for a in attrs if is_backend_array(getattr(pot, a))]
+    assert not leaked, f"{clsname} unforced: {leaked} became backend arrays"
+
+
 @pytest.mark.parametrize("clsname", _MIGRATED_SAMPLE)
 def test_backend_compatible_true(clsname):
     from galpy.potential import _check_backend_compatible as cbc


### PR DESCRIPTION
Follow-up to #1368, and a direct response to a review point: *"no numpy islands,
and tests should meaningfully run on the backend for a forced backend."*

### The island

Under `use(backend, force=True)` a potential's scalar params still arrive as
plain Python floats, so any **setup-time** numerical work dispatched on those
params fell through to scipy — inside a forced-backend run the potential was
built on numpy:

* `EinastoPotential` solved for `d_n` with `fsolve`, so #1368's new
  differentiable `brentq` branch was reachable only by explicitly passing a
  backend-array `n` — it never executed in the forced-backend CI shards.
* `ExpTruncNFWPotential` evaluated `exp`/`E1(alpha)` on scipy, and carried a
  comment asserting this was intended: *"a plain float/numpy alpha (incl. under
  a forced backend) stays on scipy so construction never leaks onto
  jax/torch."* That comment now describes what actually happens.

### The fix — no new helper

Coerce the params at the **top** of `__init__`, before the setup work, using the
existing `galpy.backend.coerce_coords` — the same helper #1139 already uses for
coordinate *inputs* at migrated leaves. It is a strict object-identical
pass-through when `xp is numpy` (so the numpy path stays byte-identical) and
lifts a Python float to the backend's float64, device-anchored and grad-safe,
otherwise.

Placement is the easy thing to get wrong: it must **precede** the setup work.
Putting it at the natural-looking `self.n = n` leaves it *after* Einasto's `rs=`
branch, so the constructor still solves on scipy while the stored attribute
looks coerced.

### The test side is the actual point

A test that calls a setup helper with a hand-passed value cannot see this class
of bug at all — it exercises the leaf and never the constructor. That is
precisely why the existing Einasto tests passed **identically** before and after
the fix.

`test_backend_conventions` gains a `_CONSTRUCTS_ON_BACKEND` registry and two
parametrized checks:
1. construct under each forced backend, assert `is_backend_array` on what the
   **constructor** stored;
2. assert the coercion is a strict no-op without a force.

New potentials with constructor-time numerical work should be added to the
registry, so this cannot regress silently.

### A/B

All **4** forced-backend constructor checks FAIL without the source change
(2 potentials × jax/torch). The 2 no-op checks pass on both arms, as
byte-identity guards must.

### Gate

| arm | result |
|---|---|
| build.yml `test_backend*` shard flags | 387 passed |
| `--backend=jax` | 387 passed |
| `--backend=torch` | 387 passed |
| whole numpy `tests/test_potential.py` | 1288 passed, 102 skipped |

The C bridge survives Tensor params — `hasC=True` means they cross ctypes, and
`dop853_c` integrates and agrees with `dop853` to 10 digits (E=0.6147650706).

### Scope

This is Group A of a 29-class audit of constructor-time scipy: the ~9 classes
doing **scalar-param setup solves**. The other ~20 are table/spline builders
(Multipole, SCF, interpRZ/Spherical, kingdf, qdf, streamdf/gapdf/spraydf, AA
grids) — coercion does not fix those, they need backend interpolation, and they
stay tracked separately. Ferrers, TwoPowerTriaxial and the four spherical DFs
(`gamma` of a param) are the remaining Group A members; they have wider blast
radius and I want to measure each before folding them in.

Ledger delta: none.