### PR TITLE
backend: keep the jax isinstance out of dynamo's way (unblocks #1204 on torch 2.14)

### DIFF
--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -70,19 +70,29 @@ def is_backend_array(x):
     pass-through branch keyed on this. Detection is by direct ``isinstance``
     against the public ``jax.Array`` / ``torch.Tensor`` base classes, gated on the
     optional-dependency flags so a numpy-only install never imports jax/torch.
+
+    torch is tested first, and the jax test is skipped entirely while dynamo is
+    tracing: ``jax.Array`` is an ABC, so ``isinstance`` against it runs
+    ``ABCMeta.__instancecheck__``, which torch 2.14 refuses to trace (a custom
+    type check may read external mutable state) and which therefore breaks any
+    ``fullgraph=True`` compile in an install that merely *has* jax. Nothing under
+    a torch trace can be a jax array, so the branch is dead there anyway.
     """
     if _is_python_scalar(x) or isinstance(x, (numpy.ndarray, numpy.generic)):
         return False
-    if _JAX_LOADED:
-        import jax
-
-        if isinstance(x, jax.Array):
-            return True
     if _TORCH_LOADED:
         import torch
 
         if isinstance(x, torch.Tensor):
             return True
+    if _JAX_LOADED:
+        from ._tracectx import is_compiling
+
+        if not is_compiling():
+            import jax
+
+            if isinstance(x, jax.Array):
+                return True
     return False
 
 
@@ -224,19 +234,26 @@ def under_torch_grad(*xs):
 
 
 def stop_gradient(x):
-    """Backend stop-gradient: identity (numpy), ``jax.lax.stop_gradient`` / ``.detach``."""
+    """Backend stop-gradient: identity (numpy), ``jax.lax.stop_gradient`` / ``.detach``.
+
+    torch first, and no jax ``isinstance`` under a dynamo trace -- see
+    ``is_backend_array`` for why that ordering is load-bearing.
+    """
     import sys
 
-    if "jax" in sys.modules:
-        import jax
-
-        if isinstance(x, jax.Array):
-            return jax.lax.stop_gradient(x)
     if "torch" in sys.modules:
         import torch
 
         if isinstance(x, torch.Tensor):
             return x.detach()
+    if "jax" in sys.modules:
+        from ._tracectx import is_compiling
+
+        if not is_compiling():
+            import jax
+
+            if isinstance(x, jax.Array):
+                return jax.lax.stop_gradient(x)
     return x
 
 

--- a/tests/test_backend_tracectx.py
+++ b/tests/test_backend_tracectx.py
@@ -191,3 +191,34 @@ def test_set_and_reset_survive_a_fullgraph_compile():
         )
     assert float(got) == 3.0  # the True branch ran, i.e. .get() saw the .set()
     assert var.get() is False  # and the trace left no residue behind
+
+
+@pytest.mark.skipif(torch is None, reason="torch not installed")
+def test_backend_predicates_compile_when_jax_is_merely_installed():
+    # torch 2.14 regression. is_backend_array/stop_gradient tested ``jax.Array``
+    # BEFORE ``torch.Tensor``; ``jax.Array`` is an ABC, so that isinstance runs
+    # ABCMeta.__instancecheck__, which dynamo refuses to trace on a tensor
+    # ("custom type check ... may read external mutable state"). Any install
+    # that merely HAS jax then broke every fullgraph compile -- which is exactly
+    # the CI backend shard, the one job that installs both frameworks.
+    jax = pytest.importorskip("jax", reason="the break needs jax INSTALLED")
+    assert "jax" in sys.modules  # the sys.modules gate stop_gradient reads
+    t = torch.tensor([1.0, 2.0], dtype=torch.float64)
+
+    def compiled(f):
+        torch._dynamo.reset()
+        with no_torch_compile_deprecations():
+            return torch.compile(f, fullgraph=True, dynamic=False)(t)
+
+    from galpy.backend._namespaces import (
+        is_backend_array,
+        stop_gradient,
+        under_jax_trace,
+    )
+
+    # a tensor is a backend array, and stays one through the trace
+    assert bool(compiled(lambda x: torch.tensor(is_backend_array(x))))
+    assert not bool(compiled(lambda x: torch.tensor(under_jax_trace(x))))
+    assert torch.equal(compiled(stop_gradient), t)
+    # and the jax branch still works outside a trace
+    assert is_backend_array(jax.numpy.asarray([1.0]))


### PR DESCRIPTION
Unblocks #1204, whose `tests/test_backend*.py` shard went red on
`test_forced_backend_survives_a_fullgraph_compile` with no galpy change behind it.

## Not a flake — a torch release

| run | date | torch | jax | result |
|---|---|---|---|---|
| 33446590776 | Aug 31 | **2.13.0** | 0.11.1 | pass |
| 33562177210 | Sep 1 | **2.14.0** | 0.11.1 | fail |

CI installs torch unpinned. Reproduced locally on both sides with the *same*
worktree: torch 2.12 → `12 passed`; torch 2.14 → the CI failure, same line,
same message.

## Cause

`is_backend_array` and `stop_gradient` both tested jax **before** torch.
`jax.Array` is an ABC, so `isinstance(x, jax.Array)` runs
`ABCMeta.__instancecheck__` — which dynamo 2.14 refuses to trace on a tensor
("custom type check ... may read external mutable state", gb2736), and
`fullgraph=True` turns any graph break into an error.

The gate is `_JAX_LOADED`, an *install* flag, so the jax branch runs whenever
jax is merely **installed**, whatever backend is active. `tests/test_backend*.py`
is the only shard that installs both frameworks — which is why one shard went
red and 40-odd others stayed green, and why it looked intermittent.

## Fix

Test torch first, and skip the jax branch entirely while dynamo is tracing:
nothing under a torch trace can be a jax array, so it is dead code there.
`torch.compiler.is_compiling()` folds to a constant during tracing, so the
branch disappears rather than breaking.

Order is not observable — a value cannot be both a `Tensor` and a `jax.Array` —
and the numpy paths return before reaching either branch, so numpy behaviour is
untouched.

## Audit of the same pattern

Compile-probed all four `isinstance`-against-jax sites under torch 2.14:

| site | verdict |
|---|---|
| `_namespaces.is_backend_array` | **broke** → fixed |
| `_namespaces.stop_gradient` | **broke** (latent, not yet hit by a test) → fixed |
| `_namespaces.under_jax_trace` | OK — `jax.core.Tracer` is a plain class |
| `random.py` key check | OK — never sees a tensor (`_TorchKey` is caught first) |

## Test

`test_backend_predicates_compile_when_jax_is_merely_installed` compiles all
three predicates with `fullgraph=True`. A/B'd: reverting only the source (test
kept) fails it; with the fix, `13 passed` under torch 2.14 and 2.12 both.

## Follow-up for a maintainer

Worth pinning a torch ceiling in the backend shard's install — this class of
break arrives with any minor release, and it landed mid-merge. That file is
`.github/workflows/**`, which I can't edit.