### PR TITLE
OblateStaeckelWrapperPotential: optional tabulated C evaluation (ntab=), ~10-16x faster C integration

### DIFF
--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -418,8 +418,8 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
             if getattr(p, "_ntab", 0):
                 # tabulated: plain type, no wrapped potential in C at all
                 pot_type.append(47)
-                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 pot_args.extend(p._tabargs)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
             else:
                 pot_type.append(-3)
                 # Not sure how to easily avoid this duplication
@@ -431,8 +431,8 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_args.extend(wrap_pot_args)
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
-                # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 14)
+                # exact-cache scratch (see OblateStaeckelWrapperPotential.c)
+                pot_args.extend([float("nan")] * 14)
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -431,6 +431,8 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_args.extend(wrap_pot_args)
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+                # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
+                pot_args.extend([0.0] + [float("nan")] * 10)
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -432,7 +432,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([float("nan")] * 14)
+                pot_args.extend([float("nan")] * 16)
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -415,16 +415,22 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
             pot_tfuncs.extend(wrap_pot_tfuncs)
             pot_args.extend([p._amp, p._omega, p._pa])
         elif isinstance(p, potential.OblateStaeckelWrapperPotential):
-            pot_type.append(-3)
-            # Not sure how to easily avoid this duplication
-            wrap_npot, wrap_pot_type, wrap_pot_args, wrap_pot_tfuncs = _parse_pot(
-                p._pot, potforactions=potforactions, potfortorus=potfortorus, t=t
-            )
-            pot_args.append(wrap_npot)
-            pot_type.extend(wrap_pot_type)
-            pot_args.extend(wrap_pot_args)
-            pot_tfuncs.extend(wrap_pot_tfuncs)
-            pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+            if getattr(p, "_ntab", 0):
+                # tabulated: plain type, no wrapped potential in C at all
+                pot_type.append(47)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+                pot_args.extend(p._tabargs)
+            else:
+                pot_type.append(-3)
+                # Not sure how to easily avoid this duplication
+                wrap_npot, wrap_pot_type, wrap_pot_args, wrap_pot_tfuncs = _parse_pot(
+                    p._pot, potforactions=potforactions, potfortorus=potfortorus, t=t
+                )
+                pot_args.append(wrap_npot)
+                pot_type.extend(wrap_pot_type)
+                pot_args.extend(wrap_pot_args)
+                pot_tfuncs.extend(wrap_pot_tfuncs)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -432,7 +432,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 14)
+                pot_args.extend([0.0] + [float("nan")] * (14 * 64))
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -432,7 +432,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * (14 * 64))
+                pot_args.extend([0.0] + [float("nan")] * 14)
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -432,7 +432,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 10)
+                pot_args.extend([0.0] + [float("nan")] * 14)
         elif isinstance(p, potential.CorotatingRotationWrapperPotential):
             pot_type.append(-4)
             # Not sure how to easily avoid this duplication

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -527,8 +527,8 @@ def _parse_pot(pot, t=None):
             if getattr(p, "_ntab", 0):
                 # tabulated: plain type, no wrapped potential in C at all
                 pot_type.append(47)
-                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 pot_args.extend(p._tabargs)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
             else:
                 pot_type.append(-3)
                 # wrap_pot_type, args, and npot obtained before this horrible if
@@ -537,8 +537,8 @@ def _parse_pot(pot, t=None):
                 pot_args.extend(wrap_pot_args)
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
-                # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 14)
+                # exact-cache scratch (see OblateStaeckelWrapperPotential.c)
+                pot_args.extend([float("nan")] * 14)
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -538,7 +538,7 @@ def _parse_pot(pot, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 14)
+                pot_args.extend([0.0] + [float("nan")] * (14 * 64))
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -538,7 +538,7 @@ def _parse_pot(pot, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * (14 * 64))
+                pot_args.extend([0.0] + [float("nan")] * 14)
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -538,7 +538,7 @@ def _parse_pot(pot, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([0.0] + [float("nan")] * 10)
+                pot_args.extend([0.0] + [float("nan")] * 14)
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -537,6 +537,8 @@ def _parse_pot(pot, t=None):
                 pot_args.extend(wrap_pot_args)
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+                # exact-cache flag + scratch (see OblateStaeckelWrapperPotential.c)
+                pot_args.extend([0.0] + [float("nan")] * 10)
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -538,7 +538,7 @@ def _parse_pot(pot, t=None):
                 pot_tfuncs.extend(wrap_pot_tfuncs)
                 pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
                 # exact-cache scratch (see OblateStaeckelWrapperPotential.c)
-                pot_args.extend([float("nan")] * 14)
+                pot_args.extend([float("nan")] * 16)
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -524,13 +524,19 @@ def _parse_pot(pot, t=None):
         ) or isinstance(p, potential.OblateStaeckelWrapperPotential):
             if not isinstance(p, potential.OblateStaeckelWrapperPotential):
                 p = p._Pot
-            pot_type.append(-3)
-            # wrap_pot_type, args, and npot obtained before this horrible if
-            pot_args.append(wrap_npot)
-            pot_type.extend(wrap_pot_type)
-            pot_args.extend(wrap_pot_args)
-            pot_tfuncs.extend(wrap_pot_tfuncs)
-            pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+            if getattr(p, "_ntab", 0):
+                # tabulated: plain type, no wrapped potential in C at all
+                pot_type.append(47)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
+                pot_args.extend(p._tabargs)
+            else:
+                pot_type.append(-3)
+                # wrap_pot_type, args, and npot obtained before this horrible if
+                pot_args.append(wrap_npot)
+                pot_type.extend(wrap_pot_type)
+                pot_args.extend(wrap_pot_args)
+                pot_tfuncs.extend(wrap_pot_tfuncs)
+                pot_args.extend([p._amp, p._delta, p._u0, p._v0, p._refpot])
         elif (
             (
                 isinstance(p, planarPotentialFromFullPotential)

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -817,6 +817,25 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
+    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
+      potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;
+      potentialArgs->zforce= &OblateStaeckelWrapperPotentialzforce;
+      potentialArgs->phitorque= &ZeroForce;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv):
+      // chain rule of Phi(u,v) = (U(u)-V(v))/(sinh^2 u + sin^2 v) through the
+      // prolate spheroidal (R,z) -> (u,v) transform, with U''/V'' built from
+      // the wrapped potential's forces and second derivatives along the
+      // reference curves. Axisymmetric by construction:
+      // phi2deriv/Rphideriv/zphideriv are 0 -> left NULL (the NULL-safe
+      // aggregators return 0 for them).
+      potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
+      potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
+      potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
+      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->ntfuncs= 0;
+      potentialArgs->requiresVelocity= false;
+      break;
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;
@@ -847,25 +866,6 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
-    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
-      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
-      potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;
-      potentialArgs->zforce= &OblateStaeckelWrapperPotentialzforce;
-      potentialArgs->phitorque= &ZeroForce;
-      // Full-3D Hessian for the 3D variational equations (integrate_dxdv):
-      // chain rule of Phi(u,v) = (U(u)-V(v))/(sinh^2 u + sin^2 v) through the
-      // prolate spheroidal (R,z) -> (u,v) transform, with U''/V'' built from
-      // the wrapped potential's forces and second derivatives along the
-      // reference curves. Axisymmetric by construction:
-      // phi2deriv/Rphideriv/zphideriv are 0 -> left NULL (the NULL-safe
-      // aggregators return 0 for them).
-      potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
-      potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
-      potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
-      potentialArgs->ntfuncs= 0;
-      potentialArgs->requiresVelocity= false;
-      break;
     case -3: //OblateStaeckelWrapperPotential
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;
@@ -881,8 +881,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      // 5 params + flag + 64 per-thread 14-slot exact-cache blocks (.c file)
-      potentialArgs->nargs= (int) 902;
+      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 20;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -818,6 +818,22 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->requiresVelocity= false;
       break;
     case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      // Six natural cubic splines (house GSL style): stream is
+      // [ntab, ugrid, Uy, dUy, d2Uy, vgrid, Vy, dVy, d2Vy] then the 5 scalars
+      potentialArgs->nspline1d= 6;
+      potentialArgs->spline1d= (gsl_spline **) \
+        malloc ( potentialArgs->nspline1d * sizeof ( gsl_spline * ) );
+      potentialArgs->acc1d= (gsl_interp_accel **) \
+        malloc ( potentialArgs->nspline1d * sizeof ( gsl_interp_accel * ) );
+      nr= (int) **pot_args;
+      for (ii=0; ii < 6; ii++) {
+        *(potentialArgs->acc1d+ii)= gsl_interp_accel_alloc();
+        *(potentialArgs->spline1d+ii)= gsl_spline_alloc(gsl_interp_cspline,nr);
+        gsl_spline_init(*(potentialArgs->spline1d+ii),
+                        *pot_args+1+ ( ii < 3 ? 0 : 4 * nr ),
+                        *pot_args+1+ ( ii < 3 ? (1+ii) : (2+ii) ) * nr,nr);
+      }
+      *pot_args+= 8 * nr + 1;
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;
       potentialArgs->zforce= &OblateStaeckelWrapperPotentialzforce;
@@ -832,7 +848,7 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->nargs= (int) 5;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
@@ -881,8 +897,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 20;
+      // 5 params + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 19;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -847,6 +847,25 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
+    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
+      potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;
+      potentialArgs->zforce= &OblateStaeckelWrapperPotentialzforce;
+      potentialArgs->phitorque= &ZeroForce;
+      // Full-3D Hessian for the 3D variational equations (integrate_dxdv):
+      // chain rule of Phi(u,v) = (U(u)-V(v))/(sinh^2 u + sin^2 v) through the
+      // prolate spheroidal (R,z) -> (u,v) transform, with U''/V'' built from
+      // the wrapped potential's forces and second derivatives along the
+      // reference curves. Axisymmetric by construction:
+      // phi2deriv/Rphideriv/zphideriv are 0 -> left NULL (the NULL-safe
+      // aggregators return 0 for them).
+      potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
+      potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
+      potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
+      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->ntfuncs= 0;
+      potentialArgs->requiresVelocity= false;
+      break;
     case -3: //OblateStaeckelWrapperPotential
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->Rforce= &OblateStaeckelWrapperPotentialRforce;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -881,7 +881,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      potentialArgs->nargs= (int) 5;
+      // 5 params + flag + 10 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 16;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -897,8 +897,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      // 5 params + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 19;
+      // 5 params + 16 primitive-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 21;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -881,8 +881,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 20;
+      // 5 params + flag + 64 per-thread 14-slot exact-cache blocks (.c file)
+      potentialArgs->nargs= (int) 902;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integrateFullOrbit.c
@@ -881,8 +881,8 @@ void parse_leapFuncArgs_Full(int npot,
       potentialArgs->R2deriv= &OblateStaeckelWrapperPotentialR2deriv;
       potentialArgs->z2deriv= &OblateStaeckelWrapperPotentialz2deriv;
       potentialArgs->Rzderiv= &OblateStaeckelWrapperPotentialRzderiv;
-      // 5 params + flag + 10 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 16;
+      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 20;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -637,7 +637,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      potentialArgs->nargs= (int) 5;
+      // 5 params + flag + 10 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 16;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -653,8 +653,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      // 5 params + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 19;
+      // 5 params + 16 primitive-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 21;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -615,6 +615,19 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
+    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
+      potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;
+      potentialArgs->planarphitorque= &ZeroPlanarForce;
+      // Planar 2nd derivatives for the planar variational equations
+      // (integrate_dxdv); axisymmetric, so the phi-derivatives vanish.
+      potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &ZeroPlanarForce;
+      potentialArgs->planarRphideriv= &ZeroPlanarForce;
+      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->ntfuncs= 0;
+      potentialArgs->requiresVelocity= false;
+      break;
     case -3: //OblateStaeckelWrapperPotential
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -594,6 +594,22 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->requiresVelocity= false;
       break;
     case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      // Six natural cubic splines (house GSL style): stream is
+      // [ntab, ugrid, Uy, dUy, d2Uy, vgrid, Vy, dVy, d2Vy] then the 5 scalars
+      potentialArgs->nspline1d= 6;
+      potentialArgs->spline1d= (gsl_spline **) \
+        malloc ( potentialArgs->nspline1d * sizeof ( gsl_spline * ) );
+      potentialArgs->acc1d= (gsl_interp_accel **) \
+        malloc ( potentialArgs->nspline1d * sizeof ( gsl_interp_accel * ) );
+      nr= (int) **pot_args;
+      for (ii=0; ii < 6; ii++) {
+        *(potentialArgs->acc1d+ii)= gsl_interp_accel_alloc();
+        *(potentialArgs->spline1d+ii)= gsl_spline_alloc(gsl_interp_cspline,nr);
+        gsl_spline_init(*(potentialArgs->spline1d+ii),
+                        *pot_args+1+ ( ii < 3 ? 0 : 4 * nr ),
+                        *pot_args+1+ ( ii < 3 ? (1+ii) : (2+ii) ) * nr,nr);
+      }
+      *pot_args+= 8 * nr + 1;
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;
       potentialArgs->planarphitorque= &ZeroPlanarForce;
@@ -602,7 +618,7 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->nargs= (int) 5;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
@@ -637,8 +653,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 20;
+      // 5 params + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 19;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -637,8 +637,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      // 5 params + flag + 10 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 16;
+      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 20;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -593,6 +593,19 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
+    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
+      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
+      potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;
+      potentialArgs->planarphitorque= &ZeroPlanarForce;
+      // Planar 2nd derivatives for the planar variational equations
+      // (integrate_dxdv); axisymmetric, so the phi-derivatives vanish.
+      potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
+      potentialArgs->planarphi2deriv= &ZeroPlanarForce;
+      potentialArgs->planarRphideriv= &ZeroPlanarForce;
+      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
+      potentialArgs->ntfuncs= 0;
+      potentialArgs->requiresVelocity= false;
+      break;
 //////////////////////////////// WRAPPERS /////////////////////////////////////
     case -1: //DehnenSmoothWrapperPotential
       potentialArgs->potentialEval= &DehnenSmoothWrapperPotentialEval;
@@ -615,19 +628,6 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;
-    case 47: //OblateStaeckelWrapperPotential, tabulated (no wrapped pot in C)
-      potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
-      potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;
-      potentialArgs->planarphitorque= &ZeroPlanarForce;
-      // Planar 2nd derivatives for the planar variational equations
-      // (integrate_dxdv); axisymmetric, so the phi-derivatives vanish.
-      potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
-      potentialArgs->planarphi2deriv= &ZeroPlanarForce;
-      potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      potentialArgs->nargs= (int) (7 + 12 * (int) *(*pot_args+5));
-      potentialArgs->ntfuncs= 0;
-      potentialArgs->requiresVelocity= false;
-      break;
     case -3: //OblateStaeckelWrapperPotential
       potentialArgs->potentialEval= &OblateStaeckelWrapperPotentialEval;
       potentialArgs->planarRforce= &OblateStaeckelWrapperPotentialPlanarRforce;
@@ -637,8 +637,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      // 5 params + flag + 64 per-thread 14-slot exact-cache blocks (.c file)
-      potentialArgs->nargs= (int) 902;
+      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
+      potentialArgs->nargs= (int) 20;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
+++ b/galpy/orbit/orbit_c_ext/integratePlanarOrbit.c
@@ -637,8 +637,8 @@ void parse_leapFuncArgs(int npot,struct potentialArg * potentialArgs,
       potentialArgs->planarR2deriv= &OblateStaeckelWrapperPotentialPlanarR2deriv;
       potentialArgs->planarphi2deriv= &ZeroPlanarForce;
       potentialArgs->planarRphideriv= &ZeroPlanarForce;
-      // 5 params + flag + 14 exact-cache scratch slots (see the .c file)
-      potentialArgs->nargs= (int) 20;
+      // 5 params + flag + 64 per-thread 14-slot exact-cache blocks (.c file)
+      potentialArgs->nargs= (int) 902;
       potentialArgs->ntfuncs= 0;
       potentialArgs->requiresVelocity= false;
       break;

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -9,6 +9,12 @@
 ###############################################################################
 import numpy
 
+# CubicSpline rather than InterpolatedUnivariateSpline: the C evaluator uses
+# the classic (values, knot second derivatives) natural-spline form, and
+# CubicSpline(bc_type="natural") both guarantees those boundary conditions
+# and returns exact knot second derivatives via its derivative evaluation
+from scipy.interpolate import CubicSpline
+
 from galpy.util import conversion, coords
 
 from .Potential import (
@@ -107,8 +113,6 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         if self._ntab:
             if self._ntab < 4:
                 raise ValueError("ntab= must be at least 4")
-            from scipy.interpolate import CubicSpline
-
             umax = float(numpy.arcsinh(Rmax_tab / self._delta))
             ugrid = numpy.linspace(0.0, umax, self._ntab)
             vgrid = numpy.linspace(0.0, numpy.pi / 2.0, self._ntab)

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -8,6 +8,7 @@
 #
 ###############################################################################
 import numpy
+from scipy.interpolate import CubicSpline
 
 from galpy.util import conversion, coords
 
@@ -72,7 +73,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         u0 : float or tuple or tuple of Quantity, optional
             Reference u value, the curve along which V(v) is built; if a tuple is given, this is assumed to be a (R,z) value to be converted to u. Defaults to arcsinh(1/delta), the value that places the reference curve at R=1 in the plane, whatever delta is. V(v) only represents the wrapped potential well near the reference curve unless the potential is exactly of Staeckel form, so this should sit near the orbits of interest; u0=0 is the symmetry axis and is degenerate for anything that is not exactly Staeckel.
         ntab : int, optional
-            If set, tabulate the 1-D building blocks U(u), V(v) and their first and second derivatives on ntab-point grids at initialization and have the C potential/force/Hessian routines interpolate them (natural cubic splines) instead of evaluating the wrapped potential along the reference curves on every call; ~20x faster C orbit integration at spline accuracy (u covers [0, arcsinh(Rmax_tab/delta)], v covers [0, pi/2] with z-symmetry folding; u beyond the table is clamped). Default is None (exact evaluations).
+            If set, tabulate the 1-D building blocks U(u), V(v) and their first and second derivatives on ntab-point grids at initialization and have the potential/force/Hessian routines (Python and C, which agree to machine precision) interpolate them (natural cubic splines) instead of evaluating the wrapped potential along the reference curves on every call; ~20x faster C orbit integration at spline accuracy (u covers [0, arcsinh(Rmax_tab/delta)], v covers [0, pi/2] with z-symmetry folding; u beyond the table is clamped). Default is None (exact evaluations).
         Rmax_tab : float, optional
             Cylindrical radius in the plane out to which the u table extends when ntab is set. Default is 100.
         ro : float or Quantity, optional
@@ -104,6 +105,10 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             _evaluatePotentials(self._pot, R0, z0) * numpy.cosh(self._u0) ** 2.0
         )
         self._ntab = 0 if ntab is None else int(ntab)
+        # mode discriminator, mirroring spline1d != NULL in C: None = exact
+        # (also while the tables below are being built from the exact
+        # primitives), a list of six splines = interpolate
+        self._splines = None
         if self._ntab:
             if self._ntab < 4:
                 raise ValueError("ntab= must be at least 4")
@@ -114,16 +119,31 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             # in dVdv's R0/tan v, whose limit is finite)
             veval = numpy.copy(vgrid)
             veval[0] = 1e-9
+            uvals = [
+                numpy.array([float(func(x)) for x in ugrid])
+                for func in (self._U, self._dUdu, self._d2Udu2)
+            ]
+            vvals = [
+                numpy.array([float(func(x)) for x in veval])
+                for func in (self._V, self._dVdv, self._d2Vdv2)
+            ]
             # raw (grid, values) tables; the C side builds natural cubic
             # splines from these with the house GSL 1D machinery at parse time
             tab = [float(self._ntab)]
             tab.extend(ugrid)
-            for func in (self._U, self._dUdu, self._d2Udu2):
-                tab.extend([float(func(x)) for x in ugrid])
+            for vals in uvals:
+                tab.extend(vals)
             tab.extend(vgrid)
-            for func in (self._V, self._dVdv, self._d2Vdv2):
-                tab.extend([float(func(x)) for x in veval])
+            for vals in vvals:
+                tab.extend(vals)
             self._tabargs = tab
+            # Python evaluation interpolates the same tables: a natural
+            # CubicSpline is the same mathematical object as GSL's cspline on
+            # the same knots, so Python and C agree to machine precision
+            # also in tabulated mode
+            self._splines = [
+                CubicSpline(ugrid, vals, bc_type="natural") for vals in uvals
+            ] + [CubicSpline(vgrid, vals, bc_type="natural") for vals in vvals]
         self.hasC = True
         # Advertise the (planar and 3D) C variational capabilities
         # unconditionally, as for hasC: _check_c recurses into the wrapped
@@ -425,12 +445,30 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             + dprefacdv * numpy.sinh(u) * numpy.cos(v)
         ) / self._delta
 
+    def _evalUspline(self, u, k):
+        # same semantics as evalUspline in C: u beyond the table is clamped
+        return self._splines[k](numpy.clip(u, 0.0, self._splines[k].x[-1]))
+
+    def _evalVspline(self, v, k):
+        # same semantics as evalVspline in C: tables cover v in [0, pi/2];
+        # V is even and V' odd about pi/2 (z-symmetry)
+        sgn = 1.0
+        if v > numpy.pi / 2.0:
+            v = numpy.pi - v
+            if k == 1:
+                sgn = -1.0
+        return sgn * self._splines[3 + k](numpy.clip(v, 0.0, numpy.pi / 2.0))
+
     def _U(self, u):
         """Approximated U(u) = cosh^2(u) Phi(u,pi/2)"""
+        if self._splines is not None:
+            return self._evalUspline(u, 0)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         return numpy.cosh(u) ** 2.0 * _evaluatePotentials(self._pot, Rz0[0], Rz0[1])
 
     def _dUdu(self, u):
+        if self._splines is not None:
+            return self._evalUspline(u, 1)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         # 1e-12 bc force should win the 0/0 battle
         return 2.0 * numpy.cosh(u) * numpy.sinh(u) * _evaluatePotentials(
@@ -443,6 +481,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         )
 
     def _d2Udu2(self, u):
+        if self._splines is not None:
+            return self._evalUspline(u, 2)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, Rz0[0], Rz0[1])
         tzforce = _evaluatezforces(self._pot, Rz0[0], Rz0[1])
@@ -475,12 +515,16 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
     def _V(self, v):
         """Approximated
         V(v) = cosh^2(u0) Phi(u0,pi/2) - (sinh^2(u0)+sin^2(v)) Phi(u0,v)"""
+        if self._splines is not None:
+            return self._evalVspline(v, 0)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         return self._refpot - _staeckel_prefactor(self._u0, v) * _evaluatePotentials(
             self._pot, R0z[0], R0z[1]
         )
 
     def _dVdv(self, v):
+        if self._splines is not None:
+            return self._evalVspline(v, 1)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         return -2.0 * numpy.sin(v) * numpy.cos(v) * _evaluatePotentials(
             self._pot, R0z[0], R0z[1]
@@ -490,6 +534,8 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         )
 
     def _d2Vdv2(self, v):
+        if self._splines is not None:
+            return self._evalVspline(v, 2)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         tRforce = _evaluateRforces(self._pot, R0z[0], R0z[1])
         tzforce = _evaluatezforces(self._pot, R0z[0], R0z[1])

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -48,7 +48,17 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     """
 
-    def __init__(self, amp=1.0, pot=None, delta=0.5, u0=None, ro=None, vo=None):
+    def __init__(
+        self,
+        amp=1.0,
+        pot=None,
+        delta=0.5,
+        u0=None,
+        ntab=None,
+        Rmax_tab=100.0,
+        ro=None,
+        vo=None,
+    ):
         """Initialize an OblateStaeckelWrapper Potential.
 
         Parameters
@@ -61,6 +71,10 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             The focal length. Default is 0.5.
         u0 : float or tuple or tuple of Quantity, optional
             Reference u value, the curve along which V(v) is built; if a tuple is given, this is assumed to be a (R,z) value to be converted to u. Defaults to arcsinh(1/delta), the value that places the reference curve at R=1 in the plane, whatever delta is. V(v) only represents the wrapped potential well near the reference curve unless the potential is exactly of Staeckel form, so this should sit near the orbits of interest; u0=0 is the symmetry axis and is degenerate for anything that is not exactly Staeckel.
+        ntab : int, optional
+            If set, tabulate the 1-D building blocks U(u), V(v) and their first and second derivatives on ntab-point grids at initialization and have the C potential/force/Hessian routines interpolate them (natural cubic splines) instead of evaluating the wrapped potential along the reference curves on every call; ~20x faster C orbit integration at spline accuracy (u covers [0, arcsinh(Rmax_tab/delta)], v covers [0, pi/2] with z-symmetry folding; u beyond the table is clamped). Default is None (exact evaluations).
+        Rmax_tab : float, optional
+            Cylindrical radius in the plane out to which the u table extends when ntab is set. Default is 100.
         ro : float or Quantity, optional
             Distance scale for translation into internal units (default from configuration file).
         vo : float or Quantity, optional
@@ -89,6 +103,33 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
         self._refpot = (
             _evaluatePotentials(self._pot, R0, z0) * numpy.cosh(self._u0) ** 2.0
         )
+        self._ntab = 0 if ntab is None else int(ntab)
+        if self._ntab:
+            if self._ntab < 4:
+                raise ValueError("ntab= must be at least 4")
+            from scipy.interpolate import CubicSpline
+
+            umax = float(numpy.arcsinh(Rmax_tab / self._delta))
+            ugrid = numpy.linspace(0.0, umax, self._ntab)
+            vgrid = numpy.linspace(0.0, numpy.pi / 2.0, self._ntab)
+            # evaluate the v functions just off the axis (exact v=0 is 0/0
+            # in dVdv's R0/tan v, whose limit is finite)
+            veval = numpy.copy(vgrid)
+            veval[0] = 1e-9
+            tab = [float(self._ntab), umax]
+            for func, grid, ev in (
+                (self._U, ugrid, ugrid),
+                (self._dUdu, ugrid, ugrid),
+                (self._d2Udu2, ugrid, ugrid),
+                (self._V, vgrid, veval),
+                (self._dVdv, vgrid, veval),
+                (self._d2Vdv2, vgrid, veval),
+            ):
+                y = numpy.array([float(func(x)) for x in ev])
+                spl = CubicSpline(grid, y, bc_type="natural")
+                tab.extend(y)
+                tab.extend(spl(grid, 2))
+            self._tabargs = tab
         self.hasC = True
         # Advertise the (planar and 3D) C variational capabilities
         # unconditionally, as for hasC: _check_c recurses into the wrapped

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -9,12 +9,6 @@
 ###############################################################################
 import numpy
 
-# CubicSpline rather than InterpolatedUnivariateSpline: the C evaluator uses
-# the classic (values, knot second derivatives) natural-spline form, and
-# CubicSpline(bc_type="natural") both guarantees those boundary conditions
-# and returns exact knot second derivatives via its derivative evaluation
-from scipy.interpolate import CubicSpline
-
 from galpy.util import conversion, coords
 
 from .Potential import (
@@ -120,19 +114,15 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             # in dVdv's R0/tan v, whose limit is finite)
             veval = numpy.copy(vgrid)
             veval[0] = 1e-9
-            tab = [float(self._ntab), umax]
-            for func, grid, ev in (
-                (self._U, ugrid, ugrid),
-                (self._dUdu, ugrid, ugrid),
-                (self._d2Udu2, ugrid, ugrid),
-                (self._V, vgrid, veval),
-                (self._dVdv, vgrid, veval),
-                (self._d2Vdv2, vgrid, veval),
-            ):
-                y = numpy.array([float(func(x)) for x in ev])
-                spl = CubicSpline(grid, y, bc_type="natural")
-                tab.extend(y)
-                tab.extend(spl(grid, 2))
+            # raw (grid, values) tables; the C side builds natural cubic
+            # splines from these with the house GSL 1D machinery at parse time
+            tab = [float(self._ntab)]
+            tab.extend(ugrid)
+            for func in (self._U, self._dUdu, self._d2Udu2):
+                tab.extend([float(func(x)) for x in ugrid])
+            tab.extend(vgrid)
+            for func in (self._V, self._dVdv, self._d2Vdv2):
+                tab.extend([float(func(x)) for x in veval])
             self._tabargs = tab
         self.hasC = True
         # Advertise the (planar and 3D) C variational capabilities

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -6,26 +6,10 @@
 #ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923
 #endif
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-//Cache scratch is per-OpenMP-thread: the orbit integrators parse one
-//potentialArgs per thread, but actionAngle_c parallelizes over points
-//SHARING one potentialArgs, so a single mutable cache would be a data race
-//(torn doubles = garbage forces). Each thread gets its own 14-slot block,
-//capped at OSTW_NTHREAD blocks (threads beyond the cap share block
-//thread%cap -- still racy in that unlikely case, so the cap is generous).
-#define OSTW_NTHREAD 64
-#define OSTW_NSLOT 14
-static inline double * ostw_scratch(struct potentialArg * potentialArgs){
-#ifdef _OPENMP
-  return potentialArgs->args + 6
-    + OSTW_NSLOT * ( omp_get_thread_num() % OSTW_NTHREAD );
-#else
-  return potentialArgs->args + 6;
-#endif
-}
-//OblateStaeckelWrapperPotential: amp, delta, u0, v0, refpot
+//Cache-safety contract: every C caller must give each OpenMP thread its own
+//parsed potentialArg copy (the orbit integrators always did; actionAngle_c
+//does since the parse-per-thread change this stacks on), so the exact-mode
+//cache below can live in plain per-instance scratch with no thread indexing.
 static inline double ostw_sq(double x){return x*x;}
 static inline double ostw_cb(double x){return x*x*x;}
 void Rz_to_uv(double R,double z,double * u, double * v,double delta){
@@ -69,8 +53,8 @@ static inline double ostw_spl(double x,double h,int n,double *y,double *M){
   b= (x - i*h)/h; a= 1.-b;
   return a*y[i]+b*y[i+1]+((a*a*a-a)*M[i]+(b*b*b-b)*M[i+1])*h*h/6.;
 }
-//Exact-mode cache (type -3): args[5] = 0 flag, then OSTW_NTHREAD blocks of
-//OSTW_NSLOT per-thread scratch doubles (see ostw_scratch above):
+//Exact-mode cache (type -3, nargs = 20): args[5] = 0 flag, args[6..19] are
+//per-instance scratch (each thread owns its parsed copy, see contract above):
 //              [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
 //               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v,
 //               last_R, last_z, FR_out, Fz_out] (the last four: a

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -1,5 +1,11 @@
 #include <math.h>
 #include <galpy_potentials.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+#ifndef M_PI_2
+#define M_PI_2 1.57079632679489661923
+#endif
 //OblateStaeckelWrapperPotential: amp, delta, u0, v0, refpot
 void Rz_to_uv(double R,double z,double * u, double * v,double delta){
   double d12, d22, coshu, cosv;

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -48,6 +48,80 @@ static inline double ostw_spl(double x,double h,int n,double *y,double *M){
   b= (x - i*h)/h; a= 1.-b;
   return a*y[i]+b*y[i+1]+((a*a*a-a)*M[i]+(b*b*b-b)*M[i+1])*h*h/6.;
 }
+//Exact-mode cache (type -3, nargs = 16): args[5] = 0 flag, args[6..15] are
+//per-instance scratch (potentialArgs is parsed per OpenMP thread, so this is
+//thread-safe): [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
+//               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v].
+//The wrapped Phi and forces along the reference curves depend on u (or v)
+//alone, and successive Eval/Rforce/zforce calls hit the same point, so a
+//one-slot exact cache removes the dominant redundancy. Lazily filled per
+//quantity group: Phi separately from the forces, because planar-parsed
+//instances only wire the wrapped potential's planar functions (planardUdu
+//stores the planar Rforce in the FR slot; a planar-parsed instance never
+//calls the 3D primitives, so the slots never mix semantics).
+static inline double ostw_phiu(double u,double v0,double delta,
+                               struct potentialArg * potentialArgs){
+  double * c= potentialArgs->args + 6;
+  double R,z0;
+  if ( u != *c ) {
+    uv_to_Rz(u,v0,&R,&z0,delta);
+    *(c+1)= evaluatePotentials(R,z0,potentialArgs->nwrapped,
+                               potentialArgs->wrappedPotentialArg);
+    *c= u;
+  }
+  return *(c+1);
+}
+static inline void ostw_Fu(double u,double v0,double delta,
+                           struct potentialArg * potentialArgs,int planar,
+                           double * FR,double * Fz){
+  double * c= potentialArgs->args + 8;
+  double R,z0;
+  if ( u != *c ) {
+    uv_to_Rz(u,v0,&R,&z0,delta);
+    if ( planar ) {
+      *(c+1)= calcPlanarRforce(R,0.,0.,potentialArgs->nwrapped,
+                               potentialArgs->wrappedPotentialArg);
+      *(c+2)= 0.;
+    }
+    else {
+      *(c+1)= calcRforce(R,z0,0.,0.,potentialArgs->nwrapped,
+                         potentialArgs->wrappedPotentialArg);
+      *(c+2)= calczforce(R,z0,0.,0.,potentialArgs->nwrapped,
+                         potentialArgs->wrappedPotentialArg);
+    }
+    *c= u;
+  }
+  *FR= *(c+1);
+  *Fz= *(c+2);
+}
+static inline double ostw_phiv(double v,double u0,double delta,
+                               struct potentialArg * potentialArgs){
+  double * c= potentialArgs->args + 11;
+  double R0,z;
+  if ( v != *c ) {
+    uv_to_Rz(u0,v,&R0,&z,delta);
+    *(c+1)= evaluatePotentials(R0,z,potentialArgs->nwrapped,
+                               potentialArgs->wrappedPotentialArg);
+    *c= v;
+  }
+  return *(c+1);
+}
+static inline void ostw_Fv(double v,double u0,double delta,
+                           struct potentialArg * potentialArgs,
+                           double * FR,double * Fz){
+  double * c= potentialArgs->args + 13;
+  double R0,z;
+  if ( v != *c ) {
+    uv_to_Rz(u0,v,&R0,&z,delta);
+    *(c+1)= calcRforce(R0,z,0.,0.,potentialArgs->nwrapped,
+                       potentialArgs->wrappedPotentialArg);
+    *(c+2)= calczforce(R0,z,0.,0.,potentialArgs->nwrapped,
+                       potentialArgs->wrappedPotentialArg);
+    *c= v;
+  }
+  *FR= *(c+1);
+  *Fz= *(c+2);
+}
 static inline double ostw_utab(double u,int k,struct potentialArg * potentialArgs){
   double * args= potentialArgs->args;
   int n= (int) args[5];
@@ -61,31 +135,26 @@ static inline double ostw_vtab(double v,int k,struct potentialArg * potentialArg
   return s * ostw_spl(v,M_PI_2/(n-1),n,args+7+(6+2*k)*n,args+7+(7+2*k)*n);
 }
 double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,0,potentialArgs);
-  double R,z0;
-  uv_to_Rz(u,v0,&R,&z0,delta);
-  return pow(cosh(u),2) \
-    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg);
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_utab(u,0,potentialArgs);
+  return pow(cosh(u),2) * ostw_phiu(u,v0,delta,potentialArgs);
 }
 double dUdu(double u,double v0,double delta,
 	    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,1,potentialArgs);
-  double R,z0;
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_utab(u,1,potentialArgs);
+  double R,z0,FR,Fz;
   uv_to_Rz(u,v0,&R,&z0,delta);
+  ostw_Fu(u,v0,delta,potentialArgs,0,&FR,&Fz);
   // 1e-12 bc force should win the 0/0 battle
-  return 2 * cosh(u) * sinh(u)				\
-    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg) \
+  return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
     - pow(cosh(u),2) \
-    * ( calcRforce(R,z0,0.,0.,potentialArgs->nwrapped,
-		  potentialArgs->wrappedPotentialArg) * R / ( tanh(u) + 1e-12)
-	+ calczforce(R,z0,0.,0.,potentialArgs->nwrapped,
-		   potentialArgs->wrappedPotentialArg) * z0 * tanh(u));
+    * ( FR * R / ( tanh(u) + 1e-12) + Fz * z0 * tanh(u));
 }
 double d2Udu2(double u,double v0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,2,potentialArgs);
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_utab(u,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Udu2 in Python
   double R,z0;
   double tRforce, tzforce;
@@ -115,20 +184,19 @@ double d2Udu2(double u,double v0,double delta,
 }
 double planardUdu(double u,double v0,double delta,
 		  struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,1,potentialArgs);
-  double R,z0;
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_utab(u,1,potentialArgs);
+  double R,z0,FR,Fz;
   uv_to_Rz(u,v0,&R,&z0,delta);
+  ostw_Fu(u,v0,delta,potentialArgs,1,&FR,&Fz);
   // 1e-12 bc force should win the 0/0 battle
-  return 2 * cosh(u) * sinh(u)				\
-    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg) \
-    - pow(cosh(u),2) \
-    *  calcPlanarRforce(R,0.,0.,potentialArgs->nwrapped,
-			potentialArgs->wrappedPotentialArg) * R / ( tanh(u) + 1e-12);
+  return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
+    - pow(cosh(u),2) * FR * R / ( tanh(u) + 1e-12);
 }
 double planard2Udu2(double u,double v0,double delta,
 		    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,2,potentialArgs);
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_utab(u,2,potentialArgs);
   // planar counterpart of d2Udu2: at v0 = pi/2 the U reference curve lies in
   // the z=0 plane (z0 = delta cosh u cos(pi/2) = O(1e-16)), so every
   // z0-suppressed term (zforce, Rzderiv, z2deriv) drops and only the wrapped
@@ -152,30 +220,26 @@ double planard2Udu2(double u,double v0,double delta,
 }
 double V(double v,double u0,double delta,double refpot,
 	 struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,0,potentialArgs);
-  double R0, z;
-  uv_to_Rz(u0,v,&R0,&z,delta);
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_vtab(v,0,potentialArgs);
   return refpot - staeckel_prefactor(u0,v)	\
-    * evaluatePotentials(R0,z,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg);
+    * ostw_phiv(v,u0,delta,potentialArgs);
 }
 double dVdv(double v,double u0,double delta,double refpot,
 	    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,1,potentialArgs);
-  double R0, z;
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_vtab(v,1,potentialArgs);
+  double R0,z,FR,Fz;
   uv_to_Rz(u0,v,&R0,&z,delta);
-  return -2 * sin(v) * cos(v)				\
-    *evaluatePotentials(R0,z,potentialArgs->nwrapped,
-			potentialArgs->wrappedPotentialArg) \
+  ostw_Fv(v,u0,delta,potentialArgs,&FR,&Fz);
+  return -2 * sin(v) * cos(v) * ostw_phiv(v,u0,delta,potentialArgs)	\
     + staeckel_prefactor(u0,v)					\
-    * ( calcRforce(R0,z,0.,0.,potentialArgs->nwrapped,
-                         potentialArgs->wrappedPotentialArg) * R0 / tan(v)
-	- calczforce(R0,z,0.,0.,potentialArgs->nwrapped,
-		     potentialArgs->wrappedPotentialArg) * z * tan(v));
+    * ( FR * R0 / tan(v) - Fz * z * tan(v));
 }
 double d2Vdv2(double v,double u0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,2,potentialArgs);
+  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+    return ostw_vtab(v,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Vdv2 in Python
   double R0, z;
   double tRforce, tzforce;

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -6,10 +6,16 @@
 #ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923
 #endif
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 //Cache-safety contract: every C caller must give each OpenMP thread its own
 //parsed potentialArg copy (the orbit integrators always did; actionAngle_c
 //does since the parse-per-thread change this stacks on), so the exact-mode
-//cache below can live in plain per-instance scratch with no thread indexing.
+//cache below lives in plain per-instance scratch with no thread indexing.
+static inline double * ostw_scratch(struct potentialArg * potentialArgs){
+  return potentialArgs->args + 5;
+}
 static inline double ostw_sq(double x){return x*x;}
 static inline double ostw_cb(double x){return x*x*x;}
 void Rz_to_uv(double R,double z,double * u, double * v,double delta){
@@ -39,22 +45,8 @@ void dstaeckel_prefactord2ud2v(double u,double v,
   *d2prefacdu2= 2 * cosh(2 * u);
   *d2prefacdv2= 2 * cos(2 * v);
 }
-//Tabulated mode (nargs > 5): args= [amp,delta,u0,v0,refpot,ntab,umax,
-//  then six (values, natural-cubic 2nd derivs) table pairs of ntab each:
-//  U, dU/du, d2U/du2 on uniform u in [0,umax]; V, dV/dv, d2V/dv2 on
-//  uniform v in [0,pi/2]]
-//parsed as plain type 47 (no wrapped potential in C); exact mode (type -3,
-//nargs=5) keeps the wrapped-potential path below.
-static inline double ostw_spl(double x,double h,int n,double *y,double *M){
-  int i; double a,b;
-  if ( x <= 0. ) x= 0.;
-  if ( x >= (n-1)*h ) x= (n-1)*h;
-  i= (int) (x/h); if (i > n-2) i= n-2;
-  b= (x - i*h)/h; a= 1.-b;
-  return a*y[i]+b*y[i+1]+((a*a*a-a)*M[i]+(b*b*b-b)*M[i+1])*h*h/6.;
-}
-//Exact-mode cache (type -3, nargs = 20): args[5] = 0 flag, args[6..19] are
-//per-instance scratch (each thread owns its parsed copy, see contract above):
+//Exact-mode cache (type -3, nargs = 19): args[5..18] are per-instance
+//scratch (each thread owns its parsed copy, see the contract above):
 //              [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
 //               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v,
 //               last_R, last_z, FR_out, Fz_out] (the last four: a
@@ -129,26 +121,34 @@ static inline void ostw_Fv(double v,double u0,double delta,
   *FR= *(c+1);
   *Fz= *(c+2);
 }
+//Tabulated mode (plain type 47, no wrapped potential in C): six natural
+//cubic splines in potentialArgs->spline1d / acc1d, house GSL style --
+//0..2 = U, dU/du, d2U/du2 on u in [0, umax]; 3..5 = V, dV/dv, d2V/dv2 on
+//v in [0, pi/2] (z-symmetry folding below). Mode discriminator everywhere:
+//spline1d != NULL (cf. the spline-branching convention of other potentials).
 static inline double ostw_utab(double u,int k,struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  int n= (int) args[5];
-  return ostw_spl(u,args[6]/(n-1),n,args+7+2*k*n,args+7+(2*k+1)*n);
+  gsl_spline * spl= *(potentialArgs->spline1d+k);
+  double umax= spl->x[spl->size-1];
+  if ( u < 0. ) u= 0.;
+  if ( u > umax ) u= umax;  // beyond-table = clamped (Rmax_tab is generous)
+  return gsl_spline_eval(spl,u,*(potentialArgs->acc1d+k));
 }
 static inline double ostw_vtab(double v,int k,struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  int n= (int) args[5];
   double s= 1.;
   if ( v > M_PI_2 ) { v= M_PI - v; if ( k == 1 ) s= -1.; }
-  return s * ostw_spl(v,M_PI_2/(n-1),n,args+7+(6+2*k)*n,args+7+(7+2*k)*n);
+  if ( v < 0. ) v= 0.;
+  if ( v > M_PI_2 ) v= M_PI_2;
+  return s * gsl_spline_eval(*(potentialArgs->spline1d+3+k),v,
+                             *(potentialArgs->acc1d+3+k));
 }
 double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_utab(u,0,potentialArgs);
   return ostw_sq(cosh(u)) * ostw_phiu(u,v0,delta,potentialArgs);
 }
 double dUdu(double u,double v0,double delta,
 	    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_utab(u,1,potentialArgs);
   double R,z0,FR,Fz;
   uv_to_Rz(u,v0,&R,&z0,delta);
@@ -160,7 +160,7 @@ double dUdu(double u,double v0,double delta,
 }
 double d2Udu2(double u,double v0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_utab(u,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Udu2 in Python
   double R,z0;
@@ -191,7 +191,7 @@ double d2Udu2(double u,double v0,double delta,
 }
 double planardUdu(double u,double v0,double delta,
 		  struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_utab(u,1,potentialArgs);
   double R,z0,FR,Fz;
   uv_to_Rz(u,v0,&R,&z0,delta);
@@ -202,7 +202,7 @@ double planardUdu(double u,double v0,double delta,
 }
 double planard2Udu2(double u,double v0,double delta,
 		    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_utab(u,2,potentialArgs);
   // planar counterpart of d2Udu2: at v0 = pi/2 the U reference curve lies in
   // the z=0 plane (z0 = delta cosh u cos(pi/2) = O(1e-16)), so every
@@ -227,14 +227,14 @@ double planard2Udu2(double u,double v0,double delta,
 }
 double V(double v,double u0,double delta,double refpot,
 	 struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_vtab(v,0,potentialArgs);
   return refpot - staeckel_prefactor(u0,v)	\
     * ostw_phiv(v,u0,delta,potentialArgs);
 }
 double dVdv(double v,double u0,double delta,double refpot,
 	    struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_vtab(v,1,potentialArgs);
   double R0,z,FR,Fz;
   uv_to_Rz(u0,v,&R0,&z,delta);
@@ -245,7 +245,7 @@ double dVdv(double v,double u0,double delta,double refpot,
 }
 double d2Vdv2(double v,double u0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
+  if ( potentialArgs->spline1d )
     return ostw_vtab(v,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Vdv2 in Python
   double R0, z;
@@ -287,9 +287,9 @@ static void ostw_forces(double R,double z,
                         struct potentialArg * potentialArgs,
                         double * FRout,double * Fzout){
   double * args= potentialArgs->args;
-  // the point cache lives in exact-mode scratch only: in tabulated mode
-  // (args[5] = ntab > 0) args+16 is table data and must not be written
-  int exact= ( (int) *(args+5) ) == 0;
+  // the point cache lives in exact-mode scratch only (tabulated instances
+  // carry no scratch and are cheap without it)
+  int exact= potentialArgs->spline1d == NULL;
   double * c= ostw_scratch(potentialArgs) + 10;
   if ( exact && R == *c && z == *(c+1) ) { *FRout= *(c+2); *Fzout= *(c+3); return; }
   double amp= *args, delta= *(args+1), u0= *(args+2), v0= *(args+3),

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -28,7 +28,34 @@ void dstaeckel_prefactord2ud2v(double u,double v,
   *d2prefacdu2= 2 * cosh(2 * u);
   *d2prefacdv2= 2 * cos(2 * v);
 }
+//Tabulated mode (nargs > 5): args= [amp,delta,u0,v0,refpot,ntab,umax,
+//  then six (values, natural-cubic 2nd derivs) table pairs of ntab each:
+//  U, dU/du, d2U/du2 on uniform u in [0,umax]; V, dV/dv, d2V/dv2 on
+//  uniform v in [0,pi/2]]
+//parsed as plain type 47 (no wrapped potential in C); exact mode (type -3,
+//nargs=5) keeps the wrapped-potential path below.
+static inline double ostw_spl(double x,double h,int n,double *y,double *M){
+  int i; double a,b;
+  if ( x <= 0. ) x= 0.;
+  if ( x >= (n-1)*h ) x= (n-1)*h;
+  i= (int) (x/h); if (i > n-2) i= n-2;
+  b= (x - i*h)/h; a= 1.-b;
+  return a*y[i]+b*y[i+1]+((a*a*a-a)*M[i]+(b*b*b-b)*M[i+1])*h*h/6.;
+}
+static inline double ostw_utab(double u,int k,struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  int n= (int) args[5];
+  return ostw_spl(u,args[6]/(n-1),n,args+7+2*k*n,args+7+(2*k+1)*n);
+}
+static inline double ostw_vtab(double v,int k,struct potentialArg * potentialArgs){
+  double * args= potentialArgs->args;
+  int n= (int) args[5];
+  double s= 1.;
+  if ( v > M_PI_2 ) { v= M_PI - v; if ( k == 1 ) s= -1.; }
+  return s * ostw_spl(v,M_PI_2/(n-1),n,args+7+(6+2*k)*n,args+7+(7+2*k)*n);
+}
 double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,0,potentialArgs);
   double R,z0;
   uv_to_Rz(u,v0,&R,&z0,delta);
   return pow(cosh(u),2) \
@@ -37,6 +64,7 @@ double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
 }
 double dUdu(double u,double v0,double delta,
 	    struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,1,potentialArgs);
   double R,z0;
   uv_to_Rz(u,v0,&R,&z0,delta);
   // 1e-12 bc force should win the 0/0 battle
@@ -51,6 +79,7 @@ double dUdu(double u,double v0,double delta,
 }
 double d2Udu2(double u,double v0,double delta,
 	      struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Udu2 in Python
   double R,z0;
   double tRforce, tzforce;
@@ -80,6 +109,7 @@ double d2Udu2(double u,double v0,double delta,
 }
 double planardUdu(double u,double v0,double delta,
 		  struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,1,potentialArgs);
   double R,z0;
   uv_to_Rz(u,v0,&R,&z0,delta);
   // 1e-12 bc force should win the 0/0 battle
@@ -92,6 +122,7 @@ double planardUdu(double u,double v0,double delta,
 }
 double planard2Udu2(double u,double v0,double delta,
 		    struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_utab(u,2,potentialArgs);
   // planar counterpart of d2Udu2: at v0 = pi/2 the U reference curve lies in
   // the z=0 plane (z0 = delta cosh u cos(pi/2) = O(1e-16)), so every
   // z0-suppressed term (zforce, Rzderiv, z2deriv) drops and only the wrapped
@@ -115,6 +146,7 @@ double planard2Udu2(double u,double v0,double delta,
 }
 double V(double v,double u0,double delta,double refpot,
 	 struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,0,potentialArgs);
   double R0, z;
   uv_to_Rz(u0,v,&R0,&z,delta);
   return refpot - staeckel_prefactor(u0,v)	\
@@ -123,6 +155,7 @@ double V(double v,double u0,double delta,double refpot,
 }
 double dVdv(double v,double u0,double delta,double refpot,
 	    struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,1,potentialArgs);
   double R0, z;
   uv_to_Rz(u0,v,&R0,&z,delta);
   return -2 * sin(v) * cos(v)				\
@@ -136,6 +169,7 @@ double dVdv(double v,double u0,double delta,double refpot,
 }
 double d2Vdv2(double v,double u0,double delta,
 	      struct potentialArg * potentialArgs){
+  if ( potentialArgs->nargs > 5 ) return ostw_vtab(v,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Vdv2 in Python
   double R0, z;
   double tRforce, tzforce;

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -7,10 +7,12 @@
 #define M_PI_2 1.57079632679489661923
 #endif
 //OblateStaeckelWrapperPotential: amp, delta, u0, v0, refpot
+static inline double ostw_sq(double x){return x*x;}
+static inline double ostw_cb(double x){return x*x*x;}
 void Rz_to_uv(double R,double z,double * u, double * v,double delta){
   double d12, d22, coshu, cosv;
-  d12= pow(z+delta,2) + pow(R,2);
-  d22= pow(z-delta,2) + pow(R,2);
+  d12= ostw_sq(z+delta) + ostw_sq(R);
+  d22= ostw_sq(z-delta) + ostw_sq(R);
   coshu= 0.5 / delta * ( sqrt(d12) + sqrt(d22) );
   cosv=  0.5 / delta * ( sqrt(d12) - sqrt(d22) );
   *u= acosh(coshu);
@@ -21,7 +23,7 @@ void uv_to_Rz(double u,double v,double * R, double * z,double delta){
   *z= delta * cosh(u) * cos(v);
 }
 double staeckel_prefactor(double u,double v){
-  return pow(sinh(u),2)+pow(sin(v),2);
+  return ostw_sq(sinh(u))+ostw_sq(sin(v));
 }
 void dstaeckel_prefactordudv(double u,double v,
 			       double * dprefacdu, double * dprefacdv){
@@ -51,7 +53,9 @@ static inline double ostw_spl(double x,double h,int n,double *y,double *M){
 //Exact-mode cache (type -3, nargs = 16): args[5] = 0 flag, args[6..15] are
 //per-instance scratch (potentialArgs is parsed per OpenMP thread, so this is
 //thread-safe): [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
-//               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v].
+//               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v,
+//               last_R, last_z, FR_out, Fz_out] (the last four: a
+//point-level cache computing both forces in one pass -- exact mode only).
 //The wrapped Phi and forces along the reference curves depend on u (or v)
 //alone, and successive Eval/Rforce/zforce calls hit the same point, so a
 //one-slot exact cache removes the dominant redundancy. Lazily filled per
@@ -137,7 +141,7 @@ static inline double ostw_vtab(double v,int k,struct potentialArg * potentialArg
 double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
   if ( potentialArgs->nargs > 5 && potentialArgs->args[5] > 0 )
     return ostw_utab(u,0,potentialArgs);
-  return pow(cosh(u),2) * ostw_phiu(u,v0,delta,potentialArgs);
+  return ostw_sq(cosh(u)) * ostw_phiu(u,v0,delta,potentialArgs);
 }
 double dUdu(double u,double v0,double delta,
 	    struct potentialArg * potentialArgs){
@@ -148,7 +152,7 @@ double dUdu(double u,double v0,double delta,
   ostw_Fu(u,v0,delta,potentialArgs,0,&FR,&Fz);
   // 1e-12 bc force should win the 0/0 battle
   return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
-    - pow(cosh(u),2) \
+    - ostw_sq(cosh(u)) \
     * ( FR * R / ( tanh(u) + 1e-12) + Fz * z0 * tanh(u));
 }
 double d2Udu2(double u,double v0,double delta,
@@ -170,16 +174,16 @@ double d2Udu2(double u,double v0,double delta,
     - 4 * cosh(u) * sinh(u)						\
     * ( tRforce * R / ( tanh(u) + 1e-12 )
 	+ tzforce * z0 * tanh(u) )					\
-    - pow(cosh(u),2)							\
+    - ostw_sq(cosh(u))							\
     * ( - calcR2deriv(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* R * R / pow( tanh(u) + 1e-12 , 2 )
+	* R * R / ostw_sq(tanh(u) + 1e-12)
 	- 2. * calcRzderiv(R,z0,0.,0.,potentialArgs->nwrapped,
 			   potentialArgs->wrappedPotentialArg) * R * z0
 	+ tRforce * R
 	- calcz2deriv(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* z0 * z0 * pow( tanh(u) , 2 )
+	* z0 * z0 * ostw_sq(tanh(u))
 	+ tzforce * z0 );
 }
 double planardUdu(double u,double v0,double delta,
@@ -191,7 +195,7 @@ double planardUdu(double u,double v0,double delta,
   ostw_Fu(u,v0,delta,potentialArgs,1,&FR,&Fz);
   // 1e-12 bc force should win the 0/0 battle
   return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
-    - pow(cosh(u),2) * FR * R / ( tanh(u) + 1e-12);
+    - ostw_sq(cosh(u)) * FR * R / ( tanh(u) + 1e-12);
 }
 double planard2Udu2(double u,double v0,double delta,
 		    struct potentialArg * potentialArgs){
@@ -212,10 +216,10 @@ double planard2Udu2(double u,double v0,double delta,
     * evaluatePotentials(R,z0,potentialArgs->nwrapped,
 			 potentialArgs->wrappedPotentialArg)		\
     - 4 * cosh(u) * sinh(u) * tRforce * R / ( tanh(u) + 1e-12 )	\
-    - pow(cosh(u),2)							\
+    - ostw_sq(cosh(u))							\
     * ( - calcPlanarR2deriv(R,0.,0.,potentialArgs->nwrapped,
 			    potentialArgs->wrappedPotentialArg)
-	* R * R / pow( tanh(u) + 1e-12 , 2 )
+	* R * R / ostw_sq(tanh(u) + 1e-12)
 	+ tRforce * R );
 }
 double V(double v,double u0,double delta,double refpot,
@@ -256,13 +260,13 @@ double d2Vdv2(double v,double u0,double delta,
     + staeckel_prefactor(u0,v)						\
     * ( - calcR2deriv(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* R0 * R0 / pow( tan(v) , 2 )
+	* R0 * R0 / ostw_sq(tan(v))
 	+ 2. * calcRzderiv(R0,z,0.,0.,potentialArgs->nwrapped,
 			   potentialArgs->wrappedPotentialArg) * R0 * z
 	- tRforce * R0
 	- calcz2deriv(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* z * z * pow( tan(v) , 2 )
+	* z * z * ostw_sq(tan(v))
 	- tzforce * z );
 }
 double OblateStaeckelWrapperPotentialEval(double R,double z,double phi,
@@ -276,45 +280,49 @@ double OblateStaeckelWrapperPotentialEval(double R,double z,double phi,
 		   - V(v,*(args+2),*(args+1),*(args+4),potentialArgs) ) \
     / staeckel_prefactor(u,v);
 }
+static void ostw_forces(double R,double z,
+                        struct potentialArg * potentialArgs,
+                        double * FRout,double * Fzout){
+  double * args= potentialArgs->args;
+  // the point cache lives in exact-mode scratch only: in tabulated mode
+  // (args[5] = ntab > 0) args+16 is table data and must not be written
+  int exact= ( (int) *(args+5) ) == 0;
+  double * c= args + 16;
+  if ( exact && R == *c && z == *(c+1) ) { *FRout= *(c+2); *Fzout= *(c+3); return; }
+  double amp= *args, delta= *(args+1), u0= *(args+2), v0= *(args+3),
+    refpot= *(args+4);
+  double u,v;
+  Rz_to_uv(R,z,&u,&v,delta);
+  double shu= sinh(u), chu= cosh(u), snv= sin(v), csv= cos(v);
+  double thu= shu/chu;
+  double prefac= shu*shu + snv*snv;
+  double dprefacdu= 2.*shu*chu, dprefacdv= 2.*snv*csv;
+  double tU= U(u,v0,delta,potentialArgs);
+  double tdU= dUdu(u,v0,delta,potentialArgs);
+  double tV= V(v,u0,delta,refpot,potentialArgs);
+  double tdV= dVdv(v,u0,delta,refpot,potentialArgs);
+  double denom= amp / ostw_sq( delta * prefac );
+  double umv= (tU - tV) / prefac;
+  double dsc= delta * snv * chu;
+  *FRout= denom * ( -tdU * dsc + tdV * thu * z
+                  + umv * ( dprefacdu * dsc + dprefacdv * thu * z ) );
+  *Fzout= denom * ( -tdU * R * csv / snv - tdV * dsc
+                  + umv * ( dprefacdu * R * csv / snv - dprefacdv * dsc ) );
+  if ( exact ) { *c= R; *(c+1)= z; *(c+2)= *FRout; *(c+3)= *Fzout; }
+}
 double OblateStaeckelWrapperPotentialRforce(double R,double z,double phi,
 					    double t,
 					    struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  //Calculate Rforce
-  double u,v;
-  double prefac, dprefacdu, dprefacdv;
-  Rz_to_uv(R,z,&u,&v,*(args+1));
-  prefac= staeckel_prefactor(u,v);
-  dstaeckel_prefactordudv(u,v,&dprefacdu,&dprefacdv);
-  return *args * ( ( -dUdu(u,*(args+3),*(args+1),potentialArgs)
-		     * *(args+1) * sin(v) * cosh(u)
-		     + dVdv(v,*(args+2),*(args+1),*(args+4),potentialArgs)
-		     * tanh(u) * z
-		     + ( U(u,*(args+3),*(args+1),potentialArgs)
-			 - V(v,*(args+2),*(args+1),*(args+4),potentialArgs))
-		     * ( dprefacdu * *(args+1) * sin(v) * cosh(u)
-			 + dprefacdv * tanh(u) * z ) / prefac )
-		   / pow(*(args+1) * prefac,2));
+  double FR,Fz;
+  ostw_forces(R,z,potentialArgs,&FR,&Fz);
+  return FR;
 }
 double OblateStaeckelWrapperPotentialzforce(double R,double z,double phi,
 					    double t,
 					    struct potentialArg * potentialArgs){
-  double * args= potentialArgs->args;
-  //Calculate zforce
-  double u,v;
-  double prefac, dprefacdu, dprefacdv;
-  Rz_to_uv(R,z,&u,&v,*(args+1));
-  prefac= staeckel_prefactor(u,v);
-  dstaeckel_prefactordudv(u,v,&dprefacdu,&dprefacdv);
-  return *args * (( -dUdu(u,*(args+3),*(args+1),potentialArgs) * R / tan(v)
-		    - dVdv(v,*(args+2),*(args+1),*(args+4),potentialArgs)
-		    * *(args+1) * sin(v) * cosh(u)
-		    + ( U(u,*(args+3),*(args+1),potentialArgs)
-			- V(v,*(args+2),*(args+1),*(args+4),potentialArgs))
-		    * ( dprefacdu / tan(v) * R
-			- dprefacdv * *(args+1) * sin(v) * cosh(u))
-		    /prefac)
-		  / pow(*(args+1) * prefac,2));
+  double FR,Fz;
+  ostw_forces(R,z,potentialArgs,&FR,&Fz);
+  return Fz;
 }
 double OblateStaeckelWrapperPotentialPlanarRforce(double R,double phi,
 						  double t,
@@ -330,7 +338,7 @@ double OblateStaeckelWrapperPotentialPlanarRforce(double R,double phi,
 		     * *(args+1) * sin(v) * cosh(u)
 		     + U(u,*(args+3),*(args+1),potentialArgs)
 		     * dprefacdu * *(args+1) * sin(v) * cosh(u) / prefac )
-		   / pow(*(args+1) * prefac,2));
+		   / ostw_sq(*(args+1) * prefac));
 }
 // --- Full 3D Hessian for the variational equations ---
 // Direct transcriptions of the Python _R2deriv/_z2deriv/_Rzderiv: chain rule
@@ -370,23 +378,23 @@ double OblateStaeckelWrapperPotentialR2deriv(double R,double z,double phi,
   tdVdv= dVdv(v,u0,delta,refpot,potentialArgs);
   td2Vdv2= d2Vdv2(v,u0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * pow(sin(v),2) * pow(cosh(u),2)
+      td2Udu2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
     + tdUdu * sinh(u) * cosh(u)
-    - td2Vdv2 * pow(sinh(u),2) * pow(cos(v),2)
+    - td2Vdv2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
     - tdVdv * sin(v) * cos(v)
     + ( ( -tdUdu * cosh(u) * sin(v) + tdVdv * sinh(u) * cos(v) )
 	/ delta * umvfac
 	+ ( tU - tV )
-	* ( -d2prefacdu2 * pow(cosh(u),2) * pow(sin(v),2)
+	* ( -d2prefacdu2 * ostw_sq(cosh(u)) * ostw_sq(sin(v))
 	    - dprefacdu * sinh(u) * cosh(u)
-	    - d2prefacdv2 * pow(sinh(u),2) * pow(cos(v),2)
+	    - d2prefacdv2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
 	    - dprefacdv * sin(v) * cos(v) ) / prefac
 	+ ( tU - tV ) * umvfac / prefac / delta
 	* ( dprefacdu * cosh(u) * sin(v)
 	    + dprefacdv * sinh(u) * cos(v) ) ) )
-    / pow(delta,2) / pow(prefac,3)
+    / ostw_sq(delta) / ostw_cb(prefac)
     + 2. * OblateStaeckelWrapperPotentialRforce(R,z,phi,t,potentialArgs)
-    / pow(prefac,2)
+    / ostw_sq(prefac)
     * ( dprefacdu * cosh(u) * sin(v) + dprefacdv * sinh(u) * cos(v) )
     / delta;
 }
@@ -416,23 +424,23 @@ double OblateStaeckelWrapperPotentialz2deriv(double R,double z,double phi,
   tdVdv= dVdv(v,u0,delta,refpot,potentialArgs);
   td2Vdv2= d2Vdv2(v,u0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * pow(sinh(u),2) * pow(cos(v),2)
+      td2Udu2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
     + tdUdu * cosh(u) * sinh(u)
-    - td2Vdv2 * pow(sin(v),2) * pow(cosh(u),2)
+    - td2Vdv2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
     - tdVdv * cos(v) * sin(v)
     + ( ( -tdUdu * sinh(u) * cos(v) - tdVdv * cosh(u) * sin(v) )
 	/ delta * umvfac
 	+ ( tU - tV )
-	* ( -d2prefacdu2 * pow(sinh(u),2) * pow(cos(v),2)
+	* ( -d2prefacdu2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
 	    - dprefacdu * sinh(u) * cosh(u)
-	    - d2prefacdv2 * pow(sin(v),2) * pow(cosh(u),2)
+	    - d2prefacdv2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
 	    - dprefacdv * cos(v) * sin(v) ) / prefac
 	- ( tU - tV ) * umvfac / prefac / delta
 	* ( -dprefacdu * sinh(u) * cos(v)
 	    + dprefacdv * cosh(u) * sin(v) ) ) )
-    / pow(delta,2) / pow(prefac,3)
+    / ostw_sq(delta) / ostw_cb(prefac)
     - 2. * OblateStaeckelWrapperPotentialzforce(R,z,phi,t,potentialArgs)
-    / pow(prefac,2)
+    / ostw_sq(prefac)
     * ( -dprefacdu * sinh(u) * cos(v) + dprefacdv * cosh(u) * sin(v) )
     / delta;
 }
@@ -475,9 +483,9 @@ double OblateStaeckelWrapperPotentialRzderiv(double R,double z,double phi,
 	+ ( tU - tV ) * umvfac / prefac / delta
 	* ( dprefacdu * cosh(u) * sin(v)
 	    + dprefacdv * sinh(u) * cos(v) ) ) )
-    / pow(delta,2) / pow(prefac,3)
+    / ostw_sq(delta) / ostw_cb(prefac)
     + 2. * OblateStaeckelWrapperPotentialzforce(R,z,phi,t,potentialArgs)
-    / pow(prefac,2)
+    / ostw_sq(prefac)
     * ( dprefacdu * cosh(u) * sin(v) + dprefacdv * sinh(u) * cos(v) )
     / delta;
 }
@@ -508,13 +516,13 @@ double OblateStaeckelWrapperPotentialPlanarR2deriv(double R,double phi,
   tdUdu= planardUdu(u,v0,delta,potentialArgs);
   td2Udu2= planard2Udu2(u,v0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * pow(sin(v),2) * pow(cosh(u),2)
+      td2Udu2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
     + tdUdu * sinh(u) * cosh(u)
     + ( -tdUdu * cosh(u) * sin(v) / delta * umvfac
-	+ tU * ( -d2prefacdu2 * pow(cosh(u),2) * pow(sin(v),2)
+	+ tU * ( -d2prefacdu2 * ostw_sq(cosh(u)) * ostw_sq(sin(v))
 		 - dprefacdu * sinh(u) * cosh(u) ) / prefac
 	+ tU * umvfac / prefac / delta * dprefacdu * cosh(u) * sin(v) ) )
-    / pow(delta,2) / pow(prefac,3)
+    / ostw_sq(delta) / ostw_cb(prefac)
     + 2. * OblateStaeckelWrapperPotentialPlanarRforce(R,phi,t,potentialArgs)
-    / pow(prefac,2) * dprefacdu * cosh(u) * sin(v) / delta;
+    / ostw_sq(prefac) * dprefacdu * cosh(u) * sin(v) / delta;
 }

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -6,6 +6,25 @@
 #ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923
 #endif
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+//Cache scratch is per-OpenMP-thread: the orbit integrators parse one
+//potentialArgs per thread, but actionAngle_c parallelizes over points
+//SHARING one potentialArgs, so a single mutable cache would be a data race
+//(torn doubles = garbage forces). Each thread gets its own 14-slot block,
+//capped at OSTW_NTHREAD blocks (threads beyond the cap share block
+//thread%cap -- still racy in that unlikely case, so the cap is generous).
+#define OSTW_NTHREAD 64
+#define OSTW_NSLOT 14
+static inline double * ostw_scratch(struct potentialArg * potentialArgs){
+#ifdef _OPENMP
+  return potentialArgs->args + 6
+    + OSTW_NSLOT * ( omp_get_thread_num() % OSTW_NTHREAD );
+#else
+  return potentialArgs->args + 6;
+#endif
+}
 //OblateStaeckelWrapperPotential: amp, delta, u0, v0, refpot
 static inline double ostw_sq(double x){return x*x;}
 static inline double ostw_cb(double x){return x*x*x;}
@@ -50,9 +69,9 @@ static inline double ostw_spl(double x,double h,int n,double *y,double *M){
   b= (x - i*h)/h; a= 1.-b;
   return a*y[i]+b*y[i+1]+((a*a*a-a)*M[i]+(b*b*b-b)*M[i+1])*h*h/6.;
 }
-//Exact-mode cache (type -3, nargs = 16): args[5] = 0 flag, args[6..15] are
-//per-instance scratch (potentialArgs is parsed per OpenMP thread, so this is
-//thread-safe): [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
+//Exact-mode cache (type -3): args[5] = 0 flag, then OSTW_NTHREAD blocks of
+//OSTW_NSLOT per-thread scratch doubles (see ostw_scratch above):
+//              [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
 //               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v,
 //               last_R, last_z, FR_out, Fz_out] (the last four: a
 //point-level cache computing both forces in one pass -- exact mode only).
@@ -65,7 +84,7 @@ static inline double ostw_spl(double x,double h,int n,double *y,double *M){
 //calls the 3D primitives, so the slots never mix semantics).
 static inline double ostw_phiu(double u,double v0,double delta,
                                struct potentialArg * potentialArgs){
-  double * c= potentialArgs->args + 6;
+  double * c= ostw_scratch(potentialArgs);
   double R,z0;
   if ( u != *c ) {
     uv_to_Rz(u,v0,&R,&z0,delta);
@@ -78,7 +97,7 @@ static inline double ostw_phiu(double u,double v0,double delta,
 static inline void ostw_Fu(double u,double v0,double delta,
                            struct potentialArg * potentialArgs,int planar,
                            double * FR,double * Fz){
-  double * c= potentialArgs->args + 8;
+  double * c= ostw_scratch(potentialArgs) + 2;
   double R,z0;
   if ( u != *c ) {
     uv_to_Rz(u,v0,&R,&z0,delta);
@@ -100,7 +119,7 @@ static inline void ostw_Fu(double u,double v0,double delta,
 }
 static inline double ostw_phiv(double v,double u0,double delta,
                                struct potentialArg * potentialArgs){
-  double * c= potentialArgs->args + 11;
+  double * c= ostw_scratch(potentialArgs) + 5;
   double R0,z;
   if ( v != *c ) {
     uv_to_Rz(u0,v,&R0,&z,delta);
@@ -113,7 +132,7 @@ static inline double ostw_phiv(double v,double u0,double delta,
 static inline void ostw_Fv(double v,double u0,double delta,
                            struct potentialArg * potentialArgs,
                            double * FR,double * Fz){
-  double * c= potentialArgs->args + 13;
+  double * c= ostw_scratch(potentialArgs) + 7;
   double R0,z;
   if ( v != *c ) {
     uv_to_Rz(u0,v,&R0,&z,delta);
@@ -287,7 +306,7 @@ static void ostw_forces(double R,double z,
   // the point cache lives in exact-mode scratch only: in tabulated mode
   // (args[5] = ntab > 0) args+16 is table data and must not be written
   int exact= ( (int) *(args+5) ) == 0;
-  double * c= args + 16;
+  double * c= ostw_scratch(potentialArgs) + 10;
   if ( exact && R == *c && z == *(c+1) ) { *FRout= *(c+2); *Fzout= *(c+3); return; }
   double amp= *args, delta= *(args+1), u0= *(args+2), v0= *(args+3),
     refpot= *(args+4);

--- a/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
+++ b/galpy/potential/potential_c_ext/OblateStaeckelWrapperPotential.c
@@ -6,22 +6,25 @@
 #ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923
 #endif
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-//Cache-safety contract: every C caller must give each OpenMP thread its own
-//parsed potentialArg copy (the orbit integrators always did; actionAngle_c
-//does since the parse-per-thread change this stacks on), so the exact-mode
-//cache below lives in plain per-instance scratch with no thread indexing.
-static inline double * ostw_scratch(struct potentialArg * potentialArgs){
-  return potentialArgs->args + 5;
-}
-static inline double ostw_sq(double x){return x*x;}
-static inline double ostw_cb(double x){return x*x*x;}
+//OblateStaeckelWrapperPotential: amp, delta, u0, v0, refpot
+//
+//Two evaluation modes for the U/V primitives below:
+// - exact (type -3): each primitive caches its last input/output pair in
+//   per-instance scratch appended to the parsed args (args[5-20]), because
+//   successive Eval/force/deriv calls at the same point repeat the same
+//   primitives, each of which costs several wrapped-potential evaluations;
+//   dUdu and dVdv additionally reuse the cached U/V for the wrapped
+//   potential's value. A new input simply recomputes, so exactness is
+//   unconditional.
+// - interpolated (type 47, ntab= in Python): U, U', U'' and V, V', V'' are
+//   natural cubic splines in potentialArgs->spline1d (0-2: functions of u on
+//   [0, umax]; 3-5: functions of v on [0, pi/2], extended by z-symmetry),
+//   built by the parser from tables shipped from Python; no wrapped
+//   potential reaches C. Mode discriminator: spline1d != NULL.
 void Rz_to_uv(double R,double z,double * u, double * v,double delta){
   double d12, d22, coshu, cosv;
-  d12= ostw_sq(z+delta) + ostw_sq(R);
-  d22= ostw_sq(z-delta) + ostw_sq(R);
+  d12= pow(z+delta,2) + pow(R,2);
+  d22= pow(z-delta,2) + pow(R,2);
   coshu= 0.5 / delta * ( sqrt(d12) + sqrt(d22) );
   cosv=  0.5 / delta * ( sqrt(d12) - sqrt(d22) );
   *u= acosh(coshu);
@@ -32,7 +35,7 @@ void uv_to_Rz(double u,double v,double * R, double * z,double delta){
   *z= delta * cosh(u) * cos(v);
 }
 double staeckel_prefactor(double u,double v){
-  return ostw_sq(sinh(u))+ostw_sq(sin(v));
+  return pow(sinh(u),2)+pow(sin(v),2);
 }
 void dstaeckel_prefactordudv(double u,double v,
 			       double * dprefacdu, double * dprefacdv){
@@ -45,165 +48,113 @@ void dstaeckel_prefactord2ud2v(double u,double v,
   *d2prefacdu2= 2 * cosh(2 * u);
   *d2prefacdv2= 2 * cos(2 * v);
 }
-//Exact-mode cache (type -3, nargs = 19): args[5..18] are per-instance
-//scratch (each thread owns its parsed copy, see the contract above):
-//              [last_u_phi, Phi_u, last_u_F, FR_u, Fz_u,
-//               last_v_phi, Phi_v, last_v_F, FR_v, Fz_v,
-//               last_R, last_z, FR_out, Fz_out] (the last four: a
-//point-level cache computing both forces in one pass -- exact mode only).
-//The wrapped Phi and forces along the reference curves depend on u (or v)
-//alone, and successive Eval/Rforce/zforce calls hit the same point, so a
-//one-slot exact cache removes the dominant redundancy. Lazily filled per
-//quantity group: Phi separately from the forces, because planar-parsed
-//instances only wire the wrapped potential's planar functions (planardUdu
-//stores the planar Rforce in the FR slot; a planar-parsed instance never
-//calls the 3D primitives, so the slots never mix semantics).
-static inline double ostw_phiu(double u,double v0,double delta,
-                               struct potentialArg * potentialArgs){
-  double * c= ostw_scratch(potentialArgs);
-  double R,z0;
-  if ( u != *c ) {
-    uv_to_Rz(u,v0,&R,&z0,delta);
-    *(c+1)= evaluatePotentials(R,z0,potentialArgs->nwrapped,
-                               potentialArgs->wrappedPotentialArg);
-    *c= u;
-  }
-  return *(c+1);
-}
-static inline void ostw_Fu(double u,double v0,double delta,
-                           struct potentialArg * potentialArgs,int planar,
-                           double * FR,double * Fz){
-  double * c= ostw_scratch(potentialArgs) + 2;
-  double R,z0;
-  if ( u != *c ) {
-    uv_to_Rz(u,v0,&R,&z0,delta);
-    if ( planar ) {
-      *(c+1)= calcPlanarRforce(R,0.,0.,potentialArgs->nwrapped,
-                               potentialArgs->wrappedPotentialArg);
-      *(c+2)= 0.;
-    }
-    else {
-      *(c+1)= calcRforce(R,z0,0.,0.,potentialArgs->nwrapped,
-                         potentialArgs->wrappedPotentialArg);
-      *(c+2)= calczforce(R,z0,0.,0.,potentialArgs->nwrapped,
-                         potentialArgs->wrappedPotentialArg);
-    }
-    *c= u;
-  }
-  *FR= *(c+1);
-  *Fz= *(c+2);
-}
-static inline double ostw_phiv(double v,double u0,double delta,
-                               struct potentialArg * potentialArgs){
-  double * c= ostw_scratch(potentialArgs) + 5;
-  double R0,z;
-  if ( v != *c ) {
-    uv_to_Rz(u0,v,&R0,&z,delta);
-    *(c+1)= evaluatePotentials(R0,z,potentialArgs->nwrapped,
-                               potentialArgs->wrappedPotentialArg);
-    *c= v;
-  }
-  return *(c+1);
-}
-static inline void ostw_Fv(double v,double u0,double delta,
-                           struct potentialArg * potentialArgs,
-                           double * FR,double * Fz){
-  double * c= ostw_scratch(potentialArgs) + 7;
-  double R0,z;
-  if ( v != *c ) {
-    uv_to_Rz(u0,v,&R0,&z,delta);
-    *(c+1)= calcRforce(R0,z,0.,0.,potentialArgs->nwrapped,
-                       potentialArgs->wrappedPotentialArg);
-    *(c+2)= calczforce(R0,z,0.,0.,potentialArgs->nwrapped,
-                       potentialArgs->wrappedPotentialArg);
-    *c= v;
-  }
-  *FR= *(c+1);
-  *Fz= *(c+2);
-}
-//Tabulated mode (plain type 47, no wrapped potential in C): six natural
-//cubic splines in potentialArgs->spline1d / acc1d, house GSL style --
-//0..2 = U, dU/du, d2U/du2 on u in [0, umax]; 3..5 = V, dV/dv, d2V/dv2 on
-//v in [0, pi/2] (z-symmetry folding below). Mode discriminator everywhere:
-//spline1d != NULL (cf. the spline-branching convention of other potentials).
-static inline double ostw_utab(double u,int k,struct potentialArg * potentialArgs){
+static inline double evalUspline(double u,int k,
+				 struct potentialArg * potentialArgs){
   gsl_spline * spl= *(potentialArgs->spline1d+k);
   double umax= spl->x[spl->size-1];
   if ( u < 0. ) u= 0.;
-  if ( u > umax ) u= umax;  // beyond-table = clamped (Rmax_tab is generous)
+  else if ( u > umax ) u= umax;  // beyond the table = clamped
   return gsl_spline_eval(spl,u,*(potentialArgs->acc1d+k));
 }
-static inline double ostw_vtab(double v,int k,struct potentialArg * potentialArgs){
-  double s= 1.;
-  if ( v > M_PI_2 ) { v= M_PI - v; if ( k == 1 ) s= -1.; }
+static inline double evalVspline(double v,int k,
+				 struct potentialArg * potentialArgs){
+  // tables cover v in [0, pi/2]; V is even and V' odd about pi/2 (z-symmetry)
+  double sgn= 1.;
+  if ( v > M_PI_2 ) {
+    v= M_PI - v;
+    if ( k == 1 ) sgn= -1.;
+  }
   if ( v < 0. ) v= 0.;
-  if ( v > M_PI_2 ) v= M_PI_2;
-  return s * gsl_spline_eval(*(potentialArgs->spline1d+3+k),v,
-                             *(potentialArgs->acc1d+3+k));
+  else if ( v > M_PI_2 ) v= M_PI_2;
+  return sgn * gsl_spline_eval(*(potentialArgs->spline1d+3+k),v,
+			       *(potentialArgs->acc1d+3+k));
 }
 double U(double u,double v0,double delta,struct potentialArg * potentialArgs){
+  double R,z0;
+  double * cache= potentialArgs->args + 5;  // last [u, U(u)]
   if ( potentialArgs->spline1d )
-    return ostw_utab(u,0,potentialArgs);
-  return ostw_sq(cosh(u)) * ostw_phiu(u,v0,delta,potentialArgs);
+    return evalUspline(u,0,potentialArgs);
+  if ( u == *cache )
+    return *(cache+1);
+  uv_to_Rz(u,v0,&R,&z0,delta);
+  *cache= u;
+  return *(cache+1)= pow(cosh(u),2) \
+    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
+			 potentialArgs->wrappedPotentialArg);
 }
 double dUdu(double u,double v0,double delta,
 	    struct potentialArg * potentialArgs){
+  double R,z0;
+  double * cache= potentialArgs->args + 7;  // last [u, dUdu(u)]
   if ( potentialArgs->spline1d )
-    return ostw_utab(u,1,potentialArgs);
-  double R,z0,FR,Fz;
+    return evalUspline(u,1,potentialArgs);
+  if ( u == *cache )
+    return *(cache+1);
   uv_to_Rz(u,v0,&R,&z0,delta);
-  ostw_Fu(u,v0,delta,potentialArgs,0,&FR,&Fz);
-  // 1e-12 bc force should win the 0/0 battle
-  return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
-    - ostw_sq(cosh(u)) \
-    * ( FR * R / ( tanh(u) + 1e-12) + Fz * z0 * tanh(u));
+  *cache= u;
+  // 1e-12 bc force should win the 0/0 battle;
+  // 2 cosh u sinh u Phi = 2 tanh(u) U(u): reuses the cached U
+  return *(cache+1)= 2 * tanh(u) * U(u,v0,delta,potentialArgs)	\
+    - pow(cosh(u),2) \
+    * ( calcRforce(R,z0,0.,0.,potentialArgs->nwrapped,
+		  potentialArgs->wrappedPotentialArg) * R / ( tanh(u) + 1e-12)
+	+ calczforce(R,z0,0.,0.,potentialArgs->nwrapped,
+		   potentialArgs->wrappedPotentialArg) * z0 * tanh(u));
 }
 double d2Udu2(double u,double v0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->spline1d )
-    return ostw_utab(u,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Udu2 in Python
   double R,z0;
   double tRforce, tzforce;
+  double * cache= potentialArgs->args + 9;  // last [u, d2Udu2(u)]
+  if ( potentialArgs->spline1d )
+    return evalUspline(u,2,potentialArgs);
+  if ( u == *cache )
+    return *(cache+1);
   uv_to_Rz(u,v0,&R,&z0,delta);
   tRforce= calcRforce(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg);
   tzforce= calczforce(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg);
-  // 1e-12 bc force should win the 0/0 battle (as in dUdu)
-  return 2 * cosh(2 * u)						\
-    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg)		\
+  *cache= u;
+  // 1e-12 bc force should win the 0/0 battle (as in dUdu);
+  // 2 cosh(2u) Phi = 2 cosh(2u) U(u) / cosh^2 u: reuses the cached U
+  return *(cache+1)= 2 * cosh(2 * u) / pow(cosh(u),2)			\
+    * U(u,v0,delta,potentialArgs)					\
     - 4 * cosh(u) * sinh(u)						\
     * ( tRforce * R / ( tanh(u) + 1e-12 )
 	+ tzforce * z0 * tanh(u) )					\
-    - ostw_sq(cosh(u))							\
+    - pow(cosh(u),2)							\
     * ( - calcR2deriv(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* R * R / ostw_sq(tanh(u) + 1e-12)
+	* R * R / pow( tanh(u) + 1e-12 , 2 )
 	- 2. * calcRzderiv(R,z0,0.,0.,potentialArgs->nwrapped,
 			   potentialArgs->wrappedPotentialArg) * R * z0
 	+ tRforce * R
 	- calcz2deriv(R,z0,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* z0 * z0 * ostw_sq(tanh(u))
+	* z0 * z0 * pow( tanh(u) , 2 )
 	+ tzforce * z0 );
 }
 double planardUdu(double u,double v0,double delta,
 		  struct potentialArg * potentialArgs){
+  double R,z0;
+  double * cache= potentialArgs->args + 11;  // last [u, planardUdu(u)]
   if ( potentialArgs->spline1d )
-    return ostw_utab(u,1,potentialArgs);
-  double R,z0,FR,Fz;
+    return evalUspline(u,1,potentialArgs);
+  if ( u == *cache )
+    return *(cache+1);
   uv_to_Rz(u,v0,&R,&z0,delta);
-  ostw_Fu(u,v0,delta,potentialArgs,1,&FR,&Fz);
-  // 1e-12 bc force should win the 0/0 battle
-  return 2 * cosh(u) * sinh(u) * ostw_phiu(u,v0,delta,potentialArgs)	\
-    - ostw_sq(cosh(u)) * FR * R / ( tanh(u) + 1e-12);
+  *cache= u;
+  // 1e-12 bc force should win the 0/0 battle;
+  // 2 cosh u sinh u Phi = 2 tanh(u) U(u): reuses the cached U
+  return *(cache+1)= 2 * tanh(u) * U(u,v0,delta,potentialArgs)	\
+    - pow(cosh(u),2) \
+    *  calcPlanarRforce(R,0.,0.,potentialArgs->nwrapped,
+			potentialArgs->wrappedPotentialArg) * R / ( tanh(u) + 1e-12);
 }
 double planard2Udu2(double u,double v0,double delta,
 		    struct potentialArg * potentialArgs){
-  if ( potentialArgs->spline1d )
-    return ostw_utab(u,2,potentialArgs);
   // planar counterpart of d2Udu2: at v0 = pi/2 the U reference curve lies in
   // the z=0 plane (z0 = delta cosh u cos(pi/2) = O(1e-16)), so every
   // z0-suppressed term (zforce, Rzderiv, z2deriv) drops and only the wrapped
@@ -211,51 +162,78 @@ double planard2Udu2(double u,double v0,double delta,
   // planar parser only wires the wrapped potential's planar functions.
   double R,z0;
   double tRforce;
+  double * cache= potentialArgs->args + 13;  // last [u, planard2Udu2(u)]
+  if ( potentialArgs->spline1d )
+    return evalUspline(u,2,potentialArgs);
+  if ( u == *cache )
+    return *(cache+1);
   uv_to_Rz(u,v0,&R,&z0,delta);
   tRforce= calcPlanarRforce(R,0.,0.,potentialArgs->nwrapped,
 			    potentialArgs->wrappedPotentialArg);
-  // 1e-12 bc force should win the 0/0 battle (as in dUdu)
-  return 2 * cosh(2 * u)						\
-    * evaluatePotentials(R,z0,potentialArgs->nwrapped,
-			 potentialArgs->wrappedPotentialArg)		\
+  *cache= u;
+  // 1e-12 bc force should win the 0/0 battle (as in dUdu);
+  // 2 cosh(2u) Phi = 2 cosh(2u) U(u) / cosh^2 u: reuses the cached U
+  return *(cache+1)= 2 * cosh(2 * u) / pow(cosh(u),2)			\
+    * U(u,v0,delta,potentialArgs)					\
     - 4 * cosh(u) * sinh(u) * tRforce * R / ( tanh(u) + 1e-12 )	\
-    - ostw_sq(cosh(u))							\
+    - pow(cosh(u),2)							\
     * ( - calcPlanarR2deriv(R,0.,0.,potentialArgs->nwrapped,
 			    potentialArgs->wrappedPotentialArg)
-	* R * R / ostw_sq(tanh(u) + 1e-12)
+	* R * R / pow( tanh(u) + 1e-12 , 2 )
 	+ tRforce * R );
 }
 double V(double v,double u0,double delta,double refpot,
 	 struct potentialArg * potentialArgs){
+  double R0, z;
+  double * cache= potentialArgs->args + 15;  // last [v, V(v)]
   if ( potentialArgs->spline1d )
-    return ostw_vtab(v,0,potentialArgs);
-  return refpot - staeckel_prefactor(u0,v)	\
-    * ostw_phiv(v,u0,delta,potentialArgs);
+    return evalVspline(v,0,potentialArgs);
+  if ( v == *cache )
+    return *(cache+1);
+  uv_to_Rz(u0,v,&R0,&z,delta);
+  *cache= v;
+  return *(cache+1)= refpot - staeckel_prefactor(u0,v)	\
+    * evaluatePotentials(R0,z,potentialArgs->nwrapped,
+			 potentialArgs->wrappedPotentialArg);
 }
 double dVdv(double v,double u0,double delta,double refpot,
 	    struct potentialArg * potentialArgs){
+  double R0, z;
+  double prefac;
+  double * cache= potentialArgs->args + 17;  // last [v, dVdv(v)]
   if ( potentialArgs->spline1d )
-    return ostw_vtab(v,1,potentialArgs);
-  double R0,z,FR,Fz;
+    return evalVspline(v,1,potentialArgs);
+  if ( v == *cache )
+    return *(cache+1);
   uv_to_Rz(u0,v,&R0,&z,delta);
-  ostw_Fv(v,u0,delta,potentialArgs,&FR,&Fz);
-  return -2 * sin(v) * cos(v) * ostw_phiv(v,u0,delta,potentialArgs)	\
-    + staeckel_prefactor(u0,v)					\
-    * ( FR * R0 / tan(v) - Fz * z * tan(v));
+  prefac= staeckel_prefactor(u0,v);
+  *cache= v;
+  // -2 sin v cos v Phi with Phi = (refpot - V(v)) / prefac: reuses the cached V
+  return *(cache+1)= -2 * sin(v) * cos(v)				\
+    * ( refpot - V(v,u0,delta,refpot,potentialArgs) ) / prefac \
+    + prefac							\
+    * ( calcRforce(R0,z,0.,0.,potentialArgs->nwrapped,
+                         potentialArgs->wrappedPotentialArg) * R0 / tan(v)
+	- calczforce(R0,z,0.,0.,potentialArgs->nwrapped,
+		     potentialArgs->wrappedPotentialArg) * z * tan(v));
 }
 double d2Vdv2(double v,double u0,double delta,
 	      struct potentialArg * potentialArgs){
-  if ( potentialArgs->spline1d )
-    return ostw_vtab(v,2,potentialArgs);
   // mirrors OblateStaeckelWrapperPotential._d2Vdv2 in Python
   double R0, z;
   double tRforce, tzforce;
+  double * cache= potentialArgs->args + 19;  // last [v, d2Vdv2(v)]
+  if ( potentialArgs->spline1d )
+    return evalVspline(v,2,potentialArgs);
+  if ( v == *cache )
+    return *(cache+1);
   uv_to_Rz(u0,v,&R0,&z,delta);
   tRforce= calcRforce(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg);
   tzforce= calczforce(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg);
-  return -2. * cos(2. * v)						\
+  *cache= v;
+  return *(cache+1)= -2. * cos(2. * v)					\
     * evaluatePotentials(R0,z,potentialArgs->nwrapped,
 			 potentialArgs->wrappedPotentialArg)		\
     + 2. * sin(2. * v)							\
@@ -263,13 +241,13 @@ double d2Vdv2(double v,double u0,double delta,
     + staeckel_prefactor(u0,v)						\
     * ( - calcR2deriv(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* R0 * R0 / ostw_sq(tan(v))
+	* R0 * R0 / pow( tan(v) , 2 )
 	+ 2. * calcRzderiv(R0,z,0.,0.,potentialArgs->nwrapped,
 			   potentialArgs->wrappedPotentialArg) * R0 * z
 	- tRforce * R0
 	- calcz2deriv(R0,z,0.,0.,potentialArgs->nwrapped,
 		      potentialArgs->wrappedPotentialArg)
-	* z * z * ostw_sq(tan(v))
+	* z * z * pow( tan(v) , 2 )
 	- tzforce * z );
 }
 double OblateStaeckelWrapperPotentialEval(double R,double z,double phi,
@@ -283,49 +261,45 @@ double OblateStaeckelWrapperPotentialEval(double R,double z,double phi,
 		   - V(v,*(args+2),*(args+1),*(args+4),potentialArgs) ) \
     / staeckel_prefactor(u,v);
 }
-static void ostw_forces(double R,double z,
-                        struct potentialArg * potentialArgs,
-                        double * FRout,double * Fzout){
-  double * args= potentialArgs->args;
-  // the point cache lives in exact-mode scratch only (tabulated instances
-  // carry no scratch and are cheap without it)
-  int exact= potentialArgs->spline1d == NULL;
-  double * c= ostw_scratch(potentialArgs) + 10;
-  if ( exact && R == *c && z == *(c+1) ) { *FRout= *(c+2); *Fzout= *(c+3); return; }
-  double amp= *args, delta= *(args+1), u0= *(args+2), v0= *(args+3),
-    refpot= *(args+4);
-  double u,v;
-  Rz_to_uv(R,z,&u,&v,delta);
-  double shu= sinh(u), chu= cosh(u), snv= sin(v), csv= cos(v);
-  double thu= shu/chu;
-  double prefac= shu*shu + snv*snv;
-  double dprefacdu= 2.*shu*chu, dprefacdv= 2.*snv*csv;
-  double tU= U(u,v0,delta,potentialArgs);
-  double tdU= dUdu(u,v0,delta,potentialArgs);
-  double tV= V(v,u0,delta,refpot,potentialArgs);
-  double tdV= dVdv(v,u0,delta,refpot,potentialArgs);
-  double denom= amp / ostw_sq( delta * prefac );
-  double umv= (tU - tV) / prefac;
-  double dsc= delta * snv * chu;
-  *FRout= denom * ( -tdU * dsc + tdV * thu * z
-                  + umv * ( dprefacdu * dsc + dprefacdv * thu * z ) );
-  *Fzout= denom * ( -tdU * R * csv / snv - tdV * dsc
-                  + umv * ( dprefacdu * R * csv / snv - dprefacdv * dsc ) );
-  if ( exact ) { *c= R; *(c+1)= z; *(c+2)= *FRout; *(c+3)= *Fzout; }
-}
 double OblateStaeckelWrapperPotentialRforce(double R,double z,double phi,
 					    double t,
 					    struct potentialArg * potentialArgs){
-  double FR,Fz;
-  ostw_forces(R,z,potentialArgs,&FR,&Fz);
-  return FR;
+  double * args= potentialArgs->args;
+  //Calculate Rforce
+  double u,v;
+  double prefac, dprefacdu, dprefacdv;
+  Rz_to_uv(R,z,&u,&v,*(args+1));
+  prefac= staeckel_prefactor(u,v);
+  dstaeckel_prefactordudv(u,v,&dprefacdu,&dprefacdv);
+  return *args * ( ( -dUdu(u,*(args+3),*(args+1),potentialArgs)
+		     * *(args+1) * sin(v) * cosh(u)
+		     + dVdv(v,*(args+2),*(args+1),*(args+4),potentialArgs)
+		     * tanh(u) * z
+		     + ( U(u,*(args+3),*(args+1),potentialArgs)
+			 - V(v,*(args+2),*(args+1),*(args+4),potentialArgs))
+		     * ( dprefacdu * *(args+1) * sin(v) * cosh(u)
+			 + dprefacdv * tanh(u) * z ) / prefac )
+		   / pow(*(args+1) * prefac,2));
 }
 double OblateStaeckelWrapperPotentialzforce(double R,double z,double phi,
 					    double t,
 					    struct potentialArg * potentialArgs){
-  double FR,Fz;
-  ostw_forces(R,z,potentialArgs,&FR,&Fz);
-  return Fz;
+  double * args= potentialArgs->args;
+  //Calculate zforce
+  double u,v;
+  double prefac, dprefacdu, dprefacdv;
+  Rz_to_uv(R,z,&u,&v,*(args+1));
+  prefac= staeckel_prefactor(u,v);
+  dstaeckel_prefactordudv(u,v,&dprefacdu,&dprefacdv);
+  return *args * (( -dUdu(u,*(args+3),*(args+1),potentialArgs) * R / tan(v)
+		    - dVdv(v,*(args+2),*(args+1),*(args+4),potentialArgs)
+		    * *(args+1) * sin(v) * cosh(u)
+		    + ( U(u,*(args+3),*(args+1),potentialArgs)
+			- V(v,*(args+2),*(args+1),*(args+4),potentialArgs))
+		    * ( dprefacdu / tan(v) * R
+			- dprefacdv * *(args+1) * sin(v) * cosh(u))
+		    /prefac)
+		  / pow(*(args+1) * prefac,2));
 }
 double OblateStaeckelWrapperPotentialPlanarRforce(double R,double phi,
 						  double t,
@@ -341,7 +315,7 @@ double OblateStaeckelWrapperPotentialPlanarRforce(double R,double phi,
 		     * *(args+1) * sin(v) * cosh(u)
 		     + U(u,*(args+3),*(args+1),potentialArgs)
 		     * dprefacdu * *(args+1) * sin(v) * cosh(u) / prefac )
-		   / ostw_sq(*(args+1) * prefac));
+		   / pow(*(args+1) * prefac,2));
 }
 // --- Full 3D Hessian for the variational equations ---
 // Direct transcriptions of the Python _R2deriv/_z2deriv/_Rzderiv: chain rule
@@ -381,23 +355,23 @@ double OblateStaeckelWrapperPotentialR2deriv(double R,double z,double phi,
   tdVdv= dVdv(v,u0,delta,refpot,potentialArgs);
   td2Vdv2= d2Vdv2(v,u0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
+      td2Udu2 * pow(sin(v),2) * pow(cosh(u),2)
     + tdUdu * sinh(u) * cosh(u)
-    - td2Vdv2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
+    - td2Vdv2 * pow(sinh(u),2) * pow(cos(v),2)
     - tdVdv * sin(v) * cos(v)
     + ( ( -tdUdu * cosh(u) * sin(v) + tdVdv * sinh(u) * cos(v) )
 	/ delta * umvfac
 	+ ( tU - tV )
-	* ( -d2prefacdu2 * ostw_sq(cosh(u)) * ostw_sq(sin(v))
+	* ( -d2prefacdu2 * pow(cosh(u),2) * pow(sin(v),2)
 	    - dprefacdu * sinh(u) * cosh(u)
-	    - d2prefacdv2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
+	    - d2prefacdv2 * pow(sinh(u),2) * pow(cos(v),2)
 	    - dprefacdv * sin(v) * cos(v) ) / prefac
 	+ ( tU - tV ) * umvfac / prefac / delta
 	* ( dprefacdu * cosh(u) * sin(v)
 	    + dprefacdv * sinh(u) * cos(v) ) ) )
-    / ostw_sq(delta) / ostw_cb(prefac)
+    / pow(delta,2) / pow(prefac,3)
     + 2. * OblateStaeckelWrapperPotentialRforce(R,z,phi,t,potentialArgs)
-    / ostw_sq(prefac)
+    / pow(prefac,2)
     * ( dprefacdu * cosh(u) * sin(v) + dprefacdv * sinh(u) * cos(v) )
     / delta;
 }
@@ -427,23 +401,23 @@ double OblateStaeckelWrapperPotentialz2deriv(double R,double z,double phi,
   tdVdv= dVdv(v,u0,delta,refpot,potentialArgs);
   td2Vdv2= d2Vdv2(v,u0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
+      td2Udu2 * pow(sinh(u),2) * pow(cos(v),2)
     + tdUdu * cosh(u) * sinh(u)
-    - td2Vdv2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
+    - td2Vdv2 * pow(sin(v),2) * pow(cosh(u),2)
     - tdVdv * cos(v) * sin(v)
     + ( ( -tdUdu * sinh(u) * cos(v) - tdVdv * cosh(u) * sin(v) )
 	/ delta * umvfac
 	+ ( tU - tV )
-	* ( -d2prefacdu2 * ostw_sq(sinh(u)) * ostw_sq(cos(v))
+	* ( -d2prefacdu2 * pow(sinh(u),2) * pow(cos(v),2)
 	    - dprefacdu * sinh(u) * cosh(u)
-	    - d2prefacdv2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
+	    - d2prefacdv2 * pow(sin(v),2) * pow(cosh(u),2)
 	    - dprefacdv * cos(v) * sin(v) ) / prefac
 	- ( tU - tV ) * umvfac / prefac / delta
 	* ( -dprefacdu * sinh(u) * cos(v)
 	    + dprefacdv * cosh(u) * sin(v) ) ) )
-    / ostw_sq(delta) / ostw_cb(prefac)
+    / pow(delta,2) / pow(prefac,3)
     - 2. * OblateStaeckelWrapperPotentialzforce(R,z,phi,t,potentialArgs)
-    / ostw_sq(prefac)
+    / pow(prefac,2)
     * ( -dprefacdu * sinh(u) * cos(v) + dprefacdv * cosh(u) * sin(v) )
     / delta;
 }
@@ -486,9 +460,9 @@ double OblateStaeckelWrapperPotentialRzderiv(double R,double z,double phi,
 	+ ( tU - tV ) * umvfac / prefac / delta
 	* ( dprefacdu * cosh(u) * sin(v)
 	    + dprefacdv * sinh(u) * cos(v) ) ) )
-    / ostw_sq(delta) / ostw_cb(prefac)
+    / pow(delta,2) / pow(prefac,3)
     + 2. * OblateStaeckelWrapperPotentialzforce(R,z,phi,t,potentialArgs)
-    / ostw_sq(prefac)
+    / pow(prefac,2)
     * ( dprefacdu * cosh(u) * sin(v) + dprefacdv * sinh(u) * cos(v) )
     / delta;
 }
@@ -519,13 +493,13 @@ double OblateStaeckelWrapperPotentialPlanarR2deriv(double R,double phi,
   tdUdu= planardUdu(u,v0,delta,potentialArgs);
   td2Udu2= planard2Udu2(u,v0,delta,potentialArgs);
   return amp * (
-      td2Udu2 * ostw_sq(sin(v)) * ostw_sq(cosh(u))
+      td2Udu2 * pow(sin(v),2) * pow(cosh(u),2)
     + tdUdu * sinh(u) * cosh(u)
     + ( -tdUdu * cosh(u) * sin(v) / delta * umvfac
-	+ tU * ( -d2prefacdu2 * ostw_sq(cosh(u)) * ostw_sq(sin(v))
+	+ tU * ( -d2prefacdu2 * pow(cosh(u),2) * pow(sin(v),2)
 		 - dprefacdu * sinh(u) * cosh(u) ) / prefac
 	+ tU * umvfac / prefac / delta * dprefacdu * cosh(u) * sin(v) ) )
-    / ostw_sq(delta) / ostw_cb(prefac)
+    / pow(delta,2) / pow(prefac,3)
     + 2. * OblateStaeckelWrapperPotentialPlanarRforce(R,phi,t,potentialArgs)
-    / ostw_sq(prefac) * dprefacdu * cosh(u) * sin(v) / delta;
+    / pow(prefac,2) * dprefacdu * cosh(u) * sin(v) / delta;
 }

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -3910,6 +3910,65 @@ def test_actionAngleStaeckel_conserved_actions_c():
     return None
 
 
+# Regression test for the exact-mode evaluation cache of
+# OblateStaeckelWrapperPotential in C: the cache is stateful per parsed
+# potentialArg, so it relies on every actionAngle C entry point handing each
+# OpenMP thread its own parsed copy; a shared copy shows up as nondeterministic,
+# wrong results (torn cache doubles). Check that all six C entry points are
+# deterministic under repetition with enough points to engage multiple threads,
+# that the cached exact mode agrees with the cache-free tabulated mode, and
+# that the actions agree with pure Python
+def test_actionAngle_oblatestaeckelwrapper_cache_c():
+    from galpy.actionAngle import actionAngleAdiabatic, actionAngleStaeckel
+    from galpy.potential import MWPotential2014, OblateStaeckelWrapperPotential
+
+    swp = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.45)
+    swptab = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.45, ntab=3000)
+    n = 64
+    R = numpy.linspace(0.8, 1.2, n)
+    vR = 0.15 * numpy.sin(9.0 * R)
+    vT = 1.05 + 0.1 * numpy.cos(7.0 * R)
+    z = 0.1 * numpy.sin(13.0 * R)
+    vz = 0.05 * numpy.cos(11.0 * R)
+    phi = numpy.linspace(0.0, 2.0 * numpy.pi, n)
+    all_results = []
+    for pot in (swp, swptab):
+        aAS = actionAngleStaeckel(pot=pot, delta=0.45, c=True)
+        aAA = actionAngleAdiabatic(pot=pot, c=True)
+        results = []
+        for _ in range(2):
+            out = []
+            out.extend(aAS(R, vR, vT, z, vz))
+            out.extend(aAS.actionsFreqs(R, vR, vT, z, vz))
+            out.extend(aAS.actionsFreqsAngles(R, vR, vT, z, vz, phi))
+            out.extend(aAS.EccZmaxRperiRap(R, vR, vT, z, vz))
+            out.extend(aAA(R, vR, vT, z, vz))
+            out.extend(aAA.EccZmaxRperiRap(R, vR, vT, z, vz))
+            results.append(out)
+        for first, second in zip(*results):
+            assert numpy.all(first == second), (
+                "OblateStaeckelWrapperPotential C actionAngle evaluation is not "
+                "deterministic under repetition; the exact-mode cache is likely "
+                "racing between OpenMP threads"
+            )
+        all_results.append(results[0])
+    # residual difference is tabulation truncation (the frequencies lean on the
+    # tabulated second derivatives); a racing cache errs at the percent level
+    for exact, tab in zip(*all_results):
+        assert numpy.amax(numpy.fabs(exact - tab)) < 1e-4, (
+            "Cached exact-mode and cache-free tabulated-mode "
+            "OblateStaeckelWrapperPotential disagree in C actionAngle evaluation"
+        )
+    aASpy = actionAngleStaeckel(pot=swp, delta=0.45, c=False)
+    sub = slice(0, n, 16)
+    jpy = aASpy(R[sub], vR[sub], vT[sub], z[sub], vz[sub])
+    for jc, jp in zip(all_results[0][:3], jpy):
+        assert numpy.amax(numpy.fabs(jc[sub] - jp)) < 1e-4, (
+            "C and Python actions of the cached OblateStaeckelWrapperPotential disagree"
+        )
+    return None
+
+
 # Test the actions of an actionAngleStaeckel, for a dblexp disk far away from the center
 def test_actionAngleStaeckel_conserved_actions_c_specialdblexp():
     from galpy.actionAngle import actionAngleStaeckel

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1904,6 +1904,59 @@ def test_kuzminlike_dxdv_3d_c_vs_miyamotonagai():
 # Hessians are direct transcriptions of the trusted Python
 # _R2deriv/_z2deriv/_Rzderiv, so C and Python share only the analytic
 # formulas, not integrator code.
+def test_oblatestaeckelwrapper_ntab_c():
+    # Tabulated (ntab=) OblateStaeckelWrapper C path (plain type 47, no
+    # wrapped potential in C) must reproduce the exact wrapped C path: 3D and
+    # planar orbits, and the 3D variational (Hessian) path, plus input checks
+    import numpy
+
+    from galpy.orbit import Orbit
+    from galpy.potential import MWPotential2014, OblateStaeckelWrapperPotential
+
+    swpE = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4)
+    swpT = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4, ntab=3000)
+    ts = numpy.linspace(0.0, 20.0, 1001)
+    oE = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
+    otb = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
+    oE.integrate(ts, swpE, method="dop853_c")
+    otb.integrate(ts, swpT, method="dop853_c")
+    assert numpy.amax(numpy.fabs(oE.R(ts) - otb.R(ts))) < 1e-6, (
+        "Tabulated OblateStaeckelWrapper 3D C orbit deviates from the exact one"
+    )
+    assert numpy.amax(numpy.fabs(oE.z(ts) - otb.z(ts))) < 1e-6, (
+        "Tabulated OblateStaeckelWrapper 3D C orbit deviates from the exact one"
+    )
+    # planar
+    opE = Orbit([0.9, 0.55, 0.45, 0.0])
+    optb = Orbit([0.9, 0.55, 0.45, 0.0])
+    opE.integrate(ts, swpE.toPlanar(), method="dop853_c")
+    optb.integrate(ts, swpT.toPlanar(), method="dop853_c")
+    assert numpy.amax(numpy.fabs(opE.R(ts) - optb.R(ts))) < 1e-6, (
+        "Tabulated OblateStaeckelWrapper planar C orbit deviates from the exact one"
+    )
+    # 3D variational equations exercise the tabulated Hessian branch
+    odE = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
+    odtb = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
+    tsd = numpy.linspace(0.0, 3.0, 101)
+    dxdv = [1e-6, 0.0, 0.0, 0.0, 0.0, 0.0]
+    odE.integrate_dxdv(dxdv, tsd, swpE, method="dop853_c")
+    odtb.integrate_dxdv(dxdv, tsd, swpT, method="dop853_c")
+    assert numpy.amax(
+        numpy.fabs(odE.getOrbit_dxdv() - odtb.getOrbit_dxdv())
+    ) < 1e-4 * numpy.amax(numpy.fabs(odE.getOrbit_dxdv())), (
+        "Tabulated OblateStaeckelWrapper 3D variational C path deviates "
+        "from the exact one"
+    )
+    # ntab too small raises
+    try:
+        OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4, ntab=3)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("ntab=3 should have raised a ValueError")
+    return None
+
+
 def test_oblatestaeckelwrapper_dxdv_planar_c_vs_python():
     # First-time enablement of the planar C variational path for
     # OblateStaeckelWrapperPotential: the C planar R2deriv (the v=pi/2

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1911,15 +1911,70 @@ def test_oblatestaeckelwrapper_ntab_c():
     import numpy
 
     from galpy.orbit import Orbit
-    from galpy.potential import MWPotential2014, OblateStaeckelWrapperPotential
+    from galpy.potential import (
+        MWPotential2014,
+        OblateStaeckelWrapperPotential,
+        evaluatePotentials,
+        evaluateR2derivs,
+        evaluateRforces,
+        evaluatezforces,
+    )
 
     swpE = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4)
     swpT = OblateStaeckelWrapperPotential(pot=MWPotential2014, delta=0.4, ntab=3000)
+    # Python evaluation interpolates the same tables as C (natural cubic
+    # splines on the same knots), so the two languages define the same
+    # potential also in tabulated mode; value-level checks of the Python side:
+    # agreement with exact inside the table, z-symmetry through the v fold,
+    # and active clamping beyond Rmax_tab (where exact and tabulated differ
+    # at order unity by construction)
+    for R, z in [(0.9, 0.2), (1.1, -0.15), (0.75, 0.05)]:
+        assert (
+            numpy.fabs(evaluatePotentials(swpT, R, z) - evaluatePotentials(swpE, R, z))
+            < 1e-8
+        ), "Tabulated OblateStaeckelWrapper Python potential deviates from exact"
+        assert (
+            numpy.fabs(evaluateRforces(swpT, R, z) - evaluateRforces(swpE, R, z)) < 1e-8
+        ), "Tabulated OblateStaeckelWrapper Python Rforce deviates from exact"
+        assert (
+            numpy.fabs(
+                evaluateR2derivs(swpT, R, z, use_physical=False)
+                - evaluateR2derivs(swpE, R, z, use_physical=False)
+            )
+            < 1e-6
+        ), "Tabulated OblateStaeckelWrapper Python R2deriv deviates from exact"
+    assert (
+        numpy.fabs(
+            evaluatePotentials(swpT, 0.9, 0.2) - evaluatePotentials(swpT, 0.9, -0.2)
+        )
+        < 1e-14
+    ), "Tabulated OblateStaeckelWrapper Python potential is not z-symmetric"
+    assert (
+        numpy.fabs(evaluatezforces(swpT, 0.9, 0.2) + evaluatezforces(swpT, 0.9, -0.2))
+        < 1e-14
+    ), "Tabulated OblateStaeckelWrapper Python zforce is not z-antisymmetric"
+    assert (
+        numpy.fabs(
+            evaluatePotentials(swpT, 150.0, 0.5) - evaluatePotentials(swpE, 150.0, 0.5)
+        )
+        > 0.1
+    ), (
+        "Tabulated OblateStaeckelWrapper Python evaluation beyond Rmax_tab does "
+        "not clamp (exact evaluation reached instead of the table edge)"
+    )
     ts = numpy.linspace(0.0, 20.0, 1001)
     oE = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
     otb = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
     oE.integrate(ts, swpE, method="dop853_c")
     otb.integrate(ts, swpT, method="dop853_c")
+    # C and Python tabulated evaluation agree to spline-coefficient roundoff
+    # (~n eps pointwise); over this integration that amplifies to well below
+    # the exact-vs-tabulated truncation scale
+    opytb = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
+    opytb.integrate(ts, swpT, method="dop853")
+    assert numpy.amax(numpy.fabs(opytb.R(ts) - otb.R(ts))) < 1e-6, (
+        "Tabulated OblateStaeckelWrapper Python orbit deviates from the C one"
+    )
     assert numpy.amax(numpy.fabs(oE.R(ts) - otb.R(ts))) < 1e-6, (
         "Tabulated OblateStaeckelWrapper 3D C orbit deviates from the exact one"
     )

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1934,6 +1934,20 @@ def test_oblatestaeckelwrapper_ntab_c():
     assert numpy.amax(numpy.fabs(opE.R(ts) - optb.R(ts))) < 1e-6, (
         "Tabulated OblateStaeckelWrapper planar C orbit deviates from the exact one"
     )
+    # planar variational equations exercise the tabulated planar-Hessian
+    # branch (planard2Udu2's table path)
+    opdE = Orbit([0.9, 0.55, 0.45, 0.0])
+    opdT = Orbit([0.9, 0.55, 0.45, 0.0])
+    tspd = numpy.linspace(0.0, 3.0, 101)
+    dxdvp = [1e-6, 0.0, 0.0, 0.0]
+    opdE.integrate_dxdv(dxdvp, tspd, swpE.toPlanar(), method="dop853_c")
+    opdT.integrate_dxdv(dxdvp, tspd, swpT.toPlanar(), method="dop853_c")
+    assert numpy.amax(
+        numpy.fabs(opdE.getOrbit_dxdv() - opdT.getOrbit_dxdv())
+    ) < 1e-4 * numpy.amax(numpy.fabs(opdE.getOrbit_dxdv())), (
+        "Tabulated OblateStaeckelWrapper planar variational C path deviates "
+        "from the exact one"
+    )
     # 3D variational equations exercise the tabulated Hessian branch
     odE = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])
     odtb = Orbit([0.9, 0.55, 0.45, 0.2, 0.25, 0.0])


### PR DESCRIPTION
Two complementary speedups for `OblateStaeckelWrapperPotential`'s C evaluation, whose every force/Hessian call previously evaluated the wrapped potential 6-10 times along the U/V reference curves. Stacked on #1475 (per-thread `potentialArg` parsing in the actionAngle C extensions), which makes per-instance state in parsed args safe everywhere. The C file is main's original plus minimal additions (+112/-23 lines): no helper layer, no thread references, every formula unchanged.

**1. Exact per-primitive caching (default path, no API change): ~3x.** Each U/V primitive memoizes its last input/output pair in per-instance scratch appended to the parsed args (`args[5-20]`; a 4-line pattern per primitive), because successive Eval/force/deriv calls at the same point repeat the same primitives; `dUdu`/`dVdv`/`d2Udu2` additionally reuse the cached `U`/`V` for the wrapped potential's value (`2 cosh u sinh u Phi = 2 tanh(u) U(u)`, etc.), keeping the force path at six wrapped evaluations per fresh point. A new input simply recomputes, so exactness is unconditional. Measured: single-orbit C integration 0.32s -> 0.109s; strict dxdv C-vs-Python parity unchanged.

**2. Optional interpolated evaluation (`ntab=`): ~16-20x.** Since `delta`/`u0` are fixed at init, U(u), V(v) and their first/second derivatives are 1-D functions: with `ntab=` set, the Python side ships raw sample tables (u on [0, arcsinh(Rmax_tab/delta)], v on [0, pi/2] with z-symmetry folding; no scipy involved) and the C parser builds six natural cubic splines with the house GSL machinery (`potentialArgs->spline1d`/`acc1d`, `gsl_interp_cspline`, case-36 idiom), parsed as plain positive type 47 carrying the tables (no wrapped potential reaches C). In the potential C file this is a two-line branch at the top of each primitive plus two small spline-eval helpers; mode discriminator is `spline1d != NULL` per the existing convention. Trajectories agree with exact to 2e-8 at ntab=3000; tabulated single-orbit integration 0.021s. The exact path remains the default.

Motivating benchmark (adiabatic-transformation crossfade, 64 orbits, tintJ=30): 10.4s -> ~4s (exact+cache) -> 1.1s (ntab), the latter essentially the wrapped MWPotential2014's own cost.

Tests: `test_oblatestaeckelwrapper_ntab_c` (C parity tabulated-vs-exact for 3D, planar, and both variational paths + input validation); existing wrapper dxdv C-vs-Python parity tests cover the cached exact path; new `test_actionAngle_oblatestaeckelwrapper_cache_c` exercises all six actionAngle C entry points on the cached wrapper (64 points, bitwise determinism under repetition, cached-exact vs cache-free-tabulated agreement, Python anchor) as the race regression test for the #1475 contract. New Python lines fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
