### PR TITLE
C bridge: keep a potential's tables whole in pot_args (streamTrack 7x under jax)

### DIFF
--- a/galpy/orbit/integrateFullOrbit.py
+++ b/galpy/orbit/integrateFullOrbit.py
@@ -31,6 +31,7 @@ from .integratePlanarOrbit import (
     _parse_noninertial_frame_force,
     _parse_scf_pot,
     _parse_tol,
+    _PotArgs,
     _prep_tfuncs,
 )
 
@@ -60,7 +61,7 @@ def _parse_pot(pot, potforactions=False, potfortorus=False, t=None):
         )
     # Initialize everything
     pot_type = []
-    pot_args = []
+    pot_args = _PotArgs()
     pot_tfuncs = []
     npot = len(pot)
     for p in pot:

--- a/galpy/orbit/integrateLinearOrbit.py
+++ b/galpy/orbit/integrateLinearOrbit.py
@@ -22,6 +22,7 @@ from .integratePlanarOrbit import (
     _parse_integrator,
     _parse_multipole_expansion_pot,
     _parse_tol,
+    _PotArgs,
     _prep_tfuncs,
 )
 
@@ -37,7 +38,7 @@ def _parse_pot(pot):
 
     # Initialize everything
     pot_type = []
-    pot_args = []
+    pot_args = _PotArgs()
     pot_tfuncs = []
     npot = len(pot)
     for p in pot:

--- a/galpy/orbit/integratePlanarOrbit.py
+++ b/galpy/orbit/integratePlanarOrbit.py
@@ -44,7 +44,7 @@ def _parse_pot(pot, t=None):
 
     # Initialize everything
     pot_type = []
-    pot_args = []
+    pot_args = _PotArgs()
     pot_tfuncs = []
     npot = len(pot)
     for p in pot:
@@ -663,6 +663,28 @@ def _parse_pot(pot, t=None):
     return (npot, pot_type, pot_args, pot_tfuncs)
 
 
