### PR TITLE
SCF: batch the general (non-axi) coefficient quadrature (traced test_density1_Order 300s+ -> 13s, ledger -1)

### DIFF
--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2534,6 +2534,44 @@ def scf_compute_coeffs(
         _cs = like(phi_nl, _cs)
         return _dens * phi_nl[numpy.newaxis, :, :, :] * _cs * dV
 
+    def integrand_batched(xi, costheta, phi):
+        # Node-batched twin of `integrand`: same expression with the node axis
+        # LEADING, so the 3-D solve's thousands of nodes go through in one call
+        # instead of one eager dispatch each. Nodes stay NUMPY, exactly as the
+        # scalar twin passes numpy scalars -- batching must not change what user
+        # density code receives (see scf_compute_coeffs_axi).
+        xi = numpy.asarray(xi)
+        costheta = numpy.asarray(costheta)
+        phi = numpy.asarray(phi)
+        l = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :, numpy.newaxis]
+        m = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, numpy.newaxis, :]
+        r = _xiToR(xi, a)
+        R = r * numpy.sqrt(1 - costheta**2.0)
+        z = r * costheta
+        PP = assoc_legendre(L, L, costheta)[:, numpy.newaxis, :, :]
+        dV = ((1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0))[
+            :, None, None, None, None
+        ]
+        # _C puts the node axis LAST; move it to the front through the resolved
+        # namespace (numpy.moveaxis on a Tensor hits transpose(list), which torch
+        # rejects).
+        _CC_raw = _C(xi, N, L)
+        _cxp = get_namespace(_CC_raw)
+        _CC = _cxp.permute_dims(_CC_raw, (2, 0, 1))[..., numpy.newaxis]
+        _xiB = xi[:, None, None, None]
+        # `l` must cross to the backend BEFORE the power, as in the axi twin.
+        _pref = like(_CC, -(a**3) * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
+        phi_nl = _pref * _CC * PP
+        _dens = dens(R, z, phi, **dens_kw)
+        _dens = like(phi_nl, numpy.asarray(_dens)[:, None, None, None, None])
+        _mp = m * phi[:, None, None, None]
+        _cs = like(phi_nl, numpy.stack([numpy.cos(_mp), numpy.sin(_mp)], axis=1))
+        return _dens * phi_nl[:, numpy.newaxis] * _cs * like(phi_nl, dV)
+
+    with _use_backend("numpy", force=True):
+        if _dens_accepts_arrays(dens, 3, dens_kw):
+            integrand.batched = integrand_batched
+
     Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20), max(L + 1, 20)]
     if radial_order != None:
         Ksample[0] = radial_order

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -339,7 +339,6 @@ jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 326.8s trace
 # 11 do not. Two of the 8 were NEVER eager entries -- inheritance only
 # propagates eager entries forward, so it could not have found them at all.
 jax-jit tests/test_dynamfric.py::test_dynamfric_c  # 300s cap traced
-jax-jit tests/test_scf.py::test_density1_Order  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
 jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_wSpherical_conserved_actions_c  # measured 2026-09-07 in the traced CI dispatch (run 34082291086): Failed: Timeout (>300.0s). Recorded now only because CI had never run the suite traced, not because anything got slower.
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -817,3 +817,77 @@ def test_scf_axi_batched_matches_sequential(backend_name):
     scale = numpy.max(numpy.abs(ref))
     numpy.testing.assert_allclose(batched, seq, rtol=0, atol=1e-15 * scale)
     numpy.testing.assert_allclose(batched, ref, rtol=0, atol=1e-15 * scale)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scf_general_batched_matches_sequential(backend_name):
+    # Same parity check as the axi twin above, for the GENERAL (non-axi) routine:
+    # its 3-D node grid is where the sequential loop hurt most. Reduced quadrature
+    # orders keep the sequential arm affordable while still walking many nodes.
+    import importlib
+
+    from galpy import backend as _b
+
+    S = importlib.import_module("galpy.potential.SCFPotential")
+    orders = dict(radial_order=6, costheta_order=5, phi_order=5)
+
+    def dens_vec(R, z, phi):  # accepts arrays -> batched path
+        r = numpy.sqrt(R**2 + z**2)
+        return numpy.exp(-r) * (1.0 + 0.2 * numpy.cos(phi) + 0.1 * numpy.sin(2 * phi))
+
+    def dens_scalar(R, z, phi):  # rejects arrays -> sequential path
+        if numpy.ndim(R) != 0:
+            raise TypeError("scalar-only density")
+        return dens_vec(R, z, phi)
+
+    # guard the premise: the two really do take different paths
+    assert S._dens_accepts_arrays(dens_vec, 3, {})
+    assert not S._dens_accepts_arrays(dens_scalar, 3, {})
+
+    # Call counts are the real assertion: a value comparison alone cannot tell
+    # "both paths correct" from "the batched branch never ran".
+    calls = {"scalar": 0, "batched": 0}
+    _orig_quad = S._gaussianQuadrature
+
+    def counting_quad(integrand, bounds, Ksample=[20], roundoff=0):
+        _b_fn = getattr(integrand, "batched", None)
+
+        def wrapped(*a):
+            calls["scalar"] += 1
+            return integrand(*a)
+
+        if _b_fn is not None:
+
+            def wrapped_batched(*a):
+                calls["batched"] += 1
+                return _b_fn(*a)
+
+            wrapped.batched = wrapped_batched
+        return _orig_quad(wrapped, bounds, Ksample=Ksample, roundoff=roundoff)
+
+    with _b.use(backend_name, force=True):
+        S._gaussianQuadrature = counting_quad
+        try:
+            bat = S.scf_compute_coeffs(dens_vec, 4, 3, a=1.0, **orders)
+            bat_c, bat_s = as_numpy(bat[0]), as_numpy(bat[1])
+            n_batched = calls["batched"]
+            calls["scalar"] = calls["batched"] = 0
+            seq = S.scf_compute_coeffs(dens_scalar, 4, 3, a=1.0, **orders)
+            seq_c, seq_s = as_numpy(seq[0]), as_numpy(seq[1])
+            n_seq_scalar, n_seq_batched = calls["scalar"], calls["batched"]
+        finally:
+            S._gaussianQuadrature = _orig_quad
+    assert n_batched > 0, "vectorizable density must take the BATCHED path"
+    assert n_seq_batched == 0, "scalar-only density must NOT take the batched path"
+    assert n_seq_scalar > 1, "scalar-only density must step the sequential loop"
+    # Nodes and weights are identical; only the reduction order differs, so the
+    # bar is ~1 ulp of the quadrature's own magnitude. Acos and Asin come out of
+    # the SAME sum, so they share one scale: Asin is the small array here (0.55
+    # against Acos' 45) and most of it vanishes by symmetry, so scaling it to
+    # itself would judge pure cancellation noise against an unfairly tiny bar
+    # while the absolute error -- ~1e-15 across both -- is what actually differs.
+    ref_c, ref_s = S.scf_compute_coeffs(dens_vec, 4, 3, a=1.0, **orders)
+    scale = max(numpy.max(numpy.abs(ref_c)), numpy.max(numpy.abs(ref_s)))
+    for b, s, r in ((bat_c, seq_c, ref_c), (bat_s, seq_s, ref_s)):
+        numpy.testing.assert_allclose(b, s, rtol=0, atol=1e-15 * scale)
+        numpy.testing.assert_allclose(b, r, rtol=0, atol=1e-15 * scale)


### PR DESCRIPTION
`scf_compute_coeffs` — the general, non-axisymmetric coefficient routine — walked
its 3-D Gauss-Legendre grid one node at a time: `20^3 = 8000` sequential integrand
calls, each dispatching a few hundred tiny eager ops through `_C`/gegenbauer/
`assoc_legendre`. numpy shrugs that off; a backend pays per-dispatch overhead on
every one of them.

`_gaussianQuadrature` has had the batched hook since #1416, but only
`scf_compute_coeffs_axi` ever opted in. This attaches the node-batched twin to the
general routine as well, following that same pattern exactly: node axis **leading**,
nodes kept **numpy** so a user density still receives what the scalar twin passes it,
and `like()` carrying the numpy factors across so the backend owns each product.

### Measured (this session, float64)

| | before | after |
|---|---|---|
| `scf_compute_coeffs(density1, 5, 5)`, jax | 58.74 s | **4.63 s** (12.7x) |
| same call, numpy | 2.86 s | 2.86 s (untouched) |
| `test_density1_Order`, `--backend jax --jit` | **>300 s (CI timeout)** | **13.1 s** |

That test is one of the four traced timeouts recorded from the traced CI dispatch
(run 34082291086), so this drops it from the slow-skip ledger (**ledger -1**).

### Correctness

Agreement with numpy is **5.7e-15 relative** — the batched-vs-sequential
reduction-order roundoff #1417 already documented, not a value change. The numpy
path is untouched: the diff is purely additive (38 lines added, 0 removed) and
numpy never enters the batched branch (`_amb is not numpy`).

`test_scf_general_batched_matches_sequential` mirrors #1416's axi parity test:
it drives both paths with mathematically identical densities (one vectorizable,
one that rejects arrays) and asserts on the **integrand call counts** first — a
value comparison alone cannot tell "both paths correct" from "the batched branch
is dead code", which is the failure #1416's test was written to catch.

### Gates

- `tests/test_scf.py`: numpy 95 passed / torch 95 passed / jax 92 passed + 3 ledgered skips
- `tests/test_backend_scf.py`: full file, jax + torch

### Not in this PR

The three *time-dependent* SCF slow-skips (`test_tdep_from_density_*`, 380-670 s
eager jax) need the same treatment on `_scf_compute_coeffs_timedep`, but that one
also carries a time axis, so a `(K, Nt, 2, N, L, L)` batch would blow the 32 MB
`_TIMEDEP_BATCH_BYTES` budget by a factor of K. Its integrand is separable
(`_ft[k,t] * base[k,...]`), so the weighted node sum is exactly one `tensordot`
that never materializes that array — a follow-up PR.

Stacked on #1452 (which is where the ledger entry was recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
