### PR TITLE
CI: fetch GSL from the nearest GNU mirror rather than ftp.gnu.org

### DIFF
--- a/.github/workflows/build_pyodide_wheels.yml
+++ b/.github/workflows/build_pyodide_wheels.yml
@@ -71,7 +71,11 @@ jobs:
           export LIBDIR=`pwd`/.libs
           export PKG_CONFIG_PATH=`pwd`/.libs/lib/pkgconfig
           # Build gsl
-          wget https://ftp.gnu.org/gnu/gsl/gsl-${{ env.GSL_VERSION }}.tar.gz
+          # ftpmirror.gnu.org redirects to the nearest working GNU mirror
+          wget --tries=3 --timeout=30 \
+             https://ftpmirror.gnu.org/gsl/gsl-${{ env.GSL_VERSION }}.tar.gz \
+             || wget --tries=3 --timeout=30 \
+             https://ftp.gnu.org/gnu/gsl/gsl-${{ env.GSL_VERSION }}.tar.gz
           tar -xvzf gsl-${{ env.GSL_VERSION }}.tar.gz
           cd gsl-${{ env.GSL_VERSION }}
           emconfigure ./configure \


### PR DESCRIPTION
The pyodide wheel builds keep failing at the **Build GSL** step because
`ftp.gnu.org` is intermittently unreachable, taking down a job that has nothing
to do with the change under test. It is currently red on several open PRs for
that reason alone.

Current state:

```
https://ftp.gnu.org/gnu/gsl/gsl-2.8.tar.gz    -> no response
https://ftpmirror.gnu.org/gsl/gsl-2.8.tar.gz  -> 302 -> live mirror -> 200 OK, 8997136 bytes
```

`ftpmirror.gnu.org` is GNU's own redirector to the nearest working mirror, so it
makes the better primary. `ftp.gnu.org` stays as a fallback, so the step fails
only if both the mirror network *and* the canonical host are down, and `wget`
gets `--tries=3 --timeout=30` rather than potentially hanging.

Note for review: the redirector's path is `/gsl/`, not `/gnu/gsl/`.

Verified locally — the command as written downloads 8997136 bytes and the
tarball extracts; sha256
`6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190`.