### PR TITLE
actionAngle_c: parse one potentialArg copy per OpenMP thread

### DIFF
--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
@@ -89,7 +89,10 @@ static inline void calcEREzL(int ndata,
 			     struct potentialArg * actionAngleArgs){
   int ii;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii)
+#ifdef _OPENMP
+  int nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
+#endif
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk) private(ii)
   for (ii=0; ii < ndata; ii++){
     *(ER+ii)= evaluatePotentials(*(R+ii),0.,
 				 nargs,AA_TARGS(actionAngleArgs,nargs))
@@ -123,7 +126,8 @@ void actionAngleAdiabatic_RperiRapZmax(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -182,7 +186,8 @@ void actionAngleAdiabatic_actions(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -246,7 +251,10 @@ void calcJRAdiabatic(int ndata,
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,gi) \
+#ifdef _OPENMP
+  int nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
+#endif
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk) private(ii,gi) \
   shared(jr,rperi,rap,T,ER,Lz)
   for (ii=0; ii < ndata; ii++){
     if ( *(rperi+ii) == -9999.99 || *(rap+ii) == -9999.99 ){
@@ -290,7 +298,10 @@ void calcJzAdiabatic(int ndata,
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,gi) \
+#ifdef _OPENMP
+  int nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
+#endif
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk) private(ii,gi) \
   shared(jz,zmax,T,Ez,R)
   for (ii=0; ii < ndata; ii++){
     if ( *(zmax+ii) == -9999.99 ){
@@ -324,7 +335,7 @@ void calcRapRperi(int ndata,
 		  struct potentialArg * actionAngleArgs){
   int ii, tid, nthreads;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -345,7 +356,7 @@ void calcRapRperi(int ndata,
   }
   UNUSED int chunk= CHUNKSIZE;
   gsl_set_error_handler_off();
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,iter,status,R_lo,R_hi,meps,peps)			\
   shared(rperi,rap,JRRoot,params,s,R,ER,Lz,max_iter)
   for (ii=0; ii < ndata; ii++){
@@ -526,7 +537,7 @@ void calcZmax(int ndata,
 	      struct potentialArg * actionAngleArgs){
   int ii, tid, nthreads;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -546,7 +557,7 @@ void calcZmax(int ndata,
   }
   UNUSED int chunk= CHUNKSIZE;
   gsl_set_error_handler_off();
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,iter,status,z_lo,z_hi)				\
   shared(zmax,JzRoot,params,s,z,Ez,R,max_iter)
   for (ii=0; ii < ndata; ii++){

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleAdiabatic.c
@@ -16,6 +16,14 @@
 #define CHUNKSIZE 10
 //Potentials
 #include <galpy_potentials.h>
+//Per-thread potential structs: potentials may keep per-instance caches in
+//their args (cf. OblateStaeckelWrapperPotential), so every OpenMP loop over
+//points must use its own thread's parsed copy rather than sharing one
+#ifdef _OPENMP
+#define AA_TARGS(args,n) ((args) + omp_get_thread_num() * (n))
+#else
+#define AA_TARGS(args,n) (args)
+#endif
 #include <integrateFullOrbit.h>
 #include <actionAngle.h>
 #ifndef M_PI
@@ -84,11 +92,11 @@ static inline void calcEREzL(int ndata,
 #pragma omp parallel for schedule(static,chunk) private(ii)
   for (ii=0; ii < ndata; ii++){
     *(ER+ii)= evaluatePotentials(*(R+ii),0.,
-				 nargs,actionAngleArgs)
+				 nargs,AA_TARGS(actionAngleArgs,nargs))
       + 0.5 * *(vR+ii) * *(vR+ii)
       + 0.5 * *(vT+ii) * *(vT+ii);
     *(Ez+ii)= evaluateVerticalPotentials(*(R+ii),*(z+ii),
-					 nargs,actionAngleArgs)
+					 nargs,AA_TARGS(actionAngleArgs,nargs))
       + 0.5 * *(vz+ii) * *(vz+ii);
     *(Lz+ii)= *(R+ii) * *(vT+ii);
   }
@@ -113,8 +121,24 @@ void actionAngleAdiabatic_RperiRapZmax(int ndata,
 				       int * err){
   int ii;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //ER, Ez, Lz
   double *ER= (double *) malloc ( ndata * sizeof(double) );
   double *Ez= (double *) malloc ( ndata * sizeof(double) );
@@ -133,7 +157,7 @@ void actionAngleAdiabatic_RperiRapZmax(int ndata,
       - 0.5 * *(vT+ii) * *(vT+ii);
   }
   calcRapRperi(ndata,rperi,rap,R,ER,Lz,npot,actionAngleArgs);
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(ER);
   free(Ez);
@@ -156,8 +180,24 @@ void actionAngleAdiabatic_actions(int ndata,
 				  int * err){
   int ii;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //ER, Ez, Lz
   double *ER= (double *) malloc ( ndata * sizeof(double) );
   double *Ez= (double *) malloc ( ndata * sizeof(double) );
@@ -179,7 +219,7 @@ void actionAngleAdiabatic_actions(int ndata,
   }
   calcRapRperi(ndata,rperi,rap,R,ER,Lz,npot,actionAngleArgs);
   calcJRAdiabatic(ndata,jr,rperi,rap,ER,Lz,npot,actionAngleArgs,20);
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(ER);
   free(Ez);
@@ -224,7 +264,7 @@ void calcJRAdiabatic(int ndata,
     for (gi=0; gi < order; gi++){
       gsl_integration_glfixed_point(0.,M_PI,gi,&xi,&wi,T);
       double r= cc - rr*cos(xi);
-      double FR= tER - evaluatePotentials(r,0.,nargs,actionAngleArgs)
+      double FR= tER - evaluatePotentials(r,0.,nargs,AA_TARGS(actionAngleArgs,nargs))
 	- Lz22/(r*r);
       if ( FR <= 0. ) continue;
       acc+= wi*sqrt(FR)*rr*sin(xi);
@@ -266,7 +306,7 @@ void calcJzAdiabatic(int ndata,
     for (gi=0; gi < order; gi++){
       gsl_integration_glfixed_point(0.,0.5*M_PI,gi,&xi,&wi,T);
       double Fz= tEz - evaluateVerticalPotentials(tR,tzmax*sin(xi),
-						  nargs,actionAngleArgs);
+						  nargs,AA_TARGS(actionAngleArgs,nargs));
       if ( Fz <= 0. ) continue;
       acc+= wi*sqrt(Fz)*tzmax*cos(xi);
     }
@@ -300,7 +340,7 @@ void calcRapRperi(int ndata,
   T = gsl_root_fsolver_brent;
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
     (s+tid)->s= gsl_root_fsolver_alloc (T);
   }
   UNUSED int chunk= CHUNKSIZE;
@@ -501,7 +541,7 @@ void calcZmax(int ndata,
   T = gsl_root_fsolver_brent;
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
     (s+tid)->s= gsl_root_fsolver_alloc (T);
   }
   UNUSED int chunk= CHUNKSIZE;

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -350,7 +350,8 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -390,7 +391,7 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
   double *I3V= (double *) malloc ( ndata * sizeof(double) );
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+#pragma omp parallel for num_threads(aa_nthreads) schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
     struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
@@ -474,7 +475,8 @@ void actionAngleStaeckel_actions(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -514,7 +516,7 @@ void actionAngleStaeckel_actions(int ndata,
   double *I3V= (double *) malloc ( ndata * sizeof(double) );
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+#pragma omp parallel for num_threads(aa_nthreads) schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
     struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
@@ -607,7 +609,7 @@ void calcJRStaeckel(int ndata,
   int ii, tid, nthreads;
   double mid;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -621,7 +623,7 @@ void calcJRStaeckel(int ndata,
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,mid)							\
   shared(jr,umin,umax,JRInt,params,T,delta,E,Lz,I3U,u0,sinh2u0,v0,sin2v0,potu0v0)
   for (ii=0; ii < ndata; ii++){
@@ -689,7 +691,7 @@ void calcJzStaeckel(int ndata,
   int ii, tid, nthreads;
   double mid;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -703,7 +705,7 @@ void calcJzStaeckel(int ndata,
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,mid)							\
   shared(jz,vmin,JzInt,params,T,delta,E,Lz,I3V,u0,cosh2u0,sinh2u0,potupi2)
   for (ii=0; ii < ndata; ii++){
@@ -770,7 +772,8 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -810,7 +813,7 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
   double *I3V= (double *) malloc ( ndata * sizeof(double) );
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+#pragma omp parallel for num_threads(aa_nthreads) schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
     struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
@@ -935,7 +938,8 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
   //Set up the potentials
   // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
 #ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
+  // cap copies at the point count, as the orbit integrators cap their team
+  int aa_nthreads= ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   int aa_nthreads= 1;
 #endif
@@ -975,7 +979,7 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
   double *I3V= (double *) malloc ( ndata * sizeof(double) );
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
+#pragma omp parallel for num_threads(aa_nthreads) schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
     struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
@@ -1162,7 +1166,7 @@ void calcdJRStaeckel(int ndata,
   int ii, tid, nthreads;
   double mid;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -1176,7 +1180,7 @@ void calcdJRStaeckel(int ndata,
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,mid)							\
   shared(djrdE,djrdLz,djrdI3,umin,umax,dJRInt,params,T,delta,E,Lz,I3U,u0,sinh2u0,v0,sin2v0,potu0v0)
   for (ii=0; ii < ndata; ii++){
@@ -1255,7 +1259,7 @@ void calcdJzStaeckel(int ndata,
   int ii, tid, nthreads;
   double mid;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -1269,7 +1273,7 @@ void calcdJzStaeckel(int ndata,
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,mid)							\
   shared(djzdE,djzdLz,djzdI3,vmin,dJzInt,params,T,delta,E,Lz,I3V,u0,cosh2u0,sinh2u0,potupi2)
   for (ii=0; ii < ndata; ii++){
@@ -1372,7 +1376,7 @@ void calcAnglesStaeckel(int ndata,
   double Or1, Or2, I3r1, I3r2,phitmp;
   double mid, midpoint;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -1390,7 +1394,7 @@ void calcAnglesStaeckel(int ndata,
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,mid,midpoint,Or1,Or2,I3r1,I3r2,phitmp)			\
   shared(Angler,Anglephi,Anglez,Omegar,Omegaz,dI3dJR,dI3dJz,umin,umax,AngleuInt,AnglevInt,paramsu,paramsv,T,delta,E,Lz,I3U,u0,sinh2u0,v0,sin2v0,potu0v0,vmin,I3V,cosh2u0,potupi2)
   for (ii=0; ii < ndata; ii++){
@@ -1637,7 +1641,7 @@ void calcUminUmax(int ndata,
 		  struct potentialArg * actionAngleArgs){
   int ii, tid, nthreads;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -1659,7 +1663,7 @@ void calcUminUmax(int ndata,
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
   gsl_set_error_handler_off();
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,iter,status,u_lo,u_hi,meps,peps)				\
   shared(umin,umax,JRRoot,params,s,ux,delta,E,Lz,I3U,u0,sinh2u0,v0,sin2v0,potu0v0,max_iter)
   for (ii=0; ii < ndata; ii++){
@@ -1906,7 +1910,7 @@ void calcVmin(int ndata,
 	      struct potentialArg * actionAngleArgs){
   int ii, tid, nthreads;
 #ifdef _OPENMP
-  nthreads = omp_get_max_threads();
+  nthreads = ndata < omp_get_max_threads() ? ndata : omp_get_max_threads();
 #else
   nthreads = 1;
 #endif
@@ -1927,7 +1931,7 @@ void calcVmin(int ndata,
   int delta_stride= ndelta == 1 ? 0 : 1;
   UNUSED int chunk= CHUNKSIZE;
   gsl_set_error_handler_off();
-#pragma omp parallel for schedule(static,chunk)				\
+#pragma omp parallel for num_threads(nthreads) schedule(static,chunk)				\
   private(tid,ii,iter,status,v_lo,v_hi)				\
   shared(vmin,JzRoot,params,s,vx,delta,E,Lz,I3V,u0,cosh2u0,sinh2u0,potupi2,max_iter)
   for (ii=0; ii < ndata; ii++){

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -271,24 +271,7 @@ void calcu0(int ndata,
   int ii;
   //Set up the potentials
   struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
-#ifdef _OPENMP
-  int aa_nthreads= omp_get_max_threads();
-#else
-  int aa_nthreads= 1;
-#endif
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
-  int aa_tid;
-  int * aa_pot_type;
-  double * aa_pot_args;
-  tfuncs_type_arr aa_pot_tfuncs;
-  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
-    aa_pot_type= pot_type;
-    aa_pot_args= pot_args;
-    aa_pot_tfuncs= pot_tfuncs;
-    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
-			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
-  }
+  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
   //setup the function to be minimized
   gsl_function u0Eq;
   struct u0EqArg * params= (struct u0EqArg *) malloc ( sizeof (struct u0EqArg) );
@@ -339,7 +322,7 @@ void calcu0(int ndata,
   }
   gsl_min_fminimizer_free (s);
   free(params);
-  free_potentialArgs(npot,actionAngleArgs);free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
+  free_potentialArgs(npot,actionAngleArgs);
   free(actionAngleArgs);
   *err= status;
 }

--- a/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
+++ b/galpy/actionAngle/actionAngle_c_ext/actionAngleStaeckel.c
@@ -19,6 +19,14 @@
 #define CHUNKSIZE 10
 //Potentials
 #include <galpy_potentials.h>
+//Per-thread potential structs: potentials may keep per-instance caches in
+//their args (cf. OblateStaeckelWrapperPotential), so every OpenMP loop over
+//points must use its own thread's parsed copy rather than sharing one
+#ifdef _OPENMP
+#define AA_TARGS(args,n) ((args) + omp_get_thread_num() * (n))
+#else
+#define AA_TARGS(args,n) (args)
+#endif
 #include <integrateFullOrbit.h>
 #include <actionAngle.h>
 #ifndef M_PI
@@ -263,7 +271,24 @@ void calcu0(int ndata,
   int ii;
   //Set up the potentials
   struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //setup the function to be minimized
   gsl_function u0Eq;
   struct u0EqArg * params= (struct u0EqArg *) malloc ( sizeof (struct u0EqArg) );
@@ -314,7 +339,7 @@ void calcu0(int ndata,
   }
   gsl_min_fminimizer_free (s);
   free(params);
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(npot,actionAngleArgs);free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   *err= status;
 }
@@ -340,8 +365,24 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
   int ii;
   double tdelta;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //E,Lz
   double *E= (double *) malloc ( ndata * sizeof(double) );
   double *Lz= (double *) malloc ( ndata * sizeof(double) );
@@ -368,6 +409,7 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
+    struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
     *(coshux+ii)= cosh(*(ux+ii));
     *(sinhux+ii)= sinh(*(ux+ii));
@@ -382,23 +424,23 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
     *(v0+ii)= 0.5 * M_PI; //*(vx+ii);
     *(sin2v0+ii)= sin(*(v0+ii)) * sin(*(v0+ii));
     *(potu0v0+ii)= evaluatePotentialsUV(*(u0+ii),*(v0+ii),tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3U+ii)= *(E+ii) * *(sinhux+ii) * *(sinhux+ii)
       - 0.5 * *(pux+ii) * *(pux+ii) / tdelta / tdelta
       - 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinhux+ii) / *(sinhux+ii)
       - ( *(sinhux+ii) * *(sinhux+ii) + *(sin2v0+ii))
       *evaluatePotentialsUV(*(ux+ii),*(v0+ii),tdelta,
-			    npot,actionAngleArgs)
+			    npot,targs)
       + ( *(sinh2u0+ii) + *(sin2v0+ii) )* *(potu0v0+ii);
     *(potupi2+ii)= evaluatePotentialsUV(*(u0+ii),0.5 * M_PI,tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3V+ii)= - *(E+ii) * *(sinvx+ii) * *(sinvx+ii)
       + 0.5 * *(pvx+ii) * *(pvx+ii) / tdelta / tdelta
       + 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinvx+ii) / *(sinvx+ii)
       - *(cosh2u0+ii) * *(potupi2+ii)
       + ( *(sinh2u0+ii) + *(sinvx+ii) * *(sinvx+ii))
       * evaluatePotentialsUV(*(u0+ii),*(vx+ii),tdelta,
-			     npot,actionAngleArgs);
+			     npot,targs);
   }
   //Calculate 'peri' and 'apo'centers
   calcUminUmax(ndata,umin,umax,ux,pux,E,Lz,I3U,ndelta,delta,u0,sinh2u0,v0,
@@ -406,7 +448,7 @@ void actionAngleStaeckel_uminUmaxVmin(int ndata,
   calcVmin(ndata,vmin,vx,pvx,E,Lz,I3V,ndelta,delta,u0,cosh2u0,sinh2u0,potupi2,
 	   npot,actionAngleArgs);
   //Free
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(E);
   free(Lz);
@@ -447,8 +489,24 @@ void actionAngleStaeckel_actions(int ndata,
   int ii;
   double tdelta;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //E,Lz
   double *E= (double *) malloc ( ndata * sizeof(double) );
   double *Lz= (double *) malloc ( ndata * sizeof(double) );
@@ -475,6 +533,7 @@ void actionAngleStaeckel_actions(int ndata,
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
+    struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
     *(coshux+ii)= cosh(*(ux+ii));
     *(sinhux+ii)= sinh(*(ux+ii));
@@ -489,23 +548,23 @@ void actionAngleStaeckel_actions(int ndata,
     *(v0+ii)= 0.5 * M_PI; //*(vx+ii);
     *(sin2v0+ii)= sin(*(v0+ii)) * sin(*(v0+ii));
     *(potu0v0+ii)= evaluatePotentialsUV(*(u0+ii),*(v0+ii),tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3U+ii)= *(E+ii) * *(sinhux+ii) * *(sinhux+ii)
       - 0.5 * *(pux+ii) * *(pux+ii) / tdelta / tdelta
       - 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinhux+ii) / *(sinhux+ii)
       - ( *(sinhux+ii) * *(sinhux+ii) + *(sin2v0+ii))
       *evaluatePotentialsUV(*(ux+ii),*(v0+ii),tdelta,
-			    npot,actionAngleArgs)
+			    npot,targs)
       + ( *(sinh2u0+ii) + *(sin2v0+ii) )* *(potu0v0+ii);
     *(potupi2+ii)= evaluatePotentialsUV(*(u0+ii),0.5 * M_PI,tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3V+ii)= - *(E+ii) * *(sinvx+ii) * *(sinvx+ii)
       + 0.5 * *(pvx+ii) * *(pvx+ii) / tdelta / tdelta
       + 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinvx+ii) / *(sinvx+ii)
       - *(cosh2u0+ii) * *(potupi2+ii)
       + ( *(sinh2u0+ii) + *(sinvx+ii) * *(sinvx+ii))
       * evaluatePotentialsUV(*(u0+ii),*(vx+ii),tdelta,
-			     npot,actionAngleArgs);
+			     npot,targs);
   }
   //Calculate 'peri' and 'apo'centers
   double *umin= (double *) malloc ( ndata * sizeof(double) );
@@ -521,7 +580,7 @@ void actionAngleStaeckel_actions(int ndata,
   calcJzStaeckel(ndata,jz,vmin,E,Lz,I3V,ndelta,delta,u0,cosh2u0,sinh2u0,
 		 potupi2,npot,actionAngleArgs,order);
   //Free
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(E);
   free(Lz);
@@ -573,7 +632,7 @@ void calcJRStaeckel(int ndata,
   struct JRStaeckelArg * params= (struct JRStaeckelArg *) malloc ( nthreads * sizeof (struct JRStaeckelArg) );
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
   }
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
@@ -655,7 +714,7 @@ void calcJzStaeckel(int ndata,
   struct JzStaeckelArg * params= (struct JzStaeckelArg *) malloc ( nthreads * sizeof (struct JzStaeckelArg) );
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
   }
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
@@ -726,8 +785,24 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
   int ii;
   double tdelta;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //E,Lz
   double *E= (double *) malloc ( ndata * sizeof(double) );
   double *Lz= (double *) malloc ( ndata * sizeof(double) );
@@ -754,6 +829,7 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
+    struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
     *(coshux+ii)= cosh(*(ux+ii));
     *(sinhux+ii)= sinh(*(ux+ii));
@@ -768,23 +844,23 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
     *(v0+ii)= 0.5 * M_PI; //*(vx+ii);
     *(sin2v0+ii)= sin(*(v0+ii)) * sin(*(v0+ii));
     *(potu0v0+ii)= evaluatePotentialsUV(*(u0+ii),*(v0+ii),tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3U+ii)= *(E+ii) * *(sinhux+ii) * *(sinhux+ii)
       - 0.5 * *(pux+ii) * *(pux+ii) / tdelta / tdelta
       - 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinhux+ii) / *(sinhux+ii)
       - ( *(sinhux+ii) * *(sinhux+ii) + *(sin2v0+ii))
       *evaluatePotentialsUV(*(ux+ii),*(v0+ii),tdelta,
-			    npot,actionAngleArgs)
+			    npot,targs)
       + ( *(sinh2u0+ii) + *(sin2v0+ii) )* *(potu0v0+ii);
     *(potupi2+ii)= evaluatePotentialsUV(*(u0+ii),0.5 * M_PI,tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3V+ii)= - *(E+ii) * *(sinvx+ii) * *(sinvx+ii)
       + 0.5 * *(pvx+ii) * *(pvx+ii) / tdelta / tdelta
       + 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinvx+ii) / *(sinvx+ii)
       - *(cosh2u0+ii) * *(potupi2+ii)
       + ( *(sinh2u0+ii) + *(sinvx+ii) * *(sinvx+ii))
       * evaluatePotentialsUV(*(u0+ii),*(vx+ii),tdelta,
-			     npot,actionAngleArgs);
+			     npot,targs);
   }
   //Calculate 'peri' and 'apo'centers
   double *umin= (double *) malloc ( ndata * sizeof(double) );
@@ -817,7 +893,7 @@ void actionAngleStaeckel_actionsFreqs(int ndata,
 			      dJRdE,dJRdLz,dJRdI3,
 			      dJzdE,dJzdLz,dJzdI3);
   //Free
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(E);
   free(Lz);
@@ -874,8 +950,24 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
   int ii;
   double tdelta;
   //Set up the potentials
-  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( npot * sizeof (struct potentialArg) );
-  parse_leapFuncArgs_Full(npot,actionAngleArgs,&pot_type,&pot_args,&pot_tfuncs);
+  // one parsed copy of the potentials per OpenMP thread (see AA_TARGS above)
+#ifdef _OPENMP
+  int aa_nthreads= omp_get_max_threads();
+#else
+  int aa_nthreads= 1;
+#endif
+  struct potentialArg * actionAngleArgs= (struct potentialArg *) malloc ( aa_nthreads * npot * sizeof (struct potentialArg) );
+  int aa_tid;
+  int * aa_pot_type;
+  double * aa_pot_args;
+  tfuncs_type_arr aa_pot_tfuncs;
+  for (aa_tid=0; aa_tid < aa_nthreads; aa_tid++) {
+    aa_pot_type= pot_type;
+    aa_pot_args= pot_args;
+    aa_pot_tfuncs= pot_tfuncs;
+    parse_leapFuncArgs_Full(npot,actionAngleArgs+aa_tid*npot,
+			    &aa_pot_type,&aa_pot_args,&aa_pot_tfuncs);
+  }
   //E,Lz
   double *E= (double *) malloc ( ndata * sizeof(double) );
   double *Lz= (double *) malloc ( ndata * sizeof(double) );
@@ -902,6 +994,7 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
   UNUSED int chunk= CHUNKSIZE;
 #pragma omp parallel for schedule(static,chunk) private(ii,tdelta)
   for (ii=0; ii < ndata; ii++){
+    struct potentialArg * targs= AA_TARGS(actionAngleArgs,npot);
     tdelta= *(delta+ii*delta_stride);
     *(coshux+ii)= cosh(*(ux+ii));
     *(sinhux+ii)= sinh(*(ux+ii));
@@ -916,23 +1009,23 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
     *(v0+ii)= 0.5 * M_PI; //*(vx+ii);
     *(sin2v0+ii)= sin(*(v0+ii)) * sin(*(v0+ii));
     *(potu0v0+ii)= evaluatePotentialsUV(*(u0+ii),*(v0+ii),tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3U+ii)= *(E+ii) * *(sinhux+ii) * *(sinhux+ii)
       - 0.5 * *(pux+ii) * *(pux+ii) / tdelta / tdelta
       - 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinhux+ii) / *(sinhux+ii)
       - ( *(sinhux+ii) * *(sinhux+ii) + *(sin2v0+ii))
       *evaluatePotentialsUV(*(ux+ii),*(v0+ii),tdelta,
-			    npot,actionAngleArgs)
+			    npot,targs)
       + ( *(sinh2u0+ii) + *(sin2v0+ii) )* *(potu0v0+ii);
     *(potupi2+ii)= evaluatePotentialsUV(*(u0+ii),0.5 * M_PI,tdelta,
-					npot,actionAngleArgs);
+					npot,targs);
     *(I3V+ii)= - *(E+ii) * *(sinvx+ii) * *(sinvx+ii)
       + 0.5 * *(pvx+ii) * *(pvx+ii) / tdelta / tdelta
       + 0.5 * *(Lz+ii) * *(Lz+ii) / tdelta / tdelta / *(sinvx+ii) / *(sinvx+ii)
       - *(cosh2u0+ii) * *(potupi2+ii)
       + ( *(sinh2u0+ii) + *(sinvx+ii) * *(sinvx+ii))
       * evaluatePotentialsUV(*(u0+ii),*(vx+ii),tdelta,
-			     npot,actionAngleArgs);
+			     npot,targs);
   }
   //Calculate 'peri' and 'apo'centers
   double *umin= (double *) malloc ( ndata * sizeof(double) );
@@ -979,7 +1072,7 @@ void actionAngleStaeckel_actionsFreqsAngles(int ndata,
 		     vmin,I3V,cosh2u0,potupi2,
 		     npot,actionAngleArgs,order);
   //Free
-  free_potentialArgs(npot,actionAngleArgs);
+  free_potentialArgs(aa_nthreads*npot,actionAngleArgs);
   free(actionAngleArgs);
   free(E);
   free(Lz);
@@ -1094,7 +1187,7 @@ void calcdJRStaeckel(int ndata,
   struct dJRStaeckelArg * params= (struct dJRStaeckelArg *) malloc ( nthreads * sizeof (struct dJRStaeckelArg) );
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
   }
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
@@ -1187,7 +1280,7 @@ void calcdJzStaeckel(int ndata,
   struct dJzStaeckelArg * params= (struct dJzStaeckelArg *) malloc ( nthreads * sizeof (struct dJzStaeckelArg) );
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
   }
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
@@ -1306,9 +1399,9 @@ void calcAnglesStaeckel(int ndata,
   struct dJzStaeckelArg * paramsv= (struct dJzStaeckelArg *) malloc ( nthreads * sizeof (struct dJzStaeckelArg) );
   for (tid=0; tid < nthreads; tid++){
     (paramsu+tid)->nargs= nargs;
-    (paramsu+tid)->actionAngleArgs= actionAngleArgs;
+    (paramsu+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
     (paramsv+tid)->nargs= nargs;
-    (paramsv+tid)->actionAngleArgs= actionAngleArgs;
+    (paramsv+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
   }
   //Setup integrator
   gsl_integration_glfixed_table * T= gsl_integration_glfixed_table_alloc (order);
@@ -1577,7 +1670,7 @@ void calcUminUmax(int ndata,
   T = gsl_root_fsolver_brent;
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
     (s+tid)->s= gsl_root_fsolver_alloc (T);
   }
   int delta_stride= ndelta == 1 ? 0 : 1;
@@ -1845,7 +1938,7 @@ void calcVmin(int ndata,
   T = gsl_root_fsolver_brent;
   for (tid=0; tid < nthreads; tid++){
     (params+tid)->nargs= nargs;
-    (params+tid)->actionAngleArgs= actionAngleArgs;
+    (params+tid)->actionAngleArgs= actionAngleArgs + tid * nargs;
     (s+tid)->s= gsl_root_fsolver_alloc (T);
   }
   int delta_stride= ndelta == 1 ? 0 : 1;


### PR DESCRIPTION
The actionAngle C extensions parsed the potentials once and shared the resulting `potentialArg` structs across every OpenMP-parallel loop over evaluation points. Stateless potentials never notice, but any potential keeping per-instance state in its args would race (found via the `OblateStaeckelWrapperPotential` exact-mode cache in #1468, which showed nondeterministic Jz-conservation failures under `actionAngleStaeckel_c`). The orbit integrators already parse one copy per thread; this PR brings the actionAngle side to the same rule:

- entry points parse one copy per thread, capped at the number of input points (`min(ndata, omp_get_max_threads())`, following the orbit integrators' convention so a single-point call doesn't copy a large potential per idle thread; every parallel loop that touches the per-thread structures carries an explicit `num_threads` clause with the same capped count);
- the existing per-tid `params` setups point each thread at its own copy (`+ tid * nargs`);
- direct-use parallel loops go through an `AA_TARGS(args, n)` thread-offset macro;
- frees cover all copies; `calcu0` stays single-copy (serial loop).

No behavior change for stateless potentials. 37 actionAngle C tests pass at `OMP_NUM_THREADS=8`. The cache-specific regression test (serial-vs-parallel determinism plus cross-mode agreement across all six entry points) lives on #1468, since the stateful cache it needs arrives there; #1468 is rebased on this branch with its wrapper cache simplified to a single block (removing the 64-thread cap concern raised in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Jm4Y1A9eQRXMEaHaqwwJ
