### PR TITLE
tests: un-gate the Einasto d_n gradient to torch + pin float64 in test_backend_spherical

### DIFF
--- a/tests/test_backend_spherical.py
+++ b/tests/test_backend_spherical.py
@@ -58,6 +58,11 @@ except ImportError:  # pragma: no cover
 try:
     import torch
 
+    # Mirrors the jax_enable_x64 above: galpy's tolerances assume float64, and
+    # the identity checks here are tight enough (rtol=1e-9) to fail at float32.
+    # Not inherited -- the conftest fixture only sets this under --backend torch,
+    # so without it a single-file run of THIS file silently drops to float32.
+    torch.set_default_dtype(torch.float64)
     BACKENDS.append("torch")
 except ImportError:  # pragma: no cover
     torch = None
@@ -763,26 +768,27 @@ def test_einasto_dn_forward_matches_numpy(backend_name, n):
     )
 
 
-@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
-def test_einasto_dn_gradient_vs_finite_difference_jax():
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_einasto_dn_gradient_vs_finite_difference(backend_name):
     """d(d_n)/dn by the implicit function theorem vs a central difference.
 
-    jax ONLY, and deliberately so: the implicit-diff gradient needs dQ/da (the
-    derivative of the regularized incomplete gamma w.r.t. its ORDER), and torch
-    does not implement it -- ``NotImplementedError: the derivative for
-    'igammac: input' is not implemented``. That is an upstream torch gap, not a
-    galpy one, and closing it needs a differentiable incomplete gamma in
-    galpy.backend.special (which has no gammainc fallback today) -- a separate
-    change that would serve every gammaincc consumer, not just this one.
+    Both backends. torch gets here through galpy's own ``_IncGamma`` autograd
+    rule in ``backend.special._fallback.gammainc``: ``torch.special.gammainc``
+    taken directly still raises ``NotImplementedError`` for the derivative
+    w.r.t. its ORDER, which is precisely the derivative the implicit-function
+    theorem needs. This test was jax-only until that fallback existed.
 
-    The FD reference is computed on the NUMPY path, so this compares the backend
+    The FD reference runs on the NUMPY path, so this compares the backend
     derivative against an independent evaluation rather than against itself.
+    The h=1e-5 truncation error is the floor: both backends land 1.5e-10 from
+    it (and far closer to each other than either is to it), so the 1e-8 bar
+    measures the AD rather than the finite difference.
     """
     h = 1e-5
     fd = (_ein_dn(_EIN_N + h) - _ein_dn(_EIN_N - h)) / (2.0 * h)
-    got = float(jax.grad(_ein_dn)(jnp.asarray(_EIN_N)))
-    assert abs(got - fd) < 1e-7 * abs(fd), (
-        f"d(d_n)/dn={got!r} vs finite difference {fd!r} "
+    got = _grad_wrt(backend_name, _ein_dn, _EIN_N)
+    assert abs(got - fd) < 1e-8 * abs(fd), (
+        f"{backend_name}: d(d_n)/dn={got!r} vs finite difference {fd!r} "
         f"(rel err {abs(got - fd) / abs(fd):.3e})"
     )
 


### PR DESCRIPTION
Two fixes to the torch half of `tests/test_backend_spherical.py`. Test-only —
no source file is touched, so the numpy path is untouched by construction.

### 1. The Einasto d_n gradient test was jax-only for a reason that expired

Its docstring said closing the torch gap *"needs a differentiable incomplete
gamma in `galpy.backend.special` (which has no gammainc fallback today)"*. That
fallback now exists — the `_IncGamma` autograd rule in
`backend/special/_fallback/gammainc.py` — so the restriction is obsolete and
the docstring actively misleads the next reader.

Parametrized over `AD_BACKENDS` using the file's existing `_grad_wrt` helper
(no new helper added), measured against the same numpy finite difference:

    numpy FD  d(d_n)/dn = 2.9995632164769854
    jax   AD             = 2.9995632160143844   rel 1.542e-10
    torch AD             = 2.99956321601433     rel 1.542e-10

Both backends land on the *same* residual because it is the h=1e-5 FD
truncation error rather than backend error — they agree with each other far
more closely than either agrees with the reference. The bar is therefore
tightened **1e-7 → 1e-8** (~65x above the measured floor) so it measures the AD
rather than the finite difference.

**Negative control:** `torch.special.gammainc` taken directly still raises
`NotImplementedError` for the derivative w.r.t. its order, so it is galpy's own
fallback carrying this gradient, not an upstream torch fix.

### 2. This file ran its torch arms at float32

It never set torch's default dtype, unlike **62 sibling `test_backend_*.py`
files**, even though it sets `jax_enable_x64` for jax immediately above — a
plain asymmetry. The conftest fixture only sets float64 under `--backend
torch`, so a default pytest session left it at float32.

In CI this is invisible: the coverage shard globs all of
`tests/test_backend*.py`, and an alphabetically earlier module mutates that
global first, so this file inherits float64. Run the file **alone** and
`test_force_hessian_identities[torch-EinastoPotential]` fails at rel
**6.96e-08** — float32 epsilon — against its `rtol=1e-9` bar.

To be explicit: this is **not a develop defect**, CI is right. It is a latent
fragility (the file's precision depends on a global another file happens to
set) that also made single-file local runs an invalid precision gate — which is
how I hit it.

### Gates

| gate | result |
|---|---|
| file alone, before | 231 passed, **1 failed** |
| file alone, after | **232 passed** |
| `--backend torch` | 232 passed |
| `--backend jax` | 232 passed |
| A/B on the dtype line alone | 1 failed → 0 (arms grep-asserted to differ) |

Ledger delta: **0**.