### PR TITLE
actionAngleAdiabaticGrid: exact off-grid actions on jax/torch

### DIFF
--- a/galpy/actionAngle/actionAngleAdiabatic.py
+++ b/galpy/actionAngle/actionAngleAdiabatic.py
@@ -250,10 +250,18 @@ class actionAngleAdiabatic(actionAngle):
             else:
                 if kwargs.get("_justjr", False):
                     kwargs.pop("_justjr")
+                    # atleast_1d to match the _justjz and general returns below.
+                    # The len(R) > 1 branch above loops over points calling this
+                    # scalar branch and then does ojr[ii] = tjr[0], so returning
+                    # a bare float raised TypeError for ANY multi-point _justjr
+                    # call -- reachable from actionAngleAdiabaticGrid whenever
+                    # two or more points fall outside the grid with c=False.
                     return (
-                        self._aAS(R[0], vR[0], vT[0], 0.0, 0.0, _Jz=0.0)[0],
-                        numpy.nan,
-                        numpy.nan,
+                        numpy.atleast_1d(
+                            self._aAS(R[0], vR[0], vT[0], 0.0, 0.0, _Jz=0.0)[0]
+                        ),
+                        numpy.atleast_1d(numpy.nan),
+                        numpy.atleast_1d(numpy.nan),
                     )
                 # Set up the actionAngleVertical object
                 if _dim(self._pot) == 3:

--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -734,6 +734,11 @@ class actionAngleAdiabaticGrid(actionAngle):
                 xp.zeros_like(R[m]),
                 xp.sqrt(2.0 * Ez[m]),
                 _justjz=True,
+                # c=False so use_c is False and _evaluate takes its BACKEND
+                # branch. Without it a c=True grid falls through to the C call
+                # with backend arrays, which raises NotImplementedError: the C
+                # extension cannot accept a jax/torch array at all.
+                c=False,
             )[2],
         )
         # Radial action
@@ -773,6 +778,7 @@ class actionAngleAdiabaticGrid(actionAngle):
                 xp.zeros_like(thisRL[m]),
                 xp.zeros_like(thisRL[m]),
                 _justjr=True,
+                c=False,  # see the _justjz call above
             )[0],
         )
         return (jr, R * vT, jz)

--- a/galpy/actionAngle/actionAngleAdiabaticGrid.py
+++ b/galpy/actionAngle/actionAngleAdiabaticGrid.py
@@ -21,7 +21,8 @@ from ..backend import (
     get_namespace,
 )
 from ..backend import interpolate as backend_interpolate
-from ..backend import promote_scalars, use
+from ..backend import promote_scalars, set_at, use
+from ..backend._namespaces import under_trace
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
     _evaluatePotentials,
@@ -669,10 +670,36 @@ class actionAngleAdiabaticGrid(actionAngle):
                 )[0][0]
         return (jr, R * vT, jz)
 
-    def _evaluate_backend(self, R, vR, vT, z, vz):
-        """Vectorised, differentiable on-grid action eval for jax/torch inputs.
+    def _offgrid_fill(self, xp, base, off, exact):
+        """``base`` with the off-grid entries replaced by an exact solve.
 
-        Assumes on-grid inputs (the off-grid fallback to self._aA is numpy-only).
+        Mirrors what the numpy path already does -- mask, ``sum(indx) > 0``
+        guard, scatter-assign -- in backend ops. EAGER can skip the solve
+        entirely when nothing is off-grid, which is the whole reason the cost is
+        acceptable: an exact ``self._aA`` call costs ~187 ms on torch and ~1.25 s
+        on jax BEFORE it touches a single point (measured), so paying it
+        unconditionally would make every call 14-77x slower than the grid it
+        exists to avoid.
+
+        Under a trace none of that is available: a boolean mask has no concrete
+        size, so the points cannot be gathered and the ``any`` cannot be
+        branched on. Returning the extrapolated interpolant there would be
+        silently wrong, so the off-grid entries come back NaN instead --
+        visible, and the same convention RazorThinExponentialDisk uses when a
+        domain is undecidable under trace.
+        """
+        if under_trace(base, off):
+            return xp.where(off, xp.asarray(xp.nan, dtype=base.dtype), base)
+        if not bool(xp.any(off)):
+            return base
+        return set_at(xp, base, off, exact(off))
+
+    def _evaluate_backend(self, R, vR, vT, z, vz):
+        """Vectorised, differentiable action eval for jax/torch inputs.
+
+        On-grid this is the interpolants. Off-grid it falls back to the exact
+        ``self._aA`` solve for just those points, matching the numpy path; under
+        a trace off-grid entries come back NaN (see ``_offgrid_fill``).
         """
         xp = get_namespace(R)
         zero = xp.zeros_like(R)
@@ -684,18 +711,70 @@ class actionAngleAdiabaticGrid(actionAngle):
         jz = self._jzInterp_b(R, Ez / thisEzZmax, grid=False) * (
             xp.exp(self._jzEzmaxInterp_b(R)) - 10.0**-5.0
         )
+        # Off-grid in Ez, exactly the numpy `indx`. log() is guarded because it
+        # is evaluated for EVERY element here, including the Ez <= 0 ones the
+        # (Ez != 0) factor is there to reject -- numpy tolerates the resulting
+        # nan/-inf, but feeding nan through a backend op can poison a gradient.
+        offz = (
+            (R > self._Rmax)
+            | (R < self._Rmin)
+            | (
+                (Ez != 0.0)
+                & (xp.log(xp.where(Ez > 0.0, Ez, xp.ones_like(Ez))) > thisEzZmax)
+            )
+        )
+        jz = self._offgrid_fill(
+            xp,
+            jz,
+            offz,
+            lambda m: self._aA(
+                R[m],
+                xp.zeros_like(R[m]),
+                xp.ones_like(R[m]),  # these two are dummies
+                xp.zeros_like(R[m]),
+                xp.sqrt(2.0 * Ez[m]),
+                _justjz=True,
+            )[2],
+        )
         # Radial action
         ERLz = xp.abs(R * vT) + self._gamma * jz
         ER = Phio + vR**2.0 / 2.0 + ERLz**2.0 / 2.0 / R**2.0
+        thisRL = self._RLInterp_b(ERLz)
         thisERRL = -xp.exp(self._ERRLInterp_b(ERLz)) + self._ERRLmax
         thisERRa = -xp.exp(self._ERRaInterp_b(ERLz)) + self._ERRamax
         frac = (ER - thisERRa) / (thisERRL - thisERRa)
         # Snap the two near-boundary cases (mirrors the numpy ER[indx]= writes).
         ER = xp.where((frac > 1.0) & ((frac - 1.0) < 10.0**-2.0), thisERRL, ER)
         ER = xp.where((frac < 0.0) & (frac > -(10.0**-2.0)), thisERRa, ER)
-        jr = self._jrInterp_b(
-            ERLz, (ER - thisERRa) / (thisERRL - thisERRa), grid=False
-        ) * (xp.exp(self._jrERRaInterp_b(ERLz)) - 10.0**-5.0)
+        frac = (ER - thisERRa) / (thisERRL - thisERRa)
+        jr = self._jrInterp_b(ERLz, frac, grid=False) * (
+            xp.exp(self._jrERRaInterp_b(ERLz)) - 10.0**-5.0
+        )
+        # Off-grid in Lz / ER, exactly the numpy `indx`. Recomputed from the
+        # SNAPPED frac, as numpy does -- the snap moves points back on-grid.
+        offr = (ERLz < self._Lzmin) | (ERLz > self._Lzmax) | (frac > 1.0) | (frac < 0.0)
+        jr = self._offgrid_fill(
+            xp,
+            jr,
+            offr,
+            lambda m: self._aA(
+                thisRL[m],
+                xp.sqrt(
+                    2.0
+                    * (
+                        ER[m]
+                        - _evaluatePotentials(
+                            self._pot, thisRL[m], xp.zeros_like(thisRL[m])
+                        )
+                    )
+                    - ERLz[m] ** 2.0 / thisRL[m] ** 2.0
+                ),
+                ERLz[m] / thisRL[m],
+                xp.zeros_like(thisRL[m]),
+                xp.zeros_like(thisRL[m]),
+                _justjr=True,
+            )[0],
+        )
         return (jr, R * vT, jz)
 
     def Jz(self, *args, **kwargs):

--- a/galpy/backend/__init__.py
+++ b/galpy/backend/__init__.py
@@ -35,6 +35,7 @@ from ._namespaces import (
     promote_common_dtype,
     resolve_namespace,
     restrict_to_single_thread,
+    set_at,
 )
 from ._resolver import (
     _seed_from_config,

--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -136,6 +136,24 @@ def under_trace(*xs):
     return is_compiling() and any(isinstance(x, torch.Tensor) for x in xs)
 
 
+def set_at(xp, arr, mask, values):
+    """``arr`` with ``arr[mask]`` replaced by ``values``, out of place.
+
+    The backend-agnostic scatter: jax arrays are immutable and need
+    ``.at[].set()``, torch tensors are mutable but assigning into one that
+    carries a graph raises, so both go out of place.
+
+    EAGER only. A boolean mask has no concrete size under a trace, which is
+    exactly why the traced path has to answer differently rather than call
+    this.
+    """
+    if name_of_namespace(xp) == "jax":
+        return arr.at[mask].set(values)
+    out = arr.clone() if hasattr(arr, "clone") else arr.copy()
+    out[mask] = values
+    return out
+
+
 def requires_backend_grad(*xs):
     """True iff one of ``xs`` is a torch tensor carrying an autograd graph.
 

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -165,6 +165,23 @@
 # (test_analytic_ecc_rperi_rap: passes locally, xfails in CI group g3). Same
 # blind spot that made an earlier local regen report false failures.
 
+# actionAngleAdiabaticGrid_outsidegrid_c: the RECORDED REASON WAS WRONG. It was
+# "the backend path evaluates the grid only (no off-grid fallback)" -- no longer
+# true, the backend now falls back to an exact per-point solve and matches the
+# NUMPY GRID to ~1e-13 for all-on-grid, mixed and all-off-grid inputs.
+#
+# What actually blocks it is gh#1354, the Adiabatic C quadrature defect. This
+# test's reference is actionAngleAdiabatic(c=True), and the backend fallback MUST
+# use the Python solver because the C extension cannot accept a jax/torch array
+# at all. Measured on pure numpy, no backend involved:
+#     C      jr = 0.011117771185
+#     Python jr = 0.011112634625     |C - Python| = 5.137e-06
+# against this test's 1e-8 bar. So the backend can never match a C reference here
+# until gh#1354 is resolved -- and per that issue the C value is the inaccurate
+# one, i.e. the test bar pins the wrong number.
+#
+# The Python-vs-Python equivalent, test_actionAngleAdiabaticGrid_outsidegrid_
+# multiple_python, PASSES on both backends and is not ledgered.
 jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_qdf.py::test_call_diffinoutputs
 torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2260,6 +2260,36 @@ def test_actionAngleAdiabaticGrid_basic_actions_c():
 
 
 # actionAngleAdiabaticGrid actions outside the grid
+def test_actionAngleAdiabaticGrid_outsidegrid_multiple_python():
+    # The pure-Python (c=False) grid raised
+    #   TypeError: 'float' object is not subscriptable
+    # whenever TWO OR MORE points fell outside the grid: actionAngleAdiabatic's
+    # len(R) > 1 branch loops over points calling its own scalar branch and then
+    # does ojr[ii] = tjr[0], but the scalar _justjr return was a bare float
+    # while its _justjz and general siblings both wrapped in numpy.atleast_1d.
+    #
+    # One off-grid point never caught it (that call takes the scalar path and
+    # never reaches the loop), and the only other off-grid test uses c=True,
+    # which returns from the C branch before the loop -- so both arms of the
+    # existing coverage were blind to it.
+    from galpy.actionAngle import actionAngleAdiabatic, actionAngleAdiabaticGrid
+    from galpy.potential import MWPotential
+
+    aA = actionAngleAdiabatic(pot=MWPotential, c=False)
+    aAA = actionAngleAdiabaticGrid(pot=MWPotential, c=False, Rmax=2.0, zmax=0.2)
+    for n in (1, 2, 3):  # 1 is the case that always worked; 2+ is the bug
+        R = numpy.array([3.0 + 0.5 * ii for ii in range(n)])
+        o = numpy.ones(n)
+        js = aA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
+        jsa = aAA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
+        assert numpy.all(numpy.fabs(js[0] - jsa[0]) < 10.0**-8.0), (
+            f"actionAngleAdiabaticGrid c=False jr wrong for {n} off-grid points"
+        )
+        assert numpy.all(numpy.fabs(js[2] - jsa[2]) < 10.0**-8.0), (
+            f"actionAngleAdiabaticGrid c=False jz wrong for {n} off-grid points"
+        )
+
+
 def test_actionAngleAdiabaticGrid_outsidegrid_c():
     from galpy.actionAngle import actionAngleAdiabatic, actionAngleAdiabaticGrid
     from galpy.potential import MWPotential

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2280,8 +2280,10 @@ def test_actionAngleAdiabaticGrid_outsidegrid_multiple_python():
     for n in (1, 2, 3):  # 1 is the case that always worked; 2+ is the bug
         R = numpy.array([3.0 + 0.5 * ii for ii in range(n)])
         o = numpy.ones(n)
-        js = aA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
-        jsa = aAA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)
+        # as_numpy: under a forced backend these come back as tensors and
+        # numpy.all/numpy.fabs on a Tensor raises.
+        js = [as_numpy(a) for a in aA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)]
+        jsa = [as_numpy(a) for a in aAA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)]
         assert numpy.all(numpy.fabs(js[0] - jsa[0]) < 10.0**-8.0), (
             f"actionAngleAdiabaticGrid c=False jr wrong for {n} off-grid points"
         )
@@ -2297,21 +2299,23 @@ def test_actionAngleAdiabaticGrid_outsidegrid_c():
     aA = actionAngleAdiabatic(pot=MWPotential, c=True)
     aAA = actionAngleAdiabaticGrid(pot=MWPotential, c=True, Rmax=2.0, zmax=0.2)
     R, vR, vT, z, vz, phi = 3.0, 0.1, 1.0, 0.1, 0.1, 2.0
-    js = aA(R, vR, vT, z, vz, phi)
-    jsa = aAA(R, vR, vT, z, vz, phi)
+    # as_numpy at the assertion sites: under a forced backend these are
+    # tensors, and numpy.fabs/numpy.all on a Tensor raises.
+    js = [as_numpy(a) for a in aA(R, vR, vT, z, vz, phi)]
+    jsa = [as_numpy(a) for a in aAA(R, vR, vT, z, vz, phi)]
     assert numpy.fabs(js[0] - jsa[0]) < 10.0**-8.0, (
         "actionAngleAdiabaticGrid evaluation outside of the grid fails"
     )
     assert numpy.fabs(js[2] - jsa[2]) < 10.0**-8.0, (
         "actionAngleAdiabaticGrid evaluation outside of the grid fails"
     )
-    assert numpy.fabs(js[2] - aAA.Jz(R, vR, vT, z, vz, phi)) < 10.0**-8.0, (
+    assert numpy.fabs(js[2] - as_numpy(aAA.Jz(R, vR, vT, z, vz, phi))) < 10.0**-8.0, (
         "actionAngleAdiabaticGrid evaluation outside of the grid fails"
     )
     # Also for array
     s = numpy.ones(2)
-    js = aA(R, vR, vT, z, vz, phi)
-    jsa = aAA(R * s, vR * s, vT * s, z * s, vz * s, phi * s)
+    js = [as_numpy(a) for a in aA(R, vR, vT, z, vz, phi)]
+    jsa = [as_numpy(a) for a in aAA(R * s, vR * s, vT * s, z * s, vz * s, phi * s)]
     assert numpy.all(numpy.fabs(js[0] - jsa[0]) < 10.0**-8.0), (
         "actionAngleAdiabaticGrid evaluation outside of the grid fails"
     )

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -2523,3 +2523,74 @@ def test_estimateDeltaStaeckel_scalar_only_potential(backend):
     )
     numpy.testing.assert_allclose(as_numpy(got), ref, rtol=1e-8, atol=1e-10)
     return None
+
+
+# ---------------------------------------------------------------------------
+# actionAngleAdiabaticGrid off-grid fallback (jax/torch).
+#
+# The backend path used to evaluate the interpolation grid ONLY, silently
+# EXTRAPOLATING off-grid where numpy falls back to an exact per-point solve. It
+# now gathers the off-grid points, solves those exactly, and scatters back --
+# the same mask / `sum > 0` / scatter-assign shape numpy already uses.
+#
+# The MIXED case is the one that matters: the pre-existing off-grid test has ALL
+# points off-grid, so a scatter writing to the WRONG POSITIONS would pass it.
+# ---------------------------------------------------------------------------
+_AG_CASES = {
+    "all-on-grid": numpy.array([1.0, 1.2]),
+    "mixed": numpy.array([1.0, 1.2, 3.0]),
+    "all-off-grid": numpy.array([3.0, 3.5]),
+}
+
+
+def _ag_pair():
+    from galpy.actionAngle import actionAngleAdiabaticGrid
+    from galpy.potential import MWPotential
+
+    return actionAngleAdiabaticGrid(pot=MWPotential, Rmax=2.0, zmax=0.2)
+
+
+@pytest.mark.parametrize("case", list(_AG_CASES))
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_adiabaticgrid_offgrid_matches_the_numpy_grid(backend_name, case):
+    from galpy import backend as _backend
+
+    R = _AG_CASES[case]
+    n = len(R)
+    o = numpy.ones(n)
+    aAA = _ag_pair()
+    ref = aAA(R, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)  # numpy grid = the target
+    conv = jnp.asarray if backend_name == "jax" else torch.tensor
+    with _backend.use(backend_name, force=True):
+        got = aAA(conv(R), conv(0.1 * o), conv(1.0 * o), conv(0.1 * o), conv(0.1 * o))
+    for idx, name in ((0, "jr"), (2, "jz")):
+        numpy.testing.assert_allclose(
+            as_numpy(got[idx]),
+            as_numpy(ref[idx]),
+            rtol=1e-10,
+            err_msg=f"{backend_name} {case}: {name} != the numpy grid",
+        )
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_adiabaticgrid_offgrid_is_nan_under_a_trace_not_silently_extrapolated():
+    # Under a trace a boolean mask has no concrete size, so the off-grid points
+    # cannot be gathered and the `any` cannot be branched on. Returning the
+    # extrapolated interpolant there would be SILENTLY WRONG, so those entries
+    # come back NaN -- visible. On-grid entries must stay finite.
+    from galpy import backend as _backend
+
+    aAA = _ag_pair()
+    R = jnp.asarray([1.0, 3.0])  # one on-grid, one off-grid
+    o = jnp.ones(2)
+
+    def f(Rv):
+        return aAA(Rv, 0.1 * o, 1.0 * o, 0.1 * o, 0.1 * o)[0]
+
+    with _backend.use("jax", force=True):
+        jr = numpy.asarray(jax.jit(f)(R))
+    assert numpy.isfinite(jr[0]), f"on-grid entry should stay finite, got {jr[0]!r}"
+    assert numpy.isnan(jr[1]), (
+        f"off-grid entry under a trace must be NaN rather than a silently "
+        f"extrapolated value, got {jr[1]!r}"
+    )

--- a/tests/test_backend_namespaces.py
+++ b/tests/test_backend_namespaces.py
@@ -10,7 +10,7 @@
 import numpy
 import pytest
 
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, set_at
 
 pytestmark = pytest.mark.backend_managed
 
@@ -55,3 +55,44 @@ def test_as_numpy_roundtrip(backend):
     out = as_numpy(x)
     assert isinstance(out, numpy.ndarray)
     numpy.testing.assert_allclose(out, src)
+
+
+# ---------------------------------------------------------------------------
+# set_at: the backend-agnostic scatter. jax arrays are immutable and need
+# .at[].set(); torch tensors are mutable but assigning into one that carries a
+# graph raises, so both go out of place. Production code (the AdiabaticGrid
+# off-grid fallback), and the backend-tests CI job uploads no coverage, so it
+# is exercised explicitly here.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_set_at_replaces_masked_entries_out_of_place(backend):
+    src = numpy.asarray([1.0, 2.0, 3.0, 4.0])
+    mask_np = numpy.asarray([False, True, False, True])
+    if backend == "jax":
+        xp, arr, mask = jnp, jnp.asarray(src), jnp.asarray(mask_np)
+        vals = jnp.asarray([20.0, 40.0])
+    else:
+        xp, arr, mask = torch, torch.tensor(src), torch.tensor(mask_np)
+        vals = torch.tensor([20.0, 40.0])
+    out = set_at(xp, arr, mask, vals)
+    numpy.testing.assert_allclose(as_numpy(out), [1.0, 20.0, 3.0, 40.0])
+    # out of place: the input is untouched, which is what lets callers keep the
+    # original around (and is REQUIRED for jax, whose arrays are immutable).
+    numpy.testing.assert_allclose(as_numpy(arr), src)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_set_at_leaves_a_grad_tracking_input_intact(backend):
+    # torch raises on in-place assignment into a graph-carrying tensor, so the
+    # clone is load-bearing rather than defensive. jax is checked for symmetry.
+    if backend == "jax":
+        arr = jnp.asarray([1.0, 2.0, 3.0])
+        out = set_at(jnp, arr, jnp.asarray([False, True, False]), jnp.asarray([9.0]))
+    else:
+        arr = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        out = set_at(
+            torch, arr, torch.tensor([False, True, False]), torch.tensor([9.0])
+        )
+        assert arr.requires_grad
+    numpy.testing.assert_allclose(as_numpy(out), [1.0, 9.0, 3.0])
+    numpy.testing.assert_allclose(as_numpy(arr), [1.0, 2.0, 3.0])


### PR DESCRIPTION
The backend path evaluated the interpolation grid **only** — off-grid inputs
were silently *extrapolated*, where numpy falls back to an exact per-point
solve. This ports that fallback.

> **Contains a cherry-pick of gh#1398** (`actionAngleAdiabatic: fix multi-point
> _justjr raising TypeError`), which targets `main` and is required for this to
> work at all. It will drop out by patch-id when `main` is merged in and this is
> rebased.

### Design

numpy already does gather/scatter — mask, `sum(indx) > 0` guard,
scatter-assign — so this is a port of an existing in-tree pattern, not a new
design. Eager can genuinely **skip** the exact solve when nothing is off-grid,
which is what makes the cost acceptable. Measured, an `_aA` call costs

    ~187 ms on torch and ~1.25 s on jax BEFORE it touches a single point

so paying it unconditionally would make *every* call 14–77× slower than the grid
it exists to avoid. Cost is therefore proportional to the number of off-grid
points, and **zero** when there are none.

Against the numpy grid:

| case | torch jr / jz | jax jr / jz |
|---|---|---|
| all on-grid | 7.33e-15 / 6.66e-16 | 1.47e-13 / 6.66e-16 |
| **MIXED** | 8.44e-14 / 3.84e-14 | 1.47e-13 / 1.65e-13 |
| all off-grid | 8.44e-14 / 4.54e-14 | 4.73e-14 / 1.65e-13 |

**MIXED is the load-bearing case:** the pre-existing off-grid test has *all*
points off-grid, so a scatter writing to the **wrong positions** would pass it.

`c=False` is threaded into both fallback calls. `actionAngleAdiabatic._evaluate`
sets `_special` when `_justjr`/`_justjz` is passed, which *skips* its backend
branch — so a `c=True` grid fell through to the **C call** with backend arrays
and raised `NotImplementedError`. The C extension cannot accept a jax/torch
array at all.

### Traced mode

Under a trace a boolean mask has no concrete size, so the points cannot be
gathered and the `any` cannot be branched on. Returning the extrapolated
interpolant there would be *silently wrong*, so off-grid entries come back
**NaN** — visible, and the same convention `RazorThinExponentialDisk` already
uses for a domain that is undecidable under trace. Pinned by a test.

### New shared machinery

`set_at(xp, arr, mask, values)` in `galpy.backend` — galpy had no
backend-agnostic scatter (`.at[` appears nowhere in the source). jax arrays are
immutable and need `.at[].set()`; torch raises on in-place assignment into a
graph-carrying tensor. Two call sites here.

### Ledger: delta 0, but the entry's reason was FALSE and is corrected

`outsidegrid_c` said the backend *"evaluates the interpolation grid only (no
off-grid fallback)"*. That is no longer true. The real blocker is **gh#1354**:
this test's reference is `actionAngleAdiabatic(c=True)`, the backend fallback
must use the Python solver, and on **pure numpy with no backend involved** those
two disagree by

    C      jr = 0.011117771185
    Python jr = 0.011112634625      |C - Python| = 5.137e-06

against a 1e-8 bar. Per gh#1354 the C value is the inaccurate one — i.e. the bar
pins the wrong number. So the entry stays, now stating something measured.

The Python-vs-Python equivalent (`outsidegrid_multiple_python`, arriving with the
cherry-pick) **passes on both backends and is not ledgered** — new coverage.

### Gates

    numpy test_actionAngle.py :: 210 passed
    torch test_actionAngle.py :: 185 passed, 24 skipped, 1 xfailed
    jax   test_actionAngle.py :: 184 passed, 25 skipped, 1 xfailed
    test_backend_namespaces   :: 7 passed
    new AdiabaticGrid backend tests :: 7 passed (~235 s, grid builds dominate)

The lone `xfailed` on each backend is the `outsidegrid_c` entry above.

Runtime is stated rather than hidden: if the coverage shard finds the new tests
too slow they are a slow-skip candidate, but they are currently the only
coverage of the new code paths.