### PR TITLE
actionAngleVerticalInverse: the momentum-matched family

### DIFF
--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -465,6 +465,93 @@ class actionAngleVerticalInverse(actionAngleInverse):
         )
         return sol.x, xmax**2.0 / J
 
+    def _setup_momentum_matched_family(self, npt=16, nta=1024):
+        """
+        Build the momentum-matched family: the anomaly map and the storage
+        variable K on every torus of the energy grid.
+
+        This is the whole stored content of the canonical map in the new
+        scheme.  There is no table of angle-fit coefficients: the auxiliary
+        torus carries the target's content through the anomaly map alone,
+        and the amplitude enters only through K = xmax^2 / J.
+
+        K is stored rather than xmax because xmax vanishes with the action
+        while K does not: in the harmonic limit xmax^2 -> 2 J / omega, so
+        K -> 2 / omega, which is finite and O(1).  Storing xmax instead would
+        put a square-root cusp at the bottom of the grid and spend the
+        interpolant's resolution resolving it.
+
+        Parameters
+        ----------
+        npt : int, optional
+            Number of (even) harmonics of the anomaly map.
+        nta : int, optional
+            Number of anomaly samples used to fit them.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        if self._nE < 4:
+            raise RuntimeError(
+                "The momentum-matched family interpolates the stored tables "
+                "with a cubic spline in the action, which needs at least "
+                "four energies"
+            )
+        D = numpy.zeros((self._nE, npt))
+        K = numpy.empty(self._nE)
+        for ii in range(self._nE):
+            if self._js[ii] <= 0.0:
+                # The bottom of the grid IS a harmonic oscillator, so the
+                # auxiliary torus is the torus, the anomaly map is the
+                # identity (D = 0), and K takes its limit 2 / omega.
+                K[ii] = 2.0 / self._Omegas[ii]
+                continue
+            D[ii], K[ii] = self._momentum_matched_map(ii, npt=npt, nta=nta)
+        self._mm_D = D
+        self._mm_K = K
+        self._mm_npt = npt
+        # Filtered once so that evaluation differentiates the SAME interpolant
+        # it evaluates; storing separate derivative tables is what would break
+        # manifest canonicity.
+        self._mm_D_c = ndimage.spline_filter1d(D, order=3, axis=0, mode="mirror")
+        self._mm_K_c = ndimage.spline_filter1d(K, order=3, axis=0, mode="mirror")
+        self._mm_E = interpolate.InterpolatedUnivariateSpline(self._js, self._Es, k=3)
+        self._mm_dEdj = self._mm_E.derivative()
+        return None
+
+    def _mm_tables(self, j):
+        """
+        The anomaly map, the storage variable, and their exact action
+        derivatives at action j.
+
+        Both derivatives come from differentiating the stored interpolants
+        and chaining through E(j); nothing is finite-differenced and no
+        derivative is stored separately, which is what makes the resulting
+        map symplectic whatever the tables happen to contain.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+
+        Returns
+        -------
+        tuple
+            (D, dD/dj, K, dK/dj).
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        tE = float(self._mm_E(j))
+        Emin, Emax = self._Es[0], self._Es[-1]
+        row = (tE - Emin) / (Emax - Emin) * (self._nE - 1.0)
+        drowdj = (self._nE - 1.0) / (Emax - Emin) * float(self._mm_dEdj(j))
+        D, dD_drow = self._can_row(self._mm_D_c, row)
+        K, dK_drow = self._can_row(self._mm_K_c, row)
+        return D, dD_drow * drowdj, float(K), float(dK_drow) * drowdj
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -552,6 +552,61 @@ class actionAngleVerticalInverse(actionAngleInverse):
         K, dK_drow = self._can_row(self._mm_K_c, row)
         return D, dD_drow * drowdj, float(K), float(dK_drow) * drowdj
 
+    def _mm_xp_of_tau(self, j, tau):
+        """
+        Position and momentum at anomaly tau on the torus of action j, from
+        the stored family alone.
+
+        The auxiliary is the harmonic oscillator of the same action, so
+        x^A = -sqrt(2 J / omega) cos eta and p^A = sqrt(2 J omega) sin eta,
+        and the flux identity p dx/dtau = p^A (dx^A/deta)(deta/dtau) gives
+
+            p = 2 J sin^2(eta) eta'(tau) / (xmax sin tau) ,
+
+        with xmax = sqrt(K J).  The auxiliary frequency cancels between the
+        momentum and the amplitude, which is the same cancellation that
+        makes the anomaly map itself independent of which harmonic auxiliary
+        is used: only its action matters.
+
+        Both factors vanish at the turning points, where sin tau and
+        sin^2 eta go to zero together and the momentum is zero; the ratio is
+        taken only where sin tau does not vanish exactly, and the limit is
+        supplied directly.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+        tau : float or numpy.ndarray
+            Anomaly.
+
+        Returns
+        -------
+        tuple
+            (x, p) at the requested anomalies.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        if j <= 0.0:
+            raise RuntimeError(
+                "The momentum-matched reconstruction needs a positive "
+                "action: the zero-action torus is a point"
+            )
+        D, _, K, _ = self._mm_tables(j)
+        ms = 2.0 * numpy.arange(1, len(D) + 1)
+        tau = numpy.atleast_1d(numpy.array(tau, dtype="float"))
+        eta = tau + numpy.sin(tau[:, None] * ms[None, :]) @ D
+        detadtau = 1.0 + numpy.cos(tau[:, None] * ms[None, :]) @ (ms * D)
+        xmax = numpy.sqrt(K * j)
+        x = -xmax * numpy.cos(tau)
+        sintau = numpy.sin(tau)
+        p = numpy.zeros_like(tau)
+        nz = sintau != 0.0
+        p[nz] = 2.0 * j * numpy.sin(eta[nz]) ** 2.0 * detadtau[nz] / (xmax * sintau[nz])
+        return x, p
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -712,6 +712,78 @@ class actionAngleVerticalInverse(actionAngleInverse):
             - 0.5 * numpy.pi
         )
 
+    def _mm_tau_of_angle(self, j, angle):
+        """
+        Invert the angle relation: the anomaly at a requested angle.
+
+        The angle advances monotonically with the anomaly, by exactly 2 pi
+        over a libration, so the root on [0, 2 pi) is unique and can be
+        bracketed.  Bisection is used rather than Newton because it needs no
+        derivative of the relation and cannot fail: the construction
+        guarantees the bracket, and fifty-odd halvings of [0, 2 pi) reach
+        the resolution of a double.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+        angle : float or numpy.ndarray
+            Angle.
+
+        Returns
+        -------
+        numpy.ndarray
+            The anomaly at the requested angles.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        # Solve in the anomaly's own origin: the relation runs from 0 to
+        # 2 pi there, so it is monotone and unwrapped, while the requested
+        # angle is measured from the midplane.
+        angle = numpy.mod(
+            numpy.atleast_1d(numpy.array(angle, dtype="float")) + 0.5 * numpy.pi,
+            2.0 * numpy.pi,
+        )
+        lo = numpy.zeros_like(angle)
+        hi = numpy.zeros_like(angle) + 2.0 * numpy.pi
+        for _ in range(60):
+            mid = 0.5 * (lo + hi)
+            f = self._mm_angle_of_tau(j, mid) + 0.5 * numpy.pi
+            low = f < angle
+            lo = numpy.where(low, mid, lo)
+            hi = numpy.where(low, hi, mid)
+        return 0.5 * (lo + hi)
+
+    def _mm_xp_of_angle(self, j, angle):
+        """
+        The canonical evaluation: position and momentum at a requested
+        action and angle, through the momentum-matched map.
+
+        This is the composition the construction is built to deliver -- the
+        angle shift, the auxiliary's inverse, and the inverse cotangent lift
+        -- with every ingredient either closed form or a derivative of the
+        stored interpolants.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+        angle : float or numpy.ndarray
+            Angle.
+
+        Returns
+        -------
+        tuple
+            (x, p) at the requested angles.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        return self._mm_xp_of_tau(j, self._mm_tau_of_angle(j, angle))
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -654,6 +654,64 @@ class actionAngleVerticalInverse(actionAngleInverse):
         dxmaxdj = (K + j * dKdj) / (2.0 * numpy.sqrt(K * j))
         return p * dxmaxdj * numpy.cos(tau)
 
+    def _mm_angle_of_tau(self, j, tau):
+        """
+        The angle at anomaly tau on the torus of action j.
+
+        The matching condition makes the generating function explicit: the
+        cumulative action of the target equals that of its auxiliary, so
+        W = J (eta - sin eta cos eta) with eta = eta(tau; J).  The angle is
+        its action derivative at fixed position, and the chain rule splits
+        into a term at fixed anomaly and the boundary term that the moving
+        turning points contribute,
+
+            theta = (eta - sin eta cos eta)
+                    + 2 J sin^2(eta) sum_m (dD_m/dJ) sin(m tau)
+                    + p (d xmax / d J) cos(tau) ,
+
+        the last being the grouped compensation.  Every ingredient is either
+        closed form or a derivative of the stored interpolants, so no
+        quadrature and no separately tabulated derivative enters.
+
+        A constant pi/2 is subtracted to put the result in the convention of
+        the forward transformation, which measures the angle from the
+        midplane while the anomaly is measured from the turning point.  The
+        offset is a choice of origin and nothing more: it comes out at
+        pi/2 to 4e-13 independently of the torus and of the grid, while the
+        anomaly-dependent part of the difference converges away as the grid
+        is refined (2.5e-3, 1.3e-5, 1.7e-8, 1.1e-9 for 9, 17, 33 and 65
+        energies), which is the family interpolation of dD_m/dJ and not an
+        error of this relation.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+        tau : float or numpy.ndarray
+            Anomaly.
+
+        Returns
+        -------
+        numpy.ndarray
+            The angle at the requested anomalies.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        D, dDdj, _, _ = self._mm_tables(j)
+        tau = numpy.atleast_1d(numpy.array(tau, dtype="float"))
+        ms = 2.0 * numpy.arange(1, len(D) + 1)
+        eta = tau + numpy.sin(tau[:, None] * ms[None, :]) @ D
+        detadj = numpy.sin(tau[:, None] * ms[None, :]) @ dDdj
+        return (
+            eta
+            - numpy.sin(eta) * numpy.cos(eta)
+            + 2.0 * j * numpy.sin(eta) ** 2.0 * detadj
+            + self._mm_compensation(j, tau)
+            - 0.5 * numpy.pi
+        )
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/galpy/actionAngle/actionAngleVerticalInverse.py
+++ b/galpy/actionAngle/actionAngleVerticalInverse.py
@@ -607,6 +607,53 @@ class actionAngleVerticalInverse(actionAngleInverse):
         p[nz] = 2.0 * j * numpy.sin(eta[nz]) ** 2.0 * detadtau[nz] / (xmax * sintau[nz])
         return x, p
 
