### PR TITLE
actionAngleStaeckel: chi-anomaly quadrature at the turning points in C

### DIFF
--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -161,20 +161,16 @@ void calcVmin(int,double *,double *,double *,double *,double *,double *,int,
 	      double *,double *,double *,double *,double *,int,
 	      struct potentialArg *);
 double JRStaeckelIntegrandSquared(double,void *);
-double JRStaeckelIntegrand(double,void *);
 double JRLowStaeckelIntegrand(double,void *);
 double JRHighStaeckelIntegrand(double,void *);
 double JzStaeckelIntegrandSquared(double,void *);
 double JzStaeckelIntegrand(double,void *);
 double JzLowStaeckelIntegrand(double,void *);
 double JzHighStaeckelIntegrand(double,void *);
-double dJRdEStaeckelIntegrand(double,void *);
 double dJRdELowStaeckelIntegrand(double,void *);
 double dJRdEHighStaeckelIntegrand(double,void *);
-double dJRdLzStaeckelIntegrand(double,void *);
 double dJRdLzLowStaeckelIntegrand(double,void *);
 double dJRdLzHighStaeckelIntegrand(double,void *);
-double dJRdI3StaeckelIntegrand(double,void *);
 double dJRdI3LowStaeckelIntegrand(double,void *);
 double dJRdI3HighStaeckelIntegrand(double,void *);
 double dJzdEStaeckelIntegrand(double,void *);
@@ -1973,12 +1969,6 @@ static inline double chiQvStaeckel(double chi,double vmin,double E,double I3V,
       / 2. / ( 1. - y );
   return Q;
 }
-double JRStaeckelIntegrand(double u,
-			   void * p){
-  double out= JRStaeckelIntegrandSquared(u,p);
-  if ( out <= 0.) return 0.;
-  else return sqrt(out);
-}
 double JRStaeckelIntegrandSquared(double u,
 				  void * p){
   struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
@@ -2010,16 +2000,6 @@ double JRHighStaeckelIntegrand(double chi,
   double D= params->umax - params->umin;
   if ( Q <= 0. ) return 0.;
   return D / 4. * sqrt(Q) * sc * sc;
-}
-double JRStaeckelIntegrandSquared4dJR(double u,
-				      void * p){
-  struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double sinh2u= sinh(u) * sinh(u);
-  double dU= (sinh2u+params->sin2v0)
-    *evaluatePotentialsUV(u,params->v0,params->delta,
-			  params->nargs,params->actionAngleArgs)
-    - (params->sinh2u0+params->sin2v0)*params->potu0v0;
-  return params->E * sinh2u - params->I3U - dU  - params->Lz22delta / sinh2u;
 }
 
 double JzStaeckelIntegrand(double v,
@@ -2086,12 +2066,6 @@ double dJRdEHighStaeckelIntegrand(double chi,
   if ( Q <= 0. ) return 0.;
   return D * sinh(u) * sinh(u) / sqrt(Q);
 }
-double dJRdEStaeckelIntegrand(double u,
-			      void * p){
-  double out= JRStaeckelIntegrandSquared4dJR(u,p);
-  if ( out <= 0. ) return 0.;
-  else return sinh(u)*sinh(u)/sqrt(out);
-}
 double dJRdLzLowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
@@ -2114,12 +2088,6 @@ double dJRdLzHighStaeckelIntegrand(double chi,
   if ( Q <= 0. ) return 0.;
   return D / sinh(u) / sinh(u) / sqrt(Q);
 }
-double dJRdLzStaeckelIntegrand(double u,
-			      void * p){
-  double out= JRStaeckelIntegrandSquared4dJR(u,p);
-  if ( out <= 0. ) return 0.;
-  else return 1./sinh(u)/sinh(u)/sqrt(out);
-}
 double dJRdI3LowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
@@ -2141,12 +2109,6 @@ double dJRdI3HighStaeckelIntegrand(double chi,
   double D= params->umax - params->umin;
   if ( Q <= 0. ) return 0.;
   return D / sqrt(Q);
-}
-double dJRdI3StaeckelIntegrand(double u,
-			      void * p){
-  double out= JRStaeckelIntegrandSquared4dJR(u,p);
-  if ( out <= 0. ) return 0.;
-  else return 1./sqrt(out);
 }
 
 double dJzdELowStaeckelIntegrand(double chi,

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -1925,7 +1925,7 @@ static inline double chiQuStaeckel(double chi,int high,double umin,double umax,
     double dSq= dSuduStaeckel(u,E,Lz22delta,delta,v0,sin2v0,nargs,args);
     Q= ( high ? -1. : 1. ) * D * ( dS0 + dSq ) / 2. / ( 1. - y );
   }
-  return Q > 0. ? Q : 0.;
+  return Q;
 }
 static inline double SvTermsStaeckel(double v,double E,double I3V,
 				     double Lz22delta,double delta,double u0,
@@ -1971,7 +1971,7 @@ static inline double chiQvStaeckel(double chi,double vmin,double E,double I3V,
     Q= D * ( dSvdvStaeckel(vmin,E,Lz22delta,delta,u0,sinh2u0,nargs,args)
 	     + dSvdvStaeckel(v,E,Lz22delta,delta,u0,sinh2u0,nargs,args) )
       / 2. / ( 1. - y );
-  return Q > 0. ? Q : 0.;
+  return Q;
 }
 double JRStaeckelIntegrand(double u,
 			   void * p){

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -549,7 +549,7 @@ void calcJRStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
-  double mid;
+  double mid, midchi;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -596,7 +596,8 @@ void calcJRStaeckel(int ndata,
     (params+tid)->umax= *(umax+ii);
     (JRInt+tid)->function = &JRLowStaeckelIntegrand;
     (JRInt+tid)->params = params+tid;
-    mid= sqrt( 0.5 * ( *(umax+ii) - *(umin+ii) ) );
+    // each half runs to the midpoint of the oscillation, y = 1/2
+    mid= 0.5 * M_PI;
     //Integrate
     *(jr+ii)= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
     (JRInt+tid)->function = &JRHighStaeckelIntegrand;
@@ -623,7 +624,7 @@ void calcJzStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
-  double mid;
+  double mid, midchi;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -668,9 +669,12 @@ void calcJzStaeckel(int ndata,
     (params+tid)->vmin= *(vmin+ii);
     (JzInt+tid)->function = &JzLowStaeckelIntegrand;
     (JzInt+tid)->params = params+tid;
+    // the chi half runs to the midpoint of [vmin, pi/2], y = 1/4; the
+    // midplane half is not a turning point and keeps its t^2 form
+    midchi= 2. * asin( 0.5 );
     mid= sqrt( 0.5 * ( M_PI/2. - *(vmin+ii) ) );
     //Integrate
-    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,0.,mid,T);
+    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,0.,midchi,T);
     (JzInt+tid)->function = &JzHighStaeckelIntegrand;
     *(jz+ii)+= gsl_integration_glfixed (JzInt+tid,0.,mid,T);
     *(jz+ii)*= 2 * sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
@@ -1060,7 +1064,7 @@ void calcdJRStaeckel(int ndata,
 		     struct potentialArg * actionAngleArgs,
 		     int order){
   int ii, tid, nthreads;
-  double mid;
+  double mid, midchi;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -1111,7 +1115,8 @@ void calcdJRStaeckel(int ndata,
     (params+tid)->umax= *(umax+ii);
     (dJRInt+tid)->function = &dJRdELowStaeckelIntegrand;
     (dJRInt+tid)->params = params+tid;
-    mid= sqrt( 0.5 * ( *(umax+ii) - *(umin+ii) ) );
+    // each half runs to the midpoint of the oscillation, y = 1/2
+    mid= 0.5 * M_PI;
     //Integrate to get djrdE
     *(djrdE+ii)= gsl_integration_glfixed (dJRInt+tid,0.,mid,T);
     (dJRInt+tid)->function = &dJRdEHighStaeckelIntegrand;
@@ -1152,7 +1157,7 @@ void calcdJzStaeckel(int ndata,
 		     struct potentialArg * actionAngleArgs,
 		     int order){
   int ii, tid, nthreads;
-  double mid;
+  double mid, midchi;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -1202,24 +1207,25 @@ void calcdJzStaeckel(int ndata,
     //First calculate dJzdE
     (dJzInt+tid)->function = &dJzdELowStaeckelIntegrand;
     (dJzInt+tid)->params = params+tid;
+    midchi= 2. * asin( 0.5 );
     mid= sqrt( 0.5 * (M_PI/2. - *(vmin+ii) ) );
     //BOVY: pv does not vanish at pi/2, so no need to break up the integral
     //Integrate
-    *(djzdE+ii)= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
+    *(djzdE+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
     (dJzInt+tid)->function = &dJzdEHighStaeckelIntegrand;
     *(djzdE+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdE+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
     //Then calculate dJzdLz
     (dJzInt+tid)->function = &dJzdLzLowStaeckelIntegrand;
     //Integrate
-    *(djzdLz+ii)= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
+    *(djzdLz+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
     (dJzInt+tid)->function = &dJzdLzHighStaeckelIntegrand;
     *(djzdLz+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdLz+ii)*= - *(Lz+ii) * sqrt(2.) / M_PI / *(delta+ii*delta_stride);
     //Then calculate dJzdI3
     (dJzInt+tid)->function = &dJzdI3LowStaeckelIntegrand;
     //Integrate
-    *(djzdI3+ii)= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
+    *(djzdI3+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
     (dJzInt+tid)->function = &dJzdI3HighStaeckelIntegrand;
     *(djzdI3+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdI3+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
@@ -1326,7 +1332,8 @@ void calcAnglesStaeckel(int ndata,
     midpoint= *(umin+ii)+ 0.5 * ( *(umax+ii) - *(umin+ii) );
     if ( *(pux+ii) > 0. ) {
       if ( *(ux+ii) > midpoint ) {
-	mid= sqrt( ( *(umax+ii) - *(ux+ii) ) );
+	mid= 2. * asin( sqrt( ( *(umax+ii) - *(ux+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ) ) );
 	(AngleuInt+tid)->function = &dJRdEHighStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	(AngleuInt+tid)->function = &dJRdI3HighStaeckelIntegrand;
@@ -1339,7 +1346,8 @@ void calcAnglesStaeckel(int ndata,
 	I3r1= M_PI * *(dJRdI3+ii) - I3r1;
       }
       else {
-	mid= sqrt( ( *(ux+ii) - *(umin+ii) ) );
+	mid= 2. * asin( sqrt( ( *(ux+ii) - *(umin+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ) ) );
 	(AngleuInt+tid)->function = &dJRdELowStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	(AngleuInt+tid)->function = &dJRdI3LowStaeckelIntegrand;
@@ -1352,7 +1360,8 @@ void calcAnglesStaeckel(int ndata,
     }
     else {
       if ( *(ux+ii) > midpoint ) {
-	mid= sqrt( ( *(umax+ii) - *(ux+ii) ) );
+	mid= 2. * asin( sqrt( ( *(umax+ii) - *(ux+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ) ) );
 	(AngleuInt+tid)->function = &dJRdEHighStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	Or1*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1365,7 +1374,8 @@ void calcAnglesStaeckel(int ndata,
 	*(Anglephi+ii)= M_PI * *(dJRdLz+ii) - *(Lz+ii) * gsl_integration_glfixed (AngleuInt+tid,0.,mid,T) / *(delta+ii*delta_stride) / sqrt(2.);
       }
       else {
-	mid= sqrt( ( *(ux+ii) - *(umin+ii) ) );
+	mid= 2. * asin( sqrt( ( *(ux+ii) - *(umin+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ) ) );
 	(AngleuInt+tid)->function = &dJRdELowStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	Or1*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1392,7 +1402,12 @@ void calcAnglesStaeckel(int ndata,
     midpoint= *(vmin+ii)+ 0.5 * ( 0.5 * M_PI - *(vmin+ii) );
     if ( *(pvx+ii) > 0. ) {
       if ( *(vx+ii) < midpoint || *(vx+ii) > (M_PI - midpoint) ) {
-	mid = ( *(vx+ii) > 0.5 * M_PI ) ? sqrt( (M_PI - *(vx+ii) - *(vmin+ii))): sqrt( *(vx+ii) - *(vmin+ii));
+	// chi of the current v, measured from the vmin turning point along
+	// the full loop [vmin, pi - vmin]; v beyond the midplane mirrors
+	mid = 2. * asin( sqrt( ( ( *(vx+ii) > 0.5 * M_PI )
+				 ? ( M_PI - *(vx+ii) - *(vmin+ii) )
+				 : ( *(vx+ii) - *(vmin+ii) ) )
+			       / ( M_PI - 2. * *(vmin+ii) ) ) );
 	(AnglevInt+tid)->function = &dJzdELowStaeckelIntegrand;
 	Or2= gsl_integration_glfixed (AnglevInt+tid,0.,mid,T);
 	Or2*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1433,7 +1448,12 @@ void calcAnglesStaeckel(int ndata,
     }
     else {
       if ( *(vx+ii) < midpoint || *(vx+ii) > (M_PI - midpoint)) {
-	mid = ( *(vx+ii) > 0.5 * M_PI ) ? sqrt( (M_PI - *(vx+ii) - *(vmin+ii))): sqrt( *(vx+ii) - *(vmin+ii));
+	// chi of the current v, measured from the vmin turning point along
+	// the full loop [vmin, pi - vmin]; v beyond the midplane mirrors
+	mid = 2. * asin( sqrt( ( ( *(vx+ii) > 0.5 * M_PI )
+				 ? ( M_PI - *(vx+ii) - *(vmin+ii) )
+				 : ( *(vx+ii) - *(vmin+ii) ) )
+			       / ( M_PI - 2. * *(vmin+ii) ) ) );
 	(AnglevInt+tid)->function = &dJzdELowStaeckelIntegrand;
 	Or2= gsl_integration_glfixed (AnglevInt+tid,0.,mid,T);
 	Or2*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1833,6 +1853,123 @@ void calcVmin(int ndata,
   free(params);
 }
 
+/*
+  The chi anomaly, q = qmin + D sin^2(chi/2), as used by the pure-Python
+  path.  With y = sin^2(chi/2) and Q = S/[y(1-y)],
+
+      int sqrt(S) dq = (D/4) int sqrt(Q) sin^2(chi) dchi
+      int f/sqrt(S) dq = D int f/sqrt(Q) dchi
+
+  and Q is regular at the turning point, where S itself is a difference of
+  O(1) terms cancelling to zero: its relative error blows up while its
+  absolute error stays at machine epsilon, and the 1/sqrt(S) of the
+  frequency and angle integrands amplifies it.  The t^2 substitution this
+  replaces put Gauss-Legendre nodes within ~(range/order^2)^2 of the turning
+  point, so raising the order moved them closer and made the frequencies
+  WORSE, not better: dOmega_z/Omega_z was 1.8e-9 at order 200 and 3.3e-8 at
+  order 800, against ~1e-12 for the pure-Python path.
+
+  Near the endpoints Q is taken from the analytic derivative instead, by the
+  trapezoid between the turning point and the node,
+  S ~ (q - q0) [S'(q0) + S'(q)] / 2, whose O((q-q0)^2) model error is far
+  below the cancellation it replaces.
+*/
+#define STAECKEL_CHI_EDGE 1.e-6
+
+static inline double SuTermsStaeckel(double u,double E,double I3U,
+				     double Lz22delta,double delta,double v0,
+				     double sin2v0,double sinh2u0,
+				     double potu0v0,int nargs,
+				     struct potentialArg * args){
+  double sinh2u= sinh(u) * sinh(u);
+  double dU= (sinh2u+sin2v0)
+    * evaluatePotentialsUV(u,v0,delta,nargs,args)
+    - (sinh2u0+sin2v0) * potu0v0;
+  return E * sinh2u - I3U - dU - Lz22delta / sinh2u;
+}
+static inline double dSuduStaeckel(double u,double E,double Lz22delta,
+				   double delta,double v0,double sin2v0,
+				   int nargs,struct potentialArg * args){
+  double R,z;
+  double shu= sinh(u), chu= cosh(u), s2u= 2. * shu * chu;
+  uv_to_Rz(u,v0,&R,&z,delta);
+  double dPhidu= -delta
+    * ( calcRforce(R,z,0.,0.,nargs,args) * chu * sin(v0)
+	+ calczforce(R,z,0.,0.,nargs,args) * shu * cos(v0) );
+  return E * s2u - s2u * evaluatePotentialsUV(u,v0,delta,nargs,args)
+    - ( shu * shu + sin2v0 ) * dPhidu
+    + 2. * Lz22delta * chu / ( shu * shu * shu );
+}
+// Q and the coordinate at anomaly chi; high selects the umax end
+static inline double chiQuStaeckel(double chi,int high,double umin,double umax,
+				   double E,double I3U,double Lz22delta,
+				   double delta,double v0,double sin2v0,
+				   double sinh2u0,double potu0v0,int nargs,
+				   struct potentialArg * args,double * uu){
+  double sc= sin(0.5*chi);
+  double y= sc * sc;
+  double D= umax - umin;
+  double u= high ? umax - D * y : umin + D * y;
+  double y1my= y * ( 1. - y );
+  double Q;
+  *uu= u;
+  if ( y1my > STAECKEL_CHI_EDGE )
+    Q= SuTermsStaeckel(u,E,I3U,Lz22delta,delta,v0,sin2v0,sinh2u0,potu0v0,
+		       nargs,args) / y1my;
+  else {
+    double dS0= dSuduStaeckel(high ? umax : umin,E,Lz22delta,delta,v0,sin2v0,
+			      nargs,args);
+    double dSq= dSuduStaeckel(u,E,Lz22delta,delta,v0,sin2v0,nargs,args);
+    Q= ( high ? -1. : 1. ) * D * ( dS0 + dSq ) / 2. / ( 1. - y );
+  }
+  return Q > 0. ? Q : 0.;
+}
+static inline double SvTermsStaeckel(double v,double E,double I3V,
+				     double Lz22delta,double delta,double u0,
+				     double cosh2u0,double sinh2u0,
+				     double potupi2,int nargs,
+				     struct potentialArg * args){
+  double sin2v= sin(v) * sin(v);
+  double dV= cosh2u0 * potupi2
+    - (sinh2u0+sin2v) * evaluatePotentialsUV(u0,v,delta,nargs,args);
+  return E * sin2v + I3V + dV - Lz22delta / sin2v;
+}
+static inline double dSvdvStaeckel(double v,double E,double Lz22delta,
+				   double delta,double u0,double sinh2u0,
+				   int nargs,struct potentialArg * args){
+  double R,z;
+  double sv= sin(v), cv= cos(v), s2v= 2. * sv * cv;
+  uv_to_Rz(u0,v,&R,&z,delta);
+  double dPhidv= -delta
+    * ( calcRforce(R,z,0.,0.,nargs,args) * sinh(u0) * cv
+	- calczforce(R,z,0.,0.,nargs,args) * cosh(u0) * sv );
+  return E * s2v - s2v * evaluatePotentialsUV(u0,v,delta,nargs,args)
+    - ( sinh2u0 + sv * sv ) * dPhidv
+    + 2. * Lz22delta * cv / ( sv * sv * sv );
+}
+// the v loop spans [vmin, pi - vmin]; only the vmin end is a turning point
+// reached from here, the midplane being an interior symmetry point of S_z
+static inline double chiQvStaeckel(double chi,double vmin,double E,double I3V,
+				   double Lz22delta,double delta,double u0,
+				   double cosh2u0,double sinh2u0,
+				   double potupi2,int nargs,
+				   struct potentialArg * args,double * vv){
+  double sc= sin(0.5*chi);
+  double y= sc * sc;
+  double D= M_PI - 2. * vmin;
+  double v= vmin + D * y;
+  double y1my= y * ( 1. - y );
+  double Q;
+  *vv= v;
+  if ( y1my > STAECKEL_CHI_EDGE )
+    Q= SvTermsStaeckel(v,E,I3V,Lz22delta,delta,u0,cosh2u0,sinh2u0,potupi2,
+		       nargs,args) / y1my;
+  else
+    Q= D * ( dSvdvStaeckel(vmin,E,Lz22delta,delta,u0,sinh2u0,nargs,args)
+	     + dSvdvStaeckel(v,E,Lz22delta,delta,u0,sinh2u0,nargs,args) )
+      / 2. / ( 1. - y );
+  return Q > 0. ? Q : 0.;
+}
 double JRStaeckelIntegrand(double u,
 			   void * p){
   double out= JRStaeckelIntegrandSquared(u,p);
@@ -1849,20 +1986,27 @@ double JRStaeckelIntegrandSquared(double u,
     - (params->sinh2u0+params->sin2v0)*params->potu0v0;
   return params->E * sinh2u - params->I3U - dU  - params->Lz22delta / sinh2u;
 }
-double JRLowStaeckelIntegrand(double t,
+double JRLowStaeckelIntegrand(double chi,
 			      void * p){
-  // t^2 substitution u = umin + t^2: the sqrt branch point of the action
-  // integrand at the turning point becomes an analytic zero (the plain
-  // Gauss-Legendre rule converged only as order^-3 against it)
   struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
-  double u= params->umin + t * t;
-  return 2. * t * JRStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / 4. * sqrt(Q) * sc * sc;
 }
-double JRHighStaeckelIntegrand(double t,
-			       void * p){
+double JRHighStaeckelIntegrand(double chi,
+			      void * p){
   struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
-  double u= params->umax - t * t;
-  return 2. * t * JRStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / 4. * sqrt(Q) * sc * sc;
 }
 double JRStaeckelIntegrandSquared4dJR(double u,
 				      void * p){
@@ -1891,15 +2035,16 @@ double JzStaeckelIntegrandSquared(double v,
 			  params->nargs,params->actionAngleArgs);
   return params->E * sin2v + params->I3V + dV  - params->Lz22delta / sin2v;
 }
-double JzLowStaeckelIntegrand(double t,
+double JzLowStaeckelIntegrand(double chi,
 			      void * p){
-  // t^2 substitution v = vmin + t^2: regularizes the sqrt branch point at
-  // the turning point; the integral is split at the midpoint like the
-  // dJzd* routines (the midplane side has no singularity, but the split
-  // keeps the panels short and the rule converged at low order)
   struct JzStaeckelArg * params= (struct JzStaeckelArg *) p;
-  double v= params->vmin + t * t;
-  return 2. * t * JzStaeckelIntegrand(v,p);
+  double v, sc= sin(chi);
+  double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
+			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
+			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
+  double D= M_PI - 2. * params->vmin;
+  if ( Q <= 0. ) return 0.;
+  return D / 4. * sqrt(Q) * sc * sc;
 }
 double JzHighStaeckelIntegrand(double t,
 			       void * p){
@@ -1916,17 +2061,27 @@ double JzStaeckelIntegrandSquared4dJz(double v,
 			  params->nargs,params->actionAngleArgs);
   return params->E * sin2v + params->I3V + dV  - params->Lz22delta / sin2v;
 }
-double dJRdELowStaeckelIntegrand(double t,
-				 void * p){
+double dJRdELowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umin + t * t;
-  return 2. * t * dJRdEStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D * sinh(u) * sinh(u) / sqrt(Q);
 }
-double dJRdEHighStaeckelIntegrand(double t,
-				 void * p){
+double dJRdEHighStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umax - t * t;
-  return 2. * t * dJRdEStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D * sinh(u) * sinh(u) / sqrt(Q);
 }
 double dJRdEStaeckelIntegrand(double u,
 			      void * p){
@@ -1934,17 +2089,27 @@ double dJRdEStaeckelIntegrand(double u,
   if ( out <= 0. ) return 0.;
   else return sinh(u)*sinh(u)/sqrt(out);
 }
-double dJRdLzLowStaeckelIntegrand(double t,
-				  void * p){
+double dJRdLzLowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umin + t * t;
-  return 2. * t * dJRdLzStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / sinh(u) / sinh(u) / sqrt(Q);
 }
-double dJRdLzHighStaeckelIntegrand(double t,
-				   void * p){
+double dJRdLzHighStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umax - t * t;
-  return 2. * t * dJRdLzStaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / sinh(u) / sinh(u) / sqrt(Q);
 }
 double dJRdLzStaeckelIntegrand(double u,
 			      void * p){
@@ -1952,17 +2117,27 @@ double dJRdLzStaeckelIntegrand(double u,
   if ( out <= 0. ) return 0.;
   else return 1./sinh(u)/sinh(u)/sqrt(out);
 }
-double dJRdI3LowStaeckelIntegrand(double t,
-				  void * p){
+double dJRdI3LowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umin + t * t;
-  return 2. * t * dJRdI3StaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / sqrt(Q);
 }
-double dJRdI3HighStaeckelIntegrand(double t,
-				   void * p){
+double dJRdI3HighStaeckelIntegrand(double chi,
+			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u= params->umax - t * t;
-  return 2. * t * dJRdI3StaeckelIntegrand(u,p);
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / sqrt(Q);
 }
 double dJRdI3StaeckelIntegrand(double u,
 			      void * p){
@@ -1971,11 +2146,16 @@ double dJRdI3StaeckelIntegrand(double u,
   else return 1./sqrt(out);
 }
 
-double dJzdELowStaeckelIntegrand(double t,
-				 void * p){
+double dJzdELowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v= params->vmin + t * t;
-  return 2. * t * dJzdEStaeckelIntegrand(v,p);
+  double v, sc= sin(chi);
+  double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
+			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
+			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
+  double D= M_PI - 2. * params->vmin;
+  if ( Q <= 0. ) return 0.;
+  return D * sin(v) * sin(v) / sqrt(Q);
 }
 double dJzdEHighStaeckelIntegrand(double t,
 				 void * p){
@@ -1988,11 +2168,16 @@ double dJzdEStaeckelIntegrand(double v,
   if ( out <= 0. ) return 0.;
   else return sin(v)*sin(v)/sqrt(out);
 }
-double dJzdLzLowStaeckelIntegrand(double t,
-				  void * p){
+double dJzdLzLowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v= params->vmin + t * t;
-  return 2. * t * dJzdLzStaeckelIntegrand(v,p);
+  double v, sc= sin(chi);
+  double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
+			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
+			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
+  double D= M_PI - 2. * params->vmin;
+  if ( Q <= 0. ) return 0.;
+  return D / sin(v) / sin(v) / sqrt(Q);
 }
 double dJzdLzHighStaeckelIntegrand(double t,
 				   void * p){
@@ -2005,11 +2190,16 @@ double dJzdLzStaeckelIntegrand(double v,
   if ( out <= 0. ) return 0.;
   else return 1./sin(v)/sin(v)/sqrt(out);
 }
-double dJzdI3LowStaeckelIntegrand(double t,
-				  void * p){
+double dJzdI3LowStaeckelIntegrand(double chi,
+			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v= params->vmin + t * t;
-  return 2. * t * dJzdI3StaeckelIntegrand(v,p);
+  double v, sc= sin(chi);
+  double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
+			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
+			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
+  double D= M_PI - 2. * params->vmin;
+  if ( Q <= 0. ) return 0.;
+  return D / sqrt(Q);
 }
 double dJzdI3HighStaeckelIntegrand(double t,
 				   void * p){

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -24,6 +24,13 @@
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
+// see the chi-anomaly helpers below for what these control
+#define STAECKEL_CHI_EDGE 1.e-6
+// chi of the midpoint of [vmin, pi/2]: there y = 1/4, so chi = 2 asin(1/2).
+// A constant, so it needs no per-iteration assignment inside the OpenMP
+// loops -- where it would have been a shared write, being absent from the
+// private() clauses.
+#define STAECKEL_CHI_MID ( M_PI / 3. )
 //Macros to export functions in DLL on different OS
 #if defined(_WIN32)
 #define EXPORT __declspec(dllexport)
@@ -549,7 +556,7 @@ void calcJRStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
-  double mid, midchi;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -624,7 +631,7 @@ void calcJzStaeckel(int ndata,
 		    struct potentialArg * actionAngleArgs,
 		    int order){
   int ii, tid, nthreads;
-  double mid, midchi;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -671,10 +678,9 @@ void calcJzStaeckel(int ndata,
     (JzInt+tid)->params = params+tid;
     // the chi half runs to the midpoint of [vmin, pi/2], y = 1/4; the
     // midplane half is not a turning point and keeps its t^2 form
-    midchi= 2. * asin( 0.5 );
     mid= sqrt( 0.5 * ( M_PI/2. - *(vmin+ii) ) );
     //Integrate
-    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,0.,midchi,T);
+    *(jz+ii)= gsl_integration_glfixed (JzInt+tid,0.,STAECKEL_CHI_MID,T);
     (JzInt+tid)->function = &JzHighStaeckelIntegrand;
     *(jz+ii)+= gsl_integration_glfixed (JzInt+tid,0.,mid,T);
     *(jz+ii)*= 2 * sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
@@ -1064,7 +1070,7 @@ void calcdJRStaeckel(int ndata,
 		     struct potentialArg * actionAngleArgs,
 		     int order){
   int ii, tid, nthreads;
-  double mid, midchi;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -1157,7 +1163,7 @@ void calcdJzStaeckel(int ndata,
 		     struct potentialArg * actionAngleArgs,
 		     int order){
   int ii, tid, nthreads;
-  double mid, midchi;
+  double mid;
 #ifdef _OPENMP
   nthreads = omp_get_max_threads();
 #else
@@ -1207,25 +1213,24 @@ void calcdJzStaeckel(int ndata,
     //First calculate dJzdE
     (dJzInt+tid)->function = &dJzdELowStaeckelIntegrand;
     (dJzInt+tid)->params = params+tid;
-    midchi= 2. * asin( 0.5 );
     mid= sqrt( 0.5 * (M_PI/2. - *(vmin+ii) ) );
     //BOVY: pv does not vanish at pi/2, so no need to break up the integral
     //Integrate
-    *(djzdE+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
+    *(djzdE+ii)= gsl_integration_glfixed (dJzInt+tid,0.,STAECKEL_CHI_MID,T);
     (dJzInt+tid)->function = &dJzdEHighStaeckelIntegrand;
     *(djzdE+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdE+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
     //Then calculate dJzdLz
     (dJzInt+tid)->function = &dJzdLzLowStaeckelIntegrand;
     //Integrate
-    *(djzdLz+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
+    *(djzdLz+ii)= gsl_integration_glfixed (dJzInt+tid,0.,STAECKEL_CHI_MID,T);
     (dJzInt+tid)->function = &dJzdLzHighStaeckelIntegrand;
     *(djzdLz+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdLz+ii)*= - *(Lz+ii) * sqrt(2.) / M_PI / *(delta+ii*delta_stride);
     //Then calculate dJzdI3
     (dJzInt+tid)->function = &dJzdI3LowStaeckelIntegrand;
     //Integrate
-    *(djzdI3+ii)= gsl_integration_glfixed (dJzInt+tid,0.,midchi,T);
+    *(djzdI3+ii)= gsl_integration_glfixed (dJzInt+tid,0.,STAECKEL_CHI_MID,T);
     (dJzInt+tid)->function = &dJzdI3HighStaeckelIntegrand;
     *(djzdI3+ii)+= gsl_integration_glfixed (dJzInt+tid,0.,mid,T);
     *(djzdI3+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
@@ -1874,8 +1879,6 @@ void calcVmin(int ndata,
   S ~ (q - q0) [S'(q0) + S'(q)] / 2, whose O((q-q0)^2) model error is far
   below the cancellation it replaces.
 */
-#define STAECKEL_CHI_EDGE 1.e-6
-
 static inline double SuTermsStaeckel(double u,double E,double I3U,
 				     double Lz22delta,double delta,double v0,
 				     double sin2v0,double sinh2u0,
@@ -2064,7 +2067,7 @@ double JzStaeckelIntegrandSquared4dJz(double v,
 double dJRdELowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2075,7 +2078,7 @@ double dJRdELowStaeckelIntegrand(double chi,
 double dJRdEHighStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2092,7 +2095,7 @@ double dJRdEStaeckelIntegrand(double u,
 double dJRdLzLowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2103,7 +2106,7 @@ double dJRdLzLowStaeckelIntegrand(double chi,
 double dJRdLzHighStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2120,7 +2123,7 @@ double dJRdLzStaeckelIntegrand(double u,
 double dJRdI3LowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2131,7 +2134,7 @@ double dJRdI3LowStaeckelIntegrand(double chi,
 double dJRdI3HighStaeckelIntegrand(double chi,
 			      void * p){
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) p;
-  double u, sc= sin(chi);
+  double u;
   double Q= chiQuStaeckel(chi,1,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
@@ -2149,7 +2152,7 @@ double dJRdI3StaeckelIntegrand(double u,
 double dJzdELowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v, sc= sin(chi);
+  double v;
   double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
 			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
 			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
@@ -2171,7 +2174,7 @@ double dJzdEStaeckelIntegrand(double v,
 double dJzdLzLowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v, sc= sin(chi);
+  double v;
   double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
 			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
 			  params->potupi2,params->nargs,params->actionAngleArgs,&v);
@@ -2193,7 +2196,7 @@ double dJzdLzStaeckelIntegrand(double v,
 double dJzdI3LowStaeckelIntegrand(double chi,
 			      void * p){
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) p;
-  double v, sc= sin(chi);
+  double v;
   double Q= chiQvStaeckel(chi,params->vmin,params->E,params->I3V,params->Lz22delta,
 			  params->delta,params->u0,params->cosh2u0,params->sinh2u0,
 			  params->potupi2,params->nargs,params->actionAngleArgs,&v);


### PR DESCRIPTION
The C action, frequency and angle integrals used a `t^2` substitution around
each turning point. That removes the sqrt branch point but not the reason the
integrand is hard there: `S = p^2/(2 delta^2)` is a difference of O(1) terms
cancelling to zero, so its *relative* error blows up while its absolute error
stays at machine epsilon, and the `1/sqrt(S)` of the frequency and angle
integrands amplifies it.

Worse, `t^2` clusters Gauss-Legendre nodes as `1/order^4` onto the turning
point, so **raising the order moved them further into the cancellation and made
the answer worse**:

| | order 200 | order 800 |
|---|---|---|
| `dOmega_z/Omega_z`, C vs pure-Python | 1.8e-9 | **3.3e-8** |

against ~1e-12 for the pure-Python path at both orders. Degrading with order is
the signature of cancellation rather than truncation, and it is why this could
not be fixed by asking for more quadrature points.

### What this does

Uses the chi anomaly of the Python path at the turning points,
`q = qmin + D sin^2(chi/2)`. With `y = sin^2(chi/2)` and `Q = S/[y(1-y)]`,

    int sqrt(S) dq   = (D/4) int sqrt(Q) sin^2(chi) dchi
    int f/sqrt(S) dq = D int f/sqrt(Q) dchi

both regular at the turning point. Near the endpoints `Q` is taken from the
analytic derivative by the trapezoid `S ~ (q-q0)[S'(q0)+S'(q)]/2` instead of
from the cancelling difference -- the same switch, at the same threshold, as
`_staeckelChiQuadratures`.

The midplane half of the `v` integrals keeps its `t^2` form: the midplane is an
interior symmetry point of `S_z`, not a turning point. The `umin`/`umax`/`vmin`
root functions also keep the direct expression, since the turning points they
solve for are not known while they run.

### Measured

Agreement with the pure-Python path near the radial turning points, on an
integrated orbit:

| potential | order 200 | order 800 |
|---|---|---|
| KuzminKutuzov | 6.0e-07 -> **1.5e-09** | 2.0e-06 -> **1.4e-09** |
| MWPotential2014 | 5.9e-08 -> 1.9e-07 | 2.1e-06 -> **9.2e-08** |

Frequencies improve 10-11x for MWPotential2014 (1.6e-4 -> 1.4e-5). The
substantive change is that the result is now **stable in the quadrature order**
rather than degrading with it.

Honest caveat: MWPotential2014 at order 200 moves the wrong way (5.9e-8 ->
1.9e-7). That is a max over a small near-turning-point subsample on a potential
that is not of Staeckel form; the value is stable at ~1e-7 across orders instead
of growing to 2e-6 as before.

All 73 Staeckel tests pass, including the near-circular `interpRZPotential`
cases (`test_actionAngleStaeckel_basic_actions_u0_interppot_c`,
`test_actionAngleStaeckel_basic_freqs_u0`), which an earlier threshold-based
attempt broke -- this needs no tuned constant.

### How it was found

While checking how close `actionAngleStaeckelInverse`'s canonical map gets to
machine precision. It reproduces the exact direct construction to 3e-13, but
measured only ~1e-7 against the forward code -- and the *direct* construction,
which has no canonical machinery at all, showed the same 4.4e-8. The floor was
the forward C path, not the inverse.
---

**Scope note (from review).** The `v` path is deliberately not the literal
Python rule: Python integrates the whole `vmin -> pi/2` interval in chi, while
this converts only the turning-point half and leaves the midplane half on the
old `t^2` panel, since the midplane is an interior symmetry point of `S_z`
rather than a turning point and has nothing to regularize. The chi
parametrization is applied where the cancellation actually is.
