### PR TITLE
hyp2f1: bring the comments back in line with the code

### DIFF
--- a/galpy/backend/special/_fallback/hyp2f1.py
+++ b/galpy/backend/special/_fallback/hyp2f1.py
@@ -153,21 +153,19 @@ def hyp2f1_fallback(xp, a, b, c, z):
     Verified over 36 (a,b,c,z) combinations with 0.05 <= z <= 0.999: worst
     relative error 9.6e-07, and <= 1.4e-14 for five of the six parameter sets.
 
-    Three routes for z <= 0, in order of preference:
+    Two routes for z <= 0, in order of preference:
 
-    1. the boundary-layer Euler integral, when the parameters admit it;
-    2. Euler's transformation 2F1(a,b;c;z) = (1-z)^{c-a-b} 2F1(c-a,c-b;c;z),
-       which leaves z alone -- so the integral's z <= 0 machinery applies
-       verbatim -- and rescues the case where the only positive parameter has
-       c - P < 1 (e.g. a=-3.2, b=4.4, c=5.2 becomes 8.4, 0.8, 5.2);
-    3. otherwise a Gauss series, see _pfaff_series. Reached only when a and b
-       are both non-positive, where no transformation lands a parameter in the
-       integral's range.
+    1. the Euler integral, whenever a labelling admits it -- B > 0 and
+       c - B > 0, see _euler_labeling;
+    2. otherwise a Gauss series, see _pfaff_series. Reached only when a and b
+       are both non-positive, where neither labelling lands in the integral's
+       range.
 
-    Note a Pfaff transformation is NOT usable for route 2: it maps z <= 0 to
-    z/(z-1) in [0, 1), and the integral's substitutions assume z <= 0. (That is
-    the same identity used for entry above, in the opposite direction -- there it
-    moves positive z ONTO this domain, which is precisely what is wanted.)
+    There used to be a third route between these two: Euler's transformation
+    2F1(a,b;c;z) = (1-z)^{c-a-b} 2F1(c-a,c-b;c;z), which rescued a parameter set
+    whose only positive parameter had c - P < 1. Relaxing admissibility from
+    c - P >= 1 to c - P > 0 made it provably unreachable, so it is gone; the
+    proof is in _hyp2f1_nonpositive.
     """
     z = xp.asarray(z) * 1.0
     pos = z > 0.0
@@ -186,7 +184,7 @@ def _in_regime_mask(xp, a, b, c):
 
 
 def _nonpositive_traced(xp, a, b, c, z):
-    """The same three routes for z <= 0, selected rather than branched.
+    """The same two routes for z <= 0, selected rather than branched.
 
     Reached when a, b or c is a TRACER -- differentiating a potential w.r.t. an
     exponent, say -- where `if a > 0` has no truth value. Both surviving
@@ -221,7 +219,7 @@ def _nonpositive_traced(xp, a, b, c, z):
 
 
 def _hyp2f1_nonpositive(xp, a, b, c, z):
-    """2F1(a, b; c; z) for real z <= 0 -- the three routes named above."""
+    """2F1(a, b; c; z) for real z <= 0 -- the two routes named above."""
     if not all(has_concrete_truth_value(p > 0.0) for p in (a, b, c)):
         return _nonpositive_traced(xp, a, b, c, z)
     # No Euler-TRANSFORM branch: under `c - P > 0` it is unreachable. The regime

--- a/tests/test_backend_special.py
+++ b/tests/test_backend_special.py
@@ -1248,19 +1248,19 @@ def test_gammainc_grad_with_an_integer_order_dtype():
 # true -8.56e-02, and TwoPowerTriaxial dPhi/dalpha 0.834 against 0.548. Only
 # grad-vs-finite-difference catches that, which is what these do.
 #
-# The bar is per route, because the routes do not differentiate equally well.
-# The value is spectrally accurate only when c - B is an integer (then the
-# (1-t)^{c-B-1} factor is a polynomial and Gauss-Legendre is exact); the
-# DERIVATIVE integrand carries an extra log factor that nothing regularizes, so
-# it converges algebraically. The numbers below are measured, not guessed.
+# The bar is per case, because they do not differentiate equally well: the
+# DERIVATIVE integrand carries an extra log factor the rule does not cancel (it
+# cancels the endpoint singularities of the VALUE integrand, not of its
+# parameter derivative), so it converges more slowly than the value does. The
+# numbers below are measured, not guessed.
 _HYP2F1_PARAM_GRAD = [
     # (a, b, c, z, rtol, route)
-    (-3.2, 4.4, 5.2, -5.0, 1e-8, "euler-transformed"),
+    (-3.2, 4.4, 5.2, -5.0, 1e-8, "euler, small c-P (once needed the transform)"),
     (-0.51, -0.98, 2.51, -5.0, 1e-8, "pfaff-series"),
     (1.7, 2.3, 3.4, -5.0, 1e-4, "euler, non-integer c-B"),
     (2.0, 2.0, 3.0, -5.0, 1e-3, "euler, c-a == 1 exactly (galpy's own force call)"),
-    # tanh-sinh route (B < _TS_B_MAX). Without these the route had NO parameter-
-    # gradient coverage at all, and it sizes its own node grid from B -- exactly
+    # Small B. Without these the rule had NO parameter-gradient coverage at
+    # all, and it sizes its own node grid from B -- exactly
     # the shape that silently detaches if it reaches for float(B). It cannot:
     # under jax.grad the parameters have concrete truth values but are still
     # tracers, so the grid is chosen by comparisons only.
@@ -1334,8 +1334,8 @@ def test_hyp2f1_traced_parameters_reproduce_the_concrete_route(a, b, c):
     # With traced (a, b, c) the route can no longer be chosen with `if`, so all
     # of it -- regime test, Euler labelling, series labelling -- is selected with
     # where(). This asserts that selection lands on the same answer the Python
-    # branches give, for every parameter set the concrete tests cover, i.e. all
-    # three routes. The bar is the series' own truncation noise at |z| = 50,
+    # branches give, for every parameter set the concrete tests cover, i.e. both
+    # routes. The bar is the series' own truncation noise at |z| = 50,
     # where the two arms round differently over 512 cancelling terms.
     jax = pytest.importorskip("jax")
     import jax.numpy as jnp
@@ -1384,11 +1384,13 @@ def test_hyp1f1_parameter_gradient_matches_finite_difference(backend):
 
 
 # ---------------------------------------------------------------------------
-# hyp2f1 small-B accuracy: the Euler integral's xi^k substitution needs
-# k >= ~6/B to regularize the t^{B-1} endpoint, and k is capped at 12 because
-# X = xi^k underflows above that. So for small B the endpoint is simply not
-# regularized and plain Gauss-Legendre loses badly. tanh-sinh needs no
-# substitution and is routed in below _TS_B_MAX.
+# hyp2f1 small-B accuracy. The Euler integral is now quadratured by a single
+# tanh-sinh rule at every B, which cancels the t^{B-1} and (1-t)^{c-B-1}
+# endpoint singularities analytically against its own weight. The rule this
+# replaced was a fixed-order Gauss-Legendre one that regularized the t^{B-1}
+# endpoint with an X = xi^k substitution needing k >= ~6/B, capped at 12 because
+# X = xi^k underflows above that -- so at small B the endpoint was simply not
+# regularized and it lost badly. These cases pin that.
 #
 # B is the parameter the Euler labelling PICKS: a < 0 disqualifies a, forcing
 # B = b. That is not synthetic -- constantbetaHernquistdf(beta=-1.5) asks for


### PR DESCRIPTION
Review follow-up on the codex comment in gh#1204: several comments still
described the deleted Euler-transform route and the replaced Gauss-Legendre /
substitution rule as if they were current. Comments are the audit trail for this
work, so a comment describing a route that no longer exists is a real defect
even though nothing executes it.

Two of them named a constant that is **gone**: `_TS_B_MAX` has zero occurrences
in `hyp2f1.py`, but the tests still said the tanh-sinh rule "is routed in below
`_TS_B_MAX`" and labelled a case `tanh-sinh route (B < _TS_B_MAX)`. There is one
rule for every B now; there is no threshold to be below.

### `galpy/backend/special/_fallback/hyp2f1.py`

- **"Three routes for z <= 0" -> two.** Route 2 was Euler's transformation,
  removed in gh#1403 as provably unreachable under `c - P > 0`. The entry now
  says that and points at the proof, instead of describing the route as live.
- **Dropped the note explaining why Pfaff could not serve as route 2** -- it
  justified a design that no longer exists, and its stated reason ("the
  integral's substitutions assume z <= 0") describes substitutions the tanh-sinh
  rule does not use.
- `_nonpositive_traced`: "the same three routes" -> two.
- `_hyp2f1_nonpositive`: "the three routes named above" -> two.

### `tests/test_backend_special.py`

- Route label `"euler-transformed"` -> `"euler, small c-P (once needed the
  transform)"`. Those parameters take the DIRECT route now, so the id named a
  route the case does not use. Only used as pytest ids -- checked, neither
  ledger keys off them.
- Both `_TS_B_MAX` references removed.
- "all three routes" -> both routes.
- The per-route tolerance rationale credited Gauss-Legendre exactness for
  integer `c - B`; GL no longer runs. Restated on what is true of the shipping
  rule: it cancels the endpoint singularities of the VALUE integrand, not of its
  parameter derivative, so the derivative converges more slowly.
- The small-B section header described the `xi^k` substitution in the present
  tense; now past tense, as the thing this replaced.

### Deliberately left alone

The passages already framed as history -- "This REPLACED a fixed-order
Gauss-Legendre rule...", "when the bound was `c - B >= 1`", "the large-B cases
the GL rule was kept for". Those are the audit trail and are accurate as
written. I swept both files for `three routes|route 2|_TS_B_MAX|euler-transform|
Gauss-Legendre|substitut` and classified each hit as present-tense-wrong vs
correctly-past-tense, rather than fixing only the two spots the review named.

Comments and pytest ids only -- no executable change on any path.
Gate: `tests/test_backend_special.py` 253 passed.
Ledger delta: 0.