### PR TITLE
actionAngleStaeckel C: frequencies and angles near turning points

### DIFF
--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -1602,7 +1602,9 @@ void calcUminUmax(int ndata,
 				       *(ux+ii) - 0.000001,
 				       *(ux+ii) + 0.000001);
 	if (status == GSL_EINVAL)
-	  *(umax+ii)= *(ux+ii);
+// LCOV_EXCL_START
+	  *(umax+ii)= *(ux+ii);//can't happen: the branch condition peps*meps<0 is the bracket
+// LCOV_EXCL_STOP
 	else {
 	  iter= 0;
 	  do
@@ -1658,7 +1660,9 @@ void calcUminUmax(int ndata,
 				       *(ux+ii) - 0.000001,
 				       *(ux+ii) + 0.000001);
 	if (status == GSL_EINVAL)
-	  *(umin+ii)= *(ux+ii);
+// LCOV_EXCL_START
+	  *(umin+ii)= *(ux+ii);//can't happen: the branch condition peps*meps<0 is the bracket
+// LCOV_EXCL_STOP
 	else {
 	  iter= 0;
 	  do

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -295,7 +295,7 @@ void calcu0(int ndata,
 	u_lo = gsl_min_fminimizer_x_lower (s);
 	u_hi = gsl_min_fminimizer_x_upper (s);
 	status = gsl_min_test_interval (u_lo, u_hi,
-					 9.9999999999999998e-13,
+					 4.4408920985006262e-16,
 					 4.4408920985006262e-16);
       }
     while (status == GSL_CONTINUE && iter < max_iter);
@@ -1333,8 +1333,8 @@ void calcAnglesStaeckel(int ndata,
     midpoint= *(umin+ii)+ 0.5 * ( *(umax+ii) - *(umin+ii) );
     if ( *(pux+ii) > 0. ) {
       if ( *(ux+ii) > midpoint ) {
-	mid= 2. * asin( sqrt( ( *(umax+ii) - *(ux+ii) )
-			      / ( *(umax+ii) - *(umin+ii) ) ) );
+	mid= 2. * asin( sqrt( fmin ( fmax ( ( *(umax+ii) - *(ux+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ), 0. ), 1. ) ) );
 	(AngleuInt+tid)->function = &dJRdEHighStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	(AngleuInt+tid)->function = &dJRdI3HighStaeckelIntegrand;
@@ -1347,8 +1347,8 @@ void calcAnglesStaeckel(int ndata,
 	I3r1= M_PI * *(dJRdI3+ii) - I3r1;
       }
       else {
-	mid= 2. * asin( sqrt( ( *(ux+ii) - *(umin+ii) )
-			      / ( *(umax+ii) - *(umin+ii) ) ) );
+	mid= 2. * asin( sqrt( fmin ( fmax ( ( *(ux+ii) - *(umin+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ), 0. ), 1. ) ) );
 	(AngleuInt+tid)->function = &dJRdELowStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	(AngleuInt+tid)->function = &dJRdI3LowStaeckelIntegrand;
@@ -1361,8 +1361,8 @@ void calcAnglesStaeckel(int ndata,
     }
     else {
       if ( *(ux+ii) > midpoint ) {
-	mid= 2. * asin( sqrt( ( *(umax+ii) - *(ux+ii) )
-			      / ( *(umax+ii) - *(umin+ii) ) ) );
+	mid= 2. * asin( sqrt( fmin ( fmax ( ( *(umax+ii) - *(ux+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ), 0. ), 1. ) ) );
 	(AngleuInt+tid)->function = &dJRdEHighStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	Or1*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1375,8 +1375,8 @@ void calcAnglesStaeckel(int ndata,
 	*(Anglephi+ii)= M_PI * *(dJRdLz+ii) - *(Lz+ii) * gsl_integration_glfixed (AngleuInt+tid,0.,mid,T) / *(delta+ii*delta_stride) / sqrt(2.);
       }
       else {
-	mid= 2. * asin( sqrt( ( *(ux+ii) - *(umin+ii) )
-			      / ( *(umax+ii) - *(umin+ii) ) ) );
+	mid= 2. * asin( sqrt( fmin ( fmax ( ( *(ux+ii) - *(umin+ii) )
+			      / ( *(umax+ii) - *(umin+ii) ), 0. ), 1. ) ) );
 	(AngleuInt+tid)->function = &dJRdELowStaeckelIntegrand;
 	Or1= gsl_integration_glfixed (AngleuInt+tid,0.,mid,T);
 	Or1*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1405,10 +1405,10 @@ void calcAnglesStaeckel(int ndata,
       if ( *(vx+ii) < midpoint || *(vx+ii) > (M_PI - midpoint) ) {
 	// chi of the current v, measured from the vmin turning point along
 	// the full loop [vmin, pi - vmin]; v beyond the midplane mirrors
-	mid = 2. * asin( sqrt( ( ( *(vx+ii) > 0.5 * M_PI )
+	mid = 2. * asin( sqrt( fmin ( fmax ( ( ( *(vx+ii) > 0.5 * M_PI )
 				 ? ( M_PI - *(vx+ii) - *(vmin+ii) )
 				 : ( *(vx+ii) - *(vmin+ii) ) )
-			       / ( M_PI - 2. * *(vmin+ii) ) ) );
+			       / ( M_PI - 2. * *(vmin+ii) ), 0. ), 1. ) ) );
 	(AnglevInt+tid)->function = &dJzdELowStaeckelIntegrand;
 	Or2= gsl_integration_glfixed (AnglevInt+tid,0.,mid,T);
 	Or2*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1451,10 +1451,10 @@ void calcAnglesStaeckel(int ndata,
       if ( *(vx+ii) < midpoint || *(vx+ii) > (M_PI - midpoint)) {
 	// chi of the current v, measured from the vmin turning point along
 	// the full loop [vmin, pi - vmin]; v beyond the midplane mirrors
-	mid = 2. * asin( sqrt( ( ( *(vx+ii) > 0.5 * M_PI )
+	mid = 2. * asin( sqrt( fmin ( fmax ( ( ( *(vx+ii) > 0.5 * M_PI )
 				 ? ( M_PI - *(vx+ii) - *(vmin+ii) )
 				 : ( *(vx+ii) - *(vmin+ii) ) )
-			       / ( M_PI - 2. * *(vmin+ii) ) ) );
+			       / ( M_PI - 2. * *(vmin+ii) ), 0. ), 1. ) ) );
 	(AnglevInt+tid)->function = &dJzdELowStaeckelIntegrand;
 	Or2= gsl_integration_glfixed (AnglevInt+tid,0.,mid,T);
 	Or2*= *(delta+ii*delta_stride) / sqrt(2.);
@@ -1591,7 +1591,33 @@ void calcUminUmax(int ndata,
     meps= GSL_FN_EVAL(JRRoot+tid,*(ux+ii)-0.000001);
     if ( fabs(GSL_FN_EVAL(JRRoot+tid,*(ux+ii))) < 0.0000001 && peps*meps < 0. ){ //we are at umin or umax
       if ( peps < 0. && meps > 0. ) {//umax
-	*(umax+ii)= *(ux+ii);
+	//The point lies within 1e-6 of umax. Adopting the point itself as
+	//the turning point is fine for the actions (an O(eps) endpoint
+	//error only enters them at O(eps^1.5)), but the frequency and
+	//angle integrands diverge as 1/sqrt(W) at the endpoint, so there
+	//it enters at O(sqrt(eps)); solve for the true root instead (the
+	//+-1e-6 bracket has the sign change by the branch condition),
+	//keeping the point itself only as the degenerate fallback
+	status = gsl_root_fsolver_set ((s+tid)->s, JRRoot+tid,
+				       *(ux+ii) - 0.000001,
+				       *(ux+ii) + 0.000001);
+	if (status == GSL_EINVAL)
+	  *(umax+ii)= *(ux+ii);
+	else {
+	  iter= 0;
+	  do
+	    {
+	      iter++;
+	      status = gsl_root_fsolver_iterate ((s+tid)->s);
+	      u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
+	      u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
+	      status = gsl_root_test_interval (u_lo, u_hi,
+					       4.4408920985006262e-16,
+					       4.4408920985006262e-16);
+	    }
+	  while (status == GSL_CONTINUE && iter < max_iter);
+	  *(umax+ii)= gsl_root_fsolver_root ((s+tid)->s);
+	}
 	u_lo= 0.9 * (*(ux+ii) - 0.000001);
 	u_hi= *(ux+ii) - 0.0000001;
 	while ( GSL_FN_EVAL(JRRoot+tid,u_lo) >= 0. && u_lo > 0.000000001){
@@ -1611,7 +1637,7 @@ void calcUminUmax(int ndata,
 	      u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
 	      u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
 	      status = gsl_root_test_interval (u_lo, u_hi,
-					       9.9999999999999998e-13,
+					       4.4408920985006262e-16,
 					       4.4408920985006262e-16);
 	    }
 	  while (status == GSL_CONTINUE && iter < max_iter);
@@ -1626,7 +1652,28 @@ void calcUminUmax(int ndata,
 	}
       }
       else {// JB: Should catch all: if ( peps > 0. && meps < 0. ){//umin
-	*(umin+ii)= *(ux+ii);
+	//Same as the umax case above: solve for the true root, with the
+	//point itself only as the degenerate fallback
+	status = gsl_root_fsolver_set ((s+tid)->s, JRRoot+tid,
+				       *(ux+ii) - 0.000001,
+				       *(ux+ii) + 0.000001);
+	if (status == GSL_EINVAL)
+	  *(umin+ii)= *(ux+ii);
+	else {
+	  iter= 0;
+	  do
+	    {
+	      iter++;
+	      status = gsl_root_fsolver_iterate ((s+tid)->s);
+	      u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
+	      u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
+	      status = gsl_root_test_interval (u_lo, u_hi,
+					       4.4408920985006262e-16,
+					       4.4408920985006262e-16);
+	    }
+	  while (status == GSL_CONTINUE && iter < max_iter);
+	  *(umin+ii)= gsl_root_fsolver_root ((s+tid)->s);
+	}
 	u_lo= *(ux+ii) + 0.000001;
 	u_hi= 1.1 * (*(ux+ii) + 0.000001);
 	while ( GSL_FN_EVAL(JRRoot+tid,u_hi) >= 0. && u_hi < asinh(37.5/ *(delta+ii*delta_stride))) {
@@ -1648,7 +1695,7 @@ void calcUminUmax(int ndata,
 	    u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
 	    u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
 	    status = gsl_root_test_interval (u_lo, u_hi,
-					     9.9999999999999998e-13,
+					     4.4408920985006262e-16,
 					     4.4408920985006262e-16);
 	  }
 	while (status == GSL_CONTINUE && iter < max_iter);
@@ -1687,7 +1734,7 @@ void calcUminUmax(int ndata,
 	    u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
 	    u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
 	    status = gsl_root_test_interval (u_lo, u_hi,
-					     9.9999999999999998e-13,
+					     4.4408920985006262e-16,
 					     4.4408920985006262e-16);
 	  }
 	while (status == GSL_CONTINUE && iter < max_iter);
@@ -1723,7 +1770,7 @@ void calcUminUmax(int ndata,
 	  u_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
 	  u_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
 	  status = gsl_root_test_interval (u_lo, u_hi,
-					   9.9999999999999998e-13,
+					   4.4408920985006262e-16,
 					   4.4408920985006262e-16);
 	}
       while (status == GSL_CONTINUE && iter < max_iter);
@@ -1803,8 +1850,41 @@ void calcVmin(int ndata,
     (JzRoot+tid)->function = &JzStaeckelIntegrandSquared;
     (JzRoot+tid)->params = params+tid;
     //Find starting points for minimum
-    if ( fabs(GSL_FN_EVAL(JzRoot+tid,*(vx+ii))) < 0.0000001) //we are at vmin
-      *(vmin+ii)= ( *(vx+ii) > 0.5 * M_PI ) ? M_PI - *(vx+ii): *(vx+ii);
+    if ( fabs(GSL_FN_EVAL(JzRoot+tid,*(vx+ii))) < 0.0000001) {//we are at vmin
+      //The point lies within 1e-6 of vmin. Adopting the point itself as
+      //the turning point is fine for the actions (an O(eps) endpoint
+      //error only enters them at O(eps^1.5)), but the frequency and
+      //angle integrands diverge as 1/sqrt(W) at the endpoint, so there
+      //it enters at O(sqrt(eps)); solve for the true root instead: W is
+      //negative below vmin and positive above, so the +-1e-6 bracket
+      //around the (mirrored) point holds unless the point is degenerate
+      //at roundoff level, where the point IS the turning point and the
+      //old assignment remains as the fallback
+      v_lo= ( ( *(vx+ii) > 0.5 * M_PI ) ? M_PI - *(vx+ii): *(vx+ii) )
+	- 0.000001;
+      if ( v_lo < 0.000000001 ) v_lo= 0.000000001;
+      v_hi= ( ( *(vx+ii) > 0.5 * M_PI ) ? M_PI - *(vx+ii): *(vx+ii) )
+	+ 0.000001;
+      if ( v_hi > 0.5 * M_PI ) v_hi= 0.5 * M_PI;
+      status = gsl_root_fsolver_set ((s+tid)->s, JzRoot+tid, v_lo, v_hi);
+      if (status == GSL_EINVAL)
+	*(vmin+ii)= ( *(vx+ii) > 0.5 * M_PI ) ? M_PI - *(vx+ii): *(vx+ii);
+      else {
+	iter= 0;
+	do
+	  {
+	    iter++;
+	    status = gsl_root_fsolver_iterate ((s+tid)->s);
+	    v_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
+	    v_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
+	    status = gsl_root_test_interval (v_lo, v_hi,
+					     4.4408920985006262e-16,
+					     4.4408920985006262e-16);
+	  }
+	while (status == GSL_CONTINUE && iter < max_iter);
+	*(vmin+ii)= gsl_root_fsolver_root ((s+tid)->s);
+      }
+    }
     else {
       if ( *(vx+ii) > 0.5 * M_PI ){
 	v_lo= 0.9 * ( M_PI - *(vx+ii) );
@@ -1832,7 +1912,7 @@ void calcVmin(int ndata,
 	  v_lo = gsl_root_fsolver_x_lower ((s+tid)->s);
 	  v_hi = gsl_root_fsolver_x_upper ((s+tid)->s);
 	  status = gsl_root_test_interval (v_lo, v_hi,
-					   9.9999999999999998e-13,
+					   4.4408920985006262e-16,
 					   4.4408920985006262e-16);
 	}
       while (status == GSL_CONTINUE && iter < max_iter);

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -2521,6 +2521,72 @@ def test_actionAngleStaeckel_zerolz_actions_c():
 
 
 # Check that precision increases with increasing Gauss-Legendre order
+def test_actionAngleStaeckel_c_angles_freqs_near_turning_point():
+    # c=True frequencies and angles used to go wrong for points near a
+    # turning point: when |p^2| < 1e-7 there, the C code adopted the
+    # evaluation point ITSELF as the turning point instead of solving for
+    # it. That O(eps) endpoint error enters the actions only at
+    # O(eps^1.5) (invisible, ~1e-12) but the 1/sqrt(W)-divergent
+    # frequency and angle integrands at O(sqrt(eps)) -- theta_z errors up
+    # to ~1e-4 -- and, through ~1e-12-absolute root tolerances, also left
+    # an order-growing angle error on generic points. Frequencies are
+    # torus constants and the Python path is exact here, so both provide
+    # sharp regression checks.
+    import numpy
+
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.orbit import Orbit
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    o = Orbit([1.1, 0.35, 1.1, 0.3, 0.25, 0.0])
+    ts = numpy.linspace(0.0, 8.0, 17)
+    o.integrate(ts, kkp)
+    R, vR, vT, z, vz, phi = (
+        numpy.array([float(f(t)) for t in ts])
+        for f in (o.R, o.vR, o.vT, o.z, o.vz, o.phi)
+    )
+    # a point of this orbit within ~1e-8 of its upper vertical turning
+    # point (p_v^2 ~ 6e-8), given as a literal so the near-turning
+    # regime is hit deterministically on every platform
+    R[-1], vR[-1], vT[-1], z[-1], vz[-1], phi[-1] = (
+        1.0374878950211397,
+        0.26453976273320806,
+        1.166278667740467,
+        0.3280135549475248,
+        0.0331712140016195,
+        -2.550334704756344,
+    )
+    aAC = actionAngleStaeckel(pot=kkp, delta=1.3, c=True, order=100)
+    aAP = actionAngleStaeckel(pot=kkp, delta=1.3, c=False)
+    C = aAC.actionsFreqsAngles(R, vR, vT, z, vz, phi)
+    # frequencies are torus constants: they may not vary along the orbit
+    # (the near-turning point used to be off by ~2e-4 in Omega_z)
+    for k, name in ((3, "Omega_R"), (5, "Omega_z")):
+        spread = numpy.ptp(numpy.array(C[k])) / numpy.fabs(
+            numpy.median(numpy.array(C[k]))
+        )
+        assert spread < 1e-8, (
+            "c=True %s varies along an orbit by %g near a turning point"
+            % (name, spread)
+        )
+    # angles agree with the (exact) Python path pointwise, including at
+    # the near-turning sample (used to be off by ~4e-4 in theta_z)
+    P = aAP.actionsFreqsAngles(R, vR, vT, z, vz, phi)
+    for k, name in ((6, "theta_R"), (8, "theta_z")):
+        d = (
+            numpy.remainder(
+                numpy.array(C[k]) - numpy.array(P[k]) + numpy.pi, 2.0 * numpy.pi
+            )
+            - numpy.pi
+        )
+        assert numpy.max(numpy.fabs(d)) < 1e-6, (
+            "c=True %s disagrees with c=False by %g near a turning point"
+            % (name, numpy.max(numpy.fabs(d)))
+        )
+    return None
+
+
 def test_actionAngleStaeckel_actions_order():
     from galpy.actionAngle import actionAngleStaeckel
     from galpy.orbit import Orbit


### PR DESCRIPTION
Fixes a long-standing accuracy defect of the C `actionAngleStaeckel` frequency and angle computation, found while validating stream-modeling accuracy against exact orbits (where true angles are exactly linear in time and frequencies are constants). Requested by Jo after diagnosis; the full investigation trail lives in the fast-orbits working notes.

### The defect, two layers

**1. Near-turning evaluation points were adopted as the turning point.** When the evaluation point sits within `|p²| < 1e-7` of a turning point, `calcUminUmax`/`calcVmin` skipped the root solve and set `umax = ux` (resp. `vmin = vx`). The O(ε) endpoint error enters the **actions** only at O(ε^1.5) — ~1e-12, which is why every action-based validation passed for years — but the frequency and angle integrands diverge as 1/√W at the endpoint, so it enters **them** at O(√ε): measured up to **6.2e-5 rms in θ_z** along an exact KuzminKutuzov orbit (a −3.7e-4 pointwise spike at the sample 1e-8 from its vertical turning point) and **2.1e-4 in Ω_z orbit-constancy** — order-independent, i.e. converged to the wrong values.

**2. Absolute ~1e-12 root tolerances meet endpoint-clustered quadrature nodes.** High-order Gauss-Legendre nodes sample the √-regularized integrands within ~1e-13 of the endpoint, where a 5e-13 turning-point error is O(1) on the integrand — leaving an order-*growing* angle error (~2e-7 converged plateau) even for generic points far from turning points.

### The fix

- In the near-turning branches: **solve for the true root** in the ±1e-6 bracket — the branch condition itself guarantees the sign change — keeping the point-as-turning-point assignment only as the degenerate `GSL_EINVAL` fallback (a point exactly at a double root, e.g. shell orbits).
- `fmax(·, 0.)` guards on the six incomplete-integral `sqrt` limits, since roundoff can now put an evaluation point marginally beyond the exactly-solved root.
- All root tolerances in the file tightened from ~1e-12-absolute to machine-relative.

### Measured (KuzminKutuzov, order=100, exact orbit; on top of #1404's chi quadrature)

| | before | after |
|---|---|---|
| θ_R rms nonlinearity | 4.2e-7 | **1.6e-12** |
| θ_z rms nonlinearity | 6.2e-5 | **2.6e-12** |
| Ω_z orbit-constancy | 2.1e-4 | **1.4e-11** |
| actions (ptp/med) | 5.7e-11 | 5.7e-11 |
| c=False reference | 3e-12 | 3e-12 |

That is machine level, matching the exact Python path: #1404's chi-anomaly quadrature regularized the integrand and this PR locates its endpoints exactly — both were needed, and together they close the defect completely.

### Tests

The new `test_actionAngleStaeckel_c_angles_freqs_near_turning_point` pins a literal orbit sample 1e-8 from its vertical turning point (deterministic on every platform) and asserts frequency orbit-constancy (< 1e-8) and pointwise c=True-vs-c=False angle agreement (< 1e-6). It fails on the previous code at 1.6e-6 (Ω_R constancy, generic samples) and 3.7e-4 (near-turning θ_z). The full forward-Staeckel battery (73 tests) passes on the fixed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
