### PR TITLE
integrate_dxdv: transform the base state in C, restoring bit-identity with plain integrate

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,17 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
+- ``Orbit.integrate_dxdv`` with a C integrator now hands the base state to C
+  in cylindrical coordinates, so the base orbit carried alongside the
+  deviation goes through the very same cyl<->rect transforms
+  (``cyl_to_rect_galpy``/``rect_to_cyl_galpy``) as a plain ``Orbit.integrate``
+  and is bit-identical to it. Previously the base was transformed on the
+  Python side with numpy, whose vectorized trig is dispatched on CPU features
+  and need not agree with the C library's in the last bit; where it did not,
+  the two runs started from initial conditions differing by 1 ulp and drifted
+  apart by ~1e-15, which the symplectic dxdv bit-identity test caught
+  intermittently depending on which machine it ran on.
+
 - ``OblateStaeckelWrapperPotential`` chooses its reference curve ``u0`` from
   the focal length when none is given, placing it at R=1 rather than on the
   symmetry axis. V(v) is built along u=u0 and only represents the wrapped

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -755,9 +755,12 @@ def integrateFullOrbit_dxdv_c(
     """
     Integrate an ode for a fullOrbit+phase space volume dxdv in C.
 
-    Both the input state ``yo`` and deviation ``dyo`` as well as the output are
-    in the rectangular frame (x,y,z,vx,vy,vz | dx,dy,dz,dvx,dvy,dvz); the
-    cylindrical<->rectangular transforms are handled by the calling
+    The base state ``yo`` is given, and returned, in the cylindrical frame
+    (R,vR,vT,z,vz,phi): the C entry converts it with the same helpers the
+    plain ``integrateFullOrbit`` uses, so the base trajectory is
+    bit-identical to a plain integration. The deviation ``dyo`` is given, and
+    returned, in the rectangular frame (dx,dy,dz,dvx,dvy,dvz); its
+    (chain-rule) transforms are handled by the calling
     ``integrateFullOrbit_dxdv``.
 
     Parameters
@@ -922,7 +925,6 @@ def integrateFullOrbit_dxdv(
     -----
     - 2026-06-03 - Written based on integratePlanarOrbit_dxdv - Bovy (UofT)
     """
-    # Go to the rectangular frame: base state (R,vR,vT,z,vz,phi) -> (x,y,z,vx,vy,vz)
     R, vR, vT, z, vz, phi = (
         yo[:, 0],
         yo[:, 1],
@@ -931,9 +933,6 @@ def integrateFullOrbit_dxdv(
         yo[:, 4],
         yo[:, 5],
     )
-    X, Y, Z = coords.cyl_to_rect(R, phi, z)
-    vX, vY, vZ = coords.cyl_to_rect_vec(vR, vT, vz, phi)
-    this_yo = numpy.array([X, Y, Z, vX, vY, vZ]).T
     if not rectIn:
         # Chain rule: rect deviation = J . cyl deviation, with J the Jacobian
         # of (x,y,z,vx,vy,vz) wrt (R,vR,vT,z,vz,phi).
@@ -943,8 +942,24 @@ def integrateFullOrbit_dxdv(
             this_dyo[ii] = numpy.dot(jac, dyo[ii])
     else:
         this_dyo = dyo
-    this_yo = numpy.hstack((this_yo, this_dyo))
-    if int_method.lower() == "dop853" or int_method.lower() == "odeint":
+    _pure_python = int_method.lower() == "dop853" or int_method.lower() == "odeint"
+    if _pure_python:
+        # Go to the rectangular frame here: the pure-Python variational RHS
+        # works in (x,y,z,vx,vy,vz)
+        X, Y, Z = coords.cyl_to_rect(R, phi, z)
+        vX, vY, vZ = coords.cyl_to_rect_vec(vR, vT, vz, phi)
+        this_yo = numpy.hstack((numpy.array([X, Y, Z, vX, vY, vZ]).T, this_dyo))
+    else:
+        # Hand the BASE state to C in cylindrical coordinates: the C entry
+        # applies the same cyl_to_rect_galpy/rect_to_cyl_galpy as the plain
+        # integrateFullOrbit, so the base trajectory carried alongside the
+        # deviation is bit-identical to a plain integration with the same
+        # method/dt/IC. Transforming it here instead would use numpy's
+        # vectorized trig, which need not agree with the C library's in the
+        # last bit (and on some machines does not), leaving the two runs to
+        # start from initial conditions differing by ~1 ulp.
+        this_yo = numpy.hstack((yo, this_dyo))
+    if _pure_python:
         from ..potential.DissipativeForce import _isDissipative
 
         if _isDissipative(pot):
@@ -997,26 +1012,36 @@ def integrateFullOrbit_dxdv(
                 integrate_for_map, this_yo, progressbar=progressbar, numcores=numcores
             )
         )
-    # Go back to the cylindrical frame: base state out[...,:6] is rectangular
-    # (x,y,z,vx,vy,vz); convert to (R,vR,vT,z,vz,phi) and (optionally) the
-    # deviation out[...,6:] from rectangular to cylindrical.
-    Rout, phiout, Zout = coords.rect_to_cyl(out[..., 0], out[..., 1], out[..., 2])
-    vRout, vTout, vzout = coords.rect_to_cyl_vec(
-        out[..., 3], out[..., 4], out[..., 5], out[..., 0], out[..., 1], out[..., 2]
-    )
-    # rect_to_cyl/rect_to_cyl_vec pass Z/vz through BY REFERENCE, so Zout and
-    # vzout are views into out[...,2]/out[...,5]; copy them before the in-place
-    # assignments below overwrite those columns (otherwise out[...,3] ends up
-    # holding vT instead of z, corrupting the returned base orbit and any
-    # restart that uses it, e.g. the lyapunov renormalization segments)
-    Zout = numpy.copy(Zout)
-    vzout = numpy.copy(vzout)
-    out[..., 0] = Rout
-    out[..., 1] = vRout
-    out[..., 2] = vTout
-    out[..., 3] = Zout
-    out[..., 4] = vzout
-    out[..., 5] = phiout
+    if _pure_python:
+        # Go back to the cylindrical frame: base state out[...,:6] is
+        # rectangular (x,y,z,vx,vy,vz); convert to (R,vR,vT,z,vz,phi). The C
+        # path returns the base already in cylindrical coordinates, converted
+        # by the same helper the plain integrate path uses.
+        Rout, phiout, Zout = coords.rect_to_cyl(out[..., 0], out[..., 1], out[..., 2])
+        vRout, vTout, vzout = coords.rect_to_cyl_vec(
+            out[..., 3], out[..., 4], out[..., 5], out[..., 0], out[..., 1], out[..., 2]
+        )
+        # rect_to_cyl/rect_to_cyl_vec pass Z/vz through BY REFERENCE, so Zout
+        # and vzout are views into out[...,2]/out[...,5]; copy them before the
+        # in-place assignments below overwrite those columns (otherwise
+        # out[...,3] ends up holding vT instead of z, corrupting the returned
+        # base orbit and any restart that uses it, e.g. the lyapunov
+        # renormalization segments)
+        Zout = numpy.copy(Zout)
+        vzout = numpy.copy(vzout)
+        out[..., 0] = Rout
+        out[..., 1] = vRout
+        out[..., 2] = vTout
+        out[..., 3] = Zout
+        out[..., 4] = vzout
+        out[..., 5] = phiout
+    else:
+        Rout = out[..., 0]
+        vRout = out[..., 1]
+        vTout = out[..., 2]
+        Zout = out[..., 3]
+        vzout = out[..., 4]
+        phiout = out[..., 5]
     if not rectOut:
         # cyl deviation = J^{-1} . rect deviation, with J the cyl->rect Jacobian
         # evaluated at each (R,vR,vT,z,vz,phi) along the orbit.

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -942,8 +942,9 @@ def integrateFullOrbit_dxdv(
             this_dyo[ii] = numpy.dot(jac, dyo[ii])
     else:
         this_dyo = dyo
-    _pure_python = int_method.lower() == "dop853" or int_method.lower() == "odeint"
-    if _pure_python:
+    # C integrators are the ones whose name ends in "_c"
+    _c_integrator = int_method.lower().endswith("_c")
+    if not _c_integrator:
         # Go to the rectangular frame here: the pure-Python variational RHS
         # works in (x,y,z,vx,vy,vz)
         X, Y, Z = coords.cyl_to_rect(R, phi, z)
@@ -959,7 +960,7 @@ def integrateFullOrbit_dxdv(
         # last bit (and on some machines does not), leaving the two runs to
         # start from initial conditions differing by ~1 ulp.
         this_yo = numpy.hstack((yo, this_dyo))
-    if _pure_python:
+    if not _c_integrator:
         from ..potential.DissipativeForce import _isDissipative
 
         if _isDissipative(pot):
@@ -1012,7 +1013,7 @@ def integrateFullOrbit_dxdv(
                 integrate_for_map, this_yo, progressbar=progressbar, numcores=numcores
             )
         )
-    if _pure_python:
+    if not _c_integrator:
         # Go back to the cylindrical frame: base state out[...,:6] is
         # rectangular (x,y,z,vx,vy,vz); convert to (R,vR,vT,z,vz,phi). The C
         # path returns the base already in cylindrical coordinates, converted

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -1245,9 +1245,18 @@ EXPORT void integrateFullOrbit_dxdv(double *yo,
 			 int * err,
 			 int odeint_type){
   //Set up the forces, first count
-  int dim;
+  int dim, jj;
   struct potentialArg * potentialArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
   parse_leapFuncArgs_Full(npot,potentialArgs,&pot_type,&pot_args,&pot_tfuncs);
+  //The base block of yo arrives in cylindrical coordinates and is converted
+  //here with the very same helper the plain integrateFullOrbit uses (and
+  //converted back below), so the base trajectory carried alongside the
+  //deviation is BIT-IDENTICAL to a plain integration: doing this transform
+  //in Python instead would use numpy's vectorized trig, which need not
+  //agree with the C library's in the last bit (and on some machines does
+  //not). The deviation block is passed in, and returned in, the rectangular
+  //frame; the caller handles its (chain-rule) transform.
+  cyl_to_rect_galpy(yo);
   //Integrate
   void (*odeint_func)(void (*func)(double, double *, double *,
 			   int, struct potentialArg *),
@@ -1299,6 +1308,11 @@ EXPORT void integrateFullOrbit_dxdv(double *yo,
     odeint_func(odeint_deriv_func,dim,yo,nt,dt,t,npot,potentialArgs,
 		rtol,atol,result,err);
   }
+  //Base block of each output row back to cylindrical (same helper as the
+  //plain path); the 12D row is (x,y,z,vx,vy,vz | dx,dy,dz,dvx,dvy,dvz) for
+  //both the symplectic and the RK dxdv steppers
+  for (jj=0; jj < nt; jj++)
+    rect_to_cyl_galpy(result+12*jj);
   //Free allocated memory
   free_potentialArgs(npot,potentialArgs);
   free(potentialArgs);

--- a/tests/test_symplectic_dxdv.py
+++ b/tests/test_symplectic_dxdv.py
@@ -147,7 +147,10 @@ def test_symplectic_dxdv_base_bit_identity():
     plain (no-dxdv) integration with the same method/dt/IC: the symplectic dxdv
     step estimates its stepsize from the base block only and steps the base via
     the same drift/kick sequence, so the deviation machinery cannot perturb the
-    base integration."""
+    base integration. The cyl<->rect transform of the base is done by the same
+    C helpers as in plain integrate (see
+    test_symplectic_dxdv_base_independent_of_python_coord_transforms), so this
+    is exact rather than merely round-off-close."""
     from galpy.orbit import Orbit
     from galpy.potential import MiyamotoNagaiPotential
 
@@ -172,6 +175,59 @@ def test_symplectic_dxdv_base_bit_identity():
             f"symplectic dxdv base orbit not bit-identical to plain integrate "
             f"for {method}: max|diff|="
             f"{numpy.amax(numpy.fabs(base_dxdv - base_plain)):g}"
+        )
+    return None
+
+
+def test_symplectic_dxdv_base_independent_of_python_coord_transforms(monkeypatch):
+    """The base orbit's bit-identity must not rest on numpy's cyl<->rect
+    transforms agreeing with the C library's in the last bit: the C dxdv entry
+    converts the base with the same cyl_to_rect_galpy/rect_to_cyl_galpy as
+    plain integrate, so perturbing the Python-side transforms must leave the
+    base untouched. numpy dispatches its vectorized trig on CPU features, so a
+    1-ulp disagreement with libm does occur on some machines; before the base
+    transform moved into C that made the two runs start from initial
+    conditions differing by 1 ulp and drift apart by ~1e-15."""
+    from galpy.orbit import Orbit
+    from galpy.potential import MiyamotoNagaiPotential
+    from galpy.util import coords
+
+    up = lambda a: numpy.nextafter(numpy.asarray(a, dtype=float), numpy.inf)
+    o_c2r, o_c2rv = coords.cyl_to_rect, coords.cyl_to_rect_vec
+    o_r2c, o_r2cv = coords.rect_to_cyl, coords.rect_to_cyl_vec
+    monkeypatch.setattr(
+        coords, "cyl_to_rect", lambda R, phi, Z: tuple(up(v) for v in o_c2r(R, phi, Z))
+    )
+    monkeypatch.setattr(
+        coords,
+        "cyl_to_rect_vec",
+        lambda vr, vt, vz, phi: tuple(up(v) for v in o_c2rv(vr, vt, vz, phi)),
+    )
+    monkeypatch.setattr(
+        coords, "rect_to_cyl", lambda X, Y, Z: tuple(up(v) for v in o_r2c(X, Y, Z))
+    )
+    monkeypatch.setattr(
+        coords,
+        "rect_to_cyl_vec",
+        lambda vx, vy, vz, X, Y, Z, cyl=False: tuple(
+            up(v) for v in o_r2cv(vx, vy, vz, X, Y, Z, cyl=cyl)
+        ),
+    )
+    pot = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.1)
+    times = numpy.linspace(0.0, 5.0, 251)
+    for method in SYMPLECTIC + ["rk6_c"]:
+        o1 = Orbit(_IC)
+        o1.integrate_dxdv(
+            _CANON[0], times, pot, method=method, dt=0.01, rectIn=True, rectOut=True
+        )
+        o2 = Orbit(_IC)
+        o2.integrate(times, pot, method=method, dt=0.01)
+        assert numpy.array_equal(
+            numpy.asarray(o1.getOrbit()), numpy.asarray(o2.getOrbit())
+        ), (
+            f"the dxdv base orbit depends on the Python-side coordinate "
+            f"transforms for {method}: max|diff|="
+            f"{numpy.amax(numpy.fabs(numpy.asarray(o1.getOrbit()) - numpy.asarray(o2.getOrbit()))):g}"
         )
     return None
 


### PR DESCRIPTION
Fixes the intermittent `test_symplectic_dxdv_base_bit_identity` failures on CI — at the root, so bit-identity holds by construction rather than by coincidence.

### What was actually happening

The two paths built the *same* orbit from *different* code:

- `Orbit.integrate` passes **cylindrical** ICs into C, which converts them with `cyl_to_rect_galpy` (and back with `rect_to_cyl_galpy`) — i.e. the **C library's** `cos`/`sin`/`atan2`.
- `Orbit.integrate_dxdv` converted the base **in Python** (`coords.cyl_to_rect`/`cyl_to_rect_vec`, and `rect_to_cyl`/`rect_to_cyl_vec` on the way out) — i.e. **numpy's** vectorized trig.

The formulas are identical, but numpy dispatches its vectorized trig on CPU features, so its results need not match libm's in the last bit. Where they didn't, the two runs started from ICs differing by 1 ulp, and the integrators — which really are bit-identical; `evalRectForce_dxdv`'s base block is textually the same as `evalRectForce`, and the drift/kick kernels are element-wise over the base block — faithfully propagated that into a ~1e-15 divergence.

That explains the observed behaviour: same numpy (2.5.2) in both passing and failing runs, so it wasn't a version bump; identical failure value on repeat runs; and always reported for `leapfrog_c` only because the assert fires on the first method in the loop.

### The fix

The C dxdv entry now takes the base in cylindrical coordinates and applies the same `cyl_to_rect_galpy`/`rect_to_cyl_galpy` as the plain path (in, and on every output row); the caller no longer transforms the base for the C integrators. The deviation block is unchanged (rectangular in/out, chain-rule transforms in Python — it never feeds back into the base). The pure-Python (`odeint`/`dop853`) dxdv path keeps its numpy transform, which is unrelated to the C bit-identity claim.

### Verification

Perturbing the Python-side transforms by 1 ulp — a direct simulation of the CPU-dependent disagreement:

| method | before | after |
|---|---|---|
| leapfrog_c | 9.3e-15 | **0** |
| symplec4_c | 6.2e-15 | **0** |
| symplec6_c | 1.0e-15 | **0** |
| rk6_c | 7.1e-15 | **0** |

(Note all methods were affected, not just `leapfrog_c`.) That probe is now a test — `test_symplectic_dxdv_base_independent_of_python_coord_transforms` — so the invariant can't silently regress. Local runs: the dxdv suites (22 tests) plus `test_orbit.py -k "dxdv or lyapunov"` (116) and the `test_orbits.py`/`test_quantity.py` dxdv tests (4), all passing.

Left alone deliberately: the planar dxdv path, whose `getOrbit`-level difference is a *convention* difference (numpy `arccos` on [0,2π) vs C `atan2` on (−π,π]), already documented in `test_symplectic_dxdv_planar_base_bit_identity` and worked around there by asserting on the raw rectangular base. Changing that would change the returned φ range for planar dxdv, which is a user-visible behaviour change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