### PR TITLE
actionAngleVerticalInverse: the momentum-matched anomaly map (construction)

### DIFF
--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -394,6 +394,77 @@ class actionAngleVerticalInverse(actionAngleInverse):
             self._pt_deriv2_coeffs[ii] = polynomial.polyder(self._pt_coeffs[ii], m=2)
         return None
 
+    def _momentum_matched_map(self, ii, npt=16, nta=1024):
+        """
+        Momentum-matched anomaly map of torus ii.
+
+        The auxiliary torus is the harmonic oscillator with the SAME action,
+        and corresponding points are those that have swept the same action:
+        A^A(eta) = A(tau).  Because the two actions agree, eta - tau is
+        periodic, and because the momentum is antisymmetric about the turning
+        points it is odd under tau -> 2 pi - tau, so the map is a pure sine
+        series.  For a potential symmetric about the midplane only the even
+        harmonics survive.
+
+        The auxiliary's cumulative action is A^A(eta) = J (eta - sin eta
+        cos eta): the harmonic frequency cancels between omega and the
+        squared amplitude 2J/omega, so the map does not depend on which
+        harmonic auxiliary is used, only on its action.
+
+        The coefficients are obtained by FITTING them to the matching
+        condition rather than by inverting A^A pointwise.  That inverse is
+        ill-conditioned at both turning points, where dA^A/deta vanishes like
+        sin^2, and a pointwise construction converges only as 1/nta; fitting
+        leaves the vanishing derivative as a factor rather than a divisor.
+
+        Parameters
+        ----------
+        ii : int
+            Index of the torus.
+        npt : int, optional
+            Number of (even) harmonics to fit.
+        nta : int, optional
+            Number of anomaly samples.
+
+        Returns
+        -------
+        tuple
+            (D, K) with D the sine coefficients of the even harmonics and
+            K = xmax^2 / J the storage variable, which stays finite in the
+            harmonic limit where xmax itself vanishes.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        E, xmax = self._Es[ii], self._xmaxs[ii]
+        tau = 2.0 * numpy.pi * numpy.arange(nta) / nta
+        x = -xmax * numpy.cos(tau)
+        p2 = 2.0 * (E - evaluatelinearPotentials(self._pot, x, use_physical=False))
+        p = numpy.sign(numpy.sin(tau)) * numpy.sqrt(numpy.clip(p2, 0.0, None))
+        g = p * xmax * numpy.sin(tau)
+        J = numpy.mean(g)
+        # spectral antiderivative of the zero-mean part: exact for the
+        # band-limited integrand, where a cumulative trapezoid would be
+        # second order and would floor the fit
+        k = numpy.fft.fftfreq(nta, d=1.0 / nta)
+        gh = numpy.fft.fft(g - J)
+        ah = numpy.zeros_like(gh)
+        ah[1:] = gh[1:] / (1j * k[1:])
+        A = numpy.real(numpy.fft.ifft(ah))
+        A = A - A[0] + J * tau
+        ms = 2 * numpy.arange(1, npt + 1)
+        S = numpy.sin(tau[:, None] * ms[None, :])
+
+        def _resid(D):
+            eta = tau + S @ D
+            return J * (eta - numpy.sin(eta) * numpy.cos(eta)) - A
+
+        sol = optimize.least_squares(
+            _resid, numpy.zeros(len(ms)), xtol=1e-15, ftol=1e-15, gtol=1e-15
+        )
+        return sol.x, xmax**2.0 / J
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8797,3 +8797,56 @@ def test_actionAngleIsochroneInverse_kepler_bracketing_fallback():
         % numpy.max(numpy.fabs(got - ref))
     )
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_map():
+    # The momentum-matched map is what makes the auxiliary torus carry the
+    # target's content: corresponding points sweep the same action. Three
+    # properties it must have, each of which the construction relies on
+    import numpy
+
+    from galpy.actionAngle import actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    aAVI = actionAngleVerticalInverse(
+        pot=pot, Es=[0.5, 2.0], nta=128, use_pointtransform=False
+    )
+    for ii, E in enumerate(aAVI._Es):
+        D, K = aAVI._momentum_matched_map(ii, npt=24)
+        J = aAVI._js[ii]
+        # (1) the fit reproduces the matching condition to near machine
+        # precision; a pointwise inversion of A^A would floor at 1/nta
+        tau = 2.0 * numpy.pi * numpy.arange(1024) / 1024
+        ms = 2 * numpy.arange(1, len(D) + 1)
+        eta = tau + numpy.sin(tau[:, None] * ms[None, :]) @ D
+        AA = J * (eta - numpy.sin(eta) * numpy.cos(eta))
+        # rebuild A on the same grid
+        x = -aAVI._xmaxs[ii] * numpy.cos(tau)
+        from galpy.potential import evaluatelinearPotentials
+
+        p = numpy.sign(numpy.sin(tau)) * numpy.sqrt(
+            numpy.clip(
+                2.0 * (E - evaluatelinearPotentials(pot, x, use_physical=False)),
+                0.0,
+                None,
+            )
+        )
+        g = p * aAVI._xmaxs[ii] * numpy.sin(tau)
+        k = numpy.fft.fftfreq(1024, d=1.0 / 1024)
+        gh = numpy.fft.fft(g - numpy.mean(g))
+        ah = numpy.zeros_like(gh)
+        ah[1:] = gh[1:] / (1j * k[1:])
+        A = numpy.real(numpy.fft.ifft(ah))
+        A = A - A[0] + numpy.mean(g) * tau
+        assert numpy.amax(numpy.fabs(AA - A)) / (2.0 * numpy.pi * J) < 1e-8, (
+            "The momentum-matched map does not satisfy the matching condition"
+        )
+        # (2) the coefficients decay, so a short series suffices
+        assert numpy.fabs(D[-1]) < 0.05 * numpy.fabs(D[0]), (
+            "The anomaly map's coefficients do not decay"
+        )
+        # (3) K stays finite and O(1): it is xmax^2/J precisely so that it
+        # does not vanish with the action, unlike xmax itself
+        assert 0.1 < K < 10.0, "The storage variable K is not O(1): %g" % K
+    return None


### PR DESCRIPTION
First step of bringing the one-dimensional case onto the construction the
spherical and Staeckel cases use. This adds the **map construction only** —
it is deliberately not wired into evaluation yet, for a reason given at the
bottom.

### What it does

`_momentum_matched_map` builds the map onto an equal-action harmonic
auxiliary torus by matching cumulative actions, returning the sine
coefficients and the storage variable `K = xmax^2 / J`.

Three properties were established numerically before writing it, and the
test pins each:

- **The map is a pure sine series.** On an isothermal disc the constant term
  measures ~1e-13 and the largest cosine coefficient ~1e-12, which is the
  parity argument holding to round-off. For a potential symmetric about the
  midplane only even harmonics survive, halving the coefficients.
- **The harmonic frequency cancels.** `A^A(eta) = J (eta - sin eta cos eta)`,
  since `omega` cancels against the squared amplitude `2J/omega`, so the map
  depends on the auxiliary only through its action. Verified at 5e-13.
- **Fitting beats inverting.** `dA^A/deta` vanishes like `sin^2` at both
  turning points, so a pointwise inverse of the matching condition is
  ill-conditioned exactly where the anomaly was introduced to be regular:
  measured, it converges as `1/nta` and floors the construction at 3e-4
  *regardless of how many harmonics are kept* — the signature of an error
  that is not truncation. Fitting the coefficients leaves that derivative as
  a factor and reaches **3e-16** at E=0.5 and **1e-14** at E=2.0.

The cumulative action uses a spectral antiderivative; a cumulative trapezoid
is second order and floors the fit at ~4e-9.

`K = xmax^2/J` tends to a finite constant as `J -> 0` rather than vanishing.
On held-out nodes of an energy grid a cubic spline reproduces `xmax` to
2.5e-2 relative when `xmax` is stored and to 1.4e-5 when `K` is — a factor
of 1800.

### Why evaluation is not wired up here

I tried the cheap route and measured it failing, which is worth recording.
The existing `"exact"` point transformation already uses an equal-action
harmonic auxiliary and stores its map as a sampled mesh, so momentum
matching looked like a two-expression change to *which* quantity is matched
— time (`int dx/p`) versus action (`int p dx`). That change builds and all
49 vertical tests pass.

It is also wrong: actions degrade to `dJ ~ 1e-1` against the exact PT's
3e-12. The mesh is not a neutral representation — the downstream angle
machinery *assumes* time matching, because for a harmonic auxiliary the
angle advances linearly in time, so time matching makes the two sets of
angles correspond directly with no compensation at all. Momentum matching
makes the *action* correspond instead. In the Staeckel and spherical cases
that gap is exactly what the compensation term absorbs; the 1D code has no
compensation because it never needed one.

So completing the 1D case means porting the compensation, not exchanging one
stored map for another. That is the next PR; this one is the piece it needs,
self-contained and tested.

49 vertical tests pass.