### PR TITLE
backend: finite_part_quad batching + symmetric_quad eager-torch limit + AnyAxisym torch construction (#1204 review, 2/5)

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -530,7 +530,21 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
     # folding it -- so asking about the converted limit always answers "unknown"
     # and the infinite branch would be unreachable. A Python/numpy ``b`` is still
     # concrete here and answers directly.
-    if not under_trace(b) and not bool(numpy.all(numpy.isfinite(numpy.asarray(b)))):
+    if under_trace(b):
+        # A tracer's finiteness is unknowable, so the finite branch it is.
+        concretely_infinite = False
+    elif is_backend_array(b):
+        # Eager backend array: ask the BACKEND, not numpy. numpy.asarray on a
+        # grad-tracking torch tensor RAISES rather than answering, so an
+        # ordinary finite limit that happens to require grad used to be
+        # rejected outright. isfinite returns a plain bool array with no grad
+        # of its own, so this stays a pure question about the value -- and an
+        # eager backend inf still reaches the semi-infinite branch, which
+        # blanket-treating backend arrays as finite would have broken.
+        concretely_infinite = not bool(xp.all(xp.isfinite(b)))
+    else:
+        concretely_infinite = not bool(numpy.all(numpy.isfinite(numpy.asarray(b))))
+    if concretely_infinite:
         zero = asarray_on_device(xp, 0.0, device)
         return fixed_quad_semiinfinite(
             xp, integrand, zero, n=n, device=device

--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -613,15 +613,7 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     dev = device if device is not None else device_of(b)
     zero = asarray_on_device(xp, 0.0, dev)
 
-    def on_nodes(v):
-        # b, c and peak_width are each combined with a trailing quadrature-node
-        # axis below, so a batch has to be lifted onto it or (batch,) meets
-        # (batch, n) and fails to broadcast. Scalars are left alone rather than
-        # reshaped: xp.asarray on a weak python float would strong-type it into
-        # the backend default dtype, which can be f32.
-        return v[..., None] if getattr(v, "ndim", 0) > 0 else v
-
-    c_n = on_nodes(c)
+    c_n = node_axis(c)
 
     def sym(u):
         return integrand(u) + integrand(-u)
@@ -645,13 +637,13 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     # differentiable. Costs 10 extra integrand evaluations against 2n.
     lam = xp.sum(
         asarray_on_device(xp, _LOG_W, dev)
-        * residual(on_nodes(b) * asarray_on_device(xp, _LOG_U, dev)),
+        * residual(node_axis(b) * asarray_on_device(xp, _LOG_U, dev)),
         axis=-1,
     )
     finite_part = (
         fixed_quad(
             xp,
-            lambda u: residual(u) + on_nodes(lam) * xp.log(u / on_nodes(b)),
+            lambda u: residual(u) + node_axis(lam) * xp.log(u / node_axis(b)),
             zero,
             b,
             n=n,
@@ -662,7 +654,7 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     )
     wide = peak_width > 0.0
     w = xp.where(wide, peak_width, xp.ones_like(peak_width))
-    w_n = on_nodes(w)
+    w_n = node_axis(w)
     peaked = fixed_quad(
         xp,
         lambda t: sym(w_n * xp.sinh(t)) * w_n * xp.cosh(t),

--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -599,11 +599,21 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     dev = device if device is not None else device_of(b)
     zero = asarray_on_device(xp, 0.0, dev)
 
+    def on_nodes(v):
+        # b, c and peak_width are each combined with a trailing quadrature-node
+        # axis below, so a batch has to be lifted onto it or (batch,) meets
+        # (batch, n) and fails to broadcast. Scalars are left alone rather than
+        # reshaped: xp.asarray on a weak python float would strong-type it into
+        # the backend default dtype, which can be f32.
+        return v[..., None] if getattr(v, "ndim", 0) > 0 else v
+
+    c_n = on_nodes(c)
+
     def sym(u):
         return integrand(u) + integrand(-u)
 
     def residual(u):
-        return sym(u) - 2.0 * c / (u * u)
+        return sym(u) - 2.0 * c_n / (u * u)
 
     # Removing the c/u^2 model kills the pole but generally leaves a LOG:
     # residual(u) = -lam ln(u) + A + O(u). That is what caps plain GL at 1/n^2
@@ -621,12 +631,13 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     # differentiable. Costs 10 extra integrand evaluations against 2n.
     lam = xp.sum(
         asarray_on_device(xp, _LOG_W, dev)
-        * residual(b * asarray_on_device(xp, _LOG_U, dev))
+        * residual(on_nodes(b) * asarray_on_device(xp, _LOG_U, dev)),
+        axis=-1,
     )
     finite_part = (
         fixed_quad(
             xp,
-            lambda u: residual(u) + lam * xp.log(u / b),
+            lambda u: residual(u) + on_nodes(lam) * xp.log(u / on_nodes(b)),
             zero,
             b,
             n=n,
@@ -637,9 +648,10 @@ def finite_part_quad(xp, integrand, b, *, c, peak_width, n=_QUAD_N, device=None)
     )
     wide = peak_width > 0.0
     w = xp.where(wide, peak_width, xp.ones_like(peak_width))
+    w_n = on_nodes(w)
     peaked = fixed_quad(
         xp,
-        lambda t: sym(w * xp.sinh(t)) * w * xp.cosh(t),
+        lambda t: sym(w_n * xp.sinh(t)) * w_n * xp.cosh(t),
         zero,
         xp.asinh(b / w),
         n=n,

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -204,14 +204,14 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
             if _sdens_unit_input:
                 try:
                     surfdens(1.0 * units.kpc).to(units.Msun / units.pc**2)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, TypeError, units.UnitConversionError):
                     pass
                 else:
                     _sdens_unit_output = True
             else:
                 try:
                     surfdens(1.0).to(units.Msun / units.pc**2)
-                except (AttributeError, units.UnitConversionError):
+                except (AttributeError, TypeError, units.UnitConversionError):
                     pass
                 else:
                     _sdens_unit_output = True

--- a/tests/test_backend_anyaxisymdisk.py
+++ b/tests/test_backend_anyaxisymdisk.py
@@ -554,3 +554,42 @@ def test_traced_second_derivs_match_numpy_through_the_midplane(backend_name):
                         f"{backend_name} traced {fn.__name__} at R={R}, z={z}: "
                         f"rel err {rel:.2e} exceeds {tol:.0e} (numpy {ref:.6e})"
                     )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_construction_accepts_a_surfdens_that_returns_a_backend_array(backend_name):
+    # __init__ decides whether surfdens carries astropy units by DUCK-TYPING on
+    # .to(): call it and see whether the result converts to Msun/pc^2. A torch
+    # tensor HAS a .to() -- with a completely different meaning -- so instead of
+    # the expected AttributeError it raised
+    #     TypeError: to() received an invalid combination of arguments
+    #                - got (CompositeUnit)
+    # which was not in the except clause, and constructing this potential with a
+    # torch-returning surfdens died outright. jax escaped only because jax
+    # arrays have no .to at all.
+    #
+    # The module-level _surfdens does not exercise this: it dispatches on its
+    # ARGUMENT, and __init__ probes with a plain python float, so it comes back
+    # numpy on every backend. The surface density here is what a torch user
+    # actually writes -- backend array out, whatever goes in.
+    if backend_name == "jax":
+
+        def sdens(R):
+            return 1.5 * jnp.exp(-3.0 * jnp.asarray(R))
+
+    else:
+
+        def sdens(R):
+            return 1.5 * torch.exp(-3.0 * torch.as_tensor(R, dtype=torch.float64))
+
+    pot = AnyAxisymmetricRazorThinDiskPotential(surfdens=sdens)
+    # Constructing is most of the point, but not all of it: if the units probe
+    # had gone the OTHER way and decided this surfdens was unit-carrying, the
+    # amplitude would be silently rescaled. Pin the value against the
+    # equivalent numpy-dispatching surface density instead of just smoke-testing.
+    for R, z in ((0.9, 0.3), (1.3, 0.0)):
+        ref = float(evaluateRforces(_POT, numpy.float64(R), numpy.float64(z)))
+        got = float(
+            evaluateRforces(pot, _scalar(backend_name, R), _scalar(backend_name, z))
+        )
+        numpy.testing.assert_allclose(got, ref, rtol=1e-12, err_msg=f"R={R}, z={z}")

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -722,3 +722,86 @@ def test_finite_part_quad_branches_on_a_traced_peak_width(backend):
     numpy.testing.assert_allclose(
         at_zero, 2.0 * numpy.sinh(b) - 2.0 * c / b, rtol=1e-10, atol=1e-12
     )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_finite_part_quad_batches_over_its_limits(backend):
+    # b, c and peak_width are documented as arrays, and the integrand is called
+    # "vectorised over a trailing node axis" -- but every one of them used to be
+    # combined with that node axis unlifted, so a batch raised
+    # "operands could not be broadcast together with shapes (3,100) (3,)".
+    # Same closed form as the scalar test, evaluated as one batch:
+    #     f(u) = c/u**2 + exp(-u)  ->  finite part = 2 sinh(b) - 2c/b.
+    xp = _xp(backend)
+    bs = xp.asarray([1.3, 2.5, 0.4])
+    cs = xp.asarray([0.75, 1.7, 0.05])
+
+    def f(u):  # c varies per batch element, so it carries its own node axis
+        return cs[..., None] / (u * u) + xp.exp(-u)
+
+    got = finite_part_quad(xp, f, bs, c=cs, peak_width=xp.zeros_like(bs), n=200)
+    bs_n, cs_n = numpy.asarray(bs, dtype=float), numpy.asarray(cs, dtype=float)
+    expected = 2.0 * numpy.sinh(bs_n) - 2.0 * cs_n / bs_n
+    numpy.testing.assert_allclose(
+        numpy.asarray(got, dtype=float), expected, rtol=1e-10, atol=1e-12
+    )
+
+    # ...and a batch must agree with the same elements done one at a time, or
+    # the batching is quietly a different rule. This is the assertion that
+    # would catch a wrong-axis reduction (a bare xp.sum() collapsing the batch
+    # into one shared lam) which the closed form above tolerates poorly but
+    # does not pin exactly.
+    per_element = numpy.array(
+        [
+            float(
+                finite_part_quad(
+                    xp,
+                    lambda u, c0=c0: c0 / (u * u) + xp.exp(-u),
+                    xp.asarray(b0),
+                    c=c0,
+                    peak_width=xp.asarray(0.0),
+                    n=200,
+                )
+            )
+            for b0, c0 in zip(bs_n, cs_n)
+        ]
+    )
+    # numpy and jax reduce (batch, n) with the same kernel they use for (n,),
+    # so batched must be BIT-identical there. torch dispatches a different
+    # reduction for the 2-D case and lands ~1e-13 relative away (measured) --
+    # a reduction-order difference, not a different rule, so it gets a tight
+    # rtol rather than an exemption.
+    numpy.testing.assert_allclose(
+        numpy.asarray(got, dtype=float),
+        per_element,
+        rtol=1e-12 if backend == "torch" else 0.0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_finite_part_quad_batches_a_mix_of_both_branches(backend):
+    # The branch is per element, so one batch can need the finite part (w == 0)
+    # and the sinh substitution (w > 0) at once. Both arms are evaluated for
+    # every element, so this also checks the guarded width keeps asinh(b/0)
+    # from leaking nan into the elements that take the OTHER arm.
+    xp = _xp(backend)
+    bs = xp.asarray([1.3, 1.3, 1.3])
+    ws = xp.asarray([0.0, 0.25, 0.0])
+    c = 0.75
+
+    def f(u):
+        return c / (u * u) + xp.exp(-u)
+
+    got = numpy.asarray(
+        finite_part_quad(xp, f, bs, c=c, peak_width=ws, n=200), dtype=float
+    )
+    assert numpy.all(numpy.isfinite(got)), f"nan leaked from the untaken arm: {got}"
+    b = 1.3
+    # w == 0 -> the finite part; w > 0 -> the plain integral of sym, which for
+    # this f still carries the c/u**2 pole and so is NOT the finite part: the
+    # two arms must give genuinely different numbers here.
+    numpy.testing.assert_allclose(
+        got[[0, 2]], 2.0 * numpy.sinh(b) - 2.0 * c / b, rtol=1e-10, atol=1e-12
+    )
+    assert abs(got[1] - got[0]) > 1.0, "the two branches returned the same value"

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -805,3 +805,32 @@ def test_finite_part_quad_batches_a_mix_of_both_branches(backend):
         got[[0, 2]], 2.0 * numpy.sinh(b) - 2.0 * c / b, rtol=1e-10, atol=1e-12
     )
     assert abs(got[1] - got[0]) > 1.0, "the two branches returned the same value"
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_symmetric_quad_accepts_a_finite_eager_torch_limit_with_grad():
+    # The finite/infinite branch asked numpy whether b was finite:
+    #     not under_trace(b) and not numpy.all(numpy.isfinite(numpy.asarray(b)))
+    # An EAGER torch tensor is not under_trace, so an ordinary finite limit that
+    # merely requires grad went to numpy.asarray, which RAISES rather than
+    # answering ("Can't call numpy() on Tensor that requires grad"). jax never
+    # hit this: jax.grad makes b a tracer, so under_trace short-circuits.
+    b = torch.tensor(1.0, requires_grad=True)
+    got = symmetric_quad(_xp("torch"), lambda s: s * s, b)
+    numpy.testing.assert_allclose(float(got), 2.0 / 3.0, rtol=1e-13)
+    # Not crashing is not the bar -- the point of an eager grad-tracking limit
+    # is the gradient. d/db int_-b^b s^2 ds = 2 b^2 = 2 at b = 1.
+    got.backward()
+    numpy.testing.assert_allclose(float(b.grad), 2.0, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_symmetric_quad_still_takes_the_infinite_branch_for_a_backend_inf(backend):
+    # Guard on the FIX, not just the bug: the cheap repair is to treat every
+    # backend array as finite, which would silently send an eager backend inf
+    # down the finite branch and integrate over [-inf, inf] as if it were a
+    # bounded interval. Ask the backend for finiteness instead, and this stays
+    # reachable. int_-inf^inf exp(-s^2) ds = sqrt(pi).
+    xp = _xp(backend)
+    got = symmetric_quad(xp, lambda s: xp.exp(-s * s), xp.asarray(float("inf")))
+    numpy.testing.assert_allclose(float(got), numpy.sqrt(numpy.pi), rtol=1e-10)


### PR DESCRIPTION
Findings **2** and **10** from Codex's review of #1204, plus one bug the
byte-identity A/B turned up on its own. Disjoint from #1381.

## 1. `finite_part_quad` ignored its own documented signature (finding 2)

The docstring promises `b : array` and an integrand "vectorised over a trailing
node axis", but four sites combined a batch with that node axis unlifted:

```
ValueError: operands could not be broadcast together with shapes (3,100) (3,)
```

`fixed_quad` is already fully batched (`a[..., None] + span[..., None] * x01`,
reduce `axis=-1`), so everything it calls back into meets a `(batch, n)` node
array. The four: the `c/u^2` model term in `residual`; `b` in the `lam` slope
estimate **plus its reduction axis** (a bare `xp.sum` collapses the batch into
one shared `lam`); `w` in the sinh substitution; and `lam * log(u / b)` in the
log-subtraction lambda — which I only found because the batched test still
failed after fixing the first three.

A shared `on_nodes()` lifts each one and deliberately leaves **scalars alone**
rather than reshaping: `xp.asarray` on a weak python float would strong-type it
into the backend default dtype, which can be f32, and the existing callers pass
`c` as a plain float.

**Not a live bug.** The only caller is `AnyAxisym`, whose forces are decorated
`@check_potential_inputs_not_arrays`, so R and z are guaranteed scalar and the
broken path is unreachable. This is a general `galpy.backend` helper not
honouring its own signature, not a defect a user can hit today.

With no batched caller to validate against, the tests are analytic:
`f(u) = c/u^2 + exp(-u)` has finite part `2 sinh(b) - 2c/b`. They also assert
batched == per-element scalar (bit-identical on numpy/jax; torch dispatches a
different 2-D reduction and lands ~1e-13 relative away, so it gets a tight
rtol, **measured not guessed**), and cover a MIXED batch where some elements
take the finite part and others the sinh branch.

## 2. `symmetric_quad` rejected a finite eager torch limit (finding 10)

The finite/infinite branch asked **numpy** whether the limit was finite, so an
eager torch tensor that merely requires grad reached `numpy.asarray`, which
raises rather than answering. jax never hit this — `jax.grad` makes `b` a
tracer, so `under_trace` short-circuits first.

Asks the backend instead. Deliberately **not** the cheaper "treat every backend
array as finite": that would send an eager backend `inf` down the finite branch
and integrate `[-inf, inf]` as a bounded interval, trading a loud crash for a
silent wrong answer.

## 3. A torch-returning `surfdens` could not construct the potential

`AnyAxisymmetricRazorThinDiskPotential.__init__` duck-types "does surfdens carry
units?" by calling `.to()` and catching `AttributeError`. A torch tensor **has**
`.to()`, meaning something entirely different, so it raises `TypeError` — not in
the except clause, so construction died outright. jax escapes only because jax
arrays have no `.to` at all.

Found by the byte-identity A/B for (1): its torch arm would not run. Untested
because the test module's `_surfdens` dispatches on its *argument* and
`__init__` probes with a plain python float, so it comes back numpy on every
backend.

The units-**input** probe above it deliberately does **not** also catch
`TypeError`: there an exception means "expected units", while torch's means
"expected a Tensor", so catching it would mis-detect rather than fix.

## Verification

* **A/B**: all 6 new quadrature tests fail on the parent commit and pass here;
  the construction test fails for torch and passes for jax, at exactly
  `AnyAxisymmetricRazorThinDiskPotential.py:213`.
* **Gradients pinned, not just non-crashing**: `d/db ∫₋ᵦᵇ s² ds = 2b² = 2` to
  rtol 1e-12.
* Two of the `symmetric_quad` tests pass on **both** sides of the A/B by design
  — they guard the *shape* of the fix (that the semi-infinite branch stays
  reachable, `sqrt(pi)` to 1e-10 on jax and torch), not the bug.
* **numpy byte-identity** on the real caller: 32 AnyAxisym `R2deriv`/`z2deriv`
  values bit-for-bit equal on numpy **and** jax **and** torch (float64), arms
  differing only in `quadrature.py`.
* `tests/test_backend_quadrature.py`: 82 passed. Both touched files together:
  132 passed.

## Ledger delta

None. No entry added or removed.