### PR TITLE
Say which way a torus falls outside the interpolation grid

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -836,13 +836,26 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             mode="nearest",
         )[0]
         rhat = rho / rhomax
-        if not (
-            self._rhatmesh[0] <= rhat <= self._rhatmesh[-1]
-            and self._zetamesh[0] <= zeta <= self._zetamesh[-1]
-        ):
+        # Say which way the torus falls out and what the grid does reach:
+        # rho and zeta are rectified coordinates, so quoting them alone leaves
+        # the caller no way to tell a too-energetic torus from a near-circular
+        # one, nor how much of a grid change would take it in
+        if not self._zetamesh[0] <= zeta <= self._zetamesh[-1]:
             raise ValueError(
-                "Given actions lie outside the grid of this "
-                "actionAngleStaeckelInverse instance"
+                f"J_z/(J_R+J_z) = {jz / (jr + jz):g} lies outside the grid of "
+                f"this actionAngleStaeckelInverse instance, which covers "
+                f"[{numpy.sin(numpy.pi * self._zetamesh[0] / 2.0) ** 2.0:g}, "
+                f"{numpy.sin(numpy.pi * self._zetamesh[-1] / 2.0) ** 2.0:g}]"
+            )
+        if not self._rhatmesh[0] <= rhat <= self._rhatmesh[-1]:
+            lo = (self._rhatmesh[0] * rhomax) ** 2.0
+            hi = (self._rhatmesh[-1] * rhomax) ** 2.0
+            raise ValueError(
+                f"J_R+J_z = {jr + jz:g} lies outside the grid of this "
+                f"actionAngleStaeckelInverse instance, "
+                f"{'below' if rhat < self._rhatmesh[0] else 'above'} the total "
+                f"action it covers at J_phi = {Lz:g} and "
+                f"J_z/(J_R+J_z) = {jz / (jr + jz):g} ([{lo:g}, {hi:g}])"
             )
         irhat = numpy.interp(rhat, self._rhatmesh, numpy.arange(self._nE))
         c = numpy.array([[iLz + p], [irhat + p], [izeta + p]])

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8640,6 +8640,42 @@ def test_actionAngleStaeckelInverse_interp_integrals_by_name(
     )
 
 
+def test_actionAngleStaeckelInverse_interp_outside_grid_message(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # Actions outside the grid have to say which way they fall out and what
+    # the grid does reach: rho and zeta are rectified coordinates, so a
+    # near-circular torus and a too-energetic one are otherwise reported
+    # identically, with nothing to act on
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    angles = [numpy.array([0.3]) for _ in range(3)]
+    with pytest.raises(ValueError) as excinfo:
+        aASI(1e-7, 0.9, 1e-7, *angles)
+    assert "below" in str(excinfo.value) and "J_R+J_z" in str(excinfo.value), (
+        "A near-circular torus outside the grid does not report that it falls "
+        "below the covered total action"
+    )
+    with pytest.raises(ValueError) as excinfo:
+        aASI(3.0, 0.9, 2.0, *angles)
+    assert "above" in str(excinfo.value) and "J_R+J_z" in str(excinfo.value), (
+        "A too-energetic torus outside the grid does not report that it falls "
+        "above the covered total action"
+    )
+    # the direction of the oscillation can also fall outside the grid, when
+    # the planar and shell edges do not reach zeta = 0 and 1 at every column
+    zetamesh = aASI._zetamesh
+    try:
+        aASI._zetamesh = numpy.linspace(0.4, 0.6, len(zetamesh))
+        with pytest.raises(ValueError) as excinfo:
+            aASI(0.06, 0.9, 0.03, *angles)
+        assert "J_z/(J_R+J_z)" in str(excinfo.value), (
+            "A torus outside the covered range of oscillation directions does "
+            "not report which ratio of actions it has"
+        )
+    finally:
+        aASI._zetamesh = zetamesh
+
+
 def test_actionAngleStaeckelInverse_interp_integrals_roundtrip(
     setup_actionAngleStaeckelInverse_interpolated,
 ):


### PR DESCRIPTION
Third in the stack (base `staeckel-interp-units`, #1373); review #1362 and #1373 first.

`_integrals_from_actions` rejected an out-of-grid torus with

```
Given actions lie outside the grid of this actionAngleStaeckelInverse instance
```

which says nothing a caller can act on. `rho` and `zeta` are rectified coordinates, so a *near-circular* torus and a *too-energetic* one produced exactly the same message, and neither reported what the grid does reach. I hit this while probing the grid on a realistic potential and needed three separate scripts to work out that the torus was below the low-action edge rather than above the high-energy one.

Now:

```
J_R+J_z = 2e-07 lies outside the grid of this actionAngleStaeckelInverse
instance, below the total action it covers at J_phi = 0.9 and
J_z/(J_R+J_z) = 0.5 ([0.000423367, 1.91512])
```

The range is quoted in actions rather than in the internal `rhat`, since that is the quantity the caller has. The phrase "outside the grid" is kept deliberately: existing tests match on it, and so might anyone else.

The direction of the oscillation gets its own message, for when the planar and shell edges do not reach `zeta = 0` and `1` at every column — `_zetamesh` is the intersection across columns, so it is not always `[0, 1]`.

### Tests

One test covering all three paths: below, above, and the oscillation-direction case (reached by narrowing `_zetamesh`, since KuzminKutuzov gives exactly `[0, 1]` and cannot trigger it). 64 inverse tests pass and both `actionAngleStaeckelInverse.py` and `actionAngleInverse.py` stay at 100%.

### Note

I deliberately left *advice* out of the messages. My first draft suggested lowering `Rinf` to move the low-action edge down; measuring it showed that lowering `Rinf` **raises** the `rhat` floor (0.269 → 0.941 going from `Rinf=6` to `1.6`), so the hint would have been wrong. The messages state only what was measured: the direction and the covered range.