### PR TITLE
Power-law spherical DFs: compute their fE normalizations on the backend

### DIFF
--- a/galpy/df/constantbetaPowerLawdf.py
+++ b/galpy/df/constantbetaPowerLawdf.py
@@ -5,9 +5,9 @@
 #
 # For rho_pot ~ r^{-alpha} (alpha > 2) and nu_tracer ~ r^{-gamma}
 import numpy
-from scipy import special
 
-from ..backend import resolve_namespace
+from ..backend import coerce_coords, get_namespace, resolve_namespace
+from ..backend.special import gamma as _bgamma
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion
@@ -101,15 +101,24 @@ class constantbetaPowerLawdf(_constantbetadf):
             "Adjust gamma, alpha, or beta."
         )
         # eta = nu_0 * 2^beta * Gamma(p+1) / ((2*pi)^{3/2} * Gamma(1-beta) * Gamma(n+1) * C^p)
+        # Routed gamma on coerced exponents: under a forced backend the DF's
+        # normalization was computed on scipy, so the DF was not built ON the
+        # backend and no derivative could flow (scipy.special.gamma hands back a
+        # DETACHED array). The exponents are coerced HERE rather than stored
+        # coerced -- self._n drives an assert with an f-string format below, and
+        # the raw floats keep every other consumer unchanged.
+        _p, _n, _beta = coerce_coords(
+            get_namespace(self._p, self._n, self._beta), self._p, self._n, self._beta
+        )
         self._fEnorm = (
             self._nu0
-            * 2.0**self._beta
-            * special.gamma(self._p + 1.0)
+            * 2.0**_beta
+            * _bgamma(_p + 1.0)
             / (
                 (2.0 * numpy.pi) ** 1.5
-                * special.gamma(1.0 - self._beta)
-                * special.gamma(self._n + 1.0)
-                * self._C**self._p
+                * _bgamma(1.0 - _beta)
+                * _bgamma(_n + 1.0)
+                * self._C**_p
             )
         )
         self._potInf = evaluatePotentials(self._pot, self._rmax, 0, use_physical=False)

--- a/galpy/df/isotropicPowerLawdf.py
+++ b/galpy/df/isotropicPowerLawdf.py
@@ -5,9 +5,9 @@
 #
 # For rho_pot ~ r^{-alpha} (alpha > 2) and nu_tracer ~ r^{-gamma}
 import numpy
-from scipy import special
 
-from ..backend import resolve_namespace
+from ..backend import coerce_coords, get_namespace, resolve_namespace
+from ..backend.special import gamma as _bgamma
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion
@@ -86,16 +86,17 @@ class isotropicPowerLawdf(isotropicsphericaldf):
         self._s = self._gamma / (self._alpha_pot - 2.0)
         self._n = self._s - 1.5
         # eta = nu_0 * Gamma(s+1) / (2*sqrt(2) * pi^{3/2} * Gamma(s-1/2) * C^s)
+        # Routed gamma on coerced exponents: under a forced backend the DF's
+        # normalization was computed on scipy, so the DF was not built ON the
+        # backend and no derivative could flow (scipy.special.gamma hands back a
+        # DETACHED array). The exponents are coerced HERE rather than stored
+        # coerced -- self._n drives an assert with an f-string format below, and
+        # the raw floats keep every other consumer unchanged.
+        (_s,) = coerce_coords(get_namespace(self._s), self._s)
         self._fEnorm = (
             self._nu0
-            * special.gamma(self._s + 1.0)
-            / (
-                2.0
-                * numpy.sqrt(2.0)
-                * numpy.pi**1.5
-                * special.gamma(self._s - 0.5)
-                * self._C**self._s
-            )
+            * _bgamma(_s + 1.0)
+            / (2.0 * numpy.sqrt(2.0) * numpy.pi**1.5 * _bgamma(_s - 0.5) * self._C**_s)
         )
         self._potInf = evaluatePotentials(self._pot, self._rmax, 0, use_physical=False)
 

--- a/galpy/df/osipkovmerrittPowerLawdf.py
+++ b/galpy/df/osipkovmerrittPowerLawdf.py
@@ -6,9 +6,9 @@
 #
 # For rho_pot ~ r^{-alpha} (alpha > 2) and nu_tracer ~ r^{-gamma}
 import numpy
-from scipy import special
 
-from ..backend import resolve_namespace
+from ..backend import coerce_coords, get_namespace, resolve_namespace
+from ..backend.special import gamma as _bgamma
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
 from ..util import conversion
@@ -110,17 +110,23 @@ class osipkovmerrittPowerLawdf(_osipkovmerrittdf):
         self._n2 = self._s2 - 1.5
         # Eddington normalization for each power-law term of the augmented density
         edd_norm = 2.0 * numpy.sqrt(2.0) * numpy.pi**1.5
+        # Routed gamma on coerced exponents: under a forced backend these
+        # normalizations were computed on scipy, so the DF was not built ON the
+        # backend and no derivative could flow (scipy.special.gamma hands back a
+        # DETACHED array). Coerced HERE rather than stored, so every other
+        # consumer of _s1/_s2 keeps its raw float.
+        _s1, _s2 = coerce_coords(get_namespace(self._s1, self._s2), self._s1, self._s2)
         self._A1 = (
             self._nu0
-            / self._C**self._s1
-            * special.gamma(self._s1 + 1.0)
-            / (edd_norm * special.gamma(self._s1 - 0.5))
+            / self._C**_s1
+            * _bgamma(_s1 + 1.0)
+            / (edd_norm * _bgamma(_s1 - 0.5))
         )
         self._A2 = (
             self._nu0
-            / (self._ra2 * self._C**self._s2)
-            * special.gamma(self._s2 + 1.0)
-            / (edd_norm * special.gamma(self._s2 - 0.5))
+            / (self._ra2 * self._C**_s2)
+            * _bgamma(_s2 + 1.0)
+            / (edd_norm * _bgamma(_s2 - 0.5))
         )
         self._potInf = evaluatePotentials(self._pot, self._rmax, 0, use_physical=False)
 

--- a/tests/test_backend_conventions.py
+++ b/tests/test_backend_conventions.py
@@ -389,6 +389,50 @@ _CONSTRUCTS_ON_BACKEND = [
     ),
 ]
 
+# The spherical power-law DFs build their fE normalization the same way, from
+# gamma() of a derived exponent. They take a potential rather than plain kwargs,
+# so they get their own registry: (name, df kwargs, attributes).
+_DF_CONSTRUCTS_ON_BACKEND = [
+    ("isotropicPowerLawdf", {}, ("_fEnorm",)),
+    ("constantbetaPowerLawdf", {"beta": 0.3}, ("_fEnorm",)),
+    ("osipkovmerrittPowerLawdf", {"ra": 1.5}, ("_A1", "_A2")),
+]
+
+
+def _plaw_pot():
+    return potential.PowerSphericalPotential(amp=1.0, alpha=2.5, normalize=False)
+
+
+@pytest.mark.parametrize("clsname,kwargs,attrs", _DF_CONSTRUCTS_ON_BACKEND)
+@pytest.mark.parametrize("backend", [b for b in _NS if b != "numpy"])
+def test_df_constructor_builds_on_the_forced_backend(clsname, kwargs, attrs, backend):
+    """A forced backend must build the DF's normalization ON that backend."""
+    from galpy import backend as _backend
+    from galpy import df as _df
+    from galpy.backend import is_backend_array
+
+    cls = getattr(_df, clsname)
+    with _backend.use(backend, force=True):
+        d = cls(pot=_plaw_pot(), **kwargs)
+        stored = {a: getattr(d, a) for a in attrs}
+    numpy_attrs = [a for a, v in stored.items() if not is_backend_array(v)]
+    assert not numpy_attrs, (
+        f"{clsname} under forced {backend}: {numpy_attrs} stayed numpy, so the "
+        f"normalization was computed on scipy inside a forced-backend run"
+    )
+
+
+@pytest.mark.parametrize("clsname,kwargs,attrs", _DF_CONSTRUCTS_ON_BACKEND)
+def test_df_constructor_coercion_is_a_no_op_without_a_force(clsname, kwargs, attrs):
+    """No force -> strict pass-through, the numpy path is untouched."""
+    from galpy import df as _df
+    from galpy.backend import is_backend_array
+
+    d = getattr(_df, clsname)(pot=_plaw_pot(), **kwargs)
+    leaked = [a for a in attrs if is_backend_array(getattr(d, a))]
+    assert not leaked, f"{clsname} unforced: {leaked} became backend arrays"
+
+
 # (name, kwargs, param differentiated, attribute read back, backends where the
 # gradient is blocked UPSTREAM with the reason). Being a backend array is not
 # enough on its own -- see the test below.


### PR DESCRIPTION
Group A finale, after #1369 (Einasto/ExpTruncNFW) and #1370 (Ferrers/2PT).

### The island

`isotropicPowerLawdf`, `constantbetaPowerLawdf` and `osipkovmerrittPowerLawdf`
each build their fE normalization from **scipy's** `special.gamma` of a derived
exponent (`_s`, `_p`/`_n`, `_s1`/`_s2`). Under a forced backend the
normalization was therefore computed on scipy — the DF was not built ON the
backend, and no derivative could flow, since `scipy.special.gamma` returns a
**detached** array (and raises outright on a grad-requiring one).

Routed onto `galpy.backend.special.gamma`, which is a strict pass-through to
scipy on numpy.

### Coerced at the point of use

Same placement #1370 established, and here there is a concrete reason beyond
consistency: `constantbetaPowerLawdf` asserts

```python
assert self._n > -1.0, f"Energy exponent n={self._n:.3f} must be > -1 ..."
```

a few lines *above* the gamma block. A stored tensor would break that message's
formatting. Coercing locally leaves every other consumer of `_s`/`_p`/`_n`
untouched.

### The eval path was already waiting for this

`isotropicPowerLawdf` resolves its namespace with
`resolve_namespace(Ei, self._fEnorm)` — i.e. it was **already written to accept
a backend `_fEnorm`**. Only the setup had been left behind. This is the intended
end state, not a new design.

After the swap none of the three imports `scipy.special` at all any more, so the
import is dropped: the island is gone rather than routed around.

### Readers checked first

Per the rule from #1369 (where coercing `_scale` broke a dozen sphericaldf
consumers), I grepped the changed attributes across `galpy/` before touching
anything. `_fEnorm`/`_nu0`/`_A1`/`_A2` are confined to their own DF modules —
the `_C`/`_gamma` hits elsewhere are unrelated same-named attributes on
`FDMDynamicalFrictionForce` and `SpiralArmsPotential`.

### A/B

All **6** forced-backend registry checks fail without this change (3 DFs ×
jax/torch); the 3 no-op checks pass on both arms, as byte-identity guards must.

### Gate

| arm | result |
|---|---|
| build.yml `test_backend*` shard flags | 409 passed, 1 skipped |
| `--backend=jax` | 409 passed, 1 skipped |
| `--backend=torch` | 409 passed, 1 skipped |
| `tests/test_sphericaldf.py` numpy | 223 passed |
| `tests/test_sphericaldf.py --backend=torch` | 223 passed |
| `tests/test_sphericaldf.py --backend=jax` | 223 passed |

numpy byte-identity verified across 21 probes — 3 potential slopes ×
{isotropic, constantbeta at three βs, osipkovmerritt at two r_a} — identical in
**value and type**.

### What is deliberately NOT here

`constantbetadf` was excluded after an AST census: only 2 of its 16
`special.gamma` sites are in `__init__`; the other 14 sit in `_dMdE`,
`_sample_eta`, `_vmomentdensity` and the `_fE_numpy`/`_fE_backend` pair. Those
are a different problem — differentiating a DF w.r.t. its own anisotropy
parameter β — and nothing is broken today, since each is `gamma(<expr in
self._beta>)` on a plain float, i.e. a numpy scalar constant that broadcasts
fine and resolves at trace time under `--jit`. Tracked separately with the
design question it needs, rather than smuggled into a setup-island PR.

Ledger delta: none.