### PR TITLE
test_orbit: two tests bypassed _backend_integrators (ledger -4)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -148,8 +148,6 @@ jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic  # PASSES in
 # Track D in-backend default will let this un-defer. The energy/Jacobi and zmax
 # entries that used to sit here were measured fast enough on 2026-08-15 and are
 # now un-deferred.
-jax tests/test_orbit.py::test_integrate_backwards  # >420s (measured 2026-08-15, timed out)
-jax tests/test_orbit.py::test_integrate_negative_time  # 389.7s measured 2026-08-20; at the
 # measured CI/local ratio (0.71) that is ~277s against the 300s cap, i.e. ~8% margin, so it
 # passes or times out on runner variance. Already deferred for jax-jit; same test, same loop
 # over Python integrators, so it belongs here too rather than re-run until it happens to be green.
@@ -366,8 +364,6 @@ jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles
 jax-jit tests/test_orbit.py::test_zmax  # 300s cap
 jax-jit tests/test_orbit.py::test_analytic_ecc_rperi_rap  # 300s cap
 jax-jit tests/test_orbit.py::test_analytic_zmax  # 300s cap
-jax-jit tests/test_orbit.py::test_integrate_backwards  # 300s cap
-jax-jit tests/test_orbit.py::test_integrate_negative_time  # 300s cap
 # Inside the 240-300 s band -- judgement calls, not cap hits. Together with
 # test_bruteSOS_3D (277 s) these are the only 3 of 15 entries whose fate turns
 # on where the margin sits; the other 12 hit the cap outright.

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -15033,18 +15033,20 @@ def test_integrate_negative_time():
     from galpy.potential import DehnenBarPotential, MWPotential2014
 
     dp = DehnenBarPotential()
-    methods = [
-        "odeint",
-        "leapfrog",
-        "leapfrog_c",
-        "rk4_c",
-        "rk6_c",
-        "symplec4_c",
-        "symplec6_c",
-        "dopr54_c",
-        "dop853_c",
-        "ias15_c",
-    ]
+    methods = _backend_integrators(
+        [
+            "odeint",
+            "leapfrog",
+            "leapfrog_c",
+            "rk4_c",
+            "rk6_c",
+            "symplec4_c",
+            "symplec6_c",
+            "dopr54_c",
+            "dop853_c",
+            "ias15_c",
+        ]
+    )
     # negative time to negative time
     times = numpy.linspace(-70.0, -30.0, 1001)
     for method in methods:
@@ -15078,18 +15080,20 @@ def test_integrate_backwards():
     from galpy.potential import DehnenBarPotential, MWPotential2014
 
     dp = DehnenBarPotential()
-    methods = [
-        "odeint",
-        "leapfrog",
-        "leapfrog_c",
-        "rk4_c",
-        "rk6_c",
-        "symplec4_c",
-        "symplec6_c",
-        "dopr54_c",
-        "dop853_c",
-        "ias15_c",
-    ]
+    methods = _backend_integrators(
+        [
+            "odeint",
+            "leapfrog",
+            "leapfrog_c",
+            "rk4_c",
+            "rk6_c",
+            "symplec4_c",
+            "symplec6_c",
+            "dopr54_c",
+            "dop853_c",
+            "ias15_c",
+        ]
+    )
     # negative time to negative time
     times = numpy.linspace(-30.0, -70.0, 1001)
     for method in methods:


### PR DESCRIPTION
`_backend_integrators()` exists to drop the pure-Python integrators under a
non-numpy backend. Its own comment says why: they "step in Python, so each force
eval pays eager per-step jax/torch dispatch (~1 ms) — ~95% of the runtime for ~0
unique backend coverage".

16 call sites use it. `test_integrate_backwards` and
`test_integrate_negative_time` did **not** — they hardcoded the same
10-integrator list including `odeint` and `leapfrog`. Both are ledgered on
**both** arms, so the omission costs 4 entries.

## Measured, same session, same box

| test | arm | before | after | |
|---|---|---|---|---|
| `test_integrate_backwards` | jax | 608.3 s | **5.0 s** | 122× |
| `test_integrate_negative_time` | jax | 401.4 s | **0.7 s** | 573× |
| `test_integrate_backwards` | jax-jit | >300 s | **14.8 s** | |
| `test_integrate_negative_time` | jax-jit | >300 s | **9.5 s** | |

The "before" reproduces the ledger's own annotations (>420 s and 389.7 s), so
this is a real A/B rather than a comparison against a stale note. All four clear
the 300 s cap by more than an order of magnitude.

## Verified in full-file context

A single-nodeid pass is not evidence about the file the ledger actually governs,
and the whole premise here is that these tests behave differently than the
ledger recorded. Whole `tests/test_orbit.py` under `--backend jax`, all four
entries removed:

    567 passed, 15 skipped, 0 failed        2:28:36
    test_integrate_negative_time   1.7 s  pass
    test_integrate_backwards       1.2 s  pass

## numpy

Unaffected **by construction**: `_backend_integrators` returns its argument
unchanged when `backend() == "numpy"`, so the numpy run still exercises all ten
integrators. Confirmed rather than assumed — both tests on numpy: 11.8 s and
7.7 s, all 10 methods, passing.

## How it was applied

The identical 10-integrator list appears **twice** in the file, once per test.
My first edit guarded on `count == 1` and correctly refused to apply; both sites
are wanted here, so both were replaced deliberately after checking what the
second one was. A blind replace-all would have been right by luck, not by
knowledge.

Ledger delta: **−4** (slow-skip 51 → 47; jax 24 → 22, jax-jit 20 → 18).
Test-side only — no `galpy/` change, so no numpy-path risk at all.