### PR TITLE
Choose the OblateStaeckelWrapperPotential reference curve from delta

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -25,10 +25,6 @@ from .actionAngleInverse import actionAngleInverse
 # O((pi/nchi)^20), so every stored integral is at machine precision for any
 # reasonable nchi; there is no accuracy knob to tune
 _GLX, _GLW = numpy.polynomial.legendre.leggauss(10)
-# Reference u of the internal Staeckel splitting for potentials that are not
-# already wrapped; its value is irrelevant for an exactly Staeckel potential
-# (any choice gives the same U, V up to the fixed gauge)
-_U0INTERNAL = 1.15
 
 
 def _bspline_weights(t):
@@ -252,9 +248,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                     "KuzminKutuzovStaeckelPotential); wrap a general "
                     "axisymmetric potential in OblateStaeckelWrapperPotential"
                 )
-            self._staeckelwrap = OblateStaeckelWrapperPotential(
-                pot=pot, delta=delta, u0=_U0INTERNAL
-            )
+            self._staeckelwrap = OblateStaeckelWrapperPotential(pot=pot, delta=delta)
         self._delta = self._staeckelwrap._delta
         # I3 has the dimensions of an energy in the convention used here
         self._Es = conversion._parse_grid_quantity(


### PR DESCRIPTION
Fourth in the stack (base `staeckel-interp-coverage`, #1376); review #1362, #1373 and #1376 first.

### The problem

`OblateStaeckelWrapperPotential` builds V(v) along the curve u = u0 and defaulted to `u0=0.0` — the symmetry axis. V then only represents the wrapped potential near the axis, which is fine when the potential is *exactly* of Staeckel form (V is then independent of where it is sampled) and silently poor otherwise. That is exactly backwards: the potentials that need wrapping are the ones that are not Staeckel.

Concretely, wrapping MWPotential2014 at the default u0 gives a vertical curvature at the midplane of **−5e5 where the true value is +7.4** — sign-flipped, with a cusp at z=0 — and an interpolated grid whose vertical action never vanishes at the circular orbit (J_z = 0.127 at the lowest energy node, where it should be ~0). Sampling V anywhere off the axis removes it entirely: J_z = 1.8e-4, and `rhatmesh[0]` = 0.0158 against KuzminKutuzov's 0.0157.

A fixed `u0` is not a fix either, because the curve sits at R = delta·sinh(u0), so the same u0 wanders in radius as delta changes: 1.15 lands at R=0.53 for delta=0.372 but R=1.85 for delta=1.3.

### The change

The default becomes `arcsinh(1/delta)`, placing the reference curve at R=1 whatever delta is. Explicitly given `u0` is untouched, in both the scalar and `(R, z)` tuple forms.

`actionAngleStaeckelInverse` drops its private `_U0INTERNAL = 1.15` and simply takes the wrapper's default, so there is one definition rather than two constants that can drift apart.

### Why this is safe

Nothing in the codebase relied on the old default — every existing construction passes `u0` explicitly, including `tests/conftest.py`, the two wrapper subclasses in `tests/test_potential.py`, and the `test_quantity`/`test_orbit`/`test_actionAngle` call sites. The conftest fixture even comments that its delta "puts the registry orbit at u~1.5, comfortably away from the u=0 axis guard", so the axis was already known to be trouble.

### On the choice of R=1

A judgement call, not forced by the data. Sweeping the sampling radius for a typical disc orbit, the self-contained criterion (spread in H over the returned points, i.e. do they lie on one energy surface) has an interior minimum near R_ref ≈ 0.8:

| R_ref | 0.40 | 0.60 | 0.80 | 1.00 | 1.30 | 1.80 |
|---|---|---|---|---|---|---|
| dH spread | 1.4e-03 | 7.8e-04 | **4.7e-04** | 8.1e-04 | 1.4e-03 | 2.0e-03 |

R=1 is the natural-unit reference radius and is within a factor of ~1.7 of that optimum. (The action-error criterion falls monotonically toward small R_ref instead, but it measures agreement with the forward code's *per-orbit* u0, not correctness, so I did not weight it.)

### Tests

One test pinning R_ref = 1 across delta = 0.3/0.45/1.3, asserting u0 > 0, and checking both explicit forms still win. 64 inverse tests and 113 wrapper/Staeckel potential tests pass.