### PR TITLE
sphericaldf: cover the p(v|r) backend-build branches #1448 left untested

### DIFF
--- a/galpy/df/sphericaldf.py
+++ b/galpy/df/sphericaldf.py
@@ -1101,8 +1101,10 @@ class sphericaldf(df):
             # Some DFs evaluate p(v|r) numpy-side whatever the namespace -- the
             # general Osipkov-Merritt df goes through a scipy interpolator -- so
             # there is no backend table to build and no gradient to carry. Fall
-            # through to the numpy build, recomputing from the numpy vesc grid so
-            # the result stays byte-identical to a pure-numpy run.
+            # through to the numpy build. vesc was already evaluated on the
+            # backend, so the table matches a pure-numpy run to last-bit rounding
+            # (~1e-12 relative), not bit-identically; the numpy PATH itself --
+            # which never gets here -- stays byte-identical.
         vesc_grid = as_numpy(vesc_raw)
         vr_grid = v_vesc_grid * vesc_grid
         # Calculate p(v|r) with one vectorized DF evaluation. Under a backend it

--- a/tests/test_backend_sphericaldf.py
+++ b/tests/test_backend_sphericaldf.py
@@ -766,3 +766,73 @@ def test_sample_v_grad_wrt_potential(backend):
                 - float(total_vR(torch.tensor(amp0 - eps)))
             ) / (2.0 * eps)
     numpy.testing.assert_allclose(g, fd, rtol=1e-5)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_pvr_interpolator_numpy_query_after_backend_build(backend):
+    # A backend build keeps the grids as backend arrays and does NOT construct
+    # the scipy spline (handing it a traced array raises). A later numpy query
+    # has to materialise that spline on demand, and attribute delegation has to
+    # go through the same lazy path.
+    from galpy.backend import use
+    from galpy.df import isotropicHernquistdf
+    from galpy.potential import HernquistPotential
+
+    df = isotropicHernquistdf(pot=HernquistPotential(amp=2.0, a=1.3))
+    df._rmin_sampling = 0.0
+    with use(backend, force=True):
+        ip = df._make_pvr_interpolator(r_a_end=1)
+    assert ip._spl is None, "backend build should not have built a scipy spline"
+    # a numpy query materialises it and returns numpy
+    got = ip(numpy.array([0.0, 0.1]), numpy.array([0.3, 0.6]), grid=False)
+    assert ip._spl is not None, "numpy query did not materialise the scipy spline"
+    assert isinstance(got, numpy.ndarray) and numpy.all(numpy.isfinite(got))
+    # unknown attributes delegate to that same spline
+    assert ip.get_knots() is not None
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_pvr_table_falls_back_when_df_is_numpy_side(backend):
+    # A df whose p(v|r) is numpy-side whatever the namespace has no backend table
+    # to build; the builder must fall back to the numpy construction instead of
+    # applying namespace ops to a numpy array. Nothing in-tree is numpy-side any
+    # more (the general Osipkov-Merritt df was migrated), so use a synthetic.
+    from galpy.backend import use
+    from galpy.df import isotropicHernquistdf
+    from galpy.potential import HernquistPotential
+
+    class _NumpySideDF(isotropicHernquistdf):
+        def _p_v_at_r(self, v, r):
+            return as_numpy(super()._p_v_at_r(v, r))
+
+    df = _NumpySideDF(pot=HernquistPotential(amp=2.0, a=1.3))
+    df._rmin_sampling = 0.0
+    ref = df._make_pvr_interpolator(r_a_end=1)  # pure-numpy build
+    with use(backend, force=True):
+        ip = df._make_pvr_interpolator(r_a_end=1)
+    # The fallback recomputes numpy-side, so the table must match the pure-numpy
+    # build EXACTLY -- that is the contract that makes falling back safe. (The
+    # grids are still materialised onto the forced namespace afterwards, which is
+    # the pre-existing behaviour of a numpy build under a forced backend.)
+    numpy.testing.assert_allclose(
+        as_numpy(ip._z), as_numpy(ref._z), rtol=1e-10, atol=1e-14
+    )
+    got = ip(numpy.array([0.0]), numpy.array([0.5]), grid=False)
+    assert numpy.all(numpy.isfinite(got))
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_pvr_backend_warns_on_negative_df(backend):
+    # beta > 0.5 gives the DF negative parts; the backend table build clamps them
+    # away and must say so, exactly as the numpy path does
+    from galpy.backend import use
+    from galpy.df import constantbetaHernquistdf
+    from galpy.potential import HernquistPotential
+    from galpy.util import galpyWarning
+
+    df = constantbetaHernquistdf(pot=HernquistPotential(amp=2.3, a=1.3), beta=0.7)
+    df._rmin_sampling = 0.0
+    with use(backend, force=True):
+        with pytest.warns(galpyWarning, match="negative regions"):
+            ip = df._make_pvr_interpolator(r_a_end=1)
+    assert ip is not None


### PR DESCRIPTION
Follow-up to #1448, which added three branches no test reached — so `codecov/patch` flagged the patch. They only execute under a **forced backend**, so the tests belong in `tests/test_backend*.py`: that's the suite that uploads coverage (`backend-tests.yml` does not).

- **`test_pvr_interpolator_numpy_query_after_backend_build`** — a backend build deliberately does *not* construct the scipy spline (handing it a traced array raises), so a later numpy query has to materialise it on demand, and attribute delegation has to go through that same lazy path.
- **`test_pvr_table_falls_back_when_df_is_numpy_side`** — a DF whose `p(v|r)` is numpy-side whatever the namespace must fall back to the numpy build rather than applying namespace ops to a numpy array. Nothing in-tree is numpy-side any more (the general Osipkov-Merritt DF was migrated in the same PR), so this uses a **synthetic subclass** rather than pinning a real DF to a wart.
- **`test_pvr_backend_warns_on_negative_df`** — `beta > 0.5` gives the DF negative parts; the backend build clamps them away and must say so, as numpy does.

## It also corrects something #1448 got wrong

#1448's comment claimed the fallback stays *"byte-identical to a pure-numpy run"*. **It doesn't** — `vesc` is evaluated on the backend before being pulled numpy-side, so the table agrees to last-bit rounding (**~1e-12 relative**), not bit-identically. Writing the test as an exact-equality assertion is what surfaced it. The test now asserts the true bar (`rtol=1e-10`) and the comment says what actually holds.

The numpy **path** — which never reaches the fallback — remains byte-identical as claimed.

`tests/test_backend_sphericaldf.py`: **61 passed** (was 55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm