### PR TITLE
actionAngleAdiabatic: fix multi-point _justjr raising TypeError

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabatic.py
+++ b/galpy/actionAngle/actionAngleAdiabatic.py
@@ -156,10 +156,18 @@ class actionAngleAdiabatic(actionAngle):
             else:
                 if kwargs.get("_justjr", False):
                     kwargs.pop("_justjr")
+                    # atleast_1d to match the _justjz and general returns below.
+                    # The len(R) > 1 branch above loops over points calling this
+                    # scalar branch and then does ojr[ii] = tjr[0], so returning
+                    # a bare float raised TypeError for ANY multi-point _justjr
+                    # call -- reachable from actionAngleAdiabaticGrid whenever
+                    # two or more points fall outside the grid with c=False.
                     return (
-                        self._aAS(R[0], vR[0], vT[0], 0.0, 0.0, _Jz=0.0)[0],
-                        numpy.nan,
-                        numpy.nan,
+                        numpy.atleast_1d(
+                            self._aAS(R[0], vR[0], vT[0], 0.0, 0.0, _Jz=0.0)[0]
+                        ),
+                        numpy.atleast_1d(numpy.nan),
+                        numpy.atleast_1d(numpy.nan),
                     )
                 # Set up the actionAngleVertical object
                 if _dim(self._pot) == 3:

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2190,6 +2190,36 @@ def test_actionAngleAdiabaticGrid_basic_actions_c():
 
 
 # actionAngleAdiabaticGrid actions outside the grid
+def test_actionAngleAdiabaticGrid_outsidegrid_multiple_python():
+    # The pure-Python (c=False) grid raised
+    #   TypeError: 'float' object is not subscriptable
+    # whenever TWO OR MORE points fell outside the grid: actionAngleAdiabatic's
+    # len(R) > 1 branch loops over points calling its own scalar branch and then
+    # does ojr[ii] = tjr[0], but the scalar _justjr return was a bare float
+    # while its _justjz and general siblings both wrapped in numpy.atleast_1d.
+    #
+    # One off-grid point never caught it (that call takes the scalar path and
+    # never reaches the loop), and the only other off-grid test uses c=True,
+    # which returns from the C branch before the loop -- so both arms of the
+    # existing coverage were blind to it.
+    from galpy.actionAngle import actionAngleAdiabatic, actionAngleAdiabaticGrid
+    from galpy.potential import MWPotential
+
+    aA = actionAngleAdiabatic(pot=MWPotential, c=False)
+    aAA = actionAngleAdiabaticGrid(pot=MWPotential, c=False, Rmax=2.0, zmax=0.2)
+    for n in (1, 2, 3):  # 1 is the case that always worked; 2+ is the bug
+        R = numpy.array([3.0 + 0.5 * ii for ii in range(n)])
+        o = numpy.ones(n)
+        js = aA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
+        jsa = aAA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
+        assert numpy.all(numpy.fabs(js[0] - jsa[0]) < 10.0**-8.0), (
+            f"actionAngleAdiabaticGrid c=False jr wrong for {n} off-grid points"
+        )
+        assert numpy.all(numpy.fabs(js[2] - jsa[2]) < 10.0**-8.0), (
+            f"actionAngleAdiabaticGrid c=False jz wrong for {n} off-grid points"
+        )
+
+
 def test_actionAngleAdiabaticGrid_outsidegrid_c():
     from galpy.actionAngle import actionAngleAdiabatic, actionAngleAdiabaticGrid
     from galpy.potential import MWPotential


### PR DESCRIPTION
### The bug

`actionAngleAdiabaticGrid(..., c=False)` raises

    TypeError: 'float' object is not subscriptable

whenever **two or more** points fall outside the grid:

    grid c=False, 1 off-grid: OK   jr=[0.01111263]
    grid c=False, 2 off-grid: TypeError
    grid c=True,  2 off-grid: OK   jr=[0.01111777 0.01111777]

### Cause

`actionAngleAdiabatic._evaluate`'s `len(R) > 1` branch loops over points,
calling its own scalar branch and then doing `ojr[ii] = tjr[0]`. The scalar
`_justjr` return is the one branch in that method that does **not** wrap its
result:

```python
_justjz -> (atleast_1d(nan), atleast_1d(nan), Jz)      # wrapped
else    -> (atleast_1d(axiJ[0]), ...)                  # wrapped
_justjr -> (self._aAS(...)[0], nan, nan)               # NOT wrapped
```

so subscripting the returned float raises. Fixed by wrapping in
`numpy.atleast_1d`, matching its two siblings.

### Why it was invisible

Both arms of the existing coverage are blind to it:

- **one** off-grid point takes the scalar path and never reaches the loop;
- the only existing off-grid test, `test_actionAngleAdiabaticGrid_outsidegrid_c`,
  uses `c=True`, which returns from the C branch before the loop.

The new test walks 1, 2 and 3 off-grid points — **1 is the control**, since that
count always worked.

### Gates

- **A/B:** the new test fails with `TypeError` at `actionAngleAdiabatic.py:153`
  without the change and passes with it.
- **Regression, whole `tests/test_actionAngle.py`, same machine:**

  | | result |
  |---|---|
  | pristine `origin/main` | 2 failed, 225 passed |
  | this branch | 2 failed, **226** passed |

  Identical failure set — `test_actionAngleAdiabatic_c_matches_python_quadrature`
  (already filed as gh#1354) and `test_actionAngleStaeckel_actions_c_convergence`
  both fail on pristine main here too, so they are pre-existing and local to this
  environment. The only delta is the one added passing test.

Found while porting the off-grid fallback to the jax/torch backends, which
reaches the same code path.