### PR TITLE
actionAngleVerticalInverse: canonical evaluation for all point-transformation modes; old interpolated path removed

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -30,10 +30,12 @@ v1.12.1 (expected around 2026-11-01)
   compensation for every energy-dependent parameter chain -- the auxiliary
   frequency and the point transformation's shape -- is applied in closed
   form, and the canonical action labels (the gauge-independent loop
-  actions) become the public J(E)/E(j). The old behavior is available with
-  canonical=False; pt_only, an equal-time-gauge construct, is incompatible
-  with the canonical mode; the derivative tables are kept as a consistency
-  diagnostic (check_canonical_consistency).
+  actions) become the public J(E)/E(j). The old interpolated evaluation is
+  removed outright (it was strictly dominated: worse symplectic defect at
+  the same accuracy class); the per-torus non-interpolating mode is
+  unchanged and exact at its nodes; pt_only, an equal-time-gauge construct,
+  now requires setup_interp=False; the derivative tables survive only as a
+  consistency diagnostic (check_canonical_consistency).
 
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -22,16 +22,18 @@ v1.12.1 (expected around 2026-11-01)
   from the interpolation error of the old separately stored derivative
   tables (median 2.5e-4) to the finite-difference test floor (~1e-10), and
   is invariant under noise injected into the tables. The canonical mode
-  covers instances with and without a polynomial point transformation: the
+  covers every interpolating configuration -- no point transformation, the
+  polynomial one, and the exact one (canonically lifted, preserving its
+  extreme-orbit position map): the
   mapping coefficients are recomputed in the shear-free gauge by direct
   sampling (no inversion of the point transformation is needed), the
   compensation for every energy-dependent parameter chain -- the auxiliary
   frequency and the point transformation's shape -- is applied in closed
   form, and the canonical action labels (the gauge-independent loop
   actions) become the public J(E)/E(j). The old behavior is available with
-  canonical=False; the exact point transformation keeps the old path for
-  now; the derivative tables are kept as a consistency diagnostic
-  (check_canonical_consistency).
+  canonical=False; pt_only, an equal-time-gauge construct, is incompatible
+  with the canonical mode; the derivative tables are kept as a consistency
+  diagnostic (check_canonical_consistency).
 
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -21,9 +21,17 @@ v1.12.1 (expected around 2026-11-01)
   symplectic for any stored tables: the measured symplectic defect drops
   from the interpolation error of the old separately stored derivative
   tables (median 2.5e-4) to the finite-difference test floor (~1e-10), and
-  is invariant under noise injected into the tables. The old behavior is
-  available with canonical=False; the derivative tables are kept as a
-  consistency diagnostic (check_canonical_consistency).
+  is invariant under noise injected into the tables. The canonical mode
+  covers instances with and without a polynomial point transformation: the
+  mapping coefficients are recomputed in the shear-free gauge by direct
+  sampling (no inversion of the point transformation is needed), the
+  compensation for every energy-dependent parameter chain -- the auxiliary
+  frequency and the point transformation's shape -- is applied in closed
+  form, and the canonical action labels (the gauge-independent loop
+  actions) become the public J(E)/E(j). The old behavior is available with
+  canonical=False; the exact point transformation keeps the old path for
+  now; the derivative tables are kept as a consistency diagnostic
+  (check_canonical_consistency).
 
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -303,12 +303,19 @@ class actionAngleVerticalInverse(actionAngleInverse):
         # coincide and the tables can be reused as-is)
         self._identity_pt = not self._pt_exact and self._pt_deg == 1
         if canonical is None:
-            canonical = self._interp and self._identity_pt
-        if canonical and not (self._interp and self._identity_pt):
+            canonical = self._interp and not self._pt_exact and not self._pt_only
+        if canonical and not self._interp:
+            raise ValueError("canonical=True requires setup_interp=True")
+        if canonical and self._pt_exact:
             raise ValueError(
-                "canonical=True requires setup_interp=True and no point "
-                "transformation (use_pointtransform=False); the canonical "
-                "mode for point-transformed tori is not implemented yet"
+                'canonical=True is not implemented yet for use_pointtransform="exact"'
+            )
+        if canonical and self._pt_only:  # pragma: no cover
+            raise ValueError(
+                "canonical=True is incompatible with pt_only=True: pt_only "
+                "is an equal-time-gauge construct and the canonical mode "
+                "works in the shear-free gauge, where the exact point "
+                "transformation's mapping coefficients do not vanish"
             )
         self._canonical = canonical
         if self._canonical:
@@ -1315,29 +1322,96 @@ class actionAngleVerticalInverse(actionAngleInverse):
         """Build the exactly-differentiable chains of the canonical mode.
 
         Everything the evaluation uses is either an interpolant paired with
-        its own exact derivative or a closed form: the value table of nSn
-        (B-spline coefficients along the energy axis, evaluated together
-        with their derivative by one four-point stencil), E(j) and its
-        derivative (which is also the frequency: the integrator-consistency
-        contract), and OmegaHO(E) and its derivative for the compensation
-        term. The separately stored dSndJ tables are NOT used: a value table
-        and an independent derivative table only satisfy the symplectic
+        its own exact derivative or a closed form. The mapping coefficients
+        are recomputed here in the shear-free (cotangent-lift) gauge by
+        direct sampling of each torus -- x_a sampled on the auxiliary loop,
+        x = pi(x_a), p_a = v pi'(x_a), so no inversion of the point
+        transformation is ever needed -- and the canonical action labels are
+        the zero modes <J^A>, which are gauge-independent (the loop action).
+        For the identity point transformation this reproduces the stored
+        nSn to quadrature accuracy; for a polynomial point transformation
+        the equal-time-gauge nSn are NOT gauge-compatible and the
+        recomputation is essential. The separately stored dSndJ tables are
+        never used by the canonical evaluation: a value table and an
+        independent derivative table only satisfy the symplectic
         consistency relation when both are exact, and interpolation breaks
         it (the measured symplectic defect of the old mode is at the
         derivative-table interpolation error)."""
+        ntau = 2 * self._nta
+        tau = 2.0 * numpy.pi * (numpy.arange(ntau) + 0.5) / ntau
+        nn = self._nforSn
+        can_nSn = numpy.empty_like(self._nSn)
+        can_js = numpy.empty(self._nE)
+        for ii in range(self._nE):
+            if self._js[ii] < 1e-10:
+                can_nSn[ii] = 0.0
+                can_js[ii] = 0.0
+                continue
+            xa = self._pt_xmaxs[ii] * numpy.sin(tau)
+            x = self._xmaxs[ii] * polynomial.polyval(
+                xa / self._pt_xmaxs[ii], self._pt_coeffs[ii]
+            )
+            piprime = (
+                self._xmaxs[ii]
+                / self._pt_xmaxs[ii]
+                * polynomial.polyval(xa / self._pt_xmaxs[ii], self._pt_deriv_coeffs[ii])
+            )
+            v2 = 2.0 * (
+                self._Es[ii]
+                - evaluatelinearPotentials(self._pot, x, use_physical=False)
+            )
+            v2[v2 < 0.0] = 0.0
+            pa = numpy.sign(numpy.cos(tau)) * numpy.sqrt(v2) * piprime
+            om = self._OmegaHO[ii]
+            jA = 0.5 * (pa**2 + om**2 * xa**2) / om
+            thetaA = numpy.arctan2(om * xa, pa)
+            # Fourier data by the pullback: the tau-grid is regular, theta^A
+            # is not; spectral derivative of the periodic part supplies the
+            # measure and sigma follows from one spectral antiderivative
+            P = numpy.unwrap(thetaA - tau + numpy.pi) - numpy.pi
+            k = numpy.fft.fftfreq(ntau, d=1.0 / ntau)
+            dthetaAdtau = 1.0 + numpy.real(numpy.fft.ifft(1j * k * numpy.fft.fft(P)))
+            can_js[ii] = numpy.mean(jA * dthetaAdtau)
+            g = (jA - can_js[ii]) * dthetaAdtau
+            gh = numpy.fft.fft(g)
+            sh = numpy.zeros(ntau, dtype=complex)
+            sh[1:] = gh[1:] / (1j * k[1:])
+            sigma = numpy.real(numpy.fft.ifft(sh))
+            for q, n in enumerate(nn):
+                c = numpy.mean(sigma * numpy.exp(-1j * n * thetaA) * dthetaAdtau)
+                can_nSn[ii, q] = -n * numpy.imag(c)
+        self._can_nSn = can_nSn
+        self._can_js = can_js
         self._can_nSn_c = ndimage.spline_filter1d(
-            self._nSn, order=3, axis=0, mode="mirror"
+            can_nSn, order=3, axis=0, mode="mirror"
         )
-        self._can_dEdj = self.E.derivative()
+        self._can_E = interpolate.InterpolatedUnivariateSpline(can_js, self._Es, k=3)
+        self._can_J = interpolate.InterpolatedUnivariateSpline(self._Es, can_js, k=3)
+        self._can_dEdj = self._can_E.derivative()
         self._can_dOmHOdE = self.OmegaHO.derivative()
+        # derivative chains of the point-transformation parameter functions,
+        # for the PT compensation term (zero for the identity PT)
+        self._can_xmax = interpolate.InterpolatedUnivariateSpline(
+            self._Es, self._xmaxs, k=3
+        )
+        self._can_ptxmax = interpolate.InterpolatedUnivariateSpline(
+            self._Es, self._pt_xmaxs, k=3
+        )
+        self._can_dxmaxdE = self._can_xmax.derivative()
+        self._can_dptxmaxdE = self._can_ptxmax.derivative()
+        self._can_ptcoeffs_c = ndimage.spline_filter1d(
+            self._pt_coeffs, order=3, axis=0, mode="mirror"
+        )
+        # The canonical labels become the public ones: J(E) and E(j) must be
+        # the same chains the evaluation differentiates, or callers mixing
+        # J(E) with __call__ would straddle two gauges' labelings
+        self.J = self._can_J
+        self.E = self._can_E
         return None
 
