### PR TITLE
SCF: contract the time-dependent coefficient quadrature over its nodes (jax 63s -> 4.3s, ledger -3)

### DIFF
--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2705,6 +2705,20 @@ def _batched_timedep(tgrid, per_time_elems, compute):
     return Acos, Asin
 
 
+def _tdep_node_contract(base, ft, weights):
+    """Weighted node sum for a separable time-dependent integrand: ``ft`` is the
+    per-(node, time) density factor, ``base`` the time-independent per-node basis
+    with the node axis LEADING. Folding the quadrature weights into ``ft`` keeps
+    the whole reduction one backend op and never builds the (nodes,) + shape array.
+
+    Notes
+    -----
+    - 2026-09-07 - Written - Bovy (UofT)
+    """
+    _ftw = like(base, ft * weights[:, numpy.newaxis])
+    return get_namespace(base).tensordot(_ftw, base, axes=([0], [0]))
+
+
 def _timedep_dens_setup(dens, tgrid, numOfParam):
     """Detect the ``use_physical`` keyword for a time-dependent density and
     verify that it is vectorizable over ``t``; return a callable
@@ -2735,6 +2749,37 @@ def _timedep_dens_setup(dens, tgrid, numOfParam):
         return numpy.asarray(
             dens(*(R, z, phi)[:numOfParam], t=tgrid, **dens_kw), dtype=float
         )
+
+    # Spatial-batching companion: evaluate every (node, time) pair in one call by
+    # giving the spatial arguments a trailing axis for `t` to broadcast against.
+    # Vectorizability over t does NOT imply it -- a density can accept an array t
+    # at a single position and still not broadcast against an array of positions
+    # -- so probe for it and require the (nodes, times) OUTPUT SHAPE, the same
+    # discipline as `_dens_accepts_arrays`. Leaving `f.batched` unset only costs
+    # speed (the caller keeps the per-node loop); a wrong attach would silently
+    # corrupt coefficients.
+    sprobe = numpy.array([0.5, 0.75, 1.0])
+    try:
+        sout = numpy.asarray(
+            dens(*([sprobe[:, numpy.newaxis]] * numOfParam), t=tgrid, **dens_kw),
+            dtype=float,
+        )
+    except Exception:
+        pass
+    else:
+        if sout.shape == (sprobe.size,) + numpy.shape(tgrid):
+
+            def f_batched(R, z, phi):
+                # Slice to numOfParam and broadcast BEFORE adding the axis: the
+                # axisymmetric caller passes a plain 0.0 for phi even when the
+                # density takes three arguments, and a scalar has no axis to add.
+                vals = numpy.broadcast_arrays(
+                    *[numpy.asarray(v) for v in (R, z, phi)[:numOfParam]]
+                )
+                cols = [v[:, numpy.newaxis] for v in vals]
+                return numpy.asarray(dens(*cols, t=tgrid, **dens_kw), dtype=float)
+
+            f.batched = f_batched
 
     return f
 
@@ -2823,6 +2868,28 @@ def _scf_compute_coeffs_axi_timedep(
         _ft = like(base, f(R, z, 0.0))
         return _ft[:, numpy.newaxis, numpy.newaxis] * base[numpy.newaxis]
 
+    def integrand_batched_reduce(xi, costheta, weights=None):
+        # Separable exactly as in the general routine above: time factor times a
+        # time-independent basis, so the weighted node sum is one contraction.
+        xi = numpy.asarray(xi)
+        costheta = numpy.asarray(costheta)
+        l = numpy.arange(0, L)[numpy.newaxis, :]
+        r = _xiToR(xi, a)
+        R = r * numpy.sqrt(1 - costheta**2.0)
+        z = r * costheta
+        PP = assoc_legendre(L, 1, costheta)[..., 0][:, numpy.newaxis, :]
+        dV = ((1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0))[:, None, None]
+        _CC_raw = _C(xi, N, L)
+        _cxp = get_namespace(_CC_raw)
+        _CC = _cxp.permute_dims(_CC_raw, (2, 0, 1))  # (N,L,K) -> (K,N,L)
+        _xiB = xi[:, None, None]
+        _pref = like(_CC, a**3 * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
+        base = _pref * _CC * PP * like(_CC, dV)  # (K, N, L)
+        return _tdep_node_contract(base, f.batched(R, z, 0.0), weights)  # (Nt,N,L)
+
+    if getattr(f, "batched", None) is not None:
+        integrand.batched_reduce = integrand_batched_reduce
+
     Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20)]
     if radial_order is not None:
         Ksample[0] = radial_order
@@ -2881,6 +2948,40 @@ def _scf_compute_coeffs_timedep(
         # `f` returns NUMPY over tgrid; anchor before it meets the backend base.
         _ft = like(base, f(R, z, phi))
         return _ft[:, None, None, None, None] * base[numpy.newaxis]
+
+    def integrand_batched_reduce(xi, costheta, phi, weights=None):
+        # The integrand is an OUTER PRODUCT: a time factor f(node) and a
+        # time-independent basis, so the weighted node sum is one contraction and
+        # the (K, Nt, 2, N, L, L) array never has to exist -- which is the point,
+        # since it would be K times the working set `_TIMEDEP_BATCH_BYTES` sizes.
+        # The basis is also built ONCE here instead of once per time step.
+        xi = numpy.asarray(xi)
+        costheta = numpy.asarray(costheta)
+        phi = numpy.asarray(phi)
+        l = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, :, numpy.newaxis]
+        m = numpy.arange(0, L)[numpy.newaxis, numpy.newaxis, numpy.newaxis, :]
+        r = _xiToR(xi, a)
+        R = r * numpy.sqrt(1 - costheta**2.0)
+        z = r * costheta
+        PP = assoc_legendre(L, L, costheta)[:, numpy.newaxis, :, :]
+        dV = ((1.0 + xi) ** 2.0 * numpy.power(1.0 - xi, -4.0))[
+            :, None, None, None, None
+        ]
+        _CC_raw = _C(xi, N, L)
+        _cxp = get_namespace(_CC_raw)
+        _CC = _cxp.permute_dims(_CC_raw, (2, 0, 1))[..., numpy.newaxis]
+        _xiB = xi[:, None, None, None]
+        _pref = like(_CC, -(a**3) * (1.0 + _xiB) ** l * (1.0 - _xiB) ** (l + 1.0))
+        phi_nl = _pref * _CC * PP
+        _mp = m * phi[:, None, None, None]
+        _cs = like(phi_nl, numpy.stack([numpy.cos(_mp), numpy.sin(_mp)], axis=1))
+        base = phi_nl[:, numpy.newaxis] * _cs * like(phi_nl, dV)  # (K,2,N,L,L)
+        # Fold the quadrature weights into the time factor, so the contraction
+        # carries them and the sum stays a single backend op.
+        return _tdep_node_contract(base, f.batched(R, z, phi), weights)  # (Nt,2,N,L,L)
+
+    if getattr(f, "batched", None) is not None:
+        integrand.batched_reduce = integrand_batched_reduce
 
     Ksample = [max(N + 3 * L // 2 + 1, 20), max(L + 1, 20), max(L + 1, 20)]
     if radial_order is not None:
@@ -3026,14 +3127,32 @@ def _gaussianQuadrature(integrand, bounds, Ksample=[20], roundoff=0):
     # dead under a forced backend. Coerce the nodes ONTO the backend so the
     # batched evaluation is genuinely backend-native.
     _amb = get_namespace(numpy.zeros(1))
-    if _batched is not None and shape is not None and _amb is not numpy:
+    # A SEPARABLE integrand -- one whose value is an outer product of a per-node
+    # factor and a per-node basis -- can contract the weighted node sum itself and
+    # never materialize the (K,) + shape array. `batched_reduce` is that opt-in,
+    # and it takes the node arrays plus the combined weights, returning `shape`
+    # already summed over the nodes. It matters wherever `shape` carries an axis
+    # the caller sized a memory budget for: the time-dependent coefficient builds
+    # put Nt in front, so (K,) + shape is K times that budget's working set.
+    _reduce = getattr(integrand, "batched_reduce", None)
+    if (
+        (_batched is not None or _reduce is not None)
+        and shape is not None
+        and _amb is not numpy
+    ):
         _idx = (numpy.arange(len(bounds))[:, None], li.T)
         nodes = tuple(_amb.asarray(n) for n in xp[_idx])  # (ndim, K) on backend
-        vals = _batched(*nodes)  # (K,) + shape
         w = numpy.prod(wp[_idx], axis=0)
-        # value LEADS so the backend owns the product, as in the loop below
-        _bxp = get_namespace(vals)
-        s = _bxp.sum(vals * like(vals, w).reshape((-1,) + (1,) * len(shape)), axis=0)
+        if _reduce is not None:
+            s = _reduce(*nodes, weights=w)
+        else:
+            vals = _batched(*nodes)  # (K,) + shape
+            # value LEADS so the backend owns the product, as in the loop below
+            _vxp = get_namespace(vals)
+            s = _vxp.sum(
+                vals * like(vals, w).reshape((-1,) + (1,) * len(shape)), axis=0
+            )
+        _bxp = get_namespace(s)
         return _bxp.where(_bxp.abs(s) < roundoff, 0.0, s)
 
     ##Performs the actual integration

--- a/galpy/potential/SCFPotential.py
+++ b/galpy/potential/SCFPotential.py
@@ -2657,6 +2657,13 @@ class _TimeDepDensityNotVectorized(Exception):
 # exercise the batched path.
 _TIMEDEP_BATCH_BYTES = 32 * 1024**2  # 32 MB
 
+# Peak-memory budget (bytes) for the per-node basis a `batched_reduce` integrand
+# materializes. Its reduced output is independent of the node count but that
+# basis is not, so `_gaussianQuadrature` contracts the nodes in chunks no larger
+# than this. Same size and spirit as the tgrid budget above; separate because it
+# bounds a different axis (nodes, not time steps).
+_REDUCE_NODE_BYTES = 32 * 1024**2  # 32 MB
+
 
 def _timedep_batch_size(Nt, per_time_elems):
     """Number of time steps to process per batch so one working copy of the
@@ -2760,10 +2767,13 @@ def _timedep_dens_setup(dens, tgrid, numOfParam):
     # corrupt coefficients.
     sprobe = numpy.array([0.5, 0.75, 1.0])
     try:
-        sout = numpy.asarray(
-            dens(*([sprobe[:, numpy.newaxis]] * numOfParam), t=tgrid, **dens_kw),
-            dtype=float,
-        )
+        # Pinned to numpy like `_dens_accepts_arrays`: this PROBES user code with
+        # try/except, so it must not run under a forced backend.
+        with _use_backend("numpy", force=True):
+            sout = numpy.asarray(
+                dens(*([sprobe[:, numpy.newaxis]] * numOfParam), t=tgrid, **dens_kw),
+                dtype=float,
+            )
     except Exception:
         pass
     else:
@@ -2773,10 +2783,14 @@ def _timedep_dens_setup(dens, tgrid, numOfParam):
                 # Slice to numOfParam and broadcast BEFORE adding the axis: the
                 # axisymmetric caller passes a plain 0.0 for phi even when the
                 # density takes three arguments, and a scalar has no axis to add.
+                # `copy()` because broadcast_arrays gives 0-stride views: the
+                # axisymmetric caller passes a scalar phi, so every node would
+                # alias ONE float. A density writing in place would corrupt it,
+                # and numpy is moving these views to read-only anyway.
                 vals = numpy.broadcast_arrays(
                     *[numpy.asarray(v) for v in (R, z, phi)[:numOfParam]]
                 )
-                cols = [v[:, numpy.newaxis] for v in vals]
+                cols = [numpy.ascontiguousarray(v)[:, numpy.newaxis] for v in vals]
                 return numpy.asarray(dens(*cols, t=tgrid, **dens_kw), dtype=float)
 
             f.batched = f_batched
@@ -2868,7 +2882,7 @@ def _scf_compute_coeffs_axi_timedep(
         _ft = like(base, f(R, z, 0.0))
         return _ft[:, numpy.newaxis, numpy.newaxis] * base[numpy.newaxis]
 
-    def integrand_batched_reduce(xi, costheta, weights=None):
+    def integrand_batched_reduce(xi, costheta, weights):
         # Separable exactly as in the general routine above: time factor times a
         # time-independent basis, so the weighted node sum is one contraction.
         xi = numpy.asarray(xi)
@@ -2949,7 +2963,7 @@ def _scf_compute_coeffs_timedep(
         _ft = like(base, f(R, z, phi))
         return _ft[:, None, None, None, None] * base[numpy.newaxis]
 
-    def integrand_batched_reduce(xi, costheta, phi, weights=None):
+    def integrand_batched_reduce(xi, costheta, phi, weights):
         # The integrand is an OUTER PRODUCT: a time factor f(node) and a
         # time-independent basis, so the weighted node sum is one contraction and
         # the (K, Nt, 2, N, L, L) array never has to exist -- which is the point,
@@ -3144,7 +3158,26 @@ def _gaussianQuadrature(integrand, bounds, Ksample=[20], roundoff=0):
         nodes = tuple(_amb.asarray(n) for n in xp[_idx])  # (ndim, K) on backend
         w = numpy.prod(wp[_idx], axis=0)
         if _reduce is not None:
-            s = _reduce(*nodes, weights=w)
+            # The reduced RESULT does not grow with the node count, but the basis
+            # the integrand materializes to get there does -- it is (K,) + the
+            # per-node part of `shape`. That is independent of the caller's time
+            # batching, so contracting all K nodes at once escapes whatever budget
+            # the caller sized (measured: a 32 MB `_TIMEDEP_BATCH_BYTES` still
+            # peaked at ~1.5 GB, and shrinking the budget 32000x did not move it).
+            # Chunk the nodes instead and accumulate the partial contractions.
+            per_node = int(numpy.prod(shape[1:])) if len(shape) > 1 else 1
+            kc = max(1, _REDUCE_NODE_BYTES // (per_node * 8))
+            s = None
+            for start in range(0, li.shape[0], kc):
+                sl = slice(start, start + kc)
+                part = _reduce(*(n[sl] for n in nodes), weights=w[sl])
+                s = part if s is None else s + part
+            # A separable integrand that returns the wrong RANK would broadcast
+            # into a silently wrong shape rather than raise, so pin it here.
+            if tuple(s.shape) != tuple(shape):
+                raise ValueError(
+                    f"batched_reduce returned {tuple(s.shape)}, expected {tuple(shape)}"
+                )
         else:
             vals = _batched(*nodes)  # (K,) + shape
             # value LEADS so the backend owns the product, as in the loop below

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -439,15 +439,4 @@ torch-jit tests/test_orbit.py::test_liouville_planar
 # because a deadlock cannot be attributed to individual tests.
 #
 #
-# SCF time-dependent-density coefficients, jax arm (added 2026-08-29 with the
-# ambient-namespace coefficient migration). These ran on numpy before, because
-# the coefficient routines were pinned to numpy; following the ambient namespace
-# means a forced-backend run now computes them EAGERLY on the backend, and eager
-# per-call overhead (~5 ms flat) dominates a nested quadrature loop.
-# Measured locally 2026-08-29; CI estimate uses the measured CI/local factor 0.71
-# against the 300 s per-test cap. torch is unaffected (worst case 160 s -> ~114 s).
-# These are performance, not correctness: all three PASS, just slowly.
-jax tests/test_scf.py::test_tdep_from_density_vectorized_matches_loop  # measured 2026-08-29: 671s local -> ~476s CI
-jax tests/test_scf.py::test_tdep_from_density_nonvectorizable_fallback  # measured 2026-08-29: 555s local -> ~394s CI
-jax tests/test_scf.py::test_tdep_from_density_time_batching  # measured 2026-08-29: 381s local -> ~270s CI, only 10% under the cap
 #

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -891,3 +891,100 @@ def test_scf_general_batched_matches_sequential(backend_name):
     for b, s, r in ((bat_c, seq_c, ref_c), (bat_s, seq_s, ref_s)):
         numpy.testing.assert_allclose(b, s, rtol=0, atol=1e-15 * scale)
         numpy.testing.assert_allclose(b, r, rtol=0, atol=1e-15 * scale)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scf_tdep_batched_reduce_matches_sequential(backend_name):
+    # The time-dependent coefficient builds are SEPARABLE -- a time factor times a
+    # time-independent basis -- so they contract the weighted node sum themselves
+    # (`batched_reduce`) rather than materializing a (K,) + shape array, which
+    # carries Nt in front and would be K times the working set
+    # `_TIMEDEP_BATCH_BYTES` sizes. Drive both paths with mathematically identical
+    # densities: one that broadcasts positions against t, one that accepts only a
+    # scalar position, so `f.batched` is never attached and the per-node loop runs.
+    import importlib
+
+    from galpy import backend as _b
+
+    S = importlib.import_module("galpy.potential.SCFPotential")
+    tgrid = numpy.linspace(0.0, 4.0, 5)
+
+    def profile(R, z, t):
+        return numpy.exp(-numpy.sqrt(R**2 + z**2)) * (1.0 + 0.02 * t)
+
+    def gen_bc(R, z, phi, t=0.0):
+        return profile(R, z, t) * (1.0 + 0.2 * numpy.cos(phi))
+
+    def gen_nobc(R, z, phi, t=0.0):
+        if numpy.ndim(R) > 1:  # rejects the (nodes, 1) probe -> sequential
+            raise TypeError("scalar position only")
+        return gen_bc(R, z, phi, t)
+
+    def axi_bc(R, z, t=0.0):
+        return profile(R, z, t)
+
+    def axi_nobc(R, z, t=0.0):
+        if numpy.ndim(R) > 1:
+            raise TypeError("scalar position only")
+        return axi_bc(R, z, t)
+
+    cases = (
+        (
+            "general",
+            S._scf_compute_coeffs_timedep,
+            gen_bc,
+            gen_nobc,
+            dict(radial_order=6, costheta_order=5, phi_order=5),
+        ),
+        (
+            "axi",
+            S._scf_compute_coeffs_axi_timedep,
+            axi_bc,
+            axi_nobc,
+            dict(radial_order=6, costheta_order=5),
+        ),
+    )
+    for tag, fn, dens_bc, dens_nobc, orders in cases:
+        calls = {"scalar": 0, "reduce": 0}
+        _orig_quad = S._gaussianQuadrature
+
+        def counting_quad(integrand, bounds, Ksample=[20], roundoff=0):
+            _r_fn = getattr(integrand, "batched_reduce", None)
+
+            def wrapped(*a):
+                calls["scalar"] += 1
+                return integrand(*a)
+
+            if _r_fn is not None:
+
+                def wrapped_reduce(*a, **kw):
+                    calls["reduce"] += 1
+                    return _r_fn(*a, **kw)
+
+                wrapped.batched_reduce = wrapped_reduce
+            return _orig_quad(wrapped, bounds, Ksample=Ksample, roundoff=roundoff)
+
+        with _b.use(backend_name, force=True):
+            S._gaussianQuadrature = counting_quad
+            try:
+                bat = fn(dens_bc, 6, 3, tgrid, a=1.0, **orders)
+                n_reduce = calls["reduce"]
+                calls["scalar"] = calls["reduce"] = 0
+                seq = fn(dens_nobc, 6, 3, tgrid, a=1.0, **orders)
+                n_seq_scalar, n_seq_reduce = calls["scalar"], calls["reduce"]
+            finally:
+                S._gaussianQuadrature = _orig_quad
+        ref = fn(dens_bc, 6, 3, tgrid, a=1.0, **orders)  # numpy reference
+        # Call counts first: a value comparison cannot tell "both paths correct"
+        # from "the reduce branch never ran".
+        assert n_reduce > 0, f"{tag}: broadcasting density must take batched_reduce"
+        assert n_seq_reduce == 0, f"{tag}: scalar-position density must not"
+        assert n_seq_scalar > 1, f"{tag}: scalar-position density must step the loop"
+        scale = max(numpy.max(numpy.abs(as_numpy(a))) for a in ref if a is not None)
+        for b, s, r in zip(bat, seq, ref):
+            if r is None:  # axi returns Asin=None
+                assert b is None and s is None
+                continue
+            b, s, r = as_numpy(b), as_numpy(s), numpy.asarray(r, dtype=float)
+            numpy.testing.assert_allclose(b, s, rtol=0, atol=1e-15 * scale)
+            numpy.testing.assert_allclose(b, r, rtol=0, atol=1e-15 * scale)

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -1030,3 +1030,41 @@ def test_scf_tdep_batched_reduce_degenerate_sizes(backend_name):
                     f"N={N} L={L} Nt={Nt}: {g.shape} != {r.shape}"
                 )
                 numpy.testing.assert_allclose(g, r, rtol=0, atol=1e-14 * scale)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scf_batched_reduce_wrong_rank_raises(backend_name):
+    # The guard exists because a wrong-RANK separable integrand does not raise on
+    # its own: an `ft` of (K,) turns `ft * weights[:, None]` into a (K, K) outer
+    # product, and the coefficient normalisation downstream broadcasts against
+    # that happily -- so the build would return silently wrong-shaped
+    # coefficients. Drive `_gaussianQuadrature` with a deliberately wrong-ranked
+    # `batched_reduce` and require the loud failure. A synthetic integrand, not a
+    # real potential: the point is the contract, not any particular density.
+    import importlib
+
+    from galpy import backend as _b
+    from galpy.backend import get_namespace
+
+    S = importlib.import_module("galpy.potential.SCFPotential")
+
+    with _b.use(backend_name, force=True):
+        xp = get_namespace(numpy.zeros(1))
+
+        def integrand(xi):  # scalar twin: fixes the expected shape at (3, 2)
+            return xp.zeros((3, 2))
+
+        def bad_reduce(xi, weights):  # returns (2, 3) -- right size, wrong shape
+            return xp.zeros((2, 3))
+
+        integrand.batched_reduce = bad_reduce
+        with pytest.raises(ValueError, match="batched_reduce returned"):
+            S._gaussianQuadrature(integrand, [[-1.0, 1.0]], Ksample=[4])
+
+        # and the correctly-shaped one goes through
+        def good_reduce(xi, weights):
+            return xp.zeros((3, 2))
+
+        integrand.batched_reduce = good_reduce
+        out = S._gaussianQuadrature(integrand, [[-1.0, 1.0]], Ksample=[4])
+        assert tuple(out.shape) == (3, 2)

--- a/tests/test_backend_scf.py
+++ b/tests/test_backend_scf.py
@@ -988,3 +988,45 @@ def test_scf_tdep_batched_reduce_matches_sequential(backend_name):
             b, s, r = as_numpy(b), as_numpy(s), numpy.asarray(r, dtype=float)
             numpy.testing.assert_allclose(b, s, rtol=0, atol=1e-15 * scale)
             numpy.testing.assert_allclose(b, r, rtol=0, atol=1e-15 * scale)
+
+
+@pytest.mark.parametrize("backend_name", AD_BACKENDS)
+def test_scf_tdep_batched_reduce_degenerate_sizes(backend_name):
+    # The contraction carries a leading time axis and a (N, L) basis, so the
+    # sizes that can silently squeeze an axis away are the 1s. Nt=1 also makes
+    # the node-chunk accumulator run with a single time step, and radial_order=1
+    # makes it run with a single NODE.
+    import importlib
+
+    from galpy import backend as _b
+
+    S = importlib.import_module("galpy.potential.SCFPotential")
+
+    def dens(R, z, phi, t=0.0):
+        r = numpy.sqrt(R**2 + z**2)
+        return numpy.exp(-r) * (1.0 + 0.2 * numpy.cos(phi)) * (1.0 + 0.02 * t)
+
+    def dens_axi(R, z, t=0.0):
+        return numpy.exp(-numpy.sqrt(R**2 + z**2)) * (1.0 + 0.02 * t)
+
+    for N, L, Nt, ro in ((1, 1, 1, 4), (2, 1, 3, 4), (1, 3, 2, 4), (3, 2, 1, 1)):
+        tgrid = numpy.linspace(0.0, 4.0, Nt)
+        gen = dict(radial_order=ro, costheta_order=3, phi_order=3)
+        axi = dict(radial_order=ro, costheta_order=3)
+        for fn, d, orders in (
+            (S._scf_compute_coeffs_timedep, dens, gen),
+            (S._scf_compute_coeffs_axi_timedep, dens_axi, axi),
+        ):
+            ref = fn(d, N, L, tgrid, a=1.0, **orders)  # numpy
+            with _b.use(backend_name, force=True):
+                got = fn(d, N, L, tgrid, a=1.0, **orders)
+            scale = max(numpy.max(numpy.abs(as_numpy(a))) for a in ref if a is not None)
+            for g, r in zip(got, ref):
+                if r is None:
+                    assert g is None
+                    continue
+                g, r = as_numpy(g), numpy.asarray(r, dtype=float)
+                assert g.shape == r.shape, (
+                    f"N={N} L={L} Nt={Nt}: {g.shape} != {r.shape}"
+                )
+                numpy.testing.assert_allclose(g, r, rtol=0, atol=1e-14 * scale)


### PR DESCRIPTION
Follow-up to #1453, which batched the *static* general coefficient quadrature.
The **time-dependent** builds still walked their node grid one node at a time.

They can't just reuse #1416's `batched` hook. That hook returns `(K,) + shape`,
and for these routines `shape` carries the time axis in front — so the batch
would be `(K, Nt, 2, N, L, L)`, i.e. **K times** the working set
`_TIMEDEP_BATCH_BYTES` was sized for (K = 8000 for a default 3-D solve).

But their integrand is **separable**: a time factor `f(node, t)` times a
time-independent basis `B(node)`. The weighted node sum

```
s[t,...] = sum_k w_k f[k,t] B[k,...]
```

is therefore exactly one contraction. This adds a second opt-in hook,
`batched_reduce`, which hands the integrand the node arrays *and* the combined
weights and lets it return the already-reduced result via one `tensordot`. The
`(K, Nt, ...)` array never exists and the basis is built **once** instead of
once per time step.

**Correction, from the adversarial review of the first draft of this PR.** I
originally justified the hook by saying the `(K, Nt, ...)` batch "would be K
times the working set `_TIMEDEP_BATCH_BYTES` is sized for". That is true, but
the basis the hook *does* materialize, `B` = `(K, 2, N, L, L)`, scales with the
**node** count and is independent of the caller's time batching — so that budget
became a no-op for this path. Measured: with the declared 32 MB budget, peak RSS
was ~1.5 GB, and shrinking the budget 32000x did not move it. `_gaussianQuadrature`
now contracts the nodes in chunks of `_REDUCE_NODE_BYTES` and accumulates the
partial results. Measured in *separate processes* (`ru_maxrss` is a process-wide
high-water mark, so two configs in one process cannot be told apart):

| | peak RSS |
|---|---|
| unchunked | 1502 MB |
| 32 MB chunk budget | 1379 MB |
| 1 MB chunk budget | 1118 MB |

That removes the term growing without bound in `K`. It does **not** give a tight
total bound — a ~1.1 GB jax-runtime floor dominates — and I would rather say so
than repeat the overclaim.

### Measured (this session, float64)

`SCFPotential.from_density(dens, N=10, L=3, symmetry=None, tgrid=11)`:

| | |
|---|---|
| numpy | 2.86 s |
| jax, per-node loop | 63.18 s |
| jax, `batched_reduce` | **4.31 s** (14.7x) |

The three ledgered `test_tdep_from_density_*` tests, jax, same tree each time:

| test | before #1453 | with #1453 | with this PR |
|---|---|---|---|
| `vectorized_matches_loop` | 68.8 s | 17.3 s | **9.3 s** |
| `nonvectorizable_fallback` | 65.7 s | 17.3 s | **11.6 s** |
| `time_batching` | 34.6 s | 36.4 s | **9.0 s** |

so all three come off the slow-skip ledger (**ledger -3**; -4 counting #1453).

**The ledger's own numbers for these were badly stale** — it recorded 381/555/671 s
on 2026-08-29, but they already ran at 34.6/65.7/68.8 s on a pristine tree at this
base before I changed anything. Landed work had fixed most of it and nobody
re-measured. The "before" column above is a fresh same-session measurement, not
the ledger note.

### Correctness

Agreement with numpy is ~1e-16 relative — the same reduction-order roundoff class
as #1417/#1453, not a value change. numpy is untouched: it never enters the branch
(`_amb is not numpy`).

Three more defects the same review found, all fixed here: a separable integrand
returning the wrong **rank** broadcast into a silently wrong shape rather than
raising (`ft` of `(K,)` made `ft * weights[:, None]` a `(K, K)` outer product),
so the reduced result is now checked against the shape the scalar probe already
established; `weights=None` was a dead default that made `batched_reduce(*nodes)`
look positionally interchangeable with the `batched(*nodes)` hook the same `if`
dispatches, so it is now required; and `broadcast_arrays` handed the density
0-stride columns, meaning the axisymmetric `numOfParam == 3` case aliased ONE
float across every node for `phi`.

`test_scf_tdep_batched_reduce_degenerate_sizes` closes the coverage gap it found:
the original test only exercised N=6, L=3, Nt=5, so N=1, L=1, Nt=1 and the
single-node case went untested.

`f.batched` is attached only after a **probe**: vectorizability over `t` does not
imply a density will broadcast positions against `t`, so the probe requires the
`(nodes, times)` output shape, and leaving it unset merely costs speed. That
fallback is exercised in the new test, and the axi routine passes a plain `0.0`
for `phi` even when the density takes three arguments, which the broadcast in
`f_batched` handles (caught by `test_tdep_from_density_signature_and_order_branches`
under torch before it was fixed).

### Gates

`tests/test_scf.py`: numpy 95 / torch 95 / jax (ledgered skips restored to running).
`tests/test_backend_scf.py`: 123 passed.

Not batched: `_scf_compute_coeffs_spherical_timedep` — 1-D, 20 nodes, so the
per-node overhead there is noise.

Stacked on #1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
