### PR TITLE
coords: finish the inverse galcen transforms + fix the f64-constant/f32-data promotion (#1204 review, 3/4/6)

### DIFF
--- a/galpy/actionAngle/actionAngleIsochroneApprox.py
+++ b/galpy/actionAngle/actionAngleIsochroneApprox.py
@@ -963,6 +963,12 @@ class actionAngleIsochroneApprox(actionAngle):
             R, vR, vT, phi = args
             z, vz = 0.0 * R, 0.0 * vR
         xp = get_namespace(R, vR, vT, z, vz, phi)
+        # get_namespace answers from whichever argument IS a backend array, so a
+        # MIXED set -- some coordinates promoted by a caller, the rest still
+        # numpy scalars -- resolves to the backend and then fails on the numpy
+        # ones ("atleast_1d() received an invalid combination of arguments -
+        # got (numpy.float64)"). Coerce the whole set, do not data-guard.
+        R, vR, vT, z, vz, phi = coerce_coords(xp, R, vR, vT, z, vz, phi)
         R = xp.atleast_1d(R)
         vR, vT = xp.atleast_1d(vR), xp.atleast_1d(vT)
         z, vz, phi = xp.atleast_1d(z), xp.atleast_1d(vz), xp.atleast_1d(phi)

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -31,6 +31,7 @@ from ._namespaces import (
     match_input_dtype,
     name_of_namespace,
     prefer_backend_namespace,
+    promote_common_dtype,
     resolve_namespace,
     restrict_to_single_thread,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "is_backend_array",
     "is_backend_compatible",
     "match_input_dtype",
+    "promote_common_dtype",
     "name_of_namespace",
     "device_of",
     "asarray_on_device",

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -30,6 +30,7 @@ from ._namespaces import (
     is_backend_array,
     match_input_dtype,
     name_of_namespace,
+    prefer_backend_namespace,
     resolve_namespace,
     restrict_to_single_thread,
 )
@@ -64,6 +65,7 @@ __all__ = [
     "asarray_on_device",
     "as_numpy",
     "exit_cast",
+    "prefer_backend_namespace",
     "resolve_namespace",
     "fork_deadlocks_backend",
     "restrict_to_single_thread",

--- a/galpy/backend/_input.py
+++ b/galpy/backend/_input.py
@@ -41,7 +41,7 @@ import numpy
 from ._coerce import coerce_coords
 from ._compat import is_backend_compatible
 from ._jit import NOT_TRACED, traced_call
-from ._namespaces import device_of, is_backend_array
+from ._namespaces import device_of, is_backend_array, prefer_backend_namespace
 from ._resolver import get_namespace
 
 _EMPTY = inspect.Parameter.empty
@@ -174,8 +174,7 @@ def backend_input(*coords):
             # coordinates are weak and coerce_coords brings them across below,
             # whereas probing the mix raises "Multiple namespaces". Everything
             # below is skipped on the numpy path, so numpy pays just this probe.
-            on_backend = [val for val in probe if is_backend_array(val)]
-            xp = get_namespace(*(on_backend or probe))
+            xp = prefer_backend_namespace(*probe)
             if xp is not numpy and _backend_ready(args[0]):
                 # ONE device anchor for the whole call. Coercing each coordinate
                 # on its own would let each derive its own: a numpy/python

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -405,6 +405,25 @@ def effective_device(xp, device):
     return device
 
 
+def promote_common_dtype(xp, *arrays, device=None):
+    """``arrays`` on ``device``, all cast to their common ``result_type`` dtype.
+
+    galpy holds float64 constants -- rotation matrices, expansion-coefficient
+    tables, quadrature nodes -- and combines them with user coordinates. numpy
+    promotes that mismatch silently, but torch REFUSES to matmul float64
+    against float32, so at torch's DEFAULT dtype the combination raises
+    "expected m1 and m2 to have the same dtype" and an all-float64 test suite
+    never sees it. Promoting via ``result_type`` reproduces numpy's own rule,
+    so float32 input still returns the float64 result the numpy path gives
+    rather than quietly losing precision; contrast ``match_input_dtype``,
+    which is the EXIT cast for interiors that deliberately work in float64.
+    The cast goes through the namespace's ``astype``, so autodiff flows.
+    """
+    arrays = tuple(asarray_on_device(xp, a, device) for a in arrays)
+    dt = xp.result_type(*arrays)
+    return tuple(xp.astype(a, dt) for a in arrays)
+
+
 def asarray_on_device(xp, a, device, dtype=None):
     """``xp.asarray(a, dtype=dtype)`` placed on ``device`` when one is given.
 

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -223,6 +223,25 @@ def resolve_namespace(*args):
     return get_namespace(*(a for a in args if is_backend_array(a)))
 
 
+def prefer_backend_namespace(*args):
+    """Namespace of the backend args, falling back to probing ALL of them.
+
+    For entry points whose inputs may legitimately MIX backend arrays with
+    numpy/python ones -- e.g. backend coordinates with a numpy ``Xsun``.
+    Probing the mix raises "Multiple namespaces"; the numpy values are weak and
+    get coerced across, so the backend ones decide.
+
+    Distinct from :func:`resolve_namespace`, which falls back to the
+    context/forced namespace: that is right for a leaf shared by numpy and
+    backend callers, but wrong here, because it would reroute an all-numpy call
+    onto a forced backend rather than following the arguments it was given.
+    """
+    from ._resolver import get_namespace
+
+    on_backend = [a for a in args if is_backend_array(a)]
+    return get_namespace(*(on_backend or args))
+
+
 def _is_floating_dtype(dtype):
     """True for real floating-point dtypes of any backend.
 

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -125,7 +125,7 @@ def potential_positional_arg(func):
     return wrapper
 
 
-def _quad_needs_backend(xp, absz):
+def _quad_needs_backend(xp, *coords):
     """True only when scipy.integrate.quad CANNOT be used: we are inside a trace.
 
     The backend Gauss-Legendre rule exists here for exactly one reason -- under a
@@ -145,10 +145,16 @@ def _quad_needs_backend(xp, absz):
     wrong -- AnyAxisymmetricRazorThinDisk's surfdens came back 2.2e-15 instead of
     0.0662, order-dependently. ``under_trace`` asks
     ``torch.compiler.is_compiling()``, which dynamo cannot fool.
+
+    Ask about EVERY coordinate that reaches the integrand, not just the
+    integration limit. Gating on ``absz`` alone meant differentiating w.r.t. R
+    at fixed z fell into scipy and raised a jax concretization error, while the
+    same derivative w.r.t. z worked -- the integrand closes over R, phi and t
+    just as much as the limits depend on z.
     """
     if xp is numpy:
         return False
-    return under_trace(absz)
+    return any(under_trace(c) for c in coords)
 
 
 def _force_accepts_arrays(pot):
@@ -814,7 +820,7 @@ class Potential(Force):
         # numpy.fabs on a backend array emits a NumPy 2 __array_wrap__
         # DeprecationWarning, which the coverage shard turns into an error.
         absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
-        if not _quad_needs_backend(xp, absz):
+        if not _quad_needs_backend(xp, absz, R, phi, t):
             # epsabs=0 so the criterion is purely RELATIVE. quad's default
             # epsabs=1.49e-8 is ABSOLUTE, so a vertical integral whose own value is
             # at or below ~1e-8 in internal units passes the absolute test on the
@@ -911,7 +917,7 @@ class Potential(Force):
         # peaked off z=0 (6.4e-2 error vs 1.8e-4) -- see _vertical_quad_split.
         xp = get_namespace(R, z, phi, t)
         absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
-        if not _quad_needs_backend(xp, absz):
+        if not _quad_needs_backend(xp, absz, R, phi, t):
             # epsabs=0: purely RELATIVE, see the Poisson branch above.
             # MWPotential2014[0] at R=1, |z|=5 integrates to 8.2e-9 and came back
             # 9.6e-6 relative off under quad's default absolute tolerance.

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -157,6 +157,38 @@ def _promote_pair(xp, mat, data, dev):
     return xp.astype(mat, dt), xp.astype(data, dt)
 
 
+def _to_galcen_rot(xp, Xsun, Zsun):
+    """Heliocentric -> galactocentric rotation, plus ``dgc`` and promoted Xsun.
+
+    NOT the transpose of ``_galcen_rot``: here the sign(Xsun) convention lives
+    in the OPERAND rather than in the matrix, which is why the two differ and
+    still invert each other exactly (round trip 1.6e-15 at Xsun = -8). Shared
+    by XYZ_to_galcenrect and vxvyvz_to_galcenrect.
+    """
+    # Float-ify BEFORE promoting, as in _galcen_rot: an integer Xsun would drag
+    # a python-float Zsun to int and silently zero it.
+    Xsun, Zsun = promote_scalars(xp, Xsun * 1.0, Zsun * 1.0)
+    dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
+    costheta, sintheta = Xsun / dgc, Zsun / dgc
+    zero = xp.zeros_like(costheta)
+    one = xp.ones_like(costheta)
+    rot = xp.stack(
+        [
+            xp.stack([costheta, zero, -sintheta]),
+            xp.stack([zero, one, zero]),
+            xp.stack([sintheta, zero, costheta]),
+        ]
+    )
+    return rot, dgc, Xsun, getattr(costheta, "ndim", 0) > 0
+
+
+def _as_vsun(xp, vsun, dev):
+    """``vsun`` as a backend (3,) or (3, N) array; it may be a list of tracers."""
+    if isinstance(vsun, (list, tuple)):
+        return xp.stack(promote_scalars(xp, *vsun))
+    return asarray_on_device(xp, vsun, dev)
+
+
 def _apply_galcen_rot(xp, rot, data, batched, dev):
     """``rot @ data`` for backend ``data`` (3, N); mirrors the numpy einsum."""
     rot, data = _promote_pair(xp, rot, data, dev)
@@ -501,6 +533,7 @@ def lbd_to_XYZ(l, b, d, degree=False):
     """
     # Whether to use degrees and scalar input is handled by decorators
     xp = resolve_namespace(l, b, d)
+    l, b, d = coerce_coords(xp, l, b, d)
     # stack(axis=-1) IS the old numpy.array([...]).T: three (N,) columns give
     # (N, 3) either way. Written as a stack because .T on a freshly built
     # (3, N) is an extra transpose to trace through for no benefit.
@@ -632,6 +665,7 @@ def vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, l, b, d, XYZ=False, degree=False):
     """
     # Whether to use degrees and scalar input is handled by decorators
     xp = resolve_namespace(vr, pmll, pmbb, l, b, d)
+    vr, pmll, pmbb, l, b, d = coerce_coords(xp, vr, pmll, pmbb, l, b, d)
     if XYZ:  # undo the incorrect conversion that the decorator did
         if degree:
             # OUT-of-place: `l *= ...` cannot be done to a jax array.
@@ -1250,27 +1284,8 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     if _extra_rot:
         mat, data = _promote_pair(xp, galcen_extra_rot, xp.stack([X, Y, Z]), dev)
         X, Y, Z = mat @ data
-    # Float-ify BEFORE promoting, for the same reason as _galcen_rot: an integer
-    # Xsun would otherwise drag a python-float Zsun to int and silently zero it.
-    Xsun, Zsun = promote_scalars(xp, Xsun * 1.0, Zsun * 1.0)
-    dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
-    costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = xp.zeros_like(costheta)
-    one = xp.ones_like(costheta)
-    # This matrix is NOT _galcen_rot's, and deliberately so: the sign(Xsun)
-    # convention lives in the OPERAND below rather than in the matrix, which is
-    # why the two differ and still invert each other exactly (verified: the
-    # galcenrect_to_XYZ round trip is 1.6e-15 at Xsun = -8). Sharing the matrix
-    # builder here would break that. The CONTRACTION is shared instead.
-    rot = xp.stack(
-        [
-            xp.stack([costheta, zero, -sintheta]),
-            xp.stack([zero, one, zero]),
-            xp.stack([sintheta, zero, costheta]),
-        ]
-    )
+    rot, dgc, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
     data = xp.stack([-X + dgc, Y, xp.sign(Xsun) * Z])
-    batched = getattr(costheta, "ndim", 0) > 0
     return _apply_galcen_rot(xp, rot, data, batched, dev).T
 
 
@@ -1457,6 +1472,7 @@ def spher_to_cyl(r, theta, phi):
 
 
 @scalarDecorator
+@backendNative
 def XYZ_to_galcencyl(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     """
     Transform XYZ coordinates (wrt Sun) to cylindrical Galactocentric coordinates
@@ -1486,10 +1502,13 @@ def XYZ_to_galcencyl(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     - 2010-09-24 - Written - Bovy (NYU)
     - 2023-07-19 - Allowed Xsun/Zsun to be arrays - Bovy (UofT)
     """
-    XYZ = numpy.atleast_2d(
-        XYZ_to_galcenrect(X, Y, Z, Xsun=Xsun, Zsun=Zsun, _extra_rot=_extra_rot)
-    )
-    return numpy.array(rect_to_cyl(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2])).T
+    XYZ = XYZ_to_galcenrect(X, Y, Z, Xsun=Xsun, Zsun=Zsun, _extra_rot=_extra_rot)
+    xp = prefer_backend_namespace(XYZ)
+    if xp is numpy:
+        XYZ = numpy.atleast_2d(XYZ)
+        return numpy.array(rect_to_cyl(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2])).T
+    XYZ = xp.reshape(XYZ, (-1, 3))  # atleast_2d for a (3,) or (N, 3) result
+    return xp.stack(rect_to_cyl(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2], xp=xp), axis=-1)
 
 
 @scalarDecorator
@@ -1527,6 +1546,7 @@ def galcencyl_to_XYZ(R, phi, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
 
 
 @scalarDecorator
+@backendNative
 def vxvyvz_to_galcenrect(
     vx, vy, vz, vsun=[0.0, 1.0, 0.0], Xsun=1.0, Zsun=0.0, _extra_rot=True
 ):
@@ -1562,30 +1582,47 @@ def vxvyvz_to_galcenrect(
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
     - 2023-07-23 - Allowed Xsun/Zsun/vsun to be arrays- Bovy (UofT)
     """
+    vsun_probe = tuple(vsun) if isinstance(vsun, (list, tuple)) else (vsun,)
+    xp = prefer_backend_namespace(vx, vy, vz, Xsun, Zsun, *vsun_probe)
+    if xp is numpy:
+        # unchanged arithmetic: the numpy path stays BYTE-IDENTICAL (einsum and
+        # matmul disagree in the last ulp), same split as XYZ_to_galcenrect.
+        if _extra_rot:
+            vx, vy, vz = numpy.dot(galcen_extra_rot, numpy.array([vx, vy, vz]))
+        dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
+        costheta, sintheta = Xsun / dgc, Zsun / dgc
+        zero = numpy.zeros_like(costheta)
+        one = numpy.ones_like(costheta)
+        return (
+            numpy.einsum(
+                (
+                    "ijk,jk->ik"
+                    if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
+                    else "ij,jk->ik"
+                ),
+                numpy.array(
+                    [
+                        [costheta, zero, -sintheta],
+                        [zero, one, zero],
+                        [sintheta, zero, costheta],
+                    ]
+                ),
+                numpy.array([-vx, vy, numpy.sign(Xsun) * vz]),
+            ).T
+            + numpy.array(vsun).T
+        )
+    vx, vy, vz = promote_scalars(xp, vx, vy, vz)
+    dev = device_of(vx, vy, vz)
     if _extra_rot:
-        vx, vy, vz = numpy.dot(galcen_extra_rot, numpy.array([vx, vy, vz]))
-    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
-    costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = numpy.zeros_like(costheta)
-    one = numpy.ones_like(costheta)
-    return (
-        numpy.einsum(
-            (
-                "ijk,jk->ik"
-                if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
-                else "ij,jk->ik"
-            ),
-            numpy.array(
-                [
-                    [costheta, zero, -sintheta],
-                    [zero, one, zero],
-                    [sintheta, zero, costheta],
-                ]
-            ),
-            numpy.array([-vx, vy, numpy.sign(Xsun) * vz]),
-        ).T
-        + numpy.array(vsun).T
-    )
+        mat, data = _promote_pair(xp, galcen_extra_rot, xp.stack([vx, vy, vz]), dev)
+        vx, vy, vz = mat @ data
+    rot, _, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
+    data = xp.stack([-vx, vy, xp.sign(Xsun) * vz])
+    out = _apply_galcen_rot(xp, rot, data, batched, dev).T
+    vsun = _as_vsun(xp, vsun, dev)
+    # .T only when 2-D: torch deprecates .T on ndim != 2, and a (3,) vsun
+    # broadcasts against the (N, 3) result as-is.
+    return out + (vsun.T if vsun.ndim > 1 else vsun)
 
 
 @scalarDecorator
@@ -2325,6 +2362,7 @@ def galcencyl_to_galcenrect(R, vR, vT, z, vz, phi):
     - 2026-05-06 - Written - Bovy (UofT)
     """
     xp = resolve_namespace(R, vR, vT, z, vz, phi)
+    R, vR, vT, z, vz, phi = coerce_coords(xp, R, vR, vT, z, vz, phi)
     x, y, zc = cyl_to_rect(R, phi, z)
     vx, vy, vzc = cyl_to_rect_vec(vR, vT, vz, phi)
     # column_stack, spelled for any namespace. Reshape-to-(-1,) FIRST rather
@@ -3145,6 +3183,7 @@ def lambdanu_to_Rz(l, n, ac=5.0, Delta=1.0):
     - 2015-02-13 - Written - Trick (MPIA)
     """
     xp = resolve_namespace(l, n, ac, Delta)
+    l, n, ac, Delta = coerce_coords(xp, l, n, ac, Delta)
     g = Delta**2 / (1.0 - ac**2)
     a = g - Delta**2
     r2 = (l + a) * (n + a) / (a - g)

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -575,6 +575,7 @@ def sphergal_to_rectgal(l, b, d, vr, pmll, pmbb, degree=False):
 
 @scalarDecorator
 @degreeDecorator([3, 4], [])
+@backendNative
 def vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, l, b, d, XYZ=False, degree=False):
     """
     Transform velocities in the spherical Galactic coordinate frame to the rectangular Galactic coordinate frame (can take vector inputs)
@@ -609,31 +610,41 @@ def vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, l, b, d, XYZ=False, degree=False):
     - 2014-06-14 - Re-written w/ numpy functions for speed and w/ decorators for beauty - Bovy (IAS)
     """
     # Whether to use degrees and scalar input is handled by decorators
+    xp = resolve_namespace(vr, pmll, pmbb, l, b, d)
     if XYZ:  # undo the incorrect conversion that the decorator did
         if degree:
-            l *= 180.0 / numpy.pi
-            b *= 180.0 / numpy.pi
+            # OUT-of-place: `l *= ...` cannot be done to a jax array.
+            l = l * (180.0 / numpy.pi)
+            b = b * (180.0 / numpy.pi)
         lbd = XYZ_to_lbd(l, b, d, degree=False)
         l = lbd[:, 0]
         b = lbd[:, 1]
         d = lbd[:, 2]
-    R = numpy.zeros((3, 3, len(l)))
-    R[0, 0] = numpy.cos(l) * numpy.cos(b)
-    R[1, 0] = -numpy.sin(l)
-    R[2, 0] = -numpy.cos(l) * numpy.sin(b)
-    R[0, 1] = numpy.sin(l) * numpy.cos(b)
-    R[1, 1] = numpy.cos(l)
-    R[2, 1] = -numpy.sin(l) * numpy.sin(b)
-    R[0, 2] = numpy.sin(b)
-    R[2, 2] = numpy.cos(b)
-    invr = numpy.array(
+    cosl, sinl, cosb, sinb = xp.cos(l), xp.sin(l), xp.cos(b), xp.sin(b)
+    # Built by stacking rather than zeros((3,3,N)) + nine indexed writes: jax
+    # arrays are immutable. R[1, 2] was never assigned, so it stays ZERO here
+    # -- that hole is part of the transform, not an oversight.
+    zero = xp.zeros_like(l)
+    R = xp.stack(
         [
-            [vr, vr, vr],
-            [d * pmll * _K, d * pmll * _K, d * pmll * _K],
-            [d * pmbb * _K, d * pmbb * _K, d * pmbb * _K],
+            xp.stack([cosl * cosb, sinl * cosb, sinb]),
+            xp.stack([-sinl, cosl, zero]),
+            xp.stack([-cosl * sinb, -sinl * sinb, cosb]),
         ]
     )
-    return (R.T * invr.T).sum(-1)
+    rowv, rowl, rowb = vr, d * pmll * _K, d * pmbb * _K
+    invr = xp.stack(
+        [
+            xp.stack([rowv, rowv, rowv]),
+            xp.stack([rowl, rowl, rowl]),
+            xp.stack([rowb, rowb, rowb]),
+        ]
+    )
+    # (R.T * invr.T).sum(-1) contracts over the FIRST axis of the untransposed
+    # arrays: out[n, j] = sum_i R[i, j, n] * invr[i, j, n]. Spelled that way
+    # directly, because `.T` on a 3-D array reverses ALL axes and torch
+    # deprecates it for ndim > 2 -- one 2-D transpose at the end is safe.
+    return xp.sum(R * invr, axis=0).T
 
 
 @scalarDecorator

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -189,9 +189,20 @@ def _apply_galcen_rot(xp, rot, data, batched, dev):
 
 
 def _apply_extra_rot(xp, mat, out, dev):
-    """``(mat @ out.T).T``, promoted -- the astropy-alignment tweak."""
+    """``(mat @ out.T).T``, promoted -- the astropy-alignment tweak.
+
+    For an (N, 3) block of already-assembled rows; :func:`_rotate_components`
+    is the same rotation for loose components, which is the shape the FORWARD
+    transforms have it in.
+    """
     mat, outT = promote_common_dtype(xp, mat, out.T, device=dev)
     return (mat @ outT).T
+
+
+def _rotate_components(xp, mat, comps, dev):
+    """``mat @ stack(comps)``, promoted, returned as components again."""
+    mat, data = promote_common_dtype(xp, mat, xp.stack(comps), device=dev)
+    return mat @ data
 
 
 def _scale_angle_rows(xp, m, factor=1.0 / _DEGTORAD, nrows=2):
@@ -1282,10 +1293,7 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     X, Y, Z = promote_scalars(xp, X, Y, Z)
     dev = device_of(X, Y, Z)
     if _extra_rot:
-        mat, data = promote_common_dtype(
-            xp, galcen_extra_rot, xp.stack([X, Y, Z]), device=dev
-        )
-        X, Y, Z = mat @ data
+        X, Y, Z = _rotate_components(xp, galcen_extra_rot, (X, Y, Z), dev)
     rot, dgc, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
     data = xp.stack([-X + dgc, Y, xp.sign(Xsun) * Z])
     return _apply_galcen_rot(xp, rot, data, batched, dev).T
@@ -1618,10 +1626,7 @@ def vxvyvz_to_galcenrect(
     vx, vy, vz = promote_scalars(xp, vx, vy, vz)
     dev = device_of(vx, vy, vz)
     if _extra_rot:
-        mat, data = promote_common_dtype(
-            xp, galcen_extra_rot, xp.stack([vx, vy, vz]), device=dev
-        )
-        vx, vy, vz = mat @ data
+        vx, vy, vz = _rotate_components(xp, galcen_extra_rot, (vx, vy, vz), dev)
     rot, _, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
     data = xp.stack([-vx, vy, xp.sign(Xsun) * vz])
     out = _apply_galcen_rot(xp, rot, data, batched, dev).T

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -142,12 +142,33 @@ def _galcen_rot(xp, Xsun, Zsun):
     return rot, dgc, zero, batched
 
 
+def _promote_pair(xp, mat, data, dev):
+    """``mat``, ``data`` on ``dev``, both cast to their common dtype.
+
+    These rotations are float64 -- ``galcen_extra_rot`` is a float64 module
+    constant and ``_galcen_rot`` carries Xsun/Zsun's dtype. numpy promotes a
+    mismatch silently; torch REFUSES to matmul float64 against float32, so
+    with torch's DEFAULT dtype every one of these transforms raised. Promoting
+    via ``result_type`` reproduces numpy's own promotion, so float32 input
+    still returns float64 rather than quietly losing precision.
+    """
+    mat = asarray_on_device(xp, mat, dev)
+    dt = xp.result_type(mat, data)
+    return xp.astype(mat, dt), xp.astype(data, dt)
+
+
 def _apply_galcen_rot(xp, rot, data, batched, dev):
     """``rot @ data`` for backend ``data`` (3, N); mirrors the numpy einsum."""
-    rot = asarray_on_device(xp, rot, dev)
+    rot, data = _promote_pair(xp, rot, data, dev)
     if batched:  # (3, 3, N) . (3, N) -> (3, N), i.e. einsum("ijk,jk->ik")
         return xp.sum(rot * data[None, :, :], axis=1)
     return rot @ data
+
+
+def _apply_extra_rot(xp, mat, out, dev):
+    """``(mat @ out.T).T``, promoted -- the astropy-alignment tweak."""
+    mat, outT = _promote_pair(xp, mat, out.T, dev)
+    return (mat @ outT).T
 
 
 def _scale_angle_rows(xp, m, factor=1.0 / _DEGTORAD, nrows=2):
@@ -1162,6 +1183,7 @@ def cov_galcenrect_to_galcencyl(cov_galcenrect, phi):
 
 
 @scalarDecorator
+@backendNative
 def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     """
     Transform XYZ coordinates (wrt Sun) to rectangular Galactocentric coordinates.
@@ -1226,7 +1248,8 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     X, Y, Z = promote_scalars(xp, X, Y, Z)
     dev = device_of(X, Y, Z)
     if _extra_rot:
-        X, Y, Z = asarray_on_device(xp, galcen_extra_rot, dev) @ xp.stack([X, Y, Z])
+        mat, data = _promote_pair(xp, galcen_extra_rot, xp.stack([X, Y, Z]), dev)
+        X, Y, Z = mat @ data
     # Float-ify BEFORE promoting, for the same reason as _galcen_rot: an integer
     # Xsun would otherwise drag a python-float Zsun to int and silently zero it.
     Xsun, Zsun = promote_scalars(xp, Xsun * 1.0, Zsun * 1.0)
@@ -1310,7 +1333,7 @@ def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
         + asarray_on_device(xp, offset, dev).T
     )
     if _extra_rot:
-        return (asarray_on_device(xp, galcen_extra_rot.T, dev) @ out.T).T
+        return _apply_extra_rot(xp, galcen_extra_rot.T, out, dev)
     return out
 
 
@@ -1678,7 +1701,7 @@ def galcenrect_to_vxvyvz(
     data = xp.stack([vXg - vsun[0], vYg - vsun[1], vZg - vsun[2]])
     out = _apply_galcen_rot(xp, rot, data, batched, dev).T
     if _extra_rot:
-        return (asarray_on_device(xp, galcen_extra_rot.T, dev) @ out.T).T
+        return _apply_extra_rot(xp, galcen_extra_rot.T, out, dev)
     return out
 
 

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -175,6 +175,11 @@ def _as_vsun(xp, vsun, dev):
     return asarray_on_device(xp, vsun, dev)
 
 
+def _row_or_T(a):
+    """``a.T`` for a 2-D (3, N); ``a`` unchanged for a 1-D (3,)."""
+    return a.T if a.ndim > 1 else a
+
+
 def _apply_galcen_rot(xp, rot, data, batched, dev):
     """``rot @ data`` for backend ``data`` (3, N); mirrors the numpy einsum."""
     rot, data = promote_common_dtype(xp, rot, data, device=dev)
@@ -256,6 +261,15 @@ def scalarDecorator(func):
             if getattr(func, "_galpy_backend_native", False)
             else numpy
         )
+        if xp is not numpy:
+            # coerce_coords, NOT a bare xp.asarray: torch.asarray(<python
+            # float>) is float32, so a scalar call would silently compute the
+            # whole transform in single precision (measured 8.5e-9 relative on
+            # the vrpmllpmbb_to_vxvyvz speed invariant, against 2.3e-16 for
+            # numpy/array input). coerce_coords already owns this rule --
+            # preserve a real floating dtype, lift plain Python scalars to
+            # float64 -- so reuse it rather than re-spelling it here.
+            args = coerce_coords(xp, *args)
         if xp.asarray(args[0]).ndim == 0:
             scalarOut = True
             args = tuple(xp.reshape(xp.asarray(a), (1,)) for a in args)
@@ -1333,7 +1347,9 @@ def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     dev = device_of(X)
     out = (
         _apply_galcen_rot(xp, rot, xp.stack([X, Y, Z]), batched, dev).T
-        + asarray_on_device(xp, offset, dev).T
+        # .T only when 2-D: torch deprecates .T for ndim != 2, and a (3,)
+        # offset already broadcasts against the (N, 3) result.
+        + _row_or_T(asarray_on_device(xp, offset, dev))
     )
     if _extra_rot:
         return _apply_extra_rot(xp, galcen_extra_rot.T, out, dev)

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -2252,9 +2252,15 @@ def galcencyl_to_galcenrect(R, vR, vT, z, vz, phi):
     -----
     - 2026-05-06 - Written - Bovy (UofT)
     """
+    xp = resolve_namespace(R, vR, vT, z, vz, phi)
     x, y, zc = cyl_to_rect(R, phi, z)
     vx, vy, vzc = cyl_to_rect_vec(vR, vT, vz, phi)
-    return numpy.column_stack([x, y, zc, vx, vy, vzc])
+    # column_stack, spelled for any namespace. Reshape-to-(-1,) FIRST rather
+    # than stacking directly: column_stack promotes a scalar column to shape
+    # (1,), so a scalar call must come back (1, 6) and not (6,), and a bare
+    # xp.stack(..., axis=-1) would quietly give the latter.
+    cols = [xp.reshape(v, (-1,)) for v in (x, y, zc, vx, vy, vzc)]
+    return xp.stack(cols, axis=-1)
 
 
 def galcenrect_to_galcencyl_jac(x, y, z, vx, vy, vz, *, xp=None):

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -88,6 +88,7 @@ from ..backend import (
     is_backend_array,
     prefer_backend_namespace,
     promote_scalars,
+    resolve_namespace,
 )
 from ..util import _rotate_to_arbitrary_vector
 from ..util._optional_deps import _APY_LOADED
@@ -3065,23 +3066,20 @@ def lambdanu_to_Rz(l, n, ac=5.0, Delta=1.0):
     -----
     - 2015-02-13 - Written - Trick (MPIA)
     """
+    xp = resolve_namespace(l, n, ac, Delta)
     g = Delta**2 / (1.0 - ac**2)
     a = g - Delta**2
     r2 = (l + a) * (n + a) / (a - g)
     z2 = (l + g) * (n + g) / (g - a)
-    index = (r2 < 0.0) * ((n + a) > 0.0) * ((n + a) < 1e-10)
-    if numpy.any(index):
-        if isinstance(r2, numpy.ndarray):
-            r2[index] = 0.0
-        else:
-            r2 = 0.0
-    index = (z2 < 0.0) * ((n + g) < 0.0) * ((n + g) > -1e-10)
-    if numpy.any(index):
-        if isinstance(z2, numpy.ndarray):
-            z2[index] = 0.0
-        else:
-            z2 = 0.0
-    return (numpy.sqrt(r2), numpy.sqrt(z2))
+    # Clamp the roundoff-negative roots to zero. This was a python ``if`` on the
+    # data plus an in-place ``r2[index] = 0.0``, i.e. untraceable AND unwritable
+    # on jax; xp.where is the same arithmetic without either. The mask is
+    # unchanged, including the deliberately one-sided 1e-10 windows: only a root
+    # that is negative *because* (n+a) / (n+g) sits within roundoff of its
+    # boundary is snapped, never a genuinely negative one.
+    r2 = xp.where((r2 < 0.0) & ((n + a) > 0.0) & ((n + a) < 1e-10), 0.0 * r2, r2)
+    z2 = xp.where((z2 < 0.0) & ((n + g) < 0.0) & ((n + g) > -1e-10), 0.0 * z2, z2)
+    return (xp.sqrt(r2), xp.sqrt(z2))
 
 
 @scalarDecorator

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -87,6 +87,7 @@ from ..backend import (
     get_namespace,
     is_backend_array,
     prefer_backend_namespace,
+    promote_common_dtype,
     promote_scalars,
     resolve_namespace,
 )
@@ -142,21 +143,6 @@ def _galcen_rot(xp, Xsun, Zsun):
     return rot, dgc, zero, batched
 
 
-def _promote_pair(xp, mat, data, dev):
-    """``mat``, ``data`` on ``dev``, both cast to their common dtype.
-
-    These rotations are float64 -- ``galcen_extra_rot`` is a float64 module
-    constant and ``_galcen_rot`` carries Xsun/Zsun's dtype. numpy promotes a
-    mismatch silently; torch REFUSES to matmul float64 against float32, so
-    with torch's DEFAULT dtype every one of these transforms raised. Promoting
-    via ``result_type`` reproduces numpy's own promotion, so float32 input
-    still returns float64 rather than quietly losing precision.
-    """
-    mat = asarray_on_device(xp, mat, dev)
-    dt = xp.result_type(mat, data)
-    return xp.astype(mat, dt), xp.astype(data, dt)
-
-
 def _to_galcen_rot(xp, Xsun, Zsun):
     """Heliocentric -> galactocentric rotation, plus ``dgc`` and promoted Xsun.
 
@@ -191,7 +177,7 @@ def _as_vsun(xp, vsun, dev):
 
 def _apply_galcen_rot(xp, rot, data, batched, dev):
     """``rot @ data`` for backend ``data`` (3, N); mirrors the numpy einsum."""
-    rot, data = _promote_pair(xp, rot, data, dev)
+    rot, data = promote_common_dtype(xp, rot, data, device=dev)
     if batched:  # (3, 3, N) . (3, N) -> (3, N), i.e. einsum("ijk,jk->ik")
         return xp.sum(rot * data[None, :, :], axis=1)
     return rot @ data
@@ -199,7 +185,7 @@ def _apply_galcen_rot(xp, rot, data, batched, dev):
 
 def _apply_extra_rot(xp, mat, out, dev):
     """``(mat @ out.T).T``, promoted -- the astropy-alignment tweak."""
-    mat, outT = _promote_pair(xp, mat, out.T, dev)
+    mat, outT = promote_common_dtype(xp, mat, out.T, device=dev)
     return (mat @ outT).T
 
 
@@ -1282,7 +1268,9 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     X, Y, Z = promote_scalars(xp, X, Y, Z)
     dev = device_of(X, Y, Z)
     if _extra_rot:
-        mat, data = _promote_pair(xp, galcen_extra_rot, xp.stack([X, Y, Z]), dev)
+        mat, data = promote_common_dtype(
+            xp, galcen_extra_rot, xp.stack([X, Y, Z]), device=dev
+        )
         X, Y, Z = mat @ data
     rot, dgc, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
     data = xp.stack([-X + dgc, Y, xp.sign(Xsun) * Z])
@@ -1614,7 +1602,9 @@ def vxvyvz_to_galcenrect(
     vx, vy, vz = promote_scalars(xp, vx, vy, vz)
     dev = device_of(vx, vy, vz)
     if _extra_rot:
-        mat, data = _promote_pair(xp, galcen_extra_rot, xp.stack([vx, vy, vz]), dev)
+        mat, data = promote_common_dtype(
+            xp, galcen_extra_rot, xp.stack([vx, vy, vz]), device=dev
+        )
         vx, vy, vz = mat @ data
     rot, _, Xsun, batched = _to_galcen_rot(xp, Xsun, Zsun)
     data = xp.stack([-vx, vy, xp.sign(Xsun) * vz])

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -86,6 +86,7 @@ from ..backend import (
     device_of,
     get_namespace,
     is_backend_array,
+    prefer_backend_namespace,
     promote_scalars,
 )
 from ..util import _rotate_to_arbitrary_vector
@@ -97,26 +98,39 @@ _APY_COORDS *= _APY_LOADED
 _DEGTORAD = numpy.pi / 180.0
 
 
-def _galcen_rot(Xsun, Zsun):
+def _galcen_rot(xp, Xsun, Zsun):
     """Galactocentric -> heliocentric rotation, plus the ``dgc`` offset scalars.
 
-    Depends only on ``Xsun``/``Zsun``, which are configuration, never traced
-    data -- so this stays numpy even on a backend and is a compile-time
-    constant under a trace. Shape (3, 3) for scalar Xsun, (3, 3, N) when
-    Xsun/Zsun are arrays.
+    Shape (3, 3) for scalar Xsun, (3, 3, N) when Xsun/Zsun are arrays.
+
+    ``Xsun``/``Zsun`` are USUALLY configuration, but they are not always: the
+    solar position is a fit parameter, so a caller may legitimately hand in a
+    backend array and differentiate through it. This used to be hard-coded
+    numpy on the assumption that it never happened, which made
+    ``galcenrect_to_XYZ(Xsun=<torch tensor requiring grad>)`` raise "Can't call
+    numpy() on Tensor that requires grad" -- while the JACOBIAN of the same
+    transform (``galcenrect_to_XYZ_jac``) handled it fine. Build it in the
+    caller's namespace instead, which removes that asymmetry.
+
+    ``xp.stack`` rather than ``xp.asarray`` of a nested list: jax arrays are
+    immutable and a nested list of tracers is not an array constructor
+    argument. Stacking along axis 0 reproduces ``numpy.array([[...], ...])``
+    exactly for this shape pattern, so the numpy path is unchanged.
     """
-    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
+    Xsun, Zsun = promote_scalars(xp, Xsun, Zsun)
+    dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
     costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = numpy.zeros_like(costheta)
-    one = numpy.ones_like(costheta)
-    rot = numpy.array(
+    zero = xp.zeros_like(costheta)
+    one = xp.ones_like(costheta)
+    sgn = xp.sign(Xsun)
+    rot = xp.stack(
         [
-            [-costheta, zero, -sintheta],
-            [zero, one, zero],
-            [-numpy.sign(Xsun) * sintheta, zero, numpy.sign(Xsun) * costheta],
+            xp.stack([-costheta, zero, -sintheta]),
+            xp.stack([zero, one, zero]),
+            xp.stack([-sgn * sintheta, zero, sgn * costheta]),
         ]
     )
-    batched = isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
+    batched = getattr(costheta, "ndim", 0) > 0
     return rot, dgc, zero, batched
 
 
@@ -1214,9 +1228,12 @@ def galcenrect_to_XYZ(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
 
     """
-    rot, dgc, zero, batched = _galcen_rot(Xsun, Zsun)
-    offset = numpy.array([dgc, zero, zero])
-    xp = get_namespace(X, Y, Z)
+    # Xsun/Zsun join the namespace probe: they are ordinary inputs a caller
+    # may differentiate through, so a backend Xsun with numpy coordinates has
+    # to take the BACKEND path, not fall through to numpy.
+    xp = prefer_backend_namespace(X, Y, Z, Xsun, Zsun)
+    rot, dgc, zero, batched = _galcen_rot(xp, Xsun, Zsun)
+    offset = xp.stack([dgc, zero, zero])
     if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
         out = (
             numpy.einsum(
@@ -1588,8 +1605,8 @@ def galcenrect_to_vxvyvz(
     - 2017-10-24 - Allowed Xsun/Zsun/vsun to be arrays - Bovy (UofT)
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
     """
-    rot, _, _, batched = _galcen_rot(Xsun, Zsun)
-    xp = get_namespace(vXg, vYg, vZg)
+    xp = prefer_backend_namespace(vXg, vYg, vZg, Xsun, Zsun)
+    rot, _, _, batched = _galcen_rot(xp, Xsun, Zsun)
     if xp is numpy:  # unchanged arithmetic: the numpy path stays byte-identical
         out = numpy.einsum(
             "ijk,jk->ik" if batched else "ij,jk->ik",

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -117,6 +117,13 @@ def _galcen_rot(xp, Xsun, Zsun):
     argument. Stacking along axis 0 reproduces ``numpy.array([[...], ...])``
     exactly for this shape pattern, so the numpy path is unchanged.
     """
+    # Float-ify BEFORE promoting. promote_scalars anchors every value on the
+    # dtype of the first BACKEND array, so an integer Xsun (a perfectly ordinary
+    # thing to pass) would drag a python-float Zsun down to int64 -- 0.02 -> 0 --
+    # and the transform would silently return the Zsun = 0 answer. A rotation is
+    # inherently floating-point, so multiplying through by 1.0 is both correct
+    # and dtype-preserving for values that are already float (incl. f32).
+    Xsun, Zsun = Xsun * 1.0, Zsun * 1.0
     Xsun, Zsun = promote_scalars(xp, Xsun, Zsun)
     dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
     costheta, sintheta = Xsun / dgc, Zsun / dgc

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -451,6 +451,7 @@ def lb_to_radec(l, b, degree=False, epoch=2000.0):
 
 @scalarDecorator
 @degreeDecorator([0, 1], [])
+@backendNative
 def lbd_to_XYZ(l, b, d, degree=False):
     """
     Transform from spherical Galactic coordinates to rectangular Galactic coordinates (works with vector inputs)
@@ -478,13 +479,14 @@ def lbd_to_XYZ(l, b, d, degree=False):
 
     """
     # Whether to use degrees and scalar input is handled by decorators
-    return numpy.array(
-        [
-            d * numpy.cos(b) * numpy.cos(l),
-            d * numpy.cos(b) * numpy.sin(l),
-            d * numpy.sin(b),
-        ]
-    ).T
+    xp = resolve_namespace(l, b, d)
+    # stack(axis=-1) IS the old numpy.array([...]).T: three (N,) columns give
+    # (N, 3) either way. Written as a stack because .T on a freshly built
+    # (3, N) is an extra transpose to trace through for no benefit.
+    cosb = xp.cos(b)
+    return xp.stack(
+        [d * cosb * xp.cos(l), d * cosb * xp.sin(l), d * xp.sin(b)], axis=-1
+    )
 
 
 def rectgal_to_sphergal(X, Y, Z, vx, vy, vz, degree=False):

--- a/galpy/util/coords.py
+++ b/galpy/util/coords.py
@@ -1196,23 +1196,59 @@ def XYZ_to_galcenrect(X, Y, Z, Xsun=1.0, Zsun=0.0, _extra_rot=True):
     - 2018-04-18 - Tweaked to be consistent with astropy's Galactocentric frame - Bovy (UofT)
     - 2023-07-23 - Allowed Xsun/Zsun to be arrays - Bovy (UofT)
     """
+    xp = prefer_backend_namespace(X, Y, Z, Xsun, Zsun)
+    if xp is numpy:
+        # unchanged arithmetic: the numpy path stays BYTE-IDENTICAL. einsum and
+        # matmul disagree in the last ulp (measured: 2.2e-16 over 471 values),
+        # so the numpy branch keeps einsum rather than sharing the backend
+        # contraction. Same split galcenrect_to_XYZ already uses.
+        if _extra_rot:
+            X, Y, Z = numpy.dot(galcen_extra_rot, numpy.array([X, Y, Z]))
+        dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
+        costheta, sintheta = Xsun / dgc, Zsun / dgc
+        zero = numpy.zeros_like(costheta)
+        one = numpy.ones_like(costheta)
+        return numpy.einsum(
+            (
+                "ijk,jk->ik"
+                if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
+                else "ij,jk->ik"
+            ),
+            numpy.array(
+                [
+                    [costheta, zero, -sintheta],
+                    [zero, one, zero],
+                    [sintheta, zero, costheta],
+                ]
+            ),
+            numpy.array([-X + dgc, Y, numpy.sign(Xsun) * Z]),
+        ).T
+    X, Y, Z = promote_scalars(xp, X, Y, Z)
+    dev = device_of(X, Y, Z)
     if _extra_rot:
-        X, Y, Z = numpy.dot(galcen_extra_rot, numpy.array([X, Y, Z]))
-    dgc = numpy.sqrt(Xsun**2.0 + Zsun**2.0)
+        X, Y, Z = asarray_on_device(xp, galcen_extra_rot, dev) @ xp.stack([X, Y, Z])
+    # Float-ify BEFORE promoting, for the same reason as _galcen_rot: an integer
+    # Xsun would otherwise drag a python-float Zsun to int and silently zero it.
+    Xsun, Zsun = promote_scalars(xp, Xsun * 1.0, Zsun * 1.0)
+    dgc = xp.sqrt(Xsun**2.0 + Zsun**2.0)
     costheta, sintheta = Xsun / dgc, Zsun / dgc
-    zero = numpy.zeros_like(costheta)
-    one = numpy.ones_like(costheta)
-    return numpy.einsum(
-        (
-            "ijk,jk->ik"
-            if isinstance(costheta, numpy.ndarray) and costheta.ndim > 0
-            else "ij,jk->ik"
-        ),
-        numpy.array(
-            [[costheta, zero, -sintheta], [zero, one, zero], [sintheta, zero, costheta]]
-        ),
-        numpy.array([-X + dgc, Y, numpy.sign(Xsun) * Z]),
-    ).T
+    zero = xp.zeros_like(costheta)
+    one = xp.ones_like(costheta)
+    # This matrix is NOT _galcen_rot's, and deliberately so: the sign(Xsun)
+    # convention lives in the OPERAND below rather than in the matrix, which is
+    # why the two differ and still invert each other exactly (verified: the
+    # galcenrect_to_XYZ round trip is 1.6e-15 at Xsun = -8). Sharing the matrix
+    # builder here would break that. The CONTRACTION is shared instead.
+    rot = xp.stack(
+        [
+            xp.stack([costheta, zero, -sintheta]),
+            xp.stack([zero, one, zero]),
+            xp.stack([sintheta, zero, costheta]),
+        ]
+    )
+    data = xp.stack([-X + dgc, Y, xp.sign(Xsun) * Z])
+    batched = getattr(costheta, "ndim", 0) > 0
+    return _apply_galcen_rot(xp, rot, data, batched, dev).T
 
 
 @scalarDecorator

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -376,6 +376,29 @@ _CHAIN_CASES = {
     "galcenrect_to_vxvyvz": lambda c, a: c.galcenrect_to_vxvyvz(
         a["vx"], a["vy"], a["vz"], Xsun=1.0, Zsun=0.02
     ),
+    # The FORWARD galcen transforms. Their backend branches are only reachable
+    # through a test like this one: the coverage-measuring CI job runs numpy
+    # only, and the --backend shards upload no coverage at all, so a branch
+    # exercised solely under --backend reads as uncovered. Covers
+    # _to_galcen_rot and both _as_vsun branches: the default vsun is a list,
+    # the "vsun_array" case passes it pre-built.
+    "XYZ_to_galcenrect": lambda c, a: c.XYZ_to_galcenrect(
+        a["x"], a["y"], a["z"], Xsun=1.0, Zsun=0.02
+    ),
+    "XYZ_to_galcencyl": lambda c, a: c.XYZ_to_galcencyl(
+        a["x"], a["y"], a["z"], Xsun=1.0, Zsun=0.02
+    ),
+    "vxvyvz_to_galcenrect": lambda c, a: c.vxvyvz_to_galcenrect(
+        a["vx"], a["vy"], a["vz"], Xsun=1.0, Zsun=0.02
+    ),
+    "vxvyvz_to_galcenrect_vsun_array": lambda c, a: c.vxvyvz_to_galcenrect(
+        a["vx"],
+        a["vy"],
+        a["vz"],
+        Xsun=1.0,
+        Zsun=0.02,
+        vsun=numpy.array([-10.0, 240.0, 7.0]),
+    ),
     "XYZ_to_lbd": lambda c, a: c.XYZ_to_lbd(a["x"], a["y"], a["z"], degree=False),
     "vxvyvz_to_vrpmllpmbb": lambda c, a: c.vxvyvz_to_vrpmllpmbb(
         a["vx"], a["vy"], a["vz"], a["x"], a["y"], a["z"], XYZ=True, degree=False

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -623,3 +623,47 @@ def test_galcenrect_integer_Xsun_does_not_truncate_Zsun(backend_name):
     assert not numpy.allclose(
         [float(as_numpy(g)) for g in got], [float(v) for v in flat], rtol=1e-9
     ), "integer Xsun silently reproduced the Zsun=0 answer -- Zsun was truncated"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_lambdanu_to_Rz_is_traceable_and_matches_numpy(backend_name):
+    # lambdanu_to_Rz clamped its roundoff-negative roots with a python `if` on
+    # the data plus an in-place `r2[index] = 0.0` -- untraceable AND unwritable
+    # on jax. Exactly the if -> xp.where array-input class. Its FORWARD
+    # direction (Rz_to_lambdanu) was migrated long ago; this is the inverse
+    # catching up.
+    rng = numpy.random.default_rng(3)
+    R = 0.2 + 2.5 * rng.random(7)
+    z = rng.random(7) - 0.5
+    lam, nu = coords.Rz_to_lambdanu(R, z, ac=5.0, Delta=1.0)
+    ref_R, ref_z = coords.lambdanu_to_Rz(lam, nu, ac=5.0, Delta=1.0)
+
+    bl, bn = _as_backend(backend_name, lam), _as_backend(backend_name, nu)
+    got_R, got_z = coords.lambdanu_to_Rz(bl, bn, ac=5.0, Delta=1.0)
+    assert is_backend_array(got_R), "backend input must not fall through to numpy"
+    numpy.testing.assert_allclose(as_numpy(got_R), ref_R, rtol=1e-14)
+    numpy.testing.assert_allclose(as_numpy(got_z), ref_z, rtol=1e-14)
+
+    if backend_name == "jax":
+        import jax
+
+        # The clamp used to raise TracerBoolConversionError here. Grad-vs-FD
+        # rather than "it traced": a where() with the mask inverted would still
+        # trace happily and give the wrong derivative.
+        def total(lv):
+            return coords.lambdanu_to_Rz(lv, jnp.asarray(nu), ac=5.0, Delta=1.0)[
+                0
+            ].sum()
+
+        ad = numpy.asarray(jax.jit(jax.grad(total))(jnp.asarray(lam)))
+        h = 1e-6
+        fd = numpy.empty_like(lam)
+        for i in range(lam.size):
+            up, dn = lam.copy(), lam.copy()
+            up[i] += h
+            dn[i] -= h
+            fd[i] = (
+                coords.lambdanu_to_Rz(up, nu, ac=5.0, Delta=1.0)[0].sum()
+                - coords.lambdanu_to_Rz(dn, nu, ac=5.0, Delta=1.0)[0].sum()
+            ) / (2 * h)
+        numpy.testing.assert_allclose(ad, fd, rtol=1e-6, atol=1e-9)

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -599,3 +599,27 @@ def test_galcenrect_backend_Xsun_with_numpy_coordinates(backend_name):
     assert is_backend_array(got[0]), "backend Xsun must select the backend path"
     for g, r in zip(got, ref):
         numpy.testing.assert_allclose(float(as_numpy(g)), float(r), rtol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_galcenrect_integer_Xsun_does_not_truncate_Zsun(backend_name):
+    # SILENT WRONG ANSWER, not a crash. promote_scalars anchors every value on
+    # the dtype of the first BACKEND array, so an INTEGER Xsun (an ordinary
+    # thing to pass) dragged a python-float Zsun down to int64: 0.02 -> 0. The
+    # transform then returned the Zsun = 0 answer with no error at all --
+    # ~7.5e-3 off in X, which is far too small to look obviously broken and far
+    # too large to be roundoff.
+    #
+    # Pin BOTH directions: an integer Xsun must equal the float answer, and it
+    # must NOT equal the Zsun = 0 answer (which is what a re-truncation would
+    # silently give back).
+    x, y, z, Zs = 1.0, 2.0, 3.0, 0.02
+    ref = coords.galcenrect_to_XYZ(x, y, z, Xsun=8.0, Zsun=Zs)
+    flat = coords.galcenrect_to_XYZ(x, y, z, Xsun=8.0, Zsun=0.0)
+    Xi = _as_backend(backend_name, 8)  # integer dtype on purpose
+    got = coords.galcenrect_to_XYZ(x, y, z, Xsun=Xi, Zsun=Zs)
+    for g, r in zip(got, ref):
+        numpy.testing.assert_allclose(float(as_numpy(g)), float(r), rtol=1e-12)
+    assert not numpy.allclose(
+        [float(as_numpy(g)) for g in got], [float(v) for v in flat], rtol=1e-9
+    ), "integer Xsun silently reproduced the Zsun=0 answer -- Zsun was truncated"

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -724,3 +724,40 @@ def test_vrpmllpmbb_to_vxvyvz_preserves_the_backend(backend_name, XYZ):
     got = coords.vrpmllpmbb_to_vxvyvz(*args, XYZ=XYZ, degree=True)
     assert is_backend_array(got), "decorator stripped the backend off the input"
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-13)
+
+
+def test_python_scalar_is_not_silently_single_precision():
+    # REGRESSION, torch only. scalarDecorator's @backendNative path tested ndim
+    # with a bare xp.asarray(arg), and torch.asarray(<python float>) follows
+    # torch's DEFAULT dtype -- float32 for anyone who has not changed it. So a
+    # call with plain Python scalars computed the whole transform in single
+    # precision (~1e-7 relative) while the same call with numpy scalars or
+    # arrays stayed float64.
+    #
+    # conftest sets torch.set_default_dtype(float64) for the whole suite, which
+    # is why NOTHING here could see this: the harness silently supplies the
+    # very thing real users lack. This test therefore restores torch's own
+    # default for the duration, which is the configuration a user actually has.
+    #
+    # Pinned on the SPEED INVARIANT, exact independently of any reference: the
+    # (vr, d*pmll*_K, d*pmbb*_K) triad is orthonormal, so |v| is preserved.
+    torch = pytest.importorskip("torch")
+    lo, ba = coords.radec_to_lb(20.0, 30.0, degree=True)
+    vr, pmll, pmbb, dist = 30.0, -3.0, 5.0, 2.0
+    want = vr**2 + (dist * pmll * coords._K) ** 2 + (dist * pmbb * coords._K) ** 2
+
+    prev = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float32)  # what a user actually has
+    try:
+        with use("torch", force=True):
+            got = coords.vrpmllpmbb_to_vxvyvz(
+                vr, pmll, pmbb, float(lo), float(ba), dist, degree=True
+            )
+            # scalarDecorator unpacks a scalar call into a tuple of components
+            speed2 = float(sum(float(as_numpy(c)) ** 2 for c in got))
+    finally:
+        torch.set_default_dtype(prev)
+    assert abs(speed2 - want) / want < 1e-13, (
+        f"python-scalar input fell to single precision: |v|^2 off by "
+        f"{abs(speed2 - want) / want:.2e} (float64 sits at ~2e-16)"
+    )

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -695,3 +695,32 @@ def test_lbd_to_XYZ_preserves_the_backend(backend_name, degree):
     )
     assert is_backend_array(got), "decorator stripped the backend off the input"
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-14)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("XYZ", [False, True])
+def test_vrpmllpmbb_to_vxvyvz_preserves_the_backend(backend_name, XYZ):
+    # Same @scalarDecorator/@backendNative pair as lbd_to_XYZ, but the body had
+    # two more blockers: a preallocated numpy.zeros((3,3,N)) filled by nine
+    # INDEXED WRITES (jax arrays are immutable), and `l *= 180/pi` on the
+    # XYZ=True path (in-place on an input). Both are out-of-place now.
+    #
+    # XYZ=True is parametrised precisely because it is the branch with the
+    # in-place mutation -- XYZ=False never reaches it.
+    rng = numpy.random.default_rng(19)
+    n = 5
+    vr, pmll, pmbb = rng.normal(size=n) * 30, rng.normal(size=n), rng.normal(size=n)
+    if XYZ:
+        lo, ba, da = rng.normal(size=n) + 2, rng.normal(size=n), rng.normal(size=n) + 5
+    else:
+        lo, ba, da = (
+            rng.random(n) * 360,
+            (rng.random(n) - 0.5) * 180,
+            rng.random(n) * 5 + 0.5,
+        )
+    ref = coords.vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, lo, ba, da, XYZ=XYZ, degree=True)
+
+    args = [_as_backend(backend_name, a) for a in (vr, pmll, pmbb, lo, ba, da)]
+    got = coords.vrpmllpmbb_to_vxvyvz(*args, XYZ=XYZ, degree=True)
+    assert is_backend_array(got), "decorator stripped the backend off the input"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-13)

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -667,3 +667,31 @@ def test_lambdanu_to_Rz_is_traceable_and_matches_numpy(backend_name):
                 - coords.lambdanu_to_Rz(dn, nu, ac=5.0, Delta=1.0)[0].sum()
             ) / (2 * h)
         numpy.testing.assert_allclose(ad, fd, rtol=1e-6, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("degree", [True, False])
+def test_lbd_to_XYZ_preserves_the_backend(backend_name, degree):
+    # lbd_to_XYZ carried @scalarDecorator WITHOUT @backendNative, so the
+    # decorator promoted every input through numpy before the body ran --
+    # stripping the framework off a backend array. The body was raw numpy too.
+    # Both had to move: marking the function alone leaves numpy.cos in the body,
+    # and migrating the body alone leaves the decorator stripping the input.
+    #
+    # @backendNative is INNERMOST by construction (scalarDecorator reads the
+    # attribute off the function it wraps); anywhere else it is silently dead.
+    rng = numpy.random.default_rng(5)
+    n = 6
+    lo = rng.random(n) * (360.0 if degree else 6.2)
+    ba = (rng.random(n) - 0.5) * (180.0 if degree else 3.1)
+    da = rng.random(n) * 5 + 0.1
+    ref = coords.lbd_to_XYZ(lo, ba, da, degree=degree)
+
+    got = coords.lbd_to_XYZ(
+        _as_backend(backend_name, lo),
+        _as_backend(backend_name, ba),
+        _as_backend(backend_name, da),
+        degree=degree,
+    )
+    assert is_backend_array(got), "decorator stripped the backend off the input"
+    numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-14)

--- a/tests/test_backend_coords.py
+++ b/tests/test_backend_coords.py
@@ -527,3 +527,75 @@ def test_vxvyvz_to_vrpmllpmbb_XYZ_degree_backend(backend_name):
     )
     assert _all_backend(got), "XYZ+degree backend path fell back to numpy"
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-13, atol=1e-15)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_galcenrect_transforms_differentiate_through_Xsun_Zsun(backend_name):
+    # Xsun/Zsun were assumed to be "configuration, never traced data", so
+    # _galcen_rot built the rotation with hard-coded numpy. But the solar
+    # position is a FIT PARAMETER, so a caller may hand in a backend array and
+    # differentiate through it -- which raised
+    #     RuntimeError: Can't call numpy() on Tensor that requires grad
+    # on torch, and a tracer conversion error under jax.jit. The JACOBIAN of
+    # the same transform (galcenrect_to_XYZ_jac) already handled backend
+    # Xsun/Zsun, so this was an asymmetry within one transform pair.
+    #
+    # Bar is grad-vs-FD, not merely "it returns something": the whole point of
+    # a backend Xsun is the derivative w.r.t. it.
+    X0, Y0, Z0, Xs0, Zs0 = 1.0, 2.0, 3.0, 8.0, 0.02
+
+    def total(fn, xs, zs):
+        return sum(float(v) for v in fn(X0, Y0, Z0, Xsun=xs, Zsun=zs))
+
+    for fn in (coords.galcenrect_to_XYZ, coords.galcenrect_to_vxvyvz):
+        h = 1e-6
+        fd_X = (total(fn, Xs0 + h, Zs0) - total(fn, Xs0 - h, Zs0)) / (2 * h)
+        fd_Z = (total(fn, Xs0, Zs0 + h) - total(fn, Xs0, Zs0 - h)) / (2 * h)
+        if backend_name == "jax":
+            import jax
+
+            def scalar(p):
+                out = fn(
+                    jnp.asarray(X0),
+                    jnp.asarray(Y0),
+                    jnp.asarray(Z0),
+                    Xsun=p[0],
+                    Zsun=p[1],
+                )
+                return out[0] + out[1] + out[2]
+
+            ad = jax.grad(scalar)(jnp.asarray([Xs0, Zs0]))
+            ad_X, ad_Z = float(ad[0]), float(ad[1])
+        else:
+            xs = torch.tensor(Xs0, dtype=torch.float64, requires_grad=True)
+            zs = torch.tensor(Zs0, dtype=torch.float64, requires_grad=True)
+            out = fn(
+                torch.tensor(X0, dtype=torch.float64),
+                torch.tensor(Y0, dtype=torch.float64),
+                torch.tensor(Z0, dtype=torch.float64),
+                Xsun=xs,
+                Zsun=zs,
+            )
+            (out[0] + out[1] + out[2]).backward()
+            ad_X, ad_Z = float(xs.grad), float(zs.grad)
+        # FD with h=1e-6 is good to ~1e-9 here; anything looser would pass on a
+        # wrong-but-plausible gradient.
+        numpy.testing.assert_allclose(ad_X, fd_X, rtol=1e-7, atol=1e-9)
+        numpy.testing.assert_allclose(ad_Z, fd_Z, rtol=1e-7, atol=1e-9)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_galcenrect_backend_Xsun_with_numpy_coordinates(backend_name):
+    # The namespace probe used to read only the COORDINATES, so a backend
+    # Xsun alongside numpy X/Y/Z silently took the numpy path; and probing the
+    # mix naively raises "Multiple namespaces for array inputs". The rule --
+    # backend args decide, numpy ones are weak and coerce across -- is
+    # galpy.backend.prefer_backend_namespace, shared with the @backend_input
+    # boundary rather than re-spelled here.
+    x, y, z = 1.0, 2.0, 3.0
+    Xs = _as_backend(backend_name, 8.0)
+    ref = coords.galcenrect_to_XYZ(x, y, z, Xsun=8.0, Zsun=0.02)
+    got = coords.galcenrect_to_XYZ(x, y, z, Xsun=Xs, Zsun=0.02)
+    assert is_backend_array(got[0]), "backend Xsun must select the backend path"
+    for g, r in zip(got, ref):
+        numpy.testing.assert_allclose(float(as_numpy(g)), float(r), rtol=1e-14)

--- a/tests/test_backend_potential_diff.py
+++ b/tests/test_backend_potential_diff.py
@@ -300,3 +300,49 @@ def test_amp_gradient(name, backend_name):
     assert abs(grad - fd_fine) <= tol, (
         f"{name}: {backend_name} amp-grad {grad:.8g} != FD {fd_fine:.8g}"
     )
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+@pytest.mark.parametrize("forcepoisson", [True, False])
+def test_surfdens_differentiates_in_R_not_only_z(backend_name, forcepoisson):
+    # surfdens picks scipy-vs-backend-quadrature with _quad_needs_backend, which
+    # used to ask only about the INTEGRATION LIMIT (absz). The integrand closes
+    # over R, phi and t just as much, so differentiating w.r.t. R at fixed z
+    # fell into scipy and raised a concretization error -- while the very same
+    # derivative w.r.t. z worked. An asymmetry inside one function.
+    #
+    # Both surfdens routes are covered: forcepoisson=True goes through the
+    # Rforce/R2deriv/phi2deriv combination, False through _dens.
+    if backend_name == "torch":
+        pytest.skip(
+            "separate PRE-EXISTING gap: the gate is under_trace, which is False "
+            "for EAGER torch autograd (it asks torch.compiler.is_compiling()), so "
+            "surfdens takes scipy and silently returns a detached float -- no "
+            "torch gradient, in R OR z. Widening the gate to grad-tracking eager "
+            "tensors would route scalar-only potentials into the array-calling GL "
+            "rule, which is the undecidable _force_accepts_arrays problem the "
+            "_quad_needs_backend docstring describes. Its own change."
+        )
+    from galpy.potential import MiyamotoNagaiPotential
+
+    pot = MiyamotoNagaiPotential(a=0.5, b=0.1)
+    R0, z0, h = 1.0, 0.3, 1e-5
+
+    def val(R, z):
+        return float(pot.surfdens(R, z, forcepoisson=forcepoisson, use_physical=False))
+
+    fd_R = (val(R0 + h, z0) - val(R0 - h, z0)) / (2 * h)
+    fd_z = (val(R0, z0 + h) - val(R0, z0 - h)) / (2 * h)
+
+    def sd(R, z):
+        return pot.surfdens(R, z, forcepoisson=forcepoisson, use_physical=False)
+
+    jnp = jax.numpy
+    ad_R = float(jax.grad(lambda R: sd(R, jnp.asarray(z0)))(jnp.asarray(R0)))
+    ad_z = float(jax.grad(lambda z: sd(jnp.asarray(R0), z))(jnp.asarray(z0)))
+
+    # h=1e-5 central differences on a smooth integral: good to ~1e-9. d/dz is
+    # the control -- it worked before this fix, so if it ever regresses the
+    # cause is the gate, not the quadrature.
+    numpy.testing.assert_allclose(ad_R, fd_R, rtol=1e-6, atol=1e-9)
+    numpy.testing.assert_allclose(ad_z, fd_z, rtol=1e-6, atol=1e-9)

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -498,7 +498,7 @@ def test_radec_to_lb__1950_galpyvsastropy():
 # Test lb_to_XYZ
 def test_lbd_to_XYZ():
     l, b, d = 90.0, 30.0, 1.0
-    XYZ = coords.lbd_to_XYZ(l, b, d, degree=True)
+    XYZ = as_numpy(coords.lbd_to_XYZ(l, b, d, degree=True))
     assert numpy.fabs(XYZ[0]) < 10.0**-10.0, (
         "lbd_to_XYZ conversion does not work as expected"
     )
@@ -509,7 +509,9 @@ def test_lbd_to_XYZ():
         "lbd_to_XYZ conversion does not work as expected"
     )
     # Also test for degree=False
-    XYZ = coords.lbd_to_XYZ(l / 180.0 * numpy.pi, b / 180.0 * numpy.pi, d, degree=False)
+    XYZ = as_numpy(
+        coords.lbd_to_XYZ(l / 180.0 * numpy.pi, b / 180.0 * numpy.pi, d, degree=False)
+    )
     assert numpy.fabs(XYZ[0]) < 10.0**-10.0, (
         "lbd_to_XYZ conversion does not work as expected"
     )
@@ -521,8 +523,10 @@ def test_lbd_to_XYZ():
     )
     # Also test for arrays
     os = numpy.ones(2)
-    XYZ = coords.lbd_to_XYZ(
-        os * l / 180.0 * numpy.pi, os * b / 180.0 * numpy.pi, os * d, degree=False
+    XYZ = as_numpy(
+        coords.lbd_to_XYZ(
+            os * l / 180.0 * numpy.pi, os * b / 180.0 * numpy.pi, os * d, degree=False
+        )
     )
     assert numpy.all(numpy.fabs(XYZ[:, 0]) < 10.0**-10.0), (
         "lbd_to_XYZ conversion does not work as expected"
@@ -583,8 +587,8 @@ def test_XYZ_to_lbd():
 def test_vrpmllpmbb_to_vxvyvz():
     l, b, d = 90.0, 0.0, 1.0
     vr, pmll, pmbb = 10.0, 20.0 / 4.740470463496208, -10.0 / 4.740470463496208
-    vxvyvz = coords.vrpmllpmbb_to_vxvyvz(
-        vr, pmll, pmbb, l, b, d, degree=True, XYZ=False
+    vxvyvz = as_numpy(
+        coords.vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, l, b, d, degree=True, XYZ=False)
     )
     assert numpy.fabs(vxvyvz[0] + 20.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
@@ -595,15 +599,17 @@ def test_vrpmllpmbb_to_vxvyvz():
     assert numpy.fabs(vxvyvz[2] + 10.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
     )
-    vxvyvz = coords.vrpmllpmbb_to_vxvyvz(
-        vr,
-        pmll,
-        pmbb,
-        l / 180.0 * numpy.pi,
-        b / 180.0 * numpy.pi,
-        d,
-        degree=False,
-        XYZ=False,
+    vxvyvz = as_numpy(
+        coords.vrpmllpmbb_to_vxvyvz(
+            vr,
+            pmll,
+            pmbb,
+            l / 180.0 * numpy.pi,
+            b / 180.0 * numpy.pi,
+            d,
+            degree=False,
+            XYZ=False,
+        )
     )
     assert numpy.fabs(vxvyvz[0] + 20.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
@@ -614,7 +620,9 @@ def test_vrpmllpmbb_to_vxvyvz():
     assert numpy.fabs(vxvyvz[2] + 10.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
     )
-    vxvyvz = coords.vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, 0.0, 1, 0.0, XYZ=True)
+    vxvyvz = as_numpy(
+        coords.vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, 0.0, 1, 0.0, XYZ=True)
+    )
     assert numpy.fabs(vxvyvz[0] + 20.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
     )
@@ -624,8 +632,8 @@ def test_vrpmllpmbb_to_vxvyvz():
     assert numpy.fabs(vxvyvz[2] + 10.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
     )
-    vxvyvz = coords.vrpmllpmbb_to_vxvyvz(
-        vr, pmll, pmbb, 0.0, 1, 0.0, XYZ=True, degree=True
+    vxvyvz = as_numpy(
+        coords.vrpmllpmbb_to_vxvyvz(vr, pmll, pmbb, 0.0, 1, 0.0, XYZ=True, degree=True)
     )
     assert numpy.fabs(vxvyvz[0] + 20.0) < 10.0**-9.0, (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
@@ -638,8 +646,17 @@ def test_vrpmllpmbb_to_vxvyvz():
     )
     # Also test for arrays
     os = numpy.ones(2)
-    vxvyvz = coords.vrpmllpmbb_to_vxvyvz(
-        os * vr, os * pmll, os * pmbb, os * l, os * b, os * d, degree=True, XYZ=False
+    vxvyvz = as_numpy(
+        coords.vrpmllpmbb_to_vxvyvz(
+            os * vr,
+            os * pmll,
+            os * pmbb,
+            os * l,
+            os * b,
+            os * d,
+            degree=True,
+            XYZ=False,
+        )
     )
     assert numpy.all(numpy.fabs(vxvyvz[:, 0] + 20.0) < 10.0**-9.0), (
         "vrpmllpmbb_to_vxvyvz conversion did not work as expected"
@@ -782,8 +799,10 @@ def test_XYZ_to_galcenrect_vecSun():
         numpy.array([3.0, 3.0]),
         numpy.array([-2.0, -2.0]),
     )
-    gcXYZ = coords.XYZ_to_galcenrect(
-        X, Y, Z, Xsun=numpy.array([1.0, -2.0]), Zsun=numpy.array([0.0, 0.0])
+    gcXYZ = as_numpy(
+        coords.XYZ_to_galcenrect(
+            X, Y, Z, Xsun=numpy.array([1.0, -2.0]), Zsun=numpy.array([0.0, 0.0])
+        )
     )
     assert numpy.all(numpy.fabs(gcXYZ[:, 0]) < 10.0**-5.0), (
         "XYZ_to_galcenrect conversion did not work as expected"
@@ -1028,8 +1047,10 @@ def test_XYZ_to_galcencyl_vecSun():
         numpy.array([4.0, 4.0]),
         numpy.array([-2.0, -2.0]),
     )
-    gcRpZ = coords.XYZ_to_galcencyl(
-        X, Y, Z, Xsun=numpy.array([8.0, 7.0]), Zsun=numpy.array([0.0, 0.0])
+    gcRpZ = as_numpy(
+        coords.XYZ_to_galcencyl(
+            X, Y, Z, Xsun=numpy.array([8.0, 7.0]), Zsun=numpy.array([0.0, 0.0])
+        )
     )
     assert numpy.all(numpy.fabs(gcRpZ[:, 0] - 5.0) < 10.0**-5.0), (
         "XYZ_to_galcencyl conversion did not work as expected"
@@ -1197,13 +1218,15 @@ def test_vxvyvz_to_galcenrect_vecXsun():
         numpy.array([-20.0, -20.0]),
         numpy.array([30.0, 30.0]),
     )
-    vgc = coords.vxvyvz_to_galcenrect(
-        vx,
-        vy,
-        vz,
-        vsun=[-5.0, 10.0, 5.0],
-        Xsun=numpy.array([1.1, 1.0]),
-        Zsun=numpy.array([0.0, 0.0]),
+    vgc = as_numpy(
+        coords.vxvyvz_to_galcenrect(
+            vx,
+            vy,
+            vz,
+            vsun=[-5.0, 10.0, 5.0],
+            Xsun=numpy.array([1.1, 1.0]),
+            Zsun=numpy.array([0.0, 0.0]),
+        )
     )
     assert numpy.all(numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0), (
         "vxvyvz_to_galcenrect conversion did not work as expected"
@@ -1223,8 +1246,10 @@ def test_vxvyvz_to_galcenrect_vecvsun():
         numpy.array([-20.0, -10.0]),
         numpy.array([30.0, 25.0]),
     )
-    vgc = coords.vxvyvz_to_galcenrect(
-        vx, vy, vz, vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T
+    vgc = as_numpy(
+        coords.vxvyvz_to_galcenrect(
+            vx, vy, vz, vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T
+        )
     )
     assert numpy.all(numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0), (
         "vxvyvz_to_galcenrect conversion did not work as expected"
@@ -1244,13 +1269,15 @@ def test_vxvyvz_to_galcenrect_vecXsunvsun():
         numpy.array([-20.0, -10.0]),
         numpy.array([30.0, 25.0]),
     )
-    vgc = coords.vxvyvz_to_galcenrect(
-        vx,
-        vy,
-        vz,
-        Xsun=numpy.array([1.1, 1.0]),
-        Zsun=numpy.array([0.0, 0.0]),
-        vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T,
+    vgc = as_numpy(
+        coords.vxvyvz_to_galcenrect(
+            vx,
+            vy,
+            vz,
+            Xsun=numpy.array([1.1, 1.0]),
+            Zsun=numpy.array([0.0, 0.0]),
+            vsun=numpy.array([[-5.0, 10.0, 5.0], [-10.0, 0.0, 10.0]]).T,
+        )
     )
     assert numpy.all(numpy.fabs(vgc[:, 0] + 15.0) < 10.0**-4.0), (
         "vxvyvz_to_galcenrect conversion did not work as expected"

--- a/tests/test_kuzminkutuzov.py
+++ b/tests/test_kuzminkutuzov.py
@@ -699,7 +699,7 @@ def test_lambdanu_to_Rz():
     # _____test float input (z=0)_____
     # coordinate transformation:
     l, n = 2.0, -4.0
-    R, z = coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta)
+    R, z = tuple(as_numpy(v) for v in coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta))
     # true values:
     R_true = numpy.sqrt((l + a) * (n + a) / (a - g))
     z_true = numpy.sqrt((l + g) * (n + g) / (g - a))
@@ -715,7 +715,7 @@ def test_lambdanu_to_Rz():
     # coordinate transformation:
     l = numpy.array([2.0, 10.0, 20.0, 0.0])
     n = numpy.array([-4.0, -3.0, -3.5, -3.5])
-    R, z = coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta)
+    R, z = tuple(as_numpy(v) for v in coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta))
     # true values:
     R_true = numpy.sqrt((l + a) * (n + a) / (a - g))
     z_true = numpy.sqrt((l + g) * (n + g) / (g - a))
@@ -745,8 +745,11 @@ def test_Rz_to_lambdanu():
     # true values:
     l, n = 2.0, -3.0
     # coordinate transformation:
-    lt, nt = coords.Rz_to_lambdanu(
-        *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+    lt, nt = tuple(
+        as_numpy(v)
+        for v in coords.Rz_to_lambdanu(
+            *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+        )
     )
     # test:
     assert numpy.fabs(lt - l) < 10.0**-10.0, (
@@ -759,8 +762,11 @@ def test_Rz_to_lambdanu():
     # ___Also test for arrays___
     l = numpy.array([2.0, 10.0, 20.0, 0.0])
     n = numpy.array([-7.0, -3.0, -5.0, -5.0])
-    lt, nt = coords.Rz_to_lambdanu(
-        *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+    lt, nt = tuple(
+        as_numpy(v)
+        for v in coords.Rz_to_lambdanu(
+            *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+        )
     )
     assert numpy.all(numpy.fabs(lt - l) < 10.0**-10.0), (
         "Rz_to_lambdanu conversion did not work as expected (l array)"
@@ -783,8 +789,11 @@ def test_Rz_to_lambdanu_r2lt0():
     # true values:
     l, n = 2.0, -3.0 + 10.0**-10.0
     # coordinate transformation:
-    lt, nt = coords.Rz_to_lambdanu(
-        *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+    lt, nt = tuple(
+        as_numpy(v)
+        for v in coords.Rz_to_lambdanu(
+            *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+        )
     )
     # test:
     assert numpy.fabs(lt - l) < 10.0**-8.0, (
@@ -797,8 +806,11 @@ def test_Rz_to_lambdanu_r2lt0():
     # ___Also test for arrays___
     l = numpy.array([2.0, 10.0, 20.0, 0.0])
     n = numpy.array([-7.0, -3.0 + 10.0**-10.0, -5.0, -5.0])
-    lt, nt = coords.Rz_to_lambdanu(
-        *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+    lt, nt = tuple(
+        as_numpy(v)
+        for v in coords.Rz_to_lambdanu(
+            *coords.lambdanu_to_Rz(l, n, ac=ac, Delta=Delta), ac=ac, Delta=Delta
+        )
     )
     assert numpy.all(numpy.fabs(lt - l) < 10.0**-8.0), (
         "Rz_to_lambdanu conversion did not work as expected (l array)"

--- a/tests/test_streamTrack.py
+++ b/tests/test_streamTrack.py
@@ -88,7 +88,9 @@ def test_streamTrack_sample_consistency(_simple_spdf):
     track = _simple_spdf.streamTrack(n=4000, ntp=41, tail="leading")
     # Reproduce the closest-point assignment from the saved particles ->
     # closest point on the dense track itself (a stable, public reference).
-    particles_cart = coords.galcencyl_to_galcenrect(*track.particles)
+    # galcencyl_to_galcenrect is backend-native now, so under a forced backend
+    # this is a Tensor and the numpy reductions below (.std(ddof=...)) reject it.
+    particles_cart = as_numpy(coords.galcencyl_to_galcenrect(*track.particles))
     tp_grid = track.tp_grid()
     track_cart = numpy.column_stack(
         [


### PR DESCRIPTION
Review findings 3, 4 and 6. **Finding 6 is complete (7 of 7).**

### What this does

* **finding 6** — the remaining inverse transforms go backend-native:
  `lambdanu_to_Rz` (clamp via `xp.where`), `galcencyl_to_galcenrect` (off
  `numpy.column_stack`), `lbd_to_XYZ`, `vrpmllpmbb_to_vxvyvz`,
  `XYZ_to_galcenrect`, `XYZ_to_galcencyl`, `vxvyvz_to_galcenrect`.
  `vxvyvz_to_galcenrect` shares `XYZ_to_galcenrect`'s rotation, so `_to_galcen_rot`
  is hoisted rather than copied — the matrix literal now appears exactly once.
* **findings 3 + 4** — the traced-R surfdens gate (`_quad_needs_backend` made
  variadic) and backend Xsun/Zsun in coords, with `prefer_backend_namespace`
  hoisted into `galpy.backend` so the coords fix reuses the boundary's rule.

### Three defects the migration exposed

1. **f64 constant meets f32 data (pre-existing, in merged code).**
   `galcen_extra_rot` is a float64 module constant; torch refuses to matmul it
   against float32, so `galcenrect_to_XYZ` / `galcenrect_to_vxvyvz` /
   `XYZ_to_galcenrect` raised for any torch user at torch's **default** dtype.
   Invisible because the suite runs entirely in float64. Fixed by promoting via
   `result_type` — numpy's own rule, so f32 in still returns f64 exactly as the
   numpy path does. Hoisted to `galpy.backend` as `promote_common_dtype`, since
   SCF tables / quadrature nodes / spline coefficients meet coordinates the same
   way.
2. **A dead backend branch of mine.** `XYZ_to_galcenrect` had a backend branch
   but no `@backendNative`, so `scalarDecorator`'s numpy ndim probe raised before
   reaching it — on exactly the grad/traced inputs it was written for.
3. **Resolved namespace, uncoerced inputs.** `resolve_namespace` returns the
   FORCED namespace even when the coordinates are still numpy, so
   `xp.cos(ndarray)` raised under `--backend torch` in `lbd_to_XYZ`,
   `vrpmllpmbb_to_vxvyvz`, `galcencyl_to_galcenrect` and `lambdanu_to_Rz`.
   Coerced rather than data-guarded; `coerce_coords` is a no-op on numpy.

Plus: a python-scalar call no longer falls to torch float32 (user-facing only —
`conftest` sets float64, so no test outcome changes; the regression test controls
the dtype itself and is verified to fail without the fix), and a torch
`.T`-on-1-D deprecation guard.

### Gate

* `tests/test_coords.py` **98/98 under numpy, torch AND jax** (torch was 10
  failures before this branch, 0 after; the pre-branch base is also 0, so all 10
  were mine to fix, not ledger material).
* numpy path **byte-identical** over 37-element arrays x {scalar, array, negative
  Xsun} x {scalar, array Zsun} x `_extra_rot`, verified with a 1-ulp negative
  control confirming the check is sensitive.
* Gradients vs central finite differences where they are non-vacuous (at
  `Zsun != 0`, and through `vsun`): agree to 1e-8..1e-11. `jax.jit(jax.grad(...))`
  traces.

**Ledger delta: 0** — no entries added, none burned.