### PR TITLE
surfdens: keep both routes on the backend under eager torch autograd

### DIFF
--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -136,6 +136,26 @@ def under_trace(*xs):
     return is_compiling() and any(isinstance(x, torch.Tensor) for x in xs)
 
 
+def requires_backend_grad(*xs):
+    """True iff one of ``xs`` is a torch tensor carrying an autograd graph.
+
+    Companion to ``under_trace``, deliberately separate from it: ``under_trace``
+    means "no concrete value", this means "carries a graph". Call sites that
+    escape to scipy/numpy need BOTH -- a tracer cannot be evaluated there at
+    all, and a grad-tracking tensor silently DETACHES, which is worse because
+    the value stays right while the gradient goes wrong.
+
+    torch-only by construction, and no jax counterpart is needed: jax has no
+    ``requires_grad`` flag because differentiability there IS tracing, so
+    ``jax.grad`` hands you a tracer that ``under_trace`` already catches. Eager
+    torch autograd is the one differentiating mode with no trace behind it.
+
+    Plain ``getattr``, so this costs nothing and needs no torch import: numpy
+    and jax arrays simply do not carry the attribute.
+    """
+    return any(getattr(x, "requires_grad", False) for x in xs)
+
+
 def untraceable_setup(method):
     """Mark a lazy SETUP/table builder so a tracer never traces it.
 

--- a/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
+++ b/galpy/potential/AnyAxisymmetricRazorThinDiskPotential.py
@@ -15,7 +15,7 @@ from ..backend import (
 )
 from ..backend import quadrature as _bquad
 from ..backend import special as _bspecial
-from ..backend._namespaces import under_trace
+from ..backend._namespaces import requires_backend_grad, under_trace
 from ..util import conversion
 from ..util._optional_deps import _APY_LOADED
 from .Potential import Potential, check_potential_inputs_not_arrays
@@ -337,13 +337,9 @@ class AnyAxisymmetricRazorThinDiskPotential(Potential):
     def _bk_dispatch(self, numpy_fn, gl_fn, R, z):
         xp = get_namespace(R, z)
         dev = device_of(R, z)
-        if not (
-            getattr(R, "requires_grad", False)
-            or getattr(z, "requires_grad", False)
-            # torch.compile does not raise from the float() probe below (dynamo
-            # makes it symbolic) and would trace scipy's quad instead: ask.
-            or under_trace(R, z)
-        ):
+        # torch.compile does not raise from the float() probe below (dynamo
+        # makes it symbolic) and would trace scipy's quad instead: ask.
+        if not (requires_backend_grad(R, z) or under_trace(R, z)):
             # plain concrete backend input: reuse scipy's accurate value. No
             # try/except around float(): every caller is guarded by
             # @check_potential_inputs_not_arrays, so R and z are scalar here, and

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -31,7 +31,7 @@ from ..backend import (
     is_backend_compatible,
 )
 from ..backend import quadrature as _bquad
-from ..backend._namespaces import under_trace
+from ..backend._namespaces import requires_backend_grad, under_trace
 from ..util import conversion, coords, galpyWarning, plot
 from ..util._optional_deps import _APY_LOADED
 from ..util.conversion import (
@@ -154,7 +154,11 @@ def _quad_needs_backend(xp, *coords):
     """
     if xp is numpy:
         return False
-    return any(under_trace(c) for c in coords)
+    # under_trace OR grad-tracking: scipy cannot be evaluated at all on a
+    # tracer, and silently DETACHES a grad-tracking tensor -- the value stays
+    # right while the gradient comes back wrong (surfdens was 23% off in R and
+    # 72% in z on eager torch). jax needs no second test: its grad IS a trace.
+    return any(under_trace(c) or requires_backend_grad(c) for c in coords)
 
 
 def _force_accepts_arrays(pot):

--- a/tests/test_backend_potential_diff.py
+++ b/tests/test_backend_potential_diff.py
@@ -313,16 +313,6 @@ def test_surfdens_differentiates_in_R_not_only_z(backend_name, forcepoisson):
     #
     # Both surfdens routes are covered: forcepoisson=True goes through the
     # Rforce/R2deriv/phi2deriv combination, False through _dens.
-    if backend_name == "torch":
-        pytest.skip(
-            "separate PRE-EXISTING gap: the gate is under_trace, which is False "
-            "for EAGER torch autograd (it asks torch.compiler.is_compiling()), so "
-            "surfdens takes scipy and silently returns a detached float -- no "
-            "torch gradient, in R OR z. Widening the gate to grad-tracking eager "
-            "tensors would route scalar-only potentials into the array-calling GL "
-            "rule, which is the undecidable _force_accepts_arrays problem the "
-            "_quad_needs_backend docstring describes. Its own change."
-        )
     from galpy.potential import MiyamotoNagaiPotential
 
     pot = MiyamotoNagaiPotential(a=0.5, b=0.1)
