### PR TITLE
qdf: float the precomputed rg grid bound so forced-backend _rg survives

### DIFF
--- a/galpy/df/quasiisothermaldf.py
+++ b/galpy/df/quasiisothermaldf.py
@@ -142,8 +142,13 @@ class quasiisothermaldf(df):
             self._precomputergrmax = _precomputergrmax
             self._precomputergnLz = _precomputergnLz
             self._precomputergLzmin = 0.01
-            self._precomputergLzmax = self._precomputergrmax * potential.vcirc(
-                self._pot, self._precomputergrmax
+            # float(): under a forced backend vcirc returns a backend scalar, which
+            # would make this grid bound a Tensor and break the numpy _rg branch's
+            # `lz > self._precomputergLzmax` (ndarray > Tensor raises). Keep it a
+            # Python scalar; the numpy path is byte-identical (linspace stop value).
+            self._precomputergLzmax = float(
+                self._precomputergrmax
+                * potential.vcirc(self._pot, self._precomputergrmax)
             )
             self._precomputergLzgrid = numpy.linspace(
                 self._precomputergLzmin, self._precomputergLzmax, self._precomputergnLz


### PR DESCRIPTION
The rebase of `feat/backends` onto main took the all-backend regular suite from green (`b0698589`) to 8 red shards (`cb4af3a0`). This PR fixes the one **real** bug among them; the other reds are ledgered in the follow-up.

**Bug.** Under `use(torch/jax, force=True)`, `potential.vcirc` returns a backend scalar, so `quasiisothermaldf._precomputergLzmax` was stored as a Tensor. `_rg`'s numpy-caller branch then evaluates `lz > self._precomputergLzmax` with a numpy `lz` — and `ndarray > Tensor` raises under torch (jax happened to coerce, so this was torch-only).

**Fix.** `float()` the grid bound at construction so it stays a Python scalar. The numpy path is byte-identical (the value only feeds a `linspace` stop and downstream splines, unchanged for a float vs np.float64 of the same value).

**Verified** under forced torch (was red) and jax (was green, unregressed):
`test_qdf::test_sampleV{,_physical,_interpolate}`, `test_galpypaper::test_qdf`, `test_quantity::test_quasiisothermaldf_method_{returntype,returnunit}`, `test_quantity::test_quasiisothermaldf_sample` — all pass; numpy `test_sampleV` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm