### PR TITLE
xfail ledger: the eager rows are gone (31 -> 6, and every survivor is jit-only)

### DIFF
--- a/galpy/actionAngle/actionAngleStaeckel.py
+++ b/galpy/actionAngle/actionAngleStaeckel.py
@@ -18,6 +18,7 @@ from scipy import integrate, optimize
 
 from ..backend import (
     asarray_on_device,
+    concretely_true,
     device_of,
     get_namespace,
     is_backend_array,
@@ -382,11 +383,11 @@ def _staeckel_prep(xp, R, vR, vT, z, vz, pot, delta):
         delta = asarray_on_device(xp, delta, device_of(R))
     s = _staeckel_setup(xp, R, vR, vT, z, vz, pot, delta)
     umin, umax, unbound = _staeckel_uminumax(xp, s, pot, delta)
-    # Unbound orbits raise eagerly on the numpy path (mirrors the Single class);
-    # under a backend they must stay jit-traceable, so we cannot branch on the
-    # traced `unbound` -- let unbound orbits fall through to NaN instead (the
-    # caller jits/AD-traces and checks). numpy stays byte-identical (still raises).
-    if not is_backend_array(R) and bool(numpy.any(unbound)):
+    # Unbound orbits raise, mirroring the Single class. Eager jax/torch have a
+    # concrete truth value here and raise identically to numpy; only under a jax
+    # trace is `unbound` a tracer, and there the orbit falls through to NaN for
+    # the caller to check.
+    if concretely_true(xp.any(unbound)):
         raise UnboundError("Orbit seems to be unbound")
     vmin = _staeckel_vmin(xp, s, pot, delta)
     # Planar orbit (jz=0): snap vmin to exactly pi/2 (the bisection lands ~1e-8

--- a/tests/backend_skip.txt
+++ b/tests/backend_skip.txt
@@ -102,6 +102,34 @@ torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_int
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_pointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform
 torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_pointtransform_bisect
+#
+# Second wave, re-homed 2026-09-11: the exactpointtransform / ptonly tests (and
+# their test_quantity sibling) landed on main after the move above and were
+# auto-ledgered as xfail. Same guard, verified under both backends -- all 22 fail
+# with `NotImplementedError: actionAngleVerticalInverse is not yet migrated`
+# raised by `_reject_backend` -- so they belong here, not in the burndown.
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_interpolation_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform_ptonly
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_interpolation_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_ptonly_warnings_errors
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform_bisect
+jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
+jax tests/test_quantity.py::test_actionAngleVerticalInverse_units
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_interpolation_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform_ptonly
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_interpolation_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_ptonly_warnings_errors
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform_bisect
+torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
+torch tests/test_quantity.py::test_actionAngleVerticalInverse_units
 
 # --- streamdf's useTM tests reach actionAngleTorus ---
 # "NotImplementedError: actionAngleTorus wraps the external Torus C++ library

--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -182,8 +182,6 @@
 #
 # The Python-vs-Python equivalent, test_actionAngleAdiabaticGrid_outsidegrid_
 # multiple_python, PASSES on both backends and is not ledgered.
-jax tests/test_qdf.py::test_call_diffinoutputs
-torch tests/test_qdf.py::test_call_diffinoutputs
 
 # --- jax multi-orbit (test_orbits.py): action-angle accessors (Track E) ---
 # Orbits.jr()/actionsFreqsAngles()/EccZmaxRperiRap()/physical-output route through
@@ -384,26 +382,3 @@ torch-jit tests/test_potential.py::test_pickling_potential_unitful_dens
 #     the backend path deliberately does NOT raise (stays jit-traceable; unbound
 #     -> NaN, see actionAngleStaeckel.py). Neither is a coercion bug.
 # =============================================================================
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_coeffs_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_interpolation_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_freqs_wrtVertical_interpolation_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform_ptonly
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_exactpointtransform_ptonly
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_interpolation_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_orbit_interpolation_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_ptonly_warnings_errors
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_ptonly_warnings_errors
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform_bisect
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_exactpointtransform_bisect
-jax tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
-torch tests/test_actionAngle.py::test_actionAngleVerticalInverse_wrtVertical_interpolation_exactpointtransform
-jax tests/test_quantity.py::test_actionAngleVerticalInverse_units
-torch tests/test_quantity.py::test_actionAngleVerticalInverse_units
-torch tests/test_quantity.py::test_sphericaldf_method_inputAsQuantity_percall_ro

--- a/tests/test_backend_actionAngle.py
+++ b/tests/test_backend_actionAngle.py
@@ -883,21 +883,35 @@ def test_staeckel_jit_grad_rolls_direct_bisection():
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_staeckel_unbound_backend_no_raise(backend):
-    # An unbound orbit raises UnboundError on the numpy path (eager), but must NOT
-    # raise under a backend: the vectorised turning-point search cannot branch on
-    # the traced `unbound` mask under jit, so it falls through to a (garbage)
-    # backend array instead -- which is exactly what keeps actionsFreqsAngles
-    # jax.jit-traceable (jit traces+matches eager to ~9e-10). Exercises both sides
-    # of the `not is_backend_array(R)` guard in _staeckel_prep.
+def test_staeckel_unbound_eager_raises(backend):
+    # An unbound orbit raises UnboundError on the numpy path, and EAGER jax/torch
+    # raise identically: `unbound` has a concrete truth value there, so the check
+    # is a real check. The split is TRACED vs not, not backend-array vs not -- the
+    # earlier `not is_backend_array(R)` guard skipped the check on both eager
+    # backends, where this orbit came back with jr = 2.8e47 instead.
     from galpy.actionAngle import UnboundError
 
     aA = actionAngleStaeckel(pot=MWPotential2014, delta=0.5, c=False)
     ub = (0.9, 10.0, -20.0, 0.1, 10.0)
     with pytest.raises(UnboundError):
-        aA(*ub)  # numpy path: eager raise
-    out = aA(*[_arr(backend, numpy.atleast_1d(v).astype(float)) for v in ub])
-    assert _is_backend_array(backend, out[0])  # backend: no raise (garbage value ok)
+        aA(*ub)  # numpy path
+    with pytest.raises(UnboundError):  # eager backend: same raise as numpy
+        aA(*[_arr(backend, numpy.atleast_1d(v).astype(float)) for v in ub])
+
+
+@pytest.mark.skipif("jax" not in BACKENDS, reason="jax not installed")
+def test_staeckel_unbound_traced_falls_through():
+    # The other side of `concretely_true` in _staeckel_prep: under a jax trace
+    # `unbound` is a tracer with no truth value, so the check skips itself and the
+    # orbit falls through to a (garbage) backend array rather than taking down the
+    # trace. That is what keeps actionsFreqsAngles jax.jit-traceable.
+    aA = actionAngleStaeckel(pot=MWPotential2014, delta=0.5, c=False)
+    args = tuple(
+        jnp.asarray(numpy.atleast_1d(v).astype(float))
+        for v in (0.9, 10.0, -20.0, 0.1, 10.0)
+    )
+    out = jax.jit(lambda *a: aA(*a))(*args)
+    assert _is_backend_array("jax", out[0])
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -18264,8 +18264,8 @@ def test_sphericaldf_method_inputAsQuantity_percall_ro():
     for kwargs, E in [({}, Ei), ({"vo": 300.0}, Ei * (vo / 300.0) ** 2.0)]:
         assert (
             numpy.fabs(
-                dfh.dMdE(Eq, use_physical=False, **kwargs)
-                - dfh.dMdE(E, use_physical=False)
+                as_numpy(dfh.dMdE(Eq, use_physical=False, **kwargs))
+                - as_numpy(dfh.dMdE(E, use_physical=False))
             )
             < 10.0**-8.0
         ), (
@@ -18273,7 +18273,8 @@ def test_sphericaldf_method_inputAsQuantity_percall_ro():
         )
         assert (
             numpy.fabs(
-                dfh((Eq,), use_physical=False, **kwargs) - dfh((E,), use_physical=False)
+                as_numpy(dfh((Eq,), use_physical=False, **kwargs))
+                - as_numpy(dfh((E,), use_physical=False))
             )
             < 10.0**-8.0
         ), (
@@ -18307,14 +18308,16 @@ def test_sphericaldf_method_inputAsQuantity_percall_ro():
     ]:
         assert (
             numpy.fabs(
-                dfh(*quant, use_physical=False, **kwargs)
-                - dfh(
-                    Ri * ro / tro,
-                    vRi * vo / tvo,
-                    vTi * vo / tvo,
-                    zi * ro / tro,
-                    vzi * vo / tvo,
-                    use_physical=False,
+                as_numpy(dfh(*quant, use_physical=False, **kwargs))
+                - as_numpy(
+                    dfh(
+                        Ri * ro / tro,
+                        vRi * vo / tvo,
+                        vTi * vo / tvo,
+                        zi * ro / tro,
+                        vzi * vo / tvo,
+                        use_physical=False,
+                    )
                 )
             )
             < 10.0**-8.0


### PR DESCRIPTION
**Ledger: `backend_xfail.txt` 31 → 6, and every survivor is jit-only.** After this
there is no eager jax/torch test that is expected to fail. CI never runs `--jit`
(backend-tests.yml has no traced job), so the xfail ledger no longer gates
anything CI can see.

### 1. `actionAngleStaeckel`: unbound orbits under a backend (−2)

`_staeckel_prep` raised `UnboundError` only when the input was **not** a backend
array:

```python
if not is_backend_array(R) and bool(numpy.any(unbound)):
```

The reasoning in the comment was that a traced `unbound` has no truth value — true,
but eager jax and torch **do** have one, and that is exactly what `concretely_true`
exists for. So the guard was skipping a real check on two backends that could have
taken it. `test_call_diffinoutputs` builds an orbit that is supposed to be unbound
and got `jr = 2.8458e+47` back instead of the exception.

```python
if concretely_true(xp.any(unbound)):
```

Measured after the change: eager jax and torch both raise, and so do **both** jit
modes — dynamo answers `bool()` from the example value and specialises the branch,
and jax's `@backend_input` boundary hands this call concrete values. So this needs
no `-jit` row; the two entries are burned outright, not moved.

numpy is unchanged: `xp` is `numpy` there, so the guard evaluates exactly as before.

**This flips a documented contract, so please look at it on review.**
`test_staeckel_unbound_backend_no_raise` asserted that a backend must *not* raise,
and gave the reason: the vectorised turning-point search cannot branch on a traced
`unbound` mask, so raising would cost jit-traceability. The reason is right; the
criterion it was written with is not. The split is traced-vs-not, not
backend-array-vs-not. The test is rewritten to assert both halves separately, and
both are measured:

```
numpy               raises        (unchanged)
eager jax / torch   raises        (was: jr = 2.8458e+47, silently)
jax.jit             does not raise, returns a backend array
```

so the traceability the old test protected is still tested — by the property that
actually produces it. The case for the flip: under eager torch a user was getting
`2.8e47` where numpy raises, and silent garbage is the worse failure mode. The case
against is that eager and traced now disagree for unbound inputs — which is
inherent to tracing, and is what the `-jit` ledger dimension exists for.

### 2. `test_quantity` sphericaldf per-call `ro` (−1, torch)

`dMdE(1 pc as a Quantity) - dMdE(<Tensor>)` is `ndarray - Tensor`, which raises.
This is **not** a galpy defect — astropy converts the Tensor to `numpy.float64`
when the Quantity is *built*, so the backend identity is gone before galpy is
called, and `exit_cast` is right to return numpy for a numpy input:

```
Ei          torch.Tensor   tensor(-0.5079)
Eq          Quantity       value is numpy.float64     <- astropy converted it
dMdE(Eq)    numpy.ndarray  0.4599325073333405
dMdE(Ei)    torch.Tensor   0.4599325073333405
```

The values agree to every digit. `as_numpy` at the three mixed assertion sites,
which is what the other 573 uses of it in this file already do. No tolerance touched.

### 3. `actionAngleVerticalInverse`, second wave (−22, re-homed not burned)

The `exactpointtransform` / `ptonly` tests landed on main after the 48 entries moved
to `backend_skip.txt`, and were auto-ledgered as xfail. Verified under both
backends — all 22 fail with

```
NotImplementedError: actionAngleVerticalInverse is not yet migrated to the
jax/torch backends ... use it under numpy only.
```

from `_reject_backend`, i.e. `backend_skip.txt` category (b): out of scope by
decision, and failing by design. Half a ledger that will never be worked reads as
remaining work it is not.

### Remaining (6)

| | |
|---|---|
| `jax-jit` | `test_orbit::test_eccentricity` |
| `jax-jit` / `torch-jit` | `test_potential::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]` |
| `jax-jit` | `test_potential::test_pickling_potential_drops_units_wrapper` |
| `jax-jit` / `torch-jit` | `test_potential::test_pickling_potential_unitful_dens` |

### Gates

| | |
|---|---|
| numpy `test_actionAngle` | 233 passed |
| numpy `test_qdf` | 56 passed |
| torch `test_actionAngle` | 199 passed, 34 skipped |
| torch `test_qdf` | 56 passed |
| jax `test_actionAngle` | 199 passed, 34 skipped |
| jax `test_qdf` | 55 passed, 1 skipped |
| torch `test_quantity` | 245 passed, **1 pre-existing failure** |

That one failure is `test_streamgapdf_sample` (`1.313e-5` against a `1e-5` bound).
It reproduces identically with both source commits reverted in the same tree, and
the CI torch shard is green on it, so it is a local-env artifact rather than
anything in this PR. Flagging it rather than ledgering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
