### PR TITLE
actionAngleVerticalInverse: canonical evaluation mode, on by default

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -12,6 +12,19 @@ v1.12.1 (expected around 2026-11-01)
   apart by ~1e-15, which the symplectic dxdv bit-identity test caught
   intermittently depending on which machine it ran on.
 
+- ``actionAngleVerticalInverse`` gained a canonical evaluation mode, the
+  default for interpolating instances without a point transformation. The
+  angle map now uses the exact derivative of the interpolated coefficient
+  tables plus a closed-form compensation for the energy-dependent auxiliary
+  frequency, and the returned frequency is the interpolated Hamiltonian's
+  own derivative, so the assembled (J, angle) -> (x, v) map is exactly
+  symplectic for any stored tables: the measured symplectic defect drops
+  from the interpolation error of the old separately stored derivative
+  tables (median 2.5e-4) to the finite-difference test floor (~1e-10), and
+  is invariant under noise injected into the tables. The old behavior is
+  available with canonical=False; the derivative tables are kept as a
+  consistency diagnostic (check_canonical_consistency).
+
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the
   symmetry axis. V(v) is built along u=u0 and only represents the wrapped

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -52,6 +52,7 @@ class actionAngleVerticalInverse(actionAngleInverse):
         maxiter=100,
         angle_tol=1e-12,
         bisect=False,
