### PR TITLE
test_actionAngle: platform-proof the Staeckel chi-quadrature bars (3e-11 -> 1e-10)

### DIFF
--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -3154,10 +3154,16 @@ def test_actionAngleStaeckel_chi_quadrature_convergence():
     # momentum function S (a difference of O(1) potential terms), not by the
     # quadrature rule: a few 1e-12 for generic orbits, and looser for a
     # nearly planar orbit whose tiny v oscillation has S far below the
-    # cancellation scale (the old fixed-order rule erred at 4.6e-4 here)
+    # cancellation scale (the old fixed-order rule erred at 4.6e-4 here).
+    # That cancellation scale is platform-dependent, so the generic bars sit at
+    # 1e-10 rather than at the ~2e-11 measured here: torch on a CI runner has
+    # produced 3.5e-11 on the same inputs (numpy 1.1e-11 / 2.2e-11, torch
+    # 9.5e-12 / 2.0e-11, jax 4.5e-12 / 1.8e-11 locally). 1e-10 still leaves six
+    # orders of margin against the O(1) errors a branch/convention disagreement
+    # produces, which is what this test is for.
     for ic, tol in (
-        ([1.0, 0.5, 1.1, 0.2, -0.3, 0.4], 3e-11),
-        ([1.0, -0.2, 1.1, -0.2, 0.25, 2.1], 3e-11),  # z<0, vR<0: other branches
+        ([1.0, 0.5, 1.1, 0.2, -0.3, 0.4], 1e-10),
+        ([1.0, -0.2, 1.1, -0.2, 0.25, 2.1], 1e-10),  # z<0, vR<0: other branches
         ([1.1, 0.02, 0.9, 0.002, 0.02, 1.0], 1e-8),  # nearly planar
     ):
         lo = aAS.actionsFreqsAngles(*ic, fixed_quad=True, order=10)


### PR DESCRIPTION
`test_actionAngleStaeckel_chi_quadrature_convergence` compares the default-order chi-anomaly quadrature against a much finer mesh. Its bar measures the **evaluation noise of the fudge-form momentum function S** — a cancellation of O(1) potential terms — which is platform-dependent, not a property of the quadrature rule.

## Why

Measured locally at float64 (matching conftest):

| backend | IC0 | IC1 | ratio to the 3e-11 bar |
|---|---|---|---|
| numpy | 1.10e-11 | 2.17e-11 | 0.72 |
| torch | 9.48e-12 | 2.05e-11 | 0.68 |
| jax | 4.54e-12 | 1.78e-11 | 0.59 |

All pass — but by only ~1.4×. A CI runner produced **3.5074e-11** under torch on the same inputs, while **the same SHA passed in its push/pull_request twin**. So the bar sits inside the machine-to-machine spread of the cancellation rather than catching a defect.

`1e-10` still leaves **six orders of margin** against the O(1) errors a branch/convention disagreement produces, which is what the test is for. The nearly-planar orbit's `1e-8` bar is unchanged.

## main does not need this

`main` does not carry the vectorised chi-anomaly quadrature (`09d46a338` is feat/backends-only). Measured on a clean `origin/main` worktree: **5.92e-12 / 3.27e-12 — 5× inside the bar**, and main runs no backend shards to widen the spread. So this stays on feat/backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm