### PR TITLE
actionAngleStaeckelInverse: u0-only adaptation — fixed delta, u0(E, L_z)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -258,11 +258,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             raise ValueError("the only string value delta= accepts is 'fit'")
         if self._u0_fit and u0 != "fit":
             raise ValueError("the only string value u0= accepts is 'fit'")
-        if self._u0_fit and not (self._delta_fit or callable(delta)):
-            raise TypeError(
-                "u0='fit' is only meaningful together with delta='fit' or a "
-                "callable delta(E, Lz)"
-            )
         self._delta_func = delta if callable(delta) else None
         self._u0_func = u0 if callable(u0) else None
         if self._delta_fit and not setup_interp:
@@ -275,10 +270,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 "a callable delta(E, Lz) builds an adaptive interpolated "
                 "family and therefore requires setup_interp=True"
             )
-        if self._u0_func is not None and self._delta_func is None:
+        if (self._u0_func is not None or self._u0_fit) and not setup_interp:
             raise TypeError(
-                "a callable u0(E, Lz) is only meaningful together with a "
-                "callable delta(E, Lz)"
+                "an adaptive u0 (callable or 'fit') builds an adaptive "
+                "interpolated family and therefore requires setup_interp=True"
             )
         actionAngleInverse.__init__(self, **kwargs)
         if pot is None:
@@ -325,10 +320,14 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 if u0ref is None
                 else OblateStaeckelWrapperPotential(pot=pot, delta=dref, u0=u0ref)
             )
-        elif delta is not None or u0 is not None:
+        elif delta is not None or (
+            u0 is not None and not callable(u0) and not self._u0_fit
+        ):
             # the convenience spelling for a RAW potential; a potential that
             # already supplies its focal distance makes a scalar delta= (or
-            # u0=) ambiguous, and stays an error as before
+            # u0=) ambiguous, and stays an error as before -- an ADAPTIVE u0
+            # (callable or 'fit') is not the convenience spelling, so it
+            # falls through to the potential-supplied focal length below
             if isinstance(pot, OblateStaeckelWrapperPotential) or (
                 getattr(pot, "_delta", None) is not None
             ):
@@ -339,11 +338,14 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 )
             if delta is None:
                 raise TypeError("u0= requires delta= as well")
+            # an adaptive u0 leaves the reference wrapper's u0 at its
+            # default; every node of the grid gets its own
+            u0_scalar = None if callable(u0) or self._u0_fit else u0
             self._staeckelwrap = (
                 OblateStaeckelWrapperPotential(pot=pot, delta=float(delta))
-                if u0 is None
+                if u0_scalar is None
                 else OblateStaeckelWrapperPotential(
-                    pot=pot, delta=float(delta), u0=float(u0)
+                    pot=pot, delta=float(delta), u0=float(u0_scalar)
                 )
             )
         elif isinstance(pot, OblateStaeckelWrapperPotential):
@@ -359,6 +361,27 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 )
             self._staeckelwrap = OblateStaeckelWrapperPotential(pot=pot, delta=delta)
         self._delta = self._staeckelwrap._delta
+        if self._u0_fit and self._u0_func is None:
+            # u0='fit' with a FIXED focal length: the reference curve at the
+            # zero-velocity R-midpoint of each (E, L_z) -- the same rule the
+            # delta='fit' companion uses -- with no |dPhi| survey at all,
+            # because the focal length is not being optimized.  Measured on
+            # MWPotential2014: this placement carries most of the adaptive
+            # win (the optimal delta is nearly universal there, while u0
+            # placement matters by factors of a few to ~30).
+            self._u0_func = _u0_midpoint_fun(
+                self._pot,
+                conversion.parse_length(Rmin, ro=self._ro),
+                conversion.parse_length(Rmax, ro=self._ro),
+                lambda E, Lz, _d=float(self._delta): _d,
+            )
+        # a chart that varies across the family in ANY parameter builds
+        # per-node wrappers and runs its label relations chart-locally;
+        # only a varying delta needs the compensation term, because u0 is
+        # construction-only gauge (the map's (R, z) <-> (u, v) uses delta
+        # alone), so the stored delta row of a u0-only family is constant
+        # and its chain contribution vanishes identically
+        self._adaptive_chart = self._delta_func is not None or self._u0_func is not None
         # I3 has the dimensions of an energy in the convention used here
         self._Es = conversion._parse_grid_quantity(
             Es, conversion.parse_energy, vo=self._vo
@@ -1537,7 +1560,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             Emax = Phiinf + Lz**2.0 / 2.0 / Rinf**2.0
             kin = (vRp**2.0 + vTp**2.0 + vzp**2.0) / 2.0
             _save = None
-            if self._delta_func is not None:
+            if self._adaptive_chart:
                 # place the point's chart with the raw-potential energy: the
                 # chart surfaces are smooth, so the O(model error) difference
                 # from the wrapper energy is immaterial for the box
@@ -1663,7 +1686,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         self._canon_wpad = wpad
         self._canon_ushell = numpy.empty((nLz, nE))
         Es, Lzs, I3s = (numpy.empty(shape) for _ in range(3))
-        if self._delta_func is not None:
+        if self._adaptive_chart:
             self._canon_deltas = numpy.empty((nLz, nE))
             self._canon_wraps = [[None] * nE for _ in range(nLz)]
             self._delta_ref, self._wrap_ref = self._delta, self._staeckelwrap
@@ -1677,10 +1700,14 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             )
             for jj, wE in enumerate(self._wEgrid):
                 E = Ec + wE**2.0 * (Emax - Ec)
-                if self._delta_func is not None:
+                if self._adaptive_chart:
                     # the node's own chart: swap it in for the label
                     # relations, which probe W_u in the node's wrapper
-                    dnode = float(self._delta_func(E, Lz))
+                    dnode = (
+                        self._delta_ref
+                        if self._delta_func is None
+                        else float(self._delta_func(E, Lz))
+                    )
                     self._canon_deltas[ii, jj] = dnode
                     u0node = (
                         None if self._u0_func is None else float(self._u0_func(E, Lz))
@@ -1700,7 +1727,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 Lzs[ii, jj] = Lz
                 I3s[ii, jj] = Ipl + sinw * (Ish - Ipl)
                 self._canon_ushell[ii, jj] = ushell
-        if self._delta_func is None:
+        if not self._adaptive_chart:
             grid = actionAngleStaeckelInverse(
                 pot=self._staeckelwrap,
                 Es=Es.ravel(),
@@ -2045,7 +2072,11 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         because consecutive calls cluster on few charts -- and return the
         previous (wrapper, delta) for the caller's finally block"""
         _save = (self._staeckelwrap, self._delta)
-        dloc = float(self._delta_func(E, Lz))
+        dloc = (
+            float(self._delta)
+            if self._delta_func is None
+            else float(self._delta_func(E, Lz))
+        )
         u0loc = None if self._u0_func is None else float(self._u0_func(E, Lz))
         key = (round(dloc, 10), None if u0loc is None else round(u0loc, 10))
         if getattr(self, "_chart_cache_key", None) != key:
@@ -2088,7 +2119,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 f"E = {E} lies outside the grid: above the energies covered "
                 f"at L_z = {Lz}; increase Rinf"
             )
-        if self._delta_func is not None:
+        if self._adaptive_chart:
             # I3 is chart-defined, so the label relations must run in the
             # LOCAL chart at this (E, L_z) -- the same smooth surfaces the
             # nodes were built from, so labels and tables are consistent
@@ -2097,7 +2128,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             Ipl = self._I3_planar(E, Lz)
             Ish = self._I3_shell(E, Lz)
         finally:
-            if self._delta_func is not None:
+            if self._adaptive_chart:
                 self._staeckelwrap, self._delta = _save
         sfrac = numpy.clip((I3 - Ipl) / (Ish - Ipl), 0.0, 1.0)
         wI = 2.0 / numpy.pi * numpy.arcsin(numpy.sqrt(sfrac))
@@ -2786,6 +2817,30 @@ def _fit_staeckel_surface(pot, Rmin, Rmax, Rinf, nsub=6, rms_warn=0.05):
         return float(numpy.arcsinh(Rm / dfun(Ev, Lzv)))
 
     return dfun, u0fun, {"nodes": dat, "coeffs": c, "rms": rms, "clip": (lo, hi)}
+
+
+def _u0_midpoint_fun(pot, Rmin, Rmax, dfun):
+    """The zero-velocity R-midpoint reference curve: u0(E, L_z) placing
+    delta*sinh(u0) at the middle of the (planar) radial range of the
+    (E, L_z) orbit family, with the focal length supplied by dfun"""
+
+    def phieff(R, z, Lz):
+        return (
+            evaluatePotentials(pot, R, z, use_physical=False) + Lz**2.0 / 2.0 / R**2.0
+        )
+
+    def u0fun(Ev, Lzv):
+        Lzv = numpy.fabs(Lzv)
+        try:
+            Rc = rl(pot, Lzv, use_physical=False)
+            Rp = brentq(lambda R: phieff(R, 0.0, Lzv) - Ev, 0.02 * Rc, Rc)
+            Ra = brentq(lambda R: phieff(R, 0.0, Lzv) - Ev, Rc, 40.0 * Rc)
+            Rm = 0.5 * (Rp + Ra)
+        except Exception:
+            Rm = 0.5 * (Rmin + Rmax)
+        return float(numpy.arcsinh(Rm / dfun(Ev, Lzv)))
+
+    return u0fun
 
 
 def _parse_target(target):

--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -361,6 +361,15 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 )
             self._staeckelwrap = OblateStaeckelWrapperPotential(pot=pot, delta=delta)
         self._delta = self._staeckelwrap._delta
+        # the potential the per-node charts wrap: a chart is always built on
+        # the RAW potential -- rewrapping an OblateStaeckelWrapperPotential
+        # would Staeckelize the Staeckelization, a different (and much more
+        # expensive) model than intended
+        self._chart_pot = (
+            self._pot._pot
+            if isinstance(self._pot, OblateStaeckelWrapperPotential)
+            else self._pot
+        )
         if self._u0_fit and self._u0_func is None:
             # u0='fit' with a FIXED focal length: the reference curve at the
             # zero-velocity R-midpoint of each (E, L_z) -- the same rule the
@@ -370,7 +379,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             # win (the optimal delta is nearly universal there, while u0
             # placement matters by factors of a few to ~30).
             self._u0_func = _u0_midpoint_fun(
-                self._pot,
+                self._chart_pot,
                 conversion.parse_length(Rmin, ro=self._ro),
                 conversion.parse_length(Rmax, ro=self._ro),
                 lambda E, Lz, _d=float(self._delta): _d,
@@ -1713,10 +1722,10 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                         None if self._u0_func is None else float(self._u0_func(E, Lz))
                     )
                     self._canon_wraps[ii][jj] = (
-                        OblateStaeckelWrapperPotential(pot=self._pot, delta=dnode)
+                        OblateStaeckelWrapperPotential(pot=self._chart_pot, delta=dnode)
                         if u0node is None
                         else OblateStaeckelWrapperPotential(
-                            pot=self._pot, delta=dnode, u0=u0node
+                            pot=self._chart_pot, delta=dnode, u0=u0node
                         )
                     )
                     self._staeckelwrap = self._canon_wraps[ii][jj]
@@ -2081,9 +2090,11 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         key = (round(dloc, 10), None if u0loc is None else round(u0loc, 10))
         if getattr(self, "_chart_cache_key", None) != key:
             self._chart_cache = (
-                OblateStaeckelWrapperPotential(pot=self._pot, delta=dloc)
+                OblateStaeckelWrapperPotential(pot=self._chart_pot, delta=dloc)
                 if u0loc is None
-                else OblateStaeckelWrapperPotential(pot=self._pot, delta=dloc, u0=u0loc)
+                else OblateStaeckelWrapperPotential(
+                    pot=self._chart_pot, delta=dloc, u0=u0loc
+                )
             )
             self._chart_cache_key = key
         self._staeckelwrap, self._delta = self._chart_cache, dloc

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -10408,6 +10408,124 @@ def test_actionAngleStaeckelInverse_target_box_adaptive():
     return None
 
 
+def test_actionAngleStaeckelInverse_u0only_adaptive():
+    # u0-only adaptation: fixed focal length, adaptive u0(E, L_z) reference
+    # curve. Measured motivation on MWPotential2014: the |dPhi|-optimal
+    # delta is nearly universal while u0 placement carries factors of a few
+    # to ~30 of model quality; and u0 is construction-only GAUGE -- the
+    # map's (R, z) <-> (u, v) uses delta alone -- so a fixed-delta family
+    # needs no chart compensation at all: the stored delta row must come
+    # out constant, and canonicity must hold with no new terms.
+    import numpy
+    import pytest
+
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        _parse_target,
+        actionAngleStaeckelInverse,
+    )
+    from galpy.potential import KuzminKutuzovStaeckelPotential
+
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    aASI = actionAngleStaeckelInverse(
+        pot=kkp,
+        u0=lambda E, Lz: 1.05 + 0.10 * numpy.tanh(Lz),
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=4,
+        nE=4,
+        nI3=4,
+    )
+    # the delta row is CONSTANT: u0 never enters the map, only the build
+    row = 6 + 2 * aASI._npt
+    assert numpy.ptp(aASI._canon_tab_raw[row]) == 0.0, (
+        "a u0-only family's stored focal length is not constant"
+    )
+    # but the nodes genuinely differ in their reference curve
+    u0s = [aASI._canon_wraps[a][b]._u0 for a in (0, 3) for b in (0, 3)]
+    assert max(u0s) - min(u0s) > 0.01, (
+        "the u0-only family did not vary its reference curve"
+    )
+    # exactly canonical with zero new compensation terms
+    Lz = float(aASI._Lzgrid[2])
+    defect = _staeckel_symplectic_defect(aASI._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0)
+    assert defect < 3e-8, "a u0-only family is not exactly canonical: %g" % defect
+    # u0='fit' with a fixed focal length: the zero-velocity midpoint rule,
+    # no |dPhi| survey involved
+    aASIf = actionAngleStaeckelInverse(
+        pot=kkp,
+        u0="fit",
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=4,
+        nE=4,
+        nI3=4,
+    )
+    defect = _staeckel_symplectic_defect(aASIf._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0)
+    assert defect < 3e-8, "a u0='fit' family is not exactly canonical: %g" % defect
+    # the midpoint rule is sane on the grid and falls back gracefully off it
+    E22 = float(aASIf._canon_tab_raw[2][2, 2, 0])
+    assert 0.3 < aASIf._u0_func(E22, Lz) < 3.0, "the midpoint u0 is not sane"
+    assert numpy.isfinite(aASIf._u0_func(1e10, Lz)), (
+        "the midpoint rule does not fall back for an unbracketable energy"
+    )
+    # the chart-local label relations run under u0-only adaptivity
+    x = aASIf._canon_coords_integrals(E22, Lz, 0.1)
+    assert numpy.all(numpy.isfinite(x)), (
+        "chart-local integrals labels failed for a u0-only family"
+    )
+    # and so does the target box
+    aASIf._target = _parse_target([1.1, 0.15, 1.1, 0.1, 0.08])
+    aASIf._target_pad, aASIf._target_minwidth = 1.5, 0.02
+    box = aASIf._target_box(0.7, 1.6, 8.0, 0.02)
+    assert box[2][0] is None or 0.0 < box[2][0] < 1.0, (
+        "the target box failed for a u0-only family"
+    )
+    # guards: adaptive u0 needs the interpolated family
+    with pytest.raises(TypeError, match="requires setup_interp"):
+        actionAngleStaeckelInverse(pot=kkp, u0=lambda E, Lz: 1.0, Es=[0.5])
+    with pytest.raises(TypeError, match="requires setup_interp"):
+        actionAngleStaeckelInverse(pot=kkp, u0="fit", Es=[0.5])
+    return None
+
+
+def test_actionAngleStaeckelInverse_u0only_rawpot():
+    # the convenience spelling still works alongside an adaptive u0: a RAW
+    # potential with scalar delta= and callable u0= builds its reference
+    # wrapper at the DEFAULT u0 (each node gets its own), rather than
+    # trying to call float() on the callable
+    import numpy
+
+    from galpy.actionAngle.actionAngleStaeckelInverse import (
+        actionAngleStaeckelInverse,
+    )
+    from galpy.potential import LogarithmicHaloPotential
+
+    lp = LogarithmicHaloPotential(normalize=1.0, q=0.9)
+    aASI = actionAngleStaeckelInverse(
+        pot=lp,
+        delta=0.8,
+        u0=lambda E, Lz: 1.1 + 0.05 * numpy.tanh(E),
+        setup_interp=True,
+        Rmin=0.8,
+        Rmax=1.4,
+        Rinf=5.0,
+        nLz=3,
+        nE=3,
+        nI3=3,
+    )
+    assert numpy.fabs(aASI._staeckelwrap._u0 - numpy.arcsinh(1.0 / 0.8)) < 1e-12, (
+        "the reference wrapper's u0 moved off its default"
+    )
+    assert (
+        numpy.ptp([aASI._canon_wraps[a][b]._u0 for a in (0, 2) for b in (0, 2)]) > 0.0
+    ), "the nodes did not get their own u0"
+    return None
+
+
 def test_actionAngleStaeckelInverse_adaptive_delta_canonical():
     # The focal length may vary across the family -- delta(E, L_z), the
     # adaptive-Staeckel design -- provided the compensation carries its
@@ -10532,7 +10650,9 @@ def test_actionAngleStaeckelInverse_adaptive_construction():
     assert "setup_interp" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
         actionAngleStaeckelInverse(pot=kkp, u0=lambda E, Lz: 1.0, Es=[0.5])
-    assert "only meaningful" in str(excinfo.value)
+    # a callable u0 alone is now the u0-only adaptive mode, which (like any
+    # adaptive family) requires the interpolated setup
+    assert "setup_interp" in str(excinfo.value)
     # the integrals entry point runs in the LOCAL chart at (E, L_z), the
     # same smooth surface the nodes were built from
     Eq = float(aASI._canon_tab_raw[2][2, 2, 2])
@@ -10597,7 +10717,8 @@ def test_actionAngleStaeckelInverse_adaptive_construction():
     assert "only string value" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
         actionAngleStaeckelInverse(pot=kkp, u0="fit", Es=[0.5])
-    assert "only meaningful" in str(excinfo.value)
+    # u0='fit' alone is now the u0-only adaptive mode: interp-only as well
+    assert "setup_interp" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         actionAngleStaeckelInverse(
             pot=kkp, delta="fit", u0="midplane", setup_interp=True

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -10484,6 +10484,25 @@ def test_actionAngleStaeckelInverse_u0only_adaptive():
     assert box[2][0] is None or 0.0 < box[2][0] < 1.0, (
         "the target box failed for a u0-only family"
     )
+    # a WRAPPED potential with adaptive u0 must unwrap for its node charts:
+    # rewrapping would Staeckelize the Staeckelization
+    from galpy.potential import OblateStaeckelWrapperPotential
+
+    wkk = OblateStaeckelWrapperPotential(pot=kkp, delta=1.3)
+    aASIw = actionAngleStaeckelInverse(
+        pot=wkk,
+        u0=lambda E, Lz: 1.05 + 0.10 * numpy.tanh(Lz),
+        setup_interp=True,
+        Rmin=0.7,
+        Rmax=1.6,
+        Rinf=8.0,
+        nLz=3,
+        nE=3,
+        nI3=3,
+    )
+    assert aASIw._canon_wraps[0][0]._pot is kkp, (
+        "the node charts wrap the wrapper instead of the raw potential"
+    )
     # guards: adaptive u0 needs the interpolated family
     with pytest.raises(TypeError, match="requires setup_interp"):
         actionAngleStaeckelInverse(pot=kkp, u0=lambda E, Lz: 1.0, Es=[0.5])


### PR DESCRIPTION
Stacked on #1423 (stack #1397). The u0-only adaptive mode: a fixed focal length with an adaptive reference curve u0(E, L_z) — measured to be where most of the adaptive win actually lives, at a fraction of the machinery.

### The measurements that motivated it (2026-09-04, with Jo)

Scanning (δ, u0) against in-chart integral conservation along true MWPotential2014 orbits:

- **The |ΔΦ|-optimal δ is nearly universal** — ≈0.45–0.49 for inner (R≈0.45), disk (R≈1), and outer (R≈2) orbits alike (the inner optimum is sharply bracketed: δ=0.60 is already 4× worse). What actually varies from orbit to orbit is where the reference curve R0 = δ·sinh(u0) should sit.
- **u0 placement carries factors of a few to ~30**: keeping δ=0.4933 everywhere and only moving R0 to the orbit gives 3.2× (inner) and 6.7× (outer) better model quality; the u0 scans span ~30× on the outer orbit.
- The near-spherical limit (δ→0) does *not* rescue the inner MW — at R≈0.45 the disk's flattening dominates the non-sphericity, so small δ is ~10× worse than δ≈0.45.
- High-z stays at ~4e-3 under every (δ, u0): the genuine non-Stäckel residual of the model class.

### Why it is structurally free

u0 is construction-only **gauge**: the map's (R, z) ↔ (u, v) uses δ alone, so a fixed-δ family stores a constant δ row whose chain contribution vanishes identically — no compensation terms, nothing new for canonicity to survive. Measured: symplectic defect **9.5e-10** on a u0-varying KuzminKutuzov family, at the clean-family floor.

### API

`u0=` now stands alone (interp-only, like every adaptive spelling): a callable `u0(E, L_z)`, or `'fit'` for the zero-velocity midpoint rule — shared with the `delta='fit'` companion through the new `_u0_midpoint_fun`, and involving **no |ΔΦ| survey at all** (nothing is being optimized; the placement rule is closed-form up to two bracketed root-finds). Works with a δ-supplying potential (wrapper or `_delta` attribute) or with scalar `delta=` on a raw potential; the scalar convenience spelling and its ambiguity guard are unchanged. The family-build and label-relation gates generalize from δ-adaptivity to chart-adaptivity (`_adaptive_chart`), so chart-local `integrals=True` and `target=` compose with the new mode.

### Tests

The u0-only family: constant δ row (`ptp == 0` asserted), varying node u0, defect < 3e-8 for both the callable and `'fit'` spellings, the midpoint rule's off-grid fallback, chart-local labels and target-box composition, both interp-only guards, and the raw-potential + scalar-δ + callable-u0 spelling (reference wrapper stays at the default u0). All new lines covered, no pragmas.

### The deconfounding verdict (same tori, V2 metric)

| torus | fixed | u0-only | δ='fit' |
|---|---|---|---|
| benign | 1.49e-4 | 1.45e-4 | 2.63e-4 |
| moderate | 9.66e-4 | 8.56e-4 | 3.77e-3 |
| eccentric | 5.24e-3 | 5.08e-3 | 7.28e-3 |
| high-z | 4.26e-3 | 4.56e-3 | 3.94e-3 |

Near R = 1 (all four V2 tori) u0-only ties fixed within 7% — exactly as the anatomy predicts, since the default reference curve already sits there. On a **wide grid** (R ∈ [0.4, 2.2], 13³, same metric) the mode delivers where it should: inner torus (R≈0.5) 5.87e-3 → **2.35e-3** (2.5×), outer (R≈2) 2.78e-3 → **8.14e-4** (3.4×), mid tie — and the u0-only build is *faster* (300 vs 365 s). The internal `delta='fit'` hurts on three of four (the global quadratic surface again; caveat posted on #1421). Practical guidance: fixed δ by default, `u0='fit'` for wide radial ranges, `delta='fit'` for the exact-Stäckel self-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
