### PR TITLE
constantbetaHernquistdf: route the gammas so d f_E/d beta works

### DIFF
--- a/galpy/df/constantbetaHernquistdf.py
+++ b/galpy/df/constantbetaHernquistdf.py
@@ -4,7 +4,7 @@ import numpy
 import scipy.integrate
 import scipy.special
 
-from ..backend import resolve_namespace
+from ..backend import is_backend_array, resolve_namespace
 from ..backend import special as bspecial
 from ..potential import HernquistPotential, evaluatePotentials
 from ..util import conversion
@@ -40,12 +40,20 @@ class constantbetaHernquistdf(_constantbetadf):
         self._psi0 = -evaluatePotentials(self._pot, 0, 0, use_physical=False)
         self._potInf = 0.0
         self._GMa = self._psi0 * self._pot.a**2.0
+        # Routed gamma when beta is a backend value, so the normalisation is
+        # computed ON the backend and stays differentiable in beta.
+        # scipy.special.gamma on a jax tracer raises TracerArrayConversionError
+        # and on a grad-tracking torch tensor "Can't call numpy() on Tensor that
+        # requires grad" -- both here, which is why d f_E/d beta worked for the
+        # PowerLaw sibling (already routed) and not for this one. numpy keeps
+        # scipy, so that path is byte-identical.
+        _gamma = bspecial.gamma if is_backend_array(self._beta) else scipy.special.gamma
         # Final factor is mass to make the DF that of the mass density
         self._fEnorm = (
             (2.0**self._beta / (2.0 * numpy.pi) ** 2.5)
-            * scipy.special.gamma(5.0 - 2.0 * self._beta)
-            / scipy.special.gamma(1.0 - self._beta)
-            / scipy.special.gamma(3.5 - self._beta)
+            * _gamma(5.0 - 2.0 * self._beta)
+            / _gamma(1.0 - self._beta)
+            / _gamma(3.5 - self._beta)
             / self._GMa ** (1.5 - self._beta)
             * self._psi0
             * self._pot.a

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -37,7 +37,7 @@ except ImportError:  # pragma: no cover
 from backend_jit_helpers import assert_jit_matches_eager
 
 import galpy.backend
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, use
 from galpy.df import constantbetadf, constantbetaHernquistdf, constantbetaPowerLawdf
 from galpy.potential import (
     DehnenCoreSphericalPotential,
@@ -417,3 +417,47 @@ def _mk_hern(beta):
 
 def _mk_pl(beta):
     return constantbetaPowerLawdf(pot=_PP, beta=beta, rmax=100.0, rmin=1e-4)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "mk,E0,name",
+    [(_mk_hern, -0.1, "Hernquist"), (_mk_pl, -1.0, "PowerLaw")],
+    ids=["Hernquist", "PowerLaw"],
+)
+def test_fE_differentiable_in_beta(backend, mk, E0, name):
+    # d f_E / d beta -- differentiating the DF w.r.t. its own anisotropy
+    # parameter, which is the point of having a constant-beta family.
+    #
+    # The Hernquist variant could not do this: its normalisation calls
+    # scipy.special.gamma on beta, which raises TracerArrayConversionError on a
+    # jax tracer and "Can't call numpy() on Tensor that requires grad" on torch.
+    # The PowerLaw sibling was already routed, which is why only one of the two
+    # worked. Both are checked here so the pair cannot drift apart again.
+    #
+    # E0 is chosen INSIDE the bound range: outside it f_E is identically 0 for
+    # every beta, so the derivative is 0 too and the test would pass while
+    # measuring nothing.
+    b0, h = 0.3, 1e-6
+    val = float(numpy.atleast_1d(mk(b0).fE(numpy.atleast_1d(E0)))[0])
+    assert abs(val) > 1e-12, f"{name}: f_E is 0 at E={E0}; pick a bound energy"
+    ref = (
+        float(numpy.atleast_1d(mk(b0 + h).fE(numpy.atleast_1d(E0)))[0])
+        - float(numpy.atleast_1d(mk(b0 - h).fE(numpy.atleast_1d(E0)))[0])
+    ) / (2.0 * h)
+
+    with use(backend, force=True):
+        if backend == "jax":
+            import jax
+            import jax.numpy as jnp
+
+            got = float(jax.grad(lambda b: mk(b).fE(jnp.asarray(E0)))(b0))
+        else:
+            import torch
+
+            b = torch.tensor(b0, dtype=torch.float64, requires_grad=True)
+            out = mk(b).fE(torch.tensor(E0, dtype=torch.float64))
+            (grad,) = torch.autograd.grad(out, b)
+            got = float(grad)
+    # h=1e-6 central differences on a smooth function: good to ~1e-9
+    assert got == pytest.approx(ref, rel=1e-6), f"{name} d f_E/d beta"


### PR DESCRIPTION
The constant-beta family exists so `beta` can be varied, and its two members
disagreed about whether you can differentiate with respect to it:

| | `d f_E / d beta` |
| --- | --- |
| `constantbetaPowerLawdf` | works (already routed) |
| `constantbetaHernquistdf` | **raises** |

Both backends fail at the same line — `scipy.special.gamma(...)` applied to
`beta` in the normalisation:

    jax    TracerArrayConversionError
    torch  RuntimeError: Can't call numpy() on Tensor that requires grad

The file already imports `galpy.backend.special as bspecial`; the PowerLaw
sibling routes through it and this one never did. Route it when `beta` is a
backend value. numpy keeps scipy, so that path is untouched.

### Measured

Against a numpy central difference (h = 1e-6) of the same DF:

    numpy FD  d f_E/d beta at E = -0.1   -1.0406774522e-02
    jax   AD                             -1.0406774508e-02   rel 1.33e-09
    torch AD                             -1.0406774508e-02   rel 1.33e-09

### The test asserts non-vacuity, deliberately

The obvious probe point is a trap: `psi0 = 0.25` for this potential, so at
E = -0.3 `f_E` is identically 0 for **every** beta and both the AD and the FD
reference come back 0.0 — a test that passes while measuring nothing. It took
me three probes to notice, so the test now asserts `|f_E| > 1e-12` before it
compares gradients.

### Gates

* **A/B**: the new test is **2 failed / 2 passed on the unmodified source and
  4 passed here**. The PowerLaw pair passes on *both* arms — it is the control
  showing the test is real and that the siblings genuinely differed.
* **numpy byte-identity**: sha256 over `_fEnorm` plus `f_E` on a 60-point
  energy grid for beta in (-0.5, -0.2, 0.0, 0.3, 0.49) is **identical** to
  develop.
* `tests/test_backend_constantbetadf.py` 40 passed;
  `tests/test_sphericaldf.py` 223 passed on numpy and 223 under
  `--backend torch`.

**Ledger delta: 0.**