### PR TITLE
Make the traced suite green: fix the vcirc probe, record the four traced timeouts

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1615,18 +1615,34 @@ class Orbit:
             tdyn = numpy.sqrt(1.0 / tdyn) if tdyn > 0.0 else 0.0
         if tdyn > 0.0:
             return tdyn
-        # If all fail, fallback to vcirc
+        # If all fail, fallback to vcirc -- but only where a circular velocity is
+        # DEFINED. vcirc exists on a non-axisymmetric potential and raises from
+        # inside (TypeError on a None force), which the except below used to
+        # absorb. Under a traced backend that TypeError surfaces as the
+        # framework's own error (torch._dynamo TorchRuntimeError), which no
+        # except clause here catches, so the ValueError below never got raised.
+        # Feature-detect instead of probing: ask whether the potential is
+        # axisymmetric rather than calling and catching.
         vc = 0.0
-        try:
-            vc = pot.vcirc(r_init, use_physical=False)
-        except (NotImplementedError, AttributeError, TypeError):
-            # Try with subset of potentials that support vcirc
-            for p in pot:
+        if not _isNonAxi(pot):
+            try:
+                vc = pot.vcirc(r_init, use_physical=False)
+            except (NotImplementedError, AttributeError, TypeError):
+                vc = 0.0
+        if not vc > 0.0:
+            # A non-axisymmetric COMBINATION can still contain axisymmetric
+            # components that do define a circular velocity, so fall back to
+            # summing those -- skipping the non-axisymmetric ones by predicate
+            # rather than by calling them and catching.
+            vc2 = 0.0
+            for p in pot if hasattr(pot, "__iter__") else [pot]:
+                if _isNonAxi(p):
+                    continue
                 try:
-                    vc += p.vcirc(r_init, use_physical=False) ** 2.0
+                    vc2 += p.vcirc(r_init, use_physical=False) ** 2.0
                 except (NotImplementedError, AttributeError, TypeError):
                     pass
-            vc = numpy.sqrt(vc)
+            vc = numpy.sqrt(vc2)
         if vc > 0.0:
             return 2.0 * numpy.pi * r_init / vc
 

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -339,6 +339,8 @@ jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 326.8s trace
 # 11 do not. Two of the 8 were NEVER eager entries -- inheritance only
 # propagates eager entries forward, so it could not have found them at all.
 jax-jit tests/test_dynamfric.py::test_dynamfric_c  # 300s cap traced
+jax-jit tests/test_scf.py::test_density1_Order  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
+jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_wSpherical_conserved_actions_c  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap
 jax-jit tests/test_qdf.py::test_sampleV_interpolate  # 300s cap
@@ -367,6 +369,8 @@ jax-jit tests/test_orbit.py::test_liouville_planar  # re-measured 2026-09-07: 47
 # margin; --timeout-method=signal cannot interrupt C-bound tests, so PASS
 # does not imply under-cap -- these are classified by junitxml time).
 torch-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor
+torch-jit tests/test_dynamfric.py::test_dynamfric_c  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
+torch-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
 torch-jit tests/test_orbit.py::test_interprz_dxdv_3d
 torch-jit tests/test_orbit.py::test_analytic_zmax
 torch-jit tests/test_orbit.py::test_liouville_planar

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -16785,3 +16785,35 @@ def test_orbits_energy_array_times_nonbroadcasting_potential():
     # the orbits must actually differ, or a transposition would go unnoticed
     assert numpy.fabs(E3[0, 0] - E3[1, 0]) > 0.1, "orbits too similar to be diagnostic"
     assert numpy.fabs(E5[0, 0] - E5[1, 0]) > 0.1, "orbits too similar to be diagnostic"
+
+
+def test_integrate_auto_axisym_vcirc_raises():
+    # The vcirc fallback is gated on _isNonAxi, but an AXISYMMETRIC potential can
+    # still fail to provide one (a subclass that has not implemented it). Those
+    # except branches are the remaining safety net; cover them with a synthetic
+    # rather than pinning a real potential to a wart.
+    #
+    # Two details this needs, both of which a first attempt got wrong:
+    #   * it must be a PLANAR potential -- tdyn needs mass(), which planar
+    #     wrappers do not provide, so tdyn raises cleanly and control actually
+    #     reaches the vcirc fallback; a 3D potential returns from tdyn first;
+    #   * it must be a SINGLE potential, not a combination -- a composite's
+    #     vcirc is computed from the combined forces, so overriding a component's
+    #     vcirc does not make the whole-potential call raise.
+    import types
+
+    from galpy import potential
+    from galpy.orbit import Orbit
+
+    def raiser(self, *args, **kwargs):
+        raise NotImplementedError("no vcirc here")
+
+    bad = potential.MiyamotoNagaiPotential(normalize=1.0, a=1.0, b=0.2).toPlanar()
+    bad.vcirc = types.MethodType(raiser, bad)
+    assert not bad.isNonAxi, "the synthetic must stay axisymmetric to hit the branch"
+
+    # no tdyn (planar) and no usable vcirc (raises) -> the documented ValueError
+    o = Orbit([1.0, 0.1, 1.1, 0.0])
+    with pytest.raises(ValueError, match="Cannot calculate dynamical time"):
+        o.integrate(bad)
+    return None


### PR DESCRIPTION
The traced CI dispatch (run 34082291086, `jit=true`) reported **7 un-ledgered failures**. Diagnosed, they are **one real bug and four timeouts**.

## The bug (3 of the 7, one cause)

`_calculate_dynamical_time` falls back to `vcirc` by **calling it and catching** `(NotImplementedError, AttributeError, TypeError)`. Under `torch.compile` the `TypeError` raised inside `vcirc` surfaces as the framework's own error:

```
TorchRuntimeError: RuntimeError when making fake tensor call
  call_function sub(*(None, FakeTensor(..., size=()))):
  unsupported operand type(s) for -: 'NoneType' and 'FakeTensor'
```

which no `except` clause catches — so the `ValueError` the caller expects never got raised. **Exception-driven capability probing doesn't survive tracing**, because the framework rewraps the exception type.

Fix: ask the question directly. A circular velocity is only *defined* for an axisymmetric potential, and galpy already has `_isNonAxi`. Gate the whole-potential call on it, and skip non-axisymmetric **components** by the same predicate when summing the fallback.

Two things the tests caught that reasoning didn't:
- the culprit is **`vcirc`, not `tdyn`** — `tdyn` is absent on planar potentials, so it raises a clean `AttributeError` that *is* caught;
- a non-axisymmetric **combination** still contains axisymmetric components that define `vcirc`, and it's reached by *iteration*, not `isinstance(pot, list)` — a combined planar potential is a `planarCompositePotential`, iterable but **not a list**.

## The four timeouts

| | |
|---|---|
| `jax-jit` | `test_scf::test_density1_Order` |
| `jax-jit` | `test_actionAngle::test_actionAngleStaeckel_wSpherical_conserved_actions_c` |
| `torch-jit` | `test_dynamfric::test_dynamfric_c` |
| `torch-jit` | `test_FDMdynamfric::test_FDMDynamicalFrictionForce_central_limit` |

All four are `Failed: Timeout (>300.0s)`, and each already has a sibling entry for the other backend or for eager mode — the same known slowness surfacing in a mode CI had never run, not a regression.

This **grows the ledger 50 → 54**, which is the honest direction: the entries describe work that was always there and simply went unmeasured. The burndown they enable is on the other side — a prior sweep found roughly half to two-thirds of the **27 eager** entries are fast traced, so the switch retires far more than these four cost.

## Tests

| | |
|---|---|
| `test_orbit.py -k test_integrate_auto` | **16 passed** on numpy, jax `--jit`, torch `--jit` (was 3 failing) |
| full `test_orbit.py` + `test_orbits.py` (numpy) | **695 passed, 4 skipped** — no regression |
| ledger | parses; `test_dynamfric_c` now skips under `--backend torch --jit` |

**Traced suite: 7 un-ledgered failures → 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm