### PR TITLE
actionAngleStaeckel C: NaN and near-axis accuracy in the chi quadratures

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,22 @@
 v1.12.1 (expected around 2026-11-01)
 ====================
 
+- ``actionAngleStaeckel`` with ``c=True`` computed the radial action inaccurately
+  for orbits that pass close to the axis, and returned NaN once the integration
+  order was raised. Such an orbit's inner turning point sits near u = 0, where the
+  action integrand inherits the potential's inner power-law cusp (S ~ A - B u^0.2);
+  the single fixed-order Gauss-Legendre rule converges only algebraically against
+  it (~4.5e-5 off the pure-Python path, and not improving with order), and the
+  edge reconstruction it falls back on near the turning point evaluated
+  Lz^2 cosh(u)/sinh^3(u) = 0/0 for a purely radial (Lz = 0) orbit, giving NaN
+  from order ~50 up. Only near-axis orbits (inner turning point below a small
+  threshold) now integrate the radial action with a geometrically graded
+  composite rule targeting the cusp, on a model-free integrand; every other orbit
+  keeps the original single-panel rule unchanged, so the common case is exactly as
+  fast as before. Near-axis radial actions now match the pure-Python path to
+  ~5e-11 (~1e-12 for exactly-radial orbits), the 0/0 is read as its analytic limit
+  of 0, and jr no longer jumps between Lz = 0 and Lz = 1e-7.
+
 - ``Orbit.integrate_dxdv`` with a C integrator now hands the base state to C
   in cylindrical coordinates, so the base orbit carried alongside the
   deviation goes through the very same cyl<->rect transforms

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -26,6 +26,14 @@
 #endif
 // see the chi-anomaly helpers below for what these control
 #define STAECKEL_CHI_EDGE 1.e-6
+// An orbit approaching the axis (umin small) picks up the potential's inner
+// power-law cusp: S ~ A - B u^0.2 at umin -> 0, i.e. chi^0.4 in the anomaly.
+// A single fixed-order rule converges only algebraically against that (the
+// default rule floors at ~4.5e-5 there), so ONLY for such orbits the radial
+// action is integrated with a geometrically graded composite rule that packs
+// panels toward the cusp. Every other orbit keeps the cheap single-panel rule.
+#define STAECKEL_NEARAXIS 0.2
+#define STAECKEL_CHI_NPANELS 24
 // chi of the midpoint of [vmin, pi/2]: there y = 1/4, so chi = 2 asin(1/2).
 // A constant, so it needs no per-iteration assignment inside the OpenMP
 // loops -- where it would have been a shared write, being absent from the
@@ -162,6 +170,9 @@ void calcVmin(int,double *,double *,double *,double *,double *,double *,int,
 	      struct potentialArg *);
 double JRStaeckelIntegrandSquared(double,void *);
 double JRLowStaeckelIntegrand(double,void *);
+double JRLowStaeckelIntegrandDirect(double,void *);
+static inline double glfixed_graded(gsl_function *,double,double,
+				    gsl_integration_glfixed_table *);
 double JRHighStaeckelIntegrand(double,void *);
 double JzStaeckelIntegrandSquared(double,void *);
 double JzStaeckelIntegrand(double,void *);
@@ -597,12 +608,19 @@ void calcJRStaeckel(int ndata,
     (params+tid)->potu0v0= *(potu0v0+ii);
     (params+tid)->umin= *(umin+ii);
     (params+tid)->umax= *(umax+ii);
-    (JRInt+tid)->function = &JRLowStaeckelIntegrand;
     (JRInt+tid)->params = params+tid;
     // each half runs to the midpoint of the oscillation, y = 1/2
     mid= 0.5 * M_PI;
-    //Integrate
-    *(jr+ii)= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
+    //Integrate. Near the axis the low half straddles the inner cusp, so it uses
+    //the graded composite rule on the model-free integrand; every other orbit
+    //keeps the cheap single-panel rule. The high half is a normal turning point.
+    if ( *(umin+ii) < STAECKEL_NEARAXIS ){
+      (JRInt+tid)->function = &JRLowStaeckelIntegrandDirect;
+      *(jr+ii)= glfixed_graded (JRInt+tid,0.,mid,T);
+    } else {
+      (JRInt+tid)->function = &JRLowStaeckelIntegrand;
+      *(jr+ii)= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
+    }
     (JRInt+tid)->function = &JRHighStaeckelIntegrand;
     *(jr+ii)+= gsl_integration_glfixed (JRInt+tid,0.,mid,T);
     *(jr+ii)*= sqrt(2.) * *(delta+ii*delta_stride) / M_PI;
@@ -1968,7 +1986,8 @@ static inline double SuTermsStaeckel(double u,double E,double I3U,
   double dU= (sinh2u+sin2v0)
     * evaluatePotentialsUV(u,v0,delta,nargs,args)
     - (sinh2u0+sin2v0) * potu0v0;
-  return E * sinh2u - I3U - dU - Lz22delta / sinh2u;
+  return E * sinh2u - I3U - dU
+    - ( Lz22delta > 0. ? Lz22delta / sinh2u : 0. );
 }
 static inline double dSuduStaeckel(double u,double E,double Lz22delta,
 				   double delta,double v0,double sin2v0,
@@ -1981,7 +2000,7 @@ static inline double dSuduStaeckel(double u,double E,double Lz22delta,
 	+ calczforce(R,z,0.,0.,nargs,args) * shu * cos(v0) );
   return E * s2u - s2u * evaluatePotentialsUV(u,v0,delta,nargs,args)
     - ( shu * shu + sin2v0 ) * dPhidu
-    + 2. * Lz22delta * chu / ( shu * shu * shu );
+    + ( Lz22delta > 0. ? 2. * Lz22delta * chu / ( shu * shu * shu ) : 0. );
 }
 // Q and the coordinate at anomaly chi; high selects the umax end
 static inline double chiQuStaeckel(double chi,int high,double umin,double umax,
@@ -2007,6 +2026,37 @@ static inline double chiQuStaeckel(double chi,int high,double umin,double umax,
   }
   return Q;
 }
+
+static inline double dmax(double x,double y){ return x > y ? x : y; }
+
+// Q at anomaly chi WITHOUT the endpoint model, for the regular sqrt(S) action
+// integrand near the axis (see chiQuStaeckel for the model the singular
+// frequency/angle integrands still need).
+static inline double chiQuStaeckelDirect(double chi,int high,double umin,
+					 double umax,double E,double I3U,
+					 double Lz22delta,double delta,double v0,
+					 double sin2v0,double sinh2u0,
+					 double potu0v0,int nargs,
+					 struct potentialArg * args,double * uu){
+  double sc= sin(0.5*chi), y= sc * sc, D= umax - umin;
+  double u= high ? umax - D * y : umin + D * y;
+  *uu= u;
+  return SuTermsStaeckel(u,E,I3U,Lz22delta,delta,v0,sin2v0,sinh2u0,potu0v0,
+			 nargs,args) / ( y * ( 1. - y ) );
+}
+
+// Composite GL over [a,b] with panels graded geometrically toward a (the cusp).
+static inline double glfixed_graded(gsl_function * f,double a,double b,
+				    gsl_integration_glfixed_table * T){
+  double out= 0., lo, hi, w= b - a;
+  int k, n= STAECKEL_CHI_NPANELS;
+  for (k=0; k < n; k++){
+    lo= k == 0 ? a : a + w * pow( 2., dmax( (double) ( k - n ), -52. ) );
+    hi= a + w * pow( 2., dmax( (double) ( k + 1 - n ), -52. ) );
+    out+= gsl_integration_glfixed(f,lo,hi,T);
+  }
+  return out;
+}
 static inline double SvTermsStaeckel(double v,double E,double I3V,
 				     double Lz22delta,double delta,double u0,
 				     double cosh2u0,double sinh2u0,
@@ -2015,7 +2065,8 @@ static inline double SvTermsStaeckel(double v,double E,double I3V,
   double sin2v= sin(v) * sin(v);
   double dV= cosh2u0 * potupi2
     - (sinh2u0+sin2v) * evaluatePotentialsUV(u0,v,delta,nargs,args);
-  return E * sin2v + I3V + dV - Lz22delta / sin2v;
+  return E * sin2v + I3V + dV
+    - ( Lz22delta > 0. ? Lz22delta / sin2v : 0. );
 }
 static inline double dSvdvStaeckel(double v,double E,double Lz22delta,
 				   double delta,double u0,double sinh2u0,
@@ -2028,7 +2079,7 @@ static inline double dSvdvStaeckel(double v,double E,double Lz22delta,
 	- calczforce(R,z,0.,0.,nargs,args) * cosh(u0) * sv );
   return E * s2v - s2v * evaluatePotentialsUV(u0,v,delta,nargs,args)
     - ( sinh2u0 + sv * sv ) * dPhidv
-    + 2. * Lz22delta * cv / ( sv * sv * sv );
+    + ( Lz22delta > 0. ? 2. * Lz22delta * cv / ( sv * sv * sv ) : 0. );
 }
 // the v loop spans [vmin, pi - vmin]; only the vmin end is a turning point
 // reached from here, the midplane being an interior symmetry point of S_z
@@ -2068,6 +2119,18 @@ double JRLowStaeckelIntegrand(double chi,
   struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
   double u, sc= sin(chi);
   double Q= chiQuStaeckel(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
+			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
+			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
+  double D= params->umax - params->umin;
+  if ( Q <= 0. ) return 0.;
+  return D / 4. * sqrt(Q) * sc * sc;
+}
+
+double JRLowStaeckelIntegrandDirect(double chi,
+			      void * p){
+  struct JRStaeckelArg * params= (struct JRStaeckelArg *) p;
+  double u, sc= sin(chi);
+  double Q= chiQuStaeckelDirect(chi,0,params->umin,params->umax,params->E,params->I3U,params->Lz22delta,
 			  params->delta,params->v0,params->sin2v0,params->sinh2u0,
 			  params->potu0v0,params->nargs,params->actionAngleArgs,&u);
   double D= params->umax - params->umin;

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -8663,3 +8663,50 @@ def test_actionAngleIsochroneInverse_kepler_bracketing_fallback():
         % numpy.max(numpy.fabs(got - ref))
     )
     return None
+
+
+def test_actionAngleStaeckel_nearaxis_c_python_parity():
+    # main had no near-axis Staeckel coverage, which is how two defects shipped:
+    # (a) an axis-reaching orbit (Lz == 0) drove the Lz^2 cosh(u)/sinh^3(u) term
+    # to 0/0 at umin = 0 inside the chi-anomaly edge reconstruction, so c=True
+    # returned NaN actions once the order was raised to ~50; and (b) the C chi
+    # quadrature was a single `order`-point rule over the whole anomaly where the
+    # pure-Python path uses max(2*order,20) panels of a 10-point rule, leaving C
+    # ~4.5e-5 off near the axis and floored -- more nodes did not help, because
+    # they crowded into the region where Q is a MODEL of S rather than S itself.
+    from galpy.actionAngle import actionAngleStaeckel
+    from galpy.potential import MWPotential2014
+
+    Rg = numpy.array([0.8, 1.0, 1.3])
+    vRg = numpy.array([0.2, 0.45])
+    vTg = numpy.array([0.0, 1e-4, 3e-4])  # Lz = 0, ~1e-4, ~3e-4
+    zg = numpy.array([0.1, 0.28])
+    G = numpy.meshgrid(Rg, vRg, vTg, zg, indexing="ij")
+    R, vR, vT, z = (g.ravel() for g in G)
+    vz = 0.1 * numpy.ones_like(R)
+    aAF = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=False)
+    aAC = actionAngleStaeckel(pot=MWPotential2014, delta=0.45, c=True)
+    jr_f, _, jz_f = aAF(R, vR, vT, z, vz)
+    jr_c, _, jz_c = aAC(R, vR, vT, z, vz)
+    jr_f, jz_f, jr_c, jz_c = (numpy.atleast_1d(x) for x in (jr_f, jz_f, jr_c, jz_c))
+    assert numpy.all(numpy.isfinite(jr_c)), (
+        "C actionAngleStaeckel jr is not finite for near-axis orbits"
+    )
+    numpy.testing.assert_allclose(jr_f, jr_c, rtol=1e-7, atol=1e-10)
+    numpy.testing.assert_allclose(jz_f, jz_c, rtol=1e-7, atol=1e-10)
+    # the NaN regression: a high order puts nodes right at the endpoint, which is
+    # where the 0/0 used to bite
+    for order in (50, 200):
+        jr_hi = numpy.atleast_1d(aAC(R, vR, vT, z, vz, order=order)[0])
+        assert numpy.all(numpy.isfinite(jr_hi)), (
+            "C actionAngleStaeckel jr returns NaN for axis-reaching orbits at "
+            "order=%i" % order
+        )
+    # jr must not jump between an exactly-radial orbit and a nearly-radial one
+    aAC2 = actionAngleStaeckel(pot=MWPotential2014, delta=0.71, c=True)
+    j0 = numpy.atleast_1d(aAC2(1.0, 0.0, 0.0, 0.0, 0.0)[0])[0]
+    j1 = numpy.atleast_1d(aAC2(1.0, 0.0, 1e-7, 0.0, 0.0)[0])[0]
+    assert numpy.fabs(j0 - j1) < 1e-6, (
+        "C actionAngleStaeckel jr is discontinuous at Lz = 0"
+    )
+    return None


### PR DESCRIPTION
Two defects in the C Staeckel radial action, both at the inner turning point of orbits that pass close to the axis. Reproducible on a clean `main` checkout — its own `c=True` and `c=False` disagree by **4.5e-5** for near-axis orbits, and `c=True` returns **NaN** for exactly-radial (`Lz = 0`) orbits once the order is raised past ~50. main has no near-axis coverage, so this shipped unseen.

## Causes

At the inner turning point `u ~ 0`:
- the edge reconstruction evaluates `Lz² cosh(u)/sinh³(u)` there, which is `0/0` for `Lz = 0`; and
- the action integrand inherits the potential's inner power-law cusp — `S ~ A - B·u^0.2`, i.e. `chi^0.4` in the anomaly — against which the single fixed-order Gauss-Legendre rule converges only **algebraically**. More nodes don't help; they crowd into the region where `Q` is a *model* of `S` rather than `S`.

## Fix — gated on near-axis, so the common case is untouched

The error only occurs when the inner turning point `umin` is small. Only those orbits (`umin < STAECKEL_NEARAXIS`) integrate the radial action with a **geometrically graded composite** rule — panels packed toward the cusp — on the **model-free** integrand (`sqrt(S)` is regular at a turning point, and near the axis `umin` is a domain boundary with `S(umin) > 0`, not a turning point). The `0/0` term is read as its analytic limit of 0.

**Every orbit with `umin` above the threshold — all disk orbits — takes main's original single-panel rule completely unchanged**, and the frequencies, angles and vertical action are untouched.

## Speed — unchanged for the common case

`actionAngleStaeckel` is a hot path, so this was measured (20 000 disk orbits, `Lz ~ 1`):

| | main | this PR |
|---|---|---|
| `actions` | 5.6 µs/orbit | **5.7** |
| `actionsFreqs` | 10.9 | **10.9** |
| `actionsFreqsAngles` | 13.6 | **13.4** |

Only genuinely near-axis orbits pay the graded cost, and only on the radial-action integral.

## Accuracy

| | before | after |
|---|---|---|
| jr vs python, near-axis (`Lz != 0`) | 4.5e-5 | **5.3e-11** |
| jr, exactly radial (`Lz = 0`) | 4.5e-5 | **1.4e-12** |
| NaN at order 50/200 | yes | **none** |
| `jr(Lz=0)` vs `jr(Lz=1e-7)` | 1.3e-6 | **5.0e-8** |
| generic orbits | — | 1.9e-16 (unchanged) |

## Tests

`tests/test_actionAngle.py`: **231 passed**. main's own tests are unchanged. Adds `test_actionAngleStaeckel_nearaxis_c_python_parity`, A/B'd both ways — fails against the unfixed C, passes against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm