### PR TITLE
tests: roundoff tolerance for batched-vs-sequential mass quadrature

### DIFF
--- a/tests/test_backend_quadrature.py
+++ b/tests/test_backend_quadrature.py
@@ -1095,12 +1095,16 @@ def test_mass_batches_a_potential_that_opts_in(backend, monkeypatch):
     assert len(calls) < 10, f"driven node-by-node: {len(calls)} Rforce calls"
     assert any(sh != () for sh in calls), f"never saw an array: shapes {calls}"
     # The VALUE must be untouched: same Gauss-Legendre rule and same nodes, only
-    # the call pattern changes. Measured bit-identical to the node-by-node drive
-    # (0.19292490375107788 both ways), so this is a routing change, not a
-    # numerical one. It is deliberately NOT compared against the numpy/scipy
-    # answer: the backend GL rule already differs from adaptive scipy by 5.8e-09
-    # for mass(), which is pre-existing and outside this change.
-    numpy.testing.assert_allclose(float(got), float(batched_ref), rtol=0, atol=0)
+    # the call pattern changes. Agreement is to roundoff, not bit-identity: the
+    # node-by-node drive evaluates f(x_i) in separate XLA calls while the batched
+    # drive evaluates f(x) over the whole node array at once, so fusion/FMA
+    # contraction can move the last ulp between compiler versions (observed 1.4e-16
+    # on one jax build, 0.0 on another). rtol=1e-14 is still ~5 orders tighter than
+    # the 5.8e-09 by which this GL rule differs from adaptive scipy for mass(), so
+    # it continues to show a routing change rather than a numerical one. It is
+    # deliberately NOT compared against the numpy/scipy answer: that GL-vs-adaptive
+    # gap is pre-existing and outside this change.
+    numpy.testing.assert_allclose(float(got), float(batched_ref), rtol=1e-14, atol=0)
 
 
 @pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])


### PR DESCRIPTION
Follow-up to #1416, from a codex review of `d8098c7e`.

`test_mass_batches_a_potential_that_opts_in` asserted `rtol=0, atol=0` between the batched and node-by-node quadrature drives, with a comment claiming the two were "measured bit-identical".

**That is not a galpy contract.** The node-by-node drive evaluates `f(x_i)` in separate XLA calls; the batched drive evaluates `f(x)` over the whole node array at once. Whether XLA emits identical arithmetic for the scalar and vectorized forms — fusion, FMA contraction, intermediate precision — is a compiler implementation detail that moves between versions. The assertion passes on the build it was written against (and in CI) and fails at 1.4e-16 on another. It pinned a compiler accident as a contract.

The intent was right — show that batching is a **routing** change, not a numerical one — but bit-identity was the wrong instrument for it. `rtol=1e-14` is still ~5 orders of magnitude tighter than the 5.8e-09 by which this GL rule already differs from adaptive scipy for `mass()`, so it continues to demonstrate exactly that. The comment is corrected to match what was actually measured.

Note the sibling batched-vs-sequential SCF assertion in the same PR already used `atol=1e-15 * scale` for this reason; this brings the two into line.

**Numpy byte-identity is unaffected.** That rule compares the numpy path against a fixed reference on deterministic hardware and stays at `rtol=0`. This test compares two routes *within* an accelerator backend — a different claim.

Audited the three other exact comparisons in `tests/test_backend_*.py` and left them as-is: `x**2` at 3.0 and `v*2.0` are exactly representable (and those tests exercise the helper, not numerics), and the `gammainc` int64-vs-float64 order comparison is same-path-same-value, where exactness is the assertion. The principle: exact comparison is sound for the *same computation on the same values*, unsound for *different execution shapes of the same math*.

Local: `tests/test_backend_quadrature.py` 107 passed, 1 skipped.

Ledger delta: none.