### PR TITLE
Backend shard: eager torch.compile for jit tests (real ~10x on the heaviest)

### DIFF
--- a/galpy/backend/_jit.py
+++ b/galpy/backend/_jit.py
@@ -194,9 +194,19 @@ def _torch_compiled(method):
     dynamo compiled that frame end-to-end, so those lines never executed as
     Python and coverage.py could not see them (galpy #1358, 4 lines).
     """
+    import os
+
     import torch
 
-    compiled = torch.compile(method, fullgraph=False, dynamic=False)
+    # backend defaults to inductor (the real, kernel-generating path). Tests set
+    # GALPY_JIT_TORCH_BACKEND=eager to keep dynamo tracing -- which is what galpy's
+    # contract is -- while skipping inductor codegen, whose per-graph cost
+    # dominates the jit tests (one anyaxisymdisk second-deriv test is ~10min of
+    # codegen on CI). Whether inductor's generated kernel is correct is torch's
+    # concern; a dedicated test (test_hyp2f1_survives_inductor_fusion) still pins
+    # it via a direct torch.compile, unaffected by this knob.
+    _backend = os.environ.get("GALPY_JIT_TORCH_BACKEND", "inductor")
+    compiled = torch.compile(method, fullgraph=False, dynamic=False, backend=_backend)
 
     def call(*args, **kwargs):
         token = _TRACING.set(True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,16 @@ _inductor_cache = tempfile.mkdtemp(prefix="torchinductor_galpy_")
 os.environ["TORCHINDUCTOR_CACHE_DIR"] = _inductor_cache
 atexit.register(shutil.rmtree, _inductor_cache, True)
 
+# galpy.backend.jit("torch") verifies that galpy code TRACES and produces the
+# right value under torch.compile; the inductor kernel it generates is torch's
+# concern, not galpy's, and its per-graph codegen dominates the jit tests (one
+# second-derivative test alone is ~10min of it on CI). Default the tests to the
+# eager backend -- dynamo still traces, the value is still checked, codegen is
+# skipped. setdefault so GALPY_JIT_TORCH_BACKEND=inductor still exercises the
+# real path when wanted; test_hyp2f1_survives_inductor_fusion pins inductor
+# directly (raw torch.compile) regardless.
+os.environ.setdefault("GALPY_JIT_TORCH_BACKEND", "eager")
+
 
 def torch_compiles():
     """Whether torch.compile actually WORKS on this interpreter.


### PR DESCRIPTION
Stacked on #1433. Unlike the split below it, this **reduces total compute**, not just wall-clock — you asked for an actual speedup, not just splitting.

## The problem
`galpy.backend.jit("torch")` hardcoded torch.compile's **inductor** backend. Inductor's per-graph codegen dominates the jit tests: `test_traced_second_derivs_match_numpy_through_the_midplane` alone is **~629s (10.5 min)** of the ~96-min backend shard — and that's *codegen*, not the computation.

What that test (and the jit tests generally) verify is galpy's contract: the code **traces** under dynamo and the traced value matches numpy. Whether inductor's *generated kernel* is correct is torch's concern — same argument as #1432.

## The change
- `galpy/backend/_jit.py`: a `GALPY_JIT_TORCH_BACKEND` knob (default `"inductor"` — **users unchanged**)
- `tests/conftest.py`: `setdefault` it to `"eager"` for the test session — dynamo still traces, value still checked, codegen skipped

## Result
The midplane test: **~629s → ~63s (~10×)**. It still catches the `z==0` finite-part defect, because eager runs the traced graph through the backend GL path (not scipy — that's what makes it a real test).

`test_hyp2f1_survives_inductor_fusion` is **unaffected** — it pins inductor with a *direct* `torch.compile`, not `galpy.backend.jit`, so the one place inductor codegen must be exercised still is. `setdefault` lets `GALPY_JIT_TORCH_BACKEND=inductor` restore the real path locally.

24 jit tests (incl. the midplane and the inductor-fusion test) pass.

## On the split stack
This makes #1433's durations file mildly stale (midplane now ~63s, not 629s), which just means the durations bootstrap should be regenerated on CI after this lands — already the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm