### PR TITLE
Do not fork a worker per task when numcores=1 (Orbit.lyapunov 94x faster)

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -2505,7 +2505,7 @@ class Orbit:
         spectrum=False,
         progressbar=False,
         dt=None,
-        numcores=_NUMCORES,
+        numcores=1,
         force_map=False,
         rtol=None,
         atol=None,
@@ -2557,7 +2557,7 @@ class Orbit:
         dt : float, optional
             If set, force the integrator to use this basic stepsize; must be an integer divisor of output stepsize (only works for the C integrators that use a fixed stepsize) (can be Quantity).
         numcores : int, optional
-            Number of cores to use for Python-based multiprocessing (pure Python or using force_map=True); default = OMP_NUM_THREADS.
+            Number of cores to use for Python-based multiprocessing (pure Python or using force_map=True). Default is 1 (serial), unlike elsewhere in galpy: the Lyapunov calculation integrates the variational equations in many short segments (one per ``renorm_every``), so each parallel task is far shorter than the ~10 ms it costs to fork a worker for it, and forking makes the calculation ~100x slower. Raise it only if each segment is genuinely long.
         force_map : bool, optional
             If True, force use of Python-based multiprocessing (not recommended). Default is False.
         rtol : float, optional

--- a/galpy/util/multi.py
+++ b/galpy/util/multi.py
@@ -195,6 +195,11 @@ def parallel_map(function, sequence, numcores=None, progressbar=False):
 
     if numcores is None:
         numcores = _ncpus
+    if numcores == 1:
+        # Asking for one core still forked one child per task, and a fork alone
+        # costs ~12 ms -- so `numcores=1` was slower than not parallelizing at
+        # all. Serial is what "one core" means.
+        return list(map(function, sequence))
 
     if platform.system() == "Windows":  # JB: don't think this works on Win
         return list(map(function, sequence))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -148,3 +148,34 @@ def test_quad_over_limits():
         quad_over_limits(f, 0.0, 1.3, epsabs=1e-3) == quad(f, 0.0, 1.3, epsabs=1e-3)[0]
     ), "quad_over_limits does not pass kwargs through to quad"
     return None
+
+
+def test_parallel_map_numcores_one_does_not_fork():
+    # Regression: `numcores=1` used to fall through to the fork-based path and
+    # spawn ONE CHILD PER TASK. A fork alone costs ~10 ms, so asking for a single
+    # core was slower than not parallelizing at all -- and that is what
+    # Orbit.lyapunov did for every one of its short renormalization segments,
+    # costing ~100x. Assert the contract directly: with numcores=1 no
+    # multiprocessing context is created at all.
+    import multiprocessing
+
+    from galpy.util import multi
+
+    calls = []
+    orig_get_context = multiprocessing.get_context
+
+    def spy(*args, **kwargs):
+        calls.append(args)
+        return orig_get_context(*args, **kwargs)
+
+    multiprocessing.get_context = spy
+    try:
+        out = multi.parallel_map(lambda x: x * x, numpy.arange(8), numcores=1)
+    finally:
+        multiprocessing.get_context = orig_get_context
+    assert not calls, (
+        "parallel_map(numcores=1) must not create a multiprocessing context"
+    )
+    assert numpy.array_equal(numpy.asarray(out), numpy.arange(8) ** 2), (
+        "parallel_map(numcores=1) returned the wrong result"
+    )


### PR DESCRIPTION
`parallel_map` short-circuited to a serial `map` only when the sequence had **one
element**. `numcores=1` fell straight through to the fork-based path and spawned
one child per task — so asking for a single core was *slower* than not
parallelizing at all.

`Orbit.lyapunov` walked into exactly that. It integrates the variational equations
in short segments (one per `renorm_every`) and parallel-maps the deviation vectors
*within* each segment, so a 1001-step spectrum run forks ~500 children for work
totalling ~0.1 s. Profiling a single call:

| | calls | tottime |
|---|---|---|
| `posix.fork` | 500 | 6.00 s |
| `posix.waitpid` | 1595 | 3.08 s |
| `select.poll` | 100 | 2.05 s |
| `posix.read` | 13400 | 1.69 s |

Essentially all of the 12 s runtime is process management.

### Fixes

1. `parallel_map` honours `numcores=1` by running serially — that is what "one
   core" means, and it had no way to express it before.
2. `Orbit.lyapunov` defaults to `numcores=1`. Its tasks are always far shorter
   than the ~10 ms a fork costs, and that does **not** improve with more orbits,
   because each extra orbit adds a fork of its own. The parameter is still there
   for anyone whose segments genuinely are long, and the docstring now says why
   the default differs from the rest of galpy.

### Measured

```
o.lyapunov(ts, pot=hh, method="dop853_c", spectrum=True)
    12.089 s -> 0.129 s   (94x)
```

Results are **bitwise identical** — 4000 finite elements equal, `nan` positions
matching — so this is pure overhead removal, not a change in what is computed.

```
pytest tests/test_orbit.py -k lyapunov
    337.9 s -> 30.4 s
    test_lyapunov_spectrum_henonheiles_chaotic  160.3 s -> 4.9 s
    test_lyapunov_spectrum_integrable            74.0 s -> < 3.6 s
    test_lyapunov_spectrum_consistency           62.3 s -> 4.9 s
```

### How it surfaced

The jax backend was ~100x **faster** than numpy on the same call with identical
output, which made no sense until the profile showed jax was simply skipping the
fork: `parallel_map` already runs serially under jax because forking is unsafe
there. The backend was accidentally dodging a pathology that numpy users pay in
full.

### Testing

`test_parallel_map_numcores_one_does_not_fork` asserts the contract directly — no
multiprocessing context is created for `numcores=1` — rather than timing anything,
so it cannot go flaky on a loaded runner. Verified it **fails without the fix**.

Regression gates on the change: `tests/test_orbit.py` 579 passed, `tests/test_orbits.py`
116 passed (the one `test_from_name_values` failure is a SIMBAD `DALServiceError`,
i.e. the network, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
