### PR TITLE
actionAngleStaeckelInverse: target= — localize the grid on an orbit or stream

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -137,6 +137,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         Lzlim=None,
         wElim=None,
         wIlim=None,
+        target=None,
+        target_pad=1.5,
+        target_minwidth=0.02,
         **kwargs,
     ):
         """
@@ -196,22 +199,47 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         npt : int, optional
             Number of sine modes of the stored momentum-matching anomaly
             maps (at most ncanon/2 - 1).
-        canonical : bool, optional
-            If True, additionally build the canonical (momentum-matched)
-            construction for the discrete tori: each torus is lifted onto
-            its equal-action isochrone torus by per-degree momentum-matched
-            point transformations, and evaluation runs through the analytic
-            isochrone inverse (STAECKEL_CANONICAL_MATH.md section 10).
-        ncanon : int, optional
-            Number of anomaly samples (even) of the canonical
-            correspondence tables per degree of freedom.
-        npt : int, optional
-            Number of sine modes of the stored momentum-matching anomaly
-            maps (at most ncanon/2 - 1).
+        isochrone_ab : (float, float), optional
+            Frozen (GM, b) of the auxiliary isochrone to use instead of
+            fitting one; the adaptive build hands every node the same
+            auxiliary through this, because the compensation's closed-form
+            auxiliary chains assume a single isochrone across the family.
         maxiter : int, optional
             Maximum number of Newton iterations in the angle inversion.
         angle_tol : float, optional
             Convergence tolerance of the angle inversion.
+        Lzlim, wElim, wIlim : (float or None, float or None), optional
+            Explicit (lower, upper) limits of the interpolation grid's box
+            in each of its axes (L_z, w_E, w_I): a box narrower than the
+            default localizes the grid -- on a stream, say -- and is worth
+            as much as proportionally more nodes, because the interpolation
+            error goes as the spacing. None on either end means that axis's
+            own default edge; this matters because the w_I edges are the
+            planar and shell degeneracies, which the grid must reach
+            exactly or not at all (only used when setup_interp is True).
+        target : Orbit or array_like, optional
+            Localize the grid on a target instead of setting the box
+            explicitly: phase-space points -- an Orbit (possibly an array
+            of orbits, or one evaluated at an array of times) or rows
+            (R, vR, vT, z, vz[, phi]) in internal units -- whose tori the
+            grid should cover. The box is the target's own (L_z, w_E, w_I)
+            range padded by target_pad, computed through the same label
+            relations the node lattice uses (chart-local for an adaptive
+            family), and is recorded in the _targetbox attribute. The
+            labelling does a few root-finds per point, so subsample very
+            large debris sets.
+        target_pad : float, optional
+            Padding of the target's box: each axis is extended by this
+            factor times the target's spread on BOTH ends. Generous
+            padding is load-bearing, because a box tight around the target
+            puts it in the boundary layer of the interpolation stencil,
+            and that failure mode is silent (the median error never
+            notices; the worst case does).
+        target_minwidth : float, optional
+            Minimum width of the target box on each axis, as a fraction of
+            that axis's default span -- what keeps the box of a single
+            orbit, whose spread is zero on every axis, a grid rather than
+            a point.
 
         Notes
         -----
@@ -360,6 +388,23 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._ncanon = ncanon
         self._npt = npt
         self._nforDm = numpy.arange(1, npt + 1)
+        self._targetbox = None
+        self._target_pad = target_pad
+        self._target_minwidth = target_minwidth
+        if target is not None:
+            if not setup_interp:
+                raise TypeError(
+                    "target= localizes the interpolation grid and therefore "
+                    "requires setup_interp=True"
+                )
+            if Lzlim is not None or wElim is not None or wIlim is not None:
+                raise TypeError(
+                    "target= computes Lzlim/wElim/wIlim itself and cannot "
+                    "be combined with setting them explicitly"
+                )
+            self._target = _parse_target(target)
+        else:
+            self._target = None
         if setup_interp:
             # the interpolated family is the canonical construction (the
             # contingent interpolated-direct path was removed once the
@@ -1471,6 +1516,110 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         vals = numpy.einsum("qpabc,pa,pb,pc->qp", block, wts[0], wts[1], wts[2])
         return vals
 
+    def _target_box(self, Rmin, Rmax, Rinf, wpad):
+        """The padded (L_z, w_E, w_I) box that localizes the grid on the
+        target's tori.  Every target point is labelled through the same
+        relations the node lattice uses (chart-local for an adaptive
+        family); the box is the labels' range, padded by target_pad times
+        the spread on both ends of each axis -- generous padding is
+        load-bearing, because a box tight around the target puts it in the
+        boundary layer of the interpolation stencil, and that failure mode
+        is silent -- and an end that reaches its axis's default edge is
+        returned as None, i.e. the edge itself, which matters because the
+        w_I edges are the planar and shell degeneracies, which the grid
+        must reach exactly or not at all."""
+        R, vR, vT, z, vz = self._target
+        Lzs = R * numpy.fabs(vT)
+        wEs, wIs = numpy.empty(len(Lzs)), numpy.empty(len(Lzs))
+        Phiinf = evaluatePotentials(self._pot, Rinf, 0.0, use_physical=False)
+        for i, (Rp, vRp, vTp, zp, vzp, Lz) in enumerate(zip(R, vR, vT, z, vz, Lzs)):
+            Ec = self._circular_orbit(Lz)[1]
+            Emax = Phiinf + Lz**2.0 / 2.0 / Rinf**2.0
+            kin = (vRp**2.0 + vTp**2.0 + vzp**2.0) / 2.0
+            _save = None
+            if self._delta_func is not None:
+                # place the point's chart with the raw-potential energy: the
+                # chart surfaces are smooth, so the O(model error) difference
+                # from the wrapper energy is immaterial for the box
+                _save = self._swap_local_chart(
+                    kin + evaluatePotentials(self._pot, Rp, zp, use_physical=False),
+                    Lz,
+                )
+            try:
+                E = kin + evaluatePotentials(
+                    self._staeckelwrap, Rp, zp, use_physical=False
+                )
+                u, v = coords.Rz_to_uv(Rp, zp, delta=self._delta)
+                sh = numpy.sinh(u)
+                # the point's third integral, from the u-equation of the
+                # separated relation (the same convention as _Wu: p_u^2 =
+                # 2 delta^2 [E sinh^2 u - U(u) - I3] - L_z^2/sinh^2 u)
+                pu = self._delta * (
+                    vRp * numpy.cosh(u) * numpy.sin(v) + vzp * sh * numpy.cos(v)
+                )
+                try:
+                    I3 = (
+                        E * sh**2.0
+                        - self._staeckelwrap._U(u)
+                        - (pu**2.0 + Lz**2.0 / sh**2.0) / 2.0 / self._delta**2.0
+                    )
+                    Ipl = self._I3_planar(E, Lz)
+                    den = self._I3_shell(E, Lz) - Ipl
+                    wIs[i] = (
+                        0.5
+                        if den <= 0.0
+                        else 2.0
+                        / numpy.pi
+                        * numpy.arcsin(
+                            numpy.sqrt(numpy.clip((I3 - Ipl) / den, 0.0, 1.0))
+                        )
+                    )
+                except ValueError:
+                    # too close to the circular degeneracy for the shell
+                    # relation to bracket; every I3 label coincides there,
+                    # so the direction is free
+                    wIs[i] = 0.5
+            finally:
+                if _save is not None:
+                    self._staeckelwrap, self._delta = _save
+            if E > Emax:
+                raise ValueError(
+                    "a target point's energy lies above the energies the "
+                    "grid can cover; increase Rinf"
+                )
+            wEs[i] = numpy.sqrt(numpy.clip((E - Ec) / (Emax - Ec), 0.0, 1.0))
+
+        def _padded(vals, lo0, hi0, snap=True):
+            lo, hi = float(numpy.min(vals)), float(numpy.max(vals))
+            lo, hi = (
+                lo - self._target_pad * (hi - lo),
+                hi + self._target_pad * (hi - lo),
+            )
+            minw = self._target_minwidth * (hi0 - lo0)
+            if hi - lo < minw:
+                mid = 0.5 * (lo + hi)
+                lo, hi = mid - 0.5 * minw, mid + 0.5 * minw
+            if snap:
+                # an end that reaches the default edge IS the edge: None,
+                # which _edge resolves per end
+                return (None if lo <= lo0 else lo, None if hi >= hi0 else hi)
+            # the L_z ends are anchors rather than degeneracies, so the box
+            # may exceed them; only guard the lower end against L_z <= 0
+            return (max(lo, 0.5 * float(numpy.min(vals))), hi)
+
+        box = (
+            _padded(
+                Lzs,
+                Rmin * vcirc(self._pot, Rmin, use_physical=False),
+                Rmax * vcirc(self._pot, Rmax, use_physical=False),
+                snap=False,
+            ),
+            _padded(wEs, wpad, 1.0 - wpad),
+            _padded(wIs, 0.0, 1.0),
+        )
+        self._targetbox = {"Lzlim": box[0], "wElim": box[1], "wIlim": box[2]}
+        return box
+
     def _setup_canonical_grid(
         self, Rmin, Rmax, Rinf, nLz, nE, nI3, wpad, Lzlim=None, wElim=None, wIlim=None
     ):
@@ -1480,6 +1629,8 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         own derivatives drive every evaluation chain (manifest canonicity:
         the labels are the stored action tables, inverted implicitly, and
         no derivative is ever stored separately)"""
+        if self._target is not None:
+            Lzlim, wElim, wIlim = self._target_box(Rmin, Rmax, Rinf, wpad)
         self._nLz, self._nE, self._nI3 = nLz, nE, nI3
         self._Lzgrid = numpy.linspace(
             *_edge(
@@ -1889,6 +2040,24 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         thetaA = numpy.arccos(numpy.clip(costh, -1.0, 1.0))
         return thetaA, pAth
 
+    def _swap_local_chart(self, E, Lz):
+        """Swap in an adaptive family's LOCAL chart at (E, L_z) -- cached,
+        because consecutive calls cluster on few charts -- and return the
+        previous (wrapper, delta) for the caller's finally block"""
+        _save = (self._staeckelwrap, self._delta)
+        dloc = float(self._delta_func(E, Lz))
+        u0loc = None if self._u0_func is None else float(self._u0_func(E, Lz))
+        key = (round(dloc, 10), None if u0loc is None else round(u0loc, 10))
+        if getattr(self, "_chart_cache_key", None) != key:
+            self._chart_cache = (
+                OblateStaeckelWrapperPotential(pot=self._pot, delta=dloc)
+                if u0loc is None
+                else OblateStaeckelWrapperPotential(pot=self._pot, delta=dloc, u0=u0loc)
+            )
+            self._chart_cache_key = key
+        self._staeckelwrap, self._delta = self._chart_cache, dloc
+        return _save
+
     def _canon_coords_integrals(self, E, Lz, I3):
         """Fractional grid coordinates directly from the integrals
         (E, L_z, I3) -- the rectified coordinates are closed forms, so
@@ -1923,20 +2092,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             # I3 is chart-defined, so the label relations must run in the
             # LOCAL chart at this (E, L_z) -- the same smooth surfaces the
             # nodes were built from, so labels and tables are consistent
-            _save = (self._staeckelwrap, self._delta)
-            dloc = float(self._delta_func(E, Lz))
-            u0loc = None if self._u0_func is None else float(self._u0_func(E, Lz))
-            key = (round(dloc, 10), None if u0loc is None else round(u0loc, 10))
-            if getattr(self, "_chart_cache_key", None) != key:
-                self._chart_cache = (
-                    OblateStaeckelWrapperPotential(pot=self._pot, delta=dloc)
-                    if u0loc is None
-                    else OblateStaeckelWrapperPotential(
-                        pot=self._pot, delta=dloc, u0=u0loc
-                    )
-                )
-                self._chart_cache_key = key
-            self._staeckelwrap, self._delta = self._chart_cache, dloc
+            _save = self._swap_local_chart(E, Lz)
         try:
             Ipl = self._I3_planar(E, Lz)
             Ish = self._I3_shell(E, Lz)
@@ -2630,6 +2786,39 @@ def _fit_staeckel_surface(pot, Rmin, Rmax, Rinf, nsub=6, rms_warn=0.05):
         return float(numpy.arcsinh(Rm / dfun(Ev, Lzv)))
 
     return dfun, u0fun, {"nodes": dat, "coeffs": c, "rms": rms, "clip": (lo, hi)}
+
+
+def _parse_target(target):
+    """The phase-space rows (R, vR, vT, z, vz) of a target, from an Orbit
+    (possibly an array of orbits, or one evaluated at an array of times) or
+    from array rows (R, vR, vT, z, vz[, phi]) in internal units; phi, when
+    present, is ignored because the potential is axisymmetric"""
+    from ..orbit import Orbit
+
+    if isinstance(target, Orbit):
+        out = numpy.array(
+            [
+                numpy.atleast_1d(target.R(use_physical=False)).ravel(),
+                numpy.atleast_1d(target.vR(use_physical=False)).ravel(),
+                numpy.atleast_1d(target.vT(use_physical=False)).ravel(),
+                numpy.atleast_1d(target.z(use_physical=False)).ravel(),
+                numpy.atleast_1d(target.vz(use_physical=False)).ravel(),
+            ]
+        )
+    else:
+        arr = numpy.atleast_2d(numpy.asarray(target, dtype="float64"))
+        if arr.ndim != 2 or arr.shape[1] not in (5, 6):
+            raise ValueError(
+                "target= rows must be (R, vR, vT, z, vz) or "
+                f"(R, vR, vT, z, vz, phi); got shape {arr.shape}"
+            )
+        out = arr[:, :5].T.copy()
+    if numpy.any(out[0] <= 0.0) or numpy.any(out[0] * numpy.fabs(out[2]) <= 0.0):
+        raise ValueError(
+            "target= needs R > 0 and L_z = R vT != 0 for every point: the "
+            "grid is a box in |L_z| > 0"
+        )
+    return out
 
 
 def _edge(lim, default):

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -10111,6 +10111,303 @@ def test_actionAngleStaeckelInverse_narrow_grid():
     return None
 
 
+def test_actionAngleStaeckelInverse_target_box():
+    # target= localizes the grid on the tori of a set of phase-space points
+    # without the user expressing the box in the grid's own (L_z, w_E, w_I)
+    # coordinates: the constructor labels the points through the same
+    # relations the node lattice uses and pads their range -- the local-grid
+    # support for a target orbit or stream.
+    import numpy
+
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        actionAngleStaeckelInverse,
+    )
+    from galpy.orbit import Orbit
+    from galpy.potential import MWPotential2014, OblateStaeckelWrapperPotential
+
+    swp = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4933)
+    # a target orbit, sampled at a few times; its (E, L_z, I3) are conserved,
+    # so all points share ONE torus and the box comes from target_minwidth
+    o = Orbit([1.05, 0.12, 1.05, 0.12, 0.06, 0.0])
+    ts = numpy.linspace(0.0, 12.0, 8)
+    o.integrate(ts, swp)
+    kw = dict(
+        pot=swp, setup_interp=True, Rmin=0.75, Rmax=1.25, Rinf=3.0, nLz=5, nE=5, nI3=5
+    )
+    wide = actionAngleStaeckelInverse(**kw)
+    loc = actionAngleStaeckelInverse(target=o(ts), **kw)
+    # the box is recorded and the grids honor it
+    assert loc._targetbox is not None, "the target box was not recorded"
+    for key, grid in (("Lzlim", "_Lzgrid"), ("wElim", "_wEgrid"), ("wIlim", "_wIgrid")):
+        lo, hi = loc._targetbox[key]
+        assert numpy.fabs(getattr(loc, grid)[0] - lo) < 1e-12, (
+            "%s was not honored by the grid" % key
+        )
+        assert numpy.fabs(getattr(loc, grid)[-1] - hi) < 1e-12, (
+            "%s was not honored by the grid" % key
+        )
+        assert numpy.ptp(getattr(loc, grid)) < numpy.ptp(getattr(wide, grid)), (
+            "the target grid is not narrower in %s" % grid
+        )
+    # the target's torus sits INSIDE the local grid with room for the stencil
+    # (labels from the forward transform with c=False: the Python angles are
+    # exact along an orbit, while the C ones carry a converged ~2e-7 defect
+    # for wrapper potentials)
+    aAS = actionAngleStaeckel(pot=swp, delta=0.4933, c=False)
+    R, vR, vT, z, vz = (
+        numpy.atleast_1d(getattr(o(ts), name)(use_physical=False)).ravel()
+        for name in ("R", "vR", "vT", "z", "vz")
+    )
+    dxw, dxl = [], []
+    for ii in range(len(R)):
+        jr, lz, jz, _, _, _, ar, ap, az = (
+            float(numpy.atleast_1d(q)[0])
+            for q in aAS.actionsFreqsAngles(R[ii], vR[ii], vT[ii], z[ii], vz[ii], 0.0)
+        )
+        x = loc._canon_coords(jr, lz, jz)
+        assert numpy.min(numpy.array([numpy.min(x), 4.0 - numpy.max(x)])) > 1.0, (
+            "a target point's torus sits within a cell of the box faces: %s" % x
+        )
+        for aa, dx in ((wide, dxw), (loc, dxl)):
+            out = aa(
+                jr,
+                lz,
+                jz,
+                numpy.array([ar]),
+                numpy.array([ap]),
+                numpy.array([az]),
+            )
+            dx.append(
+                numpy.hypot(
+                    float(numpy.atleast_1d(out[0])[0]) - R[ii],
+                    float(numpy.atleast_1d(out[3])[0]) - z[ii],
+                )
+            )
+    # localization pays: the same 5^3 nodes reproduce the target orders of
+    # magnitude better than the default box does (measured 7.7e-7 vs 2.7e-3)
+    assert numpy.max(dxl) < 5e-6, (
+        "the target-localized grid does not reproduce the target: %g" % numpy.max(dxl)
+    )
+    assert numpy.max(dxl) < numpy.max(dxw) / 100.0, (
+        "the target-localized grid is not much better than the default box "
+        "(%g vs %g)" % (numpy.max(dxl), numpy.max(dxw))
+    )
+    return None
+
+
+def test_actionAngleStaeckelInverse_target_box_relations():
+    # The box machinery itself, on a discrete instance (the label relations
+    # exist before any grid does): padding, the minimum width, snapping to
+    # the default edges, the circular-degeneracy guards, and the input
+    # parser and its errors.
+    import numpy
+    import pytest
+    from scipy import optimize
+
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        _parse_target,
+        actionAngleStaeckelInverse,
+    )
+    from galpy.orbit import Orbit
+    from galpy.potential import (
+        MWPotential2014,
+        OblateStaeckelWrapperPotential,
+        evaluatePotentials,
+        rl,
+        vcirc,
+    )
+
+    delta = 0.4933
+    swp = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=delta)
+    # a valid discrete torus: circular energy plus a mid-range third integral
+    Lz = 0.9
+    Rc = rl(swp, Lz, use_physical=False)
+    Ec = evaluatePotentials(swp, Rc, 0.0, use_physical=False) + Lz**2.0 / 2.0 / Rc**2.0
+    Emax = (
+        evaluatePotentials(swp, 3.0, 0.0, use_physical=False) + Lz**2.0 / 2.0 / 3.0**2.0
+    )
+    E = Ec + 0.4**2.0 * (Emax - Ec)
+    Ipl = Lz**2.0 / 2.0 / delta**2.0 - E
+
+    def maxWu(I3):
+        return -optimize.minimize_scalar(
+            lambda u: (
+                -(
+                    2.0 * delta**2.0 * (E * numpy.sinh(u) ** 2.0 - swp._U(u) - I3)
+                    - Lz**2.0 / numpy.sinh(u) ** 2.0
+                )
+            ),
+            bounds=(1e-3, 20.0),
+            method="bounded",
+            options={"xatol": 1e-13},
+        ).fun
+
+    Ish = optimize.brentq(maxWu, Ipl, Ipl + 5.0, xtol=1e-14)
+    aA = actionAngleStaeckelInverse(
+        pot=swp, Es=[E], Lzs=[Lz], I3s=[Ipl + 0.4 * (Ish - Ipl)]
+    )
+    # a spread-out target: a numeric box strictly inside the defaults
+    aA._target = _parse_target(
+        numpy.array(
+            [
+                [1.07, 0.13, 0.98, 0.13, 0.08],
+                [1.0, 0.05, 1.02, 0.05, 0.02],
+                [1.12, -0.1, 0.95, 0.2, -0.05],
+            ]
+        )
+    )
+    aA._target_pad, aA._target_minwidth = 1.5, 0.02
+    box = aA._target_box(0.75, 1.25, 3.0, 0.02)
+    for lim, w0, w1 in zip(box, (None, None, 0.0), (None, None, 1.0)):
+        assert lim[0] is None or lim[1] is None or lim[0] < lim[1], (
+            f"the box is not ordered: {box}"
+        )
+    assert box[2][0] is not None and box[2][1] is not None, (
+        f"an interior w_I box should be numeric: {box}"
+    )
+    # huge padding: every degeneracy-bounded end snaps to its own edge
+    # (None), while the L_z ends are anchors rather than degeneracies, so
+    # the lower one is merely guarded against L_z <= 0
+    aA._target_pad = 50.0
+    box = aA._target_box(0.75, 1.25, 3.0, 0.02)
+    assert box[1] == (None, None) and box[2] == (None, None), (
+        f"a box beyond the default edges did not snap to them: {box}"
+    )
+    assert numpy.fabs(box[0][0] - 0.51) < 1e-12, (
+        "the L_z lower end was not guarded at half the smallest target L_z"
+    )
+    assert box[0][1] > vcirc(swp, 1.25, use_physical=False) * 1.25, (
+        "the L_z upper end should exceed its anchor (it is not a degeneracy)"
+    )
+    # a single point: zero spread on every axis, so the box is the minimum
+    # width, centered on the point's torus
+    aA._target = _parse_target([1.07, 0.13, 0.98, 0.13, 0.08])
+    aA._target_pad = 1.5
+    box = aA._target_box(0.75, 1.25, 3.0, 0.02)
+    assert numpy.fabs(box[1][1] - box[1][0] - 0.02 * 0.96) < 1e-12, (
+        f"the single-point w_E box is not the minimum width: {box}"
+    )
+    assert numpy.fabs(box[2][1] - box[2][0] - 0.02) < 1e-12, (
+        f"the single-point w_I box is not the minimum width: {box}"
+    )
+    # the circular degeneracy: when the shell relation degenerates to the
+    # planar one (or cannot bracket at all), every I3 label coincides and
+    # the w_I direction is free, centered at 1/2
+    aA._I3_shell = lambda E, Lz: aA._I3_planar(E, Lz)
+    box = aA._target_box(0.75, 1.25, 3.0, 0.02)
+    assert (
+        numpy.fabs(box[2][0] - 0.49) < 1e-12 and numpy.fabs(box[2][1] - 0.51) < 1e-12
+    ), f"a degenerate shell relation did not center the w_I box: {box}"
+
+    def _nobracket(E, Lz):
+        raise ValueError("f(a) and f(b) must have different signs")
+
+    aA._I3_shell = _nobracket
+    box = aA._target_box(0.75, 1.25, 3.0, 0.02)
+    assert (
+        numpy.fabs(box[2][0] - 0.49) < 1e-12 and numpy.fabs(box[2][1] - 0.51) < 1e-12
+    ), f"an unbracketable shell relation did not center the w_I box: {box}"
+    # the parser: an Orbit and its own rows are the same target, a sixth
+    # (phi) column is ignored, and a bare point is one row
+    vxvv = numpy.array(
+        [[1.07, 0.13, 0.98, 0.13, 0.08, 0.3], [1.0, 0.05, 1.02, 0.05, 0.02, 5.2]]
+    )
+    assert numpy.array_equal(_parse_target(Orbit(vxvv)), _parse_target(vxvv)), (
+        "an Orbit and its own rows parse differently"
+    )
+    assert numpy.array_equal(_parse_target(vxvv), _parse_target(vxvv[:, :5])), (
+        "the phi column was not ignored"
+    )
+    assert _parse_target([1.07, 0.13, 0.98, 0.13, 0.08]).shape == (5, 1), (
+        "a bare point is not one row"
+    )
+    with pytest.raises(ValueError, match="rows must be"):
+        _parse_target([1.0, 0.1, 1.0, 0.1])
+    with pytest.raises(ValueError, match="rows must be"):
+        _parse_target(numpy.ones((2, 2, 5)))
+    with pytest.raises(ValueError, match="R > 0"):
+        _parse_target([-1.0, 0.1, 1.0, 0.1, 0.05])
+    with pytest.raises(ValueError, match="R > 0"):
+        _parse_target([1.0, 0.1, 0.0, 0.1, 0.05])
+    # constructor guards: target= shapes the interpolation grid, so it
+    # needs one, and it computes the box itself
+    with pytest.raises(TypeError, match="requires setup_interp"):
+        actionAngleStaeckelInverse(pot=swp, target=[1.0, 0.1, 1.0, 0.1, 0.05])
+    with pytest.raises(TypeError, match="cannot be combined"):
+        actionAngleStaeckelInverse(
+            pot=swp,
+            setup_interp=True,
+            target=[1.0, 0.1, 1.0, 0.1, 0.05],
+            wIlim=(0.3, 0.5),
+        )
+    # a target the grid cannot cover: energy above the outer energy
+    with pytest.raises(ValueError, match="increase Rinf"):
+        actionAngleStaeckelInverse(
+            pot=swp,
+            setup_interp=True,
+            Rmin=0.75,
+            Rmax=1.25,
+            Rinf=1.3,
+            target=[1.0, 0.9, 1.0, 0.3, 0.9],
+        )
+    return None
+
+
+def test_actionAngleStaeckelInverse_target_box_adaptive():
+    # target= composes with an adaptive family: the labelling then runs in
+    # the LOCAL chart at each point's (E, L_z), the same smooth surfaces the
+    # node lattice is built from.
+    import numpy
+
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        actionAngleStaeckelInverse,
+    )
+    from galpy.orbit import Orbit
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    o = Orbit([1.1, 0.15, 1.1, 0.1, 0.08, 0.0])
+    ts = numpy.linspace(0.0, 10.0, 6)
+    o.integrate(ts, kkp)
+    loc = actionAngleStaeckelInverse(
+        pot=kkp,
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=4,
+        nE=4,
+        nI3=4,
+        delta=lambda E, Lz: 1.3 + 0.02 * numpy.tanh(E),
+        target=o(ts),
+    )
+    assert loc._targetbox is not None, "the target box was not recorded"
+    assert numpy.ptp(loc._canon_deltas) > 0.0, (
+        "the adaptive family did not vary its focal length"
+    )
+    # a loose round trip: the deliberately non-optimal callable delta means
+    # the local Staeckel models differ from the true KK potential, and the
+    # forward labels (fixed delta = 1.3) sit in yet another chart, so the
+    # model mismatch dominates; this checks consistency, not a floor
+    aAS = actionAngleStaeckel(pot=kkp, delta=1.3, c=False)
+    jr, lz, jz, _, _, _, ar, ap, az = (
+        float(numpy.atleast_1d(q)[0])
+        for q in aAS.actionsFreqsAngles(1.1, 0.15, 1.1, 0.1, 0.08, 0.0)
+    )
+    out = loc(jr, lz, jz, numpy.array([ar]), numpy.array([ap]), numpy.array([az]))
+    dx = numpy.hypot(
+        float(numpy.atleast_1d(out[0])[0]) - 1.1,
+        float(numpy.atleast_1d(out[3])[0]) - 0.1,
+    )
+    assert dx < 1e-3, (
+        "the adaptive target-localized family does not reproduce the target "
+        "point: %g" % dx
+    )
+    return None
+
+
 def test_actionAngleStaeckelInverse_adaptive_delta_canonical():
     # The focal length may vary across the family -- delta(E, L_z), the
     # adaptive-Staeckel design -- provided the compensation carries its


### PR DESCRIPTION
Stacked on #1421 (stack #1397). Local-grid support for a target orbit or stream: `target=` on the interpolated constructor computes the narrow `(L_z, w_E, w_I)` box itself, closing the chicken-and-egg the stream measurement had to bootstrap around (the box lives in the grid's own coordinates, so placing it used to require building a coarse wide grid first just to locate the debris).

### What it does

`target=` takes an Orbit (an array of orbits, or one evaluated at an array of times) or phase-space rows `(R, vR, vT, z, vz[, phi])`. No forward action-angle transform is involved: each point's `(E, L_z, I_3)` follow in closed form from the separated relation (the same `p_u^2 = 2δ²[E sinh²u − U(u) − I_3] − L_z²/sinh²u` convention as `_Wu`, cross-checked in dev against the v-equation to all digits), and the same label relations the node lattice uses turn them into `(w_E, w_I)` — chart-local for an adaptive family, through the same `_swap_local_chart` that `integrals=True` now shares.

The box is the labels' range padded by `target_pad` (default 1.5× the spread on both ends — the stream measurement showed generous padding is load-bearing and the failure mode silent: the median error never notices the stencil's boundary layer, the worst case does), widened to `target_minwidth` per axis (a single orbit has zero spread on every axis: its E, L_z, I_3 are conserved), and each end that reaches its axis's default edge snaps to the `None` sentinel of the narrow-grid infrastructure — which matters because the w_I edges are the planar and shell degeneracies the grid must reach exactly or not at all. The L_z ends are anchors rather than degeneracies, so they may exceed the defaults; the lower one is only guarded against L_z ≤ 0. The result is recorded in `_targetbox`.

Degeneracy guards: a target point at (or numerically below, for an adaptive family whose chart energy differs at O(model error)) its circular energy has every I_3 label coincident, so the shell relation may degenerate or fail to bracket; both routes center the free w_I direction at 1/2.

### Measured

Same 5³ nodes on MWPotential2014-as-Stäckel, a target orbit sampled at 8 times, round trip through c=False labels (the Python angles are exact along an orbit; the C ones carry the known converged ~2e-7 defect for wrapper potentials):

| | default box | `target=` box |
|---|---|---|
| max \|dx\| | 2.7e-3 | **7.7e-7** |
| median \|dx\| | 9.0e-4 | 2.1e-7 |

3500× at identical cost (both builds ~21 s), with the target's torus dead-center in the box (fractional coordinates [2.00, 2.00, 2.00] of 0..4). This is the measured spacing economy of the narrow-grid PR made usable: a domain narrower by F is worth F times more nodes.

### Also in this PR

- The chart swap of `_canon_coords_integrals` factored into `_swap_local_chart`, shared with the box labelling.
- `Lzlim`/`wElim`/`wIlim` and `isochrone_ab` documented (they never were), and a duplicated `canonical`/`ncanon`/`npt` docstring block deduplicated.

### Coverage

Functional (wide-vs-local on the same nodes, in-grid placement with stencil room), unit (the box machinery on a discrete instance — padding, minimum width, edge snapping, the L_z guard, both degeneracy routes triggered deterministically by patching `_I3_shell`, the parser and every error), and composition with an adaptive family (chart-local labelling, loose round trip — the deliberately non-optimal callable δ makes model mismatch dominate, which the test says). All new lines covered, no pragmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
