### PR TITLE
hyp2f1: the traced Euler-label selector must use the same rule as the concrete one

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -11,15 +11,12 @@
 #   Method: Euler's integral representation, valid for all z not in [1, inf):
 #       2F1(a,b;c;z) = Gamma(c)/(Gamma(B) Gamma(c-B))
 #                      * int_0^1 t^{B-1} (1-t)^{c-B-1} (1 - z t)^{-A} dt
-#   where {A, B} = {a, b} is chosen so B > 0 and c - B > 0 (preferring
-#   c - B >= 1 so the t=1 endpoint is non-singular). For z <= 0 the factor
-#   (1 - z t) = (1 + |z| t) >= 1 is smooth, but for large |z| it forms a thin
-#   boundary layer near t=0; two substitutions resolve it for fixed-order
-#   Gauss-Legendre quadrature:
-#     1. t = ((1+|z|)^X - 1)/|z| maps the boundary layer to a uniform X-grid;
-#     2. X = xi^k (k = ceil(1/B) when B < 1) regularizes the t^{B-1} endpoint
-#        singularity so plain Gauss-Legendre converges.
-#   Pure arithmetic + log1p/expm1/pow, so it differentiates under jax and torch.
+#   where {A, B} = {a, b} is chosen so B > 0 and c - B > 0 -- just what the Beta
+#   integral needs to converge. The quadrature is a tanh-sinh (double-
+#   exponential) rule that cancels BOTH endpoint singularities analytically
+#   against its own weight, so neither exponent has to be regularized by a
+#   substitution and neither endpoint has to be preferred over the other.
+#   Pure arithmetic + log1p/pow, so it differentiates under jax and torch.
 ###############################################################################
 import math
 
@@ -209,7 +206,13 @@ def _nonpositive_traced(xp, a, b, c, z):
     use_euler = ok_ab | ok_tr
     ea = xp.where(use_tr, c - a, a)
     eb = xp.where(use_tr, c - b, b)
-    oka = (ea > 0) & ((c - ea) >= 1.0)
+    # Must match _in_regime_mask / _euler_labeling EXACTLY: c - P > 0, not the
+    # old >= 1. When it did not, a first label with 0 < c-a < 1 was rejected
+    # here while the concrete path accepted it, so the traced route fell to the
+    # SECOND label even when that one was non-positive -- T**(B-1) with B <= 0
+    # is inf at the t->0 node, and the traced result came back inf or nan while
+    # eager was correct.
+    oka = (ea > 0) & ((c - ea) > 0.0)
     B = xp.where(use_euler, xp.where(oka, ea, eb), 1.0)
     A = xp.where(use_euler, xp.where(oka, eb, ea), 0.0)
     cc = xp.where(use_euler, c, 2.0)
@@ -237,28 +240,14 @@ def _euler_integral(xp, a, b, c, z):
     return _euler_quad(xp, A, B, c, z)
 
 
-# Below this B the xi^k substitution in _euler_quad cannot regularize the
-# t^{B-1} endpoint: it needs k >= ~6/B, and k is capped at 12 because X = xi^k
-# underflows above that. MEASURED (a=-1.010, c=B+3, z=-0.6), shipping rule vs
-# an uncapped k vs tanh-sinh:
-#
-#     B      k wanted   cap=12     cap=100    tanh-sinh
-#     0.500  12         7.11e-15   7.11e-15   2.22e-16
-#     0.200  30         1.76e-11   6.66e-15   4.44e-16
-#     0.100  60         1.00e-06   5.00e-15   4.44e-16
-#     0.050  120        1.04e-03   nan        8.88e-16
-#     0.020  300        7.21e-02   nan        6.80e-07
-#
-# So raising the cap helps only to B ~ 0.1 before underflowing, while tanh-sinh
-# is better at EVERY B and needs no substitution. 0.25 is where the shipping
-# rule's error first exceeds ~1e-11; above it the GL path is left untouched, so
-# this cannot regress the cases that already work.
-# ONE rule, one grid. The half-width is set by the SLOWEST endpoint decay the
-# labelling can hand us: the integrand falls off as exp(-B pi sinh|u|) at t=0
-# and exp(-(c-B) pi sinh u) at t=1, and _euler_labeling guarantees c-B >= 1, so
-# B is the binding one. 12.45 resolves B down to 1e-3 (exp(-40) ~ 4e-18, below
-# eps against an O(1) integrand); the step 0.075 is what sets the accuracy, and
-# the node count follows from the two.
+# ONE rule, one grid. The integrand falls off as exp(-B pi sinh|u|) at t=0 and
+# exp(-(c-B) pi sinh u) at t=1, and the rule is SYMMETRIC in u, so a half-width
+# that resolves one endpoint resolves the other: 12.45 covers EITHER exponent
+# down to 1e-3 (exp(-40) ~ 4e-18, below eps against an O(1) integrand). That
+# symmetry is what makes the relaxed labelling safe -- under c - B > 0 the t=1
+# exponent can now be the small one, which it never could when the bound was
+# c - B >= 1. Measured with c - B down to 1e-4: 2.3e-15. The step 0.075 sets the
+# accuracy and the node count follows from the two.
 #
 # Sizing the grid PER CALL from B was measured and dropped: over 720 cases
 # spanning B = 0.001..5.0 the fixed grid is as accurate as the adaptive one
@@ -280,7 +269,7 @@ def _log_sigmoid(xp, x):
 def _euler_quad(xp, A, B, c, z):
     """2F1 via the Euler integral on a tanh-sinh (double-exponential) rule.
 
-    Operates on an ALREADY-LABELLED (A, B): B > 0 and c - B >= 1, guaranteed by
+    Operates on an ALREADY-LABELLED (A, B): B > 0 and c - B > 0, guaranteed by
     _euler_labeling. Split out from _euler_integral so the traced-parameter
     route can choose (A, B) with xp.where instead of a Python branch and still
     reuse this verbatim.

--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -200,12 +200,12 @@ def _nonpositive_traced(xp, a, b, c, z):
     both sides, and T**(B-1) with B <= 0 is inf at the t -> 0 node, which would
     NaN-poison the gradient of the series result that actually wins there.
     """
-    ok_ab = _in_regime_mask(xp, a, b, c)
-    ok_tr = _in_regime_mask(xp, c - a, c - b, c)
-    use_tr = (~ok_ab) & ok_tr
-    use_euler = ok_ab | ok_tr
-    ea = xp.where(use_tr, c - a, a)
-    eb = xp.where(use_tr, c - b, b)
+    # Same symmetry as the concrete path: _in_regime_mask(c-a, c-b, c) is
+    # _in_regime_mask(a, b, c), so the transform selector (~ok) & ok was
+    # identically False and its (1-z)^{c-a-b} factor identically 1 -- dead
+    # computation in every traced call. Both are gone.
+    use_euler = _in_regime_mask(xp, a, b, c)
+    ea, eb = a, b
     # Must match _in_regime_mask / _euler_labeling EXACTLY: c - P > 0, not the
     # old >= 1. When it did not, a first label with 0 < c-a < 1 was rejected
     # here while the concrete path accepted it, so the traced route fell to the
@@ -217,9 +217,6 @@ def _nonpositive_traced(xp, a, b, c, z):
     A = xp.where(use_euler, xp.where(oka, eb, ea), 0.0)
     cc = xp.where(use_euler, c, 2.0)
     euler = _euler_quad(xp, A, B, cc, z)
-    # Euler's transformation carries a (1-z)^{c-a-b} prefactor; z <= 0 here so
-    # 1-z >= 1 and the unused side is finite.
-    euler = xp.where(use_tr, (1.0 - z) ** (c - a - b), 1.0) * euler
     return xp.where(use_euler, euler, _pfaff_series(xp, a, b, c, z))
 
 
@@ -227,9 +224,15 @@ def _hyp2f1_nonpositive(xp, a, b, c, z):
     """2F1(a, b; c; z) for real z <= 0 -- the three routes named above."""
     if not all(has_concrete_truth_value(p > 0.0) for p in (a, b, c)):
         return _nonpositive_traced(xp, a, b, c, z)
+    # No Euler-TRANSFORM branch: under `c - P > 0` it is unreachable. The regime
+    # test is symmetric under (a, b) -> (c-a, c-b), because
+    #   _in_regime(c-a, c-b, c) = (c-a > 0 and a > 0) or (c-b > 0 and b > 0)
+    # is literally _in_regime(a, b, c) with the conjuncts swapped. So the
+    # transform can never rescue a parameter set the direct route rejects.
+    # Under the OLD bound `c - P >= 1` the two were NOT symmetric and the branch
+    # was live (2031 hits over a -3..5 grid; 0 after the relaxation), which is
+    # why it existed. The relaxation SUBSUMED it.
     if not _in_regime(a, b, c):
-        if _in_regime(c - a, c - b, c):
-            return (1.0 - z) ** (c - a - b) * _euler_integral(xp, c - a, c - b, c, z)
         return _pfaff_series(xp, a, b, c, z)
     return _euler_integral(xp, a, b, c, z)
 

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -460,9 +460,16 @@ def test_hyp2f1_fallback_alt_labeling(backend):
 # DFs request all three (measured by instrumenting the fallback over
 # test_sphericaldf), and before the transformation/series routes existed each one
 # raised NotImplementedError.
-_HYP2F1_EULER_TRANSFORMED = [
-    (-3.2, 4.4, 5.2),  # only positive parameter has c-b = 0.8 < 1
-    (2.0, 2.0, 2.5),  # c-a = c-b = 0.5 < 1, both positive
+# These used to reach Euler's TRANSFORM, because c - P < 1 failed the old
+# admissibility bound and the direct route refused them. Under `c - P > 0` the
+# direct route accepts them, and the transform branch is gone entirely (it is
+# unreachable once the regime test is symmetric under (a,b) -> (c-a,c-b)). They
+# are kept because they remain good SMALL c-P cases for the direct route -- but
+# the name had to change, since a test whose title names a route it no longer
+# takes is how coverage rots silently.
+_HYP2F1_SMALL_C_MINUS_P = [
+    (-3.2, 4.4, 5.2),  # only positive parameter has c-b = 0.8
+    (2.0, 2.0, 2.5),  # c-a = c-b = 0.5, both positive
 ]
 _HYP2F1_BOTH_NONPOSITIVE = [
     (-0.98, -0.04, 2.98),  # |a-b| = 0.94
@@ -473,12 +480,11 @@ _HYP2F1_BOTH_NONPOSITIVE = [
 
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 @pytest.mark.parametrize(
-    "a,b,c", _HYP2F1_EULER_TRANSFORMED, ids=[str(x) for x in _HYP2F1_EULER_TRANSFORMED]
+    "a,b,c", _HYP2F1_SMALL_C_MINUS_P, ids=[str(x) for x in _HYP2F1_SMALL_C_MINUS_P]
 )
-def test_hyp2f1_fallback_euler_transformed(backend, a, b, c):
-    # Euler's transformation, 2F1(a,b;c;z) = (1-z)^(c-a-b) 2F1(c-a,c-b;c;z),
-    # leaves z alone, so the quadrature's z<=0 machinery applies verbatim to the
-    # transformed parameters. Accuracy is therefore the quadrature's own: this
+def test_hyp2f1_fallback_small_c_minus_P(backend, a, b, c):
+    # Small c - P on the DIRECT Euler route (these once needed the transform;
+    # see the list above). Accuracy is the quadrature's own: this
     # measures 1e-14 across the whole grid, so 1e-12 is a real bound, not a
     # smoke check. Includes z=0 (where 2F1=1 exactly) and r/a=500.
     z = -numpy.array([0.0, 1e-3, 0.06, 0.617, 1.0, 5.0, 50.0, 500.0])
@@ -525,8 +531,8 @@ def test_hyp2f1_series_route_degrades_but_stays_bounded(backend):
 @pytest.mark.parametrize("backend", AD_BACKENDS)
 @pytest.mark.parametrize(
     "a,b,c",
-    _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE,
-    ids=[str(x) for x in _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE],
+    _HYP2F1_SMALL_C_MINUS_P + _HYP2F1_BOTH_NONPOSITIVE,
+    ids=[str(x) for x in _HYP2F1_SMALL_C_MINUS_P + _HYP2F1_BOTH_NONPOSITIVE],
 )
 def test_hyp2f1_new_routes_grad_vs_fd(backend, a, b, c):
     # Both new routes must differentiate, not merely evaluate: the DFs that need
@@ -1318,10 +1324,10 @@ def test_hyp2f1_torch_parameter_gradient_matches_finite_difference(
 
 @pytest.mark.parametrize(
     "a,b,c",
-    _HYP2F1_CASES + _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE,
+    _HYP2F1_CASES + _HYP2F1_SMALL_C_MINUS_P + _HYP2F1_BOTH_NONPOSITIVE,
     ids=[
         str(x)
-        for x in _HYP2F1_CASES + _HYP2F1_EULER_TRANSFORMED + _HYP2F1_BOTH_NONPOSITIVE
+        for x in _HYP2F1_CASES + _HYP2F1_SMALL_C_MINUS_P + _HYP2F1_BOTH_NONPOSITIVE
     ],
 )
 def test_hyp2f1_traced_parameters_reproduce_the_concrete_route(a, b, c):

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1445,3 +1445,56 @@ def test_hyp2f1_large_B_is_machine_precision(backend):
             got = as_numpy(gsp.hyp2f1(a, b, c, _asarray(backend, z)))
             rel = abs(got / ref - 1.0)
             assert rel < tol, f"{backend} regressed at ({a},{b},{c},{z}): {rel:.3e}"
+
+
+# The traced Euler-label selector must use the SAME admissibility rule as the
+# concrete one. It did not: `_nonpositive_traced` kept `(c - ea) >= 1.0` after
+# the concrete side relaxed to `c - P > 0`, so a first label with 0 < c-a < 1
+# was rejected only under tracing. The traced route then fell through to the
+# SECOND label -- which here is NON-POSITIVE -- and T**(B-1) with B <= 0 is inf
+# at the t->0 node, so jit returned inf/nan while eager was exact.
+#
+# These parameters all have 0 < c-a < 1 AND b <= 0, which is what makes the
+# mismatch reachable: the first label is the only admissible one, so wrongly
+# rejecting it is fatal rather than merely suboptimal.
+_TRACED_LABEL_CASES = [
+    (2.0, -0.2, 2.5, -0.7),  # was inf
+    (2.0, -1.0, 2.5, -0.7),  # was nan
+    (2.0, -0.5, 2.2, -0.7),  # was inf
+    (3.0, -0.2, 3.4, -2.0),  # was inf
+]
+
+
+@pytest.mark.parametrize(
+    "a,b,c,z", _TRACED_LABEL_CASES, ids=[str(x[:3]) for x in _TRACED_LABEL_CASES]
+)
+def test_hyp2f1_traced_label_matches_the_concrete_rule(a, b, c, z):
+    jax = pytest.importorskip("jax")
+    import jax.numpy as jnp
+
+    ref = scipy_special.hyp2f1(a, b, c, z)
+    with use("jax", force=True):
+        zb = jnp.asarray(z)
+        eager = float(as_numpy(gsp.hyp2f1(a, b, c, zb)))
+        traced = float(
+            as_numpy(jax.jit(lambda aa: gsp.hyp2f1(aa, b, c, zb))(jnp.asarray(a)))
+        )
+    # eager was already right; the point is that the traced arm now agrees.
+    assert numpy.isfinite(traced), f"traced hyp2f1({a},{b},{c},{z}) = {traced}"
+    numpy.testing.assert_allclose(eager, ref, rtol=1e-13)
+    numpy.testing.assert_allclose(traced, ref, rtol=1e-13)
+
+
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_hyp2f1_small_c_minus_B_is_accurate(backend):
+    # Relaxing the labelling to c - B > 0 lets the t=1 endpoint exponent become
+    # the SMALL one, which it never could under c - B >= 1. The fixed tanh-sinh
+    # grid still resolves it because the rule is symmetric in u -- a half-width
+    # that covers a small B covers a small c-B. Guards that symmetry argument.
+    xp = _asarray  # noqa: F841  (documenting intent; value comes from gsp below)
+    for cmb in (0.5, 0.1, 0.01, 1e-3, 1e-4):
+        for B, A, z in ((0.5, 2.3, -0.588), (2.0, -1.6, -40.0)):
+            c = B + cmb
+            ref = scipy_special.hyp2f1(A, B, c, z)
+            got = as_numpy(gsp.hyp2f1(A, B, c, _asarray(backend, z)))
+            numpy.testing.assert_allclose(got, ref, rtol=1e-13)


### PR DESCRIPTION
Fixes the blocker in #1204 comment 5440895453.

### The miss

#1402 relaxed the concrete admissibility rule from `c - B >= 1` to `c - B > 0` in **three** places — `_in_regime`, `_euler_labeling`, `_in_regime_mask` — but there is a **fourth** copy inside `_nonpositive_traced`:

```python
oka = (ea > 0) & ((c - ea) >= 1.0)
```

so under tracing a first label with `0 < c-a < 1` was still rejected. The traced route then fell through to the **second** label, which in these cases is non-positive, and `T**(B-1)` with `B <= 0` is `inf` at the `t -> 0` node. Eager was exact; jit returned `inf`/`nan`.

Reproduced before fixing, and after:

| (a, b, c, z) | scipy | traced BEFORE | traced AFTER |
|---|---|---|---|
| (2.0, −0.2, 2.5, −0.7) | 1.09213476189 | `inf` | rel 0.0 |
| (2.0, −1.0, 2.5, −0.7) | 1.56 | `nan` | rel 1.1e-16 |
| (2.0, −0.5, 2.2, −0.7) | 1.27837324696 | `inf` | rel 2.4e-15 |
| (3.0, −0.2, 3.4, −2.0) | 1.2241297706 | `inf` | rel 3.6e-15 |

**Why my audit missed it:** I grepped for `c - a) >= 1.0`, and this site spells the same predicate with different variable names — `(c - ea) >= 1.0`. Re-swept with a pattern that cannot care about the names (`\(c - [a-z_]+\)|>= 1\.0`); this was the only remaining site, and the two surviving `>= 1` strings are historical prose explaining why the old bound existed.

### The stale comments were not only cosmetic

You asked for the stale GL comments to go. One of them encoded an assumption the relaxation had silently broken:

> "… and `_euler_labeling` guarantees c-B >= 1, so B is the binding one."

Under `c - B > 0` the **t=1 exponent can now be the small one**, which it never could before — so that sentence no longer justifies the fixed half-width. Measured rather than assumed: `c - B` down to **1e-4 is accurate to 2.3e-15**, because the tanh–sinh rule is *symmetric in u* — a half-width that resolves a small `B` resolves a small `c-B` identically. The comment now states that reason, and `test_hyp2f1_small_c_minus_B_is_accurate` pins it.

The module header's description of the two Gauss–Legendre substitutions, and the `xi^k` / cap-at-12 / 0.25-threshold block, are deleted outright — that machinery no longer exists after #1402. The remaining GL mentions are deliberate rationale ("the old requirement was…", "This REPLACED…").

### Tests

* `test_hyp2f1_traced_label_matches_the_concrete_rule` — the four cases above, asserting the traced arm is finite *and* matches scipy to 1e-13. The parameters all have `0 < c-a < 1` **and** `b <= 0`, which is what makes the mismatch reachable: the first label is the only admissible one, so wrongly rejecting it is fatal rather than merely suboptimal.
* `test_hyp2f1_small_c_minus_B_is_accurate` — guards the symmetry argument above.

### Gates

* **numpy byte-identical**: sha256 `245bc0e3…` over 315 values matches develop `8c320b39` exactly, arms grep-asserted to differ (traced selector 1 → 0).
* **391 passed, 1 skipped** across `test_backend_special` / `_constantbetadf` / `_quadrature`.
* Ledger delta: **0**.