@@ -337,12 +327,104 @@ def test_surfdens_differentiates_in_R_not_only_z(backend_name, forcepoisson):
     def sd(R, z):
         return pot.surfdens(R, z, forcepoisson=forcepoisson, use_physical=False)
 
-    jnp = jax.numpy
-    ad_R = float(jax.grad(lambda R: sd(R, jnp.asarray(z0)))(jnp.asarray(R0)))
-    ad_z = float(jax.grad(lambda z: sd(jnp.asarray(R0), z))(jnp.asarray(z0)))
+    # Both backends now. torch reaches this because _quad_needs_backend asks
+    # requires_backend_grad as well as under_trace: eager torch autograd is the
+    # one differentiating mode with no trace behind it, so scipy used to run and
+    # silently detach -- returning a bare float here (forcepoisson=False) or a
+    # tensor whose gradient was 23% wrong in R and 72% in z (forcepoisson=True).
+    ad_R, live_R = _surfdens_ad(backend_name, pot, forcepoisson, "R", R0, z0)
+    ad_z, live_z = _surfdens_ad(backend_name, pot, forcepoisson, "z", R0, z0)
+    assert live_R and live_z, (
+        f"{backend_name} forcepoisson={forcepoisson}: surfdens returned a bare "
+        "float, severing the autograd graph"
+    )
 
     # h=1e-5 central differences on a smooth integral: good to ~1e-9. d/dz is
     # the control -- it worked before this fix, so if it ever regresses the
     # cause is the gate, not the quadrature.
     numpy.testing.assert_allclose(ad_R, fd_R, rtol=1e-6, atol=1e-9)
     numpy.testing.assert_allclose(ad_z, fd_z, rtol=1e-6, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# surfdens: BOTH routes must stay on the backend and stay differentiable.
+#
+# scipy.integrate.quad cannot be evaluated on a tracer at all, but on an eager
+# grad-tracking torch tensor it does something worse: it silently DETACHES the
+# integrated piece while the algebraic prefactor keeps its graph, so the value
+# stays right and the gradient comes back wrong. Measured on develop, before
+# `_quad_needs_backend` learned to ask `requires_backend_grad`:
+#
+#   forcepoisson=False -> a bare Python float (graph severed entirely)
+#   forcepoisson=True  -> Tensor, requires_grad=True, grad_fn set,
+#                         gradient 23.3% wrong in R and 71.8% wrong in z
+#
+# jax never had this: jax.grad passes a tracer, which `under_trace` already
+# caught. Only eager torch autograd differentiates with no trace behind it.
+# ---------------------------------------------------------------------------
+_SURFDENS_R0, _SURFDENS_Z0 = 1.0, 0.3
+
+
+def _surfdens_ad(backend_name, pot, forcepoisson, wrt, R0, z0):
+    with _ctx(backend_name):
+        if backend_name == "jax":
+            import jax.numpy as jnp
+
+            def f(v):
+                R = v if wrt == "R" else jnp.asarray(R0)
+                z = v if wrt == "z" else jnp.asarray(z0)
+                return pot.surfdens(R, z, forcepoisson=forcepoisson, use_physical=False)
+
+            x0 = R0 if wrt == "R" else z0
+            return float(jax.grad(f)(jnp.asarray(x0))), True
+        leaf = torch.tensor(R0 if wrt == "R" else z0, requires_grad=True)
+        R = leaf if wrt == "R" else torch.tensor(R0)
+        z = leaf if wrt == "z" else torch.tensor(z0)
+        out = pot.surfdens(R, z, forcepoisson=forcepoisson, use_physical=False)
+        # A bare float here IS the bug: the graph was severed, so there is no
+        # gradient to be wrong about. Report it rather than raising obscurely.
+        if not isinstance(out, torch.Tensor):
+            return float("nan"), False
+        (g,) = torch.autograd.grad(out, leaf)
+        return float(g), True
+
+
+def _surfdens_fd(pot, wrt, eps=1e-6):
+    def at(R, z):
+        return float(pot.surfdens(R, z, use_physical=False))
+
+    if wrt == "R":
+        hi, lo = (
+            at(_SURFDENS_R0 + eps, _SURFDENS_Z0),
+            at(_SURFDENS_R0 - eps, _SURFDENS_Z0),
+        )
+    else:
+        hi, lo = (
+            at(_SURFDENS_R0, _SURFDENS_Z0 + eps),
+            at(_SURFDENS_R0, _SURFDENS_Z0 - eps),
+        )
+    return (hi - lo) / (2 * eps)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_surfdens_gradient_for_a_potential_that_opts_out_of_array_forces(
+    backend_name,
+):
+    # AnySphericalPotential sets _force_accepts_arrays = False, the case that
+    # motivated a possible "raise unless array-safe" guard. Measured: it needs
+    # no guard -- the backend quadrature handles it and the gradient is right,
+    # so the simpler predicate-only fix is enough.
+    from galpy.potential import AnySphericalPotential
+
+    pot = AnySphericalPotential(
+        amp=1.0, dens=lambda r: 1.0 / (r * (1.0 + r) ** 3) / (4.0 * numpy.pi)
+    )
+    fd = _surfdens_fd(pot, "R")
+    ad, on_backend = _surfdens_ad(
+        backend_name, pot, False, "R", _SURFDENS_R0, _SURFDENS_Z0
+    )
+    assert on_backend, f"{backend_name}: bare float, graph severed"
+    assert abs(ad - fd) < 1e-7 * abs(fd), (
+        f"{backend_name} opt-out potential d/dR: {ad!r} vs FD {fd!r} "
+        f"(rel {abs(ad - fd) / abs(fd):.3e})"
+    )


### PR DESCRIPTION
Implements the fix agreed on gh#1204 (finding 11): option **(b)**, widen the
predicate. Option (c) turned out to be unnecessary — see below, it was measured
rather than assumed.

### The bug

`_quad_needs_backend` chose scipy-vs-backend-quadrature by asking only
`under_trace`, which is False for **eager torch autograd** (it asks
`torch.compiler.is_compiling()`). So scipy ran, and scipy cannot carry an
autograd graph. On develop, MiyamotoNagai(a=0.5, b=0.1) at R=1, z=0.3:

    forcepoisson=False -> a bare Python float (graph severed entirely)
    forcepoisson=True  -> Tensor, requires_grad=True, grad_fn=DivBackward0,
                          gradient 23.3% wrong in R and 71.8% wrong in z

The second is the dangerous one: the value stays correct and the tensor looks
fully differentiable, because the algebraic prefactor keeps its graph while the
integrated piece detaches. Only grad-vs-FD catches it.

Both routes gate on the same predicate (`Potential.py:823` and `:920`), so one
change repairs both — which is the "everything stays on the backend" outcome
asked for. Versus a numpy central difference:

| | torch | jax |
|---|---|---|
| `forcepoisson=False` | dR **0.0%** off, dz **0.0%** off | rel 6.05e-12 |
| `forcepoisson=True` | dR **0.0%** off, dz **0.0%** off | rel 6.05e-12 |

### Why a second predicate rather than widening `under_trace`

`under_trace` means *"no concrete value"*; `requires_backend_grad` means
*"carries a graph"*. Call sites compose them. Two of the four `under_trace`
call sites must **not** ask about grad:

| site | grad too? |
|---|---|
| `Potential.py:157` `_quad_needs_backend` | **yes** — this bug |
| `quadrature.py:533` | no — its `is_backend_array` branch already handles grad-tracking limits correctly; folding grad in would force `concretely_infinite=False` and kill the semi-infinite branch |
| `RazorThinExponentialDisk.py:292` | no — it asks a decidability question a grad-tracking tensor *can* answer; widening it would replace a clear `AttributeError` with silent off-plane NaN |
| `AnyAxisymmetricRazorThinDisk.py:345` | **already hand-rolled it** |

That last row is why this is a helper and not an abstraction: one site had
independently hit the same problem and open-coded
`getattr(R, "requires_grad", False) or ... or under_trace(R, z)`. It now uses
the shared predicate, so the duplicate is gone.

**No jax counterpart exists or is needed.** jax has no `requires_grad` flag
because differentiability there *is* tracing — `jax.grad` hands you a tracer
that `under_trace` already catches. Verified directly: under `jax.grad`,
`under_trace=True` and the `requires_grad` attribute is absent entirely. Eager
torch autograd is the one differentiating mode with no trace behind it.

### Option (c) is not needed — measured

The proposed "raise unless `_force_accepts_arrays(pot)`" guard was motivated by
scalar-only potentials being routed into the array-calling GL rule.
`AnySphericalPotential` is the only in-tree potential that opts out, and it
computes a **correct** gradient through the backend quadrature: **4.01e-11 vs
numpy FD**, on both routes. So the simpler predicate-only fix stands.

### Tests

`test_surfdens_differentiates_in_R_not_only_z` already covered both routes and
both variables, but was hardcoded to jax with a torch skip reading *"…Its own
change."* This is that change: the skip is removed and its AD is
backend-dispatched. A case for the array-opt-out potential is added. **No
duplicate test** — I wrote one, then dropped it in favour of generalising the
existing one.

### Gates

- A/B on the source alone, same tests: **3 failed / 3 passed → 6 passed** (the 3
  passing on base are the jax arms, which already worked)
- numpy **byte-identical**: sha256 over both routes on a 5×3 (R, z) grid matches
  develop, arms grep-asserted to differ. `_quad_needs_backend` returns False for
  numpy before any new code runs, so the numpy path is unreachable by this change
- `tests/test_potential.py` 1288 passed · `test_backend_potential_diff.py` 212
  passed · `test_backend_anyaxisymdisk.py` 53 passed ·
  `test_backend_anyspherical.py` 14 passed · `test_backend_namespaces.py` 3 passed

Ledger delta: **0**.