+        canonical=None,
         **kwargs,
     ):
         """
@@ -83,6 +84,8 @@ class actionAngleVerticalInverse(actionAngleInverse):
             tolerance for angle root-finding (f(x) is within tol of desired value)
         bisect : bool
             if True, use simple bisection for root-finding, otherwise first try Newton-Raphson (mainly useful for testing the bisection fallback)
+        canonical : bool, optional
+            if True, use the canonical evaluation mode: the angle map uses the exact derivative of the interpolated nSn tables plus the closed-form compensation for the energy-dependent auxiliary frequency, so the assembled (J, angle) -> (x, v) map is exactly symplectic for any stored tables (the separately stored dSndJ tables are kept only as a consistency diagnostic). Default: True for interpolating instances without a point transformation (where the stored coefficients are gauge-compatible), False otherwise; canonical=True with a point transformation is not implemented yet.
 
         Notes
         -----
@@ -293,6 +296,23 @@ class actionAngleVerticalInverse(actionAngleInverse):
             self._setup_interp()
         else:
             self._interp = False
+        # Canonical evaluation: manifestly symplectic for any stored tables.
+        # Default for interpolating instances without a point transformation,
+        # where the stored nSn are the coefficients of the xi = 0 gauge (the
+        # identity PT has no shear, so the equal-time and cotangent gauges
+        # coincide and the tables can be reused as-is)
+        self._identity_pt = not self._pt_exact and self._pt_deg == 1
+        if canonical is None:
+            canonical = self._interp and self._identity_pt
+        if canonical and not (self._interp and self._identity_pt):
+            raise ValueError(
+                "canonical=True requires setup_interp=True and no point "
+                "transformation (use_pointtransform=False); the canonical "
+                "mode for point-transformed tori is not implemented yet"
+            )
+        self._canonical = canonical
+        if self._canonical:
+            self._setup_canonical()
         return None
 
     def _setup_pointtransform(self, pt_deg, pt_nxa):
@@ -1291,6 +1311,165 @@ class actionAngleVerticalInverse(actionAngleInverse):
             )
         return self._js[indx]
 
+    def _setup_canonical(self):
+        """Build the exactly-differentiable chains of the canonical mode.
+
+        Everything the evaluation uses is either an interpolant paired with
+        its own exact derivative or a closed form: the value table of nSn
+        (B-spline coefficients along the energy axis, evaluated together
+        with their derivative by one four-point stencil), E(j) and its
+        derivative (which is also the frequency: the integrator-consistency
+        contract), and OmegaHO(E) and its derivative for the compensation
+        term. The separately stored dSndJ tables are NOT used: a value table
+        and an independent derivative table only satisfy the symplectic
+        consistency relation when both are exact, and interpolation breaks
+        it (the measured symplectic defect of the old mode is at the
+        derivative-table interpolation error)."""
+        self._can_nSn_c = ndimage.spline_filter1d(
+            self._nSn, order=3, axis=0, mode="mirror"
+        )
+        self._can_dEdj = self.E.derivative()
+        self._can_dOmHOdE = self.OmegaHO.derivative()
+        return None
+
+    def _canonical_tables(self, j):
+        """nSn and d(nSn)/dj at action j, as value and exact derivative of
+        one stored interpolant (cubic B-spline along the energy axis chained
+        through E(j))."""
+        tE = float(self.E(j))
+        x = (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
+        x = min(max(x, 0.0), self._nE - 1.0)
+        i0 = int(numpy.floor(x))
+        if i0 > self._nE - 2:  # pragma: no cover
+            i0 = self._nE - 2
+        t = x - i0
+        taps = numpy.array([i0 - 1, i0, i0 + 1, i0 + 2])
+        taps = numpy.abs(taps)
+        taps[taps > self._nE - 1] = 2 * (self._nE - 1) - taps[taps > self._nE - 1]
+        C = self._can_nSn_c[taps]
+        w = numpy.array(
+            [
+                (1.0 - t) ** 3 / 6.0,
+                (4.0 - 6.0 * t**2 + 3.0 * t**3) / 6.0,
+                (1.0 + 3.0 * t + 3.0 * t**2 - 3.0 * t**3) / 6.0,
+                t**3 / 6.0,
+            ]
+        )
+        wd = numpy.array(
+            [
+                -((1.0 - t) ** 2) / 2.0,
+                (-12.0 * t + 9.0 * t**2) / 6.0,
+                (3.0 + 6.0 * t - 9.0 * t**2) / 6.0,
+                t**2 / 2.0,
+            ]
+        )
+        val = w @ C
+        dval_dE = (wd @ C) * (self._nE - 1.0) / (self._Emax - self._Emin)
+        return val, dval_dE * float(self._can_dEdj(j))
+
+    def check_canonical_consistency(self, ntheta=256):
+        """The three-way consistency relation between the two derivative
+        routes (STAECKEL_CANONICAL_MATH.md C8): the stored dSndJ tables are
+        the fixed-omega angle-fit fields, the canonical chain differentiates
+        the value interpolant, and the two must differ by exactly the
+        closed-form compensation for the varying auxiliary frequency,
+        D_n = d(Sbar_n)/dj + [omega'/(2 omega)] g_n with g_n the sine
+        coefficients of J^A(theta^A) sin(2 theta^A). Returns the maximum
+        absolute mismatch over the interior nodes; a value at the
+        table-interpolation error certifies both routes, a large value means
+        a broken chain and localizes the offending node.
+
+        Parameters
+        ----------
+        ntheta : int, optional
+            Number of angles for the Fourier transform of the compensation.
+
+        Returns
+        -------
+        float
+            Maximum absolute mismatch of the consistency relation.
+
+        Notes
+        -----
+        - 2026-08-25 - Written - Bovy (UofT)
+        """
+        th = 2.0 * numpy.pi * numpy.arange(ntheta) / ntheta
+        mism = 0.0
+        for idx in range(2, self._nE - 2):
+            jn = float(self._js[idx])
+            _, dnSndj = self._canonical_tables(jn)
+            dSdj = dnSndj / self._nforSn
+            tE = float(self.E(jn))
+            om = float(self.OmegaHO(tE))
+            domdj = float(self._can_dOmHOdE(tE)) * float(self._can_dEdj(jn))
+            ja = jn + 2.0 * numpy.sum(
+                self._nSn[idx] * numpy.cos(numpy.outer(th, self._nforSn)), axis=1
+            )
+            comp = ja * numpy.sin(2.0 * th)
+            gn = -numpy.imag(numpy.fft.rfft(comp))[1 : len(self._nforSn) + 1] / ntheta
+            pred = dSdj + domdj / (2.0 * om) * gn
+            mism = max(mism, numpy.max(numpy.abs(pred - self._dSndJ[idx])))
+        return mism
+
+    def _xvFreqs_canonical(self, j, angle):
+        """The canonical evaluation: every ingredient is an interpolant
+        differentiated exactly or a closed form, so the map is exactly
+        symplectic whatever the tables contain. The compensation for the
+        j-dependent auxiliary frequency is closed form: dW^A/domega at fixed
+        (x, J^A) equals x_a v_a / (2 omega) = [J^A sin(2 theta^A)] / (2
+        omega)."""
+        angle = numpy.atleast_1d(angle)
+        nSn, dnSndj = self._canonical_tables(j)
+        n = self._nforSn
+        dSdj = dnSndj / n
+        tE = float(self.E(j))
+        om = float(self.OmegaHO(tE))
+        dEdj = float(self._can_dEdj(j))
+        domdj = float(self._can_dOmHOdE(tE)) * dEdj
+        pref = domdj / (2.0 * om)
+        anglea = copy.copy(angle)
+        cntr = 0
+        maxda = 2.0 * numpy.pi / 101.0
+        while cntr <= self._maxiter:
+            san = numpy.sin(n * numpy.atleast_2d(anglea).T)
+            can = numpy.cos(n * numpy.atleast_2d(anglea).T)
+            ja = j + 2.0 * numpy.sum(nSn * can, axis=1)
+            F = (
+                anglea
+                + 2.0 * numpy.sum(dSdj * san, axis=1)
+                + pref * ja * numpy.sin(2.0 * anglea)
+                - angle
+            )
+            F = (F + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            if numpy.max(numpy.fabs(F)) < self._angle_tol:
+                break
+            djada = -2.0 * numpy.sum(n * nSn * san, axis=1)
+            dF = (
+                1.0
+                + 2.0 * numpy.sum(n * dSdj * can, axis=1)
+                + pref
+                * (djada * numpy.sin(2.0 * anglea) + 2.0 * ja * numpy.cos(2.0 * anglea))
+            )
+            da = -F / dF
+            da[numpy.fabs(da) > maxda] = (numpy.sign(da) * maxda)[
+                numpy.fabs(da) > maxda
+            ]
+            anglea = anglea + da
+            cntr += 1
+        else:  # pragma: no cover
+            warnings.warn(
+                "Canonical angle mapping did not converge in {} iterations".format(
+                    self._maxiter
+                ),
+                galpyWarning,
+            )
+        ja = j + 2.0 * numpy.sum(
+            nSn * numpy.cos(n * numpy.atleast_2d(anglea).T), axis=1
+        )
+        hoaainv = actionAngleHarmonicInverse(omega=om)
+        xa, va = hoaainv(ja, anglea)
+        return (xa, va, dEdj)
+
     def _evaluate(self, j, angle, **kwargs):
         """
         Evaluate the phase-space coordinates (x,v) for a number of angles on a single torus
@@ -1333,6 +1512,8 @@ class actionAngleVerticalInverse(actionAngleInverse):
         -----
         - 2018-04-15 - Written - Bovy (UofT)
         """
+        if self._canonical:
+            return self._xvFreqs_canonical(j, angle)
         # Find torus
         if not self._interp:
             indx = numpy.nanargmin(numpy.fabs(j - self._js))
@@ -1522,6 +1703,10 @@ class actionAngleVerticalInverse(actionAngleInverse):
         - 2018-04-08 - Written - Bovy (UofT)
 
         """
+        if self._canonical:
+            # the frequency of the interpolated Hamiltonian itself: exactly
+            # consistent with the canonical chart (the integrator contract)
+            return float(self._can_dEdj(j))
         # Find torus
         if not self._interp:
             indx = numpy.nanargmin(numpy.fabs(j - self._js))

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -7720,7 +7720,11 @@ def test_actionAngleVerticalInverse_freqs_wrtVertical_interpolation(
     aAV = actionAngleVertical(pot=isopot)
     x, vx = 0.1, -0.3
     obs = Orbit([x, vx])
-    tol = -10.0
+    # The canonical default returns the frequency of the interpolated
+    # Hamiltonian itself (the E(j) interpolant's own derivative), which is
+    # exactly consistent with the returned chart but a shade less accurate
+    # against the true frequency than the old separately interpolated one
+    tol = -9.0
     Om = aAVI.Freqs(aAVI.J(obs.E(pot=isopot)))
     # Compute frequency with actionAngleHarmonic
     _, Omi = aAV.actionsFreqs(*aAVI(aAVI.J(obs.E(pot=isopot)), 0.0))
@@ -8104,6 +8108,153 @@ def test_actionAngleVerticalInverse_notE_errors():
 
 
 # Test that computing actionAngle coordinates in C for a NullPotential leads to an error
+
+
+def _vertical_canonical_setup(canonical=None, nE=21):
+    from galpy.actionAngle.actionAngleVerticalInverse import (
+        actionAngleVerticalInverse,
+    )
+    from galpy.potential import MWPotential2014, toVerticalPotential
+
+    vp = toVerticalPotential(MWPotential2014, 1.0)
+    kwargs = {} if canonical is None else dict(canonical=canonical)
+    return actionAngleVerticalInverse(
+        pot=vp, Es=numpy.linspace(0.02, 0.35, nE), setup_interp=True, nta=128, **kwargs
+    )
+
+
+def _vertical_symplectic_defect(aAVI, j, angle, h=1e-6):
+    Om = numpy.array([[0.0, 1.0], [-1.0, 0.0]])
+
+    def st(jj, aa):
+        o = aAVI(jj, numpy.array([aa]))
+        return numpy.array(
+            [float(numpy.atleast_1d(o[0])[0]), float(numpy.atleast_1d(o[1])[0])]
+        )
+
+    A = numpy.empty((2, 2))
+    A[:, 0] = (st(j, angle + h) - st(j, angle - h)) / (2.0 * h)
+    A[:, 1] = (st(j + h, angle) - st(j - h, angle)) / (2.0 * h)
+    return numpy.max(numpy.abs(A.T @ Om @ A - Om))
+
+
+def test_actionAngleVerticalInverse_canonical_defect():
+    # The canonical mode's symplectic defect must sit at the finite-difference
+    # floor, orders below the old mode's, which lives at the interpolation
+    # error of its separately stored derivative tables
+    gold = _vertical_canonical_setup(canonical=False)
+    gnew = _vertical_canonical_setup()
+    assert gnew._canonical, (
+        "canonical does not default to True for an interpolating no-PT instance"
+    )
+    ds_old, ds_new = [], []
+    for E in numpy.linspace(0.06, 0.30, 4):
+        j = float(numpy.atleast_1d(gnew.J(E))[0])
+        for th in (0.8, 2.1):
+            ds_old.append(_vertical_symplectic_defect(gold, j, th))
+            ds_new.append(_vertical_symplectic_defect(gnew, j, th))
+    assert numpy.max(ds_new) < 1e-8, (
+        "canonical-mode symplectic defect %g not at the test floor" % numpy.max(ds_new)
+    )
+    assert numpy.median(ds_old) > 1e-6, (
+        "the old mode's defect is unexpectedly small; this test has lost its "
+        "discriminating power"
+    )
+    return None
+
+
+def test_actionAngleVerticalInverse_canonical_manifest():
+    # THE defining property: inject noise into the stored tables and the
+    # symplectic defect must not move -- noise changes which canonical map
+    # the tables define, never whether it is one
+    gnew = _vertical_canonical_setup()
+    j = float(numpy.atleast_1d(gnew.J(0.15))[0])
+    x0 = float(numpy.atleast_1d(gnew(j, numpy.array([0.8]))[0])[0])
+    d0 = max(_vertical_symplectic_defect(gnew, j, th) for th in (0.8, 2.1, 4.0))
+    rng = numpy.random.default_rng(7)
+    gnew._can_nSn_c = gnew._can_nSn_c * (
+        1.0 + 1e-5 * rng.standard_normal(gnew._can_nSn_c.shape)
+    )
+    dn = max(_vertical_symplectic_defect(gnew, j, th) for th in (0.8, 2.1, 4.0))
+    xn = float(numpy.atleast_1d(gnew(j, numpy.array([0.8]))[0])[0])
+    assert dn < 1e-8, (
+        "symplectic defect moved to %g under table noise: not manifest" % dn
+    )
+    assert numpy.fabs(xn - x0) > 1e-10, (
+        "the noise did not change the evaluation at all; the manifest test "
+        "did not actually test anything"
+    )
+    return None
+
+
+def test_actionAngleVerticalInverse_canonical_consistency():
+    # C8: the stored dSndJ (fixed-omega angle-fit fields) equal the canonical
+    # chain's interpolant derivative plus the closed-form compensation for
+    # the varying auxiliary frequency; without the compensation the relation
+    # fails by more than the tables' own scale
+    gnew = _vertical_canonical_setup(nE=31)
+    mism = gnew.check_canonical_consistency()
+    assert mism < 1e-2, "C8 consistency mismatch %g too large" % mism
+
+    class _Zero:
+        def __call__(self, x):
+            return 0.0
+
+    import copy
+
+    gzero = copy.copy(gnew)
+    gzero._can_dOmHOdE = _Zero()
+    mism0 = gzero.check_canonical_consistency()
+    assert mism0 > 10.0 * mism, (
+        "dropping the compensation does not degrade the consistency relation "
+        "(%g vs %g): the check is not sharp" % (mism0, mism)
+    )
+    return None
+
+
+def test_actionAngleVerticalInverse_canonical_freq():
+    # In the canonical mode the frequency is the exact derivative of the
+    # interpolated E(j) -- consistent with the chart (the integrator
+    # contract) -- and close to, but not identical with, the old mode's
+    # separately interpolated frequency
+    gold = _vertical_canonical_setup(canonical=False)
+    gnew = _vertical_canonical_setup()
+    for E in (0.1, 0.2):
+        j = float(numpy.atleast_1d(gnew.J(E))[0])
+        Onew = gnew._Freqs(j)
+        assert numpy.fabs(Onew - float(gnew.E.derivative()(j))) < 1e-14, (
+            "canonical frequency is not the E(j) interpolant's own derivative"
+        )
+        assert numpy.fabs(Onew / gold._Freqs(j) - 1.0) < 1e-3, (
+            "canonical frequency far from the old mode's"
+        )
+    return None
+
+
+def test_actionAngleVerticalInverse_canonical_errors():
+    # canonical=True requires interpolation and no point transformation
+    from galpy.actionAngle.actionAngleVerticalInverse import (
+        actionAngleVerticalInverse,
+    )
+    from galpy.potential import MWPotential2014, toVerticalPotential
+
+    vp = toVerticalPotential(MWPotential2014, 1.0)
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleVerticalInverse(pot=vp, Es=[0.1, 0.2], canonical=True)
+    assert "canonical" in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        actionAngleVerticalInverse(
+            pot=vp,
+            Es=numpy.linspace(0.02, 0.3, 5),
+            setup_interp=True,
+            use_pointtransform=True,
+            pt_deg=3,
+            canonical=True,
+        )
+    assert "point transformation" in str(excinfo.value)
+    return None
+
+
 def test_nullpotential_error():
     from galpy.actionAngle import actionAngleStaeckel
     from galpy.potential import NullPotential


### PR DESCRIPTION
Stage 1 of the canonical-inverse program (fast-orbits `STAECKEL_CANONICAL_MATH.md` §5.1/§8) — the smallest complete instance of the architecture, repairing measured defects in merged code.

### The problem, measured

The interpolating evaluation stores coefficient values (`_nSn`) and their J-derivatives (`_dSndJ`) as **separate** tables. Exact tables satisfy the symplectic consistency relation between them; independently interpolated ones don't, and the assembled map's symplectic defect sits at the derivative-table interpolation error:

| | min / median / max over a sweep |
|---|---|
| old mode | 2.9e-06 / **2.5e-04** / 1.5e-03 |
| canonical mode | 8.0e-12 / **1.3e-10** / 4.9e-10 |
| canonical + 1e-5 table noise | unchanged |

The map's own *accuracy* is orders better than its old defect — accuracy and canonicity are independent axes — but a symplectic integrator built on the old chart cannot converge to machine precision by shrinking its step.

### The canonical mode

Everything the evaluation uses is an interpolant differentiated exactly, or a closed form:

- `d(S̄_n)/dj` = the exact derivative of the **value** table (cubic B-spline stencil along the energy axis) chained through `E(j)`;
- the compensation for the energy-dependent auxiliary frequency is closed form — `∂W^A/∂ω` at fixed `(x, J^A)` equals `x_a v_a/2ω = J^A sin(2θ^A)/2ω` — and enters the angle Newton;
- the returned frequency is the `E(j)` interpolant's **own derivative**: exactly consistent with the chart, which is what a symplectic splitting needs (`H = H̃ + (H−H̃)` with the kick carrying all approximation error).

The noise-invariance line is the defining property, now a unit test: perturbing every stored coefficient changes *which* canonical map the tables define, never *whether* it is one.

### Scope and defaults

- **Default ON** for interpolating instances without a point transformation (Jo-authorized behavior change). There the stored `_nSn` are gauge-compatible as-is: the identity PT has no shear, so the equal-time and cotangent-lift gauges coincide.
- `canonical=False` restores the old behavior exactly.
- **Point-transformed tori keep the old path** (with `canonical=True` raising a clear error): their equal-time gauge carries the ξ-shear, so the canonical form needs recomputed tables — the next PR.
- The old derivative tables are not deleted: they become the consistency diagnostic `check_canonical_consistency()`, verifying the three-way relation `D_n = dS̄_n/dj + (ω′/2ω)·g_n`. With the compensation, interior-node mismatch is 1e-6–7e-5 against a 3.4e-2 table scale; **without it, 5e-2–7.5e-2 — larger than the tables themselves** (the compensation term is the dominant content of `D_n` at n=2, as the closed form predicts).

### Tests

Five new: the defect sweep asserted at the test floor, the noise-injection manifest test (with a check that the noise really moved the evaluation), the consistency relation with a sharpness check (dropping the compensation must degrade it >10×), frequency-consistency, and the two error paths. One legacy tolerance widened 1e-10 → 1e-9 with the reason in a comment: the chart-consistent frequency is a shade less accurate against the truth than the separately interpolated one it replaces (3.8e-10 relative here).

47 vertical tests pass; `actionAngleVerticalInverse.py` at 100% coverage. Diff ≈ 330 lines including tests.