### PR TITLE
Route the orbit integrator loops through _backend_integrators (SOS_3D 573s -> 12s, ledger -3)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -23,7 +23,6 @@
 # jax and exceed the per-test budget (same eager-per-step cost as single-orbit;
 # numpy covers them). Un-defer as Track D in-backend vectorization lands.
 jax tests/test_orbits.py::test_ChandrasekharDynamicalFrictionForce_constLambda  # 300s (failed)
-jax tests/test_orbits.py::test_SOS_3D  # 269s -- inside the cap, but within 20% of it
 
 # --- jax/torch FDM dynamical friction (Track A group-b dissipative migration) ---
 # The FDM friction force is not yet backend-vectorized: frictionFactor uses
@@ -343,10 +342,8 @@ jax-jit tests/test_actionAngle.py::test_actionAngleStaeckel_wSpherical_conserved
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 300s cap
 jax-jit tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_const_FDMfactor  # 300s cap
 jax-jit tests/test_qdf.py::test_sampleV_interpolate  # 300s cap
-jax-jit tests/test_orbits.py::test_SOS_3D  # re-measured 2026-09-07: 582.3s traced (269s eager -> 2.2x SLOWER traced)
 # NOT an eager entry: tracing alone makes these slow, so inheritance could never
 # have produced them.
-jax-jit tests/test_orbits.py::test_bruteSOS_3D  # re-measured 2026-09-07: 310.7s traced (was noted 277s) -- the only entry
                                                 # INSIDE the 240-300s band; every
                                                 # other keeper hit the cap
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,25 @@ def _load_backend_skip(backend_name):
     return _load_backend_nodeids(_backend_skip_path(), backend_name)
 
 
+def _backend_integrators(integrators):
+    """Prune an integrator list to the C integrators under a non-numpy backend.
+
+    The pure-Python integrators (odeint/dop853/leapfrog/rk4/rk6) step in Python,
+    so each force eval pays eager per-step jax/torch dispatch (~1 ms) -- ~95% of
+    the runtime for ~0 unique backend coverage (their numerics are backend
+    -agnostic and the numpy run exercises all of them; the jax/torch-relevant
+    force path is shared with the C integrators). numpy runs the list unchanged.
+
+    Lives here, not in a test module, because both test_orbit.py and
+    test_orbits.py need it.
+    """
+    from galpy.backend import backend
+
+    if backend() == "numpy":
+        return integrators
+    return [i for i in integrators if i.endswith("_c")]
+
+
 def _run_backend(config):
     """Name the burndown lists are keyed by: "jax", or "jax-jit" when traced."""
     name = config.getoption("--backend")

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -106,19 +106,7 @@ else:
 _NOLONGINTEGRATIONS = False
 
 
-def _backend_integrators(integrators):
-    # Under a non-numpy backend, keep only the C integrators (``*_c``): the pure-
-    # Python ones (odeint/dop853/leapfrog/rk4/rk6) step in Python, so each force
-    # eval pays eager per-step jax/torch dispatch (~1 ms) -- ~95% of the runtime
-    # for ~0 unique backend coverage (their numerics are backend-agnostic and the
-    # numpy run exercises all of them; the jax/torch-relevant force path is shared
-    # with the C integrators). numpy runs the full list unchanged.
-    from galpy.backend import backend
-
-    if backend() == "numpy":
-        return integrators
-    return [i for i in integrators if i.endswith("_c")]
-
+from conftest import _backend_integrators
 
 # Don't show all warnings, to reduce log output
 warnings.simplefilter("always", galpyWarning)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -4002,7 +4002,7 @@ def test_integrate_dxdv_3d_base_orbit_integrity():
 
     ts = numpy.linspace(0.0, 5.0, 51)
     ic = [1.0, 0.1, 1.1, 0.2, 0.15, 0.3]
-    for method in ["dop853_c", "dop853"]:
+    for method in _backend_integrators(["dop853_c", "dop853"]):
         odx = Orbit(ic)
         odx.integrate_dxdv(
             [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -5390,6 +5390,8 @@ def test_softenedneedlebar_planar_dxdv_fd_of_flow():
     ic = [1.0, 0.1, 1.1, 0.3]  # planar [R, vR, vT, phi]
     eps = 1e-7
     canonical = numpy.eye(4)
+    # NOT routed: this test's purpose is the planar Hessian validated through
+    # BOTH the C and the pure-Python variational integrator (see comment above).
     for method in ["dopr54_c", "dop853"]:
         obase = Orbit(ic)
         obase.integrate(times, pot, method=method)
@@ -5428,7 +5430,9 @@ def test_integrate_SOS_3D():
     pot = potential.MWPotential2014
     o = setup_orbit_energy(pot, axi=True)
     psis = numpy.linspace(0.0, 20.0 * numpy.pi, 1001)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.integrate_SOS(psis, pot, method=method)
         Es = _to_numpy(o.E(o.t))
         assert (numpy.std(Es) / numpy.mean(Es)) ** 2.0 < 10.0**-10, (
@@ -5441,7 +5445,9 @@ def test_integrate_SOS_3D():
 def test_SOS_3D():
     pot = potential.MWPotential2014
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.SOS(
             pot,
             method=method,
@@ -5463,7 +5469,9 @@ def test_SOS_3D():
 def test_bruteSOS_3D():
     pot = potential.MWPotential2014
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,
@@ -5502,7 +5510,9 @@ def test_integrate_indiv_t_3D():
             numpy.linspace(0.0, 9.0, nt),
         ]
     )
-    for method in ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]
+    ):
         # Batched per-orbit-t integration
         o_batch = Orbit(vxvvs)
         o_batch.integrate(ts_indiv, pot, method=method)
@@ -5541,7 +5551,9 @@ def test_integrate_indiv_t_2D():
             numpy.linspace(0.0, 9.0, nt),
         ]
     )
-    for method in ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]
+    ):
         o_batch = Orbit(vxvvs)
         o_batch.integrate(ts_indiv, pot, method=method)
         for ii in range(len(vxvvs)):
@@ -5572,7 +5584,9 @@ def test_integrate_indiv_t_1D():
             numpy.linspace(0.0, 9.0, nt),
         ]
     )
-    for method in ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dop853_c", "dopr54_c", "rk4_c", "symplec4_c", "dop853", "odeint"]
+    ):
         o_batch = Orbit(vxvvs)
         o_batch.integrate(ts_indiv, pot, method=method)
         for ii in range(len(vxvvs)):
@@ -5948,7 +5962,9 @@ def test_integrate_SOS_2D():
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
     o = setup_orbit_energy(pot, axi=True)
     psis = numpy.linspace(0.0, 20.0 * numpy.pi, 1001)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         for surface in ["x", "y"]:
             o.integrate_SOS(psis, pot, method=method)  # default is surface='x'
             Es = _to_numpy(o.E(o.t))
@@ -5962,7 +5978,9 @@ def test_integrate_SOS_2D():
 def test_SOS_2Dx():
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.SOS(
             pot,
             method=method,
@@ -5985,7 +6003,9 @@ def test_SOS_2Dx():
 def test_SOS_2Dy():
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.SOS(
             pot,
             method=method,
@@ -6008,7 +6028,9 @@ def test_SOS_2Dy():
 def test_bruteSOS_2Dx():
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,
@@ -6032,7 +6054,9 @@ def test_bruteSOS_2Dx():
 def test_bruteSOS_2Dy():
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
     o = setup_orbit_energy(pot)
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         o.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,

--- a/tests/test_orbits.py
+++ b/tests/test_orbits.py
@@ -4,7 +4,7 @@ import astropy.coordinates as apycoords
 import astropy.units as u
 import numpy
 import pytest
-from conftest import _to_numpy
+from conftest import _backend_integrators, _to_numpy
 
 from galpy import potential
 from galpy.backend import as_numpy
@@ -2534,7 +2534,9 @@ def test_SOS_3D():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.MWPotential2014
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.SOS(
             pot,
             method=method,
@@ -2565,7 +2567,9 @@ def test_SOS_2Dx():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.SOS(
             pot,
             method=method,
@@ -2597,7 +2601,9 @@ def test_SOS_2Dy():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.SOS(
             pot,
             method=method,
@@ -2643,7 +2649,9 @@ def test_bruteSOS_3D():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.MWPotential2014
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,
@@ -2673,7 +2681,9 @@ def test_bruteSOS_2Dx():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,
@@ -2706,7 +2716,9 @@ def test_bruteSOS_2Dy():
     ]
     orbits = Orbit(orbits_list)
     pot = potential.LogarithmicHaloPotential(normalize=1.0, q=0.9).toPlanar()
-    for method in ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]:
+    for method in _backend_integrators(
+        ["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]
+    ):
         orbits.bruteSOS(
             numpy.linspace(0.0, 20.0 * numpy.pi, 100001),
             pot,


### PR DESCRIPTION
`test_orbit.py` has had `_backend_integrators` since 3650f095: under a non-numpy
backend it keeps only the C integrators, because the pure-Python ones step in
**Python**, so every force evaluation pays eager per-step jax/torch dispatch — for
no unique backend coverage, since their numerics are backend-agnostic and the numpy
run exercises the full list.

It was barely used. `test_orbits.py` had the helper nowhere at all, and
`test_orbit.py` applied it in only 3 of 18 integrator loops. This PR routes both
files, and the two are now fully covered (0 routable-but-unrouted loops remain).

### Part 1 — `test_orbits.py` (ledger -3)

Its six SOS/bruteSOS loops all ran
`["dopr54_c", "dop853_c", "rk4_c", "rk6_c", "dop853", "odeint"]`. The A/B, same
tree, minutes apart, jax:

| | |
|---|---|
| `test_SOS_3D`, full list | 572.65 s |
| `test_SOS_3D`, C integrators only | **12.79 s** |

The two Python-stepped arms are **97.8%** of it. Routing gives:

| test | before | after |
|---|---|---|
| `test_SOS_3D`, jax eager | 572.65 s | **12.38 s** |
| `test_SOS_3D`, `jax --jit` | 582 s | **17.07 s** |
| `test_bruteSOS_3D`, `jax --jit` | 311 s | **2.81 s** |

so those three come off the slow-skip ledger.

### Part 2 — `test_orbit.py`'s own loops (margin, not burndown)

Twelve more loops routed there. None are ledgered; they were running at roughly
two-thirds of the 300 s per-test cap with no headroom, which is exactly how the
entries already in the ledger got there.

| test (jax) | before | after |
|---|---|---|
| whole `-k` selection | 789.0 s | **135.1 s** |
| `test_SOS_3D` | 195.6 s | **6.6 s** |
| `test_integrate_SOS_3D` | 102.4 s | **2.9 s** |
| `test_integrate_indiv_t_3D` | 70.0 s | <1.3 s |
| `test_bruteSOS_3D` | 46.2 s | <1.3 s |

`test_softenedneedlebar_planar_dxdv_c_vs_python` (~104 s) has no method loop and is
untouched; its numbers move with ambient load.

### The trap this deliberately avoids

Two loops in `test_orbit.py` run `["odeint", "dop853"]` with **no** C method:
`test_noninertial_dxdv_flags_and_gate` and `test_dissipative_dxdv_python_raises`.
Routing those would hand the loop an empty list, and the test would pass while
asserting nothing. The mechanical rule is therefore "route only a loop that has
Python arms **and** keeps at least one `_c`", verified after the edit: 12 routed,
0 of them without a `_c`.

That rule cannot see *intent*, though, so one more is excluded by hand:
`test_softenedneedlebar_planar_dxdv_fd_of_flow` documents itself as validating the
planar Hessian "in both the C (dopr54_c) and pure-Python (dop853) variational
integrators". Routing it would have quietly dropped half of that and still passed
(and still gone 95 s -> 1.3 s). It keeps the full list, its ~95 s, and a comment
saying why.

### numpy is unaffected

The helper returns the list unchanged on numpy, so the full loops still run there
and still provide the coverage for the Python integrators.

### Placement

The helper moves from `test_orbit.py` to `conftest.py`, since two modules now need
it and conftest is where the rest of the backend policy already lives. It imports
galpy only *inside* the function, so the no-module-level-galpy-import rule holds —
and `test_orbits.py` already did `from conftest import _to_numpy`, so this is the
established pattern in that very file.

### Gates

| suite | numpy | jax | torch |
|---|---|---|---|
| `test_orbits.py` | 116 passed | 113 passed, 3 skipped | 114 passed, 2 skipped |
| `test_orbit.py` | 580 passed, 4 skipped | 568 passed, 15 skipped | 575 passed, 9 skipped |

The one jax `test_orbit.py` failure in that gate run was `test_fixedstepsize`, a
wall-clock assertion ("runtime with 10x smaller steps must be 10x larger") that
flaked while three full suites shared the box; it passes in 14.8 s on a quiet box
and has an all-C integrator list, so it is untouched by this PR.

The 3 remaining jax skips in `test_orbits.py` are the Chandrasekhar
dynamical-friction entries, which hardcode `method="leapfrog"` on purpose ("also
tests fallback onto odeint") and so cannot be routed. The other ledgered orbit
tests (`test_analytic_zmax`, `test_analytic_ecc_rperi_rap`, `test_liouville_planar`,
`test_zmax`) are already routed — their cost is the analytic action computations,
not the integrator loop.

Stacked on #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
