### PR TITLE
backend: map_coordinates must dispatch on the GRID too (#1204 review, batch 2 item 2)

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -43,6 +43,7 @@ from ._namespaces import (
     device_of,
     is_backend_array,
     name_of_namespace,
+    prefer_backend_namespace,
 )
 from ._resolver import get_namespace
 
@@ -791,8 +792,16 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
         (byte-identical); jax/torch -> a backend array differentiable in the
         query coordinates.
     """
-    if not is_backend_array(coords):
-        # numpy / scalar coords: literal scipy passthrough (byte-identical).
+    # Dispatch on EITHER side being a backend array, not on ``coords`` alone.
+    # The grid carries derivatives too: ``spline_filter`` on a backend grid
+    # returns backend coefficients, and querying those at FIXED numpy points is
+    # the ordinary way to differentiate an interpolant w.r.t. the data it was
+    # built from. Keying on coords sent that case to scipy, which then tried
+    # numpy.asarray(filtered) and raised -- "Can't call numpy() on Tensor that
+    # requires grad" on torch, TracerArrayConversionError under jax.jit.
+    if not is_backend_array(coords) and not is_backend_array(filtered):
+        # numpy / scalar on both sides: literal scipy passthrough
+        # (byte-identical).
         return _scipy_ndimage.map_coordinates(
             numpy.asarray(filtered),
             coords,
@@ -808,9 +817,13 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
         raise NotImplementedError(
             "backend map_coordinates only implements mode='mirror'|'nearest'"
         )
-    import array_api_compat
-
-    xp = array_api_compat.array_namespace(coords)
+    # Whichever side is a backend array decides the namespace; the other is
+    # weak and is promoted onto it (and onto its device) below. Same rule as
+    # the @backend_input boundary -- shared, not re-spelled.
+    xp = prefer_backend_namespace(filtered, coords)
+    dev = device_of(filtered, coords)
+    filtered = asarray_on_device(xp, filtered, dev)
+    coords = asarray_on_device(xp, coords, dev)
     dev = device_of(coords, filtered)
     # A backend ``filtered`` (native prefilter, GPU-resident/differentiable) stays
     # on its backend; a numpy ``filtered`` is materialised onto the coords' device.

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -821,10 +821,9 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
     # weak and is promoted onto it (and onto its device) below. Same rule as
     # the @backend_input boundary -- shared, not re-spelled.
     xp = prefer_backend_namespace(filtered, coords)
-    dev = device_of(filtered, coords)
+    dev = device_of(coords, filtered)
     filtered = asarray_on_device(xp, filtered, dev)
     coords = asarray_on_device(xp, coords, dev)
-    dev = device_of(coords, filtered)
     # A backend ``filtered`` (native prefilter, GPU-resident/differentiable) stays
     # on its backend; a numpy ``filtered`` is materialised onto the coords' device.
     filt = filtered if is_backend_array(filtered) else numpy.asarray(filtered)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1230,3 +1230,60 @@ def test_map_coordinates_rejects_unimplemented_mode(backend):
     filt = spline_filter(_BN_GRID, order=3)
     with pytest.raises(NotImplementedError, match="mirror.*nearest"):
         map_coordinates(filt, _asarray(backend, _BN_NODES), mode="reflect")
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_map_coordinates_backend_grid_with_numpy_query_points(backend_name):
+    # Dispatch was keyed on the QUERY COORDINATES alone, so a backend
+    # prefiltered grid queried at fixed numpy points went to scipy, which then
+    # called numpy.asarray on it and raised -- "Can't call numpy() on Tensor
+    # that requires grad" (torch), TracerArrayConversionError (jax.jit).
+    #
+    # That combination is not exotic: it is how you differentiate an
+    # interpolant w.r.t. the DATA it was built from, with the sample points
+    # held fixed. The grid carries derivatives just as much as the coords do.
+    grid = numpy.sin(numpy.linspace(0.0, 3.0, 12))
+    pts = numpy.array([[2.3, 5.7, 9.1]])
+    ref = map_coordinates(
+        spline_filter(grid), pts, order=3, mode="nearest", prefilter=False
+    )
+
+    if backend_name == "jax":
+        import jax
+
+        def total(g):
+            return map_coordinates(
+                spline_filter(g), pts, order=3, mode="nearest", prefilter=False
+            ).sum()
+
+        got = jax.jit(total)(jnp.asarray(grid))
+        assert numpy.isfinite(float(got))
+        numpy.testing.assert_allclose(float(got), float(ref.sum()), rtol=1e-12)
+        return
+
+    g = torch.tensor(grid, dtype=torch.float64, requires_grad=True)
+    out = map_coordinates(
+        spline_filter(g), pts, order=3, mode="nearest", prefilter=False
+    )
+    # Value parity with the numpy/scipy answer first...
+    numpy.testing.assert_allclose(as_numpy(out.detach()), ref, rtol=1e-12, atol=1e-14)
+    # ...then the gradient this whole path exists for, against central
+    # differences at every grid node rather than "finite and nonzero".
+    out.sum().backward()
+    ad = as_numpy(g.grad)
+
+    def total_np(gv):
+        return float(
+            map_coordinates(
+                spline_filter(gv), pts, order=3, mode="nearest", prefilter=False
+            ).sum()
+        )
+
+    h = 1e-6
+    fd = numpy.empty_like(grid)
+    for i in range(grid.size):
+        up, dn = grid.copy(), grid.copy()
+        up[i] += h
+        dn[i] -= h
+        fd[i] = (total_np(up) - total_np(dn)) / (2 * h)
+    numpy.testing.assert_allclose(ad, fd, rtol=1e-6, atol=1e-8)


### PR DESCRIPTION
Review batch 2, item 2. Dispatch in `galpy.backend.interpolate.map_coordinates`
was keyed on the query coordinates alone:

```python
if not is_backend_array(coords):
    return _scipy_ndimage.map_coordinates(numpy.asarray(filtered), ...)
```

so a backend **prefiltered grid** queried at fixed numpy points fell into scipy,
which then called `numpy.asarray` on it and raised:

    RuntimeError: Can't call numpy() on Tensor that requires grad     (torch)
    TracerArrayConversionError                                        (jax.jit)

That combination is not exotic — it is how you differentiate an interpolant with
respect to the **data it was built from**, sample points held fixed. The grid
carries derivatives just as much as the coordinates do; only one of the two was
allowed to.

Take the scipy path only when NEITHER side is a backend array. On the backend
path the namespace comes from whichever side IS backend, via the shared
`galpy.backend.prefer_backend_namespace`, with the other side promoted onto it
and onto its device — the same rule as the `@backend_input` boundary and the
coords transforms, reused rather than spelled a third time.

### Verification

* **A/B**: both new tests fail on the parent commit, with exactly the two errors
  above, and pass here.
* **Value parity first**: torch grid + numpy query points reproduces the
  numpy/scipy answer to **3.3e-16**.
* **Then the gradient the path exists for**, grad-vs-FD at EVERY grid node
  rather than "finite and nonzero": max |AD − FD| = **3.0e-10** over all 12
  nodes (h = 1e-6 central differences, i.e. at the FD floor).
* `tests/test_backend_interpolate.py`: **165 passed on numpy, 165 under
  `--backend jax`** (and 165 under `--backend torch` when gated pre-rebase).

**numpy path**: the all-numpy branch is character-for-character the old one and
is still selected for numpy inputs — the added condition is False there — so the
scipy passthrough is unchanged.

The second commit is the pre-open audit: the coercion this branch adds computed
`dev`, and the pre-existing line then recomputed it one statement later on
operands that had just been placed on that very device. One line net, no
behaviour change.

**Ledger delta: 0.**