### PR TITLE
actionAngleStaeckelInverse: canonicity for a varying focal length

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -1252,7 +1252,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             self._Omegaz[ii],
         )
 
-    def _canon_unlift(self, out, a, e, LA, thmin, Dmu, Dmv, umin, umax, vmin, Lz):
+    def _canon_unlift(
+        self, out, a, e, LA, thmin, Dmu, Dmv, umin, umax, vmin, Lz, delta=None
+    ):
         """Map the toy-chart reconstruction to the target chart: per-degree
         anomaly inversions through the stored maps (closed-form radius and
         linear polar-angle inversions), momenta through the per-degree
@@ -1332,8 +1334,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # prolate -> cylindrical, exactly as the direct path
         sh, ch = numpy.sinh(u), numpy.cosh(u)
         sn, cs = numpy.sin(v), numpy.cos(v)
-        Rt, zt = coords.uv_to_Rz(u, v, delta=self._delta)
-        den = self._delta * (sh**2 + sn**2)
+        dl = self._delta if delta is None else float(delta)
+        Rt, zt = coords.uv_to_Rz(u, v, delta=dl)
+        den = dl * (sh**2 + sn**2)
         vRt = (pu * ch * sn + pv * sh * cs) / den
         vzt = (pu * sh * cs - pv * ch * sn) / den
         return Rt, vRt, Lz / Rt, zt, vzt, phi % (2.0 * numpy.pi)
@@ -1464,7 +1467,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # and K_v = (pi/2-vmin)^2/J_z -- both bounded and smooth right up to
         # the edge, where the vanishing is carried entirely by the action
         # itself, which is known exactly at evaluation time.
-        nq = 6 + 2 * self._npt
+        nq = 7 + 2 * self._npt
         tab = numpy.empty((nq,) + shape)
         tab[0] = grid._jr.reshape(shape)
         tab[1] = grid._jz.reshape(shape)
@@ -1475,9 +1478,17 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         tab[6 : 6 + self._npt] = numpy.moveaxis(
             grid._can_Dmu.reshape(shape + (self._npt,)), -1, 0
         )
-        tab[6 + self._npt :] = numpy.moveaxis(
+        tab[6 + self._npt : 6 + 2 * self._npt] = numpy.moveaxis(
             grid._can_Dmv.reshape(shape + (self._npt,)), -1, 0
         )
+        # The focal length as one more stored row, constant along I3 (delta
+        # depends on (E, L_z) only) and simply constant everywhere until the
+        # adaptive construction fills it.  Storing it as a table row buys its
+        # action-derivative chain for free: d delta/dJ comes out of the same
+        # differentiated interpolant as every other stored quantity, so the
+        # compensation's new term obeys the same no-separate-derivative
+        # discipline as the rest of the map.
+        tab[6 + 2 * self._npt] = self._delta
         # the analytic limits at the degenerate edges: the vanishing action
         # is exactly zero, the degenerate oscillation's midpoint sits at its
         # analytic point (the shell u), and its anomaly map vanishes (both
@@ -1491,7 +1502,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             tab[6 : 6 + self._npt, :, :, -1] = 0.0
         if self._wIgrid[0] == 0.0:
             tab[1, :, :, 0] = 0.0
-            tab[6 + self._npt :, :, :, 0] = 0.0
+            tab[6 + self._npt : 6 + 2 * self._npt, :, :, 0] = 0.0
         self._canon_tab_raw = tab
         self._canon_dLz = (self._Lzgrid[-1] - self._Lzgrid[0]) / (nLz - 1)
         self._rebuild_canon_interp()
@@ -1851,8 +1862,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         npt = self._npt
         umin, umax, vmin = v[3], v[4], v[5]
         dumin, dumax, dvmin = dq[3], dq[4], dq[5]
-        Dmu, Dmv = v[6 : 6 + npt], v[6 + npt :]
-        dDmu, dDmv = dq[6 : 6 + npt], dq[6 + npt :]
+        Dmu, Dmv = v[6 : 6 + npt], v[6 + npt : 6 + 2 * npt]
+        dDmu, dDmv = dq[6 : 6 + npt], dq[6 + npt : 6 + 2 * npt]
+        delc, ddel = v[6 + 2 * npt], dq[6 + 2 * npt]
         # closed-form toy-parameter chains: a, e from (J^A_r = J_R, L^A)
         GM, bb = self._GMc, self._bc
         sq = numpy.sqrt(LA**2 + 4.0 * bb * GM)
@@ -1949,6 +1961,31 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         gth = 0.5 * numpy.pi - thmin
         pv = pAthv * gth * srv * detav / (0.5 * (numpy.pi - 2.0 * vmin))
         cv = numpy.cos(tvv)
+        # The focal length's own compensation (ADAPTIVE_STAECKEL_MATH.md
+        # section 2): (R, z) are homogeneous of degree one in delta at fixed
+        # (u, v), so the un-lift's generating function contributes
+        # (p_R R + p_z z)/delta = [sinh u cosh u p_u - sin v cos v p_v] /
+        # [(sinh^2 u + sin^2 v) delta] per unit d delta/dJ_i, entering with
+        # the TARGET-chart sign: like the -p_u du_i and -p_v dv_i terms
+        # below, a parameter that moves the target position at fixed
+        # anomaly contributes with a minus, opposite to the auxiliary's
+        # terms.  (Wired the other way, the symplectic defect under a 5%
+        # delta variation is 0.88 -- twice the uncompensated 0.47, the
+        # signature of a sign error -- and with this sign it is 1.4e-9,
+        # the clean-family floor.)  Manifestly
+        # regular -- delta > 0 and the numerator vanishes with the momenta
+        # at the turning points -- and identically zero for a constant-delta
+        # family, which is the fixed-focal special case.
+        ucrd = umin * c2u + umax * s2u
+        vcrd = vmin + (numpy.pi - 2.0 * vmin) * numpy.sin(tvv / 2.0) ** 2
+        shc, chc = numpy.sinh(ucrd), numpy.cosh(ucrd)
+        snc, csc = numpy.sin(vcrd), numpy.cos(vcrd)
+        pdq = numpy.zeros(len(thetaAr))
+        if not udeg:
+            pdq += shc * chc * pu
+        if not vdeg:
+            pdq -= snc * csc * pv
+        pdq /= (shc**2 + snc**2) * delc
         for i in range(3):
             if udeg:
                 uterm = 0.0
@@ -1966,7 +2003,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 dth_i = dthmin[i] * cosetav + gth * sinetav * (smat_v @ dDmv[:, i])
                 dv_i = dvmin[i] * cv
                 vterm = pAthv * dth_i - pv * dv_i
-            comp[i] = uterm + vterm
+            comp[i] = uterm + vterm - pdq * ddel[i]
         return comp[0], comp[1], comp[2]
 
     def _toy_angle_solve(self, thR, thz, jr, LA, Lz, v, dq):
@@ -2070,11 +2107,12 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             LA,
             thmin,
             v[6 : 6 + npt],
-            v[6 + npt :],
+            v[6 + npt : 6 + 2 * npt],
             v[3],
             v[4],
             v[5],
             Lz,
+            delta=v[6 + 2 * npt],
         )
         # frequencies: the stored energy table's own derivative chains
         OmR, Omphi, Omz = dq[2]

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -10109,3 +10109,70 @@ def test_actionAngleStaeckelInverse_narrow_grid():
     )
     assert numpy.fabs(edged._wIgrid[0] - 0.8) < 1e-12, "the given w_I end moved"
     return None
+
+
+def test_actionAngleStaeckelInverse_adaptive_delta_canonical():
+    # The focal length may vary across the family -- delta(E, L_z), the
+    # adaptive-Staeckel design -- provided the compensation carries its
+    # chain. Manifest canonicity then extends to the chart parameter: the
+    # map must stay exactly symplectic for an ARBITRARY smooth delta table,
+    # not merely for the constant one construction wrote.
+    import numpy
+
+    from galpy.actionAngle import actionAngleStaeckelInverse
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    aASI = actionAngleStaeckelInverse(
+        pot=kkp,
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=6,
+        nE=6,
+        nI3=6,
+    )
+    Lz = float(aASI._Lzgrid[3])
+    args = (0.06, Lz, 0.10, numpy.array([2.0]), numpy.array([1.0]), numpy.array([2.0]))
+    x0 = numpy.array(aASI._xvFreqs(*args)[:6]).flatten()
+    # a LARGE smooth chart variation: 5% in delta across (L_z, E), constant
+    # in I3 as the design prescribes
+    row = 6 + 2 * aASI._npt
+    nLz, nE, nI3 = aASI._canon_shape
+    ii, jj = numpy.meshgrid(numpy.arange(nLz), numpy.arange(nE), indexing="ij")
+    mod = 1.0 + 0.05 * numpy.sin(2.0 * ii / (nLz - 1) + 3.0 * jj / (nE - 1))
+    aASI._canon_tab_raw[row] = aASI._delta * mod[:, :, None]
+    aASI._rebuild_canon_interp()
+    x1 = numpy.array(aASI._xvFreqs(*args)[:6]).flatten()
+    moved = numpy.max(numpy.fabs(x1 - x0))
+    assert moved > 1e-3, (
+        "A 5%% delta variation did not reach the evaluation (moved %g)" % moved
+    )
+    defect = _staeckel_symplectic_defect(aASI._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0)
+    assert defect < 3e-8, (
+        "The map is not symplectic under a varying focal length: %g" % defect
+    )
+    # and the delta-chain is load-bearing: severing it must break canonicity
+    # by orders of magnitude, or the term above is decorative
+    orig = aASI._canon_family_chains
+
+    def severed(x):
+        v, dq = orig(x)
+        dq = dq.copy()
+        dq[row] = 0.0
+        return v, dq
+
+    try:
+        aASI._canon_family_chains = severed
+        broken = _staeckel_symplectic_defect(
+            aASI._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0
+        )
+    finally:
+        aASI._canon_family_chains = orig
+    assert broken > 1e-2, (
+        "Severing the delta-chain did not break canonicity (%g), so the "
+        "compensation term is not what keeps the varying-delta map "
+        "symplectic" % broken
+    )
+    return None


### PR DESCRIPTION
Stacked on #1413 (stack #1397). PR A of the adaptive-Stäckel plan — the math and design are in fast-orbits `ADAPTIVE_STAECKEL_MATH.md`, reviewed in conversation.

### What this is

The adaptive design lets the focal length vary across the family, `delta(E, L_z)`, so each torus can be built in its own best-fitting Stäckel model. A J-dependent chart is not a fixed point transformation, so its cotangent lift alone is not canonical. This PR adds exactly the machinery that restores it — **for an arbitrary smooth delta table**, extending manifest canonicity to the chart parameter itself.

### How

- **Delta is one more stored table row** (appended last; constant along I3; filled with the constant focal length until the adaptive construction lands in the next PR). That buys `d delta/dJ` from the same differentiated interpolant as every other stored quantity — no separately tabulated derivative.
- **The un-lift and `v_T = L_z/R` use the local delta** from the row.
- **One new compensation term.** `(R, z)` are homogeneous of degree one in delta at fixed `(u, v)`, so the un-lift's generating function contributes `[sinh u cosh u p_u − sin v cos v p_v]/[(sinh² u + sin² v) delta]` per unit `d delta/dJ_i` — closed form, manifestly regular (delta > 0; the numerator vanishes with the momenta at turning points), identically zero for constant delta.

### The sign, established by measurement

The term enters with the **target-chart sign**, like the `−p_u du_i` terms. Wired the other way, the symplectic defect under a 5% delta variation is **0.88 — exactly twice the uncompensated 0.47**, the signature of a sign error; with the target-chart sign it is **1.4e-9, the clean-family floor**, nine orders down. That measurement is recorded in the code comment.

### Tests

The new test injects a 5% smooth `delta(E, L_z)` variation into a built family and asserts three things: the evaluation actually moves (the chart is live), the defect stays at the floor (canonicity is manifest in delta), and severing the delta-chain breaks it by orders (the term is load-bearing, not decorative). The existing whole-table-noise manifest test now scrambles the delta row along with everything else, and holds.

35 StaeckelInverse tests pass; module at **100% coverage, no pragmas**.

### Not in this PR

Per-node wrappers in construction, `delta='fit'` + the smooth surface machinery, and `u0(E, L_z)` — which needs no compensation at all, since the evaluation never touches the wrapper potential. That is PR B, next.