+class _PotArgs(list):
+    """The C potential-argument list, with array-valued ``extend`` kept whole.
+
+    ``_finalize_pot_args`` below concatenates array elements as chunks, so the
+    bytes handed to C are the same either way -- but ``extend(<array>)`` splats a
+    table into one Python object per entry. For the potentials that carry one (a
+    MovingObjectPotential trajectory, an interpRZ grid, the
+    DoubleExponentialDisk quadrature nodes) that is tens of thousands of objects
+    per integration, and under a FORCED backend every one of them is a 0-d
+    backend array that ``_finalize_pot_args`` then converts individually -- one
+    device transfer each. Keeping the array as a single element makes it one.
+    """
+
+    def extend(self, other):
+        from ..backend import is_backend_array
+
+        if isinstance(other, numpy.ndarray) or is_backend_array(other):
+            self.append(other)
+        else:
+            super().extend(other)
+
+
 def _finalize_pot_args(pot_args):
     """Convert pot_args list to a contiguous float64 numpy array.
 
@@ -796,7 +818,7 @@ def _parse_disk_approx_pairs(p, extra_amp=1.0, per_pair_suffix=None):
     # Stand-alone parser for disk approximation [Sigma_i, h_i] pairs used
     # in the KuijkenDubinskiDiskExpansionPotential-based potentials, bc reused
     pot_types = []
-    pot_args = []
+    pot_args = _PotArgs()
     for Sigma, hz in zip(p._Sigma_dict, p._hz_dict):
         pot_types.append(26)
         stype = Sigma.get("type", "exp")

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -214,6 +214,14 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap  # PASSES in 743.1s (meas
 # is covered by the numpy suite, the backend track/class by
 # test_backend_streamTrack.py). Un-skip when the pipeline is jit-vectorized.
 #
+# 2026-09-09 (gh#1470): test_streamTrack_with_progpot is RETIRED -- 323.7 s ->
+# under 18 s. Not a stream fix: the C bridge exploded a MovingObjectPotential's
+# 10001-point trajectory into one Python object per entry, and under a forced
+# backend each of those is a 0-d backend array that _finalize_pot_args converted
+# individually (12.0M is_backend_array calls per streamTrack). Keeping the array
+# whole makes it 12.5k. test_streamTrack_plot_spread_non_cartesian is NOT helped
+# (427.2 -> 439.2 s): its cost is elsewhere, so it stays below.
+#
 # WHY streamTrack IS NOT A BURNDOWN TARGET (measured 2026-08-22, both modes,
 # whole file, post-#1364): 0.96x-1.11x. gh#1364's as_backend_constant guard
 # removes a fixed cost PER as_backend_constant CALL, so it pays in proportion to
@@ -221,8 +229,7 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap  # PASSES in 743.1s (meas
 # call, NonInertialFrameForce 7 -> 1.07x-1.64x on its tests, streamTrack ~0 per
 # evaluation (its stream-module calls are in TRACK SETUP, run a handful of times)
 # -> nothing. Do not re-run this sweep expecting a win from that guard.
-jax tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 427.2s (CI~303s) re-measured 2026-08-22 post-#1364 (was 408.0s; 0.96x -- the guard does NOT help here)
-jax tests/test_streamTrack.py::test_streamTrack_with_progpot  # 323.7s (CI~230s) re-measured 2026-08-22 post-#1364 (was 331.7s; 1.02x). STAYS: it straddles the 240s margin on a ~2% wobble, which is noise, not a change
+jax tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 439.2s re-measured 2026-09-09 with the pot_args fix (was 427.2s; 1.03x -- unaffected)
 # jax-eager dynamical friction: these two spend the full 300 s per-test timeout,
 # which pytest-timeout delivers as a SIGNAL. Landing mid-jax-operation it leaves
 # jax's thread-local trace state as None, and then EVERY later test in the shard

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -214,8 +214,8 @@ torch tests/test_orbit.py::test_analytic_ecc_rperi_rap  # PASSES in 743.1s (meas
 # is covered by the numpy suite, the backend track/class by
 # test_backend_streamTrack.py). Un-skip when the pipeline is jit-vectorized.
 #
-# 2026-09-09 (gh#1470): test_streamTrack_with_progpot is RETIRED -- 323.7 s ->
-# under 18 s. Not a stream fix: the C bridge exploded a MovingObjectPotential's
+# 2026-09-09 (gh#1473): test_streamTrack_with_progpot is RETIRED in BOTH modes --
+# 323.7 s -> under 18 s eager, 326.8 s -> 35.7 s traced. Not a stream fix: the C bridge exploded a MovingObjectPotential's
 # 10001-point trajectory into one Python object per entry, and under a forced
 # backend each of those is a 0-d backend array that _finalize_pot_args converted
 # individually (12.0M is_backend_array calls per streamTrack). Keeping the array
@@ -310,7 +310,6 @@ jax tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 439
 # saw, because this run had one competitor rather than four. Either way both
 # clear 240 s, so the split is unchanged.
 jax-jit tests/test_streamTrack.py::test_streamTrack_plot_spread_non_cartesian  # 406.7s traced (CI~289s) re-measured 2026-08-22 post-#1364 (was 452s; 1.11x)
-jax-jit tests/test_streamTrack.py::test_streamTrack_with_progpot  # 326.8s traced (CI~232s) re-measured 2026-08-22 post-#1364 (was 314s; 0.96x). STAYS: straddles the margin on noise, same as its eager twin
 
 # --- jax-jit: measured by the 10-file traced sweep (2026-08-09) ---
 # gh#1279 stopped `-jit` inheriting the eager slow-skip list, which un-deferred


### PR DESCRIPTION
Profiling `streamTrack(n=200)` under forced jax: **165 s, of which 145 s is
`_parse_pot`** -- not physics. One call made **12,011,281** `is_backend_array`
calls and 4,000,669 `as_numpy` calls.

`_parse_pot` builds `pot_args` with `extend(<array>)`, which splats a table into
one Python object per entry: a MovingObjectPotential's 10001-point trajectory is
40,015 of them, the DoubleExponentialDisk quadrature nodes 40,005. Under a forced
backend each of those is a 0-d backend array, and `_finalize_pot_args` converts
them one at a time -- a device transfer each, repeated for every orbit integrated
(the C-STM path re-parses the potential per particle).

`_finalize_pot_args` already concatenates array-valued elements as chunks; its
docstring says so ("instead of converting millions of Python floats"). The tables
just never survived as arrays long enough to reach that path. So `pot_args`
becomes a small `list` subclass whose `extend` appends an array whole instead of
splatting it -- one change, every call site benefits, no call site touched.

| | before | after |
|---|---:|---:|
| MovingObjectPotential, `pot_args` entries | 4,011 | **10** |
| DoubleExponentialDisk, entries | 40,005 | **9** |
| `streamTrack(n=200)`, jax | 165.1 s | **23.0 s** |
| `is_backend_array` calls in that run | 12,011,281 | **12,483** |
| `streamTrack(n=200)`, numpy | 1.04 s | **0.83 s** |

**The bytes handed to C are unchanged.** `_parse_pot`'s finalized `pot_args` is
byte-for-byte identical (sha1 over the float64 buffer) for Logarithmic,
MiyamotoNagai, DoubleExponentialDisk, MovingObject, SCF, MultipoleExpansion,
interpRZ, RotateAndTilt and MWPotential2014, in both the 3D and the planar
parser. The numpy path is byte-identical -- and 20% faster on this workload.

Ledger: `test_streamTrack_with_progpot` 323.7 s -> under 18 s, retired.
`test_streamTrack_plot_spread_non_cartesian` is NOT helped (427.2 -> 439.2 s), so
it stays, with that measurement now recorded next to it -- its cost is somewhere
else and needs its own profile.

Gates: numpy `test_potential.py` 1293 passed; `test_streamTrack.py` +
`test_streamspraydf.py` 85 passed. Forced jax `test_streamTrack.py` 45 passed.
Forced torch 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm


Profiling `streamTrack(n=200)` under forced jax: 165 s, of which 145 s is
`_parse_pot` -- not physics. `is_backend_array` was called **12,011,281 times**
and `as_numpy` 4,000,669 times for one call.

The reason: `_parse_pot` builds `pot_args` with `extend(<array>)`, which splats a
table into one Python object per entry -- a MovingObjectPotential's 10001-point
trajectory is 40,015 of them, the DoubleExponentialDisk quadrature nodes 40,005.
Under a FORCED backend every one of those is a 0-d backend array, and
`_finalize_pot_args` then converts them one at a time: one device transfer each,
per orbit integrated (the C-STM path re-parses the potential for every particle).

`_finalize_pot_args` already concatenates array-valued elements as chunks -- its
docstring says so ("instead of converting millions of Python floats") -- the
tables just never survived as arrays to reach that path. `pot_args` becomes a
small list subclass whose `extend` appends an array whole instead of splatting
it; nothing else changes, so every call site benefits without being touched.

    MovingObjectPotential       4,011 list entries -> 10
    DoubleExponentialDisk      40,005              ->  9
    streamTrack(n=200), jax     165.1 s -> 23.0 s   (is_backend_array 12.0M -> 12.5k)
    streamTrack(n=200), numpy     1.04 s ->  0.83 s

The bytes handed to C are unchanged: `_parse_pot`'s finalized `pot_args` is
byte-for-byte identical (sha1 over the float64 buffer) for Logarithmic,
MiyamotoNagai, DoubleExponentialDisk, MovingObject, SCF, MultipoleExpansion,
interpRZ, RotateAndTilt and MWPotential2014, in both the 3D and planar parsers.
So the numpy path is byte-identical, and faster.

Ledger: test_streamTrack_with_progpot 323.7 s -> under 18 s, retired.
test_streamTrack_plot_spread_non_cartesian is NOT helped (427.2 -> 439.2 s) and
stays, now with that measurement recorded.

numpy: test_potential.py 1293 passed, test_streamTrack.py + test_streamspraydf.py
85 passed. Forced jax: test_streamTrack.py 45 passed. Forced torch: 3 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>