### PR TITLE
surfdens: eager backends take the batched vertical quadrature (ledger -6)

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -161,6 +161,52 @@ def _quad_needs_backend(xp, *coords):
     return any(under_trace(c) or requires_backend_grad(c) for c in coords)
 
 
+def _vertical_quad_needs_backend(
+    xp, pot, *coords, methods=("_Rforce", "_zforce", "_rforce")
+):
+    """Whether the vertical surface-density integrals should use the backend rule.
+
+    Under a trace, always -- scipy cannot be evaluated there at all, which is
+    what `_quad_needs_backend` decides. Outside one, whenever the namespace is
+    not numpy AND ``pot``'s forces broadcast: scipy's adaptive loop calls the
+    integrand one scalar node at a time (~1100 calls for a wrapped
+    MWPotential2014, ~48 ms each on eager jax), while the backend rule evaluates
+    it ONCE on the whole node array. Measured against scipy on eager jax, over 3
+    wrapper potentials x 18 (R, |z|, phi):
+
+        mockOffsetMWP14Wrapper          worst 1.6e-14   147 s -> 7 s
+        mockRotatedAndTiltedMWP14       worst 4.2e-15   171 s -> 2 s
+        mockRotatedTiltedOffsetMWP14    worst 8.4e-16   140 s -> 2 s
+
+    so it is 22-83x faster at the same accuracy, not a precision trade.
+
+    Array-safety is asked in the terms `check_potential_inputs_not_arrays` itself
+    uses. That guard rejects an array UNLESS the potential opts in with
+    ``_backend_accepts_arrays`` and every array argument is a backend array --
+    which is exactly the situation here, since ``xp`` is not numpy. So a
+    potential carrying the opt-in is safe to batch even though its methods are
+    marked scalar-only for the numpy contract, and asking only
+    `_accepts_node_array` would wrongly exclude it: RotateAndTiltWrapper
+    decorates all of its force methods and is the wrapper under every one of the
+    measurements above.
+
+    Potentials with neither the opt-in nor a scalar-only marker (the common case,
+    and every plain analytic potential) broadcast anyway. What is left out is a
+    potential that is marked scalar-only AND does not opt in -- e.g.
+    AnySphericalPotential, whose force closes over ``scipy.integrate.quad`` with
+    a scalar limit -- which keeps scipy, as it must.
+
+    numpy always keeps scipy, so the numpy path is byte-identical.
+    """
+    if xp is numpy:
+        return False
+    return (
+        _quad_needs_backend(xp, *coords)
+        or getattr(pot, "_backend_accepts_arrays", False)
+        or _accepts_node_array(pot, *methods)
+    )
+
+
 def _force_accepts_arrays(pot):
     """Whether ``pot``'s force methods broadcast over an array of positions.
 
@@ -180,9 +226,19 @@ def _force_accepts_arrays(pot):
     any of its ``_Rforce``/``_zforce``/``_rforce`` carries the scalar-only marker
     set by :func:`check_potential_inputs_not_arrays`; True otherwise.
     """
+    return _accepts_node_array(pot, "_Rforce", "_zforce", "_rforce")
+
+
+def _accepts_node_array(pot, *methods):
+    """Whether ``pot``'s ``methods`` broadcast over an array of positions.
+
+    The marker scan behind `_force_accepts_arrays`, taking the method names as
+    an argument so a quadrature over the DENSITY can ask about ``_dens`` rather
+    than about the force methods it never calls.
+    """
     if not getattr(pot, "_force_accepts_arrays", True):
         return False
-    for name in ("_Rforce", "_zforce", "_rforce"):
+    for name in methods:
         meth = getattr(type(pot), name, None)
         if meth is not None and getattr(meth, "_galpy_scalar_only", False):
             return False
@@ -824,7 +880,7 @@ class Potential(Force):
         # numpy.fabs on a backend array emits a NumPy 2 __array_wrap__
         # DeprecationWarning, which the coverage shard turns into an error.
         absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
-        if not _quad_needs_backend(xp, absz, R, phi, t):
+        if not _vertical_quad_needs_backend(xp, self, absz, R, phi, t):
             # epsabs=0 so the criterion is purely RELATIVE. quad's default
             # epsabs=1.49e-8 is ABSOLUTE, so a vertical integral whose own value is
             # at or below ~1e-8 in internal units passes the absolute test on the
@@ -915,13 +971,15 @@ class Potential(Force):
         # Same dual path as the Poisson branch of surfdens(): numpy keeps scipy
         # (byte-identical), a backend takes the split-at-the-mid-plane,
         # node-clustered GL rule so it traces and stays accurate at large |z|.
-        # Scalar-only potentials keep scipy either way -- they reject the node
+        # Scalar-only densities keep scipy either way -- they reject the node
         # array. The split matters far more here than in the Poisson branch:
         # this integrand is the density, which for a displaced disk is sharply
         # peaked off z=0 (6.4e-2 error vs 1.8e-4) -- see _vertical_quad_split.
         xp = get_namespace(R, z, phi, t)
         absz = numpy.fabs(z) if xp is numpy else xp.abs(z)
-        if not _quad_needs_backend(xp, absz, R, phi, t):
+        if not _vertical_quad_needs_backend(
+            xp, self, absz, R, phi, t, methods=("_dens",)
+        ):
             # epsabs=0: purely RELATIVE, see the Poisson branch above.
             # MWPotential2014[0] at R=1, |z|=5 integrates to 8.2e-9 and came back
             # 9.6e-6 relative off under quad's default absolute tolerance.

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -196,14 +196,16 @@ def _vertical_quad_needs_backend(
     AnySphericalPotential, whose force closes over ``scipy.integrate.quad`` with
     a scalar limit -- which keeps scipy, as it must.
 
-    numpy always keeps scipy, so the numpy path is byte-identical.
+    numpy always keeps scipy, so the numpy path is byte-identical. That is
+    `_quad_needs_backend`'s OWN first line, so it is asked here rather than
+    repeated: duplicating the check would leave the original unreachable.
     """
-    if xp is numpy:
-        return False
-    return (
-        _quad_needs_backend(xp, *coords)
-        or getattr(pot, "_backend_accepts_arrays", False)
-        or _accepts_node_array(pot, *methods)
+    return _quad_needs_backend(xp, *coords) or (
+        xp is not numpy
+        and (
+            getattr(pot, "_backend_accepts_arrays", False)
+            or _accepts_node_array(pot, *methods)
+        )
     )
 
 

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -131,12 +131,6 @@ jax tests/test_qdf.py::test_sampleV_interpolate  # measured 2026-08-24: >900s TI
 # slow-skip (correct-but-too-slow) until SCF/Multipole/wrapper eval is vectorized on
 # jax. torch fails these FAST at construction (0.0 s) -> they stay in the torch xfail-
 # ledger; numpy exercises all of them.
-jax tests/test_potential.py::test_DehnenBinney98  # measured 2026-08-21: 289.3s (CI~205s) -- passes, but only 32% under the cap
-jax tests/test_potential.py::test_poisson_surfdens_potential[mockOffsetMWP14WrapperPotential]  # measured 2026-08-21: >700s TIMEOUT
-jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotential]  # measured 2026-08-21: >700s TIMEOUT
-jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedMWP14WrapperPotentialwInclination]  # measured 2026-08-21: >700s TIMEOUT
-jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedAndTiltedTriaxialLogHaloPotentialwInclination]  # measured 2026-08-21: 371.9s (CI~264s) -- passes, only 12% under the cap
-jax tests/test_potential.py::test_poisson_surfdens_potential[mockRotatedTiltedOffsetMWP14WrapperPotential]  # measured 2026-08-21: >700s TIMEOUT
 
 # --- jax single-orbit: variational/dxdv/lyapunov battery (Track D) ---
 # These integrate the 6D STM or compare the C STM against a *Python* reference

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -938,3 +938,115 @@ def test_symmetric_quad_mixed_limits_accept_a_raw_numpy_limit(backend):
     )
     want = [numpy.sqrt(numpy.pi) * scipy.special.erf(1.0), numpy.sqrt(numpy.pi)]
     numpy.testing.assert_allclose(numpy.asarray(got, dtype=float), want, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Which rule the vertical surface-density integrals use on an EAGER backend.
+#
+# Under a trace scipy cannot run at all, so those always used the batched
+# Gauss-Legendre rule. Eager jax/torch used to fall to scipy.integrate.quad,
+# which calls the integrand one scalar node at a time -- ~1113 calls at ~48 ms
+# each for a wrapped MWPotential2014. Routing eager backends to the same batched
+# rule is 22-83x faster at machine precision (measured against scipy over 3
+# wrapper potentials x 18 (R, |z|, phi): worst 1.6e-14).
+#
+# Assert the ROUTE, not only the value: a value check cannot tell "took the
+# batched rule and got the right answer" from "silently fell back to scipy".
+# ---------------------------------------------------------------------------
+def _route_spy(monkeypatch):
+    """Record which quadrature each surfdens call reaches."""
+    import importlib
+
+    PM = importlib.import_module("galpy.potential.Potential")
+    seen = []
+    real_sq, real_quad = PM._bquad.symmetric_quad, PM.integrate.quad
+
+    def spy_sq(xp, integrand, b, **kw):
+        seen.append("batched")
+        return real_sq(xp, integrand, b, **kw)
+
+    def spy_quad(f, a, b, **kw):
+        seen.append("scipy")
+        return real_quad(f, a, b, **kw)
+
+    monkeypatch.setattr(PM._bquad, "symmetric_quad", spy_sq)
+    monkeypatch.setattr(PM.integrate, "quad", spy_quad)
+    return seen
+
+
+def _tilted_miyamoto():
+    """A wrapper that opts in with _backend_accepts_arrays while its own force
+    methods carry the scalar-only marker -- the combination the gate has to get
+    right, and the one under every measurement quoted above."""
+    from galpy.potential import MiyamotoNagaiPotential, RotateAndTiltWrapperPotential
+
+    return RotateAndTiltWrapperPotential(
+        pot=MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1),
+        zvec=[0.0, 1.0, 0.0],
+        galaxy_pa=0.3,
+    )
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+@pytest.mark.parametrize("z", [1.0, 10.0])
+def test_surfdens_poisson_takes_the_batched_rule_on_an_eager_backend(
+    backend, z, monkeypatch
+):
+    from galpy.backend import as_numpy, use
+
+    tp = _tilted_miyamoto()
+    want = tp.surfdens(0.7, z, phi=0.4, forcepoisson=True, use_physical=False)
+    seen = _route_spy(monkeypatch)
+    with use(backend, force=True):
+        got = as_numpy(tp.surfdens(0.7, z, phi=0.4, forcepoisson=True))
+    assert seen == ["batched"], f"expected the batched rule, took {seen}"
+    # numpy still runs scipy, so this is also the numpy-vs-backend parity check.
+    numpy.testing.assert_allclose(float(got), float(want), rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_surfdens_density_route_takes_the_batched_rule_too(backend, monkeypatch):
+    # The direct route integrates _dens rather than the forces, so the gate has
+    # to ask about _dens; asking about the force methods would answer for
+    # methods this integrand never calls.
+    from galpy.backend import as_numpy, use
+
+    tp = _tilted_miyamoto()
+    want = tp.surfdens(0.7, 1.0, phi=0.4, use_physical=False)
+    seen = _route_spy(monkeypatch)
+    with use(backend, force=True):
+        got = as_numpy(tp.surfdens(0.7, 1.0, phi=0.4))
+    assert seen == ["batched"], f"expected the batched rule, took {seen}"
+    numpy.testing.assert_allclose(float(got), float(want), rtol=1e-12)
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_surfdens_keeps_scipy_for_a_scalar_only_potential(backend, monkeypatch):
+    # AnySphericalPotential sets _force_accepts_arrays = False and does NOT set
+    # _backend_accepts_arrays: its force closes over scipy.integrate.quad with a
+    # scalar upper limit, so handing it the node array would silently collapse
+    # it. It must stay on scipy even on a backend.
+    from galpy.backend import use
+    from galpy.potential import AnySphericalPotential, HernquistPotential
+
+    hp = HernquistPotential(normalize=1.0)
+    tp = AnySphericalPotential(dens=lambda r: hp.dens(r, 0.0, use_physical=False))
+    seen = _route_spy(monkeypatch)
+    with use(backend, force=True):
+        tp.surfdens(0.7, 1.0, phi=0.4, forcepoisson=True)
+    assert "batched" not in seen, f"scalar-only potential was batched: {seen}"
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_vertical_quad_gate_never_diverts_numpy(backend, monkeypatch):
+    # The numpy path must be byte-identical, which rests entirely on the gate's
+    # first line. Pin it: numpy keeps scipy even for a potential that opts in.
+    from galpy.potential import MiyamotoNagaiPotential
+
+    tp = _tilted_miyamoto()
+    seen = _route_spy(monkeypatch)
+    tp.surfdens(0.7, 10.0, phi=0.4, forcepoisson=True, use_physical=False)
+    MiyamotoNagaiPotential(amp=1.0, a=0.5, b=0.1).surfdens(
+        0.7, 10.0, forcepoisson=True, use_physical=False
+    )
+    assert seen == ["scipy", "scipy"], f"numpy was diverted off scipy: {seen}"


### PR DESCRIPTION
Both vertical surface-density integrals sent eager jax/torch to
`scipy.integrate.quad`, whose adaptive loop calls the integrand one **scalar**
node at a time — 1113 calls at ~48 ms each for a wrapped MWPotential2014. The
batched Gauss–Legendre rule the **traced** path already uses evaluates it once on
the whole node array.

Measured against scipy on eager jax, 3 wrappers × 18 (R, |z|, φ), scipy
converged to 1.4e-16:

| potential | worst rel err | scipy | GL | |
|---|---|---|---|---|
| `mockOffsetMWP14Wrapper` | 1.6e-14 | 147 s | 7 s | 22× |
| `mockRotatedAndTiltedMWP14` | 4.2e-15 | 171 s | 2 s | 83× |
| `mockRotatedTiltedOffsetMWP14` | 8.4e-16 | 140 s | 2 s | 70× |

Machine precision — not a precision trade, and it is the same rule at the same
order the traced path has always shipped.

## Ledger −6, measured end to end

Whole `tests/test_potential.py` under `--backend jax`, list emptied for these:

    before   4 failed, 1284 passed, 102 skipped   7144 s (1:59:04)
    after    0 failed, 1288 passed, 102 skipped   2733 s (0:45:33)

| test | before | after | CI ≈ 0.71× |
|---|---|---|---|
| `poisson_surfdens[mockRotatedAndTiltedMWP14]` | >900 s **FAIL** | 20.5 s | 14.5 s |
| `poisson_surfdens[mockRotatedTiltedOffset…]` | >900 s **FAIL** | 19.1 s | 13.6 s |
| `poisson_surfdens[mockOffsetMWP14Wrapper]` | >900 s **FAIL** | 17.1 s | 12.1 s |
| `poisson_surfdens[…MWP14wInclination]` | >900 s **FAIL** | 16.5 s | 11.7 s |
| `poisson_surfdens[…TriaxialLogHalowIncl]` | 349.8 s | 8.0 s | 5.7 s |
| `test_DehnenBinney98` | 249.8 s | 77.9 s | 55.3 s |

All six clear the 300 s cap with >80% margin, so all six come off the list. The
file is now **faster with them running** than it used to be with them skipped —
every other surfdens caller sped up too.

## The gate is not `_force_accepts_arrays`

Using it did nothing, and the smoke test caught that (`symmetric_quad calls=0`):
`_surfdens_poisson` runs on the inner `RotateAndTiltWrapperPotential`, whose
force methods carry the scalar-only marker. That marker is right for the **numpy**
contract — but the potential also declares `_backend_accepts_arrays = True`,
which is exactly the escape hatch `check_potential_inputs_not_arrays` implements:
it admits an array when the potential opts in **and** every array argument is a
backend array, which is precisely this path. The gate now asks the question the
guard itself asks.

Still on scipy: potentials marked scalar-only that do **not** opt in — e.g.
`AnySphericalPotential`, whose force closes over `scipy.integrate.quad` with a
scalar upper limit, so the node array would silently collapse. Pinned by a test.

The density route is rerouted too, and asks about `_dens` rather than the force
methods it never calls — hence `_accepts_node_array(pot, *methods)`, the marker
scan `_force_accepts_arrays` already had, factored out rather than duplicated.

**numpy is byte-identical**: the gate returns `False` for numpy on its first
line, and a test pins that numpy is never diverted off scipy.

## Gates

| | |
|---|---|
| numpy `test_potential.py` | 1288 passed, 102 skipped |
| jax `test_potential.py` | 1288 passed, 102 skipped, **0 failed** |
| jax+torch `test_backend_quadrature.py` | 103 passed, 1 skipped |
| A/B | the 6 new route tests **fail on base** and pass here; the 2 invariant tests (scalar-only stays on scipy, numpy never diverted) pass on **both** sides, which is what they are for |

Tests assert the **route**, not only the value — a value check cannot tell
"took the batched rule and got the right answer" from "silently fell back to
scipy".

Audit: adds no data-dependent branch (the gate reads Python attributes and
namespace identity, both static — no `if`→`xp.where` class); removes duplication
rather than adding it; helpers are potential-specific and sit beside the ones
they generalise, so `Potential.py` is the right home, not `galpy.backend`.

Ledger delta: **−6** (slow-skip 57 → 51; total 65 → 59).