### PR TITLE
the numpy/backend boundary in orbit integration: warn on the demotion, and stop the friction force paying for it

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -1820,6 +1820,22 @@ class Orbit:
                 "differentiable integrator; use method='diffrax' (jax) or "
                 f"method='torchdiffeq' (torch), not method='{method}'"
             )
+        if ic_backend is not None:
+            # Reaching here means every differentiable route above declined this
+            # method (in-backend solver, C-STM), so the numpy/C path below returns
+            # a NUMPY trajectory from a backend IC. That fall-through is deliberate
+            # -- it is what lets the suite run under a forced backend, and what
+            # keeps the symplectic default from being silently rerouted (gh#1094)
+            # -- but the type demotion is invisible to the caller, so say it.
+            warnings.warn(
+                f"this Orbit has a jax/torch initial condition, but method="
+                f"'{method}' integrates in numpy: the orbit is returned as a numpy "
+                "array and is not differentiable. Use method='diffrax' (jax) or "
+                "method='torchdiffeq' (torch) to integrate in the backend, or one "
+                "of the Runge-Kutta C methods (dop853_c, rk4_c, rk6_c, dopr54_c) "
+                "to keep the differentiable C state-transition path",
+                galpyWarning,
+            )
         self.check_integrator(method)
         pot = _check_potential_list_and_deprecate(pot)
         _check_potential_dim(self, pot)

--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -13,7 +13,11 @@ from ..backend import special as _backend_special
 from ..backend.interpolate import Spline1D
 from ..util import conversion
 from .DissipativeForce import DissipativeForce
-from .Potential import _check_c, _check_potential_list_and_deprecate, evaluateDensities
+from .Potential import (
+    _check_c,
+    _check_potential_list_and_deprecate,
+    _evaluateDensities,
+)
 
 _INVSQRTTWO = 1.0 / numpy.sqrt(2.0)
 _INVSQRTPI = 1.0 / numpy.sqrt(numpy.pi)
@@ -115,8 +119,12 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
                 sigmar = lambda x: _INVSQRTTWO
         dens = _check_potential_list_and_deprecate(dens)
         self._dens_pot = dens
-        self._dens_host = lambda R, z, phi=0.0, t=0.0: evaluateDensities(
-            self._dens_pot, R, z, phi=phi, t=t, use_physical=False
+        # The UNDECORATED evaluator, like every other force in the EOM: this is
+        # called once per force evaluation, and the decorated public one re-enters
+        # unit parsing + @backend_input coercion every time (98,800 boundary
+        # crossings for a five-point integration under a forced backend).
+        self._dens_host = lambda R, z, phi=0.0, t=0.0: _evaluateDensities(
+            self._dens_pot, R, z, phi=phi, t=t
         )
         from ..df import jeans
 
@@ -334,8 +342,12 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
     def __setstate__(self, pdict):
         self.__dict__ = pdict
         # Re-setup _dens_host
-        self._dens_host = lambda R, z, phi=0.0, t=0.0: evaluateDensities(
-            self._dens_pot, R, z, phi=phi, t=t, use_physical=False
+        # The UNDECORATED evaluator, like every other force in the EOM: this is
+        # called once per force evaluation, and the decorated public one re-enters
+        # unit parsing + @backend_input coercion every time (98,800 boundary
+        # crossings for a five-point integration under a forced backend).
+        self._dens_host = lambda R, z, phi=0.0, t=0.0: _evaluateDensities(
+            self._dens_pot, R, z, phi=phi, t=t
         )
         # Re-setup sigmar_orig
         if self._dens_kwarg is None and self._sigmar_kwarg is None:

--- a/galpy/potential/Potential.py
+++ b/galpy/potential/Potential.py
@@ -793,6 +793,13 @@ class Potential(Force):
         - 2018-03-21 - Modified - Webb (UofT)
 
         """
+        return self._dens_nodecorator(R, z, phi=phi, t=t, forcepoisson=forcepoisson)
+
+    def _dens_nodecorator(self, R, z, phi=0.0, t=0.0, forcepoisson=False):
+        """Raw, undecorated density for internal use, like ``_call_nodecorator``
+        and the ``_*force_nodecorator`` family. An internal per-step caller (the
+        dissipative friction forces) must not re-enter the unit-parsing /
+        backend-coercion decorator stack on every force evaluation."""
         try:
             if forcepoisson:
                 raise AttributeError  # Hack!
@@ -2361,12 +2368,16 @@ def evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
     - 2013-12-28 - Added forcepoisson - Bovy (IAS)
 
     """
-    nonAxi = _isNonAxi(Pot)
-    if nonAxi and phi is None:
+    return _evaluateDensities(Pot, R, z, phi=phi, t=t, forcepoisson=forcepoisson)
+
+
+def _evaluateDensities(Pot, R, z, phi=None, t=0.0, forcepoisson=False):
+    """Raw, undecorated function for internal use"""
+    if _isNonAxi(Pot) and phi is None:
         raise PotentialError(
             "The (combination of) Potential instances is non-axisymmetric, but you did not provide phi"
         )
-    return Pot.dens(R, z, phi=phi, t=t, forcepoisson=forcepoisson, use_physical=False)
+    return Pot._dens_nodecorator(R, z, phi=phi, t=t, forcepoisson=forcepoisson)
 
 
 @potential_positional_arg

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -45,11 +45,20 @@
 torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 619.0s (2026-08-21) -> 507.1s re-measured 2026-09-11 after the friction force stopped
 # calling the DECORATED evaluateDensities once per force evaluation (98,800 @backend_input
 # crossings for a five-point integration -> 0). Its sibling const_FDMfactor went 253.1 -> 188.6s
-# and stays un-ledgered. STILL OVER the cap: what is left is the Python dop853 loop itself,
-# which under a forced backend does ZERO backend work (measured: boundary calls = 0 for an
-# orbit integration), so this arm costs ~500s for no unique backend coverage -- the FDM force's
-# backend path is covered directly by tests/test_backend_dynamfric.py. A sici rewrite was tried
-# first and changed nothing (615.2 -> 615.2s): the backend friction factor is never reached here.
+# and stays un-ledgered. STILL OVER the cap here, and the residue is NOT backend overhead:
+# the same arm costs 459.5s under forced torch against 106.3s on plain numpy for an identical
+# trajectory (max rel err 1.747e-04 both ways), and the gap is a DEAD CACHE that costs 3x on
+# numpy as well -- _force_hash is compared but never stored, so the friction factor and the
+# host density are recomputed once per force COMPONENT instead of once per step (1,423,884
+# host-density evaluations for 474,628 steps). Fixed on main; this row comes out after the
+# rebase picks it up.
+#
+# Two things measured on the way that are worth not re-deriving:
+#   * a sici rewrite changed nothing (615.2 -> 615.2s): this path runs the NUMPY _calc_force,
+#     so the backend friction factor -- and its sici -- is never reached.
+#   * `boundary calls = 0` for an orbit integration does NOT mean no backend work. It counts
+#     @backend_input COERCION crossings; the potentials dispatch on the resolved namespace and
+#     run on torch without crossing (measured: _Rforce/_zforce/_dens all return Tensors).
 
 # --- torch ExpTruncNFWPotential: RETIRED 2026-09-10 (gh#1477) ---
 # It was 340.4 s under torch against 198.8 s under jax, and that inversion was

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -42,7 +42,14 @@
 # the numpy-on-Tensor collision it was simultaneously fixing (6.47 s to raise
 # TypeError), so the "fast" reading measured a fail-fast, not the work. Torch is
 # the same un-vectorized dissipative path as jax above; it belongs here with them.
-torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # measured 2026-08-21: 619.0s (CI~440s)
+torch tests/test_FDMdynamfric.py::test_FDMDynamicalFrictionForce_central_limit  # 619.0s (2026-08-21) -> 507.1s re-measured 2026-09-11 after the friction force stopped
+# calling the DECORATED evaluateDensities once per force evaluation (98,800 @backend_input
+# crossings for a five-point integration -> 0). Its sibling const_FDMfactor went 253.1 -> 188.6s
+# and stays un-ledgered. STILL OVER the cap: what is left is the Python dop853 loop itself,
+# which under a forced backend does ZERO backend work (measured: boundary calls = 0 for an
+# orbit integration), so this arm costs ~500s for no unique backend coverage -- the FDM force's
+# backend path is covered directly by tests/test_backend_dynamfric.py. A sici rewrite was tried
+# first and changed nothing (615.2 -> 615.2s): the backend friction factor is never reached here.
 
 # --- torch ExpTruncNFWPotential: RETIRED 2026-09-10 (gh#1477) ---
 # It was 340.4 s under torch against 198.8 s under jax, and that inversion was

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -15,6 +15,8 @@
 #
 # Self-skips unless the runtime ODE extra (diffrax / torchdiffeq) is installed.
 ###############################################################################
+import warnings
+
 import numpy
 import pytest
 
@@ -42,6 +44,7 @@ from galpy.potential import (
     TriaxialNFWPotential,
     TwoPowerSphericalPotential,
 )
+from galpy.util import galpyWarning
 
 pytestmark = pytest.mark.backend_managed
 
@@ -858,3 +861,71 @@ def test_accessor_jittable_at_traced_grid_times():
     ob.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="dop853_c")
     val = float(jax.jit(lambda tq: ob.R(tq)[-1])(jnp.asarray(_TS)))
     numpy.testing.assert_allclose(val, float(as_numpy(ob.R(_TS))[-1]), rtol=1e-6)
+
+
+###############################################################################
+# A CONCRETE backend IC + a method with no differentiable route DEMOTES the
+# trajectory to numpy. That fall-through is deliberate -- it is what lets the
+# existing suite run under a forced backend, and gh#1094 keeps the symplectic
+# default from being silently rerouted -- but the caller cannot see the demotion,
+# so it warns. Measured, with a concrete (non-grad) torch IC:
+#
+#   dop853 / odeint / leapfrog          ndarray   numpy loop, no in-backend path
+#   leapfrog_c / symplec4_c / symplec6_c ndarray  concrete IC is not rerouted
+#   ias15_c                             ndarray   no dxdv, so no C-STM
+#   dop853_c / rk4_c / rk6_c / dopr54_c Tensor    C-STM, differentiable
+###############################################################################
+_DEMOTES_TO_NUMPY = [
+    "dop853",
+    "odeint",
+    "leapfrog",
+    "leapfrog_c",
+    "symplec4_c",
+    "symplec6_c",
+    "ias15_c",
+]
+_KEEPS_BACKEND_ARRAY = ["dop853_c", "rk4_c", "rk6_c", "dopr54_c"]
+
+
+def _demotion_warnings(record):
+    return [w for w in record if "integrates in numpy" in str(w.message)]
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("method", _DEMOTES_TO_NUMPY)
+def test_integrate_concrete_backend_ic_numpy_method_warns(method):
+    o = Orbit(torch.tensor(_IC))
+    with pytest.warns(galpyWarning, match="integrates in numpy"):
+        o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method=method)
+    assert not is_backend_array(o.orbit), (
+        f"{method}: the warning says the orbit is demoted to numpy, but it is not"
+    )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("method", _KEEPS_BACKEND_ARRAY)
+def test_integrate_concrete_backend_ic_cstm_method_does_not_warn(method):
+    # The Runge-Kutta dxdv C methods route to the C-STM, so nothing is demoted and
+    # nothing is warned about. Asserted as the other half of the table: a warning
+    # that fires on every method would be noise rather than information.
+    o = Orbit(torch.tensor(_IC))
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method=method)
+    assert not _demotion_warnings(rec), f"{method} warned but keeps the backend array"
+    assert is_backend_array(o.orbit)
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+def test_integrate_numpy_ic_under_forced_backend_does_not_warn():
+    # The forced-backend harness builds orbits from LISTS, so _ic_backend is None and
+    # nothing warns. The warning is for a caller who actually handed in a backend
+    # array -- not for every test run under --backend torch, which would bury it.
+    from galpy.backend import use
+
+    with use("torch", force=True):
+        o = Orbit(list(_IC))
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="dop853")
+    assert not _demotion_warnings(rec)


### PR DESCRIPTION
Two halves of the same thing: a jax/torch initial condition and galpy's orbit
integrators. **Ledger delta 0** — deliberately, and the reason is measured below.

### The measurement that started it

A boundary-call counter on `galpy.backend._input.traced_call` (with a control, so
a zero means "no boundaries" rather than "instrument broken"), under
`use("torch", force=True)`:

```
CONTROL  pot.Rforce(1.0, 0.1)                 boundary=1        <- instrument live
orbit dop853,   list IC                       boundary=0        orbit=ndarray
orbit dop853_c, list IC                       boundary=0        orbit=ndarray
orbit dop853 + FDM friction                   boundary=98800    orbit=ndarray
```

An ordinary orbit integration crosses `@backend_input` **zero** times — the Python
EOM calls the `_nodecorator` force paths on purpose. The dissipative friction force
is the outlier, and that is the bug fixed here.

**Read that count narrowly.** `boundary=0` means no *coercion crossings*; it does
**not** mean no backend work. The potentials dispatch on the resolved namespace and
execute on torch without crossing one — measured directly, `_Rforce` / `_zforce` /
`_dens` all return Tensors throughout the same integration. I originally drew the
wider conclusion from this table and it was wrong; the ledger annotation in this PR
was corrected in a follow-up commit rather than left to mislead the next reader.

### 1. `Potential._dens_nodecorator`

`Potential` has `_call_nodecorator`, `_Rforce_nodecorator`, `_zforce_nodecorator`,
`_phitorque_nodecorator`, and module-level `_evaluatePotentials` /
`_evaluateRforces` / `_evaluatezforces` to match. The **density** was the one
member with no undecorated twin, so `ChandrasekharDynamicalFrictionForce` had
nothing to call and wired itself to the decorated public entry point:

```python
self._dens_host = lambda R, z, phi=0.0, t=0.0: evaluateDensities(...)
```

once per force evaluation, inside an EOM where every other force is undecorated.
`_dens_nodecorator` is the existing `dens` body moved verbatim (the Poisson
fallback untouched); `_evaluateDensities` mirrors `_evaluateRforces`.

| | |
|---|---|
| boundary crossings, 5-point integration | **98,800 → 0** |
| `test_FDMDynamicalFrictionForce_central_limit` (torch) | 619.0 s (2026-08-21) → **507.1 s** |
| `test_FDMDynamicalFrictionForce_const_FDMfactor` (torch) | 253.1 → **188.6 s** |

**The ledger row stays here, and comes out after the rebase.** 507 s does not clear
the 300 s cap. What remained turned out not to be backend overhead at all: the same
arm costs 459.5 s under forced torch against **106.3 s on plain numpy** for an
identical trajectory, and the gap is a dead cache that costs 3× on numpy too —
`_force_hash` is compared but never stored, so the friction factor and the host
density are recomputed once per force *component* instead of once per step. That is
fixed on **main** in #1484 (`central_limit` → 299.7 s), and this row comes out once
the rebase picks it up.

I also tried a sici rewrite first, on the theory that two `sici` calls per force
evaluation dominated; it changed nothing (615.2 → 615.2 s), because this path runs
the *numpy* `_calc_force` and never reaches the backend friction factor. Recorded
next to the row so nobody re-tries it.

### 2. `Orbit.integrate` warns when a backend IC comes back as numpy

Measured, concrete (non-grad) torch IC:

```
dop853 / odeint / leapfrog             ndarray   numpy loop, no in-backend path
leapfrog_c / symplec4_c / symplec6_c   ndarray   concrete IC is not rerouted (gh#1094)
ias15_c                                ndarray   no dxdv, so no C-STM
dop853_c / rk4_c / rk6_c / dopr54_c    Tensor    C-STM, differentiable
```

Seven of eleven demote — including galpy's **default**, so
`Orbit(torch.tensor(...)).integrate(ts, pot)` with no `method=` hands back numpy
with nothing said. It now warns, naming both the in-backend solvers and the
Runge-Kutta C methods that keep the differentiable path. The warning sits after
every differentiable route has returned, so it carries no method list of its own
and cannot drift out of sync with the routing above it.

It does **not** fire for the test harness: a list/numpy IC under
`use(backend, force=True)` leaves `_ic_backend` None. Verified two ways — directly,
and by a forced-torch `test_FDMdynamfric + test_noninertial` run (68 passed) that
emits **zero** of these warnings.

### Gates

| | |
|---|---|
| numpy `test_potential` + `test_dynamfric` + `test_FDMdynamfric` | 1352 passed, 102 skipped |
| torch `test_FDMdynamfric` | 16 passed |
| torch `test_FDMdynamfric` + `test_noninertial` | 68 passed |
| `test_backend_orbit_*` + `test_backend_inbackend_ode` | 415 passed |
| new demotion tests | 12 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
