### PR TITLE
backend burndown 1: numpy sigmar byte-identity + drop 4 stale xfail entries

### DIFF
--- a/galpy/df/jeans.py
+++ b/galpy/df/jeans.py
@@ -74,6 +74,11 @@ def sigmar(Pot, r, dens=None, beta=0.0):
                 ),
                 r,
                 numpy.inf,
+                # epsabs=0: match main (#1439) -- the default 1.49e-8 absolute
+                # floor truncates the small tail at large r (~6e-6 in sigma_r at
+                # r=25); rely on the relative tol so this stays byte-identical to
+                # the numpy sigmar on main.
+                epsabs=0.0,
             )[0]
             / dens(r)
             / intFactor(r)

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -182,9 +182,7 @@
 #
 # The Python-vs-Python equivalent, test_actionAngleAdiabaticGrid_outsidegrid_
 # multiple_python, PASSES on both backends and is not ledgered.
-jax tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 jax tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_actionAngle.py::test_actionAngleAdiabaticGrid_outsidegrid_c
 torch tests/test_qdf.py::test_call_diffinoutputs
 
 # --- jax multi-orbit (test_orbits.py): action-angle accessors (Track E) ---
@@ -369,13 +367,11 @@ torch-jit tests/test_potential.py::test_pickling_potential_unitful_dens
 #   (StaeckelGrid ...EccZmaxRperiRap_c is NOT ledgered: its circular-orbit e is
 #   (rap-rperi)/(rap+rperi), a machine-eps cancellation the backend reorders to
 #   1.59e-16; the test's 1e-16 bar was loosened to 1e-14 instead.)
-#   * jeans sigmar_on_grid ...expensive_integrand (2): the backend sigmar
-#     (fixed_quad_semiinfinite, converged) matches a tight-scipy/mpmath gold to
-#     9e-9; the test's reference (_sigmar_on_grid & numpy sigmar via scipy.quad
-#     DEFAULT epsabs=1.49e-8) truncates the small r=25 tail by 6.1e-6. The backend
-#     is the MORE accurate side; the real fix is numpy-side (scipy tolerance),
-#     going in as a separate PR to main -- this entry XPASSes and can be dropped
-#     once that lands here.
+#   (jeans sigmar_on_grid ...expensive_integrand: DROPPED -- the numpy-side scipy
+#   truncation was fixed on main (#1439, epsabs=0.0) and this branch now matches
+#   it in both sigmar and _sigmar_on_grid, so the test passes under both backends.)
+#   (adiabaticGrid_outsidegrid_c: DROPPED -- stale, now XPASSes under both
+#   backends from an earlier coercion fix; verified 2026-09-04.)
 #   * sphericaldf dMdE ...percall_ro (1, torch): main added a Quantity-energy
 #     per-call-vo test; under torch dMdE returns ndarray for one input and Tensor
 #     for the other, so the subtraction raises. torch-only units-path coercion
@@ -401,8 +397,6 @@ jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exact
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform_bisect
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
-jax tests/test_jeans.py::test_sigmar_on_grid_matches_the_loop_for_an_expensive_integrand
-torch tests/test_jeans.py::test_sigmar_on_grid_matches_the_loop_for_an_expensive_integrand
 jax tests/test_quantity.py::test_actionAngleVerticalInverse_units
 torch tests/test_quantity.py::test_actionAngleVerticalInverse_units
 torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity_percall_ro

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -376,6 +376,13 @@ torch-jit tests/test_potential.py::test_pickling_potential_unitful_dens
 #     per-call-vo test; under torch dMdE returns ndarray for one input and Tensor
 #     for the other, so the subtraction raises. torch-only units-path coercion
 #     edge -- narrow, real, fixable follow-up.
+#   * NOT-REDUCIBLE (confirmed 2026-09-04, stay ledgered): sphericaldf dMdE
+#     percall_ro is the exit_cast design -- a Quantity input parses to numpy
+#     and its consumption output stays numpy (astropy can't hold a backend
+#     Quantity), so `dMdE(Quantity) - dMdE(rawTensor)` mixes types only under
+#     a forced backend. qdf test_call_diffinoutputs expects UnboundError, but
+#     the backend path deliberately does NOT raise (stays jit-traceable; unbound
+#     -> NaN, see actionAngleStaeckel.py). Neither is a coercion bug.
 # =============================================================================
 jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform


### PR DESCRIPTION
First burndown PR, stacked on the feat/backends→main rebase (`backend/rebase-onto-main-0904`; retarget base to `feat/backends` after the rebase is force-pushed).

**xfail ledger 35 → 31:**
- **jeans (2, dropped):** the rebase brought main's #1439 `_sigmar_on_grid` tail `epsabs=0.0` but left `sigmar`'s numpy branch truncating — breaking numpy byte-identity with main. Added `epsabs=0.0` there too; both sigma_r paths now hit the gold (`0.174832526535`). Test passes under both backends → entries dropped.
- **adiabaticGrid_outsidegrid_c (2, dropped):** stale — XPASSes under both backends from an earlier coercion fix.
- **sphericaldf dMdE / qdf test_call_diffinoutputs:** investigated, **annotated as not-reducible** (deliberate design — exit_cast keeps Quantity outputs numpy; the backend intentionally doesn't raise UnboundError). Left ledgered so future sweeps skip them.

Reducible xfail entries are now exhausted (VerticalInverse is out of scope per Jo; 6 jit-mode entries are local-only). Next in the stack: slow-skip vectorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm