### PR TITLE
Avoid duplicate builds/tests on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Linux/Mac build
 
 on:
   push:
+    # Only trunk/integration branches on push; every other branch gets CI via
+    # pull_request, so a PR branch is not built twice (push + pull_request).
+    branches:
+      - main
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -2,6 +2,10 @@ name: Windows build
 
 on:
   push:
+    # Only trunk/integration branches on push; every other branch gets CI via
+    # pull_request, so a PR branch is not built twice (push + pull_request).
+    branches:
+      - main
     paths:
       - '**'
       - '!*'

--- a/.github/workflows/test-doc-notebooks.yml
+++ b/.github/workflows/test-doc-notebooks.yml
@@ -2,6 +2,10 @@ name: Test documentation notebooks
 
 on:
   push:
+    # Only trunk/integration branches on push; every other branch gets CI via
+    # pull_request, so a PR branch is not built twice (push + pull_request).
+    branches:
+      - main
     paths:
       - '**'
       - '!*'


### PR DESCRIPTION
Every PR runs its whole matrix twice: once from the `push` event on the branch,
once from `pull_request`, both attaching their checks to the PR. On a recent PR
that is 51 duplicated jobs per push:

| workflow | jobs | duplicated |
|---|---:|---|
| Linux/Mac build | 50 | 25 × 2 |
| Windows build | 42 | 21 × 2 |
| Test documentation notebooks | 10 | 5 × 2 |

Restrict `push` to `main`; every other branch still gets CI through
`pull_request`, which is what the PR gates on anyway. `pull_request` triggers are
untouched, so no coverage changes.

The only behavior change: pushing to a branch with **no** open PR no longer
builds it. Open a PR (or use the scheduled/manual runs) to get CI on it.