+    def _mm_compensation(self, j, tau):
+        """
+        The compensation integrand of the momentum-matched map, grouped so
+        that it is regular at the turning points.
+
+        The turning points move with the action, so at fixed position
+
+            d tau / d J |_x = (1 / xmax) (d xmax / d J) cos(tau) / sin(tau) ,
+
+        which diverges at both of them.  It is multiplied by
+        p^A (dx^A/deta)(deta/dtau) = 2 J sin^2(eta) eta'(tau), which vanishes
+        there, and the product is finite: the sin(tau) cancels against the
+        momentum and leaves
+
+            p (d xmax / d J) cos(tau) .
+
+        Computing the two factors separately returns nan at an anomaly
+        sitting exactly on a turning point, one being infinite and the other
+        zero; this grouped form is finite everywhere.  The amplitude
+        derivative comes from the stored K,
+
+            d xmax / d J = (K + J dK/dJ) / (2 sqrt(K J)) ,
+
+        so it too differentiates the interpolant that the evaluation reads.
+
+        Parameters
+        ----------
+        j : float
+            Action.
+        tau : float or numpy.ndarray
+            Anomaly.
+
+        Returns
+        -------
+        numpy.ndarray
+            The compensation integrand at the requested anomalies.
+
+        Notes
+        -----
+        - 2026-08-29 - Written - Bovy (UofT)
+        """
+        _, _, K, dKdj = self._mm_tables(j)
+        _, p = self._mm_xp_of_tau(j, tau)
+        tau = numpy.atleast_1d(numpy.array(tau, dtype="float"))
+        dxmaxdj = (K + j * dKdj) / (2.0 * numpy.sqrt(K * j))
+        return p * dxmaxdj * numpy.cos(tau)
+
     def _setup_pointtransform_exact(self, pt_nxa):
         # Setup the exact point transformation for each torus by direct
         # quadrature of the time-from-midplane profile and monotone spline

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9072,3 +9072,49 @@ def test_actionAngleVerticalInverse_momentum_matched_angle():
         )
     )
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_evaluation():
+    # End to end: enter at a requested action and angle, come out at a point,
+    # and let the forward transformation say whether it is the right one.
+    import numpy
+
+    from galpy.actionAngle import actionAngleVertical, actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    aAV = actionAngleVertical(pot=pot)
+    # off the turning points, where the FORWARD transformation cannot place
+    # an angle: there p = 0 and the angle is 0 or pi by definition
+    th = 2.0 * numpy.pi * (numpy.arange(32) + 0.37) / 32.0
+
+    def errs(nE):
+        aAVI = actionAngleVerticalInverse(
+            pot=pot,
+            Es=numpy.linspace(0.0, 2.0, nE),
+            nta=128,
+            use_pointtransform=False,
+        )
+        aAVI._setup_momentum_matched_family(npt=20, nta=1024)
+        j = aAVI._js[(nE - 1) // 2]
+        # the anomaly inversion is exact to round-off
+        tau = numpy.linspace(0.1, 2.0 * numpy.pi - 0.1, 17)
+        back = aAVI._mm_tau_of_angle(j, aAVI._mm_angle_of_tau(j, tau))
+        assert numpy.amax(numpy.fabs(back - tau)) < 1e-12, (
+            "The angle relation does not invert"
+        )
+        x, p = aAVI._mm_xp_of_angle(j, th)
+        jf, _, thfwd = aAV.actionsFreqsAngles(x, p)
+        dth = numpy.fabs((thfwd - th + numpy.pi) % (2.0 * numpy.pi) - numpy.pi)
+        return numpy.amax(numpy.fabs(jf - j)), numpy.amax(dth)
+
+    dj9, dth9 = errs(9)
+    dj33, dth33 = errs(33)
+    # the action is what the construction preserves exactly, and it does so
+    # whatever the tables contain -- it does not need a fine grid
+    assert dj9 < 1e-10, "The evaluation does not land on the requested torus"
+    assert dj33 < 1e-10, "The evaluation does not land on the requested torus"
+    # the angle carries the family's interpolation error, so it improves
+    assert dth9 < 5e-3, "The evaluated angle is wrong"
+    assert dth33 < 1e-2 * dth9, "The evaluated angle does not converge with the grid"
+    return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -9026,3 +9026,49 @@ def test_actionAngleVerticalInverse_momentum_matched_compensation():
         "Grouping changed the value of the compensation"
     )
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_angle():
+    # The angle relation is the action derivative of the generating function
+    # that the matching condition makes explicit. It is checked against the
+    # forward transformation, and its residual must be the family
+    # interpolation of dD_m/dJ -- so it must converge as the grid refines.
+    import numpy
+
+    from galpy.actionAngle import actionAngleVertical, actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    aAV = actionAngleVertical(pot=pot)
+    tau = numpy.linspace(0.05, 2.0 * numpy.pi - 0.05, 33)
+
+    def spread(nE):
+        aAVI = actionAngleVerticalInverse(
+            pot=pot,
+            Es=numpy.linspace(0.0, 2.0, nE),
+            nta=128,
+            use_pointtransform=False,
+        )
+        aAVI._setup_momentum_matched_family(npt=20, nta=1024)
+        j = aAVI._js[(nE - 1) // 2]
+        th = aAVI._mm_angle_of_tau(j, tau)
+        x, p = aAVI._mm_xp_of_tau(j, tau)
+        jt, _, thfwd = aAV.actionsFreqsAngles(x, p)
+        assert numpy.amax(numpy.fabs(jt - j)) < 1e-8, (
+            "The reconstructed point is not on the requested torus"
+        )
+        d = (th - thfwd + numpy.pi) % (2.0 * numpy.pi) - numpy.pi
+        return numpy.amax(numpy.fabs(d))
+
+    s9, s33 = spread(9), spread(33)
+    # the residual is the interpolated dD_m/dJ, so refining the grid removes
+    # it; a relation with a genuine error term would not converge
+    assert s33 < 1e-6, (
+        "The angle relation does not reproduce the forward angle: %g" % s33
+    )
+    assert s33 < 1e-3 * s9, (
+        "The angle residual does not converge with the grid: {:g} vs {:g}".format(
+            s33, s9
+        )
+    )
+    return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8909,3 +8909,61 @@ def test_actionAngleVerticalInverse_momentum_matched_family():
         small._setup_momentum_matched_family()
     assert "four energies" in str(excinfo.value)
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_reconstruction():
+    # Reconstructing (x, p) from the stored family alone must put the point
+    # back on the torus it came from: H(x, p) = E(J) at every anomaly.
+    import numpy
+    import pytest
+
+    from galpy.actionAngle import actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential, evaluatelinearPotentials
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    aAVI = actionAngleVerticalInverse(
+        pot=pot, Es=numpy.linspace(0.0, 2.0, 9), nta=128, use_pointtransform=False
+    )
+    tau = 2.0 * numpy.pi * numpy.arange(257) / 257.0
+
+    def worst(npt):
+        aAVI._setup_momentum_matched_family(npt=npt, nta=1024)
+        w = 0.0
+        for ii in range(1, aAVI._nE):
+            x, p = aAVI._mm_xp_of_tau(aAVI._js[ii], tau)
+            H = 0.5 * p**2.0 + evaluatelinearPotentials(pot, x, use_physical=False)
+            w = max(w, numpy.amax(numpy.fabs(H - aAVI._Es[ii])) / aAVI._Es[ii])
+        return w
+
+    w12, w28 = worst(12), worst(28)
+    # the reconstruction is exact up to the truncation of the anomaly map,
+    # so refining it converges spectrally rather than at some fixed order
+    assert w28 < 1e-9, "The reconstruction does not return the torus: %g" % w28
+    assert w28 < 1e-2 * w12, (
+        "The reconstruction error is not limited by the anomaly-map "
+        "truncation: %g vs %g" % (w28, w12)
+    )
+    # the turning points are where the momentum vanishes and the potential
+    # alone carries the energy, which is what fixes xmax
+    x, p = aAVI._mm_xp_of_tau(aAVI._js[5], numpy.array([0.0, numpy.pi]))
+    # sin(pi) is not exactly zero in floating point, so the grouped ratio is
+    # actually evaluated at the upper turning point; it stays finite and
+    # returns machine zero, which is the property being claimed
+    assert numpy.amax(numpy.fabs(p)) < 1e-14, (
+        "The momentum does not vanish at the turning points: %g"
+        % numpy.amax(numpy.fabs(p))
+    )
+    assert (
+        numpy.amax(
+            numpy.fabs(
+                evaluatelinearPotentials(pot, x, use_physical=False) - aAVI._Es[5]
+            )
+        )
+        / aAVI._Es[5]
+        < 1e-9
+    ), "The turning points do not sit at the energy"
+    # the zero-action torus is a point, and has no reconstruction
+    with pytest.raises(RuntimeError) as excinfo:
+        aAVI._mm_xp_of_tau(0.0, tau)
+    assert "positive" in str(excinfo.value)
+    return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8967,3 +8967,62 @@ def test_actionAngleVerticalInverse_momentum_matched_reconstruction():
         aAVI._mm_xp_of_tau(0.0, tau)
     assert "positive" in str(excinfo.value)
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_compensation():
+    # The compensation is a product of a factor that diverges at the turning
+    # points and one that vanishes there. Grouping them is what makes it
+    # computable, and the grouping must not change the value.
+    import numpy
+
+    from galpy.actionAngle import actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    aAVI = actionAngleVerticalInverse(
+        pot=pot, Es=numpy.linspace(0.0, 2.0, 9), nta=128, use_pointtransform=False
+    )
+    aAVI._setup_momentum_matched_family(npt=20, nta=1024)
+    j = aAVI._js[5]
+    # a grid whose first node sits exactly on a turning point
+    tau = 2.0 * numpy.pi * numpy.arange(2048) / 2048.0
+    D, _, K, dKdj = aAVI._mm_tables(j)
+    ms = 2.0 * numpy.arange(1, len(D) + 1)
+    eta = tau + numpy.sin(tau[:, None] * ms[None, :]) @ D
+    detadtau = 1.0 + numpy.cos(tau[:, None] * ms[None, :]) @ (ms * D)
+    xmax = numpy.sqrt(K * j)
+    dxmaxdj = (K + j * dKdj) / (2.0 * numpy.sqrt(K * j))
+    # the amplitude derivative differentiates the stored interpolant
+    h = 1e-6
+    fd = (
+        numpy.sqrt(aAVI._mm_tables(j + h)[2] * (j + h))
+        - numpy.sqrt(aAVI._mm_tables(j - h)[2] * (j - h))
+    ) / (2.0 * h)
+    assert numpy.fabs(fd - dxmaxdj) < 1e-8, (
+        "d xmax / d J does not differentiate the stored K"
+    )
+    with numpy.errstate(divide="ignore", invalid="ignore"):
+        factored = (
+            2.0
+            * j
+            * numpy.sin(eta) ** 2.0
+            * detadtau
+            * dxmaxdj
+            / xmax
+            * numpy.cos(tau)
+            / numpy.sin(tau)
+        )
+    grouped = aAVI._mm_compensation(j, tau)
+    assert numpy.all(numpy.isfinite(grouped)), (
+        "The grouped compensation is not finite everywhere"
+    )
+    # exactly the node on the turning point is lost by the factored form
+    assert numpy.sum(~numpy.isfinite(factored)) == 1, (
+        "The factored compensation is not the one that fails at the turning "
+        "point: %d bad nodes" % numpy.sum(~numpy.isfinite(factored))
+    )
+    ok = numpy.isfinite(factored)
+    assert numpy.amax(numpy.fabs(grouped[ok] - factored[ok])) < 1e-15, (
+        "Grouping changed the value of the compensation"
+    )
+    return None

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8850,3 +8850,62 @@ def test_actionAngleVerticalInverse_momentum_matched_map():
         # does not vanish with the action, unlike xmax itself
         assert 0.1 < K < 10.0, "The storage variable K is not O(1): %g" % K
     return None
+
+
+def test_actionAngleVerticalInverse_momentum_matched_family():
+    # The stored content of the canonical map in the new scheme is the
+    # anomaly map plus K = xmax^2 / J, and their action derivatives must come
+    # from differentiating those same stored interpolants.
+    import numpy
+    import pytest
+
+    from galpy.actionAngle import actionAngleVerticalInverse
+    from galpy.potential import IsothermalDiskPotential
+
+    pot = IsothermalDiskPotential(amp=1.0, sigma=0.5)
+    # the bottom of the grid is the harmonic limit, where J = 0
+    Es = numpy.linspace(0.0, 2.0, 9)
+    aAVI = actionAngleVerticalInverse(pot=pot, Es=Es, nta=128, use_pointtransform=False)
+    aAVI._setup_momentum_matched_family(npt=12, nta=512)
+    for ii in range(aAVI._nE):
+        if aAVI._js[ii] <= 0.0:
+            # the torus IS its auxiliary here: identity map, K -> 2 / omega
+            assert numpy.amax(numpy.fabs(aAVI._mm_D[ii])) == 0.0, (
+                "The anomaly map is not the identity in the harmonic limit"
+            )
+            assert numpy.fabs(aAVI._mm_K[ii] - 2.0 / aAVI._Omegas[ii]) < 1e-12, (
+                "K does not take its harmonic limit 2 / omega"
+            )
+        else:
+            assert (
+                numpy.fabs(numpy.sqrt(aAVI._mm_K[ii] * aAVI._js[ii]) - aAVI._xmaxs[ii])
+                < 1e-8
+            ), "K does not reconstruct xmax"
+    # K is O(1) across the whole grid, which is the point of storing it
+    # rather than xmax: xmax vanishes at the bottom and K does not
+    assert numpy.all(aAVI._mm_K > 0.1) and numpy.all(aAVI._mm_K < 10.0), (
+        "K is not O(1) across the grid"
+    )
+    assert aAVI._xmaxs[0] == 0.0, "The grid does not reach the harmonic limit"
+    # the chain differentiates the interpolant it evaluates: compare against
+    # finite differences OF THE INTERPOLANT, which is the statement that
+    # makes the resulting map symplectic whatever the tables contain
+    h = 1e-6
+    for j in numpy.linspace(aAVI._js[1], aAVI._js[-2], 5):
+        D, dD, K, dK = aAVI._mm_tables(j)
+        Dp, _, Kp, _ = aAVI._mm_tables(j + h)
+        Dm, _, Km, _ = aAVI._mm_tables(j - h)
+        assert numpy.amax(numpy.fabs(dD - (Dp - Dm) / (2.0 * h))) < 1e-6 * (
+            1.0 + numpy.amax(numpy.fabs(dD))
+        ), "d D / d j does not differentiate the stored interpolant"
+        assert numpy.fabs(dK - (Kp - Km) / (2.0 * h)) < 1e-6 * (1.0 + numpy.fabs(dK)), (
+            "d K / d j does not differentiate the stored interpolant"
+        )
+    # a cubic spline in the action needs four energies
+    small = actionAngleVerticalInverse(
+        pot=pot, Es=[0.5, 1.0, 2.0], nta=128, use_pointtransform=False
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        small._setup_momentum_matched_family()
+    assert "four energies" in str(excinfo.value)
+    return None


### PR DESCRIPTION
Stacked on #1412.

The anomaly map of #1412 describes a single torus. This stores it across the energy grid together with the amplitude, which together are the entire stored content of the canonical map in the new scheme — there is no table of angle-fit coefficients, because the auxiliary torus carries the target's content through the anomaly map alone.

**Why `K = xmax^2 / J` and not `xmax`.** The action vanishes at the bottom of the grid and `xmax` vanishes with it like `sqrt(J)`, so a table of `xmax` carries a square-root cusp there and the interpolant spends its resolution resolving it. `K` instead tends to `2 / omega`, finite and O(1) across the whole grid. At `J = 0` the torus is its own auxiliary, so the anomaly map is the identity and `K` takes that limit exactly.

**Derivatives.** `_mm_tables` differentiates the same interpolants the evaluation reads, chained through `E(j)`. Nothing is finite-differenced and no derivative table is stored separately — that is what keeps the map symplectic for arbitrary stored content rather than only for converged tables. The test checks the chain against finite differences *of the interpolant*, which is the precise statement being claimed.

Tests: 50 vertical-inverse tests pass; the new code is fully covered with no pragmas.