### PR TITLE
sphericaldf: build the p(v|r) inverse-CDF table on the backend (d(sample_v)/d(DF params))

### DIFF
--- a/galpy/df/osipkovmerrittdf.py
+++ b/galpy/df/osipkovmerrittdf.py
@@ -5,6 +5,7 @@ from scipy import integrate, interpolate, special
 from ..backend import as_numpy, device_of, get_namespace
 from ..backend import random as grandom
 from ..backend import resolve_namespace
+from ..backend.interpolate import Spline1D
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..potential import evaluateDensities
 from ..potential.Potential import _evaluatePotentials
@@ -227,14 +228,14 @@ class _osipkovmerrittdf(anisotropicsphericaldf):
         """p( v*sqrt[1+r^2/ra^2*sin^2eta] | r) used in sampling"""
         xp = resolve_namespace(v, r)
         if hasattr(self, "_logfQ_interp"):
-            # scipy interpolator (general OM df) is numpy-only; sampling numpy-side
-            # (the potential eval stays on the active backend, so pull it numpy-side
-            # before the scipy spline; no-op on the numpy path)
-            v, r = as_numpy(v), as_numpy(r)
+            # The f(Q) table is a Spline1D under a backend (scipy on numpy), so
+            # the query stays in the active namespace -- no as_numpy here, which
+            # is what makes the sampled velocity differentiable in the DF and
+            # potential parameters (see sphericaldf._make_pvr_interpolator).
             return (
-                numpy.exp(
+                xp.exp(
                     self._logfQ_interp(
-                        -as_numpy(_evaluatePotentials(self._pot, r, 0)) - 0.5 * v**2.0
+                        -_evaluatePotentials(self._pot, r, 0) - 0.5 * v**2.0
                     )
                 )
                 * v**2.0
@@ -450,17 +451,29 @@ class osipkovmerrittdf(_osipkovmerrittdf):
                     sorted(1.0 - numpy.geomspace(1e-8, 0.5, 101)),
                 )
             )
-            # scipy spline table is inherently numpy (no backend spline here);
-            # under a forced backend the potential bounds and fQ come back as
-            # backend scalars, so pull them numpy-side (no-op on the numpy path)
+            # the spline table is built on a numpy grid; under a forced backend
+            # the potential bounds are backend scalars, so pull them numpy-side
+            # (no-op on the numpy path)
             Emin = as_numpy(self._edf._Emin)
             potInf = as_numpy(self._edf._potInf)
             Qs4interp = -(Qs4interp * (Emin - potInf) + potInf)
-            fQ4interp = numpy.log(as_numpy(self.fQ(Qs4interp)))
-            iindx = numpy.isfinite(fQ4interp)
-            self._logfQ_interp = interpolate.InterpolatedUnivariateSpline(
-                Qs4interp[iindx], fQ4interp[iindx], k=3, ext=3
-            )
+            xp = get_namespace()  # context/forced default only (grid is numpy)
+            if xp is numpy:
+                fQ4interp = numpy.log(self.fQ(Qs4interp))
+                iindx = numpy.isfinite(fQ4interp)
+                self._logfQ_interp = interpolate.InterpolatedUnivariateSpline(
+                    Qs4interp[iindx], fQ4interp[iindx], k=3, ext=3
+                )
+            else:
+                # forced backend: the frozen table gets a Spline1D, which queries
+                # numpy through scipy and a backend natively -- so p(v|r) below
+                # stays on the backend instead of being pulled numpy-side, which
+                # is what let the velocity-sampling table go native too.
+                fQ4interp = numpy.log(as_numpy(self.fQ(Qs4interp)))
+                iindx = numpy.isfinite(fQ4interp)
+                self._logfQ_interp = Spline1D(
+                    Qs4interp[iindx], fQ4interp[iindx], k=3, ext=3
+                )
 
     def fQ(self, Q):
         """

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -193,16 +193,29 @@ class _PVRInterpolator:
     """
 
     def __init__(self, x_grid, y_grid, z_grid, xp):
-        # scipy spline for the byte-identical numpy path
-        self._spl = scipy.interpolate.RectBivariateSpline(
-            x_grid, y_grid, z_grid, kx=1, ky=1
-        )
         if xp is numpy:
             self._x, self._y, self._z = x_grid, y_grid, z_grid
+            # scipy spline for the byte-identical numpy path
+            self._spl = scipy.interpolate.RectBivariateSpline(
+                x_grid, y_grid, z_grid, kx=1, ky=1
+            )
         else:
             self._x = xp.asarray(x_grid) * 1.0
             self._y = xp.asarray(y_grid) * 1.0
             self._z = xp.asarray(z_grid) * 1.0
+            # Built lazily: a backend z_grid carries the DF's parameter
+            # dependence, and handing a TRACED array to scipy raises
+            # TracerArrayConversionError -- which is what used to make
+            # d(sample_v)/d(DF parameter) impossible rather than merely absent.
+            self._spl = None
+
+    def _numpy_spline(self):
+        """The scipy spline, materialised on first numpy query."""
+        if self._spl is None:
+            self._spl = scipy.interpolate.RectBivariateSpline(
+                as_numpy(self._x), as_numpy(self._y), as_numpy(self._z), kx=1, ky=1
+            )
+        return self._spl
 
     def __getattr__(self, name):
         # Delegate unknown attributes (e.g. get_knots, tck) to the scipy spline
@@ -210,7 +223,7 @@ class _PVRInterpolator:
         # Guard _spl to avoid infinite recursion before it is assigned.
         if name == "_spl":
             raise AttributeError(name)
-        return getattr(self._spl, name)
+        return getattr(self._numpy_spline(), name)
 
     def __call__(self, X, Y, grid=False):
         """Evaluate ``v/vesc`` at query points ``(X, Y)`` (paired elementwise).
@@ -218,7 +231,7 @@ class _PVRInterpolator:
         A numpy ``X`` delegates to the scipy spline (byte-identical); a backend
         ``X`` runs the native bilinear interpolation."""
         if not is_backend_array(X):
-            return self._spl(X, Y, grid=grid)
+            return self._numpy_spline()(X, Y, grid=grid)
         xp = get_namespace(X)
         xg = (
             self._x
@@ -1068,11 +1081,27 @@ class sphericaldf(df):
         r_a_values = 10.0 ** numpy.linspace(r_a_start, r_a_end, n_r_a)
         v_vesc_values = numpy.linspace(0, 1, n_v_vesc)
         r_a_grid, v_vesc_grid = numpy.meshgrid(r_a_values, v_vesc_values)
-        vesc_grid = as_numpy(self._vmax_at_r(self._pot, r_a_grid * self._scale))
+        vesc_raw = self._vmax_at_r(self._pot, r_a_grid * self._scale)
         r_grid = r_a_grid * self._scale
+        if is_backend_array(vesc_raw):
+            # Keep the whole chain on the backend: vesc carries the potential's
+            # parameters, and the velocities the DF is evaluated at are
+            # v_vesc * vesc(r), so pulling vesc numpy-side here would cut
+            # d(sample_v)/d(potential) before the DF is even called.
+            xp = get_namespace(vesc_raw)
+            vr_grid = as_backend_constant(xp, v_vesc_grid, vesc_raw) * vesc_raw
+            return self._make_pvr_interpolator_backend(
+                self._p_v_at_r(vr_grid, as_backend_constant(xp, r_grid, vesc_raw)),
+                r_a_grid,
+                v_vesc_values,
+            )
+        vesc_grid = as_numpy(vesc_raw)
         vr_grid = v_vesc_grid * vesc_grid
-        # Calculate p(v|r) (one vectorized -- possibly forced-backend -- DF eval,
-        # pulled numpy-side for the spline construction) and normalize
+        # Calculate p(v|r) with one vectorized DF evaluation. Under a backend it
+        # comes back as a backend array carrying the DF/potential parameters'
+        # dependence; building the inverse-CDF table natively from it (below) is
+        # what makes the sampled velocity differentiable in those parameters
+        # rather than merely differentiable in r.
         pvr_grid = as_numpy(self._p_v_at_r(vr_grid, r_grid))
         pvr_grid_cml = numpy.cumsum(pvr_grid, axis=0)
         pvr_grid_cml_norm = (
@@ -1125,6 +1154,52 @@ class sphericaldf(df):
             icdf_pvr_grid_reg[:, 0],
             icdf_v_vesc_grid_reg.T,
             get_namespace(),  # forced/context default (numpy build -> numpy grids)
+        )
+
+    def _make_pvr_interpolator_backend(
+        self, pvr_grid, r_a_grid, v_vesc_values, n_new_pvr=100
+    ):
+        """Backend build of the p(v|r) inverse-CDF table (see _make_pvr_interpolator).
+
+        The numpy path walks the radii in Python -- clamping, de-duplicating and
+        fitting a scipy spline per column -- which both freezes the table to numpy
+        and costs one spline fit per radius. Here the same inverse CDF is formed
+        for every radius at once: clamp the density (the DF can go slightly
+        negative near a truncation radius), accumulate, normalise, and invert on
+        the regular CDF grid by a searchsorted-and-lerp. Every step is a namespace
+        op, so the table stays a backend array and d(v)/d(DF parameters) flows.
+
+        Clamping is applied to the density BEFORE accumulating (the numpy path
+        clamps the cumulative and re-imposes monotonicity afterwards); both keep
+        the CDF non-decreasing, and a non-negative density makes its cumulative
+        monotone by construction, with no cumulative-maximum op required.
+        """
+        xp = get_namespace(pvr_grid)
+        p = xp.clip(pvr_grid, 0.0, None)
+        c = xp.cumulative_sum(p, axis=0)
+        tot = c[-1, :]
+        # A radius with no velocity probability at all (e.g. near rmax where
+        # vesc ~ 0) would normalise 0/0; give it a zero-velocity inverse CDF, as
+        # the numpy path does explicitly.
+        good = tot > 0.0
+        c = c / xp.where(good, tot, xp.ones_like(tot))[None, :]
+        u = xp.linspace(0.0, 1.0, n_new_pvr)
+        # For each radius column and each CDF level u, the number of table
+        # entries strictly below u locates the bracketing interval.
+        idx = xp.sum(xp.astype(c[None, :, :] < u[:, None, None], c.dtype), axis=1)
+        nv = c.shape[0]
+        i0 = xp.astype(xp.clip(idx - 1.0, 0.0, float(nv - 2)), xp.int64)
+        i1 = i0 + 1
+        c0 = xp.take_along_axis(c, i0, axis=0)
+        c1 = xp.take_along_axis(c, i1, axis=0)
+        vg = as_backend_constant(xp, v_vesc_values, c)
+        v0 = vg[i0]
+        v1 = vg[i1]
+        dc = c1 - c0
+        t = xp.where(dc > 0.0, (u[:, None] - c0) / xp.where(dc > 0.0, dc, 1.0), 0.0)
+        v = xp.where(good[None, :], v0 + t * (v1 - v0), xp.zeros_like(v0))
+        return _PVRInterpolator(
+            numpy.log10(r_a_grid[0, :]), as_numpy(u), xp.matrix_transpose(v), xp
         )
 
     def _setup_rphi_interpolator(self, r_a_min=1e-6, r_a_max=1e6, nra=10001):

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -33,6 +33,7 @@ from ..backend import (
 )
 from ..backend import random as grandom
 from ..backend import resolve_namespace
+from ..backend._namespaces import under_jax_trace
 from ..backend.interpolate import Spline1D, interp_bilinear, interp_linear
 from ..backend.quadrature import fixed_quad, nested_quad
 from ..orbit import Orbit
@@ -1175,6 +1176,15 @@ class sphericaldf(df):
         monotone by construction, with no cumulative-maximum op required.
         """
         xp = get_namespace(pvr_grid)
+        # Same diagnostic the numpy path emits: a DF that dips negative (e.g. an
+        # Eddington inversion near a truncation radius) still gets sampled, with
+        # the negative part clamped away. Skipped under a jax trace, where the
+        # test is data-dependent and would force a concretization.
+        if not under_jax_trace(pvr_grid) and bool(as_numpy(xp.any(pvr_grid < 0.0))):
+            warnings.warn(
+                "The DF appears to have negative regions; we'll try to ignore these for sampling the DF, but this may adversely affect the generated samples. Proceed with care!",
+                galpyWarning,
+            )
         p = xp.clip(pvr_grid, 0.0, None)
         c = xp.cumulative_sum(p, axis=0)
         tot = c[-1, :]

--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -1090,12 +1090,19 @@ class sphericaldf(df):
             # v_vesc * vesc(r), so pulling vesc numpy-side here would cut
             # d(sample_v)/d(potential) before the DF is even called.
             xp = get_namespace(vesc_raw)
-            vr_grid = as_backend_constant(xp, v_vesc_grid, vesc_raw) * vesc_raw
-            return self._make_pvr_interpolator_backend(
-                self._p_v_at_r(vr_grid, as_backend_constant(xp, r_grid, vesc_raw)),
-                r_a_grid,
-                v_vesc_values,
+            pvr_raw = self._p_v_at_r(
+                as_backend_constant(xp, v_vesc_grid, vesc_raw) * vesc_raw,
+                as_backend_constant(xp, r_grid, vesc_raw),
             )
+            if is_backend_array(pvr_raw):
+                return self._make_pvr_interpolator_backend(
+                    pvr_raw, r_a_grid, v_vesc_values
+                )
+            # Some DFs evaluate p(v|r) numpy-side whatever the namespace -- the
+            # general Osipkov-Merritt df goes through a scipy interpolator -- so
+            # there is no backend table to build and no gradient to carry. Fall
+            # through to the numpy build, recomputing from the numpy vesc grid so
+            # the result stays byte-identical to a pure-numpy run.
         vesc_grid = as_numpy(vesc_raw)
         vr_grid = v_vesc_grid * vesc_grid
         # Calculate p(v|r) with one vectorized DF evaluation. Under a backend it

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -711,3 +711,58 @@ def test_coercion_boundary_fires_for_sphericaldf(backend_name):
 # deliberately astropy-free, so an astropy import here is a hard error rather
 # than a skip. The boundary branch itself is covered without astropy by
 # test_backend_input.py::test_quantity_coordinate_passes_through.
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_sample_v_grad_wrt_potential(backend):
+    # d(sampled velocity)/d(potential parameter). This flows through the p(v|r)
+    # inverse-CDF table, which used to be built numpy-side: that did not merely
+    # drop the gradient, it RAISED (TracerArrayConversionError) under a jax
+    # trace, because the frozen table was handed to scipy.
+    #
+    # Run under a FORCED backend: the potential parameter is not a coordinate, so
+    # data-dispatch alone does not reach _vmax_at_r, which still materialises its
+    # escape-velocity grid numpy-side and would cut d/d(amp) before the DF is
+    # evaluated. Forcing routes that grid through the backend too.
+    #
+    # The reference is analytic, not just a finite difference: a Hernquist DF's
+    # velocities scale as sqrt(amp) at fixed sampled radius (amp rescales the
+    # mass uniformly, so the radial distribution is amp-independent), hence
+    # d(sum v)/d(amp) = sum(v) / (2 amp).
+    from galpy.backend import random as grandom
+    from galpy.backend import use
+    from galpy.df import isotropicHernquistdf
+    from galpy.potential import HernquistPotential
+
+    amp0 = 2.0
+
+    def total_vR(amp):
+        df = isotropicHernquistdf(pot=HernquistPotential(amp=amp, a=1.3))
+        _, vR, _, _, _, _ = df.sample(n=8, key=grandom.key(0), return_orbit=False)
+        return vR.sum()
+
+    with use(backend, force=True):
+        if backend == "jax":
+            val = float(total_vR(jnp.asarray(amp0)))
+            g = float(jax.grad(total_vR)(jnp.asarray(amp0)))
+        else:
+            t = torch.tensor(amp0, requires_grad=True)
+            out = total_vR(t)
+            val = float(out)
+            out.backward()
+            g = float(t.grad)
+        # analytic: v ~ sqrt(amp) at fixed r
+        numpy.testing.assert_allclose(g, val / (2.0 * amp0), rtol=1e-6)
+        # and against a finite difference of the same seeded draw
+        eps = 1e-4
+        if backend == "jax":
+            fd = (
+                float(total_vR(jnp.asarray(amp0 + eps)))
+                - float(total_vR(jnp.asarray(amp0 - eps)))
+            ) / (2.0 * eps)
+        else:
+            fd = (
+                float(total_vR(torch.tensor(amp0 + eps)))
+                - float(total_vR(torch.tensor(amp0 - eps)))
+            ) / (2.0 * eps)
+    numpy.testing.assert_allclose(g, fd, rtol=1e-5)


### PR DESCRIPTION
Velocity sampling was the last numpy island in the spherical-DF sampling path. `_sample_v` already evaluated the `p(v|r)` inverse-CDF table natively — so the sampled velocity was differentiable in `r` — but the **table itself** was built numpy-side, so nothing downstream of it depended on the DF or potential parameters.

That wasn't merely a missing gradient. Differentiating **any** output of `sample()` *raised*, because building the table hands a traced array to scipy:

```
TracerArrayConversionError: __array__() was called on traced array
with shape float64[100,120]          # (n_v_vesc, n_r_a)
```

## Two changes

- **`_PVRInterpolator` builds its scipy `RectBivariateSpline` lazily.** A backend build keeps the grids as backend arrays and never touches scipy; the numpy query path materialises the spline on first use, so it stays a drop-in.
- **`_make_pvr_interpolator` dispatches above the escape-velocity grid.** `vesc` carries the potential's parameters, and the DF is evaluated at `v_vesc * vesc(r)` — so pulling `vesc` numpy-side cut `d/d(parameters)` *before the DF was even called*.

The backend builder forms the same inverse CDF for **every radius at once** (clamp the density, accumulate, normalise, invert by searchsorted-and-lerp) instead of the numpy path's per-radius Python loop of scipy spline fits. Clamping moves to the density *before* accumulating — a non-negative density has a monotone cumulative by construction, so no cumulative-maximum op is needed. Radii with no velocity probability get a zero-velocity inverse CDF, as the numpy path does explicitly.

## Verification

- **numpy is byte-identical**: same sha256 over a fixed-seed 500-sample `sample()` draw as `origin/feat/backends`.
- The new test checks the gradient against an **analytic reference**, not just a finite difference. A Hernquist DF's velocities scale as `sqrt(amp)` at fixed sampled radius (amp rescales the mass uniformly, so the radial distribution is amp-independent), hence `d(sum v)/d(amp) = sum(v)/(2 amp)`. jax and torch both match to `rtol=1e-6`, and a finite difference of the same seeded draw to `1e-5`. `d(R)/d(amp)` is exactly 0 — the correct answer, not a dropped gradient.
- `test_backend_sphericaldf` **55 passed** (53 + 2 new); `test_sphericaldf` **224 passed** on numpy.

## Known remaining island (follow-up, not this PR)

`_vmax_at_r` still materialises its escape-velocity grid numpy-side when the backend is **not forced**, so a traced potential parameter alone doesn't reach it by data dispatch. The new test therefore runs under a forced backend — which is how the backend suite runs anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm