### PR TITLE
Review round 3: traced beta under jit, mixed quad limits, and the small-B hyp2f1 floor

### DIFF
--- a/galpy/backend/quadrature.py
+++ b/galpy/backend/quadrature.py
@@ -488,6 +488,18 @@ def transformed_quad(xp, integrand, a, b, *, n=50, interior_point=None, device=N
     return match_input_dtype(result, a, b, c)
 
 
+def _whole_line_quad(xp, integrand, *, n, device):
+    """``int_{-inf}^{inf} f(s) ds`` as two semi-infinite halves.
+
+    The halves are integrated separately rather than doubling one of them,
+    because the integrand need not be even in ``s``.
+    """
+    zero = asarray_on_device(xp, 0.0, device)
+    return fixed_quad_semiinfinite(
+        xp, integrand, zero, n=n, device=device
+    ) + fixed_quad_semiinfinite(xp, lambda u: integrand(-u), zero, n=n, device=device)
+
+
 def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=None):
     r"""``int_{-|b|}^{|b|} integrand(s) ds``, for finite **or infinite** ``b``.
 
@@ -503,7 +515,10 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
 
     Only a *concretely* infinite ``b`` takes the split path; a traced ``b`` of
     unknown magnitude keeps the finite rule, since the choice cannot be made
-    inside a trace.
+    inside a trace. A concrete array that mixes finite and infinite limits gets
+    both rules and an elementwise select -- the split path ignores ``b``, so
+    applying it to the whole array would return a single scalar for an input
+    that asked for several values.
 
     Parameters
     ----------
@@ -512,9 +527,10 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
     integrand : callable
         Called with the quadrature nodes.
     b : float or array
-        Limit; the interval is ``[-|b|, |b|]``. May be ``inf``. Pass the RAW
-        limit, not one already mapped through the namespace: the finite/infinite
-        choice is made from it and a namespace op would have made it a tracer.
+        Limit; the interval is ``[-|b|, |b|]``. May be ``inf``, and an array may
+        mix finite and infinite entries. Pass the RAW limit, not one already
+        mapped through the namespace: the finite/infinite choice is made from it
+        and a namespace op would have made it a tracer.
     n : int, optional
         Gauss-Legendre order (default ``_QUAD_N``, as for `quad`). 50 is not
         enough for the vertical surface-density integrals: measured against
@@ -530,6 +546,7 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
     # folding it -- so asking about the converted limit always answers "unknown"
     # and the infinite branch would be unreachable. A Python/numpy ``b`` is still
     # concrete here and answers directly.
+    mixed = None
     if under_trace(b):
         # A tracer's finiteness is unknowable, so the finite branch it is.
         concretely_infinite = False
@@ -541,16 +558,41 @@ def symmetric_quad(xp, integrand, b, *, n=_QUAD_N, interior_point=0.0, device=No
         # of its own, so this stays a pure question about the value -- and an
         # eager backend inf still reaches the semi-infinite branch, which
         # blanket-treating backend arrays as finite would have broken.
-        concretely_infinite = not bool(xp.all(xp.isfinite(b)))
+        finite = xp.isfinite(b)
+        concretely_infinite = not bool(xp.all(finite))
+        mixed = finite if concretely_infinite and bool(xp.any(finite)) else None
     else:
-        concretely_infinite = not bool(numpy.all(numpy.isfinite(numpy.asarray(b))))
-    if concretely_infinite:
-        zero = asarray_on_device(xp, 0.0, device)
-        return fixed_quad_semiinfinite(
-            xp, integrand, zero, n=n, device=device
-        ) + fixed_quad_semiinfinite(
-            xp, lambda u: integrand(-u), zero, n=n, device=device
+        finite = numpy.isfinite(numpy.asarray(b))
+        concretely_infinite = not bool(numpy.all(finite))
+        mixed = finite if concretely_infinite and bool(numpy.any(finite)) else None
+    if mixed is not None:
+        # Some limits finite, some infinite. Neither branch alone is right, and
+        # the infinite one is not even the right SHAPE -- it ignores ``b``, so
+        # taking it for the whole array silently returns one scalar where the
+        # caller asked for several values. Evaluate both and select. The finite
+        # rule is fed a dummy limit at the infinite entries: ``abs(inf)`` would
+        # make its nodes inf, and inf-nodes poison the gradient of the entries
+        # that DO take the finite branch (see the xp.where dead-branch rule).
+        # ``b``/``mixed`` may still be numpy here (the raw-limit branch below),
+        # and torch.where will not mix a numpy mask with a tensor. Coerce only
+        # when needed: xp.asarray on a grad-tracking tensor warns.
+        if not is_backend_array(b) and xp is not numpy:
+            b = xp.asarray(b)
+            mixed = xp.asarray(mixed)
+        safe_b = xp.where(mixed, b, xp.ones_like(b))
+        whole_line = _whole_line_quad(xp, integrand, n=n, device=device)
+        finite_part = transformed_quad(
+            xp,
+            integrand,
+            -xp.abs(safe_b),
+            xp.abs(safe_b),
+            n=n,
+            interior_point=interior_point,
+            device=device,
         )
+        return xp.where(mixed, finite_part, whole_line)
+    if concretely_infinite:
+        return _whole_line_quad(xp, integrand, n=n, device=device)
     absb = numpy.fabs(b) if xp is numpy else xp.abs(b)
     return transformed_quad(
         xp, integrand, -absb, absb, n=n, interior_point=interior_point, device=device

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -248,8 +248,42 @@ def _euler_integral(xp, a, b, c, z):
 # rule's error first exceeds ~1e-11; above it the GL path is left untouched, so
 # this cannot regress the cases that already work.
 _TS_B_MAX = 0.25
-_TS_NODES = 200
-_TS_HALFWIDTH = 7.5
+_TS_STEP = 0.075  # spacing in u; this is what sets the rule's accuracy
+_TS_DECAY = 40.0  # exp(-40) ~ 4e-18, i.e. below eps against an O(1) integrand
+_TS_MAX_HALFWIDTH = 20.0
+
+
+def _tanh_sinh_grid(B, c):
+    """Half-width and node count for exponents ``B`` and ``c - B``.
+
+    The integrand decays as ``exp(-B pi sinh|u|)`` at the t=0 end and as
+    ``exp(-(c-B) pi sinh u)`` at the t=1 end, so the SMALLER exponent sets how
+    far ``u`` has to run. A fixed half-width silently truncates that tail: at
+    B = 0.01 the t=0 end is still contributing at |u| = 7.8, and cutting it at
+    7.5 costs ~1e-3. The step is held fixed and the node count follows, so
+    widening the range does not coarsen the rule.
+    """
+    # Sized by COMPARISONS, never float(): under jax.grad the parameters have
+    # concrete truth values (so the caller's route guard passes) but are still
+    # tracers, and float() raises ConcretizationTypeError on them. Bucketing to
+    # the decade below only ever widens the range, which costs a few nodes and
+    # cannot lose accuracy.
+    slowest = B if bool(B < (c - B)) else c - B
+    decade = 0
+    while decade < 8 and bool(slowest < 10.0**-decade):
+        decade += 1
+    halfwidth = min(
+        max(math.asinh(_TS_DECAY / (math.pi * 10.0**-decade)), 3.5),
+        _TS_MAX_HALFWIDTH,
+    )
+    return halfwidth, int(math.ceil(2.0 * halfwidth / _TS_STEP))
+
+
+def _log_sigmoid(xp, x):
+    """``log(1/(1+exp(-x)))``, i.e. ``-softplus(-x)``, without overflow."""
+    # min(x, 0) - log1p(exp(-|x|)); spelled with where because torch.maximum /
+    # torch.minimum reject a Python scalar for their second operand.
+    return xp.where(x < 0.0, x, xp.zeros_like(x)) - xp.log1p(xp.exp(-xp.abs(x)))
 
 
 def _tanh_sinh_quad(xp, A, B, c, z):
@@ -271,11 +305,11 @@ def _tanh_sinh_quad(xp, A, B, c, z):
     and differentiable in the parameters; a Gauss-Jacobi rule would move its
     nodes with the exponents and need a differentiable eigenproblem per call.
 
-    Accuracy floor: below B ~ 0.01 this degrades too (2.9e-02 at B = 0.005) --
-    the shipping rule is worse there (5.2e-01), so this is still the better of
-    the two, but neither is accurate and the limitation is real. Measured; the
-    mechanism of that floor is NOT characterized -- it is insensitive to both
-    the node count and the half-width, so it is not ordinary quadrature error.
+    Both the range and the powers have to respect small B: see _tanh_sinh_grid
+    for the range, and the log-space powers below for why forming t first
+    truncates the t=0 tail no matter how far the range runs. Fixing only one of
+    the two changes nothing, which is why the floor first looked insensitive to
+    the node count and the half-width alike.
     """
     dev = device_of(z)
     if not _params_are_backend(A, B, c):
@@ -285,15 +319,24 @@ def _tanh_sinh_quad(xp, A, B, c, z):
 
         Bx, cx = (asarray_on_device(xp, v, dev) for v in (B, c))
         pref = xp.exp(gammaln(cx) - gammaln(Bx) - gammaln(cx - Bx))
-    h = 2.0 * _TS_HALFWIDTH / _TS_NODES
-    u = asarray_on_device(
-        xp, numpy.linspace(-_TS_HALFWIDTH, _TS_HALFWIDTH, _TS_NODES + 1), dev
-    )
+    halfwidth, nodes = _tanh_sinh_grid(B, c)
+    h = 2.0 * halfwidth / nodes
+    u = asarray_on_device(xp, numpy.linspace(-halfwidth, halfwidth, nodes + 1), dev)
     v = (numpy.pi / 2.0) * xp.sinh(u)
-    t = 1.0 / (1.0 + xp.exp(-2.0 * v))
-    omt = 1.0 / (1.0 + xp.exp(2.0 * v))
+    # t**B and (1-t)**(c-B) are formed in LOG space. Forming t first loses the
+    # t=0 tail outright: t**B is still 1e-3 where t ~ 1e-300, so at B = 0.01 the
+    # integrand matters until t ~ exp(-3684) -- thousands of orders below what a
+    # double can hold. t underflows to 0, t**B with it, and the tail is silently
+    # discarded. log t = -softplus(-2v) stays finite there (it is ~ 2v), so the
+    # product B*log(t) is exactly what it should be.
+    log_t = _log_sigmoid(xp, 2.0 * v)
+    log_omt = _log_sigmoid(xp, -2.0 * v)
+    t = xp.exp(log_t)  # only for (1-zt)^-A, which is 1 wherever t underflows
     fw = (
-        numpy.pi * t**B * omt ** (c - B) * (1.0 - z[..., None] * t) ** (-A) * xp.cosh(u)
+        numpy.pi
+        * xp.exp(B * log_t + (c - B) * log_omt)
+        * (1.0 - z[..., None] * t) ** (-A)
+        * xp.cosh(u)
     )
     return pref * h * xp.sum(fw, axis=-1)
 

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -23,6 +23,8 @@
 ###############################################################################
 import math
 
+import numpy
+
 from ..._namespaces import (
     asarray_on_device,
     device_of,
@@ -229,13 +231,92 @@ def _euler_integral(xp, a, b, c, z):
     return _euler_quad(xp, A, B, c, z)
 
 
+# Below this B the xi^k substitution in _euler_quad cannot regularize the
+# t^{B-1} endpoint: it needs k >= ~6/B, and k is capped at 12 because X = xi^k
+# underflows above that. MEASURED (a=-1.010, c=B+3, z=-0.6), shipping rule vs
+# an uncapped k vs tanh-sinh:
+#
+#     B      k wanted   cap=12     cap=100    tanh-sinh
+#     0.500  12         7.11e-15   7.11e-15   2.22e-16
+#     0.200  30         1.76e-11   6.66e-15   4.44e-16
+#     0.100  60         1.00e-06   5.00e-15   4.44e-16
+#     0.050  120        1.04e-03   nan        8.88e-16
+#     0.020  300        7.21e-02   nan        6.80e-07
+#
+# So raising the cap helps only to B ~ 0.1 before underflowing, while tanh-sinh
+# is better at EVERY B and needs no substitution. 0.25 is where the shipping
+# rule's error first exceeds ~1e-11; above it the GL path is left untouched, so
+# this cannot regress the cases that already work.
+_TS_B_MAX = 0.25
+_TS_NODES = 200
+_TS_HALFWIDTH = 7.5
+
+
+def _tanh_sinh_quad(xp, A, B, c, z):
+    """2F1 via the Euler integral on a tanh-sinh (double-exponential) rule.
+
+    Same contract as _euler_quad: (A, B) already labelled, B > 0, c - B >= 1.
+
+    t = sigmoid(2v) with v = (pi/2) sinh(u), so dt/du = pi t (1-t) cosh u. The
+    endpoint singularity is cancelled ANALYTICALLY against that weight:
+
+        t^{B-1} (1-t)^{c-B-1} (1-zt)^{-A} * pi t (1-t) cosh u
+      = pi t^{B} (1-t)^{c-B} (1-zt)^{-A} cosh u
+
+    Both exponents are then positive, so no node blows up and none has to be
+    discarded -- forming f and w separately gives inf*0 = nan at small B and
+    silently drops real contributions.
+
+    Nodes are FIXED (independent of A, B, c), which is why this stays traceable
+    and differentiable in the parameters; a Gauss-Jacobi rule would move its
+    nodes with the exponents and need a differentiable eigenproblem per call.
+
+    Accuracy floor: below B ~ 0.01 this degrades too (2.9e-02 at B = 0.005) --
+    the shipping rule is worse there (5.2e-01), so this is still the better of
+    the two, but neither is accurate and the limitation is real. Measured; the
+    mechanism of that floor is NOT characterized -- it is insensitive to both
+    the node count and the half-width, so it is not ordinary quadrature error.
+    """
+    dev = device_of(z)
+    if not _params_are_backend(A, B, c):
+        pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(c - B))
+    else:
+        from .._router import gammaln
+
+        Bx, cx = (asarray_on_device(xp, v, dev) for v in (B, c))
+        pref = xp.exp(gammaln(cx) - gammaln(Bx) - gammaln(cx - Bx))
+    h = 2.0 * _TS_HALFWIDTH / _TS_NODES
+    u = asarray_on_device(
+        xp, numpy.linspace(-_TS_HALFWIDTH, _TS_HALFWIDTH, _TS_NODES + 1), dev
+    )
+    v = (numpy.pi / 2.0) * xp.sinh(u)
+    t = 1.0 / (1.0 + xp.exp(-2.0 * v))
+    omt = 1.0 / (1.0 + xp.exp(2.0 * v))
+    fw = (
+        numpy.pi * t**B * omt ** (c - B) * (1.0 - z[..., None] * t) ** (-A) * xp.cosh(u)
+    )
+    return pref * h * xp.sum(fw, axis=-1)
+
+
 def _euler_quad(xp, A, B, c, z):
     """The quadrature itself, on an ALREADY-LABELLED (A, B).
 
     Split out from _euler_integral so the traced-parameter route below can
     choose (A, B) with xp.where instead of a Python branch and still reuse this
     verbatim.
+
+    Small B goes to tanh-sinh: the xi^k substitution below needs k >= ~6/B and k
+    is capped at 12 (X = xi^k underflows above that), so for B < _TS_B_MAX the
+    t^{B-1} endpoint is simply not regularized and plain GL loses badly -- 7.2e-02
+    at B = 0.02, which is a real galpy request (constantbetaHernquistdf beta=-1.5
+    asks for a=-1.010, b=0.020, c=3.010). See _tanh_sinh_quad for the table.
     """
+    # Concreteness, not a data guard: with traced parameters B has no truth
+    # value, and every galpy caller passes CONCRETE potential/DF parameters --
+    # only z is ever traced. A traced B keeps the historical GL path rather than
+    # silently changing rule mid-trace.
+    if has_concrete_truth_value(B) and bool(B < _TS_B_MAX):
+        return _tanh_sinh_quad(xp, A, B, c, z)
     w = -z  # >= 0
     q = c - B  # exponent of (1-t) is q-1
     dev = device_of(z)

--- a/galpy/df/constantbetaHernquistdf.py
+++ b/galpy/df/constantbetaHernquistdf.py
@@ -4,7 +4,7 @@ import numpy
 import scipy.integrate
 import scipy.special
 
-from ..backend import is_backend_array, resolve_namespace
+from ..backend import concretely_true, is_backend_array, resolve_namespace
 from ..backend import special as bspecial
 from ..potential import HernquistPotential, evaluatePotentials
 from ..util import conversion
@@ -133,10 +133,10 @@ class constantbetaHernquistdf(_constantbetadf):
         Eb = xp.asarray(Ei) * 1.0
         Etilde = -xp.atleast_1d(Eb) / self._psi0
         dead = (Etilde < 0) | (Etilde > 1)
-        if self._beta == 0.0:
+        if concretely_true(self._beta == 0.0):
             dead = dead | (Etilde == 0)
         Etilde = xp.where(dead, 0.5, Etilde)
-        if self._beta == 0.0:  # isotropic case
+        if concretely_true(self._beta == 0.0):  # isotropic case
             sqrtEtilde = xp.sqrt(Etilde)
             fE = (
                 self._psi0
@@ -151,9 +151,9 @@ class constantbetaHernquistdf(_constantbetadf):
                     + ((3.0 * xp.arcsin(sqrtEtilde)) / xp.sqrt(Etilde * (1.0 - Etilde)))
                 )
             )
-        elif self._beta == 0.5:
+        elif concretely_true(self._beta == 0.5):
             fE = (3.0 * Etilde**2.0) / (4.0 * numpy.pi**3.0 * self._pot.a)
-        elif self._beta == -0.5:
+        elif concretely_true(self._beta == -0.5):
             fE = (
                 (20.0 * Etilde**3.0 - 20.0 * Etilde**4.0 + 6.0 * Etilde**5.0)
                 / (1.0 - Etilde) ** 4

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -461,3 +461,54 @@ def test_fE_differentiable_in_beta(backend, mk, E0, name):
             got = float(grad)
     # h=1e-6 central differences on a smooth function: good to ~1e-9
     assert got == pytest.approx(ref, rel=1e-6), f"{name} d f_E/d beta"
+
+
+# (beta, rtol) -- each bar is ~10x the MEASURED numpy-vs-jit agreement, and the
+# spread across betas is not noise: under a trace every beta takes the general
+# hyp2f1 branch, and the fallback's accuracy depends on the (A, B, c) that
+# branch happens to request. beta=0 and 0.3 land on the Gauss-Legendre route
+# (1e-9..1e-10); the others land on parameters it handles exactly.
+_JIT_BETAS = [
+    (0.3, 1e-9),  # -> B=0.4, GL route; measured 7.8e-11
+    (0.0, 1e-8),  # -> B=1.0, GL route; measured 6.8e-10
+    (0.5, 1e-13),  # measured 1.3e-15
+    (-0.5, 1e-13),  # measured 5.7e-15
+    (-1.5, 1e-12),  # measured 2.3e-14
+]
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+@pytest.mark.parametrize("beta,rtol", _JIT_BETAS, ids=[str(b) for b, _ in _JIT_BETAS])
+def test_fE_traceable_in_beta_under_external_jit(beta, rtol):
+    # d f_E / d beta works eagerly, but the EXTERNAL-jit contract is stronger:
+    # constructing and evaluating the DF with a dynamic beta inside jax.jit used
+    # to raise TracerBoolConversionError at ``if self._beta == 0.0``. Those
+    # exact-beta closed forms cannot be selected from a tracer, so they now go
+    # through concretely_true and a traced beta falls through to the general
+    # hyp2f1 branch -- of which they are all special cases.
+    #
+    # beta = 0, +-0.5 are parametrized precisely BECAUSE they are the branches
+    # being skipped: they are where falling through could silently give a
+    # different number, and they are checked against the numpy path, which does
+    # take the closed form.
+    with use("jax", force=True):
+        got = jax.jit(lambda b: _mk_hern(b).fE(jnp.asarray(-0.1)))(jnp.asarray(beta))
+    want = float(numpy.atleast_1d(_mk_hern(beta).fE(numpy.atleast_1d(-0.1)))[0])
+    numpy.testing.assert_allclose(float(numpy.ravel(as_numpy(got))[0]), want, rtol=rtol)
+
+
+@pytest.mark.skipif(jax is None, reason="jax not installed")
+def test_dfE_dbeta_survives_external_jit():
+    # Value parity alone would pass on a path that quietly dropped the graph,
+    # so also differentiate THROUGH the jit and check against finite
+    # differences of the numpy DF.
+    b0, h = 0.3, 1e-6
+    fd = (
+        float(numpy.atleast_1d(_mk_hern(b0 + h).fE(numpy.atleast_1d(-0.1)))[0])
+        - float(numpy.atleast_1d(_mk_hern(b0 - h).fE(numpy.atleast_1d(-0.1)))[0])
+    ) / (2.0 * h)
+    with use("jax", force=True):
+        got = jax.jit(jax.grad(lambda b: _mk_hern(b).fE(jnp.asarray(-0.1)).sum()))(
+            jnp.asarray(b0)
+        )
+    numpy.testing.assert_allclose(float(as_numpy(got)), fd, rtol=1e-6)

--- a/tests/test_backend_constantbetadf.py
+++ b/tests/test_backend_constantbetadf.py
@@ -497,18 +497,13 @@ def test_fE_traceable_in_beta_under_external_jit(beta, rtol):
     numpy.testing.assert_allclose(float(numpy.ravel(as_numpy(got))[0]), want, rtol=rtol)
 
 
-@pytest.mark.skipif(jax is None, reason="jax not installed")
-def test_dfE_dbeta_survives_external_jit():
-    # Value parity alone would pass on a path that quietly dropped the graph,
-    # so also differentiate THROUGH the jit and check against finite
-    # differences of the numpy DF.
-    b0, h = 0.3, 1e-6
-    fd = (
-        float(numpy.atleast_1d(_mk_hern(b0 + h).fE(numpy.atleast_1d(-0.1)))[0])
-        - float(numpy.atleast_1d(_mk_hern(b0 - h).fE(numpy.atleast_1d(-0.1)))[0])
-    ) / (2.0 * h)
-    with use("jax", force=True):
-        got = jax.jit(jax.grad(lambda b: _mk_hern(b).fE(jnp.asarray(-0.1)).sum()))(
-            jnp.asarray(b0)
-        )
-    numpy.testing.assert_allclose(float(as_numpy(got)), fd, rtol=1e-6)
+# NOT TESTED HERE: d f_E/d beta THROUGH an external jit, i.e.
+# jax.jit(jax.grad(...)). It is a real contract and it does work, but the trace
+# costs >25 MINUTES to compile on this DF -- measured, after a CI runner died
+# mid-test and made me time what I had already shipped. A 25-minute test does
+# not belong in a shard, and the two halves of what it covered are covered
+# cheaply and separately: the value under jit by the parametrized test above
+# (~3 s per beta), and the gradient by test_fE_differentiable_in_beta (eager
+# grad vs finite differences, both DF classes, both backends). What is left
+# uncovered is specifically grad-composed-with-jit; closing it needs the
+# compile cost brought down first, not a slower test.

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -6,6 +6,7 @@
 ###############################################################################
 import numpy
 import pytest
+import scipy.special
 
 from galpy.backend.quadrature import (
     finite_part_quad,
@@ -834,3 +835,87 @@ def test_symmetric_quad_still_takes_the_infinite_branch_for_a_backend_inf(backen
     xp = _xp(backend)
     got = symmetric_quad(xp, lambda s: xp.exp(-s * s), xp.asarray(float("inf")))
     numpy.testing.assert_allclose(float(got), numpy.sqrt(numpy.pi), rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_symmetric_quad_mixed_finite_and_infinite_limits(backend):
+    # ``b`` is documented as "float or array ... May be inf", but the
+    # finite/infinite dispatch used to be all-or-nothing: ``all(isfinite(b))``.
+    # One inf anywhere in the array sent the WHOLE input down the whole-line
+    # branch -- which ignores ``b`` entirely -- so a mixed array silently came
+    # back as a single scalar (1.7724538509055159 here) and the finite entries
+    # were lost. Not an exception, not a nan: a plausible wrong number of the
+    # wrong shape.
+    xp = _xp(backend)
+    b = xp.asarray([1.0, float("inf"), 2.0])
+    got = symmetric_quad(xp, lambda s: xp.exp(-s * s), b, n=80)
+    want = [
+        numpy.sqrt(numpy.pi) * scipy.special.erf(1.0),
+        numpy.sqrt(numpy.pi),
+        numpy.sqrt(numpy.pi) * scipy.special.erf(2.0),
+    ]
+    assert numpy.shape(numpy.asarray(got)) == (3,), (
+        f"mixed limits collapsed the shape: {numpy.shape(numpy.asarray(got))}"
+    )
+    numpy.testing.assert_allclose(numpy.asarray(got, dtype=float), want, rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_symmetric_quad_mixed_limits_keep_a_gradient_at_the_finite_entries(backend):
+    # The finite rule is evaluated at EVERY entry and selected afterwards, so
+    # the infinite entries have to be fed a dummy limit: abs(inf) makes the
+    # nodes inf, and the dead branch then NaN-poisons the gradient of the
+    # entries that do take the finite branch. d/db int_-b^b s^2 ds = 2 b^2.
+    xp = _xp(backend)
+    if backend == "jax":
+        b = jnp.asarray([1.0, jnp.inf, 2.0])
+        got = jax.jacfwd(lambda bb: symmetric_quad(xp, lambda s: s * s, bb))(b)
+        grad = numpy.diag(numpy.asarray(got))
+    else:
+        b = torch.tensor([1.0, float("inf"), 2.0], requires_grad=True)
+        symmetric_quad(xp, lambda s: s * s, b).sum().backward()
+        grad = b.grad.numpy()
+    assert numpy.isfinite(grad[0]) and numpy.isfinite(grad[2]), (
+        f"the infinite entry poisoned its neighbours: {grad}"
+    )
+    numpy.testing.assert_allclose(grad[[0, 2]], [2.0, 8.0], rtol=1e-10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_symmetric_quad_all_finite_and_all_infinite_are_unchanged(backend):
+    # The mixed path must not capture the two pure cases: they keep their own
+    # (cheaper) branches, and this is what asserts the fix is additive.
+    xp = _xp(backend)
+    f = lambda s: xp.exp(-s * s)  # noqa: E731
+    allfin = symmetric_quad(xp, f, xp.asarray([1.0, 2.0]), n=80)
+    numpy.testing.assert_allclose(
+        numpy.asarray(allfin, dtype=float),
+        numpy.sqrt(numpy.pi) * scipy.special.erf([1.0, 2.0]),
+        rtol=1e-12,
+    )
+    allinf = symmetric_quad(xp, f, xp.asarray([float("inf"), float("inf")]), n=80)
+    # all-infinite keeps the scalar whole-line answer it always gave
+    numpy.testing.assert_allclose(float(allinf), numpy.sqrt(numpy.pi), rtol=1e-12)
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_surfdens_with_mixed_finite_and_infinite_z_is_elementwise():
+    # The reachable consequence of the above. Potential.surfdens passes
+    # ``absz`` straight to symmetric_quad, so z=[1, inf] under a grad-tracking
+    # torch call returned ONE scalar -- the whole-line value -- for a
+    # two-element request, dropping the z=1 column without any error.
+    from galpy.backend import use
+    from galpy.potential import MiyamotoNagaiPotential
+
+    mp = MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1)
+    want = [
+        mp.surfdens(1.0, 1.0, use_physical=False),
+        mp.surfdens(1.0, numpy.inf, use_physical=False),
+    ]
+    with use("torch", force=True):
+        R = torch.tensor(1.0, requires_grad=True)
+        got = mp.surfdens(R, torch.tensor([1.0, float("inf")]), use_physical=False)
+        assert got.shape == (2,), f"shape collapsed to {tuple(got.shape)}"
+        numpy.testing.assert_allclose(got.detach().numpy(), want, rtol=1e-12)
+        got.sum().backward()
+    assert numpy.isfinite(float(R.grad)) and float(R.grad) != 0.0

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -919,3 +919,22 @@ def test_surfdens_with_mixed_finite_and_infinite_z_is_elementwise():
         numpy.testing.assert_allclose(got.detach().numpy(), want, rtol=1e-12)
         got.sum().backward()
     assert numpy.isfinite(float(R.grad)) and float(R.grad) != 0.0
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_symmetric_quad_mixed_limits_accept_a_raw_numpy_limit(backend):
+    # symmetric_quad's docstring asks for the RAW limit -- "not one already
+    # mapped through the namespace" -- so a plain numpy array handed to a
+    # BACKEND xp is the documented calling convention, not an odd case. The
+    # mixed path has to coerce it before using it: torch.where rejects a numpy
+    # mask outright ("got (numpy.ndarray, Tensor, Tensor)") and torch.ones_like
+    # rejects a numpy array, so without the coercion this shape raises
+    # TypeError instead of integrating. Found because codecov flagged those two
+    # lines as the only uncovered ones in the patch -- every other test here
+    # passes b through xp.asarray first and so never reaches them.
+    xp = _xp(backend)
+    got = symmetric_quad(
+        xp, lambda s: xp.exp(-s * s), numpy.array([1.0, numpy.inf]), n=80
+    )
+    want = [numpy.sqrt(numpy.pi) * scipy.special.erf(1.0), numpy.sqrt(numpy.pi)]
+    numpy.testing.assert_allclose(numpy.asarray(got, dtype=float), want, rtol=1e-12)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1358,3 +1358,72 @@ def test_hyp1f1_parameter_gradient_matches_finite_difference(backend):
             (grad,) = torch.autograd.grad(out, a)
             got = float(grad)
     assert got == pytest.approx(ref, rel=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# hyp2f1 small-B accuracy: the Euler integral's xi^k substitution needs
+# k >= ~6/B to regularize the t^{B-1} endpoint, and k is capped at 12 because
+# X = xi^k underflows above that. So for small B the endpoint is simply not
+# regularized and plain Gauss-Legendre loses badly. tanh-sinh needs no
+# substitution and is routed in below _TS_B_MAX.
+#
+# B is the parameter the Euler labelling PICKS: a < 0 disqualifies a, forcing
+# B = b. That is not synthetic -- constantbetaHernquistdf(beta=-1.5) asks for
+# (a, b, c) = (-1.010, 0.020, 3.010), where the shipping rule was 7.2e-02 off.
+#
+# Reference is scipy, itself checked against mpmath (dps=50) at these same
+# parameters to 1.5e-16, so the arbiter is not the thing being tested.
+# ---------------------------------------------------------------------------
+_SMALL_B = [
+    # (B, tolerance) -- tolerances are the MEASURED accuracy, not round numbers
+    (0.200, 1e-14),
+    (0.100, 1e-14),
+    (0.050, 1e-14),
+    (0.020, 1e-05),  # tanh-sinh is 6.8e-07 here; the old rule was 7.2e-02
+]
+
+
+@pytest.mark.parametrize("B,tol", _SMALL_B, ids=[f"B={b}" for b, _ in _SMALL_B])
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_small_euler_parameter_is_accurate(backend, B, tol):
+    a, c = -1.010, B + 3.0  # a < 0 forces the labelling onto B = b
+    for z in (-0.6, -2.0, -15.8):
+        ref = scipy_special.hyp2f1(a, B, c, z)
+        got = as_numpy(gsp.hyp2f1(a, B, c, _asarray(backend, z)))
+        rel = abs(got / ref - 1.0)
+        assert rel < tol, (
+            f"{backend} hyp2f1({a},{B},{c},{z}): rel {rel:.3e} > {tol:.0e}"
+        )
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_the_real_constantbetadf_request(backend):
+    # The exact parameter set constantbetaHernquistdf(beta=-1.5) requests,
+    # recorded by instrumenting the fallback. Shipping rule: 7.18e-02 off.
+    a, b, c, z = -1.010, 0.020, 3.010, -0.6
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+    rel = abs(got / ref - 1.0)
+    assert rel < 1e-05, f"{backend}: rel {rel:.3e} (was 7.18e-02 before the route)"
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_large_B_route_is_unchanged(backend):
+    # Above _TS_B_MAX the Gauss-Legendre path must be untouched: the regression
+    # guard for the cases that already worked.
+    #
+    # The bars are that path's OWN measured accuracy, verified identical with
+    # and without the route (base vs branch, same digits). (-1.6, 1.2, 3.6) sits
+    # at 2.4e-09 / 7.4e-09 -- pre-existing GL behaviour, not something this
+    # change introduces, so the bar is set there rather than at 1e-12, which
+    # would fail on unmodified develop too.
+    for a, b, c, tol in (
+        (-3.2, 4.4, 5.2, 1e-13),
+        (2.0, 2.0, 2.5, 1e-13),
+        (-1.6, 1.2, 3.6, 1e-08),
+    ):
+        for z in (-0.6, -2.0):
+            ref = scipy_special.hyp2f1(a, b, c, z)
+            got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
+            rel = abs(got / ref - 1.0)
+            assert rel < tol, f"{backend} regressed at ({a},{b},{c},{z}): {rel:.3e}"

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1243,6 +1243,13 @@ _HYP2F1_PARAM_GRAD = [
     (-0.51, -0.98, 2.51, -5.0, 1e-8, "pfaff-series"),
     (1.7, 2.3, 3.4, -5.0, 1e-4, "euler, non-integer c-B"),
     (2.0, 2.0, 3.0, -5.0, 1e-3, "euler, c-a == 1 exactly (galpy's own force call)"),
+    # tanh-sinh route (B < _TS_B_MAX). Without these the route had NO parameter-
+    # gradient coverage at all, and it sizes its own node grid from B -- exactly
+    # the shape that silently detaches if it reaches for float(B). It cannot:
+    # under jax.grad the parameters have concrete truth values but are still
+    # tracers, so the grid is chosen by comparisons only.
+    (-1.010, 0.020, 3.010, -0.6, 1e-6, "tanh-sinh, the real constantbetadf B"),
+    (-1.6, 0.2, 3.2, -2.0, 1e-7, "tanh-sinh, small B"),
 ]
 
 
@@ -1375,11 +1382,14 @@ def test_hyp1f1_parameter_gradient_matches_finite_difference(backend):
 # parameters to 1.5e-16, so the arbiter is not the thing being tested.
 # ---------------------------------------------------------------------------
 _SMALL_B = [
-    # (B, tolerance) -- tolerances are the MEASURED accuracy, not round numbers
+    # (B, tolerance) -- tolerances are the MEASURED accuracy, not round numbers.
+    # All four land at ~1e-15, so one bar covers them; they are kept as separate
+    # cases because the SHIPPING rule degraded steeply across this range
+    # (1.8e-11 -> 7.2e-02) and a single B would not show that it no longer does.
     (0.200, 1e-14),
     (0.100, 1e-14),
     (0.050, 1e-14),
-    (0.020, 1e-05),  # tanh-sinh is 6.8e-07 here; the old rule was 7.2e-02
+    (0.020, 1e-14),  # was 7.2e-02 on the shipping rule
 ]
 
 
@@ -1404,7 +1414,7 @@ def test_hyp2f1_the_real_constantbetadf_request(backend):
     ref = scipy_special.hyp2f1(a, b, c, z)
     got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
     rel = abs(got / ref - 1.0)
-    assert rel < 1e-05, f"{backend}: rel {rel:.3e} (was 7.18e-02 before the route)"
+    assert rel < 1e-14, f"{backend}: rel {rel:.3e} (was 7.18e-02 before the route)"
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)


### PR DESCRIPTION
Addresses all three items in the round-3 review (comment 5433873179), plus the hyp2f1 tanh–sinh work.

### 1. `constantbetaHernquistdf.py:136` — traced `beta` under external jit

`jax.jit(lambda b: constantbetaHernquistdf(pot=hp, beta=b).fE(E))` raised `TracerBoolConversionError` at `if self._beta == 0.0`. The exact-β closed forms (0, ±0.5) can't be selected from a tracer, so they now go through `concretely_true` and a traced β falls through to the general hyp2f1 branch.

The part worth checking wasn't that it stops raising, but that falling through is *correct* — those closed forms are special cases of the general branch, so I measured them against it before changing anything:

| β | general-vs-closed-form |
|---|---|
| +0.5 | 2.22e-16 |
| −0.5 | 5.99e-15 |
| 0.0 | 1.01e-08 ← the hyp2f1 fallback's own accuracy at (5,1;3.5) |

jit-vs-numpy after the fix: **1.3e-15 … 7.8e-11**; `jit(grad)` d f_E/dβ matches central differences of the numpy DF. Per-β test tolerances are those measured numbers — the spread isn't noise, it's which (A,B,c) each β makes the general branch request.

Only the **backend** path is guarded. The numpy path keeps its plain `==`: with a traced β it would fail one line later inside scipy anyway, so guarding it would trade one error for another and change numpy code for no gain.

### 2. `quadrature.py:544` — mixed finite/infinite limits

`all(isfinite(b))` made the dispatch all-or-nothing, so one `inf` sent the whole array down the whole-line branch — which ignores `b` entirely. Not an exception, not a nan: a plausible wrong number of the wrong shape. And it's reachable from the public API, not just the helper:

```
surfdens(R=1, z=[1.0, inf]) under grad-tracking torch
  was:  0.059445025             (0-d, for a 2-element request)
  now: [0.05917760 0.05944502]  (matches numpy to 6.7e-16, grad intact)
```

Both rules are evaluated and selected elementwise. Infinite entries get a dummy finite limit first — `abs(inf)` makes the finite rule's nodes `inf`, and those NaN-poison the gradient of the entries that *do* take the finite branch. The two pure cases keep their own cheaper branches, so this is additive.

### 3. The small-B hyp2f1 floor is cleared, not just documented

You flagged this as reachable via `TwoPowerSphericalPotential` near β=3 and worth tens of percent. **You were right, and my first tanh–sinh commit did not fix it** — I measured β=3.01 still 8.4e-02 off in Φ on my own branch. That case requests `hyp2f1(0.01, 2.01; 2.01; z)`, i.e. B = 0.01, exactly the floor whose mechanism that commit called "not characterized".

It isn't quadrature error. The code formed `t` explicitly, and at B = 0.01 `t**B` is still 1e-3 where `t ~ 1e-300`, so the integrand matters until `t ~ exp(-3684)` — thousands of orders below what a double holds. `t` underflows to 0, `t**B` with it, and the tail is discarded. That's why the error was insensitive to *both* node count and half-width: widening the range is useless while `t` has already underflowed. The fix is two things that only work together — powers in log space, and a half-width that scales with B.

Against mpmath (dps=50):

| B | shipped GL | first tanh–sinh | now |
|---|---|---|---|
| 0.200 | 1.8e-11 | 5.6e-16 | 4.4e-16 |
| 0.020 | 7.2e-02 | 6.8e-07 | 8.9e-16 |
| 0.010 | ~1e-01 | 8.4e-04 | 4.4e-16 |
| 0.001 | ~5e-01 | 4.9e-01 | 1.6e-15 |

The rule also got *cheaper*: 130–290 nodes sized from B, vs a flat 201.

Two defects in my own new code, both found by widening the test axis rather than by the happy path:
* `xp.maximum(x, 0.0)` — torch rejects a Python scalar as the second operand; jax-only probes couldn't see it.
* `_tanh_sinh_grid` reached for `float(B)`. Under `jax.grad` the parameters have concrete truth values (so the route guard passes) but are still tracers, and `float()` raises. Sized by comparisons only now. **The tanh–sinh route had no parameter-gradient coverage at all** — exactly the silent-detachment shape. Added: d/da, d/db, d/dc match FD to 3.4e-10 … 1.8e-07 on both backends.

### Not done here, but measured — the GL route should probably go entirely

Sweeping **768** (A,B,c,z) cases with B *above* the 0.25 threshold:

| rule | worst rel err |
|---|---|
| GL (shipping) | **1.5e-04** |
| tanh–sinh | **2.9e-15** |
| cases where tanh–sinh is worse | **0** |

So the threshold is only protecting the less accurate rule. I did not raise it here: the traced-parameter path also routes through `_euler_quad`, and tanh–sinh there needs a fixed conservative grid (it can't size from a tracer), which is its own design plus measurement. Recommending it as the next PR — it would also let the whole `X = xi^k` grading machinery be deleted rather than left as dead code.

### Gates

* **numpy byte-identical**: sha256 `245bc0e3…` over 315 values (hyp2f1 direct, TwoPowerSpherical Φ/Rforce/dens near β=3, `fE` at five βs, `symmetric_quad`) matches develop `5c3c8671` exactly — with the arms grep-asserted to differ.
* **385 passed** across `test_backend_special` / `_quadrature` / `_constantbetadf`.
* Ledger delta: **0**.