-    def _canonical_tables(self, j):
-        """nSn and d(nSn)/dj at action j, as value and exact derivative of
-        one stored interpolant (cubic B-spline along the energy axis chained
-        through E(j))."""
-        tE = float(self.E(j))
-        x = (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
+    def _can_row(self, table_c, x):
+        """Value and d/d(row) of a row-filtered table at fractional row x,
+        by the four-point cubic B-spline stencil (mirror boundary)."""
         x = min(max(x, 0.0), self._nE - 1.0)
         i0 = int(numpy.floor(x))
         if i0 > self._nE - 2:  # pragma: no cover
@@ -1346,7 +1420,7 @@ class actionAngleVerticalInverse(actionAngleInverse):
         taps = numpy.array([i0 - 1, i0, i0 + 1, i0 + 2])
         taps = numpy.abs(taps)
         taps[taps > self._nE - 1] = 2 * (self._nE - 1) - taps[taps > self._nE - 1]
-        C = self._can_nSn_c[taps]
+        C = table_c[taps]
         w = numpy.array(
             [
                 (1.0 - t) ** 3 / 6.0,
@@ -1363,8 +1437,16 @@ class actionAngleVerticalInverse(actionAngleInverse):
                 t**2 / 2.0,
             ]
         )
-        val = w @ C
-        dval_dE = (wd @ C) * (self._nE - 1.0) / (self._Emax - self._Emin)
+        return w @ C, wd @ C
+
+    def _canonical_tables(self, j):
+        """nSn and d(nSn)/dj at action j, as value and exact derivative of
+        one stored interpolant (cubic B-spline along the energy axis chained
+        through the canonical E(j))."""
+        tE = float(self._can_E(j))
+        x = (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
+        val, dval_dx = self._can_row(self._can_nSn_c, x)
+        dval_dE = dval_dx * (self._nE - 1.0) / (self._Emax - self._Emin)
         return val, dval_dE * float(self._can_dEdj(j))
 
     def check_canonical_consistency(self, ntheta=256):
@@ -1393,13 +1475,20 @@ class actionAngleVerticalInverse(actionAngleInverse):
         -----
         - 2026-08-25 - Written - Bovy (UofT)
         """
+        if not self._identity_pt:
+            raise RuntimeError(
+                "check_canonical_consistency compares against the stored "
+                "dSndJ tables, which live in the equal-time gauge; with a "
+                "point transformation the gauges differ and the comparison "
+                "is not meaningful"
+            )
         th = 2.0 * numpy.pi * numpy.arange(ntheta) / ntheta
         mism = 0.0
         for idx in range(2, self._nE - 2):
-            jn = float(self._js[idx])
+            jn = float(self._can_js[idx])
             _, dnSndj = self._canonical_tables(jn)
             dSdj = dnSndj / self._nforSn
-            tE = float(self.E(jn))
+            tE = float(self._can_E(jn))
             om = float(self.OmegaHO(tE))
             domdj = float(self._can_dOmHOdE(tE)) * float(self._can_dEdj(jn))
             ja = jn + 2.0 * numpy.sum(
@@ -1422,34 +1511,55 @@ class actionAngleVerticalInverse(actionAngleInverse):
         nSn, dnSndj = self._canonical_tables(j)
         n = self._nforSn
         dSdj = dnSndj / n
-        tE = float(self.E(j))
+        tE = float(self._can_E(j))
         om = float(self.OmegaHO(tE))
         dEdj = float(self._can_dEdj(j))
         domdj = float(self._can_dOmHOdE(tE)) * dEdj
         pref = domdj / (2.0 * om)
-        anglea = copy.copy(angle)
-        cntr = 0
-        maxda = 2.0 * numpy.pi / 101.0
-        while cntr <= self._maxiter:
+        # point-transformation parameter chains (identity PT: pi(xa) = xa and
+        # all its parameter derivatives vanish)
+        X = float(self._can_xmax(tE))
+        PX = float(self._can_ptxmax(tE))
+        dXdE = float(self._can_dxmaxdE(tE))
+        dPXdE = float(self._can_dptxmaxdE(tE))
+        xrow = (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
+        cfs, dcfs_dx = self._can_row(self._can_ptcoeffs_c, xrow)
+        dcfs_dE = dcfs_dx * (self._nE - 1.0) / (self._Emax - self._Emin)
+        dcderiv = polynomial.polyder(cfs)
+
+        def _residual(anglea):
             san = numpy.sin(n * numpy.atleast_2d(anglea).T)
             can = numpy.cos(n * numpy.atleast_2d(anglea).T)
             ja = j + 2.0 * numpy.sum(nSn * can, axis=1)
-            F = (
+            xa = numpy.sqrt(2.0 * numpy.fabs(ja) / om) * numpy.sin(anglea)
+            pa = numpy.sqrt(2.0 * numpy.fabs(ja) * om) * numpy.cos(anglea)
+            u = xa / PX
+            piprime = X / PX * polynomial.polyval(u, dcderiv)
+            v = pa / piprime
+            # d pi / dE at fixed xa, through every stored parameter chain
+            dpidE = (
+                dXdE * polynomial.polyval(u, cfs)
+                + X * polynomial.polyval(u, dcfs_dE)
+                - X * polynomial.polyval(u, dcderiv) * u * dPXdE / PX
+            )
+            comp_pt = -v * dpidE * dEdj
+            return (
                 anglea
                 + 2.0 * numpy.sum(dSdj * san, axis=1)
                 + pref * ja * numpy.sin(2.0 * anglea)
+                + comp_pt
                 - angle
             )
-            F = (F + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+
+        anglea = copy.copy(angle)
+        cntr = 0
+        maxda = 2.0 * numpy.pi / 101.0
+        hFD = 1e-7
+        while cntr <= self._maxiter:
+            F = (_residual(anglea) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             if numpy.max(numpy.fabs(F)) < self._angle_tol:
                 break
-            djada = -2.0 * numpy.sum(n * nSn * san, axis=1)
-            dF = (
-                1.0
-                + 2.0 * numpy.sum(n * dSdj * can, axis=1)
-                + pref
-                * (djada * numpy.sin(2.0 * anglea) + 2.0 * ja * numpy.cos(2.0 * anglea))
-            )
+            dF = (_residual(anglea + hFD) - _residual(anglea - hFD)) / (2.0 * hFD)
             da = -F / dF
             da[numpy.fabs(da) > maxda] = (numpy.sign(da) * maxda)[
                 numpy.fabs(da) > maxda
@@ -1467,8 +1577,11 @@ class actionAngleVerticalInverse(actionAngleInverse):
             nSn * numpy.cos(n * numpy.atleast_2d(anglea).T), axis=1
         )
         hoaainv = actionAngleHarmonicInverse(omega=om)
-        xa, va = hoaainv(ja, anglea)
-        return (xa, va, dEdj)
+        xa, pa = hoaainv(ja, anglea)
+        u = xa / PX
+        x = X * polynomial.polyval(u, cfs)
+        v = pa / (X / PX * polynomial.polyval(u, dcderiv))
+        return (x, v, dEdj)
 
     def _evaluate(self, j, angle, **kwargs):
         """

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -85,7 +85,7 @@ class actionAngleVerticalInverse(actionAngleInverse):
         bisect : bool
             if True, use simple bisection for root-finding, otherwise first try Newton-Raphson (mainly useful for testing the bisection fallback)
         canonical : bool, optional
-            if True, use the canonical evaluation mode: the angle map uses the exact derivative of the interpolated nSn tables plus the closed-form compensation for the energy-dependent auxiliary frequency, so the assembled (J, angle) -> (x, v) map is exactly symplectic for any stored tables (the separately stored dSndJ tables are kept only as a consistency diagnostic). Default: True for interpolating instances without a point transformation (where the stored coefficients are gauge-compatible), False otherwise; canonical=True with a point transformation is not implemented yet.
+            if True, use the canonical evaluation mode: the angle map uses the exact derivative of the interpolated nSn tables plus the closed-form compensation for the energy-dependent auxiliary frequency, so the assembled (J, angle) -> (x, v) map is exactly symplectic for any stored tables (the separately stored dSndJ tables are kept only as a consistency diagnostic). The mapping coefficients are recomputed at setup in the shear-free (cotangent-lift) gauge for every mode, including the polynomial and exact point transformations, whose parameter chains are compensated in closed form. Default: True for interpolating instances (False for pt_only=True, an equal-time-gauge construct incompatible with the canonical mode).
 
         Notes
         -----
@@ -303,14 +303,10 @@ class actionAngleVerticalInverse(actionAngleInverse):
         # coincide and the tables can be reused as-is)
         self._identity_pt = not self._pt_exact and self._pt_deg == 1
         if canonical is None:
-            canonical = self._interp and not self._pt_exact and not self._pt_only
+            canonical = self._interp and not self._pt_only
         if canonical and not self._interp:
             raise ValueError("canonical=True requires setup_interp=True")
-        if canonical and self._pt_exact:
-            raise ValueError(
-                'canonical=True is not implemented yet for use_pointtransform="exact"'
-            )
-        if canonical and self._pt_only:  # pragma: no cover
+        if canonical and self._pt_only:
             raise ValueError(
                 "canonical=True is incompatible with pt_only=True: pt_only "
                 "is an equal-time-gauge construct and the canonical mode "
@@ -1342,25 +1338,51 @@ class actionAngleVerticalInverse(actionAngleInverse):
         nn = self._nforSn
         can_nSn = numpy.empty_like(self._nSn)
         can_js = numpy.empty(self._nE)
+        if self._pt_exact:
+            # ONE canonical representation of the exact point transformation:
+            # order-3 coefficients of the stored value mesh; pi' and the
+            # torus-direction derivative are ITS exact stencil derivatives
+            # (the legacy quintic value/derivative PAIR is exactly the
+            # contingent storage the canonical mode exists to avoid)
+            self._can_pt_c = ndimage.spline_filter(
+                self._pt_coeffs, order=3, mode="mirror"
+            )
+            self._can_pt_pad = (self._pt_coeffs.shape[1] - self._pt_nmesh) / 2.0
+            self._can_pt_du = 2.0 / (self._pt_nmesh - 1.0)
         for ii in range(self._nE):
             if self._js[ii] < 1e-10:
                 can_nSn[ii] = 0.0
                 can_js[ii] = 0.0
                 continue
             xa = self._pt_xmaxs[ii] * numpy.sin(tau)
-            x = self._xmaxs[ii] * polynomial.polyval(
-                xa / self._pt_xmaxs[ii], self._pt_coeffs[ii]
-            )
-            piprime = (
-                self._xmaxs[ii]
-                / self._pt_xmaxs[ii]
-                * polynomial.polyval(xa / self._pt_xmaxs[ii], self._pt_deriv_coeffs[ii])
-            )
+            if self._pt_exact:
+                f, fu, _, _, _ = self._can_pt_eval(numpy.sin(tau), float(ii))
+                x = self._xmaxs[ii] * f
+                piprime = self._xmaxs[ii] / self._pt_xmaxs[ii] * fu
+            else:
+                x = self._xmaxs[ii] * polynomial.polyval(
+                    xa / self._pt_xmaxs[ii], self._pt_coeffs[ii]
+                )
+                piprime = (
+                    self._xmaxs[ii]
+                    / self._pt_xmaxs[ii]
+                    * polynomial.polyval(
+                        xa / self._pt_xmaxs[ii], self._pt_deriv_coeffs[ii]
+                    )
+                )
             v2 = 2.0 * (
                 self._Es[ii]
                 - evaluatelinearPotentials(self._pot, x, use_physical=False)
             )
             v2[v2 < 0.0] = 0.0
+            # one gauge for every mode: the shear-free cotangent lift,
+            # p_a = v pi'. The equal-time gauge's S ~ 0 virtue for the exact
+            # PT requires its shear generating function Xi explicitly in the
+            # compensation (branch-glued; a possible future refinement); the
+            # cotangent lift of the SAME pi keeps the exact PT's
+            # extreme-orbit position map with the compensation machinery
+            # measured at the floor, at the cost of nonzero (but 1-D-cheap)
+            # mapping coefficients
             pa = numpy.sign(numpy.cos(tau)) * numpy.sqrt(v2) * piprime
             om = self._OmegaHO[ii]
             jA = 0.5 * (pa**2 + om**2 * xa**2) / om
@@ -1402,12 +1424,68 @@ class actionAngleVerticalInverse(actionAngleInverse):
         self._can_ptcoeffs_c = ndimage.spline_filter1d(
             self._pt_coeffs, order=3, axis=0, mode="mirror"
         )
+        self._can_glx, self._can_glw = numpy.polynomial.legendre.leggauss(24)
         # The canonical labels become the public ones: J(E) and E(j) must be
         # the same chains the evaluation differentiates, or callers mixing
         # J(E) with __call__ would straddle two gauges' labelings
         self.J = self._can_J
         self.E = self._can_E
         return None
+
+    def _can_pt_eval(self, u, row):
+        """Value and derivatives of the canonical exact-PT table at
+        normalized coordinate(s) u = x_a/ptxmax and fractional torus row:
+        (f, df/du, d2f/du2, df/drow, d2f/dudrow), every one the exact
+        derivative of the ONE stored order-3 interpolant."""
+        u = numpy.atleast_1d(u)
+        mesh = (u + 1.0) / self._can_pt_du + self._can_pt_pad
+        nm = self._can_pt_c.shape[1]
+        i0m = numpy.clip(numpy.floor(mesh).astype(int), 1, nm - 3)
+        tm = mesh - i0m
+        row = min(max(row, 0.0), self._nE - 1.0)
+        i0r = int(numpy.floor(row))
+        if i0r > self._nE - 2:  # pragma: no cover
+            i0r = self._nE - 2
+        tr = row - i0r
+        rtaps = numpy.array([i0r - 1, i0r, i0r + 1, i0r + 2])
+        rtaps = numpy.abs(rtaps)
+        rtaps[rtaps > self._nE - 1] = 2 * (self._nE - 1) - rtaps[rtaps > self._nE - 1]
+
+        def _w(t):
+            return numpy.array(
+                [
+                    (1.0 - t) ** 3 / 6.0,
+                    (4.0 - 6.0 * t**2 + 3.0 * t**3) / 6.0,
+                    (1.0 + 3.0 * t + 3.0 * t**2 - 3.0 * t**3) / 6.0,
+                    t**3 / 6.0,
+                ]
+            )
+
+        def _wd(t):
+            return numpy.array(
+                [
+                    -((1.0 - t) ** 2) / 2.0,
+                    (-12.0 * t + 9.0 * t**2) / 6.0,
+                    (3.0 + 6.0 * t - 9.0 * t**2) / 6.0,
+                    t**2 / 2.0,
+                ]
+            )
+
+        def _wdd(t):
+            return numpy.array([1.0 - t, 3.0 * t - 2.0, 1.0 - 3.0 * t, t])
+
+        wr, wrd = _w(tr), _wd(tr)
+        wm, wmd, wmdd = _w(tm), _wd(tm), _wdd(tm)
+        C4 = self._can_pt_c[rtaps]
+        mtaps = i0m[None, :] + numpy.arange(-1, 3)[:, None]
+        V = C4[:, mtaps]  # (4 row-taps, 4 mesh-taps, npts)
+        du = self._can_pt_du
+        f = numpy.einsum("r,rmp,mp->p", wr, V, wm)
+        fu = numpy.einsum("r,rmp,mp->p", wr, V, wmd) / du
+        fuu = numpy.einsum("r,rmp,mp->p", wr, V, wmdd) / du**2
+        frow = numpy.einsum("r,rmp,mp->p", wrd, V, wm)
+        furow = numpy.einsum("r,rmp,mp->p", wrd, V, wmd) / du
+        return f, fu, fuu, frow, furow
 
     def _can_row(self, table_c, x):
         """Value and d/d(row) of a row-filtered table at fractional row x,
@@ -1523,9 +1601,11 @@ class actionAngleVerticalInverse(actionAngleInverse):
         dXdE = float(self._can_dxmaxdE(tE))
         dPXdE = float(self._can_dptxmaxdE(tE))
         xrow = (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
-        cfs, dcfs_dx = self._can_row(self._can_ptcoeffs_c, xrow)
-        dcfs_dE = dcfs_dx * (self._nE - 1.0) / (self._Emax - self._Emin)
-        dcderiv = polynomial.polyder(cfs)
+        drowdE = (self._nE - 1.0) / (self._Emax - self._Emin)
+        if not self._pt_exact:
+            cfs, dcfs_dx = self._can_row(self._can_ptcoeffs_c, xrow)
+            dcfs_dE = dcfs_dx * drowdE
+            dcderiv = polynomial.polyder(cfs)
 
         def _residual(anglea):
             san = numpy.sin(n * numpy.atleast_2d(anglea).T)
@@ -1534,6 +1614,18 @@ class actionAngleVerticalInverse(actionAngleInverse):
             xa = numpy.sqrt(2.0 * numpy.fabs(ja) / om) * numpy.sin(anglea)
             pa = numpy.sqrt(2.0 * numpy.fabs(ja) * om) * numpy.cos(anglea)
             u = xa / PX
+            if self._pt_exact:
+                f, fu, _, frow, _ = self._can_pt_eval(u, xrow)
+                piprime = X / PX * fu
+                v = pa / piprime
+                dpidE = dXdE * f + X * (frow * drowdE - fu * u * dPXdE / PX)
+                return (
+                    anglea
+                    + 2.0 * numpy.sum(dSdj * san, axis=1)
+                    + pref * ja * numpy.sin(2.0 * anglea)
+                    - v * dpidE * dEdj
+                    - angle
+                )
             piprime = X / PX * polynomial.polyval(u, dcderiv)
             v = pa / piprime
             # d pi / dE at fixed xa, through every stored parameter chain
@@ -1579,8 +1671,13 @@ class actionAngleVerticalInverse(actionAngleInverse):
         hoaainv = actionAngleHarmonicInverse(omega=om)
         xa, pa = hoaainv(ja, anglea)
         u = xa / PX
-        x = X * polynomial.polyval(u, cfs)
-        v = pa / (X / PX * polynomial.polyval(u, dcderiv))
+        if self._pt_exact:
+            f, fu, _, _, _ = self._can_pt_eval(u, xrow)
+            x = X * f
+            v = pa / (X / PX * fu)
+        else:
+            x = X * polynomial.polyval(u, cfs)
+            v = pa / (X / PX * polynomial.polyval(u, dcderiv))
         return (x, v, dEdj)
 
     def _evaluate(self, j, angle, **kwargs):

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -52,7 +52,6 @@ class actionAngleVerticalInverse(actionAngleInverse):
         maxiter=100,
         angle_tol=1e-12,
         bisect=False,
-        canonical=None,
         **kwargs,
     ):
         """
@@ -84,8 +83,17 @@ class actionAngleVerticalInverse(actionAngleInverse):
             tolerance for angle root-finding (f(x) is within tol of desired value)
         bisect : bool
             if True, use simple bisection for root-finding, otherwise first try Newton-Raphson (mainly useful for testing the bisection fallback)
-        canonical : bool, optional
-            if True, use the canonical evaluation mode: the angle map uses the exact derivative of the interpolated nSn tables plus the closed-form compensation for the energy-dependent auxiliary frequency, so the assembled (J, angle) -> (x, v) map is exactly symplectic for any stored tables (the separately stored dSndJ tables are kept only as a consistency diagnostic). The mapping coefficients are recomputed at setup in the shear-free (cotangent-lift) gauge for every mode, including the polynomial and exact point transformations, whose parameter chains are compensated in closed form. Default: True for interpolating instances (False for pt_only=True, an equal-time-gauge construct incompatible with the canonical mode).
+        canonical evaluation
+            Interpolating instances always evaluate canonically: the mapping
+            coefficients are recomputed at setup in the shear-free
+            (cotangent-lift) gauge for every point-transformation mode, all
+            derivatives come from the stored interpolants themselves, and
+            every energy-dependent parameter chain is compensated in closed
+            form, so the assembled (J, angle) -> (x, v) map is exactly
+            symplectic for any stored tables. The separately stored dSndJ
+            tables are kept only as a consistency diagnostic. pt_only=True
+            (an equal-time-gauge construct) therefore requires
+            setup_interp=False.
 
         Notes
         -----
@@ -296,24 +304,19 @@ class actionAngleVerticalInverse(actionAngleInverse):
             self._setup_interp()
         else:
             self._interp = False
-        # Canonical evaluation: manifestly symplectic for any stored tables.
-        # Default for interpolating instances without a point transformation,
-        # where the stored nSn are the coefficients of the xi = 0 gauge (the
-        # identity PT has no shear, so the equal-time and cotangent gauges
-        # coincide and the tables can be reused as-is)
+        # Interpolating instances always evaluate canonically (manifestly
+        # symplectic for any stored tables); the per-torus non-interpolating
+        # mode keeps the direct evaluation, which is exact at its nodes
         self._identity_pt = not self._pt_exact and self._pt_deg == 1
-        if canonical is None:
-            canonical = self._interp and not self._pt_only
-        if canonical and not self._interp:
-            raise ValueError("canonical=True requires setup_interp=True")
-        if canonical and self._pt_only:
+        if self._interp and self._pt_only:
             raise ValueError(
-                "canonical=True is incompatible with pt_only=True: pt_only "
-                "is an equal-time-gauge construct and the canonical mode "
-                "works in the shear-free gauge, where the exact point "
-                "transformation's mapping coefficients do not vanish"
+                "pt_only=True requires setup_interp=False: pt_only is an "
+                "equal-time-gauge construct and interpolating instances "
+                "evaluate canonically in the shear-free gauge, where the "
+                "exact point transformation's mapping coefficients do not "
+                "vanish"
             )
-        self._canonical = canonical
+        self._canonical = self._interp
         if self._canonical:
             self._setup_canonical()
         return None
@@ -1646,12 +1649,24 @@ class actionAngleVerticalInverse(actionAngleInverse):
         anglea = copy.copy(angle)
         cntr = 0
         maxda = 2.0 * numpy.pi / 101.0
-        hFD = 1e-7
         while cntr <= self._maxiter:
             F = (_residual(anglea) + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             if numpy.max(numpy.fabs(F)) < self._angle_tol:
                 break
-            dF = (_residual(anglea + hFD) - _residual(anglea - hFD)) / (2.0 * hFD)
+            # approximate-analytic Jacobian: the main terms exactly, the
+            # small parameter-compensation derivative dropped -- this only
+            # affects the convergence rate; the residual equation defining
+            # the map is exact, so canonicity is untouched
+            san = numpy.sin(n * numpy.atleast_2d(anglea).T)
+            can = numpy.cos(n * numpy.atleast_2d(anglea).T)
+            ja = j + 2.0 * numpy.sum(nSn * can, axis=1)
+            djada = -2.0 * numpy.sum(n * nSn * san, axis=1)
+            dF = (
+                1.0
+                + 2.0 * numpy.sum(n * dSdj * can, axis=1)
+                + pref
+                * (djada * numpy.sin(2.0 * anglea) + 2.0 * ja * numpy.cos(2.0 * anglea))
+            )
             da = -F / dF
             da[numpy.fabs(da) > maxda] = (numpy.sign(da) * maxda)[
                 numpy.fabs(da) > maxda
@@ -1724,31 +1739,20 @@ class actionAngleVerticalInverse(actionAngleInverse):
         """
         if self._canonical:
             return self._xvFreqs_canonical(j, angle)
-        # Find torus
-        if not self._interp:
-            indx = numpy.nanargmin(numpy.fabs(j - self._js))
-            if numpy.fabs(j - self._js[indx]) > 1e-10:
-                raise ValueError(
-                    "Given action/energy not found, to use interpolation, initialize with setup_interp=True"
-                )
-            tnSn = self._nSn[indx]
-            tdSndJ = self._dSndJ[indx]
-            tOmegaHO = self._OmegaHO[indx]
-            tOmega = self._Omegas[indx]
-            txmax = self._xmaxs[indx]
-            tptxmax = self._pt_xmaxs[indx]
-            tptcoeffs = self._pt_coeffs[indx]
-            tptderivcoeffs = self._pt_deriv_coeffs[indx]
-        else:
-            tE = self.E(j)
-            tnSn = self.nSn(tE)[0]
-            tdSndJ = self.dSndJ(tE)[0]
-            tOmegaHO = self.OmegaHO(tE)
-            tOmega = self.Omega(tE)
-            txmax = self.xmax(tE)
-            tptxmax = self.ptxmax(tE)
-            tptcoeffs = self.pt_coeffs(tE)[0]
-            tptderivcoeffs = self.pt_deriv_coeffs(tE)[0]
+        # Per-torus evaluation at the exact nodes
+        indx = numpy.nanargmin(numpy.fabs(j - self._js))
+        if numpy.fabs(j - self._js[indx]) > 1e-10:
+            raise ValueError(
+                "Given action/energy not found, to use interpolation, initialize with setup_interp=True"
+            )
+        tnSn = self._nSn[indx]
+        tdSndJ = self._dSndJ[indx]
+        tOmegaHO = self._OmegaHO[indx]
+        tOmega = self._Omegas[indx]
+        txmax = self._xmaxs[indx]
+        tptxmax = self._pt_xmaxs[indx]
+        tptcoeffs = self._pt_coeffs[indx]
+        tptderivcoeffs = self._pt_deriv_coeffs[indx]
         if self._pt_exact and self._pt_only:
             # For the exact point transformation, the generating-function
             # mapping (J,theta) -> (JA,thetaA) is the identity, so we can
@@ -1855,13 +1859,7 @@ class actionAngleVerticalInverse(actionAngleInverse):
             # Row coordinate of this torus in the grid of tori; fractional
             # for interpolated tori, in which case the 2D spline evaluation
             # interpolates the point transformation between the grid tori
-            trowcoord = (
-                float(indx)
-                if not self._interp
-                else float(
-                    (tE - self._Emin) / (self._Emax - self._Emin) * (self._nE - 1.0)
-                )
-            )
+            trowcoord = float(indx)
             x = txmax * _ptxa_eval(
                 xa / tptxmax,
                 trowcoord,
@@ -1917,18 +1915,12 @@ class actionAngleVerticalInverse(actionAngleInverse):
             # the frequency of the interpolated Hamiltonian itself: exactly
             # consistent with the canonical chart (the integrator contract)
             return float(self._can_dEdj(j))
-        # Find torus
-        if not self._interp:
-            indx = numpy.nanargmin(numpy.fabs(j - self._js))
-            if numpy.fabs(j - self._js[indx]) > 1e-10:
-                raise ValueError(
-                    "Given action/energy not found, to use interpolation, initialize with setup_interp=True"
-                )
-            tOmega = self._Omegas[indx]
-        else:
-            tE = self.E(j)
-            tOmega = self.Omega(tE)
-        return tOmega
+        indx = numpy.nanargmin(numpy.fabs(j - self._js))
+        if numpy.fabs(j - self._js[indx]) > 1e-10:
+            raise ValueError(
+                "Given action/energy not found, to use interpolation, initialize with setup_interp=True"
+            )
+        return self._Omegas[indx]
 
 
 def _ptxa_eval(xanorm, rowcoord, pt_filtered_arr, pt_nmesh, pt_spl_deg):

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8113,16 +8113,15 @@ def test_actionAngleVerticalInverse_notE_errors():
 # Test that computing actionAngle coordinates in C for a NullPotential leads to an error
 
 
-def _vertical_canonical_setup(canonical=None, nE=21):
+def _vertical_canonical_setup(nE=21):
     from galpy.actionAngle.actionAngleVerticalInverse import (
         actionAngleVerticalInverse,
     )
     from galpy.potential import MWPotential2014, toVerticalPotential
 
     vp = toVerticalPotential(MWPotential2014, 1.0)
-    kwargs = {} if canonical is None else dict(canonical=canonical)
     return actionAngleVerticalInverse(
-        pot=vp, Es=numpy.linspace(0.02, 0.35, nE), setup_interp=True, nta=128, **kwargs
+        pot=vp, Es=numpy.linspace(0.02, 0.35, nE), setup_interp=True, nta=128
     )
 
 
@@ -8169,26 +8168,19 @@ def test_actionAngleVerticalInverse_canonical_defect_exactpt():
 
 
 def test_actionAngleVerticalInverse_canonical_defect():
-    # The canonical mode's symplectic defect must sit at the finite-difference
-    # floor, orders below the old mode's, which lives at the interpolation
-    # error of its separately stored derivative tables
-    gold = _vertical_canonical_setup(canonical=False)
+    # Interpolating instances always evaluate canonically: the symplectic
+    # defect must sit at the finite-difference floor (the removed old
+    # architecture, with separately stored derivative tables, measured
+    # median 2.5e-4 on this same sweep)
     gnew = _vertical_canonical_setup()
-    assert gnew._canonical, (
-        "canonical does not default to True for an interpolating no-PT instance"
-    )
-    ds_old, ds_new = [], []
+    assert gnew._canonical, "interpolating instance is not canonical"
+    ds_new = []
     for E in numpy.linspace(0.06, 0.30, 4):
         j = float(numpy.atleast_1d(gnew.J(E))[0])
         for th in (0.8, 2.1):
-            ds_old.append(_vertical_symplectic_defect(gold, j, th))
             ds_new.append(_vertical_symplectic_defect(gnew, j, th))
     assert numpy.max(ds_new) < 1e-8, (
         "canonical-mode symplectic defect %g not at the test floor" % numpy.max(ds_new)
-    )
-    assert numpy.median(ds_old) > 1e-6, (
-        "the old mode's defect is unexpectedly small; this test has lost its "
-        "discriminating power"
     )
     return None
 
@@ -8261,11 +8253,9 @@ def test_actionAngleVerticalInverse_canonical_consistency():
 
 
 def test_actionAngleVerticalInverse_canonical_freq():
-    # In the canonical mode the frequency is the exact derivative of the
-    # interpolated E(j) -- consistent with the chart (the integrator
-    # contract) -- and close to, but not identical with, the old mode's
-    # separately interpolated frequency
-    gold = _vertical_canonical_setup(canonical=False)
+    # The frequency is the exact derivative of the interpolated E(j) --
+    # consistent with the chart (the integrator contract) -- and close to,
+    # but not identical with, the separately interpolated true frequency
     gnew = _vertical_canonical_setup()
     for E in (0.1, 0.2):
         j = float(numpy.atleast_1d(gnew.J(E))[0])
@@ -8273,24 +8263,21 @@ def test_actionAngleVerticalInverse_canonical_freq():
         assert numpy.fabs(Onew - float(gnew.E.derivative()(j))) < 1e-14, (
             "canonical frequency is not the E(j) interpolant's own derivative"
         )
-        assert numpy.fabs(Onew / gold._Freqs(j) - 1.0) < 1e-3, (
-            "canonical frequency far from the old mode's"
+        assert numpy.fabs(Onew / float(gnew.Omega(gnew.E(j))) - 1.0) < 1e-3, (
+            "canonical frequency far from the true frequency"
         )
     return None
 
 
 def test_actionAngleVerticalInverse_canonical_errors():
-    # canonical=True requires interpolation and no point transformation
+    # every interpolating configuration is canonical; pt_only (an
+    # equal-time-gauge construct) requires setup_interp=False
     from galpy.actionAngle.actionAngleVerticalInverse import (
         actionAngleVerticalInverse,
     )
     from galpy.potential import MWPotential2014, toVerticalPotential
 
     vp = toVerticalPotential(MWPotential2014, 1.0)
-    with pytest.raises(ValueError) as excinfo:
-        actionAngleVerticalInverse(pot=vp, Es=[0.1, 0.2], canonical=True)
-    assert "canonical" in str(excinfo.value)
-    # both point-transformation modes are supported and default to canonical
     for ptkw in (
         dict(use_pointtransform=True, pt_deg=3),
         dict(use_pointtransform="exact"),
@@ -8299,11 +8286,12 @@ def test_actionAngleVerticalInverse_canonical_errors():
             pot=vp,
             Es=numpy.linspace(0.02, 0.3, 7),
             setup_interp=True,
-            canonical=True,
             **ptkw,
         )
         assert g._canonical
-    # pt_only is an equal-time-gauge construct: incompatible
+        # the PT-table accessors remain available as diagnostics
+        assert numpy.all(numpy.isfinite(g.pt_coeffs(0.1)))
+        assert numpy.all(numpy.isfinite(g.pt_deriv_coeffs(0.1)))
     with pytest.raises(ValueError) as excinfo:
         actionAngleVerticalInverse(
             pot=vp,
@@ -8311,7 +8299,6 @@ def test_actionAngleVerticalInverse_canonical_errors():
             setup_interp=True,
             use_pointtransform="exact",
             pt_only=True,
-            canonical=True,
         )
     assert "pt_only" in str(excinfo.value)
     return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8141,6 +8141,33 @@ def _vertical_symplectic_defect(aAVI, j, angle, h=1e-6):
     return numpy.max(numpy.abs(A.T @ Om @ A - Om))
 
 
+def test_actionAngleVerticalInverse_canonical_defect_exactpt():
+    # the exact point transformation, canonically lifted: defect at the floor
+    from galpy.actionAngle.actionAngleVerticalInverse import (
+        actionAngleVerticalInverse,
+    )
+    from galpy.potential import MWPotential2014, toVerticalPotential
+
+    vp = toVerticalPotential(MWPotential2014, 1.0)
+    g = actionAngleVerticalInverse(
+        pot=vp,
+        Es=numpy.linspace(0.02, 0.35, 21),
+        setup_interp=True,
+        nta=128,
+        use_pointtransform="exact",
+    )
+    assert g._canonical
+    ds = []
+    for E in numpy.linspace(0.06, 0.30, 3):
+        j = float(numpy.atleast_1d(g.J(E))[0])
+        for th in (0.8, 2.1):
+            ds.append(_vertical_symplectic_defect(g, j, th))
+    assert numpy.max(ds) < 1e-6, (
+        "canonical exact-PT symplectic defect %g not at the test floor" % numpy.max(ds)
+    )
+    return None
+
+
 def test_actionAngleVerticalInverse_canonical_defect():
     # The canonical mode's symplectic defect must sit at the finite-difference
     # floor, orders below the old mode's, which lives at the interpolation
@@ -8263,26 +8290,30 @@ def test_actionAngleVerticalInverse_canonical_errors():
     with pytest.raises(ValueError) as excinfo:
         actionAngleVerticalInverse(pot=vp, Es=[0.1, 0.2], canonical=True)
     assert "canonical" in str(excinfo.value)
-    # polynomial point transformations ARE supported (and default to
-    # canonical); the exact point transformation is not yet
-    g = actionAngleVerticalInverse(
-        pot=vp,
-        Es=numpy.linspace(0.02, 0.3, 7),
-        setup_interp=True,
-        use_pointtransform=True,
-        pt_deg=3,
-        canonical=True,
-    )
-    assert g._canonical
+    # both point-transformation modes are supported and default to canonical
+    for ptkw in (
+        dict(use_pointtransform=True, pt_deg=3),
+        dict(use_pointtransform="exact"),
+    ):
+        g = actionAngleVerticalInverse(
+            pot=vp,
+            Es=numpy.linspace(0.02, 0.3, 7),
+            setup_interp=True,
+            canonical=True,
+            **ptkw,
+        )
+        assert g._canonical
+    # pt_only is an equal-time-gauge construct: incompatible
     with pytest.raises(ValueError) as excinfo:
         actionAngleVerticalInverse(
             pot=vp,
             Es=numpy.linspace(0.02, 0.3, 7),
             setup_interp=True,
             use_pointtransform="exact",
+            pt_only=True,
             canonical=True,
         )
-    assert "exact" in str(excinfo.value)
+    assert "pt_only" in str(excinfo.value)
     return None
 
 

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -7835,10 +7835,13 @@ def test_actionAngleVerticalInverse_orbit_interpolation_pointtransform(
     x, v = aAVI(aAVI.J(Ei), Om * ts)
     orb = Orbit([x[0], v[0]])
     orb.integrate(ts, isopot)
-    assert numpy.amax(numpy.fabs(orb.x(ts) - x)) < 1e-7, (
+    # The canonical default decomposes the mapping in the shear-free gauge,
+    # whose recomputed tables agree with the equal-time ones at their common
+    # accuracy (~1.5e-7 here), slightly above the old bound of 1e-7
+    assert numpy.amax(numpy.fabs(orb.x(ts) - x)) < 3e-7, (
         "Position does not agree with that of the integrated orbit along the torus of the IsothermalDiskPotential when using interpolation and a point transformation"
     )
-    assert numpy.amax(numpy.fabs(orb.vx(ts) - v)) < 1e-7, (
+    assert numpy.amax(numpy.fabs(orb.vx(ts) - v)) < 3e-7, (
         "Velocity does not agree with that of the integrated orbit along the torus of the IsothermalDiskPotential when using interpolation and a point transformation"
     )
     return None
@@ -8209,6 +8212,24 @@ def test_actionAngleVerticalInverse_canonical_consistency():
         "dropping the compensation does not degrade the consistency relation "
         "(%g vs %g): the check is not sharp" % (mism0, mism)
     )
+    # with a point transformation the stored dSndJ live in the other gauge
+    # and the comparison is refused
+    from galpy.actionAngle.actionAngleVerticalInverse import (
+        actionAngleVerticalInverse,
+    )
+    from galpy.potential import MWPotential2014, toVerticalPotential
+
+    vp = toVerticalPotential(MWPotential2014, 1.0)
+    gpt = actionAngleVerticalInverse(
+        pot=vp,
+        Es=numpy.linspace(0.02, 0.3, 7),
+        setup_interp=True,
+        use_pointtransform=True,
+        pt_deg=3,
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        gpt.check_canonical_consistency()
+    assert "gauge" in str(excinfo.value)
     return None
 
 
@@ -8242,16 +8263,26 @@ def test_actionAngleVerticalInverse_canonical_errors():
     with pytest.raises(ValueError) as excinfo:
         actionAngleVerticalInverse(pot=vp, Es=[0.1, 0.2], canonical=True)
     assert "canonical" in str(excinfo.value)
+    # polynomial point transformations ARE supported (and default to
+    # canonical); the exact point transformation is not yet
+    g = actionAngleVerticalInverse(
+        pot=vp,
+        Es=numpy.linspace(0.02, 0.3, 7),
+        setup_interp=True,
+        use_pointtransform=True,
+        pt_deg=3,
+        canonical=True,
+    )
+    assert g._canonical
     with pytest.raises(ValueError) as excinfo:
         actionAngleVerticalInverse(
             pot=vp,
-            Es=numpy.linspace(0.02, 0.3, 5),
+            Es=numpy.linspace(0.02, 0.3, 7),
             setup_interp=True,
-            use_pointtransform=True,
-            pt_deg=3,
+            use_pointtransform="exact",
             canonical=True,
         )
-    assert "point transformation" in str(excinfo.value)
+    assert "exact" in str(excinfo.value)
     return None
 
 


### PR DESCRIPTION
Second and final PR of the 1D stack (base `aa-vertical-canonical`, #1384; gh stack #1386); review #1384 first. Now covers **every interpolating configuration**: no PT, polynomial PT, and — per Jo's requirement that everything be canonicalized, the exact PT being what works for extreme orbits — the exact PT, canonically lifted.

### Why the PT modes need more than #1384

#1384 reused the stored `_nSn` because the identity PT has no shear. With a real PT the class works in the equal-time gauge (`va = v/π′`). A correction from review: that gauge **is** a proper canonical transformation (generated by S_π = πv + Ξ, and the implemented stage is its on-torus restriction — the sheared momentum collapses to v/π′ exactly on the torus). What fails under interpolation is the same thing that always fails: cross-table consistency. Old-mode measured defects: poly-PT **6.1e-4 / 8.9e-4 / 1.1e-3**, exact-PT **1.4e-8 / 3.8e-6 / 6.8e-4**.

### What this PR does

- **One gauge for every mode — the shear-free cotangent lift** — with the mapping coefficients recomputed at setup by direct sampling (x_a on the aux loop, x = π(x_a), p_a = v·π′; the PT is never inverted). Canonical action labels are the zero modes ⟨J^A⟩ (gauge-independent loop actions) and become the public `J(E)`/`E(j)`.
- **The exact PT keeps its extreme-orbit position map**, held as ONE order-3 table whose π′, ∂²π/∂u², and torus-direction derivatives are its own stencil derivatives — the legacy quintic value/derivative *pair* is precisely the contingent storage this mode exists to avoid. The price of the gauge: S̄ is no longer ~0 (table scale 4e-2, comparable to no-PT; 1-D tables are cheap).
- **Compensations in closed form**: the ω-chain (J^A sin2θ^A/2ω) and the PT-parameter chain (−v·∂π/∂E·E′(j)) assembled from the stored interpolants' own derivatives.

### A failed attempt worth recording

The first exact-PT implementation canonicalized the equal-time gauge itself through a characteristic-function shortcut; the defect harness rejected it at **1.6e-1** — the shortcut's toy (tangent-push of the HO through π) is not canonical, and the equal-time family genuinely needs Ξ explicitly, branch-glued. That derivation stays open as a refinement (it would recover S̄ ≈ 0 tables — the equal-time sampling machinery verified S̄ = 6.4e-10 during development, so the ingredients exist). The harness catching a wrong derivation at 1e-1 while passing right ones at 1e-9 is the review process working.

### Measured

| mode | old defect | canonical defect |
|---|---|---|
| no-PT | 2.2e-05 / 2.7e-04 / 1.5e-03 | 1.1e-11 / 1.6e-10 / 8.2e-10 |
| poly-PT | 6.1e-04 / 8.9e-04 / 1.1e-03 | 4.6e-11 / 3.1e-10 / 6.6e-10 |
| exact-PT | 1.4e-08 / 3.8e-06 / 6.8e-04 | **9.7e-10 / 9.8e-09 / 3.2e-08** |

**Timing (the requested time test)**: exact-PT canonical measured 79 µs/pt vs 15 µs old before the Newton fix. To correct a possible misimpression: **no quadrature happens at evaluation time** — the landed shear-free compensation is closed form; the per-point Gauss–Legendre integral existed only in the rejected equal-time attempt. The slowdown was the finite-difference Newton Jacobian (three residual evaluations per iteration) plus the Python-side stencil; the final commit replaces the Jacobian with the approximate-analytic one (main terms exact, the small compensation derivative dropped — this only affects convergence *rate*; the residual equation defining the map is exact, so canonicity is untouched).

### The old interpolated path is removed (Jo: no backwards-compat concerns)

It was strictly dominated — worse symplectic defect at the same accuracy class — so interpolating instances now *always* evaluate canonically and the `canonical` kwarg is gone. The per-torus non-interpolating mode is unchanged (exact at its nodes). `pt_only` — an equal-time-gauge construct — now requires `setup_interp=False` (tested error). The `dSndJ` tables and PT-table accessors survive only as diagnostics (`check_canonical_consistency()`, which refuses PT instances with an explanatory error since their stored tables live in the other gauge). Two legacy tolerances adjusted with reasons in comments. 48 vertical tests pass; module coverage 100%.
