### PR TITLE
bessel_k: evaluate the ascending series in one pass (torch 2.3x on Bessel-K potentials)

### DIFF
--- a/galpy/backend/special/_fallback/bessel_k.py
+++ b/galpy/backend/special/_fallback/bessel_k.py
@@ -34,6 +34,44 @@ _TRAP_NODES = numpy.arange(_TRAP_N + 1) * _TRAP_H
 _TRAP_W = numpy.full(_TRAP_N + 1, _TRAP_H)
 _TRAP_W[0] = _TRAP_H / 2.0
 
+# Ascending-series tables. The two series are sums of coeff_k * t_k, where t_k is
+# a running product; keeping the per-step RATIOS lets a cumulative product
+# reproduce the recurrence while evaluating all _NSERIES terms in one vectorized
+# pass instead of one eager op per term. That mattered: the K0/K1 series were the
+# single largest cost in a jax RazorThinExponentialDiskPotential orbit -- 2218
+# calls x ~270 scalar ops each.
+_H = numpy.concatenate(([0.0], numpy.cumsum(1.0 / numpy.arange(1, _NSERIES + 1))))
+# K0: t_k = prod_{j=1..k} 1/j^2, coeff_k = H_k, for k = 1.._NSERIES-1
+_K0_RATIO_DEN = (numpy.arange(1, _NSERIES) ** 2).astype(float)
+_K0_COEFF = _H[1:_NSERIES]
+# K1: t_0 = 1 and t_k = t_{k-1} / (k(k+1)); coeff_k = (H_k + H_{k+1})/2 - gamma
+_K1_RATIO_DEN = numpy.concatenate(
+    ([1.0], (numpy.arange(1, _NSERIES) * numpy.arange(2, _NSERIES + 1)).astype(float))
+)
+_K1_COEFF = (_H[0:_NSERIES] + _H[1 : _NSERIES + 1]) / 2.0 - _GAMMA
+_K1_NUM_POW = numpy.concatenate(([0.0], numpy.ones(_NSERIES - 1)))  # x2^0 then x2^k
+
+
+_SERIES_CACHE = {}
+
+
+def _series_tables(xp, dev):
+    """Series tables as backend arrays, materialized once per (namespace, device).
+
+    Rebuilding them on every call put five host->device conversions in the hot
+    path, and under jax each fresh array is another primitive for the eager
+    compiler to compile.
+    """
+    key = (id(xp), repr(dev))
+    got = _SERIES_CACHE.get(key)
+    if got is None:
+        got = tuple(
+            asarray_on_device(xp, t, dev)
+            for t in (_K0_RATIO_DEN, _K0_COEFF, _K1_RATIO_DEN, _K1_COEFF, _K1_NUM_POW)
+        )
+        _SERIES_CACHE[key] = got
+    return got
+
 
 def _k01(xp, x):
     """Return (K0(x), K1(x)) for real x > 0, ~1e-15 vs scipy, AD-friendly."""
@@ -47,21 +85,18 @@ def _k01(xp, x):
     from .._router import i0, i1
 
     x2 = xs * xs / 4.0
-    K0s = -(xp.log(xs / 2.0) + _GAMMA) * i0(xs)
-    term = xp.ones_like(xs)
-    harm = 0.0
-    for k in range(1, _NSERIES):
-        harm += 1.0 / k
-        term = term * x2 / (k * k)
-        K0s = K0s + term * harm
-    s1 = xp.zeros_like(xs)
-    term = xp.ones_like(xs)
-    hk = 0.0
-    for k in range(0, _NSERIES):
-        hk1 = hk + 1.0 / (k + 1)
-        s1 = s1 + term * ((hk + hk1) / 2.0 - _GAMMA)
-        term = term * x2 / ((k + 1) * (k + 2))
-        hk = hk1
+    dev0 = device_of(x)
+    tabs = _series_tables(xp, dev0)
+    # Both series run as ONE cumulative product over the term axis rather than a
+    # Python loop of _NSERIES eager ops. `cumprod` of the per-step ratios is the
+    # same recurrence the loop ran; only the reduction is vectorized.
+    k0_den, k0_coeff, k1_den, k1_coeff, k1_pow = tabs
+    k0_terms = xp.cumulative_prod(x2[..., None] / k0_den, axis=-1)
+    K0s = -(xp.log(xs / 2.0) + _GAMMA) * i0(xs) + xp.sum(k0_terms * k0_coeff, axis=-1)
+
+    # first ratio is 1 (t_0 = 1), the rest are x2/(k(k+1))
+    k1_terms = xp.cumulative_prod((x2[..., None] ** k1_pow) / k1_den, axis=-1)
+    s1 = xp.sum(k1_terms * k1_coeff, axis=-1)
     K1s = 1.0 / xs + xp.log(xs / 2.0) * i1(xs) - (xs / 2.0) * s1
 
     # --- peak-resolving scaled trapezoidal (x > 2) ---

--- a/galpy/backend/special/_fallback/bessel_k.py
+++ b/galpy/backend/special/_fallback/bessel_k.py
@@ -23,7 +23,7 @@
 ###############################################################################
 import numpy
 
-from ..._namespaces import asarray_on_device, device_of
+from ..._namespaces import asarray_on_device, device_of, under_jax_trace
 
 _GAMMA = 0.5772156649015328606  # Euler-Mascheroni
 _NSERIES = 30  # ascending-series terms (x <= 2)
@@ -69,7 +69,12 @@ def _series_tables(xp, dev):
             asarray_on_device(xp, t, dev)
             for t in (_K0_RATIO_DEN, _K0_COEFF, _K1_RATIO_DEN, _K1_COEFF, _K1_NUM_POW)
         )
-        _SERIES_CACHE[key] = got
+        # Under a jax trace, asarray(..., device=) lowers to device_put, so these
+        # tables come back as TRACERS; caching one leaks it out of its trace
+        # (UnexpectedTracerError on the next call). Constants cost nothing inside
+        # a trace anyway, so only concrete tables are worth keeping.
+        if not under_jax_trace(*got):
+            _SERIES_CACHE[key] = got
     return got
 
 


### PR DESCRIPTION
`_k01` computed both the K0 and K1 ascending series (x ≤ 2) with a **Python loop
over 30 terms** — roughly 270 eager backend ops per call. Both loops are plain
recurrences (`term *= x²/k²`), so a cumulative product over a term axis
reproduces them exactly while evaluating every term in one vectorized pass.

Found while profiling a jax `RazorThinExponentialDiskPotential` orbit — that
potential's forces need K₀/K₁ and jax has no native implementation, so everything
routes through this fallback. `_k01` was **2218 calls / 39.7 s** of a 50 s
analytic-action call.

### Result: torch 2.3× faster, jax unchanged

| `RazorThinExponentialDisk`, adiabatic `zmax(analytic=True)` | before | after |
|---|---|---|
| torch, orbit integration | 37.55 s | **16.38 s** |
| torch, analytic call | 4.18 s | **2.61 s** |
| jax, analytic call | 50.56 s | 51.59 s |

**Why jax doesn't move, which is the part worth recording.** The vectorization
does what it claims — jax ufunc calls drop **444k → 58k**, 8× — but jax's *eager*
path compiles each primitive invocation, and that compilation is the actual cost
there: 325 compiles / 22.0 s before, and cutting the op count doesn't cut it. So
this is a torch win and a jax no-op, not the jax win I was chasing. Noting it so
nobody repeats the experiment: **for jax eager, op count is not the lever.**

The series tables are materialized once per `(namespace, device)` rather than per
call. Without that, the five extra host→device conversions made jax measurably
*worse* (55.5 s) — which is what surfaced the compilation effect to begin with.

### Precision preserved

The series branch stays at ~1e-15 against scipy, and the trapezoid branch (x > 2,
untouched) is bit-for-bit identical:

| | K0 before → after | K1 before → after |
|---|---|---|
| jax, series | 2.17e-15 → 2.60e-15 | 9.91e-16 → 9.91e-16 |
| torch, series | 2.17e-15 → 3.47e-15 | 9.91e-16 → 5.95e-16 |
| all, trapezoid | unchanged | unchanged |

Checked over 800 points spanning 1e-8 to 100, including the x = 2 branch
boundary, on numpy/jax/torch.

`tests/test_backend_special.py` 253 passed; `test_potential.py` RazorThin 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
