### PR TITLE
actionAngleStaeckelInverse: a single focal length, like the forward code

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckelInverse.py
+++ b/galpy/actionAngle/actionAngleStaeckelInverse.py
@@ -240,6 +240,27 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             that axis's default span -- what keeps the box of a single
             orbit, whose spread is zero on every axis, a grid rather than
             a point.
+        delta : float or Quantity, optional
+            Focal length of the prolate spheroidal coordinate system, as a
+            convenience for a RAW potential (which is then wrapped in an
+            OblateStaeckelWrapperPotential); conflicts with a potential
+            that already supplies its focal distance. The family always
+            uses a SINGLE focal length, like the forward
+            actionAngleStaeckel; a varying delta(E, L_z) remains a
+            documented possibility -- the map stores delta as a table row
+            and carries its chain, so the format supports it -- but has no
+            constructor spelling.
+        u0 : float, callable, or 'fit', optional
+            Reference u of the Staeckelization, whose curve
+            R0 = delta sinh(u0) is where the wrapped model is most
+            accurate. A scalar is the convenience spelling together with
+            delta= on a raw potential. A callable u0(E, L_z) or 'fit'
+            builds an adaptive family whose reference curve varies across
+            the grid (requires setup_interp=True): 'fit' places R0 at the
+            zero-velocity R-midpoint of each (E, L_z), which is measured
+            to carry most of the adaptive win -- at no cost to canonicity,
+            because u0 is construction-only gauge and the map's
+            (R, z) <-> (u, v) uses delta alone.
 
         Notes
         -----
@@ -251,25 +272,22 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         """
         delta = kwargs.pop("delta", None)
         u0 = kwargs.pop("u0", None)
-        self._fit_nsub = kwargs.pop("fit_nsub", 6)
-        self._delta_fit = isinstance(delta, str)
+        if isinstance(delta, str) or callable(delta):
+            raise TypeError(
+                "a varying focal length (delta='fit' or a callable "
+                "delta(E, Lz)) is not supported: like the forward "
+                "actionAngleStaeckel, the family uses a SINGLE delta and "
+                "varies u0 (pass u0='fit' or a callable u0(E, Lz)); the "
+                "varying-delta construction remains a documented "
+                "possibility -- the map stores delta as a table row and "
+                "carries its chain, so the format supports it -- but no "
+                "constructor spelling currently fills that row with "
+                "varying values"
+            )
         self._u0_fit = isinstance(u0, str)
-        if self._delta_fit and delta != "fit":
-            raise ValueError("the only string value delta= accepts is 'fit'")
         if self._u0_fit and u0 != "fit":
             raise ValueError("the only string value u0= accepts is 'fit'")
-        self._delta_func = delta if callable(delta) else None
         self._u0_func = u0 if callable(u0) else None
-        if self._delta_fit and not setup_interp:
-            raise TypeError(
-                "delta='fit' builds an adaptive interpolated family and "
-                "therefore requires setup_interp=True"
-            )
-        if self._delta_func is not None and not setup_interp:
-            raise TypeError(
-                "a callable delta(E, Lz) builds an adaptive interpolated "
-                "family and therefore requires setup_interp=True"
-            )
         if (self._u0_func is not None or self._u0_fit) and not setup_interp:
             raise TypeError(
                 "an adaptive u0 (callable or 'fit') builds an adaptive "
@@ -279,48 +297,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         if pot is None:
             raise OSError("Must specify pot= for actionAngleStaeckelInverse")
         self._pot = pot
-        if self._delta_fit:
-            # the fitted surfaces: survey the |dPhi|-minimizing focal length
-            # over the grid's own (L_z, E) domain, fit a smooth quadratic,
-            # and use it exactly as a user-supplied callable
-            dfun, u0fun, self._deltafit_info = _fit_staeckel_surface(
-                pot,
-                conversion.parse_length(Rmin, ro=self._ro),
-                conversion.parse_length(Rmax, ro=self._ro),
-                conversion.parse_length(Rinf, ro=self._ro),
-                nsub=self._fit_nsub,
-            )
-            self._delta_func = dfun
-            if self._u0_func is None:
-                # fitted u0 unless the caller supplied their own callable;
-                # u0='fit' and u0=None mean the same thing here, since the
-                # fitted delta wants its matching reference curve
-                self._u0_func = u0fun
-        if self._delta_func is not None:
-            # the reference chart, used only by the pre-grid helpers; every
-            # node of the grid gets its own wrapper, and the evaluation reads
-            # the focal length from the stored table row
-            # probe the callables at a physically sensible reference point:
-            # the circular orbit at the middle of the radial range, so that a
-            # delta(E, L_z) or u0(E, L_z) built on rl/vcirc never sees the
-            # degenerate (0, 0) it may not be defined at
-            Rref = 0.5 * (
-                conversion.parse_length(Rmin, ro=self._ro)
-                + conversion.parse_length(Rmax, ro=self._ro)
-            )
-            Lzref = Rref * vcirc(pot, Rref, use_physical=False)
-            Eref = (
-                evaluatePotentials(pot, Rref, 0.0, use_physical=False)
-                + Lzref**2.0 / 2.0 / Rref**2.0
-            )
-            dref = float(self._delta_func(Eref, Lzref))
-            u0ref = None if self._u0_func is None else float(self._u0_func(Eref, Lzref))
-            self._staeckelwrap = (
-                OblateStaeckelWrapperPotential(pot=pot, delta=dref)
-                if u0ref is None
-                else OblateStaeckelWrapperPotential(pot=pot, delta=dref, u0=u0ref)
-            )
-        elif delta is not None or (
+        if delta is not None or (
             u0 is not None and not callable(u0) and not self._u0_fit
         ):
             # the convenience spelling for a RAW potential; a potential that
@@ -333,8 +310,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             ):
                 raise TypeError(
                     "delta= and u0= conflict with a potential that already "
-                    "supplies its focal distance; pass the raw potential, "
-                    "or a callable delta(E, Lz) for an adaptive family"
+                    "supplies its focal distance; pass the raw potential"
                 )
             if delta is None:
                 raise TypeError("u0= requires delta= as well")
@@ -371,10 +347,9 @@ class actionAngleStaeckelInverse(actionAngleInverse):
             else self._pot
         )
         if self._u0_fit and self._u0_func is None:
-            # u0='fit' with a FIXED focal length: the reference curve at the
-            # zero-velocity R-midpoint of each (E, L_z) -- the same rule the
-            # delta='fit' companion uses -- with no |dPhi| survey at all,
-            # because the focal length is not being optimized.  Measured on
+            # u0='fit': the reference curve at the zero-velocity R-midpoint
+            # of each (E, L_z), with no |dPhi| survey at all, because the
+            # focal length is not being optimized.  Measured on
             # MWPotential2014: this placement carries most of the adaptive
             # win (the optimal delta is nearly universal there, while u0
             # placement matters by factors of a few to ~30).
@@ -390,7 +365,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # construction-only gauge (the map's (R, z) <-> (u, v) uses delta
         # alone), so the stored delta row of a u0-only family is constant
         # and its chain contribution vanishes identically
-        self._adaptive_chart = self._delta_func is not None or self._u0_func is not None
+        self._adaptive_chart = self._u0_func is not None
         # I3 has the dimensions of an energy in the convention used here
         self._Es = conversion._parse_grid_quantity(
             Es, conversion.parse_energy, vo=self._vo
@@ -1712,11 +1687,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
                 if self._adaptive_chart:
                     # the node's own chart: swap it in for the label
                     # relations, which probe W_u in the node's wrapper
-                    dnode = (
-                        self._delta_ref
-                        if self._delta_func is None
-                        else float(self._delta_func(E, Lz))
-                    )
+                    dnode = self._delta_ref
                     self._canon_deltas[ii, jj] = dnode
                     u0node = (
                         None if self._u0_func is None else float(self._u0_func(E, Lz))
@@ -1841,9 +1812,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         # differentiated interpolant as every other stored quantity, so the
         # compensation's new term obeys the same no-separate-derivative
         # discipline as the rest of the map.
-        tab[6 + 2 * self._npt] = (
-            self._delta if self._delta_func is None else self._canon_deltas[:, :, None]
-        )
+        tab[6 + 2 * self._npt] = self._delta
         # the analytic limits at the degenerate edges: the vanishing action
         # is exactly zero, the degenerate oscillation's midpoint sits at its
         # analytic point (the shell u), and its anomaly map vanishes (both
@@ -2081,11 +2050,7 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         because consecutive calls cluster on few charts -- and return the
         previous (wrapper, delta) for the caller's finally block"""
         _save = (self._staeckelwrap, self._delta)
-        dloc = (
-            float(self._delta)
-            if self._delta_func is None
-            else float(self._delta_func(E, Lz))
-        )
+        dloc = float(self._delta)
         u0loc = None if self._u0_func is None else float(self._u0_func(E, Lz))
         key = (round(dloc, 10), None if u0loc is None else round(u0loc, 10))
         if getattr(self, "_chart_cache_key", None) != key:
@@ -2708,126 +2673,6 @@ class actionAngleStaeckelInverse(actionAngleInverse):
         dsupJ, Malpha = self._canon_dsup_dJ(ii)
         dDmu, dDmv = self._canon_dDm_dJ(ii, dsupJ, Malpha)
         return dsupJ, dDmu, dDmv
-
-
-def _fit_staeckel_surface(pot, Rmin, Rmax, Rinf, nsub=6, rms_warn=0.05):
-    """Survey the max|Phi_S - Phi|-minimizing focal length over the grid's
-    (L_z, E) domain and fit a smooth quadratic surface delta(E, L_z), with
-    the matching reference curve u0(E, L_z) at the zero-velocity R-midpoint.
-
-    The smoothness is load-bearing rather than cosmetic: the stored tables
-    are chart-valued, so they interpolate well across tori only if the chart
-    varies smoothly -- and near circular orbits the per-node optimum is
-    ill-defined (the objective flattens as the accessible region shrinks),
-    so the fit supplies the smooth extension there.  The survey therefore
-    samples eccentric energies only and lets the quadratic extend inward.
-    """
-
-    def phieff(R, z, Lz):
-        return (
-            evaluatePotentials(pot, R, z, use_physical=False) + Lz**2.0 / 2.0 / R**2.0
-        )
-
-    Lzlo = Rmin * vcirc(pot, Rmin, use_physical=False)
-    Lzhi = Rmax * vcirc(pot, Rmax, use_physical=False)
-    nodes = []
-    for Lz in numpy.linspace(Lzlo, Lzhi, nsub):
-        Rc = rl(pot, Lz, use_physical=False)
-        Ec = phieff(Rc, 0.0, Lz)
-        Emax = phieff(Rinf, 0.0, Lz)
-        for w in numpy.linspace(0.3, 0.95, nsub):
-            E = Ec + w**2.0 * (Emax - Ec)
-            try:
-                Rp = brentq(lambda R: phieff(R, 0.0, Lz) - E, 0.02 * Rc, Rc)
-                Ra = brentq(lambda R: phieff(R, 0.0, Lz) - E, Rc, 40.0 * Rc)
-            except ValueError:
-                continue
-            Rmid = 0.5 * (Rp + Ra)
-            pts = []
-            for R in numpy.linspace(Rp, Ra, 9):
-                try:
-                    zm = (
-                        brentq(lambda z: phieff(R, z, Lz) - E, 0.0, 3.0 * Ra)
-                        if phieff(R, 3.0 * Ra, Lz) > E
-                        else 3.0 * Ra
-                    )
-                except ValueError:
-                    zm = 0.3 * Ra
-                for z in numpy.linspace(0.0, 0.9 * zm, 4):
-                    pts.append((R, z))
-            pts = numpy.array(pts)
-            Ptrue = evaluatePotentials(pot, pts[:, 0], pts[:, 1], use_physical=False)
-
-            def _obj(d):
-                try:
-                    w_ = OblateStaeckelWrapperPotential(
-                        pot=pot, delta=d, u0=numpy.arcsinh(Rmid / d)
-                    )
-                    return float(
-                        numpy.max(
-                            numpy.fabs(
-                                evaluatePotentials(
-                                    w_, pts[:, 0], pts[:, 1], use_physical=False
-                                )
-                                - Ptrue
-                            )
-                            / numpy.fabs(Ptrue)
-                        )
-                    )
-                except Exception:
-                    return 1e3
-
-            res = minimize_scalar(
-                _obj, bounds=(0.1, 3.0), method="bounded", options={"xatol": 1e-3}
-            )
-            nodes.append((Lz, E, float(res.x), float(res.fun), Rmid))
-    if len(nodes) < 6:
-        raise RuntimeError(
-            "delta='fit' could not survey enough (L_z, E) nodes to fit a "
-            "surface; check Rmin/Rmax/Rinf"
-        )
-    dat = numpy.array(nodes)
-    L, E, D = dat[:, 0], dat[:, 1], dat[:, 2]
-    A = numpy.vstack([numpy.ones_like(L), L, E, L * E, L**2.0, E**2.0]).T
-    c = numpy.linalg.lstsq(A, D, rcond=None)[0]
-    rms = float(numpy.sqrt(numpy.mean((A @ c - D) ** 2.0)))
-    lo, hi = 0.8 * D.min(), 1.25 * D.max()
-    if rms > rms_warn:
-        warnings.warn(
-            "delta='fit': the fitted focal-length surface has rms residual "
-            f"{rms:.3f} against the per-node optima; the family remains "
-            "exactly canonical, but the Staeckel models may fit the "
-            "potential less well than per-node optimization could",
-            galpyWarning,
-        )
-
-    def dfun(Ev, Lzv):
-        Lzv = numpy.fabs(Lzv)
-        return float(
-            numpy.clip(
-                c[0]
-                + c[1] * Lzv
-                + c[2] * Ev
-                + c[3] * Lzv * Ev
-                + c[4] * Lzv**2.0
-                + c[5] * Ev**2.0,
-                lo,
-                hi,
-            )
-        )
-
-    def u0fun(Ev, Lzv):
-        Lzv = numpy.fabs(Lzv)
-        try:
-            Rc = rl(pot, Lzv, use_physical=False)
-            Rp = brentq(lambda R: phieff(R, 0.0, Lzv) - Ev, 0.02 * Rc, Rc)
-            Ra = brentq(lambda R: phieff(R, 0.0, Lzv) - Ev, Rc, 40.0 * Rc)
-            Rm = 0.5 * (Rp + Ra)
-        except Exception:
-            Rm = 0.5 * (Rmin + Rmax)
-        return float(numpy.arcsinh(Rm / dfun(Ev, Lzv)))
-
-    return dfun, u0fun, {"nodes": dat, "coeffs": c, "rms": rms, "clip": (lo, hi)}
 
 
 def _u0_midpoint_fun(pot, Rmin, Rmax, dfun):

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -10380,17 +10380,25 @@ def test_actionAngleStaeckelInverse_target_box_adaptive():
         nLz=4,
         nE=4,
         nI3=4,
-        delta=lambda E, Lz: 1.3 + 0.02 * numpy.tanh(E),
+        u0=lambda E, Lz: 1.05 + 0.10 * numpy.tanh(Lz),
         target=o(ts),
     )
     assert loc._targetbox is not None, "the target box was not recorded"
-    assert numpy.ptp(loc._canon_deltas) > 0.0, (
-        "the adaptive family did not vary its focal length"
+    # single delta: the family varies its reference curve, not its focal
+    # length
+    assert numpy.ptp(loc._canon_deltas) == 0.0, (
+        "a u0-only family's focal length is not constant"
     )
-    # a loose round trip: the deliberately non-optimal callable delta means
-    # the local Staeckel models differ from the true KK potential, and the
-    # forward labels (fixed delta = 1.3) sit in yet another chart, so the
-    # model mismatch dominates; this checks consistency, not a floor
+    # the target box is NARROW (a single orbit), so the callable varies
+    # only a little across it -- but it must vary
+    assert (
+        max(w._u0 for row_ in loc._canon_wraps for w in row_)
+        - min(w._u0 for row_ in loc._canon_wraps for w in row_)
+        > 1e-6
+    ), "the u0-only family did not vary its reference curve"
+    # a loose round trip: on an exactly Staeckel potential the wrapper at
+    # the true focal length is exact for ANY u0, so only the coarse 4^3
+    # grid limits this
     aAS = actionAngleStaeckel(pot=kkp, delta=1.3, c=False)
     jr, lz, jz, _, _, _, ar, ap, az = (
         float(numpy.atleast_1d(q)[0])
@@ -10612,91 +10620,37 @@ def test_actionAngleStaeckelInverse_adaptive_delta_canonical():
     return None
 
 
-def test_actionAngleStaeckelInverse_adaptive_construction():
-    # A REAL adaptive family: delta(E, L_z) varies by ~6% across the grid,
-    # every (L_z, E) node is built in its own wrapper (sharing one frozen
-    # isochrone, which the compensation's closed-form chains assume), and
-    # the map must come out exactly canonical -- the full PR-A + PR-B loop,
-    # not the injected-table shortcut.
+def test_actionAngleStaeckelInverse_single_delta():
+    # The family uses a SINGLE focal length, like the forward
+    # actionAngleStaeckel (which fixes delta and varies u0): the varying-
+    # delta construction was measured to lose to a hand-tuned constant
+    # (the global surface fit was the weak link) and was removed, while
+    # the map keeps storing delta as a table row and carrying its chain,
+    # so varying delta remains a documented possibility of the FORMAT.
     import numpy
-
-    from galpy.actionAngle import actionAngleStaeckelInverse
-    from galpy.potential import KuzminKutuzovStaeckelPotential
-
-    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
-
-    def dfun(E, Lz):
-        return 1.3 * (1.0 + 0.04 * numpy.tanh(E + 1.0) + 0.03 * numpy.tanh(Lz))
-
-    aASI = actionAngleStaeckelInverse(
-        pot=kkp,
-        delta=dfun,
-        setup_interp=True,
-        Rmin=0.7,
-        Rmax=1.6,
-        Rinf=8.0,
-        nLz=5,
-        nE=5,
-        nI3=5,
-    )
-    # the stored focal lengths are the callable's values, not a constant
-    row = 6 + 2 * aASI._npt
-    assert numpy.ptp(aASI._canon_tab_raw[row]) > 0.05, (
-        "The delta table did not pick up the callable's variation"
-    )
-    # the stored node deltas must BE the callable's values on the grid
-    assert numpy.all(
-        numpy.fabs(
-            aASI._canon_deltas
-            - dfun(
-                aASI._canon_tab_raw[2][:, :, 0],
-                aASI._Lzgrid[:, None] * numpy.ones((1, aASI._nE)),
-            )
-        )
-        < 1e-12
-    ), "The stored node deltas disagree with delta(E, L_z)"
-    # the map of the adaptively built family is exactly canonical
-    Lz = float(aASI._Lzgrid[2])
-    defect = _staeckel_symplectic_defect(aASI._xvFreqs, 0.06, Lz, 0.10, 2.0, 1.0, 2.0)
-    assert defect < 3e-8, (
-        "An adaptively constructed family is not canonical: %g" % defect
-    )
-    # guards: adaptive requires interpolation, and u0 alone is meaningless
     import pytest
 
-    with pytest.raises(TypeError) as excinfo:
-        actionAngleStaeckelInverse(pot=kkp, delta=dfun, Es=[0.5])
-    assert "setup_interp" in str(excinfo.value)
-    with pytest.raises(TypeError) as excinfo:
-        actionAngleStaeckelInverse(pot=kkp, u0=lambda E, Lz: 1.0, Es=[0.5])
-    # a callable u0 alone is now the u0-only adaptive mode, which (like any
-    # adaptive family) requires the interpolated setup
-    assert "setup_interp" in str(excinfo.value)
-    # the integrals entry point runs in the LOCAL chart at (E, L_z), the
-    # same smooth surface the nodes were built from
-    Eq = float(aASI._canon_tab_raw[2][2, 2, 2])
-    I3q = Lz**2 / (2.0 * aASI._canon_deltas[2, 2] ** 2) - Eq + 0.02
-    outq = aASI._xvFreqs(
-        Eq,
-        Lz,
-        I3q,
-        numpy.array([2.0]),
-        numpy.array([1.0]),
-        numpy.array([2.0]),
-        integrals=True,
-    )
-    assert numpy.all(
-        numpy.isfinite(numpy.array([float(numpy.atleast_1d(q)[0]) for q in outq[:6]]))
-    ), "The chart-local integrals entry point did not return a point"
-    # the scalar spelling: a raw potential is wrapped at the given focal
-    # length (and u0), while u0 alone stays meaningless
+    from galpy.actionAngle import actionAngleStaeckelInverse
     from galpy.potential import (
+        KuzminKutuzovStaeckelPotential,
         MWPotential2014,
         OblateStaeckelWrapperPotential,
         evaluatePotentials,
         rl,
     )
 
+    kkp = KuzminKutuzovStaeckelPotential(amp=4.0, ac=5.0, Delta=1.3)
+    # every varying-delta spelling is rejected, discrete and interpolated
+    # alike, with the pointer to what to use instead
+    for bad in ("fit", lambda E, Lz: 1.3):
+        with pytest.raises(TypeError, match="SINGLE delta"):
+            actionAngleStaeckelInverse(pot=kkp, delta=bad, Es=[0.5])
+        with pytest.raises(TypeError, match="SINGLE delta"):
+            actionAngleStaeckelInverse(pot=kkp, delta=bad, setup_interp=True)
+    # and a u0 string other than 'fit' stays rejected
+    with pytest.raises(ValueError, match="only string value u0="):
+        actionAngleStaeckelInverse(pot=kkp, u0="midplane", setup_interp=True)
+    # the scalar convenience spelling survives unchanged
     with pytest.raises(TypeError) as excinfo:
         actionAngleStaeckelInverse(pot=MWPotential2014, u0=1.1, Es=[-1.2])
     assert "requires delta" in str(excinfo.value)
@@ -10710,91 +10664,4 @@ def test_actionAngleStaeckelInverse_adaptive_construction():
     )
     assert numpy.fabs(scal._delta - 0.45) < 1e-14, "scalar delta= not honoured"
     assert numpy.fabs(scal._staeckelwrap._u0 - 1.1) < 1e-14, "u0= not honoured"
-    # delta='fit' surveys and fits the surface itself; on an exactly
-    # Staeckel potential it must REDISCOVER the true focal length, which is
-    # the end-to-end self-check of the whole fitting pipeline
-    fitf = actionAngleStaeckelInverse(
-        pot=kkp,
-        delta="fit",
-        setup_interp=True,
-        Rmin=0.7,
-        Rmax=1.6,
-        Rinf=8.0,
-        nLz=5,
-        nE=5,
-        nI3=5,
-        fit_nsub=4,
-    )
-    assert numpy.max(numpy.fabs(fitf._canon_deltas - 1.3)) < 5e-3, (
-        "delta='fit' did not rediscover KuzminKutuzov's focal length"
-    )
-    assert fitf._deltafit_info["rms"] < 5e-3, (
-        "the fitted surface has unexpected structure on an exact target"
-    )
-    with pytest.raises(ValueError) as excinfo:
-        actionAngleStaeckelInverse(pot=kkp, delta="fittt", setup_interp=True)
-    assert "only string value" in str(excinfo.value)
-    with pytest.raises(TypeError) as excinfo:
-        actionAngleStaeckelInverse(pot=kkp, u0="fit", Es=[0.5])
-    # u0='fit' alone is now the u0-only adaptive mode: interp-only as well
-    assert "setup_interp" in str(excinfo.value)
-    with pytest.raises(ValueError) as excinfo:
-        actionAngleStaeckelInverse(
-            pot=kkp, delta="fit", u0="midplane", setup_interp=True
-        )
-    assert "only string value u0=" in str(excinfo.value)
-    with pytest.raises(TypeError) as excinfo:
-        actionAngleStaeckelInverse(pot=kkp, delta="fit", Es=[0.5])
-    assert "setup_interp" in str(excinfo.value)
-    # the u0 surface falls back to the mid-radius when the requested energy
-    # has no zero-velocity bracket
-    assert numpy.isfinite(fitf._u0_func(-1e3, 1.0)), "u0 fallback broken"
-    # survey robustness: an Rinf so large that no apocentre brackets inside
-    # the search range leaves too few nodes, and that is an error, not a fit
-    from galpy.actionAngle.actionAngleStaeckelInverse import (
-        _fit_staeckel_surface,
-    )
-
-    with pytest.raises(RuntimeError) as excinfo:
-        _fit_staeckel_surface(kkp, 0.7, 1.6, 8.0, nsub=1)
-    assert "could not survey" in str(excinfo.value)
-    # a node whose apocentre fails to bracket is skipped, not fatal
-    import sys as _sys
-
-    _mod = _sys.modules["galpy.actionAngle.actionAngleStaeckelInverse"]
-    _realbq = _mod.brentq
-    _calls = {"n": 0}
-
-    def _flakybq(*a, **k):
-        _calls["n"] += 1
-        if _calls["n"] == 1:
-            raise ValueError("forced bracket failure")
-        return _realbq(*a, **k)
-
-    try:
-        _mod.brentq = _flakybq
-        _fit_staeckel_surface(kkp, 0.7, 1.6, 8.0, nsub=3)
-    finally:
-        _mod.brentq = _realbq
-    # a rough fitted surface draws a warning (thresholded, forced here)
-    with pytest.warns(galpyWarning):
-        _fit_staeckel_surface(kkp, 0.7, 1.6, 8.0, nsub=3, rms_warn=1e-12)
-
-    # and a focal length at which the wrapper cannot be built scores as a
-    # bad objective rather than crashing the minimizer
-    class _Fussy(_mod.OblateStaeckelWrapperPotential):
-        def __init__(self, *args, **kwargs):
-            if kwargs.get("delta", 1.0) > 1.6:
-                raise ValueError("no wrapper at this focal length")
-            super().__init__(*args, **kwargs)
-
-    orig = _mod.OblateStaeckelWrapperPotential
-    try:
-        _mod.OblateStaeckelWrapperPotential = _Fussy
-        dfun2, _, info2 = _fit_staeckel_surface(kkp, 0.7, 1.6, 8.0, nsub=3)
-    finally:
-        _mod.OblateStaeckelWrapperPotential = orig
-    assert numpy.fabs(dfun2(-0.3, 1.0) - 1.3) < 0.1, (
-        "the minimizer did not route around unbuildable focal lengths"
-    )
     return None


### PR DESCRIPTION
Stacked on #1426 (stack #1397). Removes the varying-δ construction, per the deconfounding: the family now uses a **single focal length and varies u0** — the same convention as the forward `actionAngleStaeckel`.

### Why

The measurements (fast-orbits notes, checks/stream_yardstick_checks.md §F and the deconfounding block):

- The |ΔΦ|-optimal δ is **nearly universal** on MWPotential2014 (~0.45–0.49 for inner, disk, and outer orbits alike); what varies orbit-to-orbit is where the reference curve R0 = δ·sinh(u0) sits — and `u0='fit'` (#1426) captures that at 2.5–3.4× on wide grids, compensation-free.
- The shipped `delta='fit'` **lost to a hand-tuned constant** on the very tori it was showcased on (up to 3.9× worse; the global quadratic surface was the recurring weak link — see the replication caveat on #1421).

### What is removed vs kept

**Removed**: the `delta='fit'` and callable `delta(E, L_z)` constructor spellings, `_fit_staeckel_surface` and its `fit_nsub` knob, and the fit-pipeline tests (−366 lines net). Nothing was ever released, so this is plain removal, not a deprecation cycle.

**Kept, deliberately**: the δ **table row and its compensation term** — identically zero for a constant row, and what makes the map manifestly canonical for *arbitrary* row content. The format therefore still supports a varying focal length (the math and measured results stay documented in `ADAPTIVE_STAECKEL_MATH.md`); a future varying-δ family needs only a constructor spelling to fill the row, should a potential ever warrant one. The rejection message says exactly this. The row-injection canonicity test (5% δ variation via the table, defect < 3e-8, severed-chain check) stays as the substrate's regression test.

Also: the `delta=` and `u0=` constructor parameters are now documented in the docstring — they never were, through the whole adaptive series.

### Tests

`test_..._single_delta`: every varying-δ spelling rejected (discrete and interpolated), the bad-u0-string guard re-homed, the scalar convenience spelling verified unchanged; `target_box_adaptive` now exercises a u0-only family (constant δ row asserted, reference curve varies). Full StaeckelInverse battery: 41 passed; module at 100%, no pragmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
