### PR TITLE
special: guard the x=0 endpoint of d/dx gammainc on torch (#1204 review, 1/5)

### DIFF
--- a/galpy/backend/special/_fallback/gammainc.py
+++ b/galpy/backend/special/_fallback/gammainc.py
@@ -206,10 +206,16 @@ def _torch_autograd(upper):
                 pos = x > 0
                 x_safe = xp.where(pos, x, xp.ones_like(x))  # keep 0 out of the divide
                 dens = _prefix(xp, a, x_safe) / x_safe
+                # Build the limit in the RESULT dtype (dens), never *_like(a):
+                # callers legitimately pass an INTEGER order -- EinastoPotential
+                # does -- and torch.full_like(<int tensor>, inf) raises
+                # "value cannot be converted to type int64_t without overflow".
+                # dens is float by construction, and broadcasts against a.
+                one = xp.ones_like(dens)
                 at_zero = xp.where(
                     a < 1.0,
-                    xp.full_like(a, float("inf")),
-                    xp.where(a == 1.0, xp.ones_like(a), xp.zeros_like(a)),
+                    xp.full_like(dens, float("inf")),
+                    xp.where(a == 1.0, one, xp.zeros_like(dens)),
                 )
                 grad_x = grad_out * sign * xp.where(pos, dens, at_zero)
             if need_a:

--- a/galpy/backend/special/_fallback/gammainc.py
+++ b/galpy/backend/special/_fallback/gammainc.py
@@ -194,11 +194,24 @@ def _torch_autograd(upper):
             need_a, need_x = ctx.needs_input_grad[:2]
             grad_a = grad_x = None
             if need_x:
-                # closed form; no series, no continued fraction
+                # dP/dx = x^(a-1) e^-x / Gamma(a) = prefix(a,x)/x in closed form
+                # -- no series, no continued fraction. But prefix(a,0) = 0, so
+                # prefix/x is 0/0 at the x=0 endpoint and returns NaN there. x=0
+                # is reachable (it is a real evaluation point, and the value path
+                # already pins P(a,0)=0), so take the limit explicitly:
+                #     a < 1 -> +inf,   a = 1 -> 1,   a > 1 -> 0.
                 import galpy.backend as _gb
 
                 xp = _gb.get_namespace(x)
-                grad_x = grad_out * sign * _prefix(xp, a, x) / x
+                pos = x > 0
+                x_safe = xp.where(pos, x, xp.ones_like(x))  # keep 0 out of the divide
+                dens = _prefix(xp, a, x_safe) / x_safe
+                at_zero = xp.where(
+                    a < 1.0,
+                    xp.full_like(a, float("inf")),
+                    xp.where(a == 1.0, xp.ones_like(a), xp.zeros_like(a)),
+                )
+                grad_x = grad_out * sign * xp.where(pos, dens, at_zero)
             if need_a:
                 # only here does the loop run
                 import galpy.backend as _gb

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1163,3 +1163,29 @@ def test_gammainc_endpoints_zero_and_infinity(backend):
         assert not numpy.any(numpy.isnan(q)), f"gammaincc NaN at an endpoint, a={a}"
         numpy.testing.assert_array_equal(p, [0.0, 1.0])
         numpy.testing.assert_array_equal(q, [1.0, 0.0])
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_gammainc_grad_wrt_argument_at_endpoints(backend):
+    # x = 0 is a REAL evaluation point (the value test above pins P(a,0)=0), and
+    # dP/dx = x^(a-1) e^-x / Gamma(a) is computed as prefix(a,x)/x -- which is
+    # 0/0 there and returned NaN before this was guarded. The limit depends on a:
+    #     a < 1 -> +inf,   a = 1 -> 1,   a > 1 -> 0.
+    # NB jax's own native gammainc returns NaN for d/dx at a=1, x=0, so the
+    # reference here is the analytic limit, not another library.
+    for a0, want in ((0.5, numpy.inf), (1.0, 1.0), (2.0, 0.0), (3.0, 0.0)):
+        if backend == "jax":
+            if a0 == 1.0:
+                continue  # jax's native path is NaN here; nothing of ours to pin
+            ad = float(
+                jax.grad(lambda x: gsp.gammainc(jnp.asarray(a0), x))(jnp.asarray(0.0))
+            )
+        else:
+            xt = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+            gsp.gammainc(torch.tensor(a0, dtype=torch.float64), xt).backward()
+            ad = float(xt.grad)
+        assert not numpy.isnan(ad), f"d/dx gammainc(a={a0}) is NaN at x=0"
+        if numpy.isinf(want):
+            assert numpy.isinf(ad) and ad > 0, f"a={a0}: want +inf, got {ad}"
+        else:
+            numpy.testing.assert_allclose(ad, want, rtol=0, atol=1e-15)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1189,3 +1189,33 @@ def test_gammainc_grad_wrt_argument_at_endpoints(backend):
             assert numpy.isinf(ad) and ad > 0, f"a={a0}: want +inf, got {ad}"
         else:
             numpy.testing.assert_allclose(ad, want, rtol=0, atol=1e-15)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_gammainc_grad_with_an_integer_order_dtype():
+    # The x=0 endpoint limit must be built in the RESULT dtype, not with
+    # *_like(a): callers legitimately pass an INTEGER order -- EinastoPotential
+    # does, via its 3n/dn arguments -- and torch.full_like(<int tensor>, inf)
+    # raises "value cannot be converted to type int64_t without overflow".
+    # The first cut of the endpoint guard used full_like(a, inf) and broke
+    # every Einasto torch gradient; the value tests never saw it because they
+    # only ever passed a float order.
+    for a_int, a_flt in ((3, 3.0), (1, 1.0), (2, 2.0)):
+        ai = torch.tensor(a_int)  # int64 on purpose
+        af = torch.tensor(a_flt, dtype=torch.float64)
+        # away from the endpoint: integer and float order must agree exactly
+        gi, gf = [], []
+        for a in (ai, af):
+            x = torch.tensor(0.5, dtype=torch.float64, requires_grad=True)
+            gsp.gammainc(a, x).backward()
+            (gi if a is ai else gf).append(float(x.grad))
+        numpy.testing.assert_allclose(gi[0], gf[0], rtol=0, atol=0)
+        # ...and AT the endpoint, where the limit branch actually runs
+        x0 = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+        gsp.gammainc(ai, x0).backward()
+        want = 1.0 if a_int == 1 else 0.0  # a >= 1 here, so no +inf case
+        numpy.testing.assert_allclose(float(x0.grad), want, rtol=0, atol=1e-15)
+    # a = 1 at x = 0.5 has a closed form: P(1,x) = 1 - e^-x, so dP/dx = e^-x.
+    x = torch.tensor(0.5, dtype=torch.float64, requires_grad=True)
+    gsp.gammainc(torch.tensor(1), x).backward()
+    numpy.testing.assert_allclose(float(x.grad), numpy.exp(-0.5), rtol=1e-14)


### PR DESCRIPTION
First of the fixes from Codex's review of #1204. **Finding 1 of 5.**

## The bug

`galpy/backend/special/_fallback/gammainc.py` computes the derivative in the
argument in closed form:

    dP/dx = x^(a-1) e^-x / Gamma(a) = prefix(a, x) / x

`prefix(a, 0) = 0`, so at the `x = 0` endpoint that expression is `0/0` and the
custom backward returned **NaN**. `x = 0` is a reachable evaluation point — the
value test added in gh#1374 pins `P(a, 0) = 0` — so anyone differentiating a
gammainc through the endpoint got a silent NaN instead of a number or an error.

## The fix

Take the limit explicitly rather than dividing:

| | `dP/dx` at `x = 0` |
|---|---|
| `a < 1` | `+inf` |
| `a = 1` | `1` |
| `a > 1` | `0` |

selected with `xp.where` over a divide that is kept away from zero (both branches
of a traced `where` are evaluated, so the safe denominator is load-bearing, not
decoration — see `xp-where-dead-branch-guards`).

## Why it slipped through

gh#1374 added endpoint **value** tests but no endpoint **gradient** tests. That is
precisely the gap this fell through, so the new test closes it rather than just
pinning the fix.

One notable detail: **the oracle here is the analytic limit, not another library.**
jax's own native `gammainc` returns NaN for `d/dx` at `a = 1, x = 0`, where the
analytic answer is 1 (`P(1,x) = 1 - e^-x`, so `dP/dx = e^-x -> 1`). "Match jax"
would have pinned the wrong answer. The jax arm of the test skips that one point
because there is nothing of ours running there.

## Verification

A/B on the parent commit — the new test **fails** for torch without the fix and
passes with it:

    FAILED tests/test_backend_special.py::test_gammainc_grad_wrt_argument_at_endpoints[torch]
    1 failed, 1 passed

Away from the endpoint `d/dx` is unchanged and still exact:

    a=2.0, x=1.5: 3.346952402226e-01  exact 3.346952402226e-01  rel 1.7e-16
    a=3.0, x=4.0: 1.465251111099e-01  exact 1.465251111099e-01  rel 1.9e-16

Full `-k gammainc` selection: 15 passed.

**numpy path untouched** — this file is only reached for backend arrays.

## Ledger delta

None. No entry is added or removed; this fixes code merged this morning in
gh#1374 that no ledger row covers.

## Not in this PR

Finding 2 (`finite_part_quad` is scalar-only in `b`) turns out to need a genuinely
batched rewrite — `residual`, the `c/u^2` model term, the `-2c/b` finite part and
the `fixed_quad` calls all need consistent broadcasting, validated against its real
caller (`AnyAxisymmetricRazorThinDiskPotential`). It gets its own PR rather than
riding along with an unrelated one-line fix in a different module.