### PR TITLE
slow-skip: drop the traced Staeckel parity grid (ledger -1), re-measure three stale jit notes

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -342,13 +342,12 @@ jax-jit tests/test_dynamfric.py::test_dynamfric_c  # 300s cap traced
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap
 jax-jit tests/test_qdf.py::test_sampleV_interpolate  # 300s cap
-jax-jit tests/test_orbits.py::test_SOS_3D  # 300s cap (269s eager -> SLOWER traced)
+jax-jit tests/test_orbits.py::test_SOS_3D  # re-measured 2026-09-07: 582.3s traced (269s eager -> 2.2x SLOWER traced)
 # NOT an eager entry: tracing alone makes these slow, so inheritance could never
 # have produced them.
-jax-jit tests/test_orbits.py::test_bruteSOS_3D  # 277s traced -- the only entry
+jax-jit tests/test_orbits.py::test_bruteSOS_3D  # re-measured 2026-09-07: 310.7s traced (was noted 277s) -- the only entry
                                                 # INSIDE the 240-300s band; every
                                                 # other keeper hit the cap
-jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_python_c_freqsAngles  # 300s cap
 
 # --- jax-jit: test_orbit, the 10th and last file of the sweep ---
 # 581 cases, 7605 s traced, 0 non-timeout failures. Its eager `jax` list had 25
@@ -362,7 +361,7 @@ jax-jit tests/test_orbit.py::test_analytic_zmax  # 300s cap
 # test_bruteSOS_3D (277 s) these are the only 3 of 15 entries whose fate turns
 # on where the margin sits; the other 12 hit the cap outright.
 jax-jit tests/test_orbit.py::test_energy_jacobi_conservation[BurkertPotentialNoC--10.0--10.0-False]  # 296s
-jax-jit tests/test_orbit.py::test_liouville_planar  # 265s
+jax-jit tests/test_orbit.py::test_liouville_planar  # re-measured 2026-09-07: 478.8s traced (the 265s note was stale and optimistic)
 
 # torch-jit: measured by the 2026-08-09 torch sweep (duration vs the 240s
 # margin; --timeout-method=signal cannot interrupt C-bound tests, so PASS


### PR DESCRIPTION
Path C, first pass: sweep the jit entries whose underlying code has changed, and **re-measure rather than trust the recorded numbers**.

## Dropped (ledger −1)

**`jax-jit test_actionAngleStaeckel_python_c_freqsAngles`** — #1446 replaced that test's 486-point Python scalar loop with one batched array call in order to fix the *eager* entry. It turns out that fixes the **traced** path too: **49.9s against a 300s cap**, where the entry claimed the cap outright. One vectorisation, both modes.

## Re-measured and kept — all three are *slower* than recorded

| entry | noted | re-measured | |
|---|---|---|---|
| `test_liouville_planar` | 265s | **478.8s** | note was optimistic |
| `test_bruteSOS_3D` | 277s | **310.7s** | over the cap |
| `test_SOS_3D` | "300s cap" | **582.3s** | 2.2× slower than eager |

That direction matters: re-measuring an entry is as likely to **justify** it as to retire it, and a note that drifts optimistic is what invites a bad un-skip. (I made exactly that mistake earlier this session by un-skipping on an isolated-run number.) The notes now carry today's figures.

## Ledger

**50 → 49** slow-skip entries; jit entries 22 → 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm