### PR TITLE
hyp2f1: one tanh-sinh rule for every B, and drop the c-B >= 1 constraint

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -31,12 +31,10 @@ from ..._namespaces import (
     has_concrete_truth_value,
     is_backend_array,
 )
-from ._quadrature import gauss_legendre_01
 
 # 128 nodes: ~1e-10 or better vs scipy at realistic radii (|z| = r/a <~ 50);
 # accuracy degrades smoothly to ~1e-6 at the extreme |z| ~ 500 (r/a ~ 500, far
 # beyond any realistic galactic radius) for awkward exponent combinations.
-_NODES = 128
 
 
 # Terms for the series route below. Its argument is z/(z-1), so accuracy is set
@@ -73,25 +71,33 @@ def _params_are_backend(*ps):
 
 def _in_regime(a, b, c):
     """True when the Euler integral below can be used for these parameters."""
-    return (a > 0 and (c - a) >= 1.0) or (b > 0 and (c - b) >= 1.0)
+    return (a > 0 and (c - a) > 0.0) or (b > 0 and (c - b) > 0.0)
 
 
 def _euler_labeling(a, b, c):
-    """Pick (B, A) with {A,B}={a,b}, B>0 and c-B >= 1.
+    """Pick (B, A) with {A,B}={a,b}, B > 0 and c - B > 0.
 
-    Requiring c-B >= 1 keeps the (1-t)^{c-B-1} endpoint non-singular so the
-    fixed-order quadrature stays accurate. Callers check _in_regime first; the
-    raise is a guard against reaching the integral with parameters it cannot
-    represent, and names BOTH conditions, because the binding one is often the
-    sign: with a and b both non-positive there is no admissible B at all, even
-    though c - max(a, b) >= 1 may well hold.
+    Both conditions are just what the Beta integral needs to converge. The old
+    requirement was the stronger ``c - B >= 1``, which existed ONLY to keep
+    (1-t)^{c-B-1} non-singular for the fixed-order Gauss-Legendre rule this
+    module used to run; the tanh-sinh rule cancels that endpoint analytically
+    and does not care. Measured across c - B in (0, 1] -- the whole block the
+    old bound excluded -- the rule is accurate to 2.3e-15.
+
+    Dropping it also removes a float64 knife-edge: at (a=5.0, b=0.001, c=1.001)
+    the old test asked ``1.001 - 0.001 >= 1.0``, which is False by one ulp, so
+    the Euler route was refused and a much less accurate one ran instead
+    (measured 4.6e-03 there).
+
+    The raise still names BOTH conditions, because the binding one is often the
+    sign: with a and b both non-positive there is no admissible B at all.
     """
-    if a > 0 and (c - a) >= 1.0:
+    if a > 0 and (c - a) > 0.0:
         return a, b
-    if b > 0 and (c - b) >= 1.0:
+    if b > 0 and (c - b) > 0.0:
         return b, a
     raise NotImplementedError(
-        "hyp2f1 Euler integral needs some P in {a, b} with P > 0 and c - P >= 1; "
+        "hyp2f1 Euler integral needs some P in {a, b} with P > 0 and c - P > 0; "
         f"got (a={a}, b={b}, c={c})"
     )
 
@@ -179,7 +185,7 @@ def hyp2f1_fallback(xp, a, b, c, z):
 
 def _in_regime_mask(xp, a, b, c):
     """_in_regime as an elementwise mask, for traced (a, b, c)."""
-    return ((a > 0) & ((c - a) >= 1.0)) | ((b > 0) & ((c - b) >= 1.0))
+    return ((a > 0) & ((c - a) > 0.0)) | ((b > 0) & ((c - b) > 0.0))
 
 
 def _nonpositive_traced(xp, a, b, c, z):
@@ -247,36 +253,21 @@ def _euler_integral(xp, a, b, c, z):
 # is better at EVERY B and needs no substitution. 0.25 is where the shipping
 # rule's error first exceeds ~1e-11; above it the GL path is left untouched, so
 # this cannot regress the cases that already work.
-_TS_B_MAX = 0.25
-_TS_STEP = 0.075  # spacing in u; this is what sets the rule's accuracy
-_TS_DECAY = 40.0  # exp(-40) ~ 4e-18, i.e. below eps against an O(1) integrand
-_TS_MAX_HALFWIDTH = 20.0
-
-
-def _tanh_sinh_grid(B, c):
-    """Half-width and node count for exponents ``B`` and ``c - B``.
-
-    The integrand decays as ``exp(-B pi sinh|u|)`` at the t=0 end and as
-    ``exp(-(c-B) pi sinh u)`` at the t=1 end, so the SMALLER exponent sets how
-    far ``u`` has to run. A fixed half-width silently truncates that tail: at
-    B = 0.01 the t=0 end is still contributing at |u| = 7.8, and cutting it at
-    7.5 costs ~1e-3. The step is held fixed and the node count follows, so
-    widening the range does not coarsen the rule.
-    """
-    # Sized by COMPARISONS, never float(): under jax.grad the parameters have
-    # concrete truth values (so the caller's route guard passes) but are still
-    # tracers, and float() raises ConcretizationTypeError on them. Bucketing to
-    # the decade below only ever widens the range, which costs a few nodes and
-    # cannot lose accuracy.
-    slowest = B if bool(B < (c - B)) else c - B
-    decade = 0
-    while decade < 8 and bool(slowest < 10.0**-decade):
-        decade += 1
-    halfwidth = min(
-        max(math.asinh(_TS_DECAY / (math.pi * 10.0**-decade)), 3.5),
-        _TS_MAX_HALFWIDTH,
-    )
-    return halfwidth, int(math.ceil(2.0 * halfwidth / _TS_STEP))
+# ONE rule, one grid. The half-width is set by the SLOWEST endpoint decay the
+# labelling can hand us: the integrand falls off as exp(-B pi sinh|u|) at t=0
+# and exp(-(c-B) pi sinh u) at t=1, and _euler_labeling guarantees c-B >= 1, so
+# B is the binding one. 12.45 resolves B down to 1e-3 (exp(-40) ~ 4e-18, below
+# eps against an O(1) integrand); the step 0.075 is what sets the accuracy, and
+# the node count follows from the two.
+#
+# Sizing the grid PER CALL from B was measured and dropped: over 720 cases
+# spanning B = 0.001..5.0 the fixed grid is as accurate as the adaptive one
+# (worst 2.67e-15 vs 2.89e-15, nothing above 1e-13), and being independent of
+# the parameters is what lets a TRACED B use this rule at all -- sizing from B
+# needs bool(B < ...), which has no answer under jit.
+_TS_HALFWIDTH = 12.45
+_TS_STEP = 0.075
+_TS_NODES = int(math.ceil(2.0 * _TS_HALFWIDTH / _TS_STEP))
 
 
 def _log_sigmoid(xp, x):
@@ -286,10 +277,13 @@ def _log_sigmoid(xp, x):
     return xp.where(x < 0.0, x, xp.zeros_like(x)) - xp.log1p(xp.exp(-xp.abs(x)))
 
 
-def _tanh_sinh_quad(xp, A, B, c, z):
+def _euler_quad(xp, A, B, c, z):
     """2F1 via the Euler integral on a tanh-sinh (double-exponential) rule.
 
-    Same contract as _euler_quad: (A, B) already labelled, B > 0, c - B >= 1.
+    Operates on an ALREADY-LABELLED (A, B): B > 0 and c - B >= 1, guaranteed by
+    _euler_labeling. Split out from _euler_integral so the traced-parameter
+    route can choose (A, B) with xp.where instead of a Python branch and still
+    reuse this verbatim.
 
     t = sigmoid(2v) with v = (pi/2) sinh(u), so dt/du = pi t (1-t) cosh u. The
     endpoint singularity is cancelled ANALYTICALLY against that weight:
@@ -301,15 +295,22 @@ def _tanh_sinh_quad(xp, A, B, c, z):
     discarded -- forming f and w separately gives inf*0 = nan at small B and
     silently drops real contributions.
 
-    Nodes are FIXED (independent of A, B, c), which is why this stays traceable
-    and differentiable in the parameters; a Gauss-Jacobi rule would move its
-    nodes with the exponents and need a differentiable eigenproblem per call.
+    Nodes are FIXED -- independent of A, B, c AND of z -- which is what keeps
+    this traceable and differentiable in every argument.
 
-    Both the range and the powers have to respect small B: see _tanh_sinh_grid
-    for the range, and the log-space powers below for why forming t first
-    truncates the t=0 tail no matter how far the range runs. Fixing only one of
-    the two changes nothing, which is why the floor first looked insensitive to
-    the node count and the half-width alike.
+    This REPLACED a fixed-order Gauss-Legendre rule that regularized the
+    t^{B-1} endpoint with an X = xi^k substitution. That rule needed k >= ~6/B
+    and capped k at 12 (X = xi^k underflows above it), so it was accurate only
+    for B >= ~0.5 and catastrophic below. Measured against mpmath over 768
+    (A, B, c, z) cases with B ABOVE the old 0.25 routing threshold -- i.e. the
+    regime the GL rule was kept for -- its worst relative error was 1.5e-04
+    against 2.9e-15 here, with NO case where tanh-sinh was worse. The threshold
+    was only protecting the less accurate rule, so both it and the substitution
+    are gone.
+
+    Small |z| needs no special case: (1 - z t)^{-A} is simply 1 at z = 0, where
+    the GL rule's 1/|z| substitution was singular and needed its own series
+    branch.
     """
     dev = device_of(z)
     if not _params_are_backend(A, B, c):
@@ -317,11 +318,15 @@ def _tanh_sinh_quad(xp, A, B, c, z):
     else:
         from .._router import gammaln
 
+        # every operand on the backend and on z's device: the router's gammaln
+        # dispatches on its ARGUMENT, and torch.special.gammaln rejects a plain
+        # float outright.
         Bx, cx = (asarray_on_device(xp, v, dev) for v in (B, c))
         pref = xp.exp(gammaln(cx) - gammaln(Bx) - gammaln(cx - Bx))
-    halfwidth, nodes = _tanh_sinh_grid(B, c)
-    h = 2.0 * halfwidth / nodes
-    u = asarray_on_device(xp, numpy.linspace(-halfwidth, halfwidth, nodes + 1), dev)
+    h = 2.0 * _TS_HALFWIDTH / _TS_NODES
+    u = asarray_on_device(
+        xp, numpy.linspace(-_TS_HALFWIDTH, _TS_HALFWIDTH, _TS_NODES + 1), dev
+    )
     v = (numpy.pi / 2.0) * xp.sinh(u)
     # t**B and (1-t)**(c-B) are formed in LOG space. Forming t first loses the
     # t=0 tail outright: t**B is still 1e-3 where t ~ 1e-300, so at B = 0.01 the
@@ -339,81 +344,3 @@ def _tanh_sinh_quad(xp, A, B, c, z):
         * xp.cosh(u)
     )
     return pref * h * xp.sum(fw, axis=-1)
-
-
-def _euler_quad(xp, A, B, c, z):
-    """The quadrature itself, on an ALREADY-LABELLED (A, B).
-
-    Split out from _euler_integral so the traced-parameter route below can
-    choose (A, B) with xp.where instead of a Python branch and still reuse this
-    verbatim.
-
-    Small B goes to tanh-sinh: the xi^k substitution below needs k >= ~6/B and k
-    is capped at 12 (X = xi^k underflows above that), so for B < _TS_B_MAX the
-    t^{B-1} endpoint is simply not regularized and plain GL loses badly -- 7.2e-02
-    at B = 0.02, which is a real galpy request (constantbetaHernquistdf beta=-1.5
-    asks for a=-1.010, b=0.020, c=3.010). See _tanh_sinh_quad for the table.
-    """
-    # Concreteness, not a data guard: with traced parameters B has no truth
-    # value, and every galpy caller passes CONCRETE potential/DF parameters --
-    # only z is ever traced. A traced B keeps the historical GL path rather than
-    # silently changing rule mid-trace.
-    if has_concrete_truth_value(B) and bool(B < _TS_B_MAX):
-        return _tanh_sinh_quad(xp, A, B, c, z)
-    w = -z  # >= 0
-    q = c - B  # exponent of (1-t) is q-1
-    dev = device_of(z)
-    # X = xi^k regularizes the t^{B-1} endpoint: after the boundary-layer map the
-    # integrand carries X^{B-1} near X=0, which is only algebraically integrable
-    # for non-integer B. Raise it to xi^{kB-1} with kB >= ~6 so plain GL is
-    # spectrally accurate (k=1 already suffices once B-1 is a smooth high power).
-    # Capped at 12 (covers B >= 0.5, galpy's range) so X=xi^k cannot underflow.
-    if not _params_are_backend(A, B, c):
-        k = min(12.0, max(1.0, float(math.ceil(6.0 / B))))
-        pref = math.exp(math.lgamma(c) - math.lgamma(B) - math.lgamma(q))
-    else:
-        # Backend parameters: the same expressions, evaluated ON the backend, so
-        # they neither concretize a tracer nor detach a tensor. ceil is a step,
-        # so its zero gradient is the correct one -- k only shapes the
-        # substitution; the integral's value does not depend on it.
-        from .._router import gammaln
-
-        # every operand on the backend and on z's device: the router's gammaln
-        # dispatches on its ARGUMENT, and torch.special.gammaln rejects a plain
-        # float outright.
-        Bx, cx, qx = (asarray_on_device(xp, v, dev) for v in (B, c, q))
-        k = xp.clip(xp.ceil(6.0 / Bx), 1.0, 12.0)
-        pref = xp.exp(gammaln(cx) - gammaln(Bx) - gammaln(qx))
-
-    # node/weight tables stay float64 (precision is the point; the router
-    # exit-casts) but must live on the input's device (CUDA support)
-    nodes, weights = gauss_legendre_01(_NODES)
-    xg = asarray_on_device(xp, nodes, dev)
-    wg = asarray_on_device(xp, weights, dev)
-    X = xg**k
-    dX = k * xg ** (k - 1.0)
-
-    # Tiny |z|: the 1/|z| substitution is singular, so feed a safe non-zero w
-    # into the integral (double-where: the dead branch can't NaN-poison AD via
-    # 1/w / log1p(0)) and return the exact Maclaurin limit instead -- which also
-    # gives the correct gradient a*b/c at z->0 (a plain maximum-floor flattens it).
-    tiny = w < 1e-10
-    w_for_int = xp.where(tiny, xp.ones_like(w), w)
-    L = xp.log1p(w_for_int)[..., None]  # (..., 1)
-    wb = w_for_int[..., None]
-    XL = X * L  # (..., N)
-    # T = expm1(XL)/|z|, but X = xi^k puts the first node at XL ~ 1e-49, where
-    # inductor's FUSED expm1 (its standalone one is exact) degenerates to
-    # exp(x)-1 and returns 0; T**(B-1) with B < 1 is then inf and poisons the
-    # quadrature at EVERY z. Factor out expm1(u)/u -> 1 and series it below the
-    # crossover instead, so nothing tiny ever reaches expm1.
-    small = XL < 1e-8
-    u_safe = xp.where(small, xp.ones_like(XL), XL)
-    ratio = xp.where(small, 1.0 + XL / 2.0 + XL**2.0 / 6.0, xp.expm1(u_safe) / u_safe)
-    T = XL * ratio / wb
-    dt = xp.exp(XL) * L / wb
-    integ = T ** (B - 1.0) * (1.0 - T) ** (q - 1.0) * (1.0 + wb * T) ** (-A) * dt * dX
-    val_int = pref * xp.sum(integ * wg, axis=-1)
-    # A*B is a*b: {A, B} is just a relabelling of {a, b}.
-    val_series = 1.0 + (A * B / c) * z  # 2F1 = 1 + (ab/c) z + O(z^2)
-    return xp.where(tiny, val_series, val_int)

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -442,14 +442,18 @@ def test_xlogy_fallback_direct(backend):
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 def test_hyp2f1_fallback_alt_labeling(backend):
-    # 2F1 case whose accurate Euler labeling comes from b (c-a < 1 <= c-b), i.e.
-    # the second branch of _euler_labeling -- not exercised by galpy's calls
-    # (which always satisfy c-a >= 1). jax/torch route through the fallback here.
-    a, b, c = 2.0, 0.8, 2.5  # c-a=0.5 (<1), c-b=1.7 (>=1) -> labeling picks b
+    # 2F1 whose Euler labeling has to come from b, i.e. the SECOND branch of
+    # _euler_labeling. The case used to be (2.0, 0.8, 2.5), chosen when the
+    # admissibility test was c - P >= 1: c-a was 0.5 so a was refused. The test
+    # is now c - P > 0, which a satisfies, so that case silently moved to the
+    # FIRST branch and stopped covering this one -- it kept passing, because
+    # either labeling gives the right value. a < 0 is what disqualifies a for
+    # good, whatever the bound on c - P.
+    a, b, c = -1.0, 0.8, 2.5  # a < 0 -> labeling must pick b
     z = -numpy.array([0.0, 0.1, 1.0, 5.0, 30.0])
     ref = scipy_special.hyp2f1(a, b, c, z)
     got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
-    numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=1e-8)
+    numpy.testing.assert_allclose(got, ref, rtol=1e-14, atol=1e-15)
 
 
 # Parameter sets the Euler integral cannot take directly. galpy's own anisotropic
@@ -551,9 +555,15 @@ def test_fallback_unsupported_regimes_raise():
     from galpy.backend.special._fallback.hyp1f1 import hyp1f1_fallback
     from galpy.backend.special._fallback.hyp2f1 import _euler_labeling
 
-    # 2F1 with c - max(a,b) < 1 (both endpoints awkward): unsupported
+    # 2F1 outside the Euler integral's domain. The bound used to be
+    # c - P >= 1 and (2.0, 2.0, 2.5) sat just under it; with the tanh-sinh rule
+    # the requirement is only what the Beta integral needs, c - P > 0, and that
+    # case is now perfectly well supported. Both ways of being outside are
+    # checked, because they fail for different reasons:
     with pytest.raises(NotImplementedError):
-        _euler_labeling(2.0, 2.0, 2.5)  # c-a=c-b=0.5
+        _euler_labeling(2.0, 3.0, 1.5)  # c - P <= 0 for both
+    with pytest.raises(NotImplementedError):
+        _euler_labeling(-1.0, -2.0, 3.0)  # no positive P at all
     # 1F1 only implements b = a + 1
     with pytest.raises(NotImplementedError):
         hyp1f1_fallback(numpy, 1.0, 3.0, numpy.array([-1.0]))
@@ -1418,19 +1428,17 @@ def test_hyp2f1_the_real_constantbetadf_request(backend):
 
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)
-def test_hyp2f1_large_B_route_is_unchanged(backend):
-    # Above _TS_B_MAX the Gauss-Legendre path must be untouched: the regression
-    # guard for the cases that already worked.
-    #
-    # The bars are that path's OWN measured accuracy, verified identical with
-    # and without the route (base vs branch, same digits). (-1.6, 1.2, 3.6) sits
-    # at 2.4e-09 / 7.4e-09 -- pre-existing GL behaviour, not something this
-    # change introduces, so the bar is set there rather than at 1e-12, which
-    # would fail on unmodified develop too.
+def test_hyp2f1_large_B_is_machine_precision(backend):
+    # These are the large-B cases the Gauss-Legendre rule was kept for. They
+    # used to need loose bars -- (-1.6, 1.2, 3.6) sat at 5.3e-08, which is why
+    # this test once asserted 1e-08 and was named "..._route_is_unchanged".
+    # With one tanh-sinh rule for every B they are at machine precision, so the
+    # bars are tightened to the measured values: a regression here would mean
+    # the single rule had given up something the old two-rule split had.
     for a, b, c, tol in (
-        (-3.2, 4.4, 5.2, 1e-13),
-        (2.0, 2.0, 2.5, 1e-13),
-        (-1.6, 1.2, 3.6, 1e-08),
+        (-3.2, 4.4, 5.2, 1e-14),
+        (2.0, 2.0, 2.5, 1e-14),
+        (-1.6, 1.2, 3.6, 1e-14),
     ):
         for z in (-0.6, -2.0):
             ref = scipy_special.hyp2f1(a, b, c, z)


### PR DESCRIPTION
Follow-up to #1401, which routed only `B < 0.25` to tanh–sinh and kept Gauss–Legendre above it. This removes the split: **one rule for every B**, and the `c - B >= 1` constraint goes with it.

### The threshold was only protecting the less accurate rule

Measured against mpmath over **768** (A,B,c,z) cases with B *above* the old threshold — i.e. exactly the regime GL was being kept for:

| rule | worst rel err |
|---|---|
| GL (shipping) | **1.5e-04** |
| tanh–sinh | **2.9e-15** |
| cases where tanh–sinh is worse | **0** |

### Why it was kept, and why that reason dissolved

The traced-parameter path also routes through `_euler_quad`, and tanh–sinh could not size a grid from a tracer. That turned out not to be a real constraint: **one fixed grid is as accurate as the per-call adaptive one** (worst 2.67e-15 vs 2.89e-15 over 720 cases spanning B = 0.001…5.0, nothing above 1e-13). Being independent of the parameters is precisely what lets a traced B use the rule, so the concreteness guard disappears entirely — and with it the `X = xi^k` substitution, the `k <= 12` cap, the `expm1` crossover guard, and the tiny-|z| series branch. `(1 - z t)^{-A}` is simply 1 at z = 0, where GL's `1/|z|` substitution was singular and needed its own branch.

### Dropping `c - B >= 1` is part of the same change, not scope creep

That bound exists *only* to keep `(1-t)^{c-B-1}` non-singular for a fixed-order rule. The tanh–sinh weight cancels that endpoint analytically and needs just what the Beta integral needs, `c - B > 0`. Measured across the whole block the old bound excluded (`c - B` in (0, 1]): **2.3e-15**.

It also removes a float64 knife-edge. At `(a=5.0, b=0.001, c=1.001)` the old test asked `1.001 - 0.001 >= 1.0`, which is False by one ulp, so the Euler route was refused and a far worse one ran. Worst relative error over 900 cases through the **public** entry (including z = 0):

| tree | worst |
|---|---|
| develop (pre-#1401) | 8.807e-01 |
| #1401 | 4.577e-03 |
| here | **2.665e-15** |

### Three tests encoded the old contract — the middle one is the interesting one

* `test_fallback_unsupported_regimes_raise` asserted `_euler_labeling(2,2,2.5)` raises. `c - P = 0.5` is now supported, so it **failed** and the suite caught it. Replaced with both genuine ways out of the domain: `c - P <= 0` for every P, and no positive P at all.
* `test_hyp2f1_fallback_alt_labeling` still **passed**, and had quietly stopped testing what it exists for. It used `(2.0, 0.8, 2.5)`, chosen because `c-a=0.5` failed the old bound so labelling *had* to fall through to `b`. Under `c - P > 0`, `a` is admissible, so the case moved to the **first** branch and the second branch lost its only coverage — passing throughout, because either labelling gives the right value. Now `(-1.0, 0.8, 2.5)`: `a < 0` disqualifies `a` for good, whatever the bound.
* `test_hyp2f1_large_B_route_is_unchanged` guarded a route that no longer exists, with bars up to 1e-08 taken from GL's own accuracy. Renamed to `..._is_machine_precision` and retightened to the measured 1e-14; `(-1.6, 1.2, 3.6)` goes 5.3e-08 → 1.55e-15.

### Gates

* **numpy byte-identical**: sha256 `245bc0e3…` over 315 values matches develop `00a7153c` exactly, with the arms grep-asserted to differ (GL references 2 → 0, the `>= 1.0` guard 3 → 0). numpy routes hyp2f1 to scipy, so the fallback never runs there.
* **385 passed, 1 skipped** across `test_backend_special` / `_constantbetadf` / `_quadrature`, re-run *after* the rebase onto the merged base.
* Ledger delta: **0**.
* Net **deletion**: 91 insertions, 156 deletions.
