### PR TITLE
slow-skip: un-ledger three stale jax entries (ledger -3)

### DIFF
--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -139,8 +139,6 @@ jax tests/test_qdf.py::test_sampleV_interpolate  # re-measured 2026-09-06: still
 # in-backend (diffrax/torchdiffeq) STM is covered by tests/test_backend_orbit_stm.py.
 jax tests/test_orbit.py::test_dxdv_3d_c_vs_python[RotateAndTiltWrapperPotential_tiltedTriaxialNFW]  # PASSES in 528.9s (CI~375s) -- re-measured 2026-08-22 post-#1364 in the real CI shard (--splits 5 --group 3); the old '>420s timed out' was a TIMEOUT BOUND, not a time
 jax tests/test_orbit.py::test_liouville_planar  # >420s (measured 2026-08-15, timed out)
-jax tests/test_orbit.py::test_lyapunov_spectrum_consistency  # PASSES in 662s (measured 2026-08-15) -- genuinely performance-gated
-jax tests/test_orbit.py::test_lyapunov_spectrum_henonheiles_chaotic  # PASSES in 1535s (measured 2026-08-15) -- genuinely performance-gated
 
 # --- jax single-orbit: misc slow (Python-integrator paths) ---
 # Integrate paths that step in Python under jax. Track A force vectorization /
@@ -180,7 +178,6 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap  # PASSES in 743.1s (meas
 # box (~2.4x on the CI runner); even 5-way duration-split, a group clustering several
 # overflows the 4500s shard cap (jax orbit group 3 timed out). Defer the heaviest
 # until Track D vectorization; the faster majority stays un-deferred. numpy runs all.
-jax tests/test_orbit.py::test_integrate_indiv_t_python_paths  # >420s (measured 2026-08-15, timed out)
 
 # --- jax NonInertialFrameForce func/vec-omega (eager-XLA timeout) ---
 # The func/vec omega_z frame-force variants build a per-timestep interpolation of


### PR DESCRIPTION
Three slow-skip entries measured **2026-08-15** and never re-checked since. The
slow-skip ledger has no regeneration path — a skipped test produces no timing, so
entries only leave it when someone re-measures.

Re-measured by running the **whole** `tests/test_orbit.py` under `--backend jax`
with `-n 12`, so these include shard-like contention rather than being isolated
best cases:

| entry | ledger claim | measured |
|---|---|---|
| `test_lyapunov_spectrum_henonheiles_chaotic` | 1535 s | **5.6 s** |
| `test_integrate_indiv_t_python_paths` | >420 s (timed out) | **65.3 s** |
| `test_lyapunov_spectrum_consistency` | 662 s | **230.9 s** |

That run was **576 passed, 8 skipped, 0 failures** with all seven of this file's
jax entries un-skipped — so these three passing is not an artifact of running them
in isolation.

`test_integrate_indiv_t_python_paths` deserves a note: it exercises the *pure-Python
leapfrog path*, which is exactly the shape of test that looks like it can never be
fast under a backend. It runs in 65 s. I had written it off on that reasoning
before measuring it, and I was wrong.

### This is the last of the stale entries, not a sample

Every dated cohort in the ledger has now been re-measured this session:

- **2026-08-15** (4 entries) — 3 stale, dropped here; the fourth,
  `test_liouville_planar`, still takes 802 s and stays.
- **2026-08-20** (3) — `test_analytic_zmax` 1090.9 s, `test_analytic_ecc_rperi_rap`
  1867.5 s. Stay.
- **2026-08-21** (6) — the dynamfric/FDM family; two do not finish in 1500 s. Stay.
- **2026-08-22** (3) — `test_dxdv_3d_c_vs_python` 715.9 s, streamTrack 453.7/380.5 s. Stay.
- **2026-08-24** (5) — noninertial, 290–517 s. Stay. (The closest, at 290.1 s, has a
  3% margin against ~15% run-to-run variance, so it is not safe to drop.)

Ledger **45 → 42**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
