### PR TITLE
Label a torus by its integrals of motion by name, and accept Quantities

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -12,6 +12,16 @@ v1.12.1 (expected around 2026-11-01)
   the interpolation of the actions is useless rather than merely less
   accurate.
 
+- The inverse action-angle methods can label a torus by its integrals of
+  motion by name where a class supports it, e.g.,
+  ``aASI(angler,anglephi,anglez,E=E,Lz=Lz,I3=I3)`` for
+  ``actionAngleStaeckelInverse``, rather than by its actions; this saves
+  inverting the actions when the integrals are what one has. Naming the
+  integrals works the same with and without units, unlike relying on their
+  dimensions, because in internal units the integrals of motion cannot be
+  told apart from the actions. ``actionAngleStaeckelInverse`` also accepts
+  Quantity inputs for the tori it is given and for the extent of its grid.
+
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the
   symmetry axis. V(v) is built along u=u0 and only represents the wrapped

--- a/doc/source/reference/aa.rst
+++ b/doc/source/reference/aa.rst
@@ -59,6 +59,7 @@ Specific actionAngle modules
 
    actionAngleHarmonicInverse <aaharmonicinverse.rst>
    actionAngleIsochroneInverse <aaisochroneinverse.rst>
+   actionAngleStaeckelInverse <aastaeckelinverse.rst>
    actionAngleTorus <aatorus.rst>
    actionAngleVerticalInverse <aaverticalinverse.rst>
 

--- a/doc/source/reference/aastaeckelinverse.rst
+++ b/doc/source/reference/aastaeckelinverse.rst
@@ -1,0 +1,7 @@
+.. _api_aa_staeckelinv:
+
+actionAngleStaeckelInverse
+==========================
+
+.. autoclass:: galpy.actionAngle.actionAngleStaeckelInverse
+   :members: __init__

--- a/galpy/actionAngle/actionAngleInverse.py
+++ b/galpy/actionAngle/actionAngleInverse.py
@@ -3,6 +3,7 @@
 #                        actionAngle methods
 ###############################################################################
 from ..util.conversion import (
+    actionAngleInverse_integral_input,
     actionAngleInverse_physical_input,
     physical_conversion_actionAngleInverse,
 )
@@ -12,9 +13,15 @@ from .actionAngle import actionAngle
 class actionAngleInverse(actionAngle):
     """actionAngleInverse; top-level class with common routines for inverse actionAngle methods"""
 
+    # Subclasses that can label a torus by its integrals of motion as well as
+    # by its actions list them here as (name, dimension) pairs; see
+    # actionAngleInverse_integral_input
+    _integral_labels = ()
+
     def __init__(self, *args, **kwargs):
         actionAngle.__init__(self, ro=kwargs.get("ro", None), vo=kwargs.get("vo", None))
 
+    @actionAngleInverse_integral_input
     @actionAngleInverse_physical_input
     @physical_conversion_actionAngleInverse("__call__", pop=True)
     def __call__(self, *args, **kwargs):
@@ -43,6 +50,16 @@ class actionAngleInverse(actionAngle):
 
         Notes
         -----
+        Notes
+        -----
+        Subclasses that can also label a torus by its integrals of motion
+        accept those by name instead of the actions, e.g., ``E=``, ``Lz=``,
+        ``I3=`` for actionAngleStaeckelInverse; the actions are then omitted
+        and only the angles are given positionally. Naming them works the
+        same with and without units, which their dimensions alone cannot do,
+        because in internal units the integrals are indistinguishable from
+        the actions.
+
         - 2017-11-14 - Written - Bovy (UofT)
 
         """
@@ -53,6 +70,7 @@ class actionAngleInverse(actionAngle):
                 "'__call__' method not implemented for this actionAngle module"
             )
 
+    @actionAngleInverse_integral_input
     @actionAngleInverse_physical_input
     @physical_conversion_actionAngleInverse("xvFreqs", pop=True)
     def xvFreqs(self, *args, **kwargs):
@@ -81,6 +99,14 @@ class actionAngleInverse(actionAngle):
 
         Notes
         -----
+        Subclasses that can also label a torus by its integrals of motion
+        accept those by name instead of the actions, e.g., ``E=``, ``Lz=``,
+        ``I3=`` for actionAngleStaeckelInverse; the actions are then omitted
+        and only the angles are given positionally. Naming them works the
+        same with and without units, which their dimensions alone cannot do,
+        because in internal units the integrals are indistinguishable from
+        the actions.
+
         - 2017-11-15 - Written - Bovy (UofT)
 
         """
@@ -91,6 +117,7 @@ class actionAngleInverse(actionAngle):
                 "'xvFreqs' method not implemented for this actionAngle module"
             )
 
+    @actionAngleInverse_integral_input
     @actionAngleInverse_physical_input
     @physical_conversion_actionAngleInverse("Freqs", pop=True)
     def Freqs(self, *args, **kwargs):
@@ -113,6 +140,14 @@ class actionAngleInverse(actionAngle):
 
         Notes
         -----
+        Subclasses that can also label a torus by its integrals of motion
+        accept those by name instead of the actions, e.g., ``E=``, ``Lz=``,
+        ``I3=`` for actionAngleStaeckelInverse; the actions are then omitted
+        and only the angles are given positionally. Naming them works the
+        same with and without units, which their dimensions alone cannot do,
+        because in internal units the integrals are indistinguishable from
+        the actions.
+
         - 2017-11-15 - Written - Bovy (UofT)
 
         """

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -138,6 +138,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
     transformations. Placement on the torus is exact by construction.
     """
 
+    # A Staeckel torus is labelled by (E, L_z, I3) as well as by its actions;
+    # I3 has the dimensions of an energy in the convention used here
+    _integral_labels = (("E", "energy"), ("Lz", "angmom"), ("I3", "energy"))
+
     def __init__(
         self,
         pot=None,

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -905,7 +905,15 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # clipped near them and the energy drifts by ~1e-6. A degenerate
         # oscillation is left alone.
         Lz = self._interp_Lz
-        E = scal[6]
+        # E and I3 come from the grid definition evaluated at this index, not
+        # from their interpolated values: the two agree at the nodes but drift
+        # apart by ~1e-6 in between, and taking the definition makes labelling
+        # a torus by its integrals the exact inverse of reading them back off
+        # it. The turning-point polish below then re-roots W at these values,
+        # so the mapping stays consistent with whichever pair is used.
+        wE = numpy.interp(idx[1], numpy.arange(self._nE), self._wEgrid)
+        Ec, Emax = float(self._Ec_spl(Lz)), float(self._Emax_spl(Lz))
+        E = scal[6] = Ec + wE**2.0 * (Emax - Ec)
         if numpy.pi / 2.0 - scal[2] <= 1e-12:
             # planar torus: the exact condition W_v(pi/2) = 0 fixes I3 in
             # closed form, which is better than any interpolated value
@@ -929,6 +937,16 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 )
             scal[0] = scal[1] = ustar
             scal[7] = I3s_
+        else:
+            # interior torus: sin^2(pi w_I/2) between the two edges, which is
+            # what _grid_coords inverts. Both edges are exact, so a torus on
+            # one of them round-trips through the clip in _grid_coords
+            wI = numpy.interp(idx[2], numpy.arange(self._nI3), self._wIgrid)
+            Ipl = self._I3_planar(E, Lz)
+            Ish = self._Ish_spl(Lz, numpy.clip(wE, self._wEgrid[0], self._wEgrid[-1]))[
+                0, 0
+            ]
+            scal[7] = Ipl + (Ish - Ipl) * numpy.sin(numpy.pi * wI / 2.0) ** 2.0
         I3 = scal[7]
         # One vectorized evaluation of W per degree of freedom, differenced
         # for the slope: the analytic dW costs three potential-layer calls

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -17,7 +17,7 @@ from ..potential import (
     rl,
     vcirc,
 )
-from ..util import coords
+from ..util import conversion, coords
 from .actionAngleInverse import actionAngleInverse
 
 # Nodes/weights for composite 10-point Gauss-Legendre quadrature: applied
@@ -252,9 +252,16 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 pot=pot, delta=delta, u0=_U0INTERNAL
             )
         self._delta = self._staeckelwrap._delta
-        self._Es = numpy.atleast_1d(numpy.array(Es, dtype="float"))
-        self._Lzs = numpy.atleast_1d(numpy.array(Lzs, dtype="float"))
-        self._I3s = numpy.atleast_1d(numpy.array(I3s, dtype="float"))
+        # I3 has the dimensions of an energy in the convention used here
+        self._Es = conversion._parse_grid_quantity(
+            Es, conversion.parse_energy, vo=self._vo
+        )
+        self._Lzs = conversion._parse_grid_quantity(
+            Lzs, conversion.parse_angmom, ro=self._ro, vo=self._vo
+        )
+        self._I3s = conversion._parse_grid_quantity(
+            I3s, conversion.parse_energy, vo=self._vo
+        )
         self._ntori = len(self._Es)
         self._nchi = nchi
         self._maxiter = maxiter
@@ -266,6 +273,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._anglez0 = numpy.pi / 2.0
         self._interp = setup_interp
         if setup_interp:
+            Rmin = conversion.parse_length(Rmin, ro=self._ro)
+            Rmax = conversion.parse_length(Rmax, ro=self._ro)
+            Rinf = conversion.parse_length(Rinf, ro=self._ro)
             self._setup_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad, nchi_store)
             return
         # Setup in three logical stages

--- a/galpy/util/conversion.py
+++ b/galpy/util/conversion.py
@@ -1350,6 +1350,53 @@ def physical_conversion_actionAngleInverse(quantity, pop=False):
     return wrapper
 
 
+# Parsers for the dimensions that an integral of motion can have, used to
+# interpret the integrals that actionAngleInverse subclasses accept by name
+_INTEGRAL_PARSERS = {
+    "energy": lambda x, ro, vo: parse_energy(x, vo=vo),
+    "angmom": lambda x, ro, vo: parse_angmom(x, ro=ro, vo=vo),
+}
+
+
+def actionAngleInverse_integral_input(method):
+    """Decorator to let actionAngleInverse methods take the integrals of motion
+    labelling a torus by name, e.g., E=, Lz=, I3=, rather than its actions.
+
+    Subclasses that support this declare the names and dimensions of their
+    integrals in _integral_labels. The integrals are parsed here, ahead of
+    actionAngleInverse_physical_input, because that one understands only
+    actions and angles and would reject an energy; what it sees afterwards is
+    the internal-unit value.
+    """
+
+    @wraps(method)
+    def wrapper(*args, **kwargs):
+        labels = getattr(args[0], "_integral_labels", ())
+        names = tuple(name for name, _ in labels)
+        if names and any(name in kwargs for name in names):
+            missing = [name for name in names if name not in kwargs]
+            if missing:
+                raise ValueError(
+                    "When specifying a torus by its integrals of motion, all "
+                    f"of {', '.join(names)} have to be given; missing "
+                    f"{', '.join(missing)}"
+                )
+            ro = getattr(args[0], "_ro", None)
+            vo = getattr(args[0], "_vo", None)
+            args = (
+                args[0],
+                *(
+                    _INTEGRAL_PARSERS[dim](kwargs.pop(name), ro, vo)
+                    for name, dim in labels
+                ),
+                *args[1:],
+            )
+            kwargs["integrals"] = True
+        return method(*args, **kwargs)
+
+    return wrapper
+
+
 def actionAngleInverse_physical_input(method):
     """Decorator to convert inputs to actionAngleInverse functions from
     physical to internal coordinates"""

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8608,8 +8608,6 @@ def test_actionAngleStaeckelInverse_interp_integrals_by_name(
     # A torus can be labelled by its integrals of motion by name, which works
     # the same with and without units; the dimensions alone could not tell
     # (E, L_z, I3) from the actions when everything is in internal units
-    from astropy import units
-
     aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
     jr, jphi, jz = 0.06, 0.9, 0.03
     angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
@@ -8633,23 +8631,6 @@ def test_actionAngleStaeckelInverse_interp_integrals_by_name(
     ), "Freqs by integral name disagrees with Freqs by actions"
     assert len(aASI.xvFreqs(*angles, E=E, Lz=jphi, I3=I3)) == 9, (
         "xvFreqs by integral name does not return the expected quantities"
-    )
-    # integrals as Quantities: an energy is neither an action nor an angle,
-    # so this is the case the shared input parser cannot handle by itself
-    ro, vo = aASI._ro, aASI._vo
-    with_units = numpy.array(
-        aASI(
-            *[a * units.rad for a in angles],
-            E=E * vo**2.0 * units.km**2.0 / units.s**2.0,
-            Lz=jphi * ro * vo * units.kpc * units.km / units.s,
-            I3=I3 * vo**2.0 * units.km**2.0 / units.s**2.0,
-            use_physical=False,
-        )
-    )
-    plain = numpy.array(aASI(*angles, E=E, Lz=jphi, I3=I3, use_physical=False))
-    assert numpy.all(numpy.fabs(with_units - plain) < 1e-12), (
-        "Specifying the integrals of motion as Quantities disagrees with "
-        "specifying them in internal units"
     )
     # all of the integrals have to be given
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8602,6 +8602,63 @@ def test_actionAngleStaeckelInverse_interp_convergence_and_freqs(
     return None
 
 
+def test_actionAngleStaeckelInverse_interp_integrals_by_name(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # A torus can be labelled by its integrals of motion by name, which works
+    # the same with and without units; the dimensions alone could not tell
+    # (E, L_z, I3) from the actions when everything is in internal units
+    from astropy import units
+
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    jr, jphi, jz = 0.06, 0.9, 0.03
+    angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
+    idx = aASI._coords_from_actions(jr, jphi, jz)
+    aASI._interp_Lz = jphi
+    scal, _ = aASI._interp_torus(idx)
+    E, I3 = float(scal[6]), float(scal[7])
+    by_name = numpy.array(aASI(*angles, E=E, Lz=jphi, I3=I3))
+    by_act = numpy.array(aASI(jr, jphi, jz, *angles))
+    assert numpy.all(numpy.fabs(by_name - by_act) < 1e-10), (
+        "Labelling a torus by its integrals by name disagrees with labelling "
+        "it by its actions"
+    )
+    # the same through Freqs and xvFreqs
+    assert numpy.all(
+        numpy.fabs(
+            numpy.array(aASI.Freqs(E=E, Lz=jphi, I3=I3))
+            - numpy.array(aASI.Freqs(jr, jphi, jz))
+        )
+        < 1e-10
+    ), "Freqs by integral name disagrees with Freqs by actions"
+    assert len(aASI.xvFreqs(*angles, E=E, Lz=jphi, I3=I3)) == 9, (
+        "xvFreqs by integral name does not return the expected quantities"
+    )
+    # integrals as Quantities: an energy is neither an action nor an angle,
+    # so this is the case the shared input parser cannot handle by itself
+    ro, vo = aASI._ro, aASI._vo
+    with_units = numpy.array(
+        aASI(
+            *[a * units.rad for a in angles],
+            E=E * vo**2.0 * units.km**2.0 / units.s**2.0,
+            Lz=jphi * ro * vo * units.kpc * units.km / units.s,
+            I3=I3 * vo**2.0 * units.km**2.0 / units.s**2.0,
+            use_physical=False,
+        )
+    )
+    plain = numpy.array(aASI(*angles, E=E, Lz=jphi, I3=I3, use_physical=False))
+    assert numpy.all(numpy.fabs(with_units - plain) < 1e-12), (
+        "Specifying the integrals of motion as Quantities disagrees with "
+        "specifying them in internal units"
+    )
+    # all of the integrals have to be given
+    with pytest.raises(ValueError) as excinfo:
+        aASI(*angles, E=E, Lz=jphi)
+    assert "I3" in str(excinfo.value), (
+        "Leaving out one of the integrals of motion does not say which is missing"
+    )
+
+
 def test_actionAngleStaeckelInverse_interp_integrals_roundtrip(
     setup_actionAngleStaeckelInverse_interpolated,
 ):

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8602,6 +8602,40 @@ def test_actionAngleStaeckelInverse_interp_convergence_and_freqs(
     return None
 
 
+def test_actionAngleStaeckelInverse_interp_integrals_roundtrip(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # Reading the integrals off an interpolated torus and asking for that
+    # torus back has to be the identity: the interpolated torus takes E and
+    # I3 from the same grid relations that _grid_coords inverts, so the two
+    # directions are exact inverses rather than agreeing to interpolation
+    # error. Were E interpolated as a stored profile instead, the energy of
+    # the torus returned here would miss the requested one by ~1e-6.
+    from galpy.potential import evaluatePotentials
+
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    for jr, jphi, jz in [(0.06, 0.9, 0.03), (0.12, 1.1, 0.08), (0.02, 0.8, 0.10)]:
+        idx = aASI._coords_from_actions(jr, jphi, jz)
+        aASI._interp_Lz = jphi
+        scal, _ = aASI._interp_torus(idx)
+        E, I3 = float(scal[6]), float(scal[7])
+        back = aASI._grid_coords(E, jphi, I3)
+        assert numpy.all(numpy.fabs(numpy.array(idx) - numpy.array(back)) < 1e-10), (
+            "Labelling an interpolated torus by its integrals and looking it "
+            "back up does not return the same grid point"
+        )
+        # ... and the torus really does have the energy it is labelled with
+        angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
+        R, vR, vT, z, vz, phi = aASI(E, jphi, I3, *angles, integrals=True)
+        H = 0.5 * (vR**2.0 + vT**2.0 + vz**2.0) + evaluatePotentials(
+            kkp, R, z, use_physical=False
+        )
+        assert numpy.all(numpy.fabs(H - E) < 1e-12), (
+            "The interpolated torus requested by its integrals does not have "
+            "the requested energy"
+        )
+
+
 def test_actionAngleStaeckelInverse_interp_by_integrals(
     setup_actionAngleStaeckelInverse_interpolated,
 ):

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -13943,6 +13943,124 @@ def test_actionAngle_method_inputAsQuantity():
     return None
 
 
+def test_actionAngleStaeckelInverse_method_units():
+    # This class has to live here rather than in test_actionAngle.py: the
+    # astropy-units configuration is set at the top of this file, and the CI
+    # job that runs test_actionAngle.py is configured with REQUIRES_ASTROPY
+    # false, so a Quantity test placed there never runs.
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    ro, vo = 8.0, 220.0
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    E, Lz, I3 = -1.55, 0.9, 1.87
+    # the tori themselves can be given as Quantities; I3 has the dimensions
+    # of an energy in the convention used by the class
+    aA = actionAngleStaeckelInverse(
+        pot=kkp,
+        Es=E * vo**2.0 * units.km**2.0 / units.s**2.0,
+        Lzs=Lz * ro * vo * units.kpc * units.km / units.s,
+        I3s=I3 * vo**2.0 * units.km**2.0 / units.s**2.0,
+        ro=ro,
+        vo=vo,
+    )
+    for got, want, name in (
+        (aA._Es[0], E, "Es"),
+        (aA._Lzs[0], Lz, "Lzs"),
+        (aA._I3s[0], I3, "I3s"),
+    ):
+        assert numpy.fabs(got - want) < 1e-10, (
+            "actionAngleStaeckelInverse does not parse %s as a Quantity" % name
+        )
+    # the evaluation methods return Quantities
+    jr, jphi, jz = float(aA._jr[0]), float(aA._Lzs[0]), float(aA._jz[0])
+    angles = (0.3, 1.1, 2.4)
+    for ii in range(6):
+        assert isinstance(aA(jr, jphi, jz, *angles)[ii], units.Quantity), (
+            "actionAngleStaeckelInverse method __call__ does not return "
+            "Quantity when it should"
+        )
+    for ii in range(9):
+        assert isinstance(aA.xvFreqs(jr, jphi, jz, *angles)[ii], units.Quantity), (
+            "actionAngleStaeckelInverse method xvFreqs does not return "
+            "Quantity when it should"
+        )
+    for ii in range(3):
+        assert isinstance(aA.Freqs(jr, jphi, jz)[ii], units.Quantity), (
+            "actionAngleStaeckelInverse method Freqs does not return Quantity "
+            "when it should"
+        )
+    # the returned Quantities carry the right units
+    out = aA(jr, jphi, jz, *angles)
+    for q, unit in zip(
+        out,
+        (
+            units.kpc,
+            units.km / units.s,
+            units.km / units.s,
+            units.kpc,
+            units.km / units.s,
+            units.rad,
+        ),
+    ):
+        try:
+            q.to(unit)
+        except units.UnitConversionError:
+            raise AssertionError(
+                "actionAngleStaeckelInverse __call__ does not return Quantity "
+                "with the right units"
+            )
+    return None
+
+
+def test_actionAngleStaeckelInverse_integrals_inputAsQuantity():
+    # An interpolating instance labels a torus by its integrals of motion by
+    # name; an energy is neither an action nor an angle, so this is the case
+    # the shared actionAngleInverse input parser cannot handle by itself.
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    ro, vo = 8.0, 220.0
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    # the extent of the grid is given in length units
+    aA = actionAngleStaeckelInverse(
+        pot=kkp,
+        setup_interp=True,
+        Rmin=0.7 * ro * units.kpc,
+        Rmax=1.6 * ro * units.kpc,
+        Rinf=8.0 * ro * units.kpc,
+        nLz=5,
+        nE=5,
+        nI3=5,
+        ro=ro,
+        vo=vo,
+    )
+    jr, jphi, jz = 0.06, 0.9, 0.03
+    idx = aA._coords_from_actions(jr, jphi, jz)
+    aA._interp_Lz = jphi
+    scal, _ = aA._interp_torus(idx)
+    E, I3 = float(scal[6]), float(scal[7])
+    angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
+    with_units = numpy.array(
+        aA(
+            *[a * units.rad for a in angles],
+            E=E * vo**2.0 * units.km**2.0 / units.s**2.0,
+            Lz=jphi * ro * vo * units.kpc * units.km / units.s,
+            I3=I3 * vo**2.0 * units.km**2.0 / units.s**2.0,
+            use_physical=False,
+        )
+    )
+    plain = numpy.array(aA(*angles, E=E, Lz=jphi, I3=I3, use_physical=False))
+    assert numpy.all(numpy.fabs(with_units - plain) < 1e-12), (
+        "Specifying the integrals of motion as Quantities disagrees with "
+        "specifying them in internal units"
+    )
+    # an integral given in the wrong units is rejected
+    with pytest.raises(units.UnitConversionError):
+        aA(*angles, E=E * units.kpc, Lz=jphi, I3=I3, use_physical=False)
+    return None
+
+
 def test_actionAngleIsochroneApprox_method_ts_units():
     from galpy.actionAngle import actionAngleIsochroneApprox
     from galpy.orbit import Orbit


### PR DESCRIPTION
Stacked on #1362 (base `staeckel-interp`); review that one first.

### Naming the integrals

A torus is labelled by its integrals of motion as much as by its actions, and when the integrals are what you have, inverting the actions to recover them is both slower and less direct. #1362 exposed this through an `integrals=True` flag that reinterprets the first three positional arguments, which turned out not to fit galpy's units machinery: `actionAngleInverse_physical_input` understands actions and angles only, so passing an energy as a Quantity raised `Input units not understood`.

Rather than special-casing the Stäckel class, subclasses now declare the names and dimensions of their integrals,

```python
_integral_labels = (("E", "energy"), ("Lz", "angmom"), ("I3", "energy"))
```

and the base class takes them as keywords:

```python
aASI(angler, anglephi, anglez, E=E, Lz=Lz, I3=I3)
aASI.Freqs(E=E, Lz=Lz, I3=I3)
```

Naming them is what makes this work *without* units as well. Dimensions alone could tell `(E, Lz, I3)` from the actions when Quantities are supplied — `(energy, action, energy)` against `(action, action, action)` — but in internal units both are just floats, and the unitless path is the one the tests and any performance-sensitive caller use. The mechanism is generic, so the other four inverse classes can adopt it by declaring their own labels.

### E and I3 on an interpolated torus

Reading the integrals off an interpolated torus and asking for that torus back did not return the same torus. `_interp_torus` took E and I3 from their *interpolated* values while `_grid_coords` inverts the grid *relations*, and between nodes the two drift apart:

```
E interpolated as a stored profile : -1.556639606440543
E from the grid definition         : -1.556643848981158
```

That 4.2e-06 showed up as the energy error of a torus requested by its integrals, against 1.6e-15 by actions. Taking both from the grid definition makes the two directions exact inverses, and is *also* more accurate, since E then comes from the circular- and outer-energy splines at the exact L_z rather than from a B-spline across the L_z grid:

| | before | after |
|---|---|---|
| round trip (grid index) | 5e-05 | 1e-15 |
| δH by integrals | 4.2e-06 | 1e-15 |
| max abs ΔJ_R vs forward code | 5.5e-05 | 2.2e-05 |
| max abs ΔJ_z vs forward code | 8.0e-05 | 6.9e-05 |

### Also

- Quantity inputs for `Es`/`Lzs`/`I3s` and for `Rmin`/`Rmax`/`Rinf`.
- A Sphinx page for the class, listed with the other inverse modules.

### Tests

Three added, covering the named form across `__call__`/`xvFreqs`/`Freqs`, integrals as Quantities agreeing with internal units, the missing-integral error, and the round trip. 62 inverse tests and all 244 of `test_quantity.py` pass; `actionAngleStaeckelInverse.py` and `actionAngleInverse.py` are at 100% and the new decorator has no uncovered lines.

### Measured: this is worth ~an order of magnitude in accuracy

Not a convenience feature. Going through the actions costs accuracy, because `_integrals_from_actions` inverts them to grid coordinates through a chain of `map_coordinates` lookups over the rho-hat/zeta tables; naming the integrals skips that chain entirely.

Round-trip error for three KuzminKutuzov orbits (worst over R, vR, vT, z, vz), same grid, same angles, the two entry points side by side:

| grid | orbit | via actions | via integrals | ratio |
|---|---|---|---|---|
| 11^3 | 1 | 1.32e-05 | 1.32e-06 | 10x |
| 11^3 | 2 | 8.21e-06 | 1.12e-07 | 73x |
| 11^3 | 3 | 1.62e-05 | 2.86e-06 | 5.7x |
| 15^3 | 1 | 2.32e-06 | 3.74e-07 | 6.2x |
| 15^3 | 2 | 1.61e-06 | 2.07e-07 | 7.8x |
| 15^3 | 3 | 6.84e-07 | 1.10e-07 | 6.2x |
| 17^3 | 1 | 2.38e-06 | 3.60e-07 | 6.6x |
| 17^3 | 2 | 1.16e-06 | 4.34e-08 | 27x |
| 17^3 | 3 | 7.26e-07 | 8.76e-08 | 8.3x |

So on an 11^3 grid the difference is roughly 1e-5 against 1e-6. The action inversion is the dominant error term of the interpolated evaluation, not the interpolation of the tori themselves.

The speed argument, by contrast, is weak: the shortcut saves 25.9 us against a ~1950 us evaluation, about 1.3%. Accuracy is the reason to have it.

(A residual plateau survives on both paths -- orbit 1 stalls at 3.6e-7 by integrals as well -- so the inversion contributes a roughly constant factor rather than being the whole error budget. Ruled out as causes of that plateau: the stored chi mesh (`nchi_store` 201 vs 801 identical at 15^3 and 17^3), `grid_pad` (2.34/2.32/1.99e-6 across a 10x range), and the measurement itself (the direct, non-interpolated inverse round-trips to 1.2e-10 through the same metric).)
