### PR TITLE
Backend shard split (1/n): trace the torch-compile sweep under eager

### DIFF
--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -223,8 +223,6 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nstart=1001, maxrefine=3):
     return None
 
 
-
-
 @potential_physical_input
 @physical_conversion("velocity", pop=True)
 def sigmalos(Pot, R, dens=None, surfdens=None, beta=0.0, sigma_r=None):

--- a/tests/test_backend_potential_jit.py
+++ b/tests/test_backend_potential_jit.py
@@ -157,6 +157,18 @@ def test_jax_jit_traces_public_entry_point(name, entry):
     numpy.testing.assert_allclose(got, ref, rtol=1e-6, atol=_ATOL)
 
 
+# What these cases verify is that a freshly built potential's public entry point
+# TRACES under torch dynamo (and, with fullgraph=False, falls back cleanly) --
+# that is galpy's contract. torch.compile defaults to the inductor backend, whose
+# per-potential codegen dominates this shard (Isochrone alone is ~47 s; the file
+# was ~38 min), and whether inductor's *generated kernel* is correct is torch's
+# concern, not galpy's. So the sweep runs under the cheap "eager" backend, which
+# still exercises tracing and the fall-back. _INDUCTOR_NAMES opts individual
+# potentials back onto real inductor -- empty by default; populate it to
+# spot-check inductor codegen for a specific potential under investigation.
+_INDUCTOR_NAMES = frozenset()
+
+
 @pytest.mark.skipif("not _TORCH_COMPILES")
 @pytest.mark.parametrize("name,entry", _CASES)
 def test_torch_compile_traces_public_entry_point(name, entry):
@@ -173,7 +185,10 @@ def test_torch_compile_traces_public_entry_point(name, entry):
     expected_fail = (name, entry, "torch") in _NOT_TRACEABLE
     try:
         compiled = torch.compile(
-            lambda R, z: fn(pot, R, z), fullgraph=False, dynamic=False
+            lambda R, z: fn(pot, R, z),
+            fullgraph=False,
+            dynamic=False,
+            backend="inductor" if name in _INDUCTOR_NAMES else "eager",
         )
         got = float(compiled(torch.tensor(_R0), torch.tensor(_Z0)))
     except Exception as exc:


### PR DESCRIPTION
First step of shrinking the `tests/test_backend*.py` shard (~2h10m on CI). Two commits:

## 1. Pre-commit fix (`jeans.py`)
The rebase's `_sigmar_on_grid` conflict resolution left four blank lines where ruff-format wants two, so `pre-commit run --all-files` fails on a clean checkout. Whitespace only. (Flagged by Jo.)

## 2. `test_torch_compile_traces_public_entry_point` under eager

This test compiles every potential's public entry point — **46 potentials × 4 entries = 184 cases** — under `torch.compile`'s default **inductor** backend. Inductor's per-potential codegen dominates the shard: **IsochronePotential alone is ~47s**, and the file ran ~38 min on CI.

What the test actually verifies is galpy's contract — that a freshly built potential **traces** under dynamo (and, with `fullgraph=False`, falls back cleanly). Whether inductor's *generated kernel* is numerically correct is torch's concern, not galpy's. So the sweep runs under `backend="eager"`, which still exercises tracing and the fall-back but skips codegen.

| | time | outcome |
|---|---|---|
| inductor (before) | 1100s | 183 passed, 1 skipped |
| **eager (this PR)** | **450s** | 183 passed, 1 skipped |

**2.44×, identical outcomes.**

### The one judgment call — for you

`_INDUCTOR_NAMES` opts individual potentials back onto real inductor (empty by default). I tried a 6-potential representative set first, but inductor is **uniformly expensive** per potential (not just the heavy ones — Isochrone is 47s), so that gave only **1.36×**. My recommendation is **all-eager** (empty set) for the full 2.44×, with the opt-in there for spot-checking a specific potential's codegen under investigation.

If you'd rather keep a standing inductor smoke-test despite the cost, say which potentials and I'll populate the set — but I'd argue the coverage it buys (torch's codegen, not galpy's logic) isn't worth ~350s/run.

## What this unblocks

With this test no longer the outlier, the shard's per-file floor drops from ~38 → ~20 min (`test_backend_streamdf` becomes the new max). That makes a later **file-level CI split** worthwhile — steps 2–3 of the split, which touch `.github/workflows/**` and are yours to wire up. This PR is the part that's purely a test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm