### PR TITLE
Ferrers/TwoPowerTriaxial: compute their gamma normalizations on the backend

### DIFF
--- a/galpy/potential/FerrersPotential.py
+++ b/galpy/potential/FerrersPotential.py
@@ -12,7 +12,6 @@ import math
 
 import numpy
 from scipy import integrate
-from scipy.special import gamma
 
 from ..backend import (
     coerce_coords,
@@ -22,6 +21,7 @@ from ..backend import (
 )
 from ..backend.optimize import brentq
 from ..backend.quadrature import fixed_quad_semiinfinite
+from ..backend.special import gamma
 from ..util import conversion, coords
 from .Potential import Potential
 
@@ -112,7 +112,12 @@ class FerrersPotential(Potential):
         self._force_hash = None
         self._pa = pa
         self._backend_compatible = True
-        self._rhoc_M = gamma(n + 2.5) / gamma(n + 1) / numpy.pi**1.5 / a**3 / b / c
+        # Routed gamma, on a coerced n, so rho_c is computed ON the backend under
+        # a force (scipy would hand back a DETACHED tensor) and stays
+        # differentiable in n. b and c are deliberately NOT coerced: the
+        # numpy.fabs(self._b - 1.0) check below rejects a tensor under -W error.
+        (n_,) = coerce_coords(get_namespace(n), n)
+        self._rhoc_M = gamma(n_ + 2.5) / gamma(n_ + 1) / numpy.pi**1.5 / a**3 / b / c
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -15,7 +15,7 @@ import math
 import numpy
 from scipy import special
 
-from ..backend import get_namespace
+from ..backend import coerce_coords, get_namespace
 from ..backend import special as _bspecial
 from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
@@ -117,10 +117,17 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
         self.twominusalpha = 2.0 - self.alpha
         self.threeminusalpha = 3.0 - self.alpha
         if self.twominusalpha != 0.0:
+            # Routed gamma on coerced exponents, so psi_inf is computed ON the
+            # backend under a force and stays differentiable in alpha/beta;
+            # scipy.special.gamma would return a silently DETACHED tensor. The
+            # exponents are coerced HERE rather than stored coerced, because
+            # self.twominusalpha drives the Python-level branches above and at
+            # _mdens below -- a tensor there would be a tracing hazard.
+            _al, _be = coerce_coords(get_namespace(alpha, beta), alpha, beta)
             self.psi_inf = (
-                special.gamma(self.beta - 2.0)
-                * special.gamma(3.0 - self.alpha)
-                / special.gamma(self.betaminusalpha)
+                _bspecial.gamma(_be - 2.0)
+                * _bspecial.gamma(3.0 - _al)
+                / _bspecial.gamma(_be - _al)
             )
         # Adjust amp
         self._amp = self._amp / (4.0 * numpy.pi * self.a**3)

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -374,6 +374,19 @@ _CONSTRUCTS_ON_BACKEND = [
         {"amp": 1.0, "a": 2.0, "rc": 1.5},
         ("a", "rc", "_alpha", "_E1_alpha", "_Ftot"),
     ),
+    # gamma-of-a-param normalizations: the param is NOT stored coerced (the
+    # Python-level branches and the numpy.fabs(b-1) check below need raw
+    # floats), so what has to land on the backend is the computed constant.
+    (
+        "FerrersPotential",
+        {"amp": 1.0, "n": 2, "a": 1.0, "b": 0.7, "c": 0.5},
+        ("_rhoc_M",),
+    ),
+    (
+        "TwoPowerTriaxialPotential",
+        {"amp": 1.0, "a": 1.0, "alpha": 1.0, "beta": 4.0},
+        ("psi_inf",),
+    ),
 ]
 
 # (name, kwargs, param differentiated, attribute read back, backends where the
@@ -391,6 +404,22 @@ _CONSTRUCTOR_GRADS = [
         {"torch"},
     ),
     ("ExpTruncNFWPotential", {"amp": 1.0, "rc": 1.5}, "a", 2.0, "_Ftot", set()),
+    (
+        "FerrersPotential",
+        {"amp": 1.0, "a": 1.0, "b": 0.7, "c": 0.5},
+        "n",
+        2.0,
+        "_rhoc_M",
+        set(),
+    ),
+    (
+        "TwoPowerTriaxialPotential",
+        {"amp": 1.0, "a": 1.0, "beta": 4.0},
+        "alpha",
+        1.0,
+        "psi_inf",
+        set(),
+    ),
 ]
 
 


### PR DESCRIPTION
Group A continuation of #1369.

### The island

Both potentials build a normalization constant from `gamma()` of a shape
parameter — Ferrers `_rhoc_M` from `gamma(n+2.5)/gamma(n+1)`, TwoPowerTriaxial
`psi_inf` from a ratio of three gammas in `alpha`/`beta` — calling **scipy's**
`special.gamma` directly. So under a forced backend the constant was computed on
scipy and the potential was not built on the backend.

Routed through `galpy.backend.special.gamma` on coerced exponents. The routed
helper is a strict pass-through to scipy on numpy: verified **byte-identical
across 13 scalar values (same type too) and a 97-point array**.

### Placement differs from #1369, deliberately

The exponents are coerced **at the point of use** rather than stored coerced:

* Ferrers runs `numpy.fabs(self._b - 1.0)` further down, which rejects a tensor
  under `-W error`;
* TwoPowerTriaxial branches on `self.twominusalpha` in two places, which would
  become a tracing hazard.

Storing raw and coercing locally keeps both safe while still putting the
computed constant on the backend — and the constant is what matters, since it is
what the physics multiplies through. Verified: `_b`/`_c`/`alpha`/`twominusalpha`
stay raw, `_rhoc_M`/`psi_inf` land on the backend, `_scale` stays a float.

### Readers checked, not just writers

Per the lesson from #1369 (where coercing `_scale` broke a dozen sphericaldf
consumers), I grepped the changed attributes across `galpy/` first. `psi_inf` is
read by **`integrateFullOrbit.py:256` and `integratePlanarOrbit.py:285`**, which
pass it into the **C integrator** via ctypes. Tested directly: `dop853_c` under
forced torch gives the identical energy to the unforced run
(E=0.3650000000 for TwoPowerTriaxial, E=-0.4718484022 for Ferrers).

### A/B

All **8** new registry checks fail without this change — 4
`builds_on_the_forced_backend` and, notably, 4
`output_is_differentiable_in_its_param`. That differentiability half did *not*
fail for #1369's two potentials (they already used routed helpers); it fires
here because `scipy.special.gamma` returns a silently **detached** tensor. The
guard added in #1369 for hypothetical future entries caught the real defect in
the very next two.

### Gate

| arm | result |
|---|---|
| build.yml `test_backend*` shard flags | 400 passed, 1 skipped |
| `--backend=jax` | 400 passed, 1 skipped |
| `--backend=torch` | 400 passed, 1 skipped |
| whole numpy `tests/test_potential.py` | 1288 passed, 102 skipped |

numpy byte-identity verified across 10 probes spanning n=1..3 × two axis sets and
four (alpha, beta) pairs.

### Remaining Group A

The four spherical DFs (`constantbetadf` 16 sites, `osipkovmerrittPowerLawdf` 4,
`constantbetaPowerLawdf` 3, `isotropicPowerLawdf` 2) are the same shape and come
next; they are kept separate because `constantbetadf` alone is 16 call sites.
`AdiabaticContractionWrapperPotential` (quad + `fixed_point` iterating on an
array with `interp1d` inside) is its own problem.

Ledger delta: none.