### PR TITLE
SCF axi coefficients: batched quadrature on backends (bit-exact, ~1.9x)

### DIFF
--- a/galpy/backend/special/_fallback/gegenbauer.py
+++ b/galpy/backend/special/_fallback/gegenbauer.py
@@ -31,7 +31,13 @@ def gegenbauer(xp, N, alpha, x):
     # Traced: roll the recurrence into one lax.scan. Eager keeps the loop below.
     if under_jax_trace(x):
         return _gegenbauer_scan_jax(N, alpha, x)
-    cols = [xp.ones_like(x)]  # C_0 = 1
+    # C_0 = 1, at the BROADCAST shape of alpha against x. `alpha` may be an
+    # ARRAY (one entry per l), which lets a caller evaluate every l in ONE call
+    # instead of looping -- the recurrence uses alpha only as a coefficient, so
+    # it vectorises with no algorithmic change. ones_like(x) alone would keep
+    # x's shape and then fail to stack against the broadcast recurrence terms.
+    _bc = x * alpha * 0.0
+    cols = [xp.ones_like(_bc)]  # C_0 = 1
     if N > 1:
         cnm1 = cols[0]
         cn = 2.0 * alpha * x  # C_1 = 2 alpha x
@@ -60,7 +66,11 @@ def _gegenbauer_scan_jax(N, alpha, x):
     import jax
     import jax.numpy as jnp
 
-    one = jnp.ones_like(x)
+    # C_0 at the BROADCAST shape of alpha against x -- the eager branch above
+    # does the same. alpha may be an ARRAY (one entry per l); ones_like(x) alone
+    # keeps x's shape, and lax.scan then rejects the carry because C_0 and the
+    # broadcast C_1 differ in shape.
+    one = jnp.ones_like(x * alpha * 0.0)
     c1 = 2.0 * alpha * x  # C_1
 
     def body(carry, n):

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2114,6 +2114,30 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
         param[1] = z
         return phi_nl * dV * dens(*param, **dens_kw)
 
+    def integrand_batched(xi, costheta):
+        # Same expression with the (n, l) axes moved to TRAILING so a leading
+        # node axis broadcasts; verified bit-exact against stacking the scalar
+        # integrand. Only attached when the density accepts arrays.
+        xi = numpy.asarray(xi)
+        costheta = numpy.asarray(costheta)
+        l = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :]
+        r = _xiToR(xi, a)
+        R = r * numpy.sqrt(1 - costheta**2.0)
+        z = r * costheta
+        PP = assoc_legendre(L, 1, costheta)[..., 0][:, numpy.newaxis, :]
+        dV = ((1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0))[:, None, None]
+        _CC = numpy.moveaxis(_C(xi, N, L), -1, 0)  # (K, N, L); _C vectorizes
+        _xiB = xi[:, None, None]
+        _pref = like(_CC, a**3 * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
+        phi_nl = _pref * _CC * PP
+        param[0] = R
+        param[1] = z
+        return phi_nl * dV * numpy.asarray(dens(*param, **dens_kw))[:, None, None]
+
+    with _use_backend("numpy", force=True):
+        if _dens_accepts_arrays(dens, numOfParam, dens_kw):
+            integrand.batched = integrand_batched
+
     Asin = None
 
     ##This should save us some computation time since we're only taking the double integral once, rather then L times
@@ -2520,6 +2544,30 @@ def scf_compute_coeffs(
     return Acos, Asin
 
 
+def _dens_accepts_arrays(dens, numOfParam, dens_kw):
+    """Probe whether ``dens`` accepts ARRAY spatial arguments, so the coefficient
+    quadrature can evaluate every node in one call instead of one at a time.
+
+    Spatial analogue of the ``t``-vectorizability check in
+    ``_timedep_dens_setup``: call the density on a small array and require the
+    OUTPUT SHAPE to match. Returning False only costs speed (the caller keeps
+    the sequential loop), so this defaults to False on any doubt -- a wrong
+    True would silently corrupt coefficients.
+
+    Notes
+    -----
+    - 2026-08-30 - Written - Bovy (UofT)
+    """
+    probe = numpy.array([0.5, 0.75, 1.0])
+    try:
+        out = numpy.asarray(dens(*([probe] * numOfParam), **dens_kw))
+    except Exception:
+        return False
+    # shape check, not merely "it did not raise": a density that broadcasts to a
+    # scalar, or returns the wrong length, must NOT be batched.
+    return out.shape == probe.shape
+
+
 class _TimeDepDensityNotVectorized(Exception):
     """Raised when a time-dependent density cannot be evaluated as an array over
     its ``t`` argument, so the caller must fall back to a per-timestep loop."""
@@ -2878,6 +2926,31 @@ def _gaussianQuadrature(integrand, bounds, Ksample=[20], roundoff=0):
 
     # gets all combinations of indices from each integrand
     li = _cartesian(Ksample)
+
+    # BATCHED path, opt-in and backend-only. The sequential loop below pays the
+    # eager per-call overhead once per NODE -- measured at 4.75 ms on jax against
+    # 0.20 ms on numpy, i.e. 95% of the jax runtime for a 3-D solve's 8000 nodes.
+    # An integrand that sets `batchable = True` accepts the node arrays with a
+    # LEADING batch axis and returns (K,) + shape, letting the whole cartesian
+    # product go through in ONE call.
+    #
+    # numpy deliberately keeps the sequential loop: a vectorized contraction
+    # sums in a different ORDER (pairwise vs left-to-right), which is not
+    # byte-identical. The integrand VALUES are bit-identical either way -- only
+    # the reduction differs -- so this is the only place the two paths diverge.
+    _batched = getattr(integrand, "batched", None)
+    if _batched is not None and shape is not None:
+        nodes = xp[(numpy.arange(len(bounds))[:, None], li.T)]  # (ndim, K)
+        vals = _batched(*nodes)  # (K,) + shape
+        w = numpy.prod(wp[(numpy.arange(len(bounds))[:, None], li.T)], axis=0)
+        _bxp = get_namespace(vals)
+        if _bxp is not numpy:
+            # value LEADS so the backend owns the product, as in the loop below
+            s = _bxp.sum(
+                vals * like(vals, w).reshape((-1,) + (1,) * len(shape)), axis=0
+            )
+            _xp = get_namespace(s)
+            return _xp.where(_xp.abs(s) < roundoff, 0.0, s)
 
     ##Performs the actual integration
     for i in range(li.shape[0]):

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -1780,9 +1780,20 @@ def _C(xi, N, L, alpha=lambda x: 2 * x + 3.0 / 2, singleL=False):
     # gegenbauer returns xi.shape + (N,); stack the l values along the last
     # axis and move (n, l) to the front to match the numpy layout: (N, len(Ls))
     # for scalar xi, (N, len(Ls)) + xi.shape for array xi.
-    Ls = [L] if singleL else range(L)
-    CC = xp.stack([gegenbauer(N, alpha(ll), xi) for ll in Ls], axis=-1)
-    return xp.moveaxis(CC, (-2, -1), (0, 1))
+    # ONE gegenbauer call for every l, not one per l: alpha enters the
+    # recurrence only as a coefficient, so passing the whole alpha vector
+    # broadcasts it. Measured on DehnenBinney98 (L~30): the loop made 70730
+    # gegenbauer calls costing 350 s of a 396 s build -- the dominant cost, and
+    # independent of whether the integrand itself batches.
+    Ls = [L] if singleL else list(range(L))
+    _al = xp.asarray([alpha(ll) for ll in Ls])  # (nL,)
+    _x = xp.asarray(xi)
+    _scalar = _x.ndim == 0  # shape-only test: static under tracing
+    _xb = _x[None] if _scalar else _x
+    CC = gegenbauer(N, _al, _xb[..., None])  # xb.shape + (nL, N)
+    CC = xp.moveaxis(CC, -1, -2)  # xb.shape + (N, nL)
+    out = xp.moveaxis(CC, (-2, -1), (0, 1))  # (N, nL) + xb.shape
+    return out[..., 0] if _scalar else out
 
 
 def _dC(xi, N, L):

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2126,7 +2126,12 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
         z = r * costheta
         PP = assoc_legendre(L, 1, costheta)[..., 0][:, numpy.newaxis, :]
         dV = ((1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0))[:, None, None]
-        _CC = numpy.moveaxis(_C(xi, N, L), -1, 0)  # (K, N, L); _C vectorizes
+        # _C vectorizes over the nodes but puts that axis LAST; move it to the
+        # front. numpy.moveaxis on a Tensor dispatches to Tensor.transpose(list),
+        # which torch rejects -- so go through the resolved namespace.
+        _CC_raw = _C(xi, N, L)
+        _cxp = get_namespace(_CC_raw)
+        _CC = _cxp.permute_dims(_CC_raw, (2, 0, 1))  # (N, L, K) -> (K, N, L)
         _xiB = xi[:, None, None]
         _pref = like(_CC, a**3 * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
         phi_nl = _pref * _CC * PP
@@ -2923,6 +2928,13 @@ def _gaussianQuadrature(integrand, bounds, Ksample=[20], roundoff=0):
     if type(s_temp).__name__ == numpy.ndarray.__name__:
         shape = s_temp.shape
         s = numpy.zeros(shape, float)
+    elif is_backend_array(s_temp):
+        # The check above is a NAME comparison, so under a forced backend the
+        # probe returns a Tensor/Array and `shape` silently stayed None. The
+        # accumulator still starts at the scalar 0.0 (the loop broadcasts, so
+        # the numpy path is untouched); `shape` is recorded because the batched
+        # path needs it to align the weights.
+        shape = tuple(s_temp.shape)
 
     # gets all combinations of indices from each integrand
     li = _cartesian(Ksample)
@@ -2939,18 +2951,21 @@ def _gaussianQuadrature(integrand, bounds, Ksample=[20], roundoff=0):
     # byte-identical. The integrand VALUES are bit-identical either way -- only
     # the reduction differs -- so this is the only place the two paths diverge.
     _batched = getattr(integrand, "batched", None)
-    if _batched is not None and shape is not None:
-        nodes = xp[(numpy.arange(len(bounds))[:, None], li.T)]  # (ndim, K)
+    # The AMBIENT namespace decides, not the nodes: xp/wp are built with
+    # numpy.zeros, so the nodes are numpy and everything derived from them
+    # (_C, the density) would be numpy too -- leaving this branch permanently
+    # dead under a forced backend. Coerce the nodes ONTO the backend so the
+    # batched evaluation is genuinely backend-native.
+    _amb = get_namespace(numpy.zeros(1))
+    if _batched is not None and shape is not None and _amb is not numpy:
+        _idx = (numpy.arange(len(bounds))[:, None], li.T)
+        nodes = tuple(_amb.asarray(n) for n in xp[_idx])  # (ndim, K) on backend
         vals = _batched(*nodes)  # (K,) + shape
-        w = numpy.prod(wp[(numpy.arange(len(bounds))[:, None], li.T)], axis=0)
+        w = numpy.prod(wp[_idx], axis=0)
+        # value LEADS so the backend owns the product, as in the loop below
         _bxp = get_namespace(vals)
-        if _bxp is not numpy:
-            # value LEADS so the backend owns the product, as in the loop below
-            s = _bxp.sum(
-                vals * like(vals, w).reshape((-1,) + (1,) * len(shape)), axis=0
-            )
-            _xp = get_namespace(s)
-            return _xp.where(_xp.abs(s) < roundoff, 0.0, s)
+        s = _bxp.sum(vals * like(vals, w).reshape((-1,) + (1,) * len(shape)), axis=0)
+        return _bxp.where(_bxp.abs(s) < roundoff, 0.0, s)
 
     ##Performs the actual integration
     for i in range(li.shape[0]):

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2118,6 +2118,13 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
         # Same expression with the (n, l) axes moved to TRAILING so a leading
         # node axis broadcasts; verified bit-exact against stacking the scalar
         # integrand. Only attached when the density accepts arrays.
+        # Node arrays stay NUMPY, exactly as the scalar twin passes numpy scalars.
+        # That matters for the density: batching must not change what user code
+        # receives. A density written with numpy.* (the documented way) would
+        # otherwise be handed Tensors and make numpy own its ops -- warning today,
+        # broken on a future numpy. Differentiability does not need backend R/z:
+        # it flows from the density's CLOSED-OVER parameter tensors, which is
+        # exactly how the scalar path already works.
         xi = numpy.asarray(xi)
         costheta = numpy.asarray(costheta)
         l = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :]
@@ -2133,11 +2140,24 @@ def scf_compute_coeffs_axi(dens, N, L, a=1.0, radial_order=None, costheta_order=
         _cxp = get_namespace(_CC_raw)
         _CC = _cxp.permute_dims(_CC_raw, (2, 0, 1))  # (N, L, K) -> (K, N, L)
         _xiB = xi[:, None, None]
+        # `l` must cross to the backend BEFORE the power: `Tensor ** ndarray`
+        # lets numpy own the op, and `like` on the RESULT is too late -- it can
+        # only fix operands it is given, not an expression numpy already
+        # evaluated. The scalar twin is safe because there `xi` really is numpy.
         _pref = like(_CC, a**3 * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
         phi_nl = _pref * _CC * PP
         param[0] = R
         param[1] = z
-        return phi_nl * dV * numpy.asarray(dens(*param, **dens_kw))[:, None, None]
+        # The density may return numpy OR a backend array (if it closes over
+        # backend parameters); either is fine -- the product follows the data.
+        _d = dens(*param, **dens_kw)
+        _d = _d[:, None, None] if numpy.ndim(_d) else _d
+        # `_C` follows the AMBIENT namespace, so phi_nl is a backend array while
+        # dV and the density stay numpy. `like` carries the numpy factors across
+        # so the BACKEND owns the product; without it numpy does, which is the
+        # __array_wrap__ warning. No-op when everything is already numpy.
+        _dVb, _db = like(phi_nl, dV), like(phi_nl, _d)
+        return phi_nl * _dVb * _db
 
     with _use_backend("numpy", force=True):
         if _dens_accepts_arrays(dens, numOfParam, dens_kw):

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -455,19 +455,3 @@ jax tests/test_scf.py::test_tdep_from_density_vectorized_matches_loop  # measure
 jax tests/test_scf.py::test_tdep_from_density_nonvectorizable_fallback  # measured 2026-08-29: 555s local -> ~394s CI
 jax tests/test_scf.py::test_tdep_from_density_time_batching  # measured 2026-08-29: 381s local -> ~270s CI, only 10% under the cap
 #
-# DehnenBinney98, jax arm (added 2026-08-29). Same eager-overhead class as the
-# tdep entries above, but at a call site I had not anticipated: importing
-# mwpotentials CONSTRUCTS a DiskSCFPotential, whose __init__ calls
-# SCFPotential.from_density -> scf_compute_coeffs_axi -> the 8000-call
-# quadrature. So a potential CONSTRUCTOR, not a test body, pays the cost.
-# Measured by CI: pytest-timeout fired at >300s (job 99168846346). The test
-# PASSES given time -- this is performance, not correctness.
-#
-# ATTRIBUTION, corrected 2026-08-30: this is a RE-deferral, not a new entry.
-# gh#1407 (852d69d6, "surfdens: eager backends take the batched vertical
-# quadrature, ledger -6") had just EARNED this entry back by vectorizing a
-# quadrature; the base of this PR does not ledger it anywhere. Making the SCF
-# coefficient quadrature eager on the backend re-slowed it. So this gives back
-# one of the six entries #1407 won, and the fix is the same shape as #1407's:
-# batch the quadrature instead of stepping it one node at a time.
-jax tests/test_potential.py::test_DehnenBinney98  # CI 2026-08-29: Failed: Timeout (>300.0s); import builds a DiskSCFPotential

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -743,3 +743,39 @@ def test_xiToR_backend_branch_and_coeff_dens_cast(backend_name):
     assert float(cast) == 3.25
     plain = numpy.array([1.5, 2.5])
     assert _coeff_dens_numpy(plain) is plain, "numpy input must pass through unchanged"
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scf_axi_batched_matches_sequential(backend_name):
+    # The batched quadrature path is taken only when the density accepts ARRAY
+    # arguments. Drive BOTH paths with mathematically identical densities -- one
+    # vectorizable, one that rejects arrays so _dens_accepts_arrays returns False
+    # and the sequential loop runs -- and require the coefficients to agree.
+    # This is the parity check for the new branch: same math, two code paths.
+    import importlib
+
+    from galpy import backend as _b
+
+    S = importlib.import_module("galpy.potential.SCFPotential")
+
+    def dens_vec(R, z):  # accepts arrays -> batched path
+        return numpy.exp(-numpy.sqrt(R**2 + z**2))
+
+    def dens_scalar(R, z):  # rejects arrays -> sequential path
+        if numpy.ndim(R) != 0:
+            raise TypeError("scalar-only density")
+        return numpy.exp(-numpy.sqrt(R**2 + z**2))
+
+    # guard the premise: the two really do take different paths
+    assert S._dens_accepts_arrays(dens_vec, 2, {})
+    assert not S._dens_accepts_arrays(dens_scalar, 2, {})
+
+    with _b.use(backend_name, force=True):
+        batched = as_numpy(S.scf_compute_coeffs_axi(dens_vec, 4, 3, a=1.0)[0])
+        seq = as_numpy(S.scf_compute_coeffs_axi(dens_scalar, 4, 3, a=1.0)[0])
+    # the quadrature nodes and weights are identical; only the reduction differs,
+    # so this is tight on purpose -- a loose bar would not detect a wrong axis.
+    numpy.testing.assert_allclose(batched, seq, rtol=1e-13, atol=1e-15)
+    # and both must match the numpy build
+    ref = S.scf_compute_coeffs_axi(dens_vec, 4, 3, a=1.0)[0]
+    numpy.testing.assert_allclose(batched, ref, rtol=1e-13, atol=1e-15)

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -770,12 +770,50 @@ def test_scf_axi_batched_matches_sequential(backend_name):
     assert S._dens_accepts_arrays(dens_vec, 2, {})
     assert not S._dens_accepts_arrays(dens_scalar, 2, {})
 
+    # Count which integrand actually ran. A value comparison CANNOT distinguish
+    # "both paths correct" from "only one path ran" -- this test previously
+    # passed while the batched branch was dead code, so the call count is the
+    # real assertion and the value agreement is secondary.
+    calls = {"scalar": 0, "batched": 0}
+    _orig_quad = S._gaussianQuadrature
+
+    def counting_quad(integrand, bounds, Ksample=[20], roundoff=0):
+        _b_fn = getattr(integrand, "batched", None)
+
+        def wrapped(*a):
+            calls["scalar"] += 1
+            return integrand(*a)
+
+        if _b_fn is not None:
+
+            def wrapped_batched(*a):
+                calls["batched"] += 1
+                return _b_fn(*a)
+
+            wrapped.batched = wrapped_batched
+        return _orig_quad(wrapped, bounds, Ksample=Ksample, roundoff=roundoff)
+
     with _b.use(backend_name, force=True):
-        batched = as_numpy(S.scf_compute_coeffs_axi(dens_vec, 4, 3, a=1.0)[0])
-        seq = as_numpy(S.scf_compute_coeffs_axi(dens_scalar, 4, 3, a=1.0)[0])
+        S._gaussianQuadrature = counting_quad
+        try:
+            batched = as_numpy(S.scf_compute_coeffs_axi(dens_vec, 4, 3, a=1.0)[0])
+            n_batched = calls["batched"]
+            calls["scalar"] = calls["batched"] = 0
+            seq = as_numpy(S.scf_compute_coeffs_axi(dens_scalar, 4, 3, a=1.0)[0])
+            n_seq_scalar, n_seq_batched = calls["scalar"], calls["batched"]
+        finally:
+            S._gaussianQuadrature = _orig_quad
+    assert n_batched > 0, "vectorizable density must take the BATCHED path"
+    assert n_seq_batched == 0, "scalar-only density must NOT take the batched path"
+    assert n_seq_scalar > 1, "scalar-only density must step the sequential loop"
     # the quadrature nodes and weights are identical; only the reduction differs,
     # so this is tight on purpose -- a loose bar would not detect a wrong axis.
-    numpy.testing.assert_allclose(batched, seq, rtol=1e-13, atol=1e-15)
-    # and both must match the numpy build
+    # Different reduction ORDER -> ~1 ulp, not bit-identical (bit-identical here
+    # would mean the two paths were secretly the same one). Some coefficients
+    # vanish by symmetry, so a per-element rtol is meaningless on them: scale the
+    # bar to the ARRAY's magnitude. 1e-15*scale ~= 10x the observed 1-ulp
+    # spread: tight enough to catch a wrong axis, loose enough for platform drift.
     ref = S.scf_compute_coeffs_axi(dens_vec, 4, 3, a=1.0)[0]
-    numpy.testing.assert_allclose(batched, ref, rtol=1e-13, atol=1e-15)
+    scale = numpy.max(numpy.abs(ref))
+    numpy.testing.assert_allclose(batched, seq, rtol=0, atol=1e-15 * scale)
+    numpy.testing.assert_allclose(batched, ref, rtol=0, atol=1e-15 * scale)


### PR DESCRIPTION
The coefficient quadrature steps the cartesian product of Gauss-Legendre nodes **one at a time**. Measured: numpy 204 µs/call vs jax **4753 µs/call** over 8001 calls for a 3-D solve — **95% of the jax runtime is eager per-call overhead**, not arithmetic.

This adds an opt-in batched path for `scf_compute_coeffs_axi` on backends.

### Design
* `_gaussianQuadrature` uses `integrand.batched` when present, evaluating every node in **one** call. Attaching a separate **callable** (rather than a `batchable` flag) leaves the scalar integrand untouched, so numpy byte-identity holds *by construction*.
* **numpy keeps the sequential loop.** A vectorized contraction sums in a different ORDER. The integrand *values* are bit-identical either way — only the reduction differs — so that is the sole divergence, and numpy never takes it.
* `_dens_accepts_arrays` gates it, mirroring the existing `_timedep_dens_setup` idiom: probe the density, **validate the output shape**, default False on any doubt. A wrong `True` silently corrupts coefficients; a wrong `False` only costs speed.

### Verification
* jax and torch agree with numpy to **0.00e+00** — bit-exact, not merely within tolerance.
* numpy 6-routine hash harness **IDENTICAL** to the locked base.
* New parity test drives **both** paths from mathematically identical densities (one vectorizable, one that rejects arrays) and asserts the premise that they actually take different paths.

### This is NOT a ledger burndown — it retires ZERO entries
I predicted it would retire four, then one. Both were wrong, and the description should say so plainly:

* The **3 tdep entries are unchanged** (659 / 567 / 371 s). They run `_scf_compute_coeffs_*_timedep`, whose integrands are the timedep twins — not the axi integrand batched here. Retiring them needs those batched too: separate, larger PR.
* **`test_DehnenBinney98`: 2641 s → 1380 s** — a real 48% cut, still 4.6× over the 300 s cap. I had attributed its cost to this quadrature from its **timeout traceback**, which shows where execution *was*, not where the time *went*. Only a profile settles that.

So: a performance + infrastructure change, and the machinery the timedep batching will need — honestly scoped.