### PR TITLE
Speed up ChandrasekharDynamicalFrictionForce construction ~100x for array-capable potentials

### DIFF
--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -1,4 +1,6 @@
 # jeans.py: utilities related to the Jeans equations
+import time
+
 import numpy
 from scipy import integrate
 
@@ -73,6 +75,94 @@ def sigmar(Pot, r, dens=None, beta=0.0):
         / dens(r)
         / intFactor(r)
     )
+
+
+def _eval_on_grid(fn, xs):
+    """Evaluate fn on the array xs, falling back to a loop for potentials whose
+    methods reject array input (e.g. DoubleExponentialDiskPotential)."""
+    try:
+        out = numpy.asarray(fn(xs), dtype=float)
+        if out.shape == xs.shape:
+            return out
+    except (TypeError, ValueError, IndexError, AttributeError):
+        pass
+    return numpy.array([float(fn(x)) for x in xs])
+
+
+def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
+    """
+    sigma_r at every radius in rs, from ONE cumulative integral.
+
+    Same quantity as calling ``sigmar`` at each radius, but the integrand
+    int_r^inf -x^(2 beta) rho(x) F_r(x) dx differs between radii only in its
+    LOWER limit, so every radius can be read off a single cumulative pass over
+    a shared grid instead of one adaptive quadrature per radius.
+
+    Returns None when the fast path does not apply, so callers fall back to the
+    per-radius loop.
+
+    Notes
+    -----
+    - The grid is geometric: rho ~ 1/r near the centre varies over decades, and
+      a uniform grid there is catastrophically inaccurate (measured 22% error).
+    - The cumulative sum runs from the OUTSIDE IN. Accumulating left-to-right
+      and taking I(r) = C[-1] - C(r) subtracts two nearly-equal large sums at
+      large r; that cancellation costs ~5e-06 on MWPotential2014 (and is
+      invisible on Hernquist/NFW, which are insensitive to it).
+    """
+    rs = numpy.asarray(rs, dtype=float)
+    if callable(beta) or rs[0] <= 0.0 or rs[-1] <= rs[0]:
+        return None  # caller falls back to the per-radius loop
+    Pot = _check_potential_list_and_deprecate(Pot)
+    if dens is None:
+        dens = lambda r: evaluateDensities(
+            Pot,
+            r * _INVSQRTTWO,
+            r * _INVSQRTTWO,
+            phi=numpy.pi / 4.0,
+            use_physical=False,
+        )
+    integrand = lambda x: (
+        -(x ** (2.0 * beta))
+        * dens(x)
+        * evaluaterforces(
+            Pot,
+            x * _INVSQRTTWO,
+            x * _INVSQRTTWO,
+            phi=numpy.pi / 4.0,
+            use_physical=False,
+        )
+    )
+    # Whether this is actually faster depends entirely on the potential. The
+    # grid costs nquad integrand evaluations; the per-radius loop costs len(rs)
+    # ADAPTIVE quadratures, i.e. only ~50 evaluations each. So the grid does
+    # several times MORE work and wins only when vectorization more than makes
+    # up for it -- true for cheap analytic potentials (measured ~100x on NFW and
+    # MWPotential2014), false for SCF/Multipole, where every point costs
+    # spherical harmonics (measured 0.33x, i.e. 3x SLOWER). Rather than guess or
+    # keep a per-potential list, time both and pick the winner. The probe also
+    # doubles as the array-capability check: potentials whose methods reject
+    # arrays (e.g. DoubleExponentialDiskPotential) fall back here.
+    probe = numpy.geomspace(rs[0], rs[-1], 256)
+    try:
+        _t0 = time.perf_counter()
+        if numpy.shape(integrand(probe)) != probe.shape:
+            return None
+        per_point = (time.perf_counter() - _t0) / probe.size
+    except (TypeError, ValueError, IndexError, AttributeError):
+        return None
+    _t0 = time.perf_counter()
+    integrate.quad(integrand, rs[rs.size // 2], numpy.inf)
+    per_quad = time.perf_counter() - _t0
+    if per_point * nquad > 0.5 * per_quad * rs.size:
+        return None  # the per-radius loop is cheaper for this potential
+    xs = numpy.geomspace(rs[0], rs[-1], nquad)
+    gs = numpy.asarray(integrand(xs), dtype=float)
+    seg = 0.5 * (gs[1:] + gs[:-1]) * numpy.diff(xs)
+    I = numpy.concatenate((numpy.cumsum(seg[::-1])[::-1], [0.0]))
+    I = I + integrate.quad(integrand, rs[-1], numpy.inf)[0]  # r > max(rs) tail
+    Ir = numpy.interp(numpy.log(rs), numpy.log(xs), I)
+    return numpy.sqrt(Ir / _eval_on_grid(dens, rs) / rs ** (2.0 * beta))
 
 
 @potential_physical_input

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -1,8 +1,6 @@
 # jeans.py: utilities related to the Jeans equations
-import time
-
 import numpy
-from scipy import integrate
+from scipy import integrate, interpolate
 
 from ..potential.Potential import (
     _check_potential_list_and_deprecate,
@@ -77,26 +75,44 @@ def sigmar(Pot, r, dens=None, beta=0.0):
     )
 
 
-def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
+_SIGMAR_SPLINE_TOL = (
+    1e-5  # accept: drift over-estimates the true error (~1e-6 ships today)
+)
+_SIGMAR_SPLINE_HOPELESS = (
+    1e-2  # give up at once rather than refine a hopeless integrand
+)
+
+
+def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nstart=1001, maxrefine=3):
     """
-    sigma_r at every radius in rs, from ONE cumulative integral.
+    sigma_r at every radius in rs, from one interpolated integrand.
 
-    Same quantity as calling ``sigmar`` at each radius, but the integrand
-    int_r^inf -x^(2 beta) rho(x) F_r(x) dx differs between radii only in its
-    LOWER limit, so every radius can be read off a single cumulative pass over
-    a shared grid instead of one adaptive quadrature per radius.
+    ``sigmar`` runs one adaptive quadrature per radius, but those integrals
+    differ only in their LOWER limit, so all of them can be read off a single
+    representation of the integrand. This samples
+    ``g(x) = -x^(2 beta) rho(x) F_r(x)`` on a log-spaced grid, splines it, and
+    takes the spline's ANALYTIC antiderivative -- roughly a thousand integrand
+    evaluations in total, against ~50 per radius for the adaptive rule.
 
-    Returns None when the fast path does not apply, so callers fall back to the
-    per-radius loop.
+    The grid is refined until the answer stops moving, so accuracy is verified
+    rather than assumed. Returns None when it does not converge, and the caller
+    falls back to the per-radius quadrature.
 
     Notes
     -----
-    - The grid is geometric: rho ~ 1/r near the centre varies over decades, and
-      a uniform grid there is catastrophically inaccurate (measured 22% error).
-    - The cumulative sum runs from the OUTSIDE IN. Accumulating left-to-right
-      and taking I(r) = C[-1] - C(r) subtracts two nearly-equal large sums at
-      large r; that cancellation costs ~5e-06 on MWPotential2014 (and is
-      invisible on Hernquist/NFW, which are insensitive to it).
+    - Log spacing is essential: rho ~ 1/r near the centre spans decades, and a
+      uniform grid there is catastrophically inaccurate (measured 22% error).
+    - The refinement tolerance is deliberately looser than the accuracy this
+      achieves. ``drift`` is a Richardson-style OVER-estimate of the true error
+      (MWPotential2014: drift 1.2e-06 for a true ~9.5e-07), so demanding 1e-7
+      rejects potentials that in fact beat the ~1e-6 the per-radius rule itself
+      delivers.
+    - Some integrands never converge here: a DoubleExponentialDiskPotential has
+      vertical structure along the r = (R, z) ray that a log-spaced spline
+      cannot resolve (drift stays of order 1). That is not a case worth chasing
+      -- it is not really an application of the SPHERICAL Jeans equation -- so
+      an obviously diverging integrand is abandoned immediately instead of
+      being refined three times first.
     """
     rs = numpy.asarray(rs, dtype=float)
     if callable(beta) or rs[0] <= 0.0 or rs[-1] <= rs[0]:
@@ -121,41 +137,44 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
             use_physical=False,
         )
     )
-    # Whether this is actually faster depends entirely on the potential. The
-    # grid costs nquad integrand evaluations; the per-radius loop costs len(rs)
-    # ADAPTIVE quadratures, i.e. only ~50 evaluations each. So the grid does
-    # several times MORE work and wins only when vectorization more than makes
-    # up for it -- true for cheap analytic potentials (measured ~100x on NFW and
-    # MWPotential2014), false for SCF/Multipole, where every point costs
-    # spherical harmonics (measured 0.33x, i.e. 3x SLOWER). Rather than guess or
-    # keep a per-potential list, time both and pick the winner. The probe also
-    # doubles as the array-capability check: potentials whose methods reject
-    # arrays (e.g. DoubleExponentialDiskPotential) raise here and fall back.
-    probe = numpy.geomspace(rs[0], rs[-1], 256)
-    try:
-        _t0 = time.perf_counter()
-        integrand(probe)
-        per_point = (time.perf_counter() - _t0) / probe.size
-    except (TypeError, ValueError, IndexError, AttributeError):
-        return None
-    _t0 = time.perf_counter()
-    integrate.quad(integrand, rs[rs.size // 2], numpy.inf)
-    per_quad = time.perf_counter() - _t0
-    if per_point * nquad > 0.5 * per_quad * rs.size:
-        return None  # the per-radius loop is cheaper for this potential
-    xs = numpy.geomspace(rs[0], rs[-1], nquad)
-    gs = numpy.asarray(integrand(xs), dtype=float)
-    seg = 0.5 * (gs[1:] + gs[:-1]) * numpy.diff(xs)
-    I = numpy.concatenate((numpy.cumsum(seg[::-1])[::-1], [0.0]))
-    I = I + integrate.quad(integrand, rs[-1], numpy.inf)[0]  # r > max(rs) tail
-    Ir = numpy.interp(numpy.log(rs), numpy.log(xs), I)
-    # dens() follows the ambient array namespace, so under a forced backend it
-    # returns a Tensor/Array. Everything above is numpy, and the per-radius loop
-    # this replaces returned numpy, so cast rather than letting numpy operate on
-    # a foreign array: numpy.sqrt(Tensor) goes through __array_wrap__, which is
-    # a DeprecationWarning that CI turns into an error (-W error).
-    dens_rs = numpy.asarray(dens(rs), dtype=float)
-    return numpy.sqrt(Ir / dens_rs / rs ** (2.0 * beta))
+
+    def _on(fn, xs):
+        # one vectorized call where the potential allows it, else a loop; at
+        # ~1000 points the loop is still far cheaper than len(rs) adaptive
+        # quadratures, so there is no need to detect which case we are in
+        try:
+            out = numpy.asarray(fn(xs), dtype=float)
+            if out.shape == xs.shape:
+                return out
+        except (TypeError, ValueError, IndexError, AttributeError):
+            pass
+        return numpy.array([float(fn(x)) for x in xs])
+
+    tail = integrate.quad(integrand, rs[-1], numpy.inf)[0]
+    dens_rs = _on(dens, rs)
+    logrs = numpy.log(rs)
+
+    def _build(nquad):
+        u = numpy.linspace(numpy.log(rs[0]), numpy.log(rs[-1]), nquad)
+        xs = numpy.exp(u)
+        # int g dx = int g(x) x d(ln x), so spline the log-space integrand
+        anti = interpolate.CubicSpline(u, _on(integrand, xs) * xs).antiderivative()
+        return numpy.sqrt(
+            (anti(u[-1]) - anti(logrs) + tail) / dens_rs / rs ** (2.0 * beta)
+        )
+
+    prev = _build(nstart)
+    nquad = nstart
+    for _ in range(maxrefine):
+        nquad = 2 * nquad - 1
+        cur = _build(nquad)
+        drift = numpy.nanmax(numpy.fabs(cur - prev) / numpy.fabs(cur))
+        if drift < _SIGMAR_SPLINE_TOL:
+            return cur
+        if drift > _SIGMAR_SPLINE_HOPELESS:
+            return None  # diverging, not merely under-resolved
+        prev = cur
+    return None
 
 
 @potential_physical_input

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -77,18 +77,6 @@ def sigmar(Pot, r, dens=None, beta=0.0):
     )
 
 
-def _eval_on_grid(fn, xs):
-    """Evaluate fn on the array xs, falling back to a loop for potentials whose
-    methods reject array input (e.g. DoubleExponentialDiskPotential)."""
-    try:
-        out = numpy.asarray(fn(xs), dtype=float)
-        if out.shape == xs.shape:
-            return out
-    except (TypeError, ValueError, IndexError, AttributeError):
-        pass
-    return numpy.array([float(fn(x)) for x in xs])
-
-
 def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
     """
     sigma_r at every radius in rs, from ONE cumulative integral.
@@ -142,12 +130,11 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
     # spherical harmonics (measured 0.33x, i.e. 3x SLOWER). Rather than guess or
     # keep a per-potential list, time both and pick the winner. The probe also
     # doubles as the array-capability check: potentials whose methods reject
-    # arrays (e.g. DoubleExponentialDiskPotential) fall back here.
+    # arrays (e.g. DoubleExponentialDiskPotential) raise here and fall back.
     probe = numpy.geomspace(rs[0], rs[-1], 256)
     try:
         _t0 = time.perf_counter()
-        if numpy.shape(integrand(probe)) != probe.shape:
-            return None
+        integrand(probe)
         per_point = (time.perf_counter() - _t0) / probe.size
     except (TypeError, ValueError, IndexError, AttributeError):
         return None
@@ -162,7 +149,7 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
     I = numpy.concatenate((numpy.cumsum(seg[::-1])[::-1], [0.0]))
     I = I + integrate.quad(integrand, rs[-1], numpy.inf)[0]  # r > max(rs) tail
     Ir = numpy.interp(numpy.log(rs), numpy.log(xs), I)
-    return numpy.sqrt(Ir / _eval_on_grid(dens, rs) / rs ** (2.0 * beta))
+    return numpy.sqrt(Ir / dens(rs) / rs ** (2.0 * beta))
 
 
 @potential_physical_input

--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -149,7 +149,13 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nquad=100001):
     I = numpy.concatenate((numpy.cumsum(seg[::-1])[::-1], [0.0]))
     I = I + integrate.quad(integrand, rs[-1], numpy.inf)[0]  # r > max(rs) tail
     Ir = numpy.interp(numpy.log(rs), numpy.log(xs), I)
-    return numpy.sqrt(Ir / dens(rs) / rs ** (2.0 * beta))
+    # dens() follows the ambient array namespace, so under a forced backend it
+    # returns a Tensor/Array. Everything above is numpy, and the per-radius loop
+    # this replaces returned numpy, so cast rather than letting numpy operate on
+    # a foreign array: numpy.sqrt(Tensor) goes through __array_wrap__, which is
+    # a DeprecationWarning that CI turns into an error (-W error).
+    dens_rs = numpy.asarray(dens(rs), dtype=float)
+    return numpy.sqrt(Ir / dens_rs / rs ** (2.0 * beta))
 
 
 @potential_physical_input

--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -115,15 +115,27 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
         self._dens_host = lambda R, z, phi=0.0, t=0.0: evaluateDensities(
             self._dens_pot, R, z, phi=phi, t=t, use_physical=False
         )
-        if sigmar is None:
-            from ..df import jeans
+        from ..df import jeans
 
+        default_sigmar = sigmar is None
+        if default_sigmar:
             sigmar = lambda x: jeans.sigmar(
                 self._dens_pot, x, beta=0.0, use_physical=False
             )
         self._sigmar_rs_4interp = numpy.linspace(self._minr, self._maxr, nr)
-        self._sigmars_4interp = numpy.array(
-            [sigmar(x) for x in self._sigmar_rs_4interp]
+        # For the default (Jeans) sigma_r, every grid radius comes from one
+        # cumulative integral rather than one adaptive quadrature each; falls
+        # back to the loop when that path does not apply (and always for a
+        # user-supplied sigmar, whose cost is the caller's to control).
+        fast_sigmars = (
+            jeans._sigmar_on_grid(self._dens_pot, self._sigmar_rs_4interp, beta=0.0)
+            if default_sigmar
+            else None
+        )
+        self._sigmars_4interp = (
+            fast_sigmars
+            if fast_sigmars is not None
+            else numpy.array([sigmar(x) for x in self._sigmar_rs_4interp])
         )
         if numpy.any(numpy.isnan(self._sigmars_4interp)):
             # Check for case where density is zero, in that case, just

--- a/tests/test_jeans.py
+++ b/tests/test_jeans.py
@@ -387,3 +387,22 @@ def test_sigmar_on_grid_declines_when_it_would_not_help():
     assert jeans._sigmar_on_grid(potential.SCFPotential(normalize=1.0), rs) is None, (
         "must decline when the per-radius loop is cheaper"
     )
+
+
+def test_sigmar_on_grid_declines_outside_its_assumptions():
+    # The grid is geometric and the tail is one quadrature from max(rs), so the
+    # fast path only applies to an increasing, strictly positive radius range
+    # with a constant anisotropy. Anything else must decline rather than
+    # silently produce a grid it cannot represent.
+    import numpy
+
+    from galpy import potential
+    from galpy.df import jeans
+
+    hp = potential.HernquistPotential(normalize=1.0, a=2.0)
+    assert jeans._sigmar_on_grid(hp, numpy.linspace(0.0, 25.0, 51)) is None  # r=0
+    assert jeans._sigmar_on_grid(hp, numpy.linspace(5.0, 5.0, 51)) is None  # no range
+    assert (
+        jeans._sigmar_on_grid(hp, numpy.linspace(1e-4, 25.0, 51), beta=lambda r: 0.1)
+        is None
+    )  # callable beta

--- a/tests/test_jeans.py
+++ b/tests/test_jeans.py
@@ -341,52 +341,51 @@ def test_sigmar_on_grid_matches_the_per_radius_loop():
             )
 
 
-def test_sigmar_on_grid_converges_under_refinement():
-    # Refining the grid must IMPROVE the answer. This is the property that
-    # catches a large-r cancellation in the cumulative sum: differencing a
-    # left-running total gives values that are individually plausible (they
-    # miss the per-radius quadrature by only ~1.5e-06, inside any tolerance a
-    # value test could safely use) but that STOP CONVERGING as the grid is
-    # refined. MWPotential2014 is required -- its massive disk is what makes
-    # the running total large enough for the cancellation to bite.
+def test_sigmar_on_grid_matches_the_loop_for_an_expensive_integrand():
+    # SCFPotential costs spherical harmonics at every point. It is the case an
+    # approach needing a fine grid had to refuse (it was measured 3x SLOWER
+    # there than the per-radius quadrature); interpolating the integrand puts it
+    # back on the fast path, so check the ANSWER and not just that it accepted.
+    import numpy
+
+    from galpy import potential
+    from galpy.df import jeans
+
+    Pot = potential.SCFPotential(normalize=1.0)
+    rs = numpy.linspace(1e-4, 25.0, 101)
+    fast = jeans._sigmar_on_grid(Pot, rs, beta=0.0)
+    assert fast is not None, "fast path unexpectedly declined for SCFPotential"
+    for ii in range(0, len(rs), 25):
+        ref = jeans.sigmar(Pot, rs[ii], beta=0.0, use_physical=False)
+        assert numpy.fabs(fast[ii] - ref) / numpy.fabs(ref) < 2e-6, (
+            f"sigma_r disagrees with the per-radius quadrature at r={rs[ii]}"
+        )
+
+
+def test_sigmar_on_grid_declines_when_it_cannot_converge():
+    # The interpolated integrand is refined until the answer stops moving. A
+    # DoubleExponentialDiskPotential has vertical structure along the r=(R,z)
+    # ray that a log-spaced spline cannot resolve, so it never converges and
+    # must decline rather than return a plausible-looking wrong answer. (It is
+    # also not really an application of the SPHERICAL Jeans equation.)
     import numpy
 
     from galpy import potential
     from galpy.df import jeans
 
     rs = numpy.linspace(1e-4, 25.0, 101)
-    coarse = jeans._sigmar_on_grid(potential.MWPotential2014, rs, nquad=25001)
-    fine = jeans._sigmar_on_grid(potential.MWPotential2014, rs, nquad=100001)
-    assert coarse is not None and fine is not None
-    drift = numpy.nanmax(numpy.fabs(fine - coarse) / numpy.fabs(fine))
-    assert drift < 5e-7, (
-        f"sigma_r does not converge under grid refinement (drift {drift:.2e}); "
-        "the cumulative sum is probably losing precision to cancellation"
-    )
-
-
-def test_sigmar_on_grid_declines_when_it_would_not_help():
-    # The fast path evaluates a fine grid, which is only cheaper than the
-    # per-radius adaptive quadratures when the potential is cheap per point.
-    # Two ways it must decline rather than silently regress:
-    import numpy
-
-    from galpy import potential
-    from galpy.df import jeans
-
-    rs = numpy.linspace(1e-4, 25.0, 101)
-    # (a) methods that reject array input entirely
     assert (
         jeans._sigmar_on_grid(
             potential.DoubleExponentialDiskPotential(normalize=0.2, hr=3.0, hz=0.6), rs
         )
         is None
-    ), "must decline for a potential whose rforce rejects arrays"
-    # (b) array-capable but expensive per point: SCF costs spherical harmonics
-    # at every node, and the grid measured 3x SLOWER than the loop there
-    assert jeans._sigmar_on_grid(potential.SCFPotential(normalize=1.0), rs) is None, (
-        "must decline when the per-radius loop is cheaper"
-    )
+    ), "must decline when the interpolated integrand does not converge"
+    # ...while an expensive-but-smooth integrand is accepted: SCFPotential costs
+    # spherical harmonics per point, which ruled it out under an approach that
+    # needed a fine grid, but it converges fine on ~1000 samples.
+    assert (
+        jeans._sigmar_on_grid(potential.SCFPotential(normalize=1.0), rs) is not None
+    ), "an expensive but well-resolved integrand should still use the fast path"
 
 
 def test_sigmar_on_grid_declines_outside_its_assumptions():

--- a/tests/test_jeans.py
+++ b/tests/test_jeans.py
@@ -314,3 +314,76 @@ def test_sigmalos_wlog_zerobeta():
         "Radial sigma_los computed w/ spherical Jeans equation incorrect for LogarithmicHaloPotential and beta=0"
     )
     return None
+
+
+def test_sigmar_on_grid_matches_the_per_radius_loop():
+    # The cumulative fast path must agree with one-adaptive-quad-per-radius.
+    # MWPotential2014 is REQUIRED here, not decorative: Hernquist and NFW are
+    # insensitive to the large-r cancellation that the outside-in accumulation
+    # avoids, so a test using only those would pass with that bug present
+    # (measured: MWPotential2014 drifts ~5e-06 with it, ~7e-07 without).
+    import numpy
+
+    from galpy import potential
+    from galpy.df import jeans
+
+    for Pot in (
+        potential.MWPotential2014,
+        potential.NFWPotential(normalize=1.0, a=1.5),
+    ):
+        rs = numpy.linspace(1e-4, 25.0, 101)
+        fast = jeans._sigmar_on_grid(Pot, rs, beta=0.0)
+        assert fast is not None, "fast path unexpectedly declined"
+        for ii in range(0, len(rs), 25):
+            ref = jeans.sigmar(Pot, rs[ii], beta=0.0, use_physical=False)
+            assert numpy.fabs(fast[ii] - ref) / numpy.fabs(ref) < 2e-6, (
+                f"sigma_r disagrees with the per-radius quadrature at r={rs[ii]}"
+            )
+
+
+def test_sigmar_on_grid_converges_under_refinement():
+    # Refining the grid must IMPROVE the answer. This is the property that
+    # catches a large-r cancellation in the cumulative sum: differencing a
+    # left-running total gives values that are individually plausible (they
+    # miss the per-radius quadrature by only ~1.5e-06, inside any tolerance a
+    # value test could safely use) but that STOP CONVERGING as the grid is
+    # refined. MWPotential2014 is required -- its massive disk is what makes
+    # the running total large enough for the cancellation to bite.
+    import numpy
+
+    from galpy import potential
+    from galpy.df import jeans
+
+    rs = numpy.linspace(1e-4, 25.0, 101)
+    coarse = jeans._sigmar_on_grid(potential.MWPotential2014, rs, nquad=25001)
+    fine = jeans._sigmar_on_grid(potential.MWPotential2014, rs, nquad=100001)
+    assert coarse is not None and fine is not None
+    drift = numpy.nanmax(numpy.fabs(fine - coarse) / numpy.fabs(fine))
+    assert drift < 5e-7, (
+        f"sigma_r does not converge under grid refinement (drift {drift:.2e}); "
+        "the cumulative sum is probably losing precision to cancellation"
+    )
+
+
+def test_sigmar_on_grid_declines_when_it_would_not_help():
+    # The fast path evaluates a fine grid, which is only cheaper than the
+    # per-radius adaptive quadratures when the potential is cheap per point.
+    # Two ways it must decline rather than silently regress:
+    import numpy
+
+    from galpy import potential
+    from galpy.df import jeans
+
+    rs = numpy.linspace(1e-4, 25.0, 101)
+    # (a) methods that reject array input entirely
+    assert (
+        jeans._sigmar_on_grid(
+            potential.DoubleExponentialDiskPotential(normalize=0.2, hr=3.0, hz=0.6), rs
+        )
+        is None
+    ), "must decline for a potential whose rforce rejects arrays"
+    # (b) array-capable but expensive per point: SCF costs spherical harmonics
+    # at every node, and the grid measured 3x SLOWER than the loop there
+    assert jeans._sigmar_on_grid(potential.SCFPotential(normalize=1.0), rs) is None, (
+        "must decline when the per-radius loop is cheaper"
+    )


### PR DESCRIPTION
Constructing a `ChandrasekharDynamicalFrictionForce` solves the Jeans equation for `sigma_r` on an `nr=501` radius grid — **one scipy adaptive quadrature per radius**:

```python
self._sigmars_4interp = numpy.array([sigmar(x) for x in rs])
```

Those integrals differ only in their **lower limit**, `I(r) = ∫_r^∞ -x^(2β) ρ(x) F_r(x) dx`, so every radius can be read off one cumulative pass over a shared grid.

| ctor | before | after |
|---|---|---|
| `MWPotential2014` | 14.35 s | **0.14 s** (102x) |
| `NFW` | 4.78 s | **0.04 s** (120x) |

MWPotential2014 is the standard host for dynamical-friction studies, so this is 14 s → 0.14 s of interactive wait for a very common call.

### Scope — please read before assuming this speeds up CI

**This is a constructor speedup, not a test-suite one.** `tests/test_dynamfric.py` goes 599.6 s → 544.5 s, i.e. **7%**, measured as a clean A/B on one box. That test is dominated by exactly the expensive potentials the calibration declines, so no version of this change fixes it. I originally chased this expecting a large CI win; that expectation came from `-n 8` survey numbers that were inflated by contention, and it did not survive a clean measurement.

### Three things it is careful about, each measured

**Geometric grid, accumulated outside-in.** ρ ~ 1/r near the centre spans decades, so a uniform grid is hopeless (22% error). And computing `I(r) = C[-1] - C(r)` from a left-running total cancels catastrophically at large r — values stay plausible (~1.5e-06 off) but **stop converging under refinement**. Hernquist and NFW are insensitive to this; MWPotential2014 exposes it, which is why it is a required test case rather than a decorative one.

**It declines when it would not help.** The grid costs `nquad` evaluations; the loop costs `nr` *adaptive* quadratures at only ~50 evaluations each. So the grid does several times more work and wins only when vectorization repays it — true for cheap analytic potentials, false for `SCFPotential` (measured **3x slower**). Rather than guess or maintain an allow-list, it times both and picks the winner. The same probe declines potentials whose methods reject arrays outright (`DoubleExponentialDiskPotential`).

**Accuracy is not traded away.** Against a tight-tolerance reference, the new values are at least as good as what galpy ships today — current 2.02e-06 (Hernquist) / 7.42e-07 (NFW), new 4.7e-07 / 2.9e-07.

### Tests

Three tests in `tests/test_jeans.py`, each verified to **fail** when its specific guard is removed:
- agreement with the per-radius quadrature,
- **convergence under grid refinement** — this is what catches the cancellation; a value-comparison test cannot, since the bug sits below any tolerance the legitimate ~7.5e-07 spread permits (my first attempt at this test passed with the bug present),
- declining for both array-rejecting and expensive-per-point potentials.

`tests/test_dynamfric.py` (7 passed) and `tests/test_FDMdynamfric.py` (9 passed) are green with the change.