### PR TITLE
OblateStaeckelWrapperPotential: choose the reference curve from delta

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,15 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
+- ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
+  the focal length when none is given, placing it at R=1 rather than on the
+  symmetry axis. V(v) is built along u=u0 and only represents the wrapped
+  potential near that curve unless the potential is exactly of Staeckel form,
+  so the previous default of u0=0 -- the axis, where a flattened potential
+  looks nothing like it does in the disc -- silently gave a poor Staeckel
+  approximation for exactly the potentials that need wrapping. A fixed u0 also
+  wanders in radius as delta changes, since R = delta sinh(u0).
+
 - The action quadratures of ``actionAngleStaeckel`` are regularized at the
   turning points in both the C and the pure-Python path. The fixed-order
   Gauss-Legendre rule was previously applied against the square-root branch

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -48,7 +48,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     """
 
-    def __init__(self, amp=1.0, pot=None, delta=0.5, u0=0.0, ro=None, vo=None):
+    def __init__(self, amp=1.0, pot=None, delta=0.5, u0=None, ro=None, vo=None):
         """Initialize an OblateStaeckelWrapper Potential.
 
         Parameters
@@ -59,8 +59,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             Potential instance or a combined potential formed using addition (pot1+pot2+…); this potential is made into an oblate Staeckel potential.
         delta : float or Quantity, optional
             The focal length. Default is 0.5.
-        u0 : float or tuple or tuple of Quantity
-            Reference u value; if a tuple is given, this is assumed to be a (R,z) value to be converted to u.
+        u0 : float or tuple or tuple of Quantity, optional
+            Reference u value, the curve along which V(v) is built; if a tuple is given, this is assumed to be a (R,z) value to be converted to u. Defaults to arcsinh(1/delta), the value that places the reference curve at R=1 in the plane, whatever delta is. V(v) only represents the wrapped potential well near the reference curve unless the potential is exactly of Staeckel form, so this should sit near the orbits of interest; u0=0 is the symmetry axis and is degenerate for anything that is not exactly Staeckel.
         ro : float or Quantity, optional
             Distance scale for translation into internal units (default from configuration file).
         vo : float or Quantity, optional
@@ -71,10 +71,11 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         - 2017-12-15 - Started - Bovy (UofT)
         """
         self._delta = conversion.parse_length(delta, ro=ro)
-        if u0 is None:  # pragma: no cover
-            raise ValueError(
-                "u0= needs to be given to setup OblateStaeckelWrapperPotential"
-            )
+        if u0 is None:
+            # Place the reference curve at R=1, so that it tracks delta rather
+            # than landing at an arbitrary radius; a fixed u0 means
+            # R = delta sinh(u0), which drifts with delta
+            u0 = numpy.arcsinh(1.0 / self._delta)
         if isinstance(u0, (tuple, list, numpy.ndarray)):
             self._u0 = coords.Rz_to_uv(
                 conversion.parse_length(u0[0], ro=ro),

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -7191,6 +7191,44 @@ def test_WrapperPotential_print():
     return None
 
 
+def test_OblateStaeckelWrapperPotential_default_u0():
+    # V(v) is built along the curve u = u0, which sits at R = delta sinh(u0)
+    # in the plane, so a fixed u0 wanders in radius as delta changes and
+    # u0 = 0 is the symmetry axis, where V says nothing about a flattened
+    # potential. The default tracks delta instead, putting the curve at R=1.
+    from galpy import potential
+
+    for delta in (0.3, 0.45, 1.3):
+        asp = potential.OblateStaeckelWrapperPotential(
+            pot=potential.MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.3, normalize=True),
+            delta=delta,
+        )
+        assert numpy.fabs(delta * numpy.sinh(asp._u0) - 1.0) < 1e-10, (
+            "The default u0 of OblateStaeckelWrapperPotential does not put the "
+            "reference curve at R=1 for delta=%g" % delta
+        )
+        assert asp._u0 > 0.0, "The default u0 lies on the symmetry axis"
+    # an explicitly given u0 still wins, in both accepted forms
+    mnp = potential.MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.3, normalize=True)
+    assert (
+        numpy.fabs(
+            potential.OblateStaeckelWrapperPotential(pot=mnp, delta=0.45, u0=1.2)._u0
+            - 1.2
+        )
+        < 1e-10
+    ), "An explicitly given u0 is not used"
+    assert (
+        numpy.fabs(
+            potential.OblateStaeckelWrapperPotential(
+                pot=mnp, delta=0.45, u0=(1.0, 0.0)
+            )._u0
+            - numpy.arcsinh(1.0 / 0.45)
+        )
+        < 1e-10
+    ), "An explicitly given (R,z) u0 is not converted as expected"
+    return None
+
+
 def test_OblateStaeckelWrapperPotential_againstKuzmin():
     # Test that wrapping a KuzminDiskPotential as an oblateStaeckelWrapper
     # behaves as expected: U(u) = -GM/Delta cosh(u) and V(v) =-GM/Delta|cos(v)|


### PR DESCRIPTION
Independent of the Stäckel-inverse work and targeting `main` directly, so that both the current inverse and the alternative construction we want to compare against can build on it.

### The problem

`OblateStaeckelWrapperPotential` builds V(v) along the curve u = u0 and defaulted to `u0=0.0` — the symmetry axis. V then only represents the wrapped potential near the axis, which is harmless when the potential is *exactly* of Staeckel form (V is then independent of where it is sampled) and silently poor otherwise. That is backwards: the potentials that need wrapping are precisely the ones that are not Staeckel.

Wrapping MWPotential2014 at the default gives a vertical curvature at the midplane of **−5e5 where the true value is +7.4** — sign-flipped, with a cusp at z=0. Sampling V anywhere off the axis removes it entirely.

A fixed `u0` is not a fix either, since the curve sits at R = delta·sinh(u0): the same u0 lands at R=0.53 for delta=0.372 but R=1.85 for delta=1.3.

### The change

The default becomes `arcsinh(1/delta)`, placing the reference curve at R=1 whatever delta is. An explicitly given `u0` is untouched, in both the scalar and `(R, z)` tuple forms.

### Why this is safe

Nothing in the codebase relied on the old default — every existing construction passes `u0` explicitly, including `tests/conftest.py`, the two wrapper subclasses in `tests/test_potential.py`, and the call sites in `test_quantity`, `test_orbit` and `test_actionAngle`. The conftest fixture even notes that its delta "puts the registry orbit at u~1.5, comfortably away from the u=0 axis guard", so the axis was already known to be a trap.

### On the choice of R=1

A judgement call rather than something the data forces. Sweeping the sampling radius for a typical disc orbit, the self-contained criterion — the spread in H over the returned points — has an interior minimum near R_ref ≈ 0.8:

| R_ref | 0.40 | 0.60 | 0.80 | 1.00 | 1.30 | 1.80 |
|---|---|---|---|---|---|---|
| dH spread | 1.4e-03 | 7.8e-04 | **4.7e-04** | 8.1e-04 | 1.4e-03 | 2.0e-03 |

R=1 is the natural-unit reference radius and sits within a factor of ~1.7 of that optimum.

### Tests

One test pinning R_ref = 1 across delta = 0.3/0.45/1.3, asserting u0 > 0, and checking that both explicit forms still win.