### PR TITLE
backend: traceable constructors + differentiable hyp2f1/hyp1f1 parameters (#1204 review, batch 2 items 3+4)

### DIFF
--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -23,6 +23,7 @@ from ._jit import jit, jit_mode, set_jit
 from ._namespaces import (
     as_numpy,
     asarray_on_device,
+    concretely_true,
     device_of,
     exit_cast,
     fork_deadlocks_backend,
@@ -58,6 +59,7 @@ __all__ = [
     "use",
     "set_default_backend",
     "has_concrete_truth_value",
+    "concretely_true",
     "is_backend_array",
     "is_backend_compatible",
     "match_input_dtype",

--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -5,8 +5,8 @@
 #   written to be jit-COMPATIBLE and the user decides when to trace. This module
 #   is how a user -- or the test suite -- says "trace it", once, globally:
 #
-#       galpy.backend.set_jit("jax")      # jax.jit every boundary call
-#       with galpy.backend.jit("torch"):  # torch.compile every boundary call
+#       galpy.backend.set_jit("jax")      # jax.jit at the outermost boundary
+#       with galpy.backend.jit("torch"):  # torch.compile at the outermost one
 #           ...
 #
 #   Every public entry point already carries ``@backend_input(*coords)``, which
@@ -27,22 +27,40 @@ from ._tracectx import TracedContextVar
 
 # "off" | "jax" | "torch". Process-wide, like the backend selection itself.
 _JIT_CTX = TracedContextVar("galpy_jit_mode", default="off")
-# Set while a traced call is on the stack. Entry points call each other
-# (Potential.__call__ -> evaluatePotentials -> ...), and re-tracing at every
-# nested boundary multiplies compile time for no benefit -- the outermost trace
-# already inlines the inner calls.
+# Set while a traced call is on the stack. Entry points call each other --
+# measured: evaluateDensities on a two-component potential reaches the boundary
+# 4 times (once for the call itself, then Potential.dens per component), and
+# evaluateSurfaceDensities twice -- and re-tracing at every nested boundary
+# multiplies compile time for no benefit, since the outermost trace already
+# inlines the inner calls. (Potential.__call__ and evaluateRforces do NOT nest:
+# the adapters were moved onto undecorated evaluators, so those crossings are
+# gone.)
 _TRACING = TracedContextVar("galpy_jit_tracing", default=False)
 
 _VALID = ("off", "jax", "torch")
 
 
 def set_jit(mode):
-    """Trace every boundary call under the named framework ("jax"/"torch"/"off").
+    """Trace boundary calls under the named framework ("jax"/"torch"/"off").
+
+    "Every boundary call" would overstate it; two things stay eager by design,
+    and both are visible in :func:`traced_call`:
+
+    * **Nested entry points.** Only the OUTERMOST boundary is traced. Measured:
+      ``evaluateDensities`` on a two-component potential reaches the boundary
+      4 times and traces 1; ``evaluateSurfaceDensities`` reaches it twice and
+      traces 1. Re-tracing at every hop would multiply compile time for no
+      benefit, since the outer trace already inlines the inner calls.
+    * **A boundary on a different framework.** Coordinates belonging to a
+      backend other than ``mode`` run eager, so that e.g.
+      ``use("torch", force=True)`` inside a ``--backend jax --jit`` run does not
+      hand torch tensors to a ``jax.jit``. numpy coordinates stay traceable --
+      both frameworks accept them.
 
     Parameters
     ----------
     mode : str
-        ``"jax"`` wraps each entry point in ``jax.jit``, ``"torch"`` in
+        ``"jax"`` wraps the outermost entry point in ``jax.jit``, ``"torch"`` in
         ``torch.compile``, ``"off"`` (default) leaves galpy eager.
 
     Notes

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -43,6 +43,23 @@ def has_concrete_truth_value(x):
     return True
 
 
+def concretely_true(cond):
+    """True iff ``cond`` has a concrete truth value AND that value is True.
+
+    The guard for a Python-level ``if`` on something that may be TRACED. Under a
+    jax trace ``if cond`` raises ``TracerBoolConversionError``, so a *validation*
+    check (raise on a bad parameter) has to skip itself rather than take down the
+    trace, and a *special-case* branch (a closed form that degenerates at one
+    exponent, say) has to fall through to the generic case. Both read as
+    ``if concretely_true(...)``. On numpy, and on untraced jax/torch values, this
+    is exactly ``bool(cond)``, so those paths are unchanged. Under
+    ``torch.compile`` dynamo answers ``bool()`` from the example value and
+    guards on it, so the branch is specialised rather than skipped -- which is
+    what dynamo does with any Python-level branch and needs no special casing.
+    """
+    return has_concrete_truth_value(cond) and bool(cond)
+
+
 def is_backend_array(x):
     """True if ``x`` is a non-numpy backend array (a jax or torch array/tensor).
 

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -822,12 +822,13 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
     # the @backend_input boundary -- shared, not re-spelled.
     xp = prefer_backend_namespace(filtered, coords)
     dev = device_of(coords, filtered)
-    filtered = asarray_on_device(xp, filtered, dev)
+    # Both sides onto xp and onto dev, once. A backend ``filtered`` (native
+    # prefilter, GPU-resident/differentiable) is already there and stays put; a
+    # numpy one is materialised. The is_backend_array(filtered) test that used
+    # to guard a second materialisation here became dead the moment this
+    # coercion landed -- there is no numpy ``filtered`` left to catch.
+    cb = asarray_on_device(xp, filtered, dev)
     coords = asarray_on_device(xp, coords, dev)
-    # A backend ``filtered`` (native prefilter, GPU-resident/differentiable) stays
-    # on its backend; a numpy ``filtered`` is materialised onto the coords' device.
-    filt = filtered if is_backend_array(filtered) else numpy.asarray(filtered)
-    cb = asarray_on_device(xp, filt, dev)
     shape = cb.shape
     D = cb.ndim
     # coords is (D, M): split into per-dimension rows. base = floor index, frac =

--- a/galpy/backend/special/_fallback/hyp1f1.py
+++ b/galpy/backend/special/_fallback/hyp1f1.py
@@ -16,13 +16,18 @@
 ###############################################################################
 import math
 
+from ..._namespaces import concretely_true, is_backend_array
+
 
 def hyp1f1_fallback(xp, a, b, z):
     r"""1F1(a, b; z) for real z <= 0, restricted to b = a + 1 (galpy's case).
 
     a, b scalars; z a backend array/scalar.
     """
-    if abs(b - (a + 1.0)) >= 1e-12:
+    # concretely_true: with a TRACED a or b the comparison has no truth value, so
+    # the domain check has to skip itself rather than take the trace down. It is
+    # a check on galpy's own call pattern, which no traced call changes.
+    if concretely_true(abs(b - (a + 1.0)) >= 1e-12):
         raise NotImplementedError(
             "galpy.backend.special.hyp1f1 fallback only implements the b=a+1 case "
             f"(galpy's only use); got (a, b)=({a}, {b})"
@@ -36,6 +41,18 @@ def hyp1f1_fallback(xp, a, b, z):
     Xs = xp.maximum(X, xp.ones_like(X) * 1e-12)
     # ``a`` as an array (torch.special.gammainc requires both args be tensors).
     a_arr = xp.ones_like(Xs) * a
-    closed = a * Xs ** (-a) * math.gamma(a) * gammainc(a_arr, Xs)
+    # math.gamma on a BACKEND a runs via __float__ and silently detaches this
+    # factor: measured torch d/da 1F1(a, a+1; -3) came back 42% wrong, with
+    # requires_grad and a grad_fn intact. Route it instead. On jax that makes
+    # d/da correct end to end; on torch it turns the wrong answer into a loud
+    # NotImplementedError from torch.special.gammainc, which has no derivative
+    # w.r.t. its order -- a real gap, and better surfaced than hidden.
+    if is_backend_array(a):
+        from .._router import gamma as _gamma
+
+        gamma_a = _gamma(xp.ones_like(Xs) * a)
+    else:
+        gamma_a = math.gamma(a)
+    closed = a * Xs ** (-a) * gamma_a * gammainc(a_arr, Xs)
     series = 1.0 + a / (a + 1.0) * z + a / (a + 2.0) * z * z / 2.0
     return xp.where(X < 1e-6, series, closed)

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -23,7 +23,12 @@
 ###############################################################################
 import math
 
-from ..._namespaces import asarray_on_device, device_of
+from ..._namespaces import (
+    asarray_on_device,
+    device_of,
+    has_concrete_truth_value,
+    is_backend_array,
+)
 from ._quadrature import gauss_legendre_01
 
 # 128 nodes: ~1e-10 or better vs scipy at realistic radii (|z| = r/a <~ 50);
@@ -46,6 +51,22 @@ _NODES = 128
 # terms. galpy's own anisotropic DFs call this branch at |z| < 1 (measured), so
 # the exact range covers real use with a wide margin.
 _SERIES_TERMS = 512
+
+
+def _params_are_backend(*ps):
+    """True when the (a, b, c) parameters must be handled ON the backend.
+
+    Two distinct reasons, and BOTH matter:
+
+    * a tracer -- ``float()`` / ``math.lgamma`` raise, so the code cannot run;
+    * an ordinary (untraced) jax array or torch tensor -- ``math.lgamma`` DOES
+      run, via ``__float__``, and silently DETACHES that factor from the
+      autograd graph. The result still has ``requires_grad=True`` and a
+      ``grad_fn``, so nothing short of grad-vs-finite-difference notices: the
+      measured torch ``d/da 2F1(a, 2, 3; -5)`` was -8.98e-03 against a true
+      -8.56e-02, and ``dPhi/dalpha`` for TwoPowerTriaxial 0.834 against 0.548.
+    """
+    return any(is_backend_array(p) or not has_concrete_truth_value(p > 0.0) for p in ps)
 
 
 def _in_regime(a, b, c):
@@ -89,10 +110,13 @@ def _pfaff_series(xp, a, b, c, z):
     so this is the best conditioning available -- there is no relabeling that
     converges faster.
     """
-    if b > a:
+    if has_concrete_truth_value(b > a):
         A, B, pref_exp = a, c - b, -a
-    else:
-        A, B, pref_exp = c - a, b, -b
+    else:  # TRACED parameters: same choice, selected rather than branched
+        swap = b > a
+        A = xp.where(swap, a, c - a)
+        B = xp.where(swap, c - b, b)
+        pref_exp = xp.where(swap, -a, -b)
     x = z / (z - 1.0)
     term = xp.ones_like(x)
     total = xp.ones_like(x)
@@ -151,8 +175,47 @@ def hyp2f1_fallback(xp, a, b, c, z):
     return xp.where(pos, (1.0 - z) ** (-a) * pfaff, direct)
 
 
+def _in_regime_mask(xp, a, b, c):
+    """_in_regime as an elementwise mask, for traced (a, b, c)."""
+    return ((a > 0) & ((c - a) >= 1.0)) | ((b > 0) & ((c - b) >= 1.0))
+
+
+def _nonpositive_traced(xp, a, b, c, z):
+    """The same three routes for z <= 0, selected rather than branched.
+
+    Reached when a, b or c is a TRACER -- differentiating a potential w.r.t. an
+    exponent, say -- where `if a > 0` has no truth value. Both surviving
+    formulas are evaluated and one is selected, so this costs an Euler
+    quadrature plus a 512-term series per call where the concrete route pays
+    for one of them; that is the price of not knowing which route applies until
+    the values exist.
+
+    The Euler evaluation is fed a SAFE (B, A, c) = (1, 0, 2) wherever no
+    labeling is admissible, rather than the inadmissible one: xp.where evaluates
+    both sides, and T**(B-1) with B <= 0 is inf at the t -> 0 node, which would
+    NaN-poison the gradient of the series result that actually wins there.
+    """
+    ok_ab = _in_regime_mask(xp, a, b, c)
+    ok_tr = _in_regime_mask(xp, c - a, c - b, c)
+    use_tr = (~ok_ab) & ok_tr
+    use_euler = ok_ab | ok_tr
+    ea = xp.where(use_tr, c - a, a)
+    eb = xp.where(use_tr, c - b, b)
+    oka = (ea > 0) & ((c - ea) >= 1.0)
+    B = xp.where(use_euler, xp.where(oka, ea, eb), 1.0)
+    A = xp.where(use_euler, xp.where(oka, eb, ea), 0.0)
+    cc = xp.where(use_euler, c, 2.0)
+    euler = _euler_quad(xp, A, B, cc, z)
+    # Euler's transformation carries a (1-z)^{c-a-b} prefactor; z <= 0 here so
+    # 1-z >= 1 and the unused side is finite.
+    euler = xp.where(use_tr, (1.0 - z) ** (c - a - b), 1.0) * euler
+    return xp.where(use_euler, euler, _pfaff_series(xp, a, b, c, z))
+
+
 def _hyp2f1_nonpositive(xp, a, b, c, z):
     """2F1(a, b; c; z) for real z <= 0 -- the three routes named above."""
+    if not all(has_concrete_truth_value(p > 0.0) for p in (a, b, c)):
+        return _nonpositive_traced(xp, a, b, c, z)
     if not _in_regime(a, b, c):
         if _in_regime(c - a, c - b, c):
             return (1.0 - z) ** (c - a - b) * _euler_integral(xp, c - a, c - b, c, z)
@@ -162,21 +225,45 @@ def _hyp2f1_nonpositive(xp, a, b, c, z):
 
 def _euler_integral(xp, a, b, c, z):
     r"""2F1(a, b; c; z) for real z <= 0 via the boundary-layer Euler integral."""
-    w = -z  # >= 0
     B, A = _euler_labeling(a, b, c)
+    return _euler_quad(xp, A, B, c, z)
+
+
+def _euler_quad(xp, A, B, c, z):
+    """The quadrature itself, on an ALREADY-LABELLED (A, B).
+
+    Split out from _euler_integral so the traced-parameter route below can
+    choose (A, B) with xp.where instead of a Python branch and still reuse this
+    verbatim.
+    """
+    w = -z  # >= 0
     q = c - B  # exponent of (1-t) is q-1
+    dev = device_of(z)
     # X = xi^k regularizes the t^{B-1} endpoint: after the boundary-layer map the
     # integrand carries X^{B-1} near X=0, which is only algebraically integrable
     # for non-integer B. Raise it to xi^{kB-1} with kB >= ~6 so plain GL is
     # spectrally accurate (k=1 already suffices once B-1 is a smooth high power).
     # Capped at 12 (covers B >= 0.5, galpy's range) so X=xi^k cannot underflow.
-    k = min(12.0, max(1.0, float(math.ceil(6.0 / B))))
-    pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(q))
+    if not _params_are_backend(A, B, c):
+        k = min(12.0, max(1.0, float(math.ceil(6.0 / B))))
+        pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(q))
+    else:
+        # Backend parameters: the same expressions, evaluated ON the backend, so
+        # they neither concretize a tracer nor detach a tensor. ceil is a step,
+        # so its zero gradient is the correct one -- k only shapes the
+        # substitution; the integral's value does not depend on it.
+        from .._router import gammaln
+
+        # every operand on the backend and on z's device: the router's gammaln
+        # dispatches on its ARGUMENT, and torch.special.gammaln rejects a plain
+        # float outright.
+        Bx, cx, qx = (asarray_on_device(xp, v, dev) for v in (B, c, q))
+        k = xp.clip(xp.ceil(6.0 / Bx), 1.0, 12.0)
+        pref = xp.exp(gammaln(cx) - gammaln(Bx) - gammaln(qx))
 
     # node/weight tables stay float64 (precision is the point; the router
     # exit-casts) but must live on the input's device (CUDA support)
     nodes, weights = gauss_legendre_01(_NODES)
-    dev = device_of(z)
     xg = asarray_on_device(xp, nodes, dev)
     wg = asarray_on_device(xp, weights, dev)
     X = xg**k
@@ -203,5 +290,6 @@ def _euler_integral(xp, a, b, c, z):
     dt = xp.exp(XL) * L / wb
     integ = T ** (B - 1.0) * (1.0 - T) ** (q - 1.0) * (1.0 + wb * T) ** (-A) * dt * dX
     val_int = pref * xp.sum(integ * wg, axis=-1)
-    val_series = 1.0 + (a * b / c) * z  # 2F1 = 1 + (ab/c) z + O(z^2)
+    # A*B is a*b: {A, B} is just a relabelling of {a, b}.
+    val_series = 1.0 + (A * B / c) * z  # 2F1 = 1 + (ab/c) z + O(z^2)
     return xp.where(tiny, val_series, val_int)

--- a/galpy/df/constantbetaPowerLawdf.py
+++ b/galpy/df/constantbetaPowerLawdf.py
@@ -6,7 +6,12 @@
 # For rho_pot ~ r^{-alpha} (alpha > 2) and nu_tracer ~ r^{-gamma}
 import numpy
 
-from ..backend import coerce_coords, get_namespace, resolve_namespace
+from ..backend import (
+    coerce_coords,
+    concretely_true,
+    get_namespace,
+    resolve_namespace,
+)
 from ..backend.special import gamma as _bgamma
 from ..potential import PowerSphericalPotential, evaluatePotentials
 from ..potential.Potential import _evaluatePotentials
@@ -64,8 +69,14 @@ class constantbetaPowerLawdf(_constantbetadf):
         assert isinstance(pot, PowerSphericalPotential), (
             "pot= must be potential.PowerSphericalPotential"
         )
-        assert pot.alpha > 2.0, "pot.alpha must be > 2 for bound orbits"
-        assert beta < 1.0, "beta must be < 1"
+        # `not concretely_true(<negation>)` rather than the direct comparison:
+        # under a trace w.r.t. alpha or beta the comparison is a tracer with no
+        # truth value, so the check has to skip itself instead of taking the
+        # trace down. Unchanged on numpy.
+        assert not concretely_true(pot.alpha <= 2.0), (
+            "pot.alpha must be > 2 for bound orbits"
+        )
+        assert not concretely_true(beta >= 1.0), "beta must be < 1"
         self._alpha_pot = pot.alpha
         # Resolve tracer density
         if denspot is not None:
@@ -75,7 +86,9 @@ class constantbetaPowerLawdf(_constantbetadf):
             self._gamma = denspot.alpha
         else:
             self._gamma = self._alpha_pot
-        assert self._gamma < 3.0, "gamma must be < 3 for finite enclosed mass"
+        assert not concretely_true(self._gamma >= 3.0), (
+            "gamma must be < 3 for finite enclosed mass"
+        )
         _constantbetadf.__init__(
             self, pot=pot, denspot=denspot, beta=beta, rmax=rmax, ro=ro, vo=vo
         )
@@ -96,7 +109,9 @@ class constantbetaPowerLawdf(_constantbetadf):
         # Exponents
         self._p = (self._gamma - 2.0 * self._beta) / (self._alpha_pot - 2.0)
         self._n = self._p + self._beta - 1.5
-        assert self._n > -1.0, (
+        # The f-string is only built when the assert FAILS, which a traced
+        # self._n never does here -- so no tracer ever reaches "{:.3f}".
+        assert not concretely_true(self._n <= -1.0), (
             f"Energy exponent n={self._n:.3f} must be > -1 for the DF to be normalizable. "
             "Adjust gamma, alpha, or beta."
         )

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -91,6 +91,15 @@ def _handle_rmin(rmin, pot, denspot, scale, ro, df_name):
     rmin : float
         The rmin value to use (in internal units)
     """
+    # If rmin is explicitly specified, use it. FIRST: everything below is only
+    # consulted to pick an rmin automatically, so with an explicit rmin the
+    # Phi(0) probe is wasted work -- and it is not traceable (it reads a
+    # concrete Phi(0) out of the backend), so it would block building a DF
+    # inside a jitted function that differentiates w.r.t. a potential
+    # parameter.
+    if rmin is not None:
+        return conversion.parse_length(rmin, ro=ro)
+
     # Check if potential diverges at r=0
     xp = get_namespace()  # context/forced default only (inputs are scalars)
     if xp is numpy:
@@ -99,10 +108,6 @@ def _handle_rmin(rmin, pot, denspot, scale, ro, df_name):
         # coerce coords: undecorated potential evals reject scalars (torch)
         phi_at_zero = as_numpy(_evaluatePotentials(pot, xp.asarray(0.0), 0))
     is_divergent = not numpy.isfinite(phi_at_zero)
-
-    # If rmin is explicitly specified, use it
-    if rmin is not None:
-        return conversion.parse_length(rmin, ro=ro)
 
     # Check all potentials for known problematic types
     for p in denspot:

--- a/galpy/potential/ExpTruncNFWPotential.py
+++ b/galpy/potential/ExpTruncNFWPotential.py
@@ -113,7 +113,10 @@ class ExpTruncNFWPotential(SphericalPotential):
         # Threshold below which the closed-form M(<r) suffers cancellation; use
         # the series expansion instead. r/min(a, rc) < eps gives roughly eps^2
         # relative truncation error in F(r).
-        self._small_r_thresh = 1e-3 * min(a, rc)
+        # xp.minimum, not min(): min() needs a truth value, which a TRACED a or
+        # rc does not have (jax.jit(jax.grad(...)) w.r.t. a scale radius raises
+        # TracerBoolConversionError here). Same value on numpy.
+        self._small_r_thresh = 1e-3 * get_namespace(a, rc).minimum(a, rc)
         if normalize or (
             isinstance(normalize, (int, float)) and not isinstance(normalize, bool)
         ):  # pragma: no cover

--- a/galpy/potential/TwoPowerTriaxialPotential.py
+++ b/galpy/potential/TwoPowerTriaxialPotential.py
@@ -15,7 +15,7 @@ import math
 import numpy
 from scipy import special
 
-from ..backend import coerce_coords, get_namespace
+from ..backend import coerce_coords, concretely_true, get_namespace
 from ..backend import special as _bspecial
 from ..backend.special import hyp2f1 as _hyp2f1
 from ..util import conversion
@@ -107,7 +107,11 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
         a = conversion.parse_length(a, ro=self._ro)
         self.a = a
         self._scale = self.a
-        if beta <= 2.0 or alpha >= 3.0:
+        # concretely_true, and one call per clause rather than `or`: under a
+        # trace w.r.t. alpha/beta each comparison is a tracer with no truth
+        # value, so validating here would take down the trace. Identical on
+        # numpy -- concretely_true is bool() there.
+        if concretely_true(beta <= 2.0) or concretely_true(alpha >= 3.0):
             raise OSError(
                 "TwoPowerTriaxialPotential requires 0 <= alpha < 3 and beta > 2"
             )
@@ -116,7 +120,11 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
         self.betaminusalpha = self.beta - self.alpha
         self.twominusalpha = 2.0 - self.alpha
         self.threeminusalpha = 3.0 - self.alpha
-        if self.twominusalpha != 0.0:
+        # `not concretely_true(== 0)` rather than `!= 0`: alpha == 2 is a
+        # degenerate closed form, and under a trace we cannot prove we are NOT
+        # in it, so take the generic branch -- which is the one that is
+        # differentiable in alpha. _psi below makes the mirrored choice.
+        if not concretely_true(self.twominusalpha == 0.0):
             # Routed gamma on coerced exponents, so psi_inf is computed ON the
             # backend under a force and stays differentiable in alpha/beta;
             # scipy.special.gamma would return a silently DETACHED tensor. The
@@ -148,7 +156,7 @@ class TwoPowerTriaxialPotential(EllipsoidalPotential):
         r"""\psi(m) = -\int_{m^2}^\infty d m'^2 \rho(m'^2)"""
         # backend hyp2f1 (scipy on numpy, byte-identical): scipy.special.hyp2f1
         # converts a traced/tensor m to numpy, which is not jit-traceable
-        if self.twominusalpha == 0.0:
+        if concretely_true(self.twominusalpha == 0.0):
             return (
                 -2.0
                 * self.a**2

--- a/tests/test_backend_constructor_jit.py
+++ b/tests/test_backend_constructor_jit.py
@@ -1,0 +1,243 @@
+###############################################################################
+# test_backend_constructor_jit.py: BUILDING a potential or a DF inside a traced,
+# differentiated function.
+#
+# test_backend_potential_jit.py traces the EVALUATION of an already-built
+# potential. This file covers the other half, which is what a fit actually
+# needs: the scale radius / exponent / anisotropy being optimised is a tracer,
+# so the object is constructed inside jax.jit(jax.grad(...)) and the constructor
+# itself has to be traceable.
+#
+# Constructors are full of Python-level decisions -- min(a, rc) to size a
+# series-expansion threshold, `if beta <= 2` validation, `if 2-alpha == 0` for a
+# degenerate closed form, asserts on the DF exponents -- and every one of them
+# needs a truth value that a tracer does not have. The rule adopted here is
+# galpy.backend.concretely_true: a check fires only when it can be PROVEN to
+# fire, and a special case is taken only when it can be PROVEN to apply, so
+# concrete construction is unchanged and traced construction falls through to
+# the generic (differentiable) branch.
+#
+# Gradients are checked against central finite differences, never merely for
+# being finite and non-zero, and the validation errors are checked to still
+# raise on concrete bad input -- a guard that silently disables the check would
+# otherwise look like a pass.
+#
+# Backends that are not installed self-skip, so this is green on numpy alone.
+###############################################################################
+import numpy
+import pytest
+
+from galpy.backend import concretely_true, use
+from galpy.df import constantbetaPowerLawdf
+from galpy.potential import (
+    ExpTruncNFWPotential,
+    PowerSphericalPotential,
+    TwoPowerTriaxialPotential,
+)
+
+# This module manages backends explicitly (parametrizes over them), so it is
+# exempt from the global --backend force fixture.
+pytestmark = pytest.mark.backend_managed
+
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+except ImportError:  # pragma: no cover
+    jax = None
+try:
+    import torch
+
+    torch.set_default_dtype(torch.float64)
+except ImportError:  # pragma: no cover
+    torch = None
+
+requires_jax = pytest.mark.skipif(jax is None, reason="jax not installed")
+requires_torch = pytest.mark.skipif(torch is None, reason="torch not installed")
+
+
+def _central_diff(f, x, h=1e-5):
+    return (f(x + h) - f(x - h)) / (2.0 * h)
+
+
+def _jit_grad(f, x):
+    """d f/dx under jax.jit(jax.grad(...)) -- the constructor is TRACED."""
+    return float(jax.jit(jax.grad(f))(x))
+
+
+# ---------------------------------------------------------------------------
+# the helper itself
+# ---------------------------------------------------------------------------
+def test_concretely_true_matches_bool_when_concrete():
+    for v in (True, False, 1.0 > 0.0, 1.0 < 0.0, numpy.bool_(True), numpy.bool_(False)):
+        assert concretely_true(v) is bool(v)
+    # a multi-element array has no truth value either, and must not raise here
+    assert concretely_true(numpy.array([True, True])) is False
+
+
+@requires_jax
+def test_concretely_true_is_false_on_both_branches_under_trace():
+    # The property that makes it safe: while tracing it answers False for a
+    # predicate AND for its negation, so `if concretely_true(p)` and
+    # `if concretely_true(not p)` both fall through rather than one of them
+    # silently firing on a tracer.
+    seen = []
+
+    def probe(x):
+        seen.append((concretely_true(x > 0.0), concretely_true(x <= 0.0)))
+        return x
+
+    jax.jit(probe)(1.0)
+    assert seen == [(False, False)]
+
+
+# ---------------------------------------------------------------------------
+# ExpTruncNFWPotential: min(a, rc) sizes the small-r series threshold
+# ---------------------------------------------------------------------------
+@requires_jax
+@pytest.mark.parametrize("R", [1.2, 1e-5])
+def test_exptruncnfw_scale_radius_gradient_under_jit(R):
+    # R = 1.2 takes the closed form, R = 1e-5 the small-r series -- the two
+    # sides of the _small_r_thresh = 1e-3 * min(a, rc) split that min() used to
+    # make untraceable.
+    with use("jax", force=True):
+        Rb, zb = jnp.asarray(R), jnp.asarray(0.0 if R < 1e-3 else 0.1)
+
+        def f(a):
+            return ExpTruncNFWPotential(amp=1.0, a=a, rc=2.0).Rforce(Rb, zb)
+
+        assert _jit_grad(f, 1.0) == pytest.approx(_central_diff(f, 1.0), rel=1e-7)
+
+
+@requires_jax
+def test_exptruncnfw_threshold_still_selects_the_series_branch():
+    # The threshold has to keep its VALUE, not just trace: min(a, rc) is rc here.
+    with use("jax", force=True):
+        p = ExpTruncNFWPotential(amp=1.0, a=3.0, rc=0.5)
+        assert float(p._small_r_thresh) == pytest.approx(1e-3 * 0.5, rel=1e-15)
+
+
+@requires_torch
+def test_exptruncnfw_scale_radius_gradient_torch():
+    with use("torch", force=True):
+        a = torch.tensor(1.0, requires_grad=True)
+        out = ExpTruncNFWPotential(amp=1.0, a=a, rc=2.0).Rforce(
+            torch.tensor(1.2), torch.tensor(0.1)
+        )
+        (g,) = torch.autograd.grad(out, a)
+
+        def f(av):
+            return float(ExpTruncNFWPotential(amp=1.0, a=av, rc=2.0).Rforce(1.2, 0.1))
+
+        assert float(g) == pytest.approx(_central_diff(f, 1.0), rel=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# TwoPowerTriaxialPotential: the alpha/beta validation and the alpha == 2 case
+# ---------------------------------------------------------------------------
+@requires_jax
+@pytest.mark.parametrize(
+    "name,x0", [("alpha", 1.0), ("beta", 3.5)], ids=["d/dalpha", "d/dbeta"]
+)
+def test_twopower_triaxial_exponent_gradient_under_jit(name, x0):
+    with use("jax", force=True):
+        Rb, zb = jnp.asarray(1.2), jnp.asarray(0.1)
+
+        def f(x):
+            kw = {"alpha": 1.0, "beta": 3.0, name: x}
+            return TwoPowerTriaxialPotential(amp=1.0, a=1.0, b=0.9, c=0.8, **kw).Rforce(
+                Rb, zb
+            )
+
+        assert _jit_grad(f, x0) == pytest.approx(_central_diff(f, x0), rel=1e-7)
+
+
+def test_twopower_triaxial_validation_still_raises_when_concrete():
+    # The guard must not have turned the check off for ordinary construction.
+    with pytest.raises(OSError):
+        TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=1.0, beta=1.5)
+    with pytest.raises(OSError):
+        TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=3.5, beta=4.0)
+
+
+def test_twopower_triaxial_alpha_two_keeps_its_own_closed_form():
+    # alpha == 2 makes 2-alpha == 0 and the generic psi has a 1/(2-alpha) pole,
+    # so the degenerate branch must still be taken when alpha is concrete.
+    p = TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=2.0, beta=4.0, b=0.9, c=0.8)
+    assert not hasattr(p, "psi_inf")
+    assert numpy.isfinite(p.Rforce(1.2, 0.1))
+
+
+@requires_torch
+def test_twopower_triaxial_alpha_gradient_torch():
+    with use("torch", force=True):
+        alpha = torch.tensor(1.0, requires_grad=True)
+        out = TwoPowerTriaxialPotential(
+            amp=1.0, a=1.0, alpha=alpha, beta=3.0, b=0.9, c=0.8
+        ).Rforce(torch.tensor(1.2), torch.tensor(0.1))
+        (g,) = torch.autograd.grad(out, alpha)
+
+        def f(av):
+            return float(
+                TwoPowerTriaxialPotential(
+                    amp=1.0, a=1.0, alpha=av, beta=3.0, b=0.9, c=0.8
+                ).Rforce(1.2, 0.1)
+            )
+
+        assert float(g) == pytest.approx(_central_diff(f, 1.0), rel=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# constantbetaPowerLawdf: the anisotropy parameter itself
+# ---------------------------------------------------------------------------
+@requires_jax
+def test_constantbetapowerlawdf_beta_gradient_under_jit():
+    # d f_E / d beta with the DF BUILT inside the traced function: the four
+    # normalizability asserts all read beta (directly or through the exponents
+    # n and p), and _handle_rmin's Phi(0) probe sat in front of the explicit
+    # rmin.
+    with use("jax", force=True):
+        pot = PowerSphericalPotential(amp=1.0, alpha=2.5)
+        E = jnp.asarray(-1.0)
+
+        def f(beta):
+            return constantbetaPowerLawdf(pot=pot, beta=beta, rmax=100.0, rmin=1e-4).fE(
+                E
+            )
+
+        assert _jit_grad(f, 0.3) == pytest.approx(_central_diff(f, 0.3), rel=1e-7)
+
+
+def test_constantbetapowerlawdf_asserts_still_fire_when_concrete():
+    with pytest.raises(AssertionError, match="beta must be < 1"):
+        constantbetaPowerLawdf(
+            pot=PowerSphericalPotential(amp=1.0, alpha=2.5), beta=1.5, rmin=1e-4
+        )
+    with pytest.raises(AssertionError, match="alpha must be > 2"):
+        constantbetaPowerLawdf(
+            pot=PowerSphericalPotential(amp=1.0, alpha=1.5), beta=0.3, rmin=1e-4
+        )
+
+
+@requires_torch
+def test_constantbetapowerlawdf_beta_gradient_torch():
+    with use("torch", force=True):
+        pot = PowerSphericalPotential(amp=1.0, alpha=2.5)
+        beta = torch.tensor(0.3, requires_grad=True)
+        out = constantbetaPowerLawdf(pot=pot, beta=beta, rmax=100.0, rmin=1e-4).fE(
+            torch.tensor(-1.0)
+        )
+        (g,) = torch.autograd.grad(out, beta)
+
+        def f(b):
+            return float(
+                constantbetaPowerLawdf(
+                    pot=PowerSphericalPotential(amp=1.0, alpha=2.5),
+                    beta=b,
+                    rmax=100.0,
+                    rmin=1e-4,
+                ).fE(-1.0)
+            )
+
+        assert float(g) == pytest.approx(_central_diff(f, 0.3), rel=1e-7)

--- a/tests/test_backend_constructor_jit.py
+++ b/tests/test_backend_constructor_jit.py
@@ -163,10 +163,18 @@ def test_twopower_triaxial_validation_still_raises_when_concrete():
 
 def test_twopower_triaxial_alpha_two_keeps_its_own_closed_form():
     # alpha == 2 makes 2-alpha == 0 and the generic psi has a 1/(2-alpha) pole,
-    # so the degenerate branch must still be taken when alpha is concrete.
-    p = TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=2.0, beta=4.0, b=0.9, c=0.8)
-    assert not hasattr(p, "psi_inf")
-    assert numpy.isfinite(p.Rforce(1.2, 0.1))
+    # so the degenerate branch must still be taken when alpha is concrete. Both
+    # halves of that are asserted: psi_inf is not even built, and the POTENTIAL
+    # (which is where _psi is consulted -- Rforce goes through _mdens instead)
+    # is finite rather than the inf/nan the generic form would give.
+    p2 = TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=2.0, beta=4.0, b=0.9, c=0.8)
+    assert not hasattr(p2, "psi_inf")
+    assert numpy.isfinite(p2(1.2, 0.1))
+    # ... and the generic branch is still the one taken away from alpha == 2
+    p1 = TwoPowerTriaxialPotential(amp=1.0, a=1.0, alpha=1.0, beta=4.0, b=0.9, c=0.8)
+    assert hasattr(p1, "psi_inf")
+    assert numpy.isfinite(p1(1.2, 0.1))
+    assert p1(1.2, 0.1) != p2(1.2, 0.1)
 
 
 @requires_torch

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1327,3 +1327,34 @@ def test_hyp2f1_traced_parameters_reproduce_the_concrete_route(a, b, c):
         # ... and both are the scipy answer to the concrete route's own accuracy
         ref = scipy_special.hyp2f1(a, b, c, -_HYP2F1_W)
         numpy.testing.assert_allclose(traced, ref, rtol=1e-5, atol=1e-10)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp1f1_parameter_gradient_matches_finite_difference(backend):
+    # Sibling of the 2F1 case above, same defect: math.gamma(a) ran through
+    # __float__ on a backend a and silently detached the Gamma factor. torch
+    # returned a gradient that was 42% wrong -- finite, requires_grad=True,
+    # grad_fn set -- and jax raised ConcretizationTypeError. Routed, both agree
+    # with scipy's finite difference to ~5e-10.
+    a0, z0 = 1.7, -3.0
+    h = 1e-6
+    ref = (
+        scipy_special.hyp1f1(a0 + h, a0 + h + 1.0, z0)
+        - scipy_special.hyp1f1(a0 - h, a0 - h + 1.0, z0)
+    ) / (2.0 * h)
+    with use(backend, force=True):
+        if backend == "jax":
+            import jax
+            import jax.numpy as jnp
+
+            got = float(
+                jax.grad(lambda av: gsp.hyp1f1(av, av + 1.0, jnp.asarray(z0)))(a0)
+            )
+        else:
+            import torch
+
+            a = torch.tensor(a0, dtype=torch.float64, requires_grad=True)
+            out = gsp.hyp1f1(a, a + 1.0, torch.tensor(z0, dtype=torch.float64))
+            (grad,) = torch.autograd.grad(out, a)
+            got = float(grad)
+    assert got == pytest.approx(ref, rel=1e-7)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -15,6 +15,7 @@ from conftest import torch_compiles
 
 from galpy.backend import as_numpy
 from galpy.backend import special as gsp
+from galpy.backend import use
 from galpy.backend.special._router import (
     _NATIVE_MISSING,
     _NATIVE_UNRELIABLE,
@@ -1219,3 +1220,110 @@ def test_gammainc_grad_with_an_integer_order_dtype():
     x = torch.tensor(0.5, dtype=torch.float64, requires_grad=True)
     gsp.gammainc(torch.tensor(1), x).backward()
     numpy.testing.assert_allclose(float(x.grad), numpy.exp(-0.5), rtol=1e-14)
+
+
+# --- hyp2f1 with BACKEND (a, b, c): differentiable in the parameters ----------
+# Until now the fallback pinned its parameters to Python floats: math.lgamma for
+# the Gamma prefactor and float(math.ceil(...)) for the substitution exponent. On
+# jax that raised (TracerBoolConversion / Concretization) as soon as an exponent
+# was traced. On torch it did NOT raise -- __float__ ran and silently DETACHED
+# the prefactor, so the gradient came back finite, with requires_grad=True and a
+# grad_fn, and simply wrong: measured d/da 2F1(a,2;3;-5) = -8.98e-03 against a
+# true -8.56e-02, and TwoPowerTriaxial dPhi/dalpha 0.834 against 0.548. Only
+# grad-vs-finite-difference catches that, which is what these do.
+#
+# The bar is per route, because the routes do not differentiate equally well.
+# The value is spectrally accurate only when c - B is an integer (then the
+# (1-t)^{c-B-1} factor is a polynomial and Gauss-Legendre is exact); the
+# DERIVATIVE integrand carries an extra log factor that nothing regularizes, so
+# it converges algebraically. The numbers below are measured, not guessed.
+_HYP2F1_PARAM_GRAD = [
+    # (a, b, c, z, rtol, route)
+    (-3.2, 4.4, 5.2, -5.0, 1e-8, "euler-transformed"),
+    (-0.51, -0.98, 2.51, -5.0, 1e-8, "pfaff-series"),
+    (1.7, 2.3, 3.4, -5.0, 1e-4, "euler, non-integer c-B"),
+    (2.0, 2.0, 3.0, -5.0, 1e-3, "euler, c-a == 1 exactly (galpy's own force call)"),
+]
+
+
+def _hyp2f1_fd(a, b, c, z, idx, h=1e-5):
+    """d/d(param idx) of SCIPY's 2F1 by central differences -- the reference."""
+    up, dn = [a, b, c], [a, b, c]
+    up[idx] += h
+    dn[idx] -= h
+    return (scipy_special.hyp2f1(*up, z) - scipy_special.hyp2f1(*dn, z)) / (2.0 * h)
+
+
+@pytest.mark.parametrize(
+    "a,b,c,z,rtol,route",
+    _HYP2F1_PARAM_GRAD,
+    ids=[x[-1] for x in _HYP2F1_PARAM_GRAD],
+)
+def test_hyp2f1_jax_parameter_gradient_matches_finite_difference(
+    a, b, c, z, rtol, route
+):
+    jax = pytest.importorskip("jax")
+    import jax.numpy as jnp
+
+    with use("jax", force=True):
+        zb = jnp.asarray(z)
+        for idx, name in ((0, "a"), (1, "b"), (2, "c")):
+            g = float(
+                jax.grad(lambda p: gsp.hyp2f1(p[0], p[1], p[2], zb))(
+                    jnp.array([a, b, c])
+                )[idx]
+            )
+            assert g == pytest.approx(_hyp2f1_fd(a, b, c, z, idx), rel=rtol), (
+                f"d/d{name} on the {route} route"
+            )
+
+
+@pytest.mark.parametrize(
+    "a,b,c,z,rtol,route",
+    _HYP2F1_PARAM_GRAD,
+    ids=[x[-1] for x in _HYP2F1_PARAM_GRAD],
+)
+def test_hyp2f1_torch_parameter_gradient_matches_finite_difference(
+    a, b, c, z, rtol, route
+):
+    torch = pytest.importorskip("torch")
+
+    with use("torch", force=True):
+        zb = torch.tensor(z, dtype=torch.float64)
+        for idx, name in ((0, "a"), (1, "b"), (2, "c")):
+            p = torch.tensor([a, b, c], dtype=torch.float64, requires_grad=True)
+            out = gsp.hyp2f1(p[0], p[1], p[2], zb)
+            (grad,) = torch.autograd.grad(out, p)
+            assert float(grad[idx]) == pytest.approx(
+                _hyp2f1_fd(a, b, c, z, idx), rel=rtol
+            ), f"d/d{name} on the {route} route"
+
+
+@pytest.mark.parametrize(
+    "a,b,c",
+    _HYP2F1_CASES + _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE,
+    ids=[
+        str(x)
+        for x in _HYP2F1_CASES + _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE
+    ],
+)
+def test_hyp2f1_traced_parameters_reproduce_the_concrete_route(a, b, c):
+    # With traced (a, b, c) the route can no longer be chosen with `if`, so all
+    # of it -- regime test, Euler labelling, series labelling -- is selected with
+    # where(). This asserts that selection lands on the same answer the Python
+    # branches give, for every parameter set the concrete tests cover, i.e. all
+    # three routes. The bar is the series' own truncation noise at |z| = 50,
+    # where the two arms round differently over 512 cancelling terms.
+    jax = pytest.importorskip("jax")
+    import jax.numpy as jnp
+
+    with use("jax", force=True):
+        zb = jnp.asarray(-_HYP2F1_W)
+        concrete = as_numpy(gsp.hyp2f1(a, b, c, zb))
+        traced = as_numpy(
+            jax.jit(lambda p: gsp.hyp2f1(p[0], p[1], p[2], zb))(jnp.array([a, b, c]))
+        )
+        numpy.testing.assert_allclose(traced, concrete, rtol=1e-5, atol=1e-13)
+        # ... and both are the scipy answer to the concrete route's own accuracy
+        ref = scipy_special.hyp2f1(a, b, c, -_HYP2F1_W)
+        numpy.testing.assert_allclose(traced, ref, rtol=1e-5, atol=1e-10)


### PR DESCRIPTION
Review batch 2, items 3 and 4 — plus one more defect of the same class that the
audit for item 4 turned up.

### Item 3 — potential/DF constructors are not traceable

Building an object inside `jax.jit(jax.grad(...))` is what a fit needs: the
scale radius, density exponent or anisotropy being optimised arrives as a
tracer, so the **constructor** has to trace. It did not. Four sites, all the
same shape — a Python-level decision that needs a truth value a tracer does not
have:

| site | code |
| --- | --- |
| `ExpTruncNFWPotential.py:116` | `1e-3 * min(a, rc)` |
| `TwoPowerTriaxialPotential.py:110` | `if beta <= 2.0 or alpha >= 3.0: raise` |
| `TwoPowerTriaxialPotential.py:119`, `:151` | `if self.twominusalpha != 0.0` |
| `constantbetaPowerLawdf.py` | four normalizability asserts |

The rule adopted is `galpy.backend.concretely_true`, a two-line wrapper over the
existing, exported, until-now-unused `has_concrete_truth_value`: **a check fires
only when it can be proven to fire, and a degenerate special case is taken only
when it can be proven to apply.** Concrete construction is bit-for-bit
unchanged; traced construction falls through to the generic branch, which is
the differentiable one. `min(a, rc)` becomes `xp.minimum`, same value.

One site was not of that shape and mattered more than expected:
`sphericaldf._handle_rmin` probed `Phi(0)` to decide whether to pick an rmin
automatically, **before** the early return for an explicitly-given rmin. That
probe reads a concrete `Phi(0)` out of the backend, so it is not traceable, and
with an explicit rmin its result is dead. Moving the early return in front of it
is what actually unlocked `d f_E/d beta` under jit — and saves one potential
evaluation per DF construction.

### Item 4 — hyp2f1's parameters, and a silently WRONG torch gradient

The review called `hyp2f1.py:51/92/156` "scalar params". Reproducing it found
something worse than not-traceable. `math.lgamma` and `float(math.ceil(6/B))`
pin the parameters to Python floats, and the backends fail differently:

* **jax** raises, so a traced exponent is refused — visible;
* **torch** does not raise. `__float__` runs and silently **detaches** the Gamma
  prefactor. The value stays right to 1e-14, `requires_grad` stays `True`, a
  `grad_fn` is set, and the gradient is wrong by 10×: measured
  `d/da 2F1(a,2;3;-5)` = **-8.98e-03** against a true **-8.56e-02**, and
  `TwoPowerTriaxial dPhi/dalpha` = **0.834** against **0.548**.

Only grad-vs-finite-difference finds that, which is how the new tests are built.
The guard is therefore keyed on `is_backend_array`, **not** on concreteness — an
ordinary untraced tensor has a perfectly good truth value and is exactly the
broken case. Route selection, Euler labelling and series labelling move to
`where()` for backend parameters, with a safe `(B, A, c) = (1, 0, 2)` fed to the
discarded Euler branch so `T**(B-1)` with `B <= 0` cannot NaN-poison the
gradient of the series result that wins there.

Accuracy is stated **per route**, because the routes do not differentiate
equally well (AD vs central differences of scipy):

| route | agreement |
| --- | --- |
| euler-transformed `(-3.2, 4.4, 5.2)` | 1e-10 .. 1e-11 |
| pfaff-series `(-0.51, -0.98, 2.51)` | 1e-11 .. 1e-12 |
| euler, generic `(1.7, 2.3, 3.4)` | 1e-6 .. 1e-5 |
| euler, `c - a == 1` `(2.0, 2.0, 3.0)` | 1.6e-4 .. 2.9e-4 |

The last two are limited by the quadrature, not the differentiation: the
derivative integrand carries an extra `log(T)` that the `X = xi^k` substitution
does not regularize.

### The same defect one file over, found by auditing for it

Grepping for `math.<fn>` applied to values that can be backend arrays found
`hyp1f1.py:39`, `math.gamma(a)` — identical class. torch
`d/da 1F1(a, a+1; -3)` = **-1.45e-01** against a true **-1.02e-01**, 42% wrong
and silent; jax raised one line earlier at the `abs(b - (a+1))` domain check.
Both fixed the same way; both backends now agree with scipy's FD to **5.4e-10**.

Measured and **refuted**, so unchanged: `GaussianAmplitudeWrapperPotential`'s
`math.exp` fast path (`dPhi/dto` matches FD to 2.7e-11),
`RazorThinExponentialDiskPotential`'s `math.sqrt(2.0)` (a literal), and
`SpiralArmsPotential`'s `math.cos(self._alpha)` (raises visibly rather than
detaching — different class).

### Gates

* grad-vs-central-difference under `jax.jit(jax.grad(...))` so the constructor is
  traced: ExpTruncNFW `d/da` on **both** sides of the `_small_r_thresh` split,
  TwoPowerTriaxial `d/dalpha` and `d/dbeta`, constantbetaPowerLawdf
  `d f_E/d beta` — 1e-11 .. 1e-7 relative. jit(grad) reproduces eager grad to
  the last digit (`-0.13535078929592917`).
* torch autograd agrees with the jax numbers to ~1e-14.
* **numpy byte-identity**: sha256 over ExpTruncNFW forces/potentials on a
  203-point grid straddling the threshold (3 `(a, rc)` pairs), TwoPowerTriaxial
  for 3 `(alpha, beta)` including the degenerate `alpha == 2`, and the DF's
  stored constants + `f_E` for 4 betas — identical to the base. A 1-ulp
  perturbation of the threshold constant moves the hash, so the probe
  discriminates.
* A/B on the new tests: `tests/test_backend_constructor_jit.py` 7 failed /
  7 passed on the merge-base and 14 passed here; the hyp2f1 tests 17 failed /
  2 passed on base and 19 passed here; the hyp1f1 test 2 failed / 2 passed.
  The cases that pass on both sides are the "still raises when concrete" guards
  — they encode the behaviour that must NOT change.
* Regression: `test_backend_special.py` 231 passed; `test_potential.py` 1288
  passed / 102 skipped on numpy and **1288 passed / 0 failed under
  `--backend torch` in CI's exact 5-way split**; `test_sphericaldf.py` +
  `test_backend_constantbetadf.py` + `test_backend_conventions.py` 394 passed;
  `test_sphericaldf` + `test_backend_constantbetadf` 259 passed under both
  `--backend torch` and `--backend jax`.

**Ledger delta: 0.**

### Not fixed here, stated rather than hidden

`hyp2f1`'s direct-Euler route has a **pre-existing** value-accuracy gap
(identical on both A/B arms): ~1e-6..1e-7 whenever `c - B` is not an integer —
`(1.7, 2.3, 3.4)` gives 1.09e-07 at |z|=5 — against ~1e-14 when it is. Every
parameter set in the existing test grid has integer `c - B` (galpy's own force
calls are all `c = a+1`), so the suite cannot see it. `X = xi^k` regularizes the
`t^(B-1)` endpoint and nothing regularizes `(1-t)^(c-B-1)`. Raising `_NODES`
only buys ~1/N (measured 128 -> 1024: 1.1e-7 -> 9.4e-11); a **Gauss-Jacobi**
rule with weight `t^(B-1)(1-t)^(c-B-1)` would be spectral for any exponents and
would fix the derivative accuracy above at the same time. Its own change.

### Carried over from gh#1388

Its pre-merge audit found that gh#1388's own coercion made the next two lines
dead (`filtered` is a backend array by then, so the `else numpy.asarray(...)`
is unreachable and the second `asarray_on_device` a no-op). Rather than re-run
154 checks on an already-green PR for a cosmetic tidy, it rides here.

Gated in the VALID context — `tests/test_actionAngle.py` whole file, 209
passed. Worth recording why: gating the same edit with
`-k "StaeckelGrid or AdiabaticGrid"` reported 6 failures, and the *unmodified*
CI-green commit reports the same 6 under that selection. Those grid tests
depend on state a `-k` run deselects, so a filtered run says nothing about the
change.
