### PR TITLE
actionAngleStaeckelInverse: the canonical family (T2)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1139,6 +1139,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 self._grid_coords(jr, jphi, jz), jphi, angler, anglephi, anglez
             )
         if self._interp:
+            if self._canonical:
+                return self._xvFreqs_canonical_interp(
+                    jr, jphi, jz, angler, anglephi, anglez
+                )
             return self._xvFreqs_index(
                 self._coords_from_actions(jr, jphi, jz),
                 jphi,
@@ -1331,6 +1335,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             scal = self._interp_torus(self._grid_coords(jr, jphi, jz))[0]
             return (scal[3], scal[5], scal[4])
         if self._interp:
+            if self._canonical:
+                x = self._canon_coords(float(jr), float(jphi), float(jz))
+                _, dq = self._canon_family_chains(x)
+                return (dq[2, 0], dq[2, 1], dq[2, 2])
             self._interp_Lz = jphi
             scal = self._interp_torus(self._coords_from_actions(jr, jphi, jz))[0]
             return (scal[3], scal[5], scal[4])
@@ -1695,26 +1703,53 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             )
             for kk in range(6):
                 out[kk, jj] = oo[kk][0]
+        Rt, vRt, vTt, zt, vzt, phit = self._canon_unlift(
+            out,
+            self._can_a[ii],
+            self._can_e[ii],
+            self._can_LA[ii],
+            self._can_thmin[ii],
+            self._can_Dmu[ii],
+            self._can_Dmv[ii],
+            self._umins[ii],
+            self._umaxs[ii],
+            self._vmins[ii],
+            Lz,
+        )
+        return (
+            Rt,
+            vRt,
+            vTt,
+            zt,
+            vzt,
+            phit,
+            self._OmegaR[ii],
+            self._Omegaphi[ii],
+            self._Omegaz[ii],
+        )
+
+    def _canon_unlift(self, out, a, e, LA, thmin, Dmu, Dmv, umin, umax, vmin, Lz):
+        """Map the toy-chart reconstruction to the target chart: per-degree
+        anomaly inversions through the stored maps (closed-form radius and
+        linear polar-angle inversions), momenta through the per-degree
+        action-flux groups (regular at all turning points), then prolate ->
+        cylindrical exactly as the direct path"""
         R, vR, vT, z, vz, phi = out
-        # un-lift per degree through the stored anomaly maps
         rA = numpy.sqrt(R**2 + z**2)
         vrA = (R * vR + z * vz) / rA
         pAth = vR * z - vz * R
-        a, e = self._can_a[ii], self._can_e[ii]
-        LA, thmin = self._can_LA[ii], self._can_thmin[ii]
         # u-degree: eta from the closed-form radius inversion, tau from the
         # stored map, u from the cosine anomaly; p_u through the flux group
         y = (numpy.sqrt(self._bc**2 + rA**2) - self._bc) / a
         coseta = numpy.clip((1.0 - y) / e, -1.0, 1.0)
         sineta = numpy.sign(vrA) * numpy.sqrt(numpy.clip(1.0 - coseta**2, 0.0, None))
         etau = numpy.arctan2(sineta, coseta) % (2.0 * numpy.pi)
-        tuu = self._tau_of_eta(etau, self._can_Dmu[ii])
-        Du = self._umaxs[ii] - self._umins[ii]
-        u = self._umins[ii] + Du * numpy.sin(tuu / 2.0) ** 2
-        s = numpy.sqrt(self._bc**2 + rA**2)
+        tuu = self._tau_of_eta(etau, Dmu)
+        Du = umax - umin
+        u = umin + Du * numpy.sin(tuu / 2.0) ** 2
         gA = a * e * (y + self._bc / a) / numpy.sqrt(y * (y + 2.0 * self._bc / a))
         ms = self._nforDm
-        detau = 1.0 + numpy.cos(tuu[:, None] * ms[None, :]) @ (ms * self._can_Dmu[ii])
+        detau = 1.0 + numpy.cos(tuu[:, None] * ms[None, :]) @ (ms * Dmu)
         sintu = numpy.sin(tuu)
         sru = numpy.where(
             numpy.fabs(sintu) > 1e-12,
@@ -1730,10 +1765,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         )
         sinetav = numpy.sign(pAth) * numpy.sqrt(numpy.clip(1.0 - cosetav**2, 0.0, None))
         etav = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
-        tvv = self._tau_of_eta(etav, self._can_Dmv[ii])
-        Dv = numpy.pi - 2.0 * self._vmins[ii]
-        v = self._vmins[ii] + Dv * numpy.sin(tvv / 2.0) ** 2
-        detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * self._can_Dmv[ii])
+        tvv = self._tau_of_eta(etav, Dmv)
+        Dv = numpy.pi - 2.0 * vmin
+        v = vmin + Dv * numpy.sin(tvv / 2.0) ** 2
+        detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
         sintv = numpy.sin(tvv)
         srv = numpy.where(
             numpy.fabs(sintv) > 1e-12,
@@ -1749,17 +1784,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         den = self._delta * (sh**2 + sn**2)
         vRt = (pu * ch * sn + pv * sh * cs) / den
         vzt = (pu * sh * cs - pv * ch * sn) / den
-        return (
-            Rt,
-            vRt,
-            Lz / Rt,
-            zt,
-            vzt,
-            phi % (2.0 * numpy.pi),
-            self._OmegaR[ii],
-            self._Omegaphi[ii],
-            self._Omegaz[ii],
-        )
+        return Rt, vRt, Lz / Rt, zt, vzt, phi % (2.0 * numpy.pi)
 
     ################## CANONICAL FAMILY (T2) ##################################
     def _canon_table_eval(self, x, deriv=None):
@@ -1866,6 +1891,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         if self._wIgrid[0] == 0.0:
             tab[1, :, :, 0] = 0.0
         self._canon_tab_raw = tab
+        self._canon_dLz = (self._Lzgrid[-1] - self._Lzgrid[0]) / (nLz - 1)
         self._rebuild_canon_interp()
         return None
 
@@ -1915,3 +1941,243 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 "the interpolated family"
             )
         return numpy.array([xL, xE, xI])
+
+    def _canon_toy_radial(self, JAr, LA, thetaAr):
+        """The radial half of the analytic isochrone inverse: (J^A_r, L^A,
+        theta^A_r) -> (eta, r^A, p^A_r), vectorized over points"""
+        amp, bb = self._GMc, self._bc
+        sq = numpy.sqrt(LA**2 + 4.0 * bb * amp)
+        H = -2.0 * amp**2 / (2.0 * JAr + LA + sq) ** 2
+        a = -amp / 2.0 / H - bb
+        ab = a + bb
+        e = numpy.sqrt(numpy.clip(1.0 + LA**2 / (2.0 * H * a**2), 0.0, None))
+        ar = numpy.atleast_1d(thetaAr) % (2.0 * numpy.pi)
+        aeab = a * e / ab
+        x = numpy.array(ar)
+        for _ in range(self._maxiter):
+            f = x - aeab * numpy.sin(x) - ar
+            x -= numpy.clip(f / (1.0 - aeab * numpy.cos(x)), -1.0, 1.0)
+            if numpy.max(numpy.fabs(f)) < self._angle_tol:
+                break
+        else:
+            raise RuntimeError(
+                "Newton's method for the toy eccentric anomaly did not converge"
+            )
+        coseta = numpy.cos(x)
+        rA = a * numpy.sqrt((1.0 - e * coseta) * (1.0 - e * coseta + 2.0 * bb / a))
+        pA = numpy.sqrt(amp / ab) * a * e * numpy.sin(x) / rA
+        return x, rA, pA
+
+    def _canon_toy_vert(self, JAr, LA, Lz, thetaAr, thetaAz, eta):
+        """The toy's vertical geometry at given toy angles: the polar angle
+        and vertical momentum from the isochrone's own angle relations
+        (psi = theta^A_z - (omega_z/omega_r) theta^A_r + Lambda(eta)),
+        all closed forms"""
+        amp, bb = self._GMc, self._bc
+        sq = numpy.sqrt(LA**2 + 4.0 * bb * amp)
+        H = -2.0 * amp**2 / (2.0 * JAr + LA + sq) ** 2
+        a = -amp / 2.0 / H - bb
+        e = numpy.sqrt(numpy.clip(1.0 + LA**2 / (2.0 * H * a**2), 0.0, None))
+        taneta2 = numpy.tan(eta / 2.0)
+        tan11 = numpy.arctan(numpy.sqrt((1.0 + e) / (1.0 - e)) * taneta2)
+        tan12 = numpy.arctan(
+            numpy.sqrt((a * (1.0 + e) + 2.0 * bb) / (a * (1.0 - e) + 2.0 * bb))
+            * taneta2
+        )
+        tan11 = numpy.where(tan11 < 0.0, tan11 + numpy.pi, tan11)
+        tan12 = numpy.where(tan12 < 0.0, tan12 + numpy.pi, tan12)
+        Lambdaeta = tan11 + LA / sq * tan12
+        psi = thetaAz - 0.5 * (1.0 + LA / sq) * thetaAr + Lambdaeta
+        sini = numpy.sqrt(numpy.clip(1.0 - Lz**2 / LA**2, 0.0, None))
+        costh = numpy.sin(psi) * sini  # polar angle: cos(vartheta)
+        sinth = numpy.sqrt(numpy.clip(1.0 - costh**2, 0.0, None))
+        # p^A_theta = -L sin(i) cos(psi)/sin(vartheta), with magnitude
+        # sqrt(L^2 - Lz^2/sin^2 vartheta)
+        pAth = -LA * sini * numpy.cos(psi) / numpy.maximum(sinth, 1e-15)
+        thetaA = numpy.arccos(numpy.clip(costh, -1.0, 1.0))
+        return thetaA, pAth
+
+    def _canon_family_chains(self, x):
+        """All family values and their action chains at fractional grid
+        coordinates x: the stored tables' own derivatives, contracted with
+        the inverse of the label-coordinate matrix (J_R, J_phi, J_z) vs
+        (L_z, w_E-index, w_I-index)"""
+        xx = numpy.atleast_2d(x)
+        v = self._canon_table_eval(xx)[:, 0]
+        dL = self._canon_table_eval(xx, deriv=0)[:, 0] / self._canon_dLz
+        dE_ = self._canon_table_eval(xx, deriv=1)[:, 0]
+        dI_ = self._canon_table_eval(xx, deriv=2)[:, 0]
+        M = numpy.array(
+            [
+                [dL[0], dE_[0], dI_[0]],
+                [1.0, 0.0, 0.0],
+                [dL[1], dE_[1], dI_[1]],
+            ]
+        )
+        Minv = numpy.linalg.inv(M)
+        # chains of every stored quantity along (J_R, J_phi, J_z)
+        dq = numpy.stack((dL, dE_, dI_), axis=1) @ Minv  # (nq, 3)
+        return v, dq
+
+    def _canon_comp(self, thetaAr, thetaAz, jr, LA, Lz, v, dq):
+        """The two-map compensation terms along the three action chains,
+        every factor grouped through the per-degree action-flux identities
+        so it is closed-form and regular at all turning points; returns
+        (comp_R, comp_phi, comp_z) arrays over the points"""
+        npt = self._npt
+        umin, umax, vmin = v[3], v[4], v[5]
+        dumin, dumax, dvmin = dq[3], dq[4], dq[5]
+        Dmu, Dmv = v[6 : 6 + npt], v[6 + npt :]
+        dDmu, dDmv = dq[6 : 6 + npt], dq[6 + npt :]
+        # closed-form toy-parameter chains: a, e from (J^A_r = J_R, L^A)
+        GM, bb = self._GMc, self._bc
+        sq = numpy.sqrt(LA**2 + 4.0 * bb * GM)
+        CA = 0.5 * (LA + sq)
+        EA = -(GM**2) / (2.0 * (jr + CA) ** 2)
+        a = -GM / (2.0 * EA) - bb
+        e = numpy.sqrt(1.0 + LA**2 / (2.0 * EA * a**2))
+        thmin = numpy.arcsin(numpy.clip(numpy.fabs(Lz) / LA, 0.0, 1.0))
+        # dLA/d(J_R, J_phi, J_z) and the induced (a, e, thmin) chains
+        dLA = numpy.array([0.0, numpy.sign(Lz), 1.0])
+        dEA = (
+            GM**2
+            / (jr + CA) ** 3
+            * (numpy.array([1.0, 0.0, 0.0]) + 0.5 * (1.0 + LA / sq) * dLA)
+        )
+        da = GM / (2.0 * EA**2) * dEA
+        de = (
+            2.0 * LA * dLA / (2.0 * EA * a**2)
+            - LA**2 * (dEA * a + 2.0 * EA * da) / (2.0 * EA**2 * a**3)
+        ) / (2.0 * e)
+        costhmin = numpy.cos(thmin)
+        dthmin = numpy.array(
+            [
+                0.0,
+                numpy.sign(Lz) * (numpy.sign(Lz) / LA - numpy.fabs(Lz) / LA**2),
+                -numpy.fabs(Lz) / LA**2,
+            ]
+        ) / numpy.maximum(costhmin, 1e-12)
+        dthmin[1] = (
+            numpy.sign(Lz)
+            * (1.0 / LA - numpy.fabs(Lz) / LA**2 * 1.0)
+            / numpy.maximum(costhmin, 1e-12)
+        )
+        # u-degree at the current phases
+        eta_u, rA, pAr = self._canon_toy_radial(jr, LA, thetaAr)
+        tuu = self._tau_of_eta(eta_u, Dmu)
+        ms = self._nforDm
+        s = numpy.sqrt(bb**2 + rA**2)
+        y = (s - bb) / a
+        coseta = numpy.cos(eta_u)
+        sineta = numpy.sin(eta_u)
+        smat_u = numpy.sin(tuu[:, None] * ms[None, :])
+        drAdeta = a * e * sineta * (y + bb / a) / numpy.sqrt(y * (y + 2.0 * bb / a))
+        # dr^A/dJ_i at fixed tau_u, and du/dJ_i at fixed tau_u
+        gA = a * e * (y + bb / a) / numpy.sqrt(y * (y + 2.0 * bb / a))
+        detau = 1.0 + numpy.cos(tuu[:, None] * ms[None, :]) @ (ms * Dmu)
+        sintu = numpy.sin(tuu)
+        sru = numpy.where(
+            numpy.fabs(sintu) > 1e-12,
+            sineta / numpy.maximum(numpy.fabs(sintu), 1e-12) * numpy.sign(sintu),
+            1.0,
+        )
+        pu = pAr * gA * sru * detau / (0.5 * (umax - umin))
+        comp = numpy.empty((3, len(thetaAr)))
+        c2u = numpy.cos(tuu / 2.0) ** 2
+        s2u = numpy.sin(tuu / 2.0) ** 2
+        # v-degree phases from the toy's own vertical geometry
+        thetaAv, pAthv = self._canon_toy_vert(jr, LA, Lz, thetaAr, thetaAz, eta_u)
+        cosetav = numpy.clip(
+            (0.5 * numpy.pi - thetaAv) / numpy.maximum(0.5 * numpy.pi - thmin, 1e-12),
+            -1.0,
+            1.0,
+        )
+        sinetav = numpy.sign(pAthv) * numpy.sqrt(
+            numpy.clip(1.0 - cosetav**2, 0.0, None)
+        )
+        eta_v = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
+        tvv = self._tau_of_eta(eta_v, Dmv)
+        smat_v = numpy.sin(tvv[:, None] * ms[None, :])
+        detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
+        sintv = numpy.sin(tvv)
+        srv = numpy.where(
+            numpy.fabs(sintv) > 1e-12,
+            sinetav / numpy.maximum(numpy.fabs(sintv), 1e-12) * numpy.sign(sintv),
+            1.0,
+        )
+        gth = 0.5 * numpy.pi - thmin
+        pv = pAthv * gth * srv * detav / (0.5 * (numpy.pi - 2.0 * vmin))
+        cv = numpy.cos(tvv)
+        for i in range(3):
+            drA_i = (
+                y * s / rA * da[i]
+                - a * s * coseta / rA * de[i]
+                + drAdeta * (smat_u @ dDmu[:, i])
+            )
+            du_i = dumin[i] * c2u + dumax[i] * s2u
+            dth_i = dthmin[i] * cosetav + gth * sinetav * (smat_v @ dDmv[:, i])
+            dv_i = dvmin[i] * cv
+            comp[i] = (pAr * drA_i - pu * du_i) + (pAthv * dth_i - pv * dv_i)
+        return comp[0], comp[1], comp[2]
+
+    def _xvFreqs_canonical_interp(self, jr, jphi, jz, angler, anglephi, anglez):
+        """The canonical family evaluation: implicit-inverse labels, the
+        compensated 2-D angle Newton (exact residuals, identity-dominated
+        Jacobian), delegation to the analytic isochrone inverse, and the
+        per-degree un-lift with the family-interpolated maps; frequencies
+        are the stored energy table's own derivatives through the label
+        chains (the integrator contract)"""
+        jr, jphi, jz = float(jr), float(jphi), float(jz)
+        Lz = jphi
+        LA = jz + numpy.fabs(Lz)
+        thR = numpy.atleast_1d(numpy.array(angler, dtype="float"))
+        thphi = numpy.atleast_1d(numpy.array(anglephi, dtype="float"))
+        thz = numpy.atleast_1d(numpy.array(anglez, dtype="float"))
+        thR, thphi, thz = numpy.broadcast_arrays(thR, thphi, thz)
+        x = self._canon_coords(jr, Lz, jz)
+        v, dq = self._canon_family_chains(x)
+        thetaAr = numpy.copy(thR)
+        thetaAz = numpy.copy(thz)
+        for _ in range(self._maxiter):
+            cR, cphi, cz = self._canon_comp(thetaAr, thetaAz, jr, LA, Lz, v, dq)
+            f0 = (thetaAr + cR - thR + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            f1 = (thetaAz + cz - thz + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            step = numpy.maximum(numpy.fabs(f0), numpy.fabs(f1))
+            lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
+            thetaAr -= f0 * lim
+            thetaAz -= f1 * lim
+            if numpy.max(step) < self._angle_tol:
+                break
+        else:
+            raise RuntimeError("Newton's method for the toy angles did not converge")
+        thetaAphi = thphi - cphi
+        out = numpy.empty((6, len(thR)))
+        for jj in range(len(thR)):
+            oo = self._aAIinvc._xvFreqs(
+                jr, Lz, jz, thetaAr[jj], thetaAphi[jj], thetaAz[jj]
+            )
+            for kk in range(6):
+                out[kk, jj] = oo[kk][0]
+        npt = self._npt
+        GM, bb = self._GMc, self._bc
+        sq = numpy.sqrt(LA**2 + 4.0 * bb * GM)
+        EA = -(GM**2) / (2.0 * (jr + 0.5 * (LA + sq)) ** 2)
+        a = -GM / (2.0 * EA) - bb
+        e = numpy.sqrt(1.0 + LA**2 / (2.0 * EA * a**2))
+        thmin = numpy.arcsin(numpy.clip(numpy.fabs(Lz) / LA, 0.0, 1.0))
+        Rt, vRt, vTt, zt, vzt, phit = self._canon_unlift(
+            out,
+            a,
+            e,
+            LA,
+            thmin,
+            v[6 : 6 + npt],
+            v[6 + npt :],
+            v[3],
+            v[4],
+            v[5],
+            Lz,
+        )
+        # frequencies: the stored energy table's own derivative chains
+        OmR, Omphi, Omz = dq[2]
+        return (Rt, vRt, vTt, zt, vzt, phit, OmR, Omphi, Omz)

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1764,7 +1764,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         v, dq = self._canon_family_chains(x)
         thetaAr = numpy.copy(thR)
         thetaAz = numpy.copy(thz)
-        prev = numpy.inf
         for _ in range(self._maxiter):
             cR, cphi, cz = self._canon_comp(thetaAr, thetaAz, jr, LA, Lz, v, dq)
             f0 = (thetaAr + cR - thR + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
@@ -1773,20 +1772,8 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
             thetaAr -= f0 * lim
             thetaAz -= f1 * lim
-            worst = numpy.max(step)
-            if worst < self._angle_tol:
+            if numpy.max(step) < self._angle_tol:
                 break
-            # The residual is a difference of compensated angles, so it
-            # bottoms out on its own round-off floor -- measured at 3-8e-13
-            # of a radian here, within a factor of two of angle_tol.  Which
-            # side of the tolerance that floor lands on depends on the
-            # platform's libm, so stop when the iteration stops improving
-            # rather than insisting on a threshold it cannot always reach.
-            # Only where the residual is already negligible: a genuine
-            # failure to contract must still raise.
-            if worst > 0.9 * prev and worst < 1e-9:
-                break
-            prev = worst
         else:
             raise RuntimeError("Newton's method for the toy angles did not converge")
         thetaAphi = thphi - cphi

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1369,15 +1369,24 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._GMc, self._bc = grid._GMc, grid._bc
         self._aAIc, self._aAIinvc = grid._aAIc, grid._aAIinvc
         # the stacked tables: labels, energy, supports, and the two anomaly
-        # maps' sine coefficients
+        # maps' sine coefficients.  The supports are NOT stored as the
+        # turning points themselves: each oscillation's half-width vanishes
+        # at its degenerate edge, so umax - umin there is the difference of
+        # two interpolants that agree to every digit the grid resolves, and
+        # the cancellation destroys it (50% wrong one cell from the shell
+        # edge).  Stored instead are the midpoint and the SQUARED half-width
+        # divided by the action that drives it -- K_u = (umax-umin)^2/4J_R
+        # and K_v = (pi/2-vmin)^2/J_z -- both bounded and smooth right up to
+        # the edge, where the vanishing is carried entirely by the action
+        # itself, which is known exactly at evaluation time.
         nq = 6 + 2 * self._npt
         tab = numpy.empty((nq,) + shape)
         tab[0] = grid._jr.reshape(shape)
         tab[1] = grid._jz.reshape(shape)
         tab[2] = Es
-        tab[3] = grid._umins.reshape(shape)
-        tab[4] = grid._umaxs.reshape(shape)
-        tab[5] = grid._vmins.reshape(shape)
+        tab[3] = 0.5 * (grid._umins + grid._umaxs).reshape(shape)
+        tab[4] = (0.25 * (grid._umaxs - grid._umins) ** 2.0).reshape(shape) / tab[0]
+        tab[5] = ((0.5 * numpy.pi - grid._vmins) ** 2.0).reshape(shape) / tab[1]
         tab[6 : 6 + self._npt] = numpy.moveaxis(
             grid._can_Dmu.reshape(shape + (self._npt,)), -1, 0
         )
@@ -1385,18 +1394,18 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             grid._can_Dmv.reshape(shape + (self._npt,)), -1, 0
         )
         # the analytic limits at the degenerate edges: the vanishing action
-        # is exactly zero, the degenerate oscillation's support collapses to
-        # its analytic point (the shell u, the midplane), and its anomaly
-        # map vanishes (both loops are harmonic in the thin limit, so
-        # eta = tau exactly)
+        # is exactly zero, the degenerate oscillation's midpoint sits at its
+        # analytic point (the shell u), and its anomaly map vanishes (both
+        # loops are harmonic in the thin limit, so eta = tau exactly).  The
+        # half-widths need no special case at all: they are reconstructed as
+        # sqrt(K J) and so collapse onto the midpoint exactly when the
+        # action does, with K carrying its finite limit.
         if self._wIgrid[-1] == 1.0:
             tab[0, :, :, -1] = 0.0
             tab[3, :, :, -1] = self._canon_ushell
-            tab[4, :, :, -1] = self._canon_ushell
             tab[6 : 6 + self._npt, :, :, -1] = 0.0
         if self._wIgrid[0] == 0.0:
             tab[1, :, :, 0] = 0.0
-            tab[5, :, :, 0] = 0.5 * numpy.pi
             tab[6 + self._npt :, :, :, 0] = 0.0
         self._canon_tab_raw = tab
         self._canon_dLz = (self._Lzgrid[-1] - self._Lzgrid[0]) / (nLz - 1)
@@ -1593,6 +1602,21 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         Minv = numpy.linalg.inv(M)
         # chains of every stored quantity along (J_R, J_phi, J_z)
         dq = numpy.stack((dL, dE_, dI_), axis=1) @ Minv  # (nq, 3)
+        # turn the stored midpoint-and-K combinations back into the turning
+        # points, differentiating the reconstruction itself so the chains
+        # remain the exact derivatives of what is evaluated.  dq[0] and
+        # dq[1] are the identity rows (1, 0, 0) and (0, 0, 1) by the
+        # construction of M, so J_R's and J_z's own chains enter here
+        # exactly rather than through the interpolation
+        uc, duc = v[3], dq[3]
+        hw = numpy.sqrt(numpy.clip(v[4] * v[0], 0.0, None))
+        hv = numpy.sqrt(numpy.clip(v[5] * v[1], 0.0, None))
+        # below the floor the oscillation is degenerate and the compensation
+        # drops the term outright, so the divergence is never evaluated
+        dhw = (v[4] * dq[0] + v[0] * dq[4]) / (2.0 * numpy.maximum(hw, 1e-14))
+        dhv = (v[5] * dq[1] + v[1] * dq[5]) / (2.0 * numpy.maximum(hv, 1e-14))
+        v[3], v[4], v[5] = uc - hw, uc + hw, 0.5 * numpy.pi - hv
+        dq[3], dq[4], dq[5] = duc - dhw, duc + dhw, -dhv
         return v, dq
 
     def _canon_comp(self, thetaAr, thetaAz, jr, LA, Lz, v, dq):

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -6,9 +6,11 @@
 #   separable 2x2 Newton solve. No auxiliary torus, generating function, or
 #   Fourier lattice; placement on the torus is exact by construction.
 ###############################################################################
+import warnings
+
 import numpy
-from scipy.interpolate import InterpolatedUnivariateSpline, RectBivariateSpline
-from scipy.ndimage import map_coordinates, spline_filter1d
+from scipy.interpolate import InterpolatedUnivariateSpline
+from scipy.ndimage import spline_filter1d
 from scipy.optimize import brentq, minimize, minimize_scalar
 
 from ..potential import (
@@ -18,7 +20,7 @@ from ..potential import (
     rl,
     vcirc,
 )
-from ..util import conversion, coords
+from ..util import conversion, coords, galpyWarning
 from .actionAngleInverse import actionAngleInverse
 from .actionAngleIsochrone import actionAngleIsochrone
 from .actionAngleIsochroneInverse import actionAngleIsochroneInverse
@@ -57,49 +59,6 @@ def _bspline_dweights(t):
     )
 
 
-class _ProfileSet:
-    """Several angle profiles sharing one uniform chi mesh.
-
-    The profiles are stored as cubic B-spline coefficients, padded so the
-    four-point stencil is always in range, and evaluated with an explicit
-    weight formula rather than through a library routine: the Newton
-    iteration needs the same chi for several profiles at a time, and for a
-    single angle the per-call overhead of a library interpolator dominates
-    everything else.
-    """
-
-    def __init__(self, coeffs, dchi):
-        self._c = numpy.concatenate(
-            (coeffs[:, :1], coeffs[:, :1], coeffs, coeffs[:, -1:], coeffs[:, -1:]),
-            axis=1,
-        )
-        self._dchi = dchi
-        self._n = coeffs.shape[1]
-
-    def block(self, which):
-        """The padded coefficients of a subset of the profiles, sliced once
-        so that repeated evaluations do not re-copy them"""
-        return numpy.ascontiguousarray(self._c[which])
-
-    def evaluate(self, block, chi):
-        """Evaluate a block returned by block() at the angles chi"""
-        x = numpy.clip(chi / self._dchi, 0.0, self._n - 1.0)
-        i = x.astype(int)
-        t = x - i
-        j = i + 2
-        t2 = t * t
-        t3 = t2 * t
-        return (
-            (1.0 - 3.0 * t + 3.0 * t2 - t3) * block[:, j - 1]
-            + (4.0 - 6.0 * t2 + 3.0 * t3) * block[:, j]
-            + (1.0 + 3.0 * t + 3.0 * t2 - 3.0 * t3) * block[:, j + 1]
-            + t3 * block[:, j + 2]
-        ) / 6.0
-
-    def __call__(self, chi, which):
-        return self.evaluate(self.block(which), numpy.atleast_1d(chi))
-
-
 def _pad_axis(arr, axis, pad):
     """Extend arr beyond both ends of axis by quadratic extrapolation from the
     three nearest slices, vectorized over everything else"""
@@ -126,7 +85,7 @@ def _pad_axis(arr, axis, pad):
 
 def _prefilter_padded(arr, axes, pad):
     """Pad arr along axes and return its cubic-spline prefiltered form, ready
-    for map_coordinates with prefilter=False. Only the given axes are
+    for four-point-stencil evaluation. Only the given axes are
     prefiltered: the leading axis indexes distinct quantities, and filtering
     across it would mix them."""
     out = arr
@@ -168,7 +127,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         nE=9,
         nI3=9,
         grid_pad=0.02,
-        nchi_store=201,
         nchi=2001,
         canonical=False,
         ncanon=128,
@@ -234,12 +192,18 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         npt : int, optional
             Number of sine modes of the stored momentum-matching anomaly
             maps (at most ncanon/2 - 1).
-        nchi_store : int, optional
-            Number of grid points in the chi anomaly on which the angle
-            profiles of the grid tori are stored for interpolation (only used
-            when setup_interp is True). The profiles are smooth functions of
-            the anomaly by construction, so this can be much smaller than
-            nchi.
+        canonical : bool, optional
+            If True, additionally build the canonical (momentum-matched)
+            construction for the discrete tori: each torus is lifted onto
+            its equal-action isochrone torus by per-degree momentum-matched
+            point transformations, and evaluation runs through the analytic
+            isochrone inverse (STAECKEL_CANONICAL_MATH.md section 10).
+        ncanon : int, optional
+            Number of anomaly samples (even) of the canonical
+            correspondence tables per degree of freedom.
+        npt : int, optional
+            Number of sine modes of the stored momentum-matching anomaly
+            maps (at most ncanon/2 - 1).
         maxiter : int, optional
             Maximum number of Newton iterations in the angle inversion.
         angle_tol : float, optional
@@ -249,12 +213,8 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         -----
         - Angle conventions match those of the forward actionAngleStaeckel.
         - When set up with setup_interp, the evaluation methods accept
-          ``integrals=True``, which reinterprets their first three arguments
-          as (E, L_z, I3) rather than (J_R, J_phi, J_z). Tori are naturally
-          labelled by their integrals -- the construction takes those as
-          input and delivers the actions as output -- so this route skips the
-          inversion that the action route performs, and is correspondingly
-          more accurate.
+          the canonical family's tables (STAECKEL_CANONICAL_MATH.md
+          section 10).
         - 2026-08-19 - Started - Bovy (UofT)
         """
         if "delta" in kwargs or "u0" in kwargs:
@@ -265,7 +225,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 "_delta attribute)"
             )
         actionAngleInverse.__init__(self, **kwargs)
-        if pot is None:  # pragma: no cover
+        if pot is None:
             raise OSError("Must specify pot= for actionAngleStaeckelInverse")
         self._pot = pot
         if isinstance(pot, OblateStaeckelWrapperPotential):
@@ -310,13 +270,14 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._npt = npt
         self._nforDm = numpy.arange(1, npt + 1)
         if setup_interp:
+            # the interpolated family is the canonical construction (the
+            # contingent interpolated-direct path was removed once the
+            # canonical family matched its accuracy per the fast-orbits #23 review)
+            self._canonical = True
             Rmin = conversion.parse_length(Rmin, ro=self._ro)
             Rmax = conversion.parse_length(Rmax, ro=self._ro)
             Rinf = conversion.parse_length(Rinf, ro=self._ro)
-            if canonical:
-                self._setup_canonical_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad)
-                return
-            self._setup_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad, nchi_store)
+            self._setup_canonical_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad)
             return
         # Setup in three logical stages
         self._find_turning_points()
@@ -646,392 +607,29 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         because W_v(pi/2) = 2 delta^2 [E + I3] - L_z^2 vanishes there"""
         return Lz**2.0 / 2.0 / self._delta**2.0 - E
 
-    def _I3_shell(self, E, Lz):
-        """I3 of the J_R = 0 edge, where W_u acquires a double root"""
+    def _I3_shell(self, E, Lz, return_u=False):
+        """I3 of the J_R = 0 edge, where W_u acquires a double root; with
+        return_u, also the u of the shell (the double root)"""
 
-        def maxWu(I3):
-            return -minimize_scalar(
+        def argmaxWu(I3):
+            return minimize_scalar(
                 lambda u: -self._Wu(u, E, Lz, I3),
                 bounds=(1e-3, 20.0),
                 method="bounded",
                 options={"xatol": 1e-13},
-            ).fun
+            )
+
+        def maxWu(I3):
+            return -argmaxWu(I3).fun
 
         lo = self._I3_planar(E, Lz)
         hi = lo + 1.0
         while maxWu(hi) > 0.0:
             hi += 1.0
-        return brentq(maxWu, lo, hi, xtol=1e-14)
-
-    def _setup_grid(self, Rmin, Rmax, Rinf, nLz, nE, nI3, wpad, nchistore):
-        """Grid of tori spanning the bound phase space, and the tables that
-        recover a torus's integrals from its actions without root finding.
-
-        The grid is rectified at every edge, because torus properties vary as
-        the square root of the distance to each: uniform in L_z, quadratic in
-        E away from the circular orbit (as in the spherical grid), and in
-        s = sin^2(pi w_I/2) between the planar (J_z = 0) and shell (J_R = 0)
-        edges, which rectifies both at once. Uniform spacing in (E, I3) is not
-        merely slower to converge but useless, with relative errors of order
-        unity in the actions.
-        """
-        self._nLz, self._nE, self._nI3 = nLz, nE, nI3
-        self._nchistore = nchistore
-        self._Lzgrid = numpy.linspace(
-            Rmin * vcirc(self._pot, Rmin, use_physical=False),
-            Rmax * vcirc(self._pot, Rmax, use_physical=False),
-            nLz,
-        )
-        self._wEgrid = numpy.linspace(wpad, 1.0 - wpad, nE)
-        # w_I spans the CLOSED interval so that J_R = 0 (shell) and J_z = 0
-        # (planar) are grid nodes rather than lying outside the grid. The
-        # construction degenerates exactly there, so those two nodes are
-        # built a small step inside and then corrected to their analytic
-        # limits below.
-        self._wIgrid = numpy.linspace(0.0, 1.0, nI3)
-        self._wIedge = 1e-4
-        shape = (nLz, nE, nI3)
-        Es, Lzs, I3s = (numpy.empty(shape) for _ in range(3))
-        self._Ecs, self._Emaxs = numpy.empty(nLz), numpy.empty(nLz)
-        self._grid_Ish = numpy.empty((nLz, nE))
-        wIbuild = numpy.clip(self._wIgrid, self._wIedge, 1.0 - self._wIedge)
-        sinw = numpy.sin(numpy.pi * wIbuild / 2.0) ** 2.0
-        for ii, Lz in enumerate(self._Lzgrid):
-            self._Ecs[ii] = self._circular_orbit(Lz)[1]
-            self._Emaxs[ii] = (
-                evaluatePotentials(self._pot, Rinf, 0.0, use_physical=False)
-                + Lz**2.0 / 2.0 / Rinf**2.0
-            )
-            for jj, wE in enumerate(self._wEgrid):
-                E = self._Ecs[ii] + wE**2.0 * (self._Emaxs[ii] - self._Ecs[ii])
-                Ipl = self._I3_planar(E, Lz)
-                self._grid_Ish[ii, jj] = self._I3_shell(E, Lz)
-                Es[ii, jj] = E
-                Lzs[ii, jj] = Lz
-                I3s[ii, jj] = Ipl + sinw * (self._grid_Ish[ii, jj] - Ipl)
-        # Build every torus of the grid in one vectorized construction
-        grid = actionAngleStaeckelInverse(
-            pot=self._staeckelwrap,
-            Es=Es.ravel(),
-            Lzs=Lzs.ravel(),
-            I3s=I3s.ravel(),
-            nchi=self._nchi,
-        )
-        self._grid_jr = grid._jr.reshape(shape).copy()
-        self._grid_jz = grid._jz.reshape(shape).copy()
-        # Set the vanishing action to exactly zero at each edge, so that
-        # zeta reaches 0 and 1 and J_z = 0, J_R = 0 are inside the grid
-        if self._wIgrid[-1] == 1.0:
-            self._grid_jr[:, :, -1] = 0.0
-        if self._wIgrid[0] == 0.0:
-            self._grid_jz[:, :, 0] = 0.0
-        # Keep what the construction produced -- turning points,
-        # frequencies, and the six profiles with their derivatives -- on a
-        # common, coarser chi mesh: rebuilding a torus instead costs ~45 ms
-        self._chistore = numpy.linspace(0.0, numpy.pi, self._nchistore)
-        nprof = self._nchistore
-        prof = numpy.empty((12, grid._ntori, nprof))
-        for kk in range(grid._ntori):
-            for ll in range(3):
-                prof[ll, kk] = grid._Aprof[kk][ll](self._chistore)
-                prof[3 + ll, kk] = grid._Bprof[kk][ll](self._chistore)
-                prof[6 + ll, kk] = grid._dAprof[kk][ll](self._chistore)
-                prof[9 + ll, kk] = grid._dBprof[kk][ll](self._chistore)
-        # Analytic limits on the degenerate oscillation of each edge: it is
-        # harmonic there, so its angle is its anomaly (A_R = chi at the
-        # shell, B_z = chi at the planar edge) and its cross profiles vanish
-        prof = prof.reshape((12,) + shape + (nprof,))
-        chis = self._chistore
-        ones = numpy.ones_like(chis)
-        if self._wIgrid[-1] == 1.0:  # shell edge: J_R = 0
-            prof[0, :, :, -1] = chis
-            prof[6, :, :, -1] = ones
-            for ll in (1, 2):
-                prof[ll, :, :, -1] = 0.0
-                prof[6 + ll, :, :, -1] = 0.0
-        if self._wIgrid[0] == 0.0:  # planar edge: J_z = 0
-            prof[4, :, :, 0] = chis
-            prof[10, :, :, 0] = ones
-            for ll in (0, 2):
-                prof[3 + ll, :, :, 0] = 0.0
-                prof[9 + ll, :, :, 0] = 0.0
-        prof = prof.reshape((12, grid._ntori, nprof))
-        # the degenerate turning points collapse: u_min = u_max at the shell,
-        # v_min = pi/2 at the planar edge
-        umins = grid._umins.reshape(shape).copy()
-        umaxs = grid._umaxs.reshape(shape).copy()
-        vmins = grid._vmins.reshape(shape).copy()
-        if self._wIgrid[-1] == 1.0:
-            mid = 0.5 * (umins[:, :, -1] + umaxs[:, :, -1])
-            umins[:, :, -1] = mid
-            umaxs[:, :, -1] = mid
-        if self._wIgrid[0] == 0.0:
-            vmins[:, :, 0] = numpy.pi / 2.0
-        grid._umins = umins.ravel()
-        grid._umaxs = umaxs.ravel()
-        grid._vmins = vmins.ravel()
-        self._grid_scal = numpy.array(
-            [
-                grid._umins,
-                grid._umaxs,
-                grid._vmins,
-                grid._OmegaR,
-                grid._Omegaz,
-                grid._Omegaphi,
-                Es.ravel(),
-                I3s.ravel(),
-            ]
-        ).reshape((8,) + shape)
-        # Prefilter along chi once here: prefiltering and interpolation
-        # across the grid are both linear, so they commute, and doing it now
-        # keeps it off the per-torus path
-        prof = spline_filter1d(prof, order=3, axis=-1, mode="nearest")
-        self._grid_prof = prof.reshape((12,) + shape + (nprof,))
-        # Pad the grid directions by polynomial extrapolation before
-        # prefiltering: spline_filter assumes a vanishing derivative beyond
-        # the edge, which otherwise dominates the error there (7.7e-4
-        # unpadded versus 2.6e-6 padded)
-        self._gpad = 4
-        self._grid_scal_f = _prefilter_padded(self._grid_scal, (1, 2, 3), self._gpad)
-        self._grid_prof_f = _prefilter_padded(self._grid_prof, (1, 2, 3), self._gpad)
-        self._Ish_spl = RectBivariateSpline(self._Lzgrid, self._wEgrid, self._grid_Ish)
-        self._Ec_spl = InterpolatedUnivariateSpline(self._Lzgrid, self._Ecs, k=3)
-        self._Emax_spl = InterpolatedUnivariateSpline(self._Lzgrid, self._Emaxs, k=3)
-        self._build_action_lookup()
-
-    def _build_action_lookup(self):
-        """Tables giving the grid coordinates (w_E, w_I) of a torus from its
-        actions, by two nested one-dimensional monotone inversions rather
-        than a two-dimensional root find.
-
-        rho = sqrt(J_R + J_z) increases with w_E at fixed w_I, and
-        zeta = (2/pi) arcsin sqrt[J_z/(J_R + J_z)] increases with w_I at
-        fixed w_E. zeta carries the same rectification as the grid: J_z
-        vanishes as w_I^2 at the planar edge (and J_R as [1-w_I]^2 at the
-        shell edge), so w_I would be a square root of the bare action ratio
-        there, while the arcsin makes it linear.
-        """
-        nLz, nE, nI3 = self._nLz, self._nE, self._nI3
-        rho = numpy.sqrt(self._grid_jr + self._grid_jz)
-        eta = self._grid_jz / (self._grid_jr + self._grid_jz)
-        zeta = 2.0 / numpy.pi * numpy.arcsin(numpy.sqrt(numpy.clip(eta, 0.0, 1.0)))
-        self._zetamesh = numpy.linspace(
-            numpy.amax(zeta.min(axis=2)), numpy.amin(zeta.max(axis=2)), nI3
-        )
-        wI_z, rho_z = numpy.empty((nLz, nE, nI3)), numpy.empty((nLz, nE, nI3))
-        for ii in range(nLz):
-            for jj in range(nE):
-                wI_z[ii, jj] = InterpolatedUnivariateSpline(
-                    zeta[ii, jj], self._wIgrid, k=3
-                )(self._zetamesh)
-                rho_z[ii, jj] = InterpolatedUnivariateSpline(
-                    zeta[ii, jj], rho[ii, jj], k=3
-                )(self._zetamesh)
-        self._rhomax = rho_z[:, -1, :]
-        rhat = rho_z / self._rhomax[:, None, :]
-        self._rhatmesh = numpy.linspace(numpy.amax(rhat[:, 0, :]), 1.0, nE)
-        self._tab_wE, self._tab_wI = (numpy.empty((nLz, nE, nI3)) for _ in range(2))
-        self._rhomax_f = None
-        for ii in range(nLz):
-            for kk in range(nI3):
-                self._tab_wE[ii, :, kk] = InterpolatedUnivariateSpline(
-                    rhat[ii, :, kk], self._wEgrid, k=3
-                )(self._rhatmesh)
-                self._tab_wI[ii, :, kk] = InterpolatedUnivariateSpline(
-                    rhat[ii, :, kk], wI_z[ii, :, kk], k=3
-                )(self._rhatmesh)
-        # prefilter once: rebuilding splines on every call dominated the cost
-        self._tab_f = _prefilter_padded(
-            numpy.array([self._tab_wE, self._tab_wI]), (1, 2, 3), self._gpad
-        )
-        self._rhomax_f = _prefilter_padded(self._rhomax[None], (1, 2), self._gpad)
-
-    def _integrals_from_actions(self, jr, jphi, jz):
-        """(J_R, J_phi, J_z) -> (E, L_z, I3), by interpolation only: rho and
-        zeta give the position within the rectified action space, and the
-        stored tables convert that to grid coordinates"""
-        Lz = jphi
-        if Lz < self._Lzgrid[0] or Lz > self._Lzgrid[-1]:
-            raise ValueError(
-                f"J_phi = {Lz} lies outside the grid of this "
-                f"actionAngleStaeckelInverse instance "
-                f"([{self._Lzgrid[0]}, {self._Lzgrid[-1]}])"
-            )
-        rho = numpy.sqrt(jr + jz)
-        zeta = (
-            2.0
-            / numpy.pi
-            * numpy.arcsin(numpy.sqrt(numpy.clip(jz / (jr + jz), 0.0, 1.0)))
-        )
-        p = self._gpad
-        iLz = numpy.interp(Lz, self._Lzgrid, numpy.arange(self._nLz))
-        izeta = numpy.interp(zeta, self._zetamesh, numpy.arange(self._nI3))
-        rhomax = map_coordinates(
-            self._rhomax_f[0],
-            numpy.array([[iLz + p], [izeta + p]]),
-            order=3,
-            prefilter=False,
-            mode="nearest",
-        )[0]
-        rhat = rho / rhomax
-        # Say which way the torus falls out and what the grid does reach:
-        # rho and zeta are rectified coordinates, so quoting them alone leaves
-        # the caller no way to tell a too-energetic torus from a near-circular
-        # one, nor how much of a grid change would take it in
-        if not self._zetamesh[0] <= zeta <= self._zetamesh[-1]:
-            raise ValueError(
-                f"J_z/(J_R+J_z) = {jz / (jr + jz):g} lies outside the grid of "
-                f"this actionAngleStaeckelInverse instance, which covers "
-                f"[{numpy.sin(numpy.pi * self._zetamesh[0] / 2.0) ** 2.0:g}, "
-                f"{numpy.sin(numpy.pi * self._zetamesh[-1] / 2.0) ** 2.0:g}]"
-            )
-        if not self._rhatmesh[0] <= rhat <= self._rhatmesh[-1]:
-            lo = (self._rhatmesh[0] * rhomax) ** 2.0
-            hi = (self._rhatmesh[-1] * rhomax) ** 2.0
-            raise ValueError(
-                f"J_R+J_z = {jr + jz:g} lies outside the grid of this "
-                f"actionAngleStaeckelInverse instance, "
-                f"{'below' if rhat < self._rhatmesh[0] else 'above'} the total "
-                f"action it covers at J_phi = {Lz:g} and "
-                f"J_z/(J_R+J_z) = {jz / (jr + jz):g} ([{lo:g}, {hi:g}])"
-            )
-        irhat = numpy.interp(rhat, self._rhatmesh, numpy.arange(self._nE))
-        c = numpy.array([[iLz + p], [irhat + p], [izeta + p]])
-        wE = map_coordinates(
-            self._tab_f[0], c, order=3, prefilter=False, mode="nearest"
-        )[0]
-        wI = map_coordinates(
-            self._tab_f[1], c, order=3, prefilter=False, mode="nearest"
-        )[0]
-        return float(wE), float(wI)
-
-    def _coords_from_actions(self, jr, jphi, jz):
-        """(J_R, J_phi, J_z) -> fractional grid index, directly. Going via
-        (E, I3) and back would evaluate the shell edge and the energy limits
-        twice for nothing: the torus quantities that evaluation needs,
-        including E and I3 themselves, are interpolated on the grid."""
-        wE, wI = self._integrals_from_actions(jr, jphi, jz)
-        # A vanishing action means the oscillation is absent, which is an
-        # edge of the grid: snap to it, or the table's rounding leaves a
-        # sliver of oscillation behind
-        if jz <= 0.0:
-            wI = self._wIgrid[0]
-        elif jr <= 0.0:
-            wI = self._wIgrid[-1]
-        return self._fractional_index(jphi, wE, wI)
-
-    def _interp_torus(self, idx):
-        """Interpolate the stored torus quantities at a fractional grid index.
-
-        The three grid directions are contracted explicitly with the cubic
-        B-spline weights: calling a library interpolator once per profile
-        instead costs more than everything else in an evaluation. The result
-        is cached, because the usual pattern is many angles on one torus.
-        """
-        key = tuple(idx)
-        if getattr(self, "_torus_cache_key", None) == key:
-            return self._torus_cache
-        p = self._gpad
-        w, base = [], []
-        for aa in range(3):
-            x = idx[aa] + p
-            ii = int(numpy.floor(x))
-            w.append(_bspline_weights(x - ii))
-            base.append(ii - 1)
-        sl = (
-            slice(base[0], base[0] + 4),
-            slice(base[1], base[1] + 4),
-            slice(base[2], base[2] + 4),
-        )
-        Ws = w[0][:, None, None] * w[1][None, :, None] * w[2][None, None, :]
-        scal = numpy.tensordot(
-            self._grid_scal_f[:, sl[0], sl[1], sl[2]], Ws, axes=([1, 2, 3], [0, 1, 2])
-        )
-        # contract the grid axes one at a time: contracting all three at once
-        # forces a copy of the (12, 4, 4, 4, nchi) slice, which costs more
-        # than the arithmetic it saves
-        prof = self._grid_prof_f[:, sl[0], sl[1], sl[2], :]
-        prof = numpy.tensordot(prof, w[0], axes=([1], [0]))
-        prof = numpy.tensordot(prof, w[1], axes=([1], [0]))
-        prof = numpy.tensordot(prof, w[2], axes=([1], [0]))
-        profs = _ProfileSet(prof, self._chistore[1] - self._chistore[0])
-        # Polish the turning points against the interpolated integrals:
-        # interpolated, they are not exact roots of W, so p = sqrt(W) is
-        # clipped near them and the energy drifts by ~1e-6. A degenerate
-        # oscillation is left alone.
-        Lz = self._interp_Lz
-        # E and I3 come from the grid definition evaluated at this index, not
-        # from their interpolated values: the two agree at the nodes but drift
-        # apart by ~1e-6 in between, and taking the definition makes labelling
-        # a torus by its integrals the exact inverse of reading them back off
-        # it. The turning-point polish below then re-roots W at these values,
-        # so the mapping stays consistent with whichever pair is used.
-        wE = numpy.interp(idx[1], numpy.arange(self._nE), self._wEgrid)
-        Ec, Emax = float(self._Ec_spl(Lz)), float(self._Emax_spl(Lz))
-        E = scal[6] = Ec + wE**2.0 * (Emax - Ec)
-        if numpy.pi / 2.0 - scal[2] <= 1e-12:
-            # planar torus: the exact condition W_v(pi/2) = 0 fixes I3 in
-            # closed form, which is better than any interpolated value
-            scal[7] = self._I3_planar(E, Lz)
-        elif scal[1] - scal[0] <= 1e-12:
-            # shell torus: a double root needs both W_u'(u*) = 0 and
-            # W_u(u*) = 0, so u* and I3 are solved together; W_u depends on
-            # I3 only through -2 delta^2 I3, making the second update exact
-            ustar, I3s_, h = scal[0], scal[7], 1e-4
-            for _ in range(3):
-                # three points in one call give slope and curvature
-                uu = numpy.array([ustar - h, ustar, ustar + h])
-                Wq = self._Wu(uu, E, Lz, I3s_)
-                d1 = (Wq[2] - Wq[0]) / 2.0 / h
-                d2 = (Wq[2] - 2.0 * Wq[1] + Wq[0]) / h**2.0
-                ustar -= d1 / d2
-                I3s_ += (
-                    self._Wu(numpy.array([ustar]), E, Lz, I3s_)[0]
-                    / 2.0
-                    / self._delta**2.0
-                )
-            scal[0] = scal[1] = ustar
-            scal[7] = I3s_
-        else:
-            # interior torus: sin^2(pi w_I/2) between the two edges, which is
-            # what _grid_coords inverts. Both edges are exact, so a torus on
-            # one of them round-trips through the clip in _grid_coords
-            wI = numpy.interp(idx[2], numpy.arange(self._nI3), self._wIgrid)
-            Ipl = self._I3_planar(E, Lz)
-            Ish = self._Ish_spl(Lz, numpy.clip(wE, self._wEgrid[0], self._wEgrid[-1]))[
-                0, 0
-            ]
-            scal[7] = Ipl + (Ish - Ipl) * numpy.sin(numpy.pi * wI / 2.0) ** 2.0
-        I3 = scal[7]
-        # One vectorized evaluation of W per degree of freedom, differenced
-        # for the slope: the analytic dW costs three potential-layer calls
-        # against one, and only sets the step, not the root
-        h = 1e-6
-        # Two steps: the turning points arrive with the ~1e-5 error of the
-        # interpolation, so one step leaves ~1e-10, which shows up in the
-        # energy when angles sample close to a turning point
-        for _ in range(2):
-            if scal[1] - scal[0] > 1e-12:
-                uu = numpy.array(
-                    [
-                        scal[0] - h,
-                        scal[0],
-                        scal[0] + h,
-                        scal[1] - h,
-                        scal[1],
-                        scal[1] + h,
-                    ]
-                )
-                Wu = self._Wu(uu, E, Lz, I3)
-                scal[0] -= Wu[1] * 2.0 * h / (Wu[2] - Wu[0])
-                scal[1] -= Wu[4] * 2.0 * h / (Wu[5] - Wu[3])
-            if numpy.pi / 2.0 - scal[2] > 1e-12:
-                vv = numpy.array([scal[2] - h, scal[2], scal[2] + h])
-                Wv = self._Wv(vv, E, Lz, I3)
-                scal[2] -= Wv[1] * 2.0 * h / (Wv[2] - Wv[0])
-        self._torus_cache_key = key
-        self._torus_cache = (scal, profs)
-        return self._torus_cache
+        Ish = brentq(maxWu, lo, hi, xtol=1e-14)
+        if return_u:
+            return Ish, argmaxWu(Ish).x
+        return Ish
 
     def _torus_index(self, jr, jphi, jz):
         indx = numpy.nanargmin(
@@ -1061,94 +659,24 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         w = numpy.mod(w, 2.0 * numpy.pi)
         return numpy.where(w <= numpy.pi, dP(w), dP(2.0 * numpy.pi - w))
 
-    @staticmethod
-    def _fold_set(profs, w, block, half):
-        """Fold several profiles of a _ProfileSet at once.
-
-        The argument is folded BEFORE evaluation -- chi = w on the outgoing
-        branch and 2pi - w on the return branch -- so each profile is
-        evaluated once instead of on both branches, and the half-loop values
-        needed by the reflection are passed in rather than re-evaluated.
-        """
-        w = numpy.mod(w, 2.0 * numpy.pi)
-        out = w <= numpy.pi
-        chi = numpy.where(out, w, 2.0 * numpy.pi - w)
-        vals = profs.evaluate(block, chi)
-        refl = 2.0 * half[:, None] - vals
-        # rows flagged with a NaN half are derivatives: the reflection leaves
-        # them unchanged in the folded argument
-        keep = numpy.isnan(half)
-        refl[keep] = vals[keep]
-        return numpy.where(out, vals, refl)
-
     def _evaluate(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
         return self._xvFreqs(jr, jphi, jz, angler, anglephi, anglez, **kwargs)[:6]
 
-    def _grid_coords(self, E, Lz, I3):
-        """(E, L_z, I3) -> fractional grid indices. This direction needs no
-        inversion at all: w_E follows from the circular and outer energies,
-        w_I from the planar and shell edges."""
-        if Lz < self._Lzgrid[0] or Lz > self._Lzgrid[-1]:
-            raise ValueError(
-                f"L_z = {Lz} lies outside the grid of this "
-                f"actionAngleStaeckelInverse instance "
-                f"([{self._Lzgrid[0]}, {self._Lzgrid[-1]}])"
-            )
-        Ec, Emax = self._Ec_spl(Lz), self._Emax_spl(Lz)
-        wE = numpy.sqrt(numpy.clip((E - Ec) / (Emax - Ec), 0.0, numpy.inf))
-        Ipl = self._I3_planar(E, Lz)
-        Ish = self._Ish_spl(Lz, numpy.clip(wE, self._wEgrid[0], self._wEgrid[-1]))[0, 0]
-        s = numpy.clip((I3 - Ipl) / (Ish - Ipl), 0.0, 1.0)
-        wI = 2.0 / numpy.pi * numpy.arcsin(numpy.sqrt(s))
-        return self._fractional_index(Lz, float(wE), float(wI))
-
-    def _fractional_index(self, Lz, wE, wI):
-        """Fractional index into the (L_z, w_E, w_I) grid, checking that the
-        torus is inside it"""
-        out = []
-        for val, grid, name in (
-            (Lz, self._Lzgrid, "L_z"),
-            (wE, self._wEgrid, "energy"),
-            (wI, self._wIgrid, "third integral"),
-        ):
-            # a torus on an edge can land a rounding step outside it
-            tol = 1e-6 * (grid[-1] - grid[0])
-            if val < grid[0] - tol or val > grid[-1] + tol:
-                raise ValueError(
-                    f"Requested torus lies outside the grid of this "
-                    f"actionAngleStaeckelInverse instance in the {name} "
-                    "direction"
-                )
-            out.append(numpy.clip(val, grid[0], grid[-1]))
-        return (
-            numpy.interp(out[0], self._Lzgrid, numpy.arange(self._nLz)),
-            numpy.interp(out[1], self._wEgrid, numpy.arange(self._nE)),
-            numpy.interp(out[2], self._wIgrid, numpy.arange(self._nI3)),
-        )
-
     def _xvFreqs(self, jr, jphi, jz, angler, anglephi, anglez, **kwargs):
-        if kwargs.get("integrals", False):
-            if not self._interp:
-                raise ValueError(
-                    "integrals=True requires an actionAngleStaeckelInverse "
-                    "set up with setup_interp=True"
-                )
-            # (jr, jphi, jz) are really (E, L_z, I3) here: the grid
-            # coordinates follow from them directly, with no inversion
-            return self._xvFreqs_index(
-                self._grid_coords(jr, jphi, jz), jphi, angler, anglephi, anglez
+        if kwargs.get("integrals", False) and not self._interp:
+            raise ValueError(
+                "integrals=True requires an actionAngleStaeckelInverse "
+                "set up with setup_interp=True"
             )
         if self._interp:
-            if self._canonical:
+            if kwargs.get("integrals", False):
+                x = self._canon_coords_integrals(jr, jphi, jz)
+                v = self._canon_table_eval(numpy.atleast_2d(x))[:, 0]
                 return self._xvFreqs_canonical_interp(
-                    jr, jphi, jz, angler, anglephi, anglez
+                    v[0], jphi, v[1], angler, anglephi, anglez, x=x
                 )
-            return self._xvFreqs_index(
-                self._coords_from_actions(jr, jphi, jz),
-                jphi,
-                angler,
-                anglephi,
-                anglez,
+            return self._xvFreqs_canonical_interp(
+                jr, jphi, jz, angler, anglephi, anglez
             )
         ii = self._torus_index(jr, jphi, jz)
         if self._canonical:
@@ -1167,29 +695,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             self._OmegaR[ii],
             self._Omegaphi[ii],
             self._Omegaz[ii],
-            angler,
-            anglephi,
-            anglez,
-        )
-
-    def _xvFreqs_index(self, idx, Lz, angler, anglephi, anglez):
-        """Evaluate on the interpolated torus at a fractional grid index"""
-        self._interp_Lz = Lz
-        scal, profs = self._interp_torus(idx)
-        return self._solve_and_map(
-            profs,
-            None,
-            None,
-            None,
-            scal[6],
-            Lz,
-            scal[7],
-            scal[0],
-            scal[1],
-            scal[2],
-            scal[3],
-            scal[5],
-            scal[4],
             angler,
             anglephi,
             anglez,
@@ -1216,52 +721,24 @@ class actionAngleStaeckelInverse(actionAngleInverse):
     ):
         """Invert the angle system on one torus and map the result to
         (R, vR, vT, z, vz, phi); shared by the direct and interpolated paths.
-        A is either a list of profile splines (direct) or a _ProfileSet
-        holding all twelve profiles of an interpolated torus."""
+        A and B are the per-torus angle-profile splines of the direct
+        construction."""
         thR = numpy.atleast_1d(numpy.array(angler, dtype="float"))
         thz = numpy.atleast_1d(numpy.array(anglez, dtype="float"))
         thphi = numpy.atleast_1d(numpy.array(anglephi, dtype="float"))
-        batched = isinstance(A, _ProfileSet)
-        if batched:
-            profs = A
-            # profile order: A_R,A_z,A_phi,B_R,B_z,B_phi then their derivatives
-            # values and derivatives share the angle, hence the weights
-            blku = profs.block(numpy.array([0, 1, 6, 7]))
-            blkv = profs.block(numpy.array([3, 4, 9, 10]))
-            bphiu = profs.block(numpy.array([2]))
-            bphiv = profs.block(numpy.array([5]))
-            allhalf = profs(numpy.array([numpy.pi]), numpy.arange(12))[:, 0]
-            # NaN marks the derivative rows, which the reflection leaves
-            # unchanged in the folded argument
-            halfu = numpy.array([allhalf[0], allhalf[1], numpy.nan, numpy.nan])
-            halfv = numpy.array([allhalf[3], allhalf[4], numpy.nan, numpy.nan])
-
-            def fu(w):
-                return self._fold_set(profs, w, blku, halfu)
-
-            def fv(w):
-                return self._fold_set(profs, w, blkv, halfv)
-
         wu, wv = numpy.copy(thR), numpy.copy(thz)
         unconv = numpy.ones(wu.shape, dtype="bool")
         for _ in range(self._maxiter):
             twu, twv = wu[unconv], wv[unconv]
-            if batched:
-                fA, fB = fu(twu), fv(twv)
-                f0 = fA[0] + fB[0] - thR[unconv]
-                f1 = fA[1] + fB[1] + self._anglez0 - thz[unconv]
-                J00, J01 = fA[2], fB[2]
-                J10, J11 = fA[3], fB[3]
-            else:
-                f0 = self._fold(A[0], twu) + self._fold(B[0], twv) - thR[unconv]
-                f1 = (
-                    self._fold(A[1], twu)
-                    + self._fold(B[1], twv)
-                    + self._anglez0
-                    - thz[unconv]
-                )
-                J00, J01 = self._dfold(dA[0], twu), self._dfold(dB[0], twv)
-                J10, J11 = self._dfold(dA[1], twu), self._dfold(dB[1], twv)
+            f0 = self._fold(A[0], twu) + self._fold(B[0], twv) - thR[unconv]
+            f1 = (
+                self._fold(A[1], twu)
+                + self._fold(B[1], twv)
+                + self._anglez0
+                - thz[unconv]
+            )
+            J00, J01 = self._dfold(dA[0], twu), self._dfold(dB[0], twv)
+            J10, J11 = self._dfold(dA[1], twu), self._dfold(dB[1], twv)
             f0 = (f0 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             f1 = (f1 + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
             det = J00 * J11 - J01 * J10
@@ -1296,14 +773,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             if Dv <= 1e-12
             else sv * numpy.sqrt(numpy.clip(self._Wv(v, E, Lz, I3), 0.0, None))
         )
-        if batched:
-            phi = (
-                thphi
-                - self._fold_set(profs, wu, bphiu, allhalf[[2]])[0]
-                - self._fold_set(profs, wv, bphiv, allhalf[[5]])[0]
-            )
-        else:
-            phi = thphi - self._fold(A[2], wu) - self._fold(B[2], wv)
+        phi = thphi - self._fold(A[2], wu) - self._fold(B[2], wv)
         # (u, v, p_u, p_v) -> (R, z, vR, vz)
         sh, ch = numpy.sinh(u), numpy.cosh(u)
         sn, cs = numpy.sin(v), numpy.cos(v)
@@ -1325,23 +795,18 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         )
 
     def _Freqs(self, jr, jphi, jz, **kwargs):
-        if kwargs.get("integrals", False):
-            if not self._interp:
-                raise ValueError(
-                    "integrals=True requires an actionAngleStaeckelInverse "
-                    "set up with setup_interp=True"
-                )
-            self._interp_Lz = jphi
-            scal = self._interp_torus(self._grid_coords(jr, jphi, jz))[0]
-            return (scal[3], scal[5], scal[4])
+        if kwargs.get("integrals", False) and not self._interp:
+            raise ValueError(
+                "integrals=True requires an actionAngleStaeckelInverse "
+                "set up with setup_interp=True"
+            )
         if self._interp:
-            if self._canonical:
+            if kwargs.get("integrals", False):
+                x = self._canon_coords_integrals(jr, jphi, jz)
+            else:
                 x = self._canon_coords(float(jr), float(jphi), float(jz))
-                _, dq = self._canon_family_chains(x)
-                return (dq[2, 0], dq[2, 1], dq[2, 2])
-            self._interp_Lz = jphi
-            scal = self._interp_torus(self._coords_from_actions(jr, jphi, jz))[0]
-            return (scal[3], scal[5], scal[4])
+            _, dq = self._canon_family_chains(x)
+            return (dq[2, 0], dq[2, 1], dq[2, 2])
         ii = self._torus_index(jr, jphi, jz)
         return (self._OmegaR[ii], self._Omegaphi[ii], self._Omegaz[ii])
 
@@ -1738,45 +1203,60 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         rA = numpy.sqrt(R**2 + z**2)
         vrA = (R * vR + z * vz) / rA
         pAth = vR * z - vz * R
+        Du = umax - umin
+        Dv = numpy.pi - 2.0 * vmin
+        if Du < 1e-10:
+            # shell: the u-oscillation is degenerate; the u-support is the
+            # analytic shell spheroid and it carries no momentum
+            u = numpy.full_like(rA, 0.5 * (umin + umax))
+            pu = numpy.zeros_like(rA)
+        if Dv < 1e-10 or (0.5 * numpy.pi - thmin) < 1e-8:
+            # planar: the v-oscillation is degenerate
+            v = numpy.full_like(rA, 0.5 * numpy.pi)
+            pv = numpy.zeros_like(rA)
         # u-degree: eta from the closed-form radius inversion, tau from the
         # stored map, u from the cosine anomaly; p_u through the flux group
         y = (numpy.sqrt(self._bc**2 + rA**2) - self._bc) / a
         coseta = numpy.clip((1.0 - y) / e, -1.0, 1.0)
         sineta = numpy.sign(vrA) * numpy.sqrt(numpy.clip(1.0 - coseta**2, 0.0, None))
         etau = numpy.arctan2(sineta, coseta) % (2.0 * numpy.pi)
-        tuu = self._tau_of_eta(etau, Dmu)
-        Du = umax - umin
-        u = umin + Du * numpy.sin(tuu / 2.0) ** 2
-        gA = a * e * (y + self._bc / a) / numpy.sqrt(y * (y + 2.0 * self._bc / a))
-        ms = self._nforDm
-        detau = 1.0 + numpy.cos(tuu[:, None] * ms[None, :]) @ (ms * Dmu)
-        sintu = numpy.sin(tuu)
-        sru = numpy.where(
-            numpy.fabs(sintu) > 1e-12,
-            sineta / numpy.maximum(numpy.fabs(sintu), 1e-12) * numpy.sign(sintu),
-            1.0,
-        )
-        pu = vrA * gA * sru * detau / (0.5 * Du)
-        # v-degree: theta^A from the position, eta from the linear cosine
-        # inversion, tau from the stored map; p_v through the flux group
-        thetaA = numpy.arccos(numpy.clip(z / rA, -1.0, 1.0))
-        cosetav = numpy.clip(
-            (0.5 * numpy.pi - thetaA) / (0.5 * numpy.pi - thmin), -1.0, 1.0
-        )
-        sinetav = numpy.sign(pAth) * numpy.sqrt(numpy.clip(1.0 - cosetav**2, 0.0, None))
-        etav = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
-        tvv = self._tau_of_eta(etav, Dmv)
-        Dv = numpy.pi - 2.0 * vmin
-        v = vmin + Dv * numpy.sin(tvv / 2.0) ** 2
-        detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
-        sintv = numpy.sin(tvv)
-        srv = numpy.where(
-            numpy.fabs(sintv) > 1e-12,
-            sinetav / numpy.maximum(numpy.fabs(sintv), 1e-12) * numpy.sign(sintv),
-            1.0,
-        )
-        gth = 0.5 * numpy.pi - thmin
-        pv = pAth * gth * srv * detav / (0.5 * Dv)
+        if Du >= 1e-10:
+            tuu = self._tau_of_eta(etau, Dmu)
+            u = umin + Du * numpy.sin(tuu / 2.0) ** 2
+            gA = a * e * (y + self._bc / a) / numpy.sqrt(y * (y + 2.0 * self._bc / a))
+            ms = self._nforDm
+            detau = 1.0 + numpy.cos(tuu[:, None] * ms[None, :]) @ (ms * Dmu)
+            sintu = numpy.sin(tuu)
+            sru = numpy.where(
+                numpy.fabs(sintu) > 1e-12,
+                sineta / numpy.maximum(numpy.fabs(sintu), 1e-12) * numpy.sign(sintu),
+                1.0,
+            )
+            pu = vrA * gA * sru * detau / (0.5 * Du)
+        if Dv >= 1e-10 and (0.5 * numpy.pi - thmin) >= 1e-8:
+            # v-degree: theta^A from the position, eta from the linear
+            # cosine inversion, tau from the stored map; p_v through the
+            # flux group
+            ms = self._nforDm
+            thetaA = numpy.arccos(numpy.clip(z / rA, -1.0, 1.0))
+            cosetav = numpy.clip(
+                (0.5 * numpy.pi - thetaA) / (0.5 * numpy.pi - thmin), -1.0, 1.0
+            )
+            sinetav = numpy.sign(pAth) * numpy.sqrt(
+                numpy.clip(1.0 - cosetav**2, 0.0, None)
+            )
+            etav = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
+            tvv = self._tau_of_eta(etav, Dmv)
+            v = vmin + Dv * numpy.sin(tvv / 2.0) ** 2
+            detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
+            sintv = numpy.sin(tvv)
+            srv = numpy.where(
+                numpy.fabs(sintv) > 1e-12,
+                sinetav / numpy.maximum(numpy.fabs(sintv), 1e-12) * numpy.sign(sintv),
+                1.0,
+            )
+            gth = 0.5 * numpy.pi - thmin
+            pv = pAth * gth * srv * detav / (0.5 * Dv)
         # prolate -> cylindrical, exactly as the direct path
         sh, ch = numpy.sinh(u), numpy.cosh(u)
         sn, cs = numpy.sin(v), numpy.cos(v)
@@ -1839,6 +1319,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._wIedge = 1e-4
         shape = (nLz, nE, nI3)
         self._canon_shape = shape
+        self._canon_Rinf = Rinf
+        self._canon_wpad = wpad
+        self._canon_ushell = numpy.empty((nLz, nE))
         Es, Lzs, I3s = (numpy.empty(shape) for _ in range(3))
         wIbuild = numpy.clip(self._wIgrid, self._wIedge, 1.0 - self._wIedge)
         sinw = numpy.sin(numpy.pi * wIbuild / 2.0) ** 2.0
@@ -1851,10 +1334,11 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             for jj, wE in enumerate(self._wEgrid):
                 E = Ec + wE**2.0 * (Emax - Ec)
                 Ipl = self._I3_planar(E, Lz)
-                Ish = self._I3_shell(E, Lz)
+                Ish, ushell = self._I3_shell(E, Lz, return_u=True)
                 Es[ii, jj] = E
                 Lzs[ii, jj] = Lz
                 I3s[ii, jj] = Ipl + sinw * (Ish - Ipl)
+                self._canon_ushell[ii, jj] = ushell
         grid = actionAngleStaeckelInverse(
             pot=self._staeckelwrap,
             Es=Es.ravel(),
@@ -1867,6 +1351,15 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         )
         self._canon_node_maxdev = grid._can_maxdev
         self._canon_node_stokes = grid._can_stokes
+        if self._canon_node_maxdev > 1e-6:
+            warnings.warn(
+                "The stored anomaly maps are under-resolved for the most "
+                "extreme grid tori (worst node action deviation "
+                f"{self._canon_node_maxdev:.2e}); evaluation stays exactly "
+                "canonical, but the accuracy near those tori is limited to "
+                "that scale -- raise npt and/or ncanon to resolve them",
+                galpyWarning,
+            )
         self._GMc, self._bc = grid._GMc, grid._bc
         self._aAIc, self._aAIinvc = grid._aAIc, grid._aAIinvc
         # the stacked tables: labels, energy, supports, and the two anomaly
@@ -1885,11 +1378,20 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         tab[6 + self._npt :] = numpy.moveaxis(
             grid._can_Dmv.reshape(shape + (self._npt,)), -1, 0
         )
-        # the vanishing action is exactly zero at its edge
+        # the analytic limits at the degenerate edges: the vanishing action
+        # is exactly zero, the degenerate oscillation's support collapses to
+        # its analytic point (the shell u, the midplane), and its anomaly
+        # map vanishes (both loops are harmonic in the thin limit, so
+        # eta = tau exactly)
         if self._wIgrid[-1] == 1.0:
             tab[0, :, :, -1] = 0.0
+            tab[3, :, :, -1] = self._canon_ushell
+            tab[4, :, :, -1] = self._canon_ushell
+            tab[6 : 6 + self._npt, :, :, -1] = 0.0
         if self._wIgrid[0] == 0.0:
             tab[1, :, :, 0] = 0.0
+            tab[5, :, :, 0] = 0.5 * numpy.pi
+            tab[6 + self._npt :, :, :, 0] = 0.0
         self._canon_tab_raw = tab
         self._canon_dLz = (self._Lzgrid[-1] - self._Lzgrid[0]) / (nLz - 1)
         self._rebuild_canon_interp()
@@ -1908,7 +1410,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         a 2-D Newton in (w_E, w_I) at fixed L_z"""
         if Lz < self._Lzgrid[0] or Lz > self._Lzgrid[-1]:
             raise ValueError(
-                f"L_z = {Lz} outside the interpolation grid "
+                f"L_z = {Lz} lies outside the grid "
                 f"[{self._Lzgrid[0]}, {self._Lzgrid[-1]}]"
             )
         xL = (
@@ -1935,6 +1437,34 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             if max(abs(f0), abs(f1)) < 1e-12 * (1.0 + abs(jr) + abs(jz)):
                 break
         else:
+            # say which way the torus falls outside: the rectified grid
+            # means a near-circular and a too-energetic torus otherwise
+            # read the same, with nothing to act on
+            wIs = numpy.linspace(0.0, self._nI3 - 1.0, 33)
+            lo = min(
+                self._canon_table_eval(numpy.array([[xL, 0.0, w]]))[:2, 0].sum()
+                for w in wIs
+            )
+            hi = max(
+                self._canon_table_eval(numpy.array([[xL, self._nE - 1.0, w]]))[
+                    :2, 0
+                ].sum()
+                for w in wIs
+            )
+            if jr + jz < lo:
+                raise ValueError(
+                    f"(J_R, J_z) = ({jr}, {jz}) lies outside the grid: it "
+                    "falls below the covered total action J_R+J_z at "
+                    f"L_z = {Lz} (the grid reaches down to "
+                    f"J_R+J_z = {lo:g})"
+                )
+            if jr + jz > hi:
+                raise ValueError(
+                    f"(J_R, J_z) = ({jr}, {jz}) lies outside the grid: it "
+                    "falls above the covered total action J_R+J_z at "
+                    f"L_z = {Lz} (the grid reaches up to "
+                    f"J_R+J_z = {hi:g}); increase Rinf"
+                )
             raise ValueError(
                 f"(J_R, J_z) = ({jr}, {jz}) could not be matched inside the "
                 f"interpolation grid at L_z = {Lz}: the torus lies outside "
@@ -1996,6 +1526,46 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         pAth = -LA * sini * numpy.cos(psi) / numpy.maximum(sinth, 1e-15)
         thetaA = numpy.arccos(numpy.clip(costh, -1.0, 1.0))
         return thetaA, pAth
+
+    def _canon_coords_integrals(self, E, Lz, I3):
+        """Fractional grid coordinates directly from the integrals
+        (E, L_z, I3) -- the rectified coordinates are closed forms, so
+        labelling a torus by its integrals needs no inversion at all"""
+        if Lz < self._Lzgrid[0] or Lz > self._Lzgrid[-1]:
+            raise ValueError(
+                f"L_z = {Lz} lies outside the grid "
+                f"[{self._Lzgrid[0]}, {self._Lzgrid[-1]}]"
+            )
+        xL = (
+            (Lz - self._Lzgrid[0])
+            / (self._Lzgrid[-1] - self._Lzgrid[0])
+            * (self._nLz - 1)
+        )
+        Ec = self._circular_orbit(Lz)[1]
+        Emax = (
+            evaluatePotentials(self._pot, self._canon_Rinf, 0.0, use_physical=False)
+            + Lz**2 / 2.0 / self._canon_Rinf**2
+        )
+        if E < Ec:
+            raise ValueError(
+                f"E = {E} lies outside the grid: below the circular orbit's "
+                f"energy {Ec:g} at L_z = {Lz}"
+            )
+        wE = numpy.sqrt((E - Ec) / (Emax - Ec))
+        if wE > 1.0:
+            raise ValueError(
+                f"E = {E} lies outside the grid: above the energies covered "
+                f"at L_z = {Lz}; increase Rinf"
+            )
+        Ipl = self._I3_planar(E, Lz)
+        Ish = self._I3_shell(E, Lz)
+        sfrac = numpy.clip((I3 - Ipl) / (Ish - Ipl), 0.0, 1.0)
+        wI = 2.0 / numpy.pi * numpy.arcsin(numpy.sqrt(sfrac))
+        xE = numpy.clip(
+            (wE - self._canon_wpad) / (1.0 - 2.0 * self._canon_wpad), 0.0, 1.0
+        ) * (self._nE - 1)
+        xI = wI * (self._nI3 - 1)
+        return numpy.array([xL, float(xE), float(xI)])
 
     def _canon_family_chains(self, x):
         """All family values and their action chains at fractional grid
@@ -2085,6 +1655,8 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         comp = numpy.empty((3, len(thetaAr)))
         c2u = numpy.cos(tuu / 2.0) ** 2
         s2u = numpy.sin(tuu / 2.0) ** 2
+        udeg = (umax - umin) < 1e-10
+        vdeg = (0.5 * numpy.pi - thmin) < 1e-8 or (numpy.pi - 2.0 * vmin) < 1e-10
         # v-degree phases from the toy's own vertical geometry
         thetaAv, pAthv = self._canon_toy_vert(jr, LA, Lz, thetaAr, thetaAz, eta_u)
         cosetav = numpy.clip(
@@ -2109,18 +1681,26 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         pv = pAthv * gth * srv * detav / (0.5 * (numpy.pi - 2.0 * vmin))
         cv = numpy.cos(tvv)
         for i in range(3):
-            drA_i = (
-                y * s / rA * da[i]
-                - a * s * coseta / rA * de[i]
-                + drAdeta * (smat_u @ dDmu[:, i])
-            )
-            du_i = dumin[i] * c2u + dumax[i] * s2u
-            dth_i = dthmin[i] * cosetav + gth * sinetav * (smat_v @ dDmv[:, i])
-            dv_i = dvmin[i] * cv
-            comp[i] = (pAr * drA_i - pu * du_i) + (pAthv * dth_i - pv * dv_i)
+            if udeg:
+                uterm = 0.0
+            else:
+                drA_i = (
+                    y * s / rA * da[i]
+                    - a * s * coseta / rA * de[i]
+                    + drAdeta * (smat_u @ dDmu[:, i])
+                )
+                du_i = dumin[i] * c2u + dumax[i] * s2u
+                uterm = pAr * drA_i - pu * du_i
+            if vdeg:
+                vterm = 0.0
+            else:
+                dth_i = dthmin[i] * cosetav + gth * sinetav * (smat_v @ dDmv[:, i])
+                dv_i = dvmin[i] * cv
+                vterm = pAthv * dth_i - pv * dv_i
+            comp[i] = uterm + vterm
         return comp[0], comp[1], comp[2]
 
-    def _xvFreqs_canonical_interp(self, jr, jphi, jz, angler, anglephi, anglez):
+    def _xvFreqs_canonical_interp(self, jr, jphi, jz, angler, anglephi, anglez, x=None):
         """The canonical family evaluation: implicit-inverse labels, the
         compensated 2-D angle Newton (exact residuals, identity-dominated
         Jacobian), delegation to the analytic isochrone inverse, and the
@@ -2134,7 +1714,8 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         thphi = numpy.atleast_1d(numpy.array(anglephi, dtype="float"))
         thz = numpy.atleast_1d(numpy.array(anglez, dtype="float"))
         thR, thphi, thz = numpy.broadcast_arrays(thR, thphi, thz)
-        x = self._canon_coords(jr, Lz, jz)
+        if x is None:
+            x = self._canon_coords(jr, Lz, jz)
         v, dq = self._canon_family_chains(x)
         thetaAr = numpy.copy(thR)
         thetaAz = numpy.copy(thz)

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1564,14 +1564,28 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         H = -2.0 * amp**2 / (2.0 * JAr + LA + sq) ** 2
         a = -amp / 2.0 / H - bb
         e = numpy.sqrt(numpy.clip(1.0 + LA**2 / (2.0 * H * a**2), 0.0, None))
+        # theta^A_r is used unwrapped below, so eta has to be in its branch:
+        # the radial inverse returns eta on [0, 2 pi), which puts the two a
+        # full period apart whenever theta^A_r is just below zero.
+        eta = eta + 2.0 * numpy.pi * numpy.round(
+            (numpy.atleast_1d(thetaAr) - eta) / (2.0 * numpy.pi)
+        )
         taneta2 = numpy.tan(eta / 2.0)
         tan11 = numpy.arctan(numpy.sqrt((1.0 + e) / (1.0 - e)) * taneta2)
         tan12 = numpy.arctan(
             numpy.sqrt((a * (1.0 + e) + 2.0 * bb) / (a * (1.0 - e) + 2.0 * bb))
             * taneta2
         )
-        tan11 = numpy.where(tan11 < 0.0, tan11 + numpy.pi, tan11)
-        tan12 = numpy.where(tan12 < 0.0, tan12 + numpy.pi, tan12)
+        # Lambda climbs by pi (1 + L^A/sq) per radial period, cancelling the
+        # -1/2 (1 + L^A/sq) theta^A_r in psi, so psi is periodic.  Selecting
+        # the branch by the SIGN OF THE ARCTAN gets that right inside
+        # (0, 2 pi) and wrong at the ends: for eta slightly below zero the
+        # arctan is negative and picks up a spurious pi, which is the same
+        # value it takes at eta just below 2 pi.  Keying the branch to eta
+        # instead is identical on (0, 2 pi) and continuous through zero.
+        nwind = numpy.round(eta / (2.0 * numpy.pi))
+        tan11 = tan11 + numpy.pi * nwind
+        tan12 = tan12 + numpy.pi * nwind
         Lambdaeta = tan11 + LA / sq * tan12
         psi = thetaAz - 0.5 * (1.0 + LA / sq) * thetaAr + Lambdaeta
         sini = numpy.sqrt(numpy.clip(1.0 - Lz**2 / LA**2, 0.0, None))

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -939,13 +939,20 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             # ~1e-16 in three or four steps here; this is the guarantee, not
             # the expectation, and it exists because a failure of this
             # inversion used to raise and take the whole evaluation with it.
-            if not numpy.all(numpy.isfinite(Dm)) or not numpy.all(numpy.isfinite(eta)):
+            badDm = int(numpy.sum(~numpy.isfinite(Dm)))
+            badeta = int(numpy.sum(~numpy.isfinite(eta)))
+            if badDm or badeta:
                 # Bracketing compares against NaN, and every such comparison
                 # is False, so it would converge on an endpoint and return it
-                # as a root.  Fail loudly instead of silently.
+                # as a root.  Fail loudly instead of silently, and say WHICH
+                # of the two is bad: the coefficients come from the stored
+                # family and the anomaly from the request, so they go wrong
+                # for different reasons and want different fixes.
                 raise RuntimeError(
                     "Newton's method for the map anomaly did not converge, "
-                    "and the map anomaly or its coefficients are not finite"
+                    "and the map anomaly or its coefficients are not finite: "
+                    f"{badDm} of {Dm.size} coefficients and {badeta} of "
+                    f"{eta.size} anomalies are non-finite"
                 )
             if numpy.sum(ms * numpy.fabs(Dm)) >= 1.0:
                 # sum_m m |D_m| >= 1 admits d eta / d tau <= 0: the map may

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1779,6 +1779,69 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             comp[i] = uterm + vterm
         return comp[0], comp[1], comp[2]
 
+    def _toy_angle_solve(self, thR, thz, jr, LA, Lz, v, dq):
+        """
+        Solve theta^A + c(theta^A) = theta for the auxiliary angles.
+
+        A damped Picard iteration, not a Newton: the update has multiplier
+        -c', so it contracts wherever |c'| < 1 and needs no derivative of the
+        compensation.  Its one failure mode is a torus where c' reaches 1,
+        which makes it cycle with period two rather than diverge -- the
+        residual flips sign at constant amplitude, and the step limiter never
+        engages because it only caps steps above 0.5.  Under-relaxation turns
+        the multiplier into 1 - 2 omega, so halving omega on any
+        non-contracting iteration breaks the cycle while leaving a
+        contracting one untouched.
+
+        Parameters
+        ----------
+        thR, thz : numpy.ndarray
+            Requested radial and vertical angles.
+        jr, LA, Lz : float
+            Actions of the torus.
+        v, dq : numpy.ndarray
+            Family values and their action derivatives.
+
+        Returns
+        -------
+        tuple
+            (theta^A_r, theta^A_z, c_phi).
+
+        Notes
+        -----
+        - 2026-08-30 - Written - Bovy (UofT)
+        """
+        thetaAr = numpy.copy(thR)
+        thetaAz = numpy.copy(thz)
+        omega = 1.0
+        prev = numpy.inf
+        for _ in range(self._maxiter):
+            cR, cphi, cz = self._canon_comp(thetaAr, thetaAz, jr, LA, Lz, v, dq)
+            f0 = (thetaAr + cR - thR + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            f1 = (thetaAz + cz - thz + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+            step = numpy.maximum(numpy.fabs(f0), numpy.fabs(f1))
+            mx = numpy.max(step)
+            if mx >= prev:
+                # Not contracting.  This iteration is a damped Picard
+                # iteration, not the Newton the message once claimed, so its
+                # multiplier is -c' and a torus where c' reaches 1 makes it
+                # cycle with period two rather than diverge: the residual
+                # then flips sign at CONSTANT amplitude and the existing
+                # limiter never engages, since it only caps steps above 0.5.
+                # Observed within about 5e-4 of the radial turning point.
+                # Under-relaxing turns the multiplier into 1 - 2 omega, so
+                # halving omega breaks the cycle and any omega < 1 converges.
+                omega *= 0.5
+            prev = mx
+            lim = omega * numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
+            thetaAr -= f0 * lim
+            thetaAz -= f1 * lim
+            if mx < self._angle_tol:
+                break
+        else:
+            raise RuntimeError("Newton's method for the toy angles did not converge")
+        return thetaAr, thetaAz, cphi
+
     def _xvFreqs_canonical_interp(self, jr, jphi, jz, angler, anglephi, anglez, x=None):
         """The canonical family evaluation: implicit-inverse labels, the
         compensated 2-D angle Newton (exact residuals, identity-dominated
@@ -1796,20 +1859,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         if x is None:
             x = self._canon_coords(jr, Lz, jz)
         v, dq = self._canon_family_chains(x)
-        thetaAr = numpy.copy(thR)
-        thetaAz = numpy.copy(thz)
-        for _ in range(self._maxiter):
-            cR, cphi, cz = self._canon_comp(thetaAr, thetaAz, jr, LA, Lz, v, dq)
-            f0 = (thetaAr + cR - thR + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
-            f1 = (thetaAz + cz - thz + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
-            step = numpy.maximum(numpy.fabs(f0), numpy.fabs(f1))
-            lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
-            thetaAr -= f0 * lim
-            thetaAz -= f1 * lim
-            if numpy.max(step) < self._angle_tol:
-                break
-        else:
-            raise RuntimeError("Newton's method for the toy angles did not converge")
+        thetaAr, thetaAz, cphi = self._toy_angle_solve(thR, thz, jr, LA, Lz, v, dq)
         thetaAphi = thphi - cphi
         out = numpy.empty((6, len(thR)))
         for jj in range(len(thR)):

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1749,6 +1749,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         v, dq = self._canon_family_chains(x)
         thetaAr = numpy.copy(thR)
         thetaAz = numpy.copy(thz)
+        prev = numpy.inf
         for _ in range(self._maxiter):
             cR, cphi, cz = self._canon_comp(thetaAr, thetaAz, jr, LA, Lz, v, dq)
             f0 = (thetaAr + cR - thR + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
@@ -1757,8 +1758,20 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             lim = numpy.minimum(1.0, 0.5 / numpy.maximum(step, 1e-30))
             thetaAr -= f0 * lim
             thetaAz -= f1 * lim
-            if numpy.max(step) < self._angle_tol:
+            worst = numpy.max(step)
+            if worst < self._angle_tol:
                 break
+            # The residual is a difference of compensated angles, so it
+            # bottoms out on its own round-off floor -- measured at 3-8e-13
+            # of a radian here, within a factor of two of angle_tol.  Which
+            # side of the tolerance that floor lands on depends on the
+            # platform's libm, so stop when the iteration stops improving
+            # rather than insisting on a threshold it cannot always reach.
+            # Only where the residual is already negligible: a genuine
+            # failure to contract must still raise.
+            if worst > 0.9 * prev and worst < 1e-9:
+                break
+            prev = worst
         else:
             raise RuntimeError("Newton's method for the toy angles did not converge")
         thetaAphi = thphi - cphi

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -932,7 +932,41 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             if numpy.max(numpy.fabs(f)) < self._angle_tol:
                 break
         else:
-            raise RuntimeError("Newton's method for the map anomaly did not converge")
+            # The stored map is monotone whenever sum_m m |D_m| < 1, which
+            # the construction guarantees, so eta(tau) can always be
+            # bracketed on [0, 2 pi] even where Newton has not converged.
+            # Newton is the fast path and reaches its residual floor of
+            # ~1e-16 in three or four steps here; this is the guarantee, not
+            # the expectation, and it exists because a failure of this
+            # inversion used to raise and take the whole evaluation with it.
+            if not numpy.all(numpy.isfinite(Dm)) or not numpy.all(numpy.isfinite(eta)):
+                # Bracketing compares against NaN, and every such comparison
+                # is False, so it would converge on an endpoint and return it
+                # as a root.  Fail loudly instead of silently.
+                raise RuntimeError(
+                    "Newton's method for the map anomaly did not converge, "
+                    "and the map anomaly or its coefficients are not finite"
+                )
+            if numpy.sum(ms * numpy.fabs(Dm)) >= 1.0:
+                # sum_m m |D_m| >= 1 admits d eta / d tau <= 0: the map may
+                # fold, the root need not be unique, and bracketing would
+                # return a root without saying which.  That is a broken
+                # stored map rather than a slow solve, so it still raises.
+                raise RuntimeError(
+                    "Newton's method for the map anomaly did not converge, "
+                    "and the stored map is not monotone"
+                )
+            f = x + numpy.sin(x[:, None] * ms[None, :]) @ Dm - eta
+            bad = numpy.fabs(f) >= self._angle_tol
+            for ii in numpy.arange(len(x))[bad]:
+                lo, hi = 0.0, 2.0 * numpy.pi
+                for _ in range(200):
+                    mid = 0.5 * (lo + hi)
+                    if mid + numpy.sum(numpy.sin(mid * ms) * Dm) - eta[ii] < 0.0:
+                        lo = mid
+                    else:
+                        hi = mid
+                x[ii] = 0.5 * (lo + hi)
         return x
 
     def _setup_canonical(self):

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -44,6 +44,19 @@ def _bspline_weights(t):
     )
 
 
+def _bspline_dweights(t):
+    """Derivative of the cubic B-spline weights with respect to the offset"""
+    t2 = t * t
+    return numpy.array(
+        [
+            -0.5 * (1.0 - t) ** 2,
+            -2.0 * t + 1.5 * t2,
+            0.5 + t - 1.5 * t2,
+            0.5 * t2,
+        ]
+    )
+
+
 class _ProfileSet:
     """Several angle profiles sharing one uniform chi mesh.
 
@@ -296,16 +309,13 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._ncanon = ncanon
         self._npt = npt
         self._nforDm = numpy.arange(1, npt + 1)
-        if canonical and setup_interp:
-            raise NotImplementedError(
-                "canonical=True with setup_interp=True arrives with the "
-                "family PR (T2); the canonical construction currently "
-                "applies to the discrete tori"
-            )
         if setup_interp:
             Rmin = conversion.parse_length(Rmin, ro=self._ro)
             Rmax = conversion.parse_length(Rmax, ro=self._ro)
             Rinf = conversion.parse_length(Rinf, ro=self._ro)
+            if canonical:
+                self._setup_canonical_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad)
+                return
             self._setup_grid(Rmin, Rmax, Rinf, nLz, nE, nI3, grid_pad, nchi_store)
             return
         # Setup in three logical stages
@@ -1750,3 +1760,158 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             self._Omegaphi[ii],
             self._Omegaz[ii],
         )
+
+    ################## CANONICAL FAMILY (T2) ##################################
+    def _canon_table_eval(self, x, deriv=None):
+        """Evaluate the stacked, prefiltered 3-D canonical tables (and their
+        own derivatives) at fractional grid coordinates x = (xL, xE, xI),
+        vectorized over points; deriv is None or the axis (0, 1, 2) along
+        which to take the tables' own first derivative, in grid-index units"""
+        x = numpy.atleast_2d(x)
+        npts = x.shape[0]
+        vals = numpy.empty((self._canon_tab.shape[0], npts))
+        idx = numpy.floor(x).astype(int)
+        t = x - idx
+        for ax in range(3):
+            idx[:, ax] = numpy.clip(idx[:, ax], 0, self._canon_shape[ax] - 2)
+        t = x - idx
+        wts = []
+        for ax in range(3):
+            w = (
+                _bspline_dweights(t[:, ax])
+                if deriv == ax
+                else _bspline_weights(t[:, ax])
+            )
+            wts.append(w.T)  # (npts, 4)
+        # gather the 4x4x4 neighborhoods: pad offset is 2
+        i0 = idx[:, 0][:, None] + numpy.arange(4)[None, :] + 1
+        i1 = idx[:, 1][:, None] + numpy.arange(4)[None, :] + 1
+        i2 = idx[:, 2][:, None] + numpy.arange(4)[None, :] + 1
+        block = self._canon_tab[
+            :,
+            i0[:, :, None, None],
+            i1[:, None, :, None],
+            i2[:, None, None, :],
+        ]
+        vals = numpy.einsum("qpabc,pa,pb,pc->qp", block, wts[0], wts[1], wts[2])
+        return vals
+
+    def _setup_canonical_grid(self, Rmin, Rmax, Rinf, nLz, nE, nI3, wpad):
+        """The canonical family: the rectified (L_z, w_E, w_I) node lattice
+        of the direct grid, all node tori built in one vectorized canonical
+        construction, and the family stored as prefiltered 3-D tables whose
+        own derivatives drive every evaluation chain (manifest canonicity:
+        the labels are the stored action tables, inverted implicitly, and
+        no derivative is ever stored separately)"""
+        self._nLz, self._nE, self._nI3 = nLz, nE, nI3
+        self._Lzgrid = numpy.linspace(
+            Rmin * vcirc(self._pot, Rmin, use_physical=False),
+            Rmax * vcirc(self._pot, Rmax, use_physical=False),
+            nLz,
+        )
+        self._wEgrid = numpy.linspace(wpad, 1.0 - wpad, nE)
+        self._wIgrid = numpy.linspace(0.0, 1.0, nI3)
+        self._wIedge = 1e-4
+        shape = (nLz, nE, nI3)
+        self._canon_shape = shape
+        Es, Lzs, I3s = (numpy.empty(shape) for _ in range(3))
+        wIbuild = numpy.clip(self._wIgrid, self._wIedge, 1.0 - self._wIedge)
+        sinw = numpy.sin(numpy.pi * wIbuild / 2.0) ** 2.0
+        for ii, Lz in enumerate(self._Lzgrid):
+            Ec = self._circular_orbit(Lz)[1]
+            Emax = (
+                evaluatePotentials(self._pot, Rinf, 0.0, use_physical=False)
+                + Lz**2.0 / 2.0 / Rinf**2.0
+            )
+            for jj, wE in enumerate(self._wEgrid):
+                E = Ec + wE**2.0 * (Emax - Ec)
+                Ipl = self._I3_planar(E, Lz)
+                Ish = self._I3_shell(E, Lz)
+                Es[ii, jj] = E
+                Lzs[ii, jj] = Lz
+                I3s[ii, jj] = Ipl + sinw * (Ish - Ipl)
+        grid = actionAngleStaeckelInverse(
+            pot=self._staeckelwrap,
+            Es=Es.ravel(),
+            Lzs=Lzs.ravel(),
+            I3s=I3s.ravel(),
+            nchi=self._nchi,
+            canonical=True,
+            ncanon=self._ncanon,
+            npt=self._npt,
+        )
+        self._canon_node_maxdev = grid._can_maxdev
+        self._canon_node_stokes = grid._can_stokes
+        self._GMc, self._bc = grid._GMc, grid._bc
+        self._aAIc, self._aAIinvc = grid._aAIc, grid._aAIinvc
+        # the stacked tables: labels, energy, supports, and the two anomaly
+        # maps' sine coefficients
+        nq = 6 + 2 * self._npt
+        tab = numpy.empty((nq,) + shape)
+        tab[0] = grid._jr.reshape(shape)
+        tab[1] = grid._jz.reshape(shape)
+        tab[2] = Es
+        tab[3] = grid._umins.reshape(shape)
+        tab[4] = grid._umaxs.reshape(shape)
+        tab[5] = grid._vmins.reshape(shape)
+        tab[6 : 6 + self._npt] = numpy.moveaxis(
+            grid._can_Dmu.reshape(shape + (self._npt,)), -1, 0
+        )
+        tab[6 + self._npt :] = numpy.moveaxis(
+            grid._can_Dmv.reshape(shape + (self._npt,)), -1, 0
+        )
+        # the vanishing action is exactly zero at its edge
+        if self._wIgrid[-1] == 1.0:
+            tab[0, :, :, -1] = 0.0
+        if self._wIgrid[0] == 0.0:
+            tab[1, :, :, 0] = 0.0
+        self._canon_tab_raw = tab
+        self._rebuild_canon_interp()
+        return None
+
+    def _rebuild_canon_interp(self):
+        """(Re)build the prefiltered tables from the raw ones; separate so
+        that table perturbations (the noise-injection manifest test)
+        re-enter through exactly this call"""
+        self._canon_tab = _prefilter_padded(self._canon_tab_raw, (1, 2, 3), 2)
+        return None
+
+    def _canon_coords(self, jr, Lz, jz):
+        """Invert the stored label tables for the fractional grid
+        coordinates: the implicit-inverse labels (exact-in-the-family), by
+        a 2-D Newton in (w_E, w_I) at fixed L_z"""
+        if Lz < self._Lzgrid[0] or Lz > self._Lzgrid[-1]:
+            raise ValueError(
+                f"L_z = {Lz} outside the interpolation grid "
+                f"[{self._Lzgrid[0]}, {self._Lzgrid[-1]}]"
+            )
+        xL = (
+            (Lz - self._Lzgrid[0])
+            / (self._Lzgrid[-1] - self._Lzgrid[0])
+            * (self._nLz - 1)
+        )
+        xE, xI = 0.5 * (self._nE - 1), 0.5 * (self._nI3 - 1)
+        for _ in range(self._maxiter):
+            x = numpy.array([[xL, xE, xI]])
+            v = self._canon_table_eval(x)
+            dE_ = self._canon_table_eval(x, deriv=1)
+            dI_ = self._canon_table_eval(x, deriv=2)
+            f0 = v[0, 0] - jr
+            f1 = v[1, 0] - jz
+            J00, J01 = dE_[0, 0], dI_[0, 0]
+            J10, J11 = dE_[1, 0], dI_[1, 0]
+            det = J00 * J11 - J01 * J10
+            dxE = (J11 * f0 - J01 * f1) / det
+            dxI = (-J10 * f0 + J00 * f1) / det
+            lim = min(1.0, 1.0 / max(abs(dxE), abs(dxI), 1e-30))
+            xE = numpy.clip(xE - dxE * lim, 0.0, self._nE - 1.0)
+            xI = numpy.clip(xI - dxI * lim, 0.0, self._nI3 - 1.0)
+            if max(abs(f0), abs(f1)) < 1e-12 * (1.0 + abs(jr) + abs(jz)):
+                break
+        else:
+            raise ValueError(
+                f"(J_R, J_z) = ({jr}, {jz}) could not be matched inside the "
+                f"interpolation grid at L_z = {Lz}: the torus lies outside "
+                "the interpolated family"
+            )
+        return numpy.array([xL, xE, xI])

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1265,7 +1265,20 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # u-degree: eta from the closed-form radius inversion, tau from the
         # stored map, u from the cosine anomaly; p_u through the flux group
         y = (numpy.sqrt(self._bc**2 + rA**2) - self._bc) / a
-        coseta = numpy.clip((1.0 - y) / e, -1.0, 1.0)
+        # A circular auxiliary has e = 0 and no radial anomaly, so (1 - y)/e
+        # is 0/0 there and clip cannot rescue it, clip(nan) being nan.  That
+        # is reached whenever J_R = 0 exactly, and only when the rounding
+        # lands e on zero rather than on a tiny positive residue -- which is
+        # why it appeared on one platform and intermittently.  The
+        # u-oscillation is degenerate in that case and is handled above, so
+        # the anomaly is arbitrary; it only has to be finite, since a nan
+        # propagates into the map inversion and takes the evaluation down.
+        esafe = numpy.where(numpy.asarray(e) > 1e-12, e, 1.0)
+        coseta = numpy.clip(
+            numpy.where(numpy.asarray(e) > 1e-12, (1.0 - y) / esafe, 1.0),
+            -1.0,
+            1.0,
+        )
         sineta = numpy.sign(vrA) * numpy.sqrt(numpy.clip(1.0 - coseta**2, 0.0, None))
         etau = numpy.arctan2(sineta, coseta) % (2.0 * numpy.pi)
         if Du >= 1e-10:

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1291,7 +1291,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             sru = numpy.where(
                 numpy.fabs(sintu) > 1e-12,
                 sineta / numpy.maximum(numpy.fabs(sintu), 1e-12) * numpy.sign(sintu),
-                1.0,
+                # sin(eta)/sin(tau) -> eta'(tau) as either vanishes, which is
+                # detau; substituting 1 is wrong by sum_m m D_m, an O(0.1)
+                # error on any point that reaches this branch
+                detau,
             )
             pu = vrA * gA * sru * detau / (0.5 * Du)
         if Dv >= 1e-10 and (0.5 * numpy.pi - thmin) >= 1e-8:
@@ -1314,7 +1317,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             srv = numpy.where(
                 numpy.fabs(sintv) > 1e-12,
                 sinetav / numpy.maximum(numpy.fabs(sintv), 1e-12) * numpy.sign(sintv),
-                1.0,
+                detav,
             )
             gth = 0.5 * numpy.pi - thmin
             pv = pAth * gth * srv * detav / (0.5 * Dv)
@@ -1748,7 +1751,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         sru = numpy.where(
             numpy.fabs(sintu) > 1e-12,
             sineta / numpy.maximum(numpy.fabs(sintu), 1e-12) * numpy.sign(sintu),
-            1.0,
+            detau,
         )
         pu = pAr * gA * sru * detau / (0.5 * (umax - umin))
         comp = numpy.empty((3, len(thetaAr)))
@@ -1789,7 +1792,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         srv = numpy.where(
             numpy.fabs(sintv) > 1e-12,
             sinetav / numpy.maximum(numpy.fabs(sintv), 1e-12) * numpy.sign(sintv),
-            1.0,
+            detav,
         )
         gth = 0.5 * numpy.pi - thmin
         pv = pAthv * gth * srv * detav / (0.5 * (numpy.pi - 2.0 * vmin))

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -920,7 +920,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         Dm = 2.0 * numpy.mean((eta - tau)[:, None] * smat, axis=0)
         return Dm
 
-    def _tau_of_eta(self, eta, Dm):
+    def _tau_of_eta(self, eta, Dm, where=""):
         """Invert the stored anomaly map (monotone) for tau"""
         ms = self._nforDm
         x = numpy.array(eta, dtype="float")
@@ -953,6 +953,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                     "and the map anomaly or its coefficients are not finite: "
                     f"{badDm} of {Dm.size} coefficients and {badeta} of "
                     f"{eta.size} anomalies are non-finite"
+                    + (f" ({where})" if where else "")
                 )
             if numpy.sum(ms * numpy.fabs(Dm)) >= 1.0:
                 # sum_m m |D_m| >= 1 admits d eta / d tau <= 0: the map may
@@ -1268,7 +1269,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         sineta = numpy.sign(vrA) * numpy.sqrt(numpy.clip(1.0 - coseta**2, 0.0, None))
         etau = numpy.arctan2(sineta, coseta) % (2.0 * numpy.pi)
         if Du >= 1e-10:
-            tuu = self._tau_of_eta(etau, Dmu)
+            tuu = self._tau_of_eta(etau, Dmu, where="etau")
             u = umin + Du * numpy.sin(tuu / 2.0) ** 2
             gA = a * e * (y + self._bc / a) / numpy.sqrt(y * (y + 2.0 * self._bc / a))
             ms = self._nforDm
@@ -1293,7 +1294,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 numpy.clip(1.0 - cosetav**2, 0.0, None)
             )
             etav = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
-            tvv = self._tau_of_eta(etav, Dmv)
+            tvv = self._tau_of_eta(etav, Dmv, where="etav")
             v = vmin + Dv * numpy.sin(tvv / 2.0) ** 2
             detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
             sintv = numpy.sin(tvv)
@@ -1719,7 +1720,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         )
         # u-degree at the current phases
         eta_u, rA, pAr = self._canon_toy_radial(jr, LA, thetaAr)
-        tuu = self._tau_of_eta(eta_u, Dmu)
+        tuu = self._tau_of_eta(eta_u, Dmu, where="eta_u")
         ms = self._nforDm
         s = numpy.sqrt(bb**2 + rA**2)
         y = (s - bb) / a
@@ -1768,7 +1769,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             numpy.clip(1.0 - cosetav**2, 0.0, None)
         )
         eta_v = numpy.arctan2(sinetav, cosetav) % (2.0 * numpy.pi)
-        tvv = self._tau_of_eta(eta_v, Dmv)
+        tvv = self._tau_of_eta(eta_v, Dmv, where="eta_v")
         smat_v = numpy.sin(tvv[:, None] * ms[None, :])
         detav = 1.0 + numpy.cos(tvv[:, None] * ms[None, :]) @ (ms * Dmv)
         sintv = numpy.sin(tvv)

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -856,6 +856,12 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         CA = 0.5 * (L + numpy.sqrt(L**2 + 4.0 * self._GMc * self._bc))
         return -(self._GMc**2) / (2.0 * (Jr + CA) ** 2)
 
+    def _toy_ae(self, JAr, LA):
+        """Semi-major axis and eccentricity of the toy torus (J^A_r, L^A)"""
+        H = self._iso_E_of_Jr(JAr, LA)
+        a = -self._GMc / 2.0 / H - self._bc
+        return a, numpy.sqrt(numpy.clip(1.0 + LA**2 / (2.0 * H * a**2), 0.0, None))
+
     def _toy_r_profile(self, a, e, eta):
         """Toy radial loop: radius, momentum, dr/deta at anomaly eta"""
         b = self._bc
@@ -1762,3 +1768,206 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # frequencies: the stored energy table's own derivative chains
         OmR, Omphi, Omz = dq[2]
         return (Rt, vRt, vTt, zt, vzt, phit, OmR, Omphi, Omz)
+
+    ################## ANALYTIC d/dJ OF THE STORED QUANTITIES #################
+    # STAECKEL_CANONICAL_MATH.md section 10.7. The family reconstructs angles
+    # by differentiating stored map data, so those derivatives must be known
+    # analytically rather than inferred from the interpolant: supports by the
+    # implicit function theorem on W=0, anomaly maps by differentiating the
+    # action-matching condition at fixed tau.
+    def _canon_dsup_dJ(self, ii):
+        """d(umin, umax, vmin)/d(J_R, J_phi, J_z), analytic"""
+        E, Lz = self._Es[ii], self._Lzs[ii]
+        d2 = self._delta**2.0
+        out = numpy.empty((3, 3))
+        for row, (q, isu) in enumerate(
+            ((self._umins[ii], True), (self._umaxs[ii], True), (self._vmins[ii], False))
+        ):
+            if isu:
+                dWdq = self._dWu(numpy.array([q]), E, Lz)[0]
+                dWda = numpy.array(
+                    [
+                        2.0 * d2 * numpy.sinh(q) ** 2.0,
+                        -2.0 * d2,
+                        -2.0 * Lz / numpy.sinh(q) ** 2.0,
+                    ]
+                )
+            else:
+                dWdq = self._dWv(numpy.array([q]), E, Lz)[0]
+                dWda = numpy.array(
+                    [
+                        2.0 * d2 * numpy.sin(q) ** 2.0,
+                        +2.0 * d2,
+                        -2.0 * Lz / numpy.sin(q) ** 2.0,
+                    ]
+                )
+            out[row] = -dWda / dWdq
+        # d(E,I3,Lz)/d(J_R,J_z,J_phi) -> columns reordered to (J_R,J_phi,J_z)
+        return out @ self._dEI3Lz_dJ[ii][:, [0, 2, 1]], self._dEI3Lz_dJ[ii][
+            :, [0, 2, 1]
+        ]
+
+    def _toy_gu_partials(self, eta, a, e):
+        """The toy radial action integrand g = p^A_r dr^A/deta and its
+        (a, e) partials, in closed form"""
+        b = self._bc
+        c, s = numpy.cos(eta), numpy.sin(eta)
+        y = 1.0 - e * c
+        w = y + 2.0 * b / a
+        P = y + b / a
+        Q = y * w
+        K = numpy.sqrt(self._GMc / (a + b))
+        g = K * a * e**2 * s**2 * P / Q
+        # d/de at fixed eta: y_e = w_e = P_e = -c, Q_e = -c (w + y)
+        Qe = -c * (w + y)
+        dg_de = K * a * s**2 * (2.0 * e * P / Q + e**2 * (-c * Q - P * Qe) / Q**2)
+        # d/da at fixed eta
+        Ka = -0.5 * numpy.sqrt(self._GMc) * (a + b) ** -1.5
+        Pa = -b / a**2
+        Qa = y * (-2.0 * b / a**2)
+        dg_da = (
+            Ka * a * e**2 * s**2 * P / Q
+            + K * e**2 * s**2 * P / Q
+            + K * a * e**2 * s**2 * (Pa * Q - P * Qa) / Q**2
+        )
+        return g, dg_da, dg_de
+
+    def _toy_gv_partials(self, eta, LA, Lz):
+        """The toy vertical action integrand and its (L^A, L_z) partials"""
+        m = numpy.clip(numpy.fabs(Lz) / LA, 0.0, 1.0 - 1e-15)
+        thmin = numpy.arcsin(m)
+        gth = 0.5 * numpy.pi - thmin
+        c, s = numpy.cos(eta), numpy.sin(eta)
+        th = 0.5 * numpy.pi - gth * c
+        sth = numpy.sin(th)
+        pth2 = numpy.clip(LA**2 - Lz**2 / sth**2, 1e-300, None)
+        g = numpy.sqrt(pth2) * gth * numpy.fabs(s)
+        rt = 1.0 / numpy.sqrt(numpy.clip(1.0 - m**2, 1e-300, None))
+        dthmin_dLA = rt * (-numpy.fabs(Lz) / LA**2)
+        dthmin_dLz = rt * (numpy.sign(Lz) / LA)
+        out = []
+        for dthmin, dpth2_expl in (
+            (dthmin_dLA, 2.0 * LA),
+            (dthmin_dLz, -2.0 * Lz / sth**2),
+        ):
+            dgth = -dthmin
+            dth = -c * dgth
+            dpth2 = dpth2_expl + 2.0 * Lz**2 * numpy.cos(th) / sth**3 * dth
+            out.append(
+                dpth2 / (2.0 * numpy.sqrt(pth2)) * gth * numpy.fabs(s)
+                + numpy.sqrt(pth2) * dgth * numpy.fabs(s)
+            )
+        return g, out[0], out[1]
+
+    def _canon_dDm_dJ(self, ii, dsupJ, Malpha):
+        """d(D^u_m, D^v_m)/dJ by differentiating the action-matching condition
+        A^A(eta) = A_t(tau) at fixed tau. The denominator p^A dq^A/deta
+        vanishes at both turning points, so rather than dividing we expand
+        deta/dJ|_tau = sum_m x_m sin(m tau) -- exact by construction -- and
+        solve the resulting Galerkin system, which never divides."""
+        N = self._ncanon
+        tau = 2.0 * numpy.pi * (numpy.arange(N) + 0.5) / N
+        kk = numpy.fft.fftfreq(N, d=1.0 / N)
+        E, Lz, I3 = self._Es[ii], self._Lzs[ii], self._I3s[ii]
+        d2 = self._delta**2.0
+        ms = self._nforDm
+
+        def antider(f):
+            fh = numpy.fft.fft(f - numpy.mean(f))
+            ah = numpy.zeros_like(fh)
+            ah[1:] = fh[1:] / (1j * kk[1:])
+            return numpy.real(numpy.fft.ifft(ah))
+
+        def solve(gA, num):
+            MM = N // 2 - 1
+            mall = numpy.arange(1, MM + 1)
+            S = numpy.sin(tau[:, None] * mall[None, :])
+            return numpy.linalg.solve((S * gA[:, None]).T @ S / N, S.T @ num / N)[
+                : self._npt
+            ]
+
+        # ---- u-degree
+        umin, umax = self._umins[ii], self._umaxs[ii]
+        u = umin + (umax - umin) * numpy.sin(tau / 2.0) ** 2
+        dudtau = 0.5 * (umax - umin) * numpy.sin(tau)
+        # p_u is SIGNED (negative on the return branch), so that the loop mean
+        # of p_u du/dtau is the action; with |p_u| it would vanish identically
+        sgn = numpy.where(tau < numpy.pi, 1.0, -1.0)
+        pu = sgn * numpy.sqrt(numpy.clip(self._Wu(u, E, Lz, I3), 1e-300, None))
+        dWdalpha = numpy.stack(
+            (
+                2.0 * d2 * numpy.sinh(u) ** 2.0,
+                -2.0 * d2 * numpy.ones_like(u),
+                -2.0 * Lz / numpy.sinh(u) ** 2.0,
+            )
+        )
+        dW_dJ = numpy.einsum("an,ak->nk", dWdalpha, Malpha)
+        du_dJ = (numpy.cos(tau / 2.0) ** 2)[:, None] * dsupJ[0] + (
+            numpy.sin(tau / 2.0) ** 2
+        )[:, None] * dsupJ[1]
+        dgt = (self._dWu(u, E, Lz)[:, None] * du_dJ + dW_dJ) / (
+            2.0 * pu[:, None]
+        ) * dudtau[:, None] + pu[:, None] * (0.5 * numpy.sin(tau))[:, None] * (
+            dsupJ[1] - dsupJ[0]
+        )
+        jr, jz = self._jr[ii], self._jz[ii]
+        LA = jz + numpy.fabs(Lz)
+        a, e = self._toy_ae(jr, LA)
+        dLA = numpy.array([0.0, numpy.sign(Lz), 1.0])
+        sq = numpy.sqrt(LA**2 + 4.0 * self._bc * self._GMc)
+        EA = self._iso_E_of_Jr(jr, LA)
+        dEA = (
+            self._GMc**2
+            / (jr + 0.5 * (LA + sq)) ** 3
+            * (numpy.array([1.0, 0.0, 0.0]) + 0.5 * (1.0 + LA / sq) * dLA)
+        )
+        da = self._GMc / (2.0 * EA**2) * dEA
+        de = (
+            2.0 * LA * dLA / (2.0 * EA * a**2)
+            - LA**2 * (dEA * a + 2.0 * EA * da) / (2.0 * EA**2 * a**3)
+        ) / (2.0 * e)
+        smat = numpy.sin(tau[:, None] * ms[None, :])
+        cmat = numpy.cos(tau[:, None] * ms[None, :])
+        etau = tau + smat @ self._can_Dmu[ii]
+        detau = 1.0 + cmat @ (ms * self._can_Dmu[ii])
+        gu, dgu_da, dgu_de = self._toy_gu_partials(etau, a, e)
+        dgA = dgu_da[:, None] * da + dgu_de[:, None] * de
+        num_u = numpy.stack(
+            [antider(dgt[:, i]) - antider(dgA[:, i] * detau) for i in range(3)], axis=1
+        )
+        dDmu = solve(gu, num_u)
+        # ---- v-degree
+        vmin = self._vmins[ii]
+        Dv = numpy.pi - 2.0 * vmin
+        v = vmin + Dv * numpy.sin(tau / 2.0) ** 2
+        dvdtau = 0.5 * Dv * numpy.sin(tau)
+        pv = sgn * numpy.sqrt(numpy.clip(self._Wv(v, E, Lz, I3), 1e-300, None))
+        dWdalpha_v = numpy.stack(
+            (
+                2.0 * d2 * numpy.sin(v) ** 2.0,
+                +2.0 * d2 * numpy.ones_like(v),
+                -2.0 * Lz / numpy.sin(v) ** 2.0,
+            )
+        )
+        dWv_dJ = numpy.einsum("an,ak->nk", dWdalpha_v, Malpha)
+        dv_dJ = numpy.cos(tau)[:, None] * dsupJ[2]
+        dgtv = (self._dWv(v, E, Lz)[:, None] * dv_dJ + dWv_dJ) / (
+            2.0 * pv[:, None]
+        ) * dvdtau[:, None] + pv[:, None] * (-numpy.sin(tau))[:, None] * dsupJ[2]
+        etav = tau + smat @ self._can_Dmv[ii]
+        detav = 1.0 + cmat @ (ms * self._can_Dmv[ii])
+        gv, dgv_dLA, dgv_dLz = self._toy_gv_partials(etav, LA, Lz)
+        dLzv = numpy.array([0.0, 1.0, 0.0])
+        dgAv = dgv_dLA[:, None] * dLA + dgv_dLz[:, None] * dLzv
+        num_v = numpy.stack(
+            [antider(dgtv[:, i]) - antider(dgAv[:, i] * detav) for i in range(3)],
+            axis=1,
+        )
+        dDmv = solve(gv, num_v)
+        return dDmu, dDmv
+
+    def _canon_node_dJ(self, ii):
+        """Analytic d/dJ of every per-torus quantity the family stores"""
+        dsupJ, Malpha = self._canon_dsup_dJ(ii)
+        dDmu, dDmv = self._canon_dDm_dJ(ii, dsupJ, Malpha)
+        return dsupJ, dDmu, dDmv

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1685,8 +1685,23 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         comp = numpy.empty((3, len(thetaAr)))
         c2u = numpy.cos(tuu / 2.0) ** 2
         s2u = numpy.sin(tuu / 2.0) ** 2
-        udeg = (umax - umin) < 1e-10
-        vdeg = (0.5 * numpy.pi - thmin) < 1e-8 or (numpy.pi - 2.0 * vmin) < 1e-10
+        # Test degeneracy on the REQUESTED actions, not on the reconstructed
+        # supports.  An oscillation is degenerate exactly when its action
+        # vanishes, and the action is exact input, whereas umax - umin comes
+        # back as sqrt(K J) through the label inversion and so carries that
+        # inversion's residual: a torus asked for at J = 0 can reappear here
+        # with a half-width of ~1e-6, clearing a threshold on the support
+        # while the compensation's true sqrt(K/J)/2 divergence fires on what
+        # is really a degenerate torus.  Which side of such a threshold the
+        # noise lands on is platform-dependent, which is what made
+        # test_actionAngleStaeckelInverse_interp_degenerate_edges fail on
+        # Python 3.14 alone.  Keying on the action removes the ambiguity.
+        udeg = jr <= 0.0 or (umax - umin) < 1e-10
+        vdeg = (
+            (LA - numpy.fabs(Lz)) <= 0.0
+            or (0.5 * numpy.pi - thmin) < 1e-8
+            or (numpy.pi - 2.0 * vmin) < 1e-10
+        )
         # v-degree phases from the toy's own vertical geometry
         thetaAv, pAthv = self._canon_toy_vert(jr, LA, Lz, thetaAr, thetaAz, eta_u)
         cosetav = numpy.clip(

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8776,7 +8776,11 @@ def test_actionAngleStaeckelInverse_interp_by_integrals(
             "The integral and action entry points of the interpolated "
             "actionAngleStaeckelInverse disagree for %s (%g vs %g)" % (name, aa, bb)
         )
-    assert numpy.fabs(by_int[0] - ic[0]) <= numpy.fabs(by_act[0] - ic[0]), (
+    # the label Newton converges far below the interpolation error that now
+    # dominates both routes, so the inversion no longer costs anything
+    # measurable and neither route is systematically ahead; what must hold
+    # is that skipping it does not make the answer worse
+    assert numpy.fabs(by_int[0] - ic[0]) <= 2.0 * numpy.fabs(by_act[0] - ic[0]), (
         "The integral entry point, which requires no inversion, is less "
         "accurate than the action entry point"
     )
@@ -9834,4 +9838,48 @@ def test_actionAngleStaeckelInverse_canonical_node_derivatives():
             "The analytic d/dJ of the %s disagrees with finite differences: "
             "%g" % (name, numpy.max(numpy.fabs(ana - fd)))
         )
+    return None
+
+
+def test_actionAngleStaeckelInverse_canonical_family_degenerate_accuracy(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # Tori with a small action sit where the corresponding oscillation's
+    # half-width vanishes, and storing the turning points themselves loses
+    # that half-width to cancellation: umax and umin agree to every digit
+    # the grid resolves, so their difference is noise (50% wrong one cell
+    # from the shell edge, and with it the angles). Storing the midpoint and
+    # the squared half-width scaled by the action that drives it keeps these
+    # tori as accurate as the interior ones; without it every case below is
+    # an order of magnitude worse
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    Lz = float(aASI._Lzgrid[5] + 0.3 * (aASI._Lzgrid[6] - aASI._Lzgrid[5]))
+    angler = numpy.linspace(0.3, 6.0, 9)
+    for jr, jz in (
+        (0.002, 0.10),
+        (0.0005, 0.10),
+        (0.10, 0.002),
+        (0.10, 0.0005),
+        (0.005, 0.005),
+    ):
+        R, vR, vT, z, vz, phi = (
+            numpy.atleast_1d(q)
+            for q in aASI(jr, Lz, jz, angler, angler * 0.7, angler * 1.3)
+        )
+        oo = aAS.actionsFreqsAngles(R, vR, vT, z, vz, phi)
+        dR = numpy.fabs(
+            (numpy.atleast_1d(oo[6]) - angler + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+        )
+        dz = numpy.fabs(
+            (numpy.atleast_1d(oo[8]) - angler * 1.3 + numpy.pi) % (2.0 * numpy.pi)
+            - numpy.pi
+        )
+        assert numpy.max(numpy.maximum(dR, dz)) < 5e-3, (
+            "The canonical family's angles degrade at the near-degenerate "
+            "torus (J_R, J_z) = (%g, %g): %g"
+            % (jr, jz, numpy.max(numpy.maximum(dR, dz)))
+        )
+        ji = aAS(R, vR, vT, z, vz, phi)
+        assert numpy.max(numpy.fabs(ji[0] - jr)) < 2e-5
+        assert numpy.max(numpy.fabs(ji[2] - jz)) < 2e-5
     return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9565,9 +9565,31 @@ def test_actionAngleStaeckelInverse_canonical_errors():
     maxiter = aac._maxiter
     try:
         aac._maxiter = 0
+        # A monotone map is still inverted, by bracketing, when Newton is
+        # not allowed to run at all: sum_m m |D_m| < 1 makes eta(tau)
+        # strictly increasing, so the root on [0, 2 pi] is unique.
+        Dm = aac._can_Dmu[0]
+        assert numpy.sum(numpy.arange(1, len(Dm) + 1) * numpy.fabs(Dm)) < 1.0
+        tau = aac._tau_of_eta(numpy.array([2.0]), Dm)
+        eta_back = tau + numpy.sum(
+            numpy.sin(tau[:, None] * numpy.arange(1, len(Dm) + 1)[None, :]) * Dm,
+            axis=1,
+        )
+        assert numpy.fabs(eta_back - 2.0)[0] < 1e-10
+        # A non-finite map would be bracketed against NaN, so that raises
         with pytest.raises(RuntimeError) as excinfo:
-            aac._tau_of_eta(numpy.array([2.0]), aac._can_Dmu[0])
+            aac._tau_of_eta(numpy.array([2.0]), numpy.nan * Dm)
+        assert "not finite" in str(excinfo.value)
+        with pytest.raises(RuntimeError) as excinfo:
+            aac._tau_of_eta(numpy.array([numpy.nan]), Dm)
+        assert "not finite" in str(excinfo.value)
+        # A folded map has no unique root, so that still raises
+        folded = numpy.zeros_like(Dm)
+        folded[0] = 1.0
+        with pytest.raises(RuntimeError) as excinfo:
+            aac._tau_of_eta(numpy.array([2.0]), folded)
         assert "map anomaly" in str(excinfo.value)
+        assert "not monotone" in str(excinfo.value)
         with pytest.raises(RuntimeError) as excinfo:
             aac._canonical_torus_tables(0)
         assert "did not converge" in str(excinfo.value)

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9546,9 +9546,6 @@ def test_actionAngleStaeckelInverse_canonical_errors():
             npt=99,
         )
     assert "npt" in str(excinfo.value)
-    with pytest.raises(NotImplementedError) as excinfo:
-        actionAngleStaeckelInverse(pot=kk, canonical=True, setup_interp=True)
-    assert "T2" in str(excinfo.value)
     # the Newton else-raises via maxiter=0 (white-box)
     maxiter = aac._maxiter
     try:

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8578,7 +8578,10 @@ def test_actionAngleStaeckelInverse_interp_roundtrip(
             for q in aASI(jr, jphi, jz, angles[0], angles[1], angles[2])
         ]
         for got, want, name in zip(Rvv[:5], ic[:5], ("R", "vR", "vT", "z", "vz")):
-            assert numpy.fabs(got - want) < 1e-4, (
+            # the canonical family's honest interpolation error at this
+            # grid (the removed interpolated-direct path was ~2x tighter
+            # here at the price of a symplectic defect at 1e-3)
+            assert numpy.fabs(got - want) < 4e-4, (
                 "Interpolated actionAngleStaeckelInverse does not invert the "
                 "forward transformation for %s (%g vs %g)" % (name, got, want)
             )
@@ -8625,11 +8628,28 @@ def test_actionAngleStaeckelInverse_interp_convergence_and_freqs(
         (float(numpy.atleast_1d(out[ii])[0]) for ii in (3, 4, 5)),
         ("Omega_R", "Omega_phi", "Omega_z"),
     ):
-        assert numpy.fabs(got / want - 1.0) < 1e-5, (
+        # the frequencies are the stored energy table's own derivative
+        # chains (the integrator contract: exactly consistent with the
+        # family), and match the true frequencies to the chain accuracy
+        assert numpy.fabs(got / want - 1.0) < 5e-4, (
             "Interpolated actionAngleStaeckelInverse frequency %s does not "
             "agree with the forward code (%g vs %g)" % (name, got, want)
         )
     return None
+
+
+def _canon_integral_labels(aASI, jr, jphi, jz):
+    # the (E, I3) labels of an interpolated canonical torus, from the same
+    # closed rectified relations the integrals entry point inverts
+    import numpy
+
+    x = aASI._canon_coords(jr, jphi, jz)
+    E = float(aASI._canon_table_eval(numpy.atleast_2d(x))[2, 0])
+    wI = x[2] / (aASI._nI3 - 1)
+    Ipl = aASI._I3_planar(E, jphi)
+    Ish = aASI._I3_shell(E, jphi)
+    I3 = Ipl + numpy.sin(numpy.pi * wI / 2.0) ** 2 * (Ish - Ipl)
+    return E, I3
 
 
 def test_actionAngleStaeckelInverse_interp_integrals_by_name(
@@ -8641,13 +8661,12 @@ def test_actionAngleStaeckelInverse_interp_integrals_by_name(
     aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
     jr, jphi, jz = 0.06, 0.9, 0.03
     angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
-    idx = aASI._coords_from_actions(jr, jphi, jz)
-    aASI._interp_Lz = jphi
-    scal, _ = aASI._interp_torus(idx)
-    E, I3 = float(scal[6]), float(scal[7])
+    E, I3 = _canon_integral_labels(aASI, jr, jphi, jz)
     by_name = numpy.array(aASI(*angles, E=E, Lz=jphi, I3=I3))
     by_act = numpy.array(aASI(jr, jphi, jz, *angles))
-    assert numpy.all(numpy.fabs(by_name - by_act) < 1e-10), (
+    # exact at nodes; between nodes the closed rectification and the
+    # E-table's Lz-direction spline agree to spline error, not machine
+    assert numpy.all(numpy.fabs(by_name - by_act) < 1e-4), (
         "Labelling a torus by its integrals by name disagrees with labelling "
         "it by its actions"
     )
@@ -8657,7 +8676,7 @@ def test_actionAngleStaeckelInverse_interp_integrals_by_name(
             numpy.array(aASI.Freqs(E=E, Lz=jphi, I3=I3))
             - numpy.array(aASI.Freqs(jr, jphi, jz))
         )
-        < 1e-10
+        < 1e-4
     ), "Freqs by integral name disagrees with Freqs by actions"
     assert len(aASI.xvFreqs(*angles, E=E, Lz=jphi, I3=I3)) == 9, (
         "xvFreqs by integral name does not return the expected quantities"
@@ -8691,53 +8710,42 @@ def test_actionAngleStaeckelInverse_interp_outside_grid_message(
         "A too-energetic torus outside the grid does not report that it falls "
         "above the covered total action"
     )
-    # the direction of the oscillation can also fall outside the grid, when
-    # the planar and shell edges do not reach zeta = 0 and 1 at every column
-    zetamesh = aASI._zetamesh
-    try:
-        aASI._zetamesh = numpy.linspace(0.4, 0.6, len(zetamesh))
-        with pytest.raises(ValueError) as excinfo:
-            aASI(0.06, 0.9, 0.03, *angles)
-        assert "J_z/(J_R+J_z)" in str(excinfo.value), (
-            "A torus outside the covered range of oscillation directions does "
-            "not report which ratio of actions it has"
-        )
-    finally:
-        aASI._zetamesh = zetamesh
+    # (the canonical grid covers the full oscillation-direction range,
+    # so the third directional case of the old grid no longer exists)
+    return None
 
 
 def test_actionAngleStaeckelInverse_interp_integrals_roundtrip(
     setup_actionAngleStaeckelInverse_interpolated,
 ):
     # Reading the integrals off an interpolated torus and asking for that
-    # torus back has to be the identity: the interpolated torus takes E and
-    # I3 from the same grid relations that _grid_coords inverts, so the two
-    # directions are exact inverses rather than agreeing to interpolation
-    # error. Were E interpolated as a stored profile instead, the energy of
-    # the torus returned here would miss the requested one by ~1e-6.
+    # torus back has to return the same grid point: both directions go
+    # through the same closed rectified relations. The energy along the
+    # returned torus matches the label to the family's interpolation error
+    # (machine-exact H was the removed interpolated-direct path's virtue,
+    # bought with contingent canonicity; the canonical family trades it
+    # for a symplectic defect at the finite-difference floor)
     from galpy.potential import evaluatePotentials
 
     aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
     for jr, jphi, jz in [(0.06, 0.9, 0.03), (0.12, 1.1, 0.08), (0.02, 0.8, 0.10)]:
-        idx = aASI._coords_from_actions(jr, jphi, jz)
-        aASI._interp_Lz = jphi
-        scal, _ = aASI._interp_torus(idx)
-        E, I3 = float(scal[6]), float(scal[7])
-        back = aASI._grid_coords(E, jphi, I3)
-        assert numpy.all(numpy.fabs(numpy.array(idx) - numpy.array(back)) < 1e-10), (
+        x = aASI._canon_coords(jr, jphi, jz)
+        E, I3 = _canon_integral_labels(aASI, jr, jphi, jz)
+        back = aASI._canon_coords_integrals(E, jphi, I3)
+        assert numpy.all(numpy.fabs(numpy.array(x) - numpy.array(back)) < 2e-4), (
             "Labelling an interpolated torus by its integrals and looking it "
             "back up does not return the same grid point"
         )
-        # ... and the torus really does have the energy it is labelled with
         angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
         R, vR, vT, z, vz, phi = aASI(E, jphi, I3, *angles, integrals=True)
         H = 0.5 * (vR**2.0 + vT**2.0 + vz**2.0) + evaluatePotentials(
             kkp, R, z, use_physical=False
         )
-        assert numpy.all(numpy.fabs(H - E) < 1e-12), (
+        assert numpy.all(numpy.fabs(H - E) < 1e-4), (
             "The interpolated torus requested by its integrals does not have "
-            "the requested energy"
+            "the requested energy within the interpolation error"
         )
+    return None
 
 
 def test_actionAngleStaeckelInverse_interp_by_integrals(
@@ -8777,7 +8785,7 @@ def test_actionAngleStaeckelInverse_interp_by_integrals(
     for got, want in zip(
         freqs, (float(numpy.atleast_1d(out[ii])[0]) for ii in (3, 4, 5))
     ):
-        assert numpy.fabs(got / want - 1.0) < 1e-5, (
+        assert numpy.fabs(got / want - 1.0) < 5e-4, (
             "Interpolated frequencies by integrals disagree with the forward code"
         )
     # two consecutive evaluations of one torus: the second hits the cache
@@ -8841,7 +8849,10 @@ def test_actionAngleStaeckelInverse_interp_degenerate_edges(
     )
     assert numpy.amax(numpy.fabs(vz)) < 1e-12, "A J_z = 0 torus has vertical motion"
     H = 0.5 * (vR**2.0 + vz**2.0 + vT**2.0) + evaluatePotentials(kkp, R, z)
-    assert numpy.std(H) / numpy.fabs(numpy.mean(H)) < 1e-12, (
+    # the canonical family's H-constancy is its interpolation error
+    # (machine-constant H was the removed path's p = sqrt(W) virtue,
+    # bought with contingent canonicity)
+    assert numpy.std(H) / numpy.fabs(numpy.mean(H)) < 1e-4, (
         "The Hamiltonian is not constant along an interpolated J_z = 0 torus"
     )
     # J_R = 0: a shell orbit, confined to a spheroid of constant u
@@ -8853,7 +8864,7 @@ def test_actionAngleStaeckelInverse_interp_degenerate_edges(
         "A J_R = 0 torus is not confined to a spheroid of constant u"
     )
     H = 0.5 * (vR**2.0 + vz**2.0 + vT**2.0) + evaluatePotentials(kkp, R, z)
-    assert numpy.std(H) / numpy.fabs(numpy.mean(H)) < 1e-12, (
+    assert numpy.std(H) / numpy.fabs(numpy.mean(H)) < 1e-4, (
         "The Hamiltonian is not constant along an interpolated J_R = 0 torus"
     )
     return None
@@ -9579,4 +9590,181 @@ def test_actionAngleStaeckelInverse_canonical_errors():
     finally:
         aac._aAIc = aAIc
         aac._canonical_torus_tables(0)
+    return None
+
+
+def _staeckel_symplectic_defect(xvmapper, jr, jphi, jz, ar, ap, az, h=1e-6):
+    # max |A^T Omega A - Omega| of the 6x6 Jacobian of
+    # (theta, J) -> (q, p) with q = (R, z, phi), p = (v_R, v_z, R v_T)
+    def xp(args):
+        R, vR, vT, z, vz, phi = xvmapper(*args)[:6]
+        return numpy.array([R[0], z[0], phi[0], vR[0], vz[0], R[0] * vT[0]])
+
+    x0 = numpy.array([jr, jphi, jz, ar, ap, az], dtype="float")
+    idx = [3, 4, 5, 0, 1, 2]
+    A = numpy.empty((6, 6))
+    for col, ii in enumerate(idx):
+        xps = x0.copy()
+        xps[ii] += h
+        xms = x0.copy()
+        xms[ii] -= h
+        A[:, col] = (xp(xps) - xp(xms)) / (2.0 * h)
+    Om = numpy.zeros((6, 6))
+    Om[:3, 3:] = numpy.eye(3)
+    Om[3:, :3] = -numpy.eye(3)
+    return numpy.max(numpy.fabs(A.T @ Om @ A - Om))
+
+
+def test_actionAngleStaeckelInverse_canonical_family_defect(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # the assembled interpolated (J, theta) -> (x, v) map is symplectic at
+    # the finite-difference floor, calibrated by the analytic isochrone
+    # inverse through the same harness -- for ANY stored tables (the
+    # manifest test injects noise into all of them and re-checks)
+    from galpy.actionAngle import actionAngleIsochroneInverse
+    from galpy.potential import IsochronePotential
+
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    ctl = actionAngleIsochroneInverse(ip=IsochronePotential(amp=aASI._GMc, b=aASI._bc))
+    floor = max(
+        _staeckel_symplectic_defect(ctl._xvFreqs, 0.1, 0.6, 0.1, ar, 1.0, 2.0)
+        for ar in (0.7, 2.0, 4.5)
+    )
+    assert floor < 3e-8
+    Lz = float(aASI._Lzgrid[5] + 0.3 * (aASI._Lzgrid[6] - aASI._Lzgrid[5]))
+    for jr, jz in ((0.03, 0.05), (0.06, 0.10), (0.10, 0.03)):
+        for ar in (0.7, 2.0, 4.5):
+            defect = _staeckel_symplectic_defect(
+                aASI._xvFreqs, jr, Lz, jz, ar, 1.0, 2.0
+            )
+            assert defect < 3e-8, (
+                "The canonical Staeckel family's symplectic defect is not at "
+                "the finite-difference floor: %g at (jr, jz, ar) = "
+                "(%g, %g, %g)" % (defect, jr, jz, ar)
+            )
+    return None
+
+
+def test_actionAngleStaeckelInverse_canonical_family_manifest():
+    # canonicity is manifest: noise in every stored table moves the
+    # evaluation but leaves the defect at the floor; a fresh instance,
+    # because its tables get ruined
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    aASI = actionAngleStaeckelInverse(
+        pot=kkp,
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=6,
+        nE=6,
+        nI3=6,
+    )
+    Lz = float(aASI._Lzgrid[3])
+    args = (0.06, Lz, 0.10, numpy.array([2.0]), numpy.array([1.0]), numpy.array([2.0]))
+    x0 = numpy.array(aASI._xvFreqs(*args)[:6]).flatten()
+    rng = numpy.random.default_rng(11)
+    aASI._canon_tab_raw *= 1.0 + 1e-5 * rng.standard_normal(aASI._canon_tab_raw.shape)
+    aASI._rebuild_canon_interp()
+    x1 = numpy.array(aASI._xvFreqs(*args)[:6]).flatten()
+    moved = numpy.max(numpy.fabs(x1 - x0))
+    assert moved > 1e-7, (
+        "The injected table noise did not reach the evaluation (moved %g)" % moved
+    )
+    defect = _staeckel_symplectic_defect(aASI._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0)
+    assert defect < 3e-8, (
+        "The symplectic defect is not invariant under stored-table noise: %g" % defect
+    )
+    return None
+
+
+def test_actionAngleStaeckelInverse_canonical_family_warning():
+    # an under-resolved anomaly map is reported with actionable advice
+    import warnings as warnings_module
+
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+    from galpy.util import galpyWarning
+
+    kkp = KuzminKutuzovStaeckelPotential(normalize=1.0, ac=3.0, Delta=1.25)
+    with warnings_module.catch_warnings(record=True) as w:
+        warnings_module.simplefilter("always")
+        actionAngleStaeckelInverse(
+            pot=kkp,
+            setup_interp=True,
+            Rmin=0.5,
+            Rmax=1.5,
+            Rinf=6.0,
+            nLz=4,
+            nE=4,
+            nI3=4,
+            ncanon=128,
+            npt=12,
+        )
+        assert any(
+            issubclass(ww.category, galpyWarning)
+            and "under-resolved" in str(ww.message)
+            for ww in w
+        ), "An under-resolved family does not warn with actionable advice"
+    return None
+
+
+def test_actionAngleStaeckelInverse_canonical_family_guards(
+    setup_actionAngleStaeckelInverse_interpolated,
+):
+    # the remaining defensive raises, fired for real: the toy-anomaly and
+    # family-Newton non-convergence (white-box via maxiter/comp sabotage),
+    # the interior label-match failure, and the above-grid energy
+    aASI, aAS, kkp = setup_actionAngleStaeckelInverse_interpolated
+    Lz = float(aASI._Lzgrid[5])
+    maxiter = aASI._maxiter
+    try:
+        aASI._maxiter = 0
+        with pytest.raises(RuntimeError) as excinfo:
+            aASI._canon_toy_radial(0.06, 0.5, numpy.array([2.0]))
+        assert "eccentric anomaly" in str(excinfo.value)
+        with pytest.raises(ValueError) as excinfo:
+            # an interior pair that the crippled label Newton cannot match:
+            # inside the covered total-action band, so neither directional
+            # diagnosis applies
+            aASI._canon_coords(0.06, Lz, 0.10)
+        assert "could not be matched" in str(excinfo.value)
+    finally:
+        aASI._maxiter = maxiter
+    comp = aASI._canon_comp
+    try:
+        # a non-contractive sabotage: the fixed-point iteration cannot
+        # converge when the compensation grows with the angle
+        aASI._canon_comp = lambda tr, tz, jr, LA, Lzz, v, dq: (
+            2.0 * tr,
+            2.0 * tr,
+            2.0 * tz,
+        )
+        with pytest.raises(RuntimeError) as excinfo:
+            aASI._xvFreqs_canonical_interp(
+                0.06,
+                Lz,
+                0.10,
+                numpy.array([2.0]),
+                numpy.array([1.0]),
+                numpy.array([2.0]),
+            )
+        assert "toy angles" in str(excinfo.value)
+    finally:
+        aASI._canon_comp = comp
+    # E above the grid through the integrals entry point
+    E, I3 = _canon_integral_labels(aASI, 0.06, Lz, 0.10)
+    with pytest.raises(ValueError) as excinfo:
+        aASI.Freqs(100.0, Lz, I3, integrals=True)
+    assert "above the energies" in str(excinfo.value)
+    # and the constructor's pot guard
+    from galpy.actionAngle import actionAngleStaeckelInverse
+
+    with pytest.raises(OSError) as excinfo:
+        actionAngleStaeckelInverse()
+    assert "Must specify pot=" in str(excinfo.value)
     return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9768,3 +9768,70 @@ def test_actionAngleStaeckelInverse_canonical_family_guards(
         actionAngleStaeckelInverse()
     assert "Must specify pot=" in str(excinfo.value)
     return None
+
+
+def test_actionAngleStaeckelInverse_canonical_node_derivatives():
+    # the analytic d/dJ of every per-torus quantity the family stores --
+    # the two u turning points, the v turning point, and both anomaly-map
+    # degrees -- against finite differences of independently constructed
+    # neighbouring tori. The toy is held fixed, as it is across the family
+    # grid, so these are the derivatives the interpolation must reproduce
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        actionAngleStaeckelInverse,
+    )
+
+    kk, aac, _ = _staeckel_canonical_setup()
+    ii = 0
+    p0 = [aac._Es[ii], aac._Lzs[ii], aac._I3s[ii]]
+
+    def build(E, Lz, I3):
+        # a single-torus instance forced onto the family's toy
+        one = actionAngleStaeckelInverse(
+            pot=kk,
+            Es=[E],
+            Lzs=[Lz],
+            I3s=[I3],
+            canonical=True,
+            ncanon=aac._ncanon,
+            npt=aac._npt,
+        )
+        one._GMc, one._bc = aac._GMc, aac._bc
+        one._aAIc, one._aAIinvc = aac._aAIc, aac._aAIinvc
+        one._canonical_torus_tables(0)
+        return one
+
+    dsupJ, dDmu, dDmv = aac._canon_node_dJ(ii)
+    hs = [1e-5 * numpy.fabs(pp) for pp in p0]
+    fsup = numpy.empty((3, 3))
+    fu = numpy.empty((aac._npt, 3))
+    fv = numpy.empty((aac._npt, 3))
+    dJdalpha = numpy.empty((3, 3))
+    for kk_ in range(3):
+        pp, pm = list(p0), list(p0)
+        pp[kk_] += hs[kk_]
+        pm[kk_] -= hs[kk_]
+        ap, am = build(*pp), build(*pm)
+        fsup[:, kk_] = [
+            (ap._umins[0] - am._umins[0]) / (2.0 * hs[kk_]),
+            (ap._umaxs[0] - am._umaxs[0]) / (2.0 * hs[kk_]),
+            (ap._vmins[0] - am._vmins[0]) / (2.0 * hs[kk_]),
+        ]
+        fu[:, kk_] = (ap._can_Dmu[0] - am._can_Dmu[0]) / (2.0 * hs[kk_])
+        fv[:, kk_] = (ap._can_Dmv[0] - am._can_Dmv[0]) / (2.0 * hs[kk_])
+        dJdalpha[:, kk_] = [
+            (ap._jr[0] - am._jr[0]) / (2.0 * hs[kk_]),
+            (pp[1] - pm[1]) / (2.0 * hs[kk_]),
+            (ap._jz[0] - am._jz[0]) / (2.0 * hs[kk_]),
+        ]
+    # the finite differences are d/d(E, Lz, I3); convert to d/dJ
+    dalphadJ = numpy.linalg.inv(dJdalpha)
+    for name, ana, fd in (
+        ("turning points", dsupJ, fsup @ dalphadJ),
+        ("u-degree anomaly map", dDmu, fu @ dalphadJ),
+        ("v-degree anomaly map", dDmv, fv @ dalphadJ),
+    ):
+        assert numpy.max(numpy.fabs(ana - fd)) < 1e-7, (
+            "The analytic d/dJ of the %s disagrees with finite differences: "
+            "%g" % (name, numpy.max(numpy.fabs(ana - fd)))
+        )
+    return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9763,12 +9763,15 @@ def test_actionAngleStaeckelInverse_canonical_family_guards(
         aASI._maxiter = maxiter
     comp = aASI._canon_comp
     try:
-        # a non-contractive sabotage: the fixed-point iteration cannot
-        # converge when the compensation grows with the angle
+        # A sabotage that under-relaxation CANNOT rescue.  The iteration's
+        # multiplier is 1 - omega (1 + c'), so any c' > -1 converges for
+        # small enough omega -- including c' = 2, which diverges undamped but
+        # is recovered at omega = 1/2.  Only c' < -1 is hopeless: here
+        # c' = -2 gives multiplier 1 + omega, above one for every omega.
         aASI._canon_comp = lambda tr, tz, jr, LA, Lzz, v, dq: (
-            2.0 * tr,
-            2.0 * tr,
-            2.0 * tz,
+            -2.0 * tr,
+            -2.0 * tr,
+            -2.0 * tz,
         )
         with pytest.raises(RuntimeError) as excinfo:
             aASI._xvFreqs_canonical_interp(
@@ -9780,6 +9783,25 @@ def test_actionAngleStaeckelInverse_canonical_family_guards(
                 numpy.array([2.0]),
             )
         assert "toy angles" in str(excinfo.value)
+        # while c' = 2, which diverges at full step, is now recovered: this
+        # is the limit-cycle/divergence fix acting on the real evaluation
+        # path rather than on the isolated solver
+        aASI._canon_comp = lambda tr, tz, jr, LA, Lzz, v, dq: (
+            2.0 * tr,
+            2.0 * tr,
+            2.0 * tz,
+        )
+        out = aASI._xvFreqs_canonical_interp(
+            0.06,
+            Lz,
+            0.10,
+            numpy.array([2.0]),
+            numpy.array([1.0]),
+            numpy.array([2.0]),
+        )
+        assert numpy.all(numpy.isfinite(numpy.asarray(out[0], dtype=float))), (
+            "The rescued solve did not produce a finite point"
+        )
     finally:
         aASI._canon_comp = comp
     # E above the grid through the integrals entry point
@@ -9904,4 +9926,59 @@ def test_actionAngleStaeckelInverse_canonical_family_degenerate_accuracy(
         ji = aAS(R, vR, vT, z, vz, phi)
         assert numpy.max(numpy.fabs(ji[0] - jr)) < 2e-5
         assert numpy.max(numpy.fabs(ji[2] - jz)) < 2e-5
+    return None
+
+
+def test_actionAngleStaeckelInverse_toy_angle_limit_cycle():
+    # The toy-angle solve is a damped Picard iteration, so its multiplier is
+    # -c'. On a torus where c' reaches 1 it does not diverge -- it CYCLES with
+    # period two, the residual flipping sign at constant amplitude, and the
+    # step limiter never engages because it only caps steps above 0.5. This
+    # was seen within ~5e-4 of the radial turning point during a long
+    # integration. Under-relaxation turns the multiplier into 1 - 2 omega and
+    # breaks the cycle.
+    import numpy
+
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        actionAngleStaeckelInverse,
+    )
+
+    class _Cycler:
+        # c(theta^A) = theta^A exactly, so theta^A + c = 2 theta^A and the
+        # undamped update has multiplier -1: the worst case, not merely a
+        # slow one
+        _maxiter = 60
+        _angle_tol = 1e-13
+
+        def _canon_comp(self, thetaAr, thetaAz, jr, LA, Lz, v, dq):
+            return thetaAr, numpy.zeros_like(thetaAr), thetaAz
+
+    thR = numpy.array([0.7, 2.0])
+    thz = numpy.array([1.3, 4.1])
+    tAr, tAz, cphi = actionAngleStaeckelInverse._toy_angle_solve(
+        _Cycler(), thR, thz, 0.02, 1.0, 0.9, None, None
+    )
+
+    # theta^A + theta^A = theta, and the residual is taken mod 2 pi, so any
+    # branch of it is a solution
+    def wrapped(a, b):
+        return numpy.amax(numpy.fabs((a - b + numpy.pi) % (2.0 * numpy.pi) - numpy.pi))
+
+    assert wrapped(2.0 * tAr, thR) < 1e-12, (
+        "The radial toy angle did not escape the limit cycle"
+    )
+    assert wrapped(2.0 * tAz, thz) < 1e-12, (
+        "The vertical toy angle did not escape the limit cycle"
+    )
+
+    # and a contracting problem is untouched: c' = 0 converges in one step
+    class _Easy(_Cycler):
+        def _canon_comp(self, thetaAr, thetaAz, jr, LA, Lz, v, dq):
+            z = numpy.zeros_like(thetaAr)
+            return z, z, z
+
+    tAr, tAz, _ = actionAngleStaeckelInverse._toy_angle_solve(
+        _Easy(), thR, thz, 0.02, 1.0, 0.9, None, None
+    )
+    assert wrapped(tAr, thR) < 1e-13, "A contracting solve was disturbed"
     return None

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -14036,10 +14036,14 @@ def test_actionAngleStaeckelInverse_integrals_inputAsQuantity():
         vo=vo,
     )
     jr, jphi, jz = 0.06, 0.9, 0.03
-    idx = aA._coords_from_actions(jr, jphi, jz)
-    aA._interp_Lz = jphi
-    scal, _ = aA._interp_torus(idx)
-    E, I3 = float(scal[6]), float(scal[7])
+    # the (E, I3) labels of this torus, through the same closed rectified
+    # relations the canonical family's integrals entry point inverts
+    x = aA._canon_coords(jr, jphi, jz)
+    E = float(aA._canon_table_eval(numpy.atleast_2d(x))[2, 0])
+    wI = x[2] / (aA._nI3 - 1)
+    Ipl = aA._I3_planar(E, jphi)
+    Ish = aA._I3_shell(E, jphi)
+    I3 = float(Ipl + numpy.sin(numpy.pi * wI / 2.0) ** 2 * (Ish - Ipl))
     angles = [numpy.array([0.3, 2.7]) for _ in range(3)]
     with_units = numpy.array(
         aA(


### PR DESCRIPTION
**T2 of the Stage-3 canonical program** (stacked on #1395; `STAECKEL_CANONICAL_MATH.md` §10 per the fo#23 review decisions): the 3-D canonical family, its compensated evaluation, and the removal of the interpolated-direct machinery.

### The family (part 1)

The direct grid's rectified (L_z, w_E, w_I) node lattice; all node tori in one vectorized canonical construction; prefiltered 3-D tables (labels J_R/J_z, energy, supports, both anomaly-map sine series) evaluated by an explicit four-tap tensor stencil whose value/derivative weights make **every chain the stored tables' own derivative**. Implicit-inverse labels (Q10.1: grid in the integrals) round-trip at 1e-16.

### The compensated evaluation (part 2)

A 2-D angle Newton on the compensated θ-equations — one term per degree per action chain, p^A_d(∂q^A_d/∂J_i)|_τ − p_d(∂q_d/∂J_i)|_τ, flux-grouped so every factor is closed-form and regular at turning points; toy phases from the isochrone's own ψ/Λ relations; delegation to the analytic isochrone inverse; per-degree un-lift; frequencies = the E-table's own chains (the integrator contract).

**The M2 adjudication**: the harness initially said 3.5e-2, h-flat, concentrated in the {J_φ, J_z} bracket — while frozen-map mechanics, all table chains, all closed chains, and comp ≡ −Σp∂π/∂J each verified exactly. The tie-breaker was an FD adjudicator on the generating function itself (branch-aware W by quadrature), which exposed the single ported bug: the toy's vertical momentum missing its 1/sin ϑ factor (a latitude-vs-polar convention, 2.4%, self-consistently wrong in every test that used it on both sides). Fixed: **defect 5.2e-10 – 2.2e-9 across tori and angles, indistinguishable from the analytic control; invariant under 1e-5 noise in every stored table** (evaluation moves by 8.5e-5).

### The removal (part 3, per Q10.4) — with M5 recorded first

Same-budget comparison before deletion: round-trip accuracy comparable (~1e-5-grade both), **symplectic defect 3.7e-4–1.1e-3 (old) vs 1.8e-9 (canonical)**, ~3× per-point cost. Then: χ-profile storage, `_ProfileSet`, the ρ/ζ action lookup, and the batched path deleted (net −231 lines); `setup_interp=True` always builds the canonical family. **Preserved with less machinery**: `integrals=True` and by-name integral labels (the rectified coordinates are closed forms — no inversion at all), directional out-of-grid messages, and the degenerate edges, which now carry their analytic limits (shell u, midplane, vanishing anomaly maps) with guarded degenerate-degree evaluation — J_z = 0 and J_R = 0 evaluate cleanly.

**Contract change, recorded in the adapted tests**: machine-constant H along off-node tori was the removed path's p = √W virtue, bought with contingent canonicity; the canonical family's H-constancy is its (converging) interpolation error while its defect sits at the FD floor for any stored tables.

28 tests, 100% module coverage, no pragmas; the under-resolution warning gives actionable npt/ncanon advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
