### PR TITLE
mass(): ask the backend's array-safety question; re-ledger a wrong de-ledgering

### DIFF
--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -201,11 +201,24 @@ def _vertical_quad_needs_backend(
     repeated: duplicating the check would leave the original unreachable.
     """
     return _quad_needs_backend(xp, *coords) or (
-        xp is not numpy
-        and (
-            getattr(pot, "_backend_accepts_arrays", False)
-            or _accepts_node_array(pot, *methods)
-        )
+        xp is not numpy and _accepts_node_array_on_backend(pot, *methods)
+    )
+
+
+def _accepts_node_array_on_backend(pot, *methods):
+    """Whether ``pot`` can be handed the whole node array on a BACKEND path.
+
+    `check_potential_inputs_not_arrays` rejects an array UNLESS the potential
+    opts in with ``_backend_accepts_arrays`` and every array argument is a
+    backend array. So on a backend path the opt-in OVERRIDES the scalar-only
+    marker, which states the numpy contract: RotateAndTiltWrapper decorates all
+    of its force methods and still broadcasts here.
+
+    Asking `_accepts_node_array` alone would wrongly exclude exactly those
+    potentials -- which is what `Potential.mass` did until it used this.
+    """
+    return getattr(pot, "_backend_accepts_arrays", False) or _accepts_node_array(
+        pot, *methods
     )
 
 
@@ -1055,11 +1068,18 @@ class Potential(Force):
             from ..backend.quadrature import quad as _bk_quad
 
             # Scalar-only potentials (force raises on / silently mishandles an
-            # array, e.g. DoubleExponentialDiskPotential / AnySphericalPotential)
-            # must drive the backend Gauss-Legendre quadrature node-by-node, like
-            # scipy.integrate.quad does on the numpy path. No effect on the numpy
-            # path (scipy is always node-by-node) -> byte-identical there.
-            _vec = _force_accepts_arrays(self)
+            # array, e.g. AnySphericalPotential) must drive the backend
+            # Gauss-Legendre quadrature node-by-node, like scipy.integrate.quad
+            # does on the numpy path. `vectorized` is documented as ignored on
+            # the numpy (scipy) path, so this is byte-identical there.
+            #
+            # Ask in the BACKEND's terms: a potential that opts in with
+            # `_backend_accepts_arrays` broadcasts here even though its methods
+            # carry the numpy-contract scalar-only marker. `_force_accepts_arrays`
+            # says False for those, so mass() was driving DoubleExponentialDisk
+            # node-by-node for nothing -- 0.62 s vs 0.08 s on eager jax, same
+            # value to 12 digits.
+            _vec = _accepts_node_array_on_backend(self, "_Rforce", "_zforce", "_rforce")
             xp = get_namespace(R) if z is None else get_namespace(R, z)
             if z is None:  # Within spherical shell
 

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -244,12 +244,30 @@ jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetric
 # numpy.asarray(), which a tracer cannot satisfy. Eager jax/torch are fine: a
 # concrete array converts.
 #
-# `test_pickling_potential_unitful_dens` was ALSO ledgered here on that
-# reasoning and is now MEASURED PASSING traced -- the 2026-08-18
-# workflow_dispatch(jit=true, regen=true) run (32141815273) does not list it.
-# So the blanket "there is nothing to fix" claim held for the wrapper case only;
-# only `drops_units_wrapper` still hits the untraceable as_numpy() boundary.
+# `test_pickling_potential_unitful_dens` was de-ledgered on 2026-08-18 as
+# "MEASURED PASSING traced -- the workflow_dispatch(jit=true, regen=true) run
+# (32141815273) does not list it". THAT WAS WRONG, and re-ledgered here.
+# Re-measured 2026-08-28, whole test_potential.py plus single-nodeid:
+#
+#     jax  --jit   FAIL  TracerArrayConversionError
+#     torch --jit  FAIL  (the torch equivalent)
+#     jax  eager   pass
+#     torch eager  pass
+#
+# which is EXACTLY what the reasoning above predicts -- a units density routes
+# through as_numpy(), which a tracer cannot satisfy, while a concrete array
+# converts. The de-ledgering contradicted its own paragraph.
+#
+# "Does not list it" was read as "passes". Absence of a result is NO DATA, not
+# evidence of a pass: the regen run most likely never reached this test. That is
+# the rule tools/ledger_harvest.py bakes in, and it applies to reading a regen
+# run by hand too.
+#
+# CI never runs jit mode, so this only reds a workflow_dispatch(jit=true) --
+# which is precisely why it went unnoticed for ten days.
 jax-jit tests/test_potential.py::test_pickling_potential_drops_units_wrapper
+jax-jit tests/test_potential.py::test_pickling_potential_unitful_dens
+torch-jit tests/test_potential.py::test_pickling_potential_unitful_dens
 
 # jax-jit: actionAngleStaeckelGrid, MEASURED 2026-08-07 on the first traced run of
 # test_actionAngle.py (whole file, regen mode). This nodeid is ledgered for EAGER

--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -1050,3 +1050,72 @@ def test_vertical_quad_gate_never_diverts_numpy(backend, monkeypatch):
         0.7, 10.0, forcepoisson=True, use_physical=False
     )
     assert seen == ["scipy", "scipy"], f"numpy was diverted off scipy: {seen}"
+
+
+# ---------------------------------------------------------------------------
+# Potential.mass asks the same array-safety question as the surfdens gate.
+#
+# It used to ask `_force_accepts_arrays`, which answers for the NUMPY contract:
+# False for any potential whose force methods carry the scalar-only marker. But
+# `check_potential_inputs_not_arrays` admits an array when the potential opts in
+# with `_backend_accepts_arrays`, so those potentials DO broadcast on a backend
+# path -- and mass() was driving them node-by-node for nothing (measured on
+# eager jax: DoubleExponentialDisk 0.62 s -> 0.08 s, same value to 12 digits).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_mass_batches_a_potential_that_opts_in(backend, monkeypatch):
+    import importlib
+
+    from galpy.backend import as_numpy, use
+    from galpy.potential import DoubleExponentialDiskPotential
+
+    PM = importlib.import_module("galpy.potential.Potential")
+    dep = DoubleExponentialDiskPotential(amp=1.0, hr=0.4, hz=0.1)
+    # Reference: the SAME backend rule driven node-by-node, i.e. what mass() did
+    # before. Comparing against that isolates the routing change from the
+    # backend-vs-scipy difference.
+    real_pred = PM._accepts_node_array_on_backend
+    monkeypatch.setattr(PM, "_accepts_node_array_on_backend", lambda p, *m: False)
+    with use(backend, force=True):
+        batched_ref = float(as_numpy(dep.mass(2.0, z=1.0, forceint=True)))
+    monkeypatch.setattr(PM, "_accepts_node_array_on_backend", real_pred)
+
+    calls = []
+    real = type(dep).Rforce
+
+    def counting_Rforce(self, R, z=0.0, **kw):
+        calls.append(getattr(R, "shape", ()) or getattr(z, "shape", ()))
+        return real(self, R, z=z, **kw)
+
+    monkeypatch.setattr(type(dep), "Rforce", counting_Rforce)
+    with use(backend, force=True):
+        got = as_numpy(dep.mass(2.0, z=1.0, forceint=True))
+    # One BATCHED call per quadrature, not one per node: the node array reaches
+    # Rforce whole. Node-by-node would be _QUAD_N calls of shape ().
+    assert len(calls) < 10, f"driven node-by-node: {len(calls)} Rforce calls"
+    assert any(sh != () for sh in calls), f"never saw an array: shapes {calls}"
+    # The VALUE must be untouched: same Gauss-Legendre rule and same nodes, only
+    # the call pattern changes. Measured bit-identical to the node-by-node drive
+    # (0.19292490375107788 both ways), so this is a routing change, not a
+    # numerical one. It is deliberately NOT compared against the numpy/scipy
+    # answer: the backend GL rule already differs from adaptive scipy by 5.8e-09
+    # for mass(), which is pre-existing and outside this change.
+    numpy.testing.assert_allclose(float(got), float(batched_ref), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_mass_still_drives_a_scalar_only_potential_node_by_node(backend, monkeypatch):
+    # The other side: AnySphericalPotential sets _force_accepts_arrays = False
+    # and does NOT opt in, so it must keep the node-by-node drive.
+    import importlib
+
+    from galpy.backend import use
+    from galpy.potential import AnySphericalPotential, HernquistPotential
+
+    PM = importlib.import_module("galpy.potential.Potential")
+    hp = HernquistPotential(normalize=1.0)
+    tp = AnySphericalPotential(dens=lambda r: hp.dens(r, 0.0, use_physical=False))
+    with use(backend, force=True):
+        assert not PM._accepts_node_array_on_backend(
+            tp, "_Rforce", "_zforce", "_rforce"
+        ), "a scalar-only potential without the opt-in must not be batched"


### PR DESCRIPTION
Two things gh#1407's verification surfaced.

## 1. `Potential.mass` asked the wrong predicate

It used `_force_accepts_arrays`, which answers for the **numpy** contract:
`False` for any potential whose force methods carry the scalar-only marker. But
`check_potential_inputs_not_arrays` admits an array when the potential opts in
with `_backend_accepts_arrays` **and** every array argument is a backend array —
which is exactly the backend quadrature path. So `mass()` was driving opted-in
potentials node-by-node for nothing:

| `DoubleExponentialDisk.mass(forceint=True)`, eager jax | |
|---|---|
| `vectorized=False` (before) | 0.62 s |
| `vectorized=True` (after) | 0.08 s |

The **value is bit-identical** between the two drives — `0.19292490375107788`
both ways — because it is the same Gauss–Legendre rule on the same nodes; only
the call pattern changes. A routing change, not a numerical one.

gh#1407 fixed this question for the two surfdens sites, so leaving `mass()`
asking a different one was the inconsistency that PR created. Rather than spell
the condition twice, the shared concept is extracted as
`_accepts_node_array_on_backend(pot, *methods)` and **both** sites call it —
duplicating a guard is what left dead code in gh#1407, and I'm not repeating it.

Only one class is actually reachable: the two opt-in classes are
`RotateAndTiltWrapper`, whose `mass()` raises `NotImplementedError` for
non-axisymmetric potentials, and `DoubleExponentialDisk`.

**numpy is byte-identical.** `quad`'s `vectorized` is documented as "Ignored on
the numpy (scipy) path", and I verified that rather than trusting it — `mass()`
over three potentials on numpy, before vs after:

    0.1929249048691683 0.75083690302172079 0.16032126054835061   identical

## 2. A wrong de-ledgering, re-ledgered

`backend_xfail.txt` claimed `test_pickling_potential_unitful_dens` "is now
MEASURED PASSING traced — the 2026-08-18 `workflow_dispatch(jit=true,
regen=true)` run does not list it". It does not pass:

| arm | result |
|---|---|
| jax `--jit` | **FAIL** (`TracerArrayConversionError`) |
| torch `--jit` | **FAIL** |
| jax eager | pass |
| torch eager | pass |

which is exactly what the paragraph directly above that claim predicts — a units
density routes through `as_numpy()`, which a tracer cannot satisfy, while a
concrete array converts. The de-ledgering contradicted its own reasoning.

"Does not list it" was read as "passes". **Absence of a result is NO DATA, not
evidence of a pass** — the rule `tools/ledger_harvest.py` bakes in, and it
applies to reading a regen run by hand too. CI never runs jit mode, which is why
this sat wrong for ten days: only a local `--jit` run can see it.

## Tests

They assert the **route** (the node array reaches `Rforce` whole, in <10 calls
instead of `_QUAD_N`), and compare the value against the **same backend rule
driven node-by-node** — deliberately not against numpy, since the backend GL
rule already differs from adaptive scipy by 5.8e-09 for `mass()`, pre-existing
and outside this change. My first draft compared backend to numpy at rtol=1e-12
and failed; the A/B showed the two drives are bit-identical, so the bar was
wrong, not the fix.

A/B: `test_mass_batches_a_potential_that_opts_in` **fails on base**, passes here.
Gate: `tests/test_backend_quadrature.py` 107 passed, 1 skipped.

Ledger delta: **+2 xfail** (8 → 10), correcting a ledger that was wrong rather
than recording a new regression. slow-skip unchanged at 51.