### PR TITLE
backend: stop re-doing two pieces of eager work on every force evaluation

### DIFF
--- a/galpy/backend/_namespaces.py
+++ b/galpy/backend/_namespaces.py
@@ -534,6 +534,16 @@ def asarray_on_device(xp, a, device, dtype=None):
     ``torch.asarray(x, dtype=numpy.float64)`` (which raises) works.
     """
     dtype = _backend_dtype(xp, dtype)
+    # Fast path: an array that already has the requested dtype and device needs
+    # nothing done to it, and xp.asarray would still cost an eager dispatch (this
+    # helper is on every coordinate-coercion path, so those add up: ~120 calls per
+    # NonInertialFrameForce force evaluation alone).
+    if (
+        is_backend_array(a)
+        and (dtype is None or getattr(a, "dtype", None) == dtype)
+        and (device is None or getattr(a, "device", None) == device)
+    ):
+        return a
     if device is None:
         return xp.asarray(a, dtype=dtype)
     try:

--- a/galpy/potential/NonInertialFrameForce.py
+++ b/galpy/potential/NonInertialFrameForce.py
@@ -143,6 +143,7 @@ class NonInertialFrameForce(DissipativeForce):
         # integration time range; see _parse_noninertial_frame_force.
         self._cinterp_table_cache = None
         self._rot_acc = not Omega is None
+        self._const_anchor_cache = {}
         self._omegaz_only = len(numpy.atleast_1d(Omega)) == 1
         self._const_freq = Omegadot is None
         # Omega and Omegadot must be the same kind: both functions of time or
@@ -286,11 +287,33 @@ class NonInertialFrameForce(DissipativeForce):
         x, y, z, vx, vy, vz = coerce_coords(xp, x, y, z, vx, vy, vz)
         ref = x
 
+        # Anchoring the same handful of constants (mostly 0.0) is done ~180x per
+        # force call, and each miss is a device_put: it was ~40% of the eager cost.
+        # Cache per (namespace, dtype, device) -- the constants are frozen, and the
+        # key covers everything as_backend_constant anchors on, so a cached array is
+        # interchangeable with a fresh one.
+        _ckey = (
+            getattr(xp, "__name__", "numpy"),
+            getattr(ref, "dtype", None),
+            getattr(ref, "device", None),
+        )
+        _cache = self._const_anchor_cache.get(_ckey)
+        if _cache is None:
+            _cache = self._const_anchor_cache[_ckey] = {}
+
         def _anchor(c):
             # keep a backend (grad-carrying) comp; anchor a scalar/numpy const on the
             # coords' device/dtype via the shared helper (device-safe on GPU, where an
             # all-scalar _vec would otherwise land on CPU and mismatch the backend force)
-            return c if is_backend_array(c) else as_backend_constant(xp, c, ref)
+            if is_backend_array(c):
+                return c
+            try:
+                hit = _cache.get(c)
+            except TypeError:  # unhashable (numpy array constant): don't cache
+                return as_backend_constant(xp, c, ref)
+            if hit is None:
+                hit = _cache[c] = as_backend_constant(xp, c, ref)
+            return hit
 
         def _vec(comps):
             # 1D vector from (possibly backend, grad-carrying) scalar comps;

--- a/galpy/potential/NonInertialFrameForce.py
+++ b/galpy/potential/NonInertialFrameForce.py
@@ -307,10 +307,13 @@ class NonInertialFrameForce(DissipativeForce):
             # all-scalar _vec would otherwise land on CPU and mismatch the backend force)
             if is_backend_array(c):
                 return c
-            try:
-                hit = _cache.get(c)
-            except TypeError:  # unhashable (numpy array constant): don't cache
-                return as_backend_constant(xp, c, ref)
+            # every remaining c is a scalar constant: _vec/_mat pass components
+            # one at a time, and the only direct call, _anchor(self._Omega_py(t)),
+            # is guarded by _omegaz_only, where _Omega_py returns a scalar. So the
+            # key is always hashable -- an unhashable one would be a new caller
+            # doing something unintended, and should raise rather than silently
+            # fall back to re-anchoring on every call.
+            hit = _cache.get(c)
             if hit is None:
                 hit = _cache[c] = as_backend_constant(xp, c, ref)
             return hit

--- a/tests/test_backend_noninertial.py
+++ b/tests/test_backend_noninertial.py
@@ -272,3 +272,45 @@ def test_force_grad_vs_finite_difference(backend_name, name):
     numpy.testing.assert_allclose(
         ad, fd, rtol=1e-5, atol=1e-8, err_msg=f"{backend_name} {name}"
     )
+
+
+@pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
+def test_force_constant_anchor_cache(backend):
+    # _force anchors the same constants ~180x per call, so they are cached per
+    # (namespace, dtype, device). Exercise every branch of that cache: a scalar
+    # constant (cached: miss then hit), an ARRAY constant from a vector Omega
+    # function (unhashable -- must bypass the cache, not raise), and a
+    # backend-array component (returned untouched, never cached).
+    from galpy.potential import NonInertialFrameForce
+
+    with use(backend, force=True):
+        xp = __import__("galpy").backend.get_namespace()
+        one = xp.asarray(1.1) * 1.0
+        args = (
+            one,
+            xp.asarray(0.1) * 1.0,
+            xp.asarray(0.3) * 1.0,
+            xp.asarray(0.0) * 1.0,
+        )
+        v = [xp.asarray(0.1) * 1.0, xp.asarray(1.0) * 1.0, xp.asarray(0.05) * 1.0]
+
+        # scalar constants: first call populates the cache, second must reuse it
+        nif = NonInertialFrameForce(Omega=numpy.array([0.0, 0.0, 1.3]))
+        f1 = as_numpy(nif._force(*args, v))
+        assert nif._const_anchor_cache, "no constants were cached"
+        sizes = {k: len(c) for k, c in nif._const_anchor_cache.items()}
+        f2 = as_numpy(nif._force(*args, v))
+        assert {k: len(c) for k, c in nif._const_anchor_cache.items()} == sizes, (
+            "the second force call added cache entries, so it re-anchored constants"
+        )
+        numpy.testing.assert_allclose(f1, f2, rtol=0.0, atol=0.0)
+        assert numpy.all(numpy.isfinite(f1))
+
+        # vector Omega function: _Omega_py(t) hands _anchor a numpy ARRAY, which
+        # is unhashable and must take the bypass rather than raise
+        niff = NonInertialFrameForce(
+            Omega=[lambda t: 0.0 * t, lambda t: 0.0 * t, lambda t: 1.3 + 0.0 * t],
+            Omegadot=[lambda t: 0.0 * t, lambda t: 0.0 * t, lambda t: 0.0 * t],
+        )
+        fv = as_numpy(niff._force(*args, v))
+        assert numpy.all(numpy.isfinite(fv))

--- a/tests/test_backend_noninertial.py
+++ b/tests/test_backend_noninertial.py
@@ -277,10 +277,9 @@ def test_force_grad_vs_finite_difference(backend_name, name):
 @pytest.mark.parametrize("backend", [b for b in BACKENDS if b != "numpy"])
 def test_force_constant_anchor_cache(backend):
     # _force anchors the same constants ~180x per call, so they are cached per
-    # (namespace, dtype, device). Exercise every branch of that cache: a scalar
-    # constant (cached: miss then hit), an ARRAY constant from a vector Omega
-    # function (unhashable -- must bypass the cache, not raise), and a
-    # backend-array component (returned untouched, never cached).
+    # (namespace, dtype, device). Exercise both branches: a scalar constant
+    # (cached: miss, then hit on the second force call) and a backend-array
+    # component (returned untouched, never cached), under two frame setups.
     from galpy.potential import NonInertialFrameForce
 
     with use(backend, force=True):
@@ -306,8 +305,8 @@ def test_force_constant_anchor_cache(backend):
         numpy.testing.assert_allclose(f1, f2, rtol=0.0, atol=0.0)
         assert numpy.all(numpy.isfinite(f1))
 
-        # vector Omega function: _Omega_py(t) hands _anchor a numpy ARRAY, which
-        # is unhashable and must take the bypass rather than raise
+        # vector Omega function: components are anchored one at a time through
+        # _vec, so this exercises the cache under a different frame configuration
         niff = NonInertialFrameForce(
             Omega=[lambda t: 0.0 * t, lambda t: 0.0 * t, lambda t: 1.3 + 0.0 * t],
             Omegadot=[lambda t: 0.0 * t, lambda t: 0.0 * t, lambda t: 0.0 * t],


### PR DESCRIPTION
Two real defects found while profiling the eager-jax force path (Path B of the ledger-reduction plan). Both are small wins; **neither moves a ledger entry**, and the measurement says why.

## The fixes

- **`NonInertialFrameForce._force`** anchored the same handful of constants (mostly `0.0`) **~180× per call**, each a `device_put` through `as_backend_constant`. Now cached per (namespace, dtype, device) — the constants are frozen, and the key covers everything `as_backend_constant` anchors on.
- **`asarray_on_device`** re-dispatched `xp.asarray` even when the array already had the requested dtype and device. It sits on every coordinate-coercion path (~120 calls per non-inertial force evaluation), so it now returns the array unchanged when nothing would change.

## Measured

| | before | after |
|---|---|---|
| `_force` micro | 3.26 ms/call | 2.48 ms/call (**1.31×**) |
| real ledgered test (forced jax) | 340.25 s | 323.36 s (**1.06×**) |

Both arms were run in **this** session. I first compared against the ledger's recorded 343.2 s and then realised that number is from 2026-08-24 and is not a valid baseline.

## Why it's only 1.06×

The micro number proves the mechanism; the real test refuses to confirm the magnitude. Profiling the whole integration shows the cost is **diffuse, not concentrated**:

- `DehnenBarPotential._Rforce` + `_zforce` = **32.6 s** — more than the frame force's 18.6 s
- leaf: **667k jax ufunc dispatches, ~140 per force evaluation**
- `_Rforce` is ~40 array ops taking 4.6 ms, of which `_smooth` is 24%

There is no remaining single hotspot: the earlier 1.51× win took the one concentrated defect (device naming), and that hook is now silent. Cutting the 3–4× the ledger needs would mean restructuring the force math itself — which is what jit gives for free.

## Tests

`test_noninertial.py` 53 passed (numpy); `test_backend.py` + `test_backend_input.py` 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm