### PR TITLE
jeans: don't let scipy.quad's default epsabs truncate sigma_r's small outer tail

### DIFF
--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -69,6 +69,10 @@ def sigmar(Pot, r, dens=None, beta=0.0):
             ),
             r,
             numpy.inf,
+            # epsabs=0: scipy's default 1.49e-8 absolute floor truncates the small
+            # tail at large r (~6e-6 error in sigma_r at r=25); use only the
+            # relative tolerance so accuracy is scale-invariant.
+            epsabs=0.0,
         )[0]
         / dens(r)
         / intFactor(r)
@@ -150,7 +154,9 @@ def _sigmar_on_grid(Pot, rs, dens=None, beta=0.0, nstart=1001, maxrefine=3):
             pass
         return numpy.array([float(fn(x)) for x in xs])
 
-    tail = integrate.quad(integrand, rs[-1], numpy.inf)[0]
+    # epsabs=0: as in sigmar, the default absolute floor truncates this small
+    # outer tail (~6e-6 in sigma_r at the grid edge); rely on the relative tol.
+    tail = integrate.quad(integrand, rs[-1], numpy.inf, epsabs=0.0)[0]
     dens_rs = _on(dens, rs)
     logrs = numpy.log(rs)
 


### PR DESCRIPTION
`jeans.sigmar` and `jeans._sigmar_on_grid` integrate the velocity-dispersion integrand out to infinity with `scipy.integrate.quad`'s **default `epsabs=1.49e-8`**. At large radii the integral is small enough that the absolute floor dominates and the tail is truncated.

**Symptom.** For an `SCFPotential`, `sigmar(25)` returns `0.174831455556` — **6.1e-6** off a tight-scipy / mpmath gold of `0.174832526535`. `_sigmar_on_grid` truncates identically at its outer edge, so `test_sigmar_on_grid_matches_the_loop_for_an_expensive_integrand` passes today only because *both* sides are wrong the same way.

**Fix.** Pass `epsabs=0.0` to both quad calls so they rely on the relative tolerance — accuracy becomes scale-invariant. `sigmar(25)` → `0.174832526535` (gold to 1e-12). Small-r values already met the relative tol, so they're unaffected; `test_jeans` is unchanged (9 passed).

**Why now.** Surfaced by galpy's array-API backend work: the backend `sigmar` uses a converged fixed-order GL rule that lands on the *accurate* value, which exposed the scipy-side truncation as a numpy disagreement. This is the numpy-side root fix; once it lands, the corresponding backend xfail-ledger entry on the backend branch can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm