### PR TITLE
ChandrasekharDynamicalFrictionForce: the force cache has never hit (2.1x on the friction path)

### DIFF
--- a/galpy/potential/ChandrasekharDynamicalFrictionForce.py
+++ b/galpy/potential/ChandrasekharDynamicalFrictionForce.py
@@ -246,29 +246,31 @@ class ChandrasekharDynamicalFrictionForce(DissipativeForce):
                 -self._dens_host(R, z, phi=phi, t=t) / vs**3.0 * Xfactor * lnLambda
             )
 
-    def _Rforce(self, R, z, phi=0.0, t=0.0, v=None):
+    def _cached_force_factor(self, R, phi, z, v, t):
+        """The shared friction factor, recomputed only when (R, phi, z, v, t) moves.
+
+        The three force components are queried with identical arguments inside one
+        equation-of-motion evaluation, so the factor -- and the host-density
+        evaluation behind it -- is computed once per step rather than three times.
+        The hash was previously computed and compared but never STORED, so
+        ``self._force_hash`` stayed ``None`` and the cache never hit.
+        """
         new_hash = hashlib.md5(
             numpy.array([R, phi, z, v[0], v[1], v[2], t])
         ).hexdigest()
         if new_hash != self._force_hash:
             self._calc_force(R, phi, z, v, t)
-        return self._cached_force * v[0]
+            self._force_hash = new_hash
+        return self._cached_force
+
+    def _Rforce(self, R, z, phi=0.0, t=0.0, v=None):
+        return self._cached_force_factor(R, phi, z, v, t) * v[0]
 
     def _phitorque(self, R, z, phi=0.0, t=0.0, v=None):
-        new_hash = hashlib.md5(
-            numpy.array([R, phi, z, v[0], v[1], v[2], t])
-        ).hexdigest()
-        if new_hash != self._force_hash:
-            self._calc_force(R, phi, z, v, t)
-        return self._cached_force * v[1] * R
+        return self._cached_force_factor(R, phi, z, v, t) * v[1] * R
 
     def _zforce(self, R, z, phi=0.0, t=0.0, v=None):
-        new_hash = hashlib.md5(
-            numpy.array([R, phi, z, v[0], v[1], v[2], t])
-        ).hexdigest()
-        if new_hash != self._force_hash:
-            self._calc_force(R, phi, z, v, t)
-        return self._cached_force * v[2]
+        return self._cached_force_factor(R, phi, z, v, t) * v[2]
 
     # Pickling functions
     def __getstate__(self):

--- a/tests/test_FDMdynamfric.py
+++ b/tests/test_FDMdynamfric.py
@@ -463,3 +463,44 @@ def test_dynamfric_c_minr_warning():
         "Integrating an orbit that goes to r < minr with dynamical friction should have raised a warning, but didn't"
     )
     return None
+
+
+# FDMDynamicalFrictionForce overrides _calc_force but INHERITS _Rforce /
+# _phitorque / _zforce, so it relies on the same (R,phi,z,v,t) cache. Pinned
+# separately from the Chandrasekhar version because that inheritance is the only
+# thing making it true: an FDM-specific force component would reintroduce the
+# threefold recomputation without touching the base class or its test. Both
+# branches of the FDM _calc_force are covered -- the full kr-regime friction
+# factor, and the const_FDMfactor shortcut that skips it.
+@pytest.mark.parametrize("const_FDMfactor", [False, 0.1])
+def test_FDMdynamfric_force_factor_computed_once_per_step(const_FDMfactor):
+    from galpy.orbit import Orbit
+
+    pot = potential.LogarithmicHaloPotential(normalize=1.0)
+    fdf = potential.FDMDynamicalFrictionForce(
+        GMs=0.01, dens=pot, const_FDMfactor=const_FDMfactor
+    )
+    counts = {"calc": 0, "Rforce": 0}
+    orig_calc, orig_Rforce = fdf._calc_force, fdf._Rforce
+
+    def counted_calc(*args, **kwargs):
+        counts["calc"] += 1
+        return orig_calc(*args, **kwargs)
+
+    def counted_Rforce(*args, **kwargs):
+        counts["Rforce"] += 1
+        return orig_Rforce(*args, **kwargs)
+
+    fdf._calc_force, fdf._Rforce = counted_calc, counted_Rforce
+    o = Orbit([1.0, 0.1, 1.1, 0.1, 0.1, 0.0])
+    o.integrate(numpy.linspace(0.0, 2.0, 21), pot + fdf, method="dop853")
+    assert counts["Rforce"] > 100, (
+        "the integration did not exercise the FDM friction force, so this test "
+        "cannot say anything about its cache"
+    )
+    assert counts["calc"] == counts["Rforce"], (
+        "the FDM friction factor is computed %d times for %d equation-of-motion "
+        "evaluations; the (R,phi,z,v,t) cache is not hitting"
+        % (counts["calc"], counts["Rforce"])
+    )
+    return None

--- a/tests/test_dynamfric.py
+++ b/tests/test_dynamfric.py
@@ -469,3 +469,40 @@ def test_dynamfric_c_minr_warning():
         "Integrating an orbit that goes to r < minr with dynamical friction should have raised a warning, but didn't"
     )
     return None
+
+
+# The three force components are queried with identical arguments inside a single
+# equation-of-motion evaluation, so the friction factor -- and the host-density
+# evaluation behind it -- must be computed ONCE per step, not three times. The
+# hash that guards that was computed and compared but never stored, so
+# _force_hash stayed None and the cache never hit. Nothing tested it, which is
+# exactly why a dead cache stayed invisible: the values are right either way.
+def test_dynamfric_force_factor_computed_once_per_step():
+    from galpy.orbit import Orbit
+
+    pot = potential.LogarithmicHaloPotential(normalize=1.0)
+    cdf = potential.ChandrasekharDynamicalFrictionForce(GMs=0.01, dens=pot)
+    counts = {"calc": 0, "Rforce": 0}
+    orig_calc, orig_Rforce = cdf._calc_force, cdf._Rforce
+
+    def counted_calc(*args, **kwargs):
+        counts["calc"] += 1
+        return orig_calc(*args, **kwargs)
+
+    def counted_Rforce(*args, **kwargs):
+        counts["Rforce"] += 1
+        return orig_Rforce(*args, **kwargs)
+
+    cdf._calc_force, cdf._Rforce = counted_calc, counted_Rforce
+    o = Orbit([1.0, 0.1, 1.1, 0.1, 0.1, 0.0])
+    o.integrate(numpy.linspace(0.0, 2.0, 21), pot + cdf, method="dop853")
+    assert counts["Rforce"] > 100, (
+        "the integration did not exercise the friction force, so this test cannot "
+        "say anything about its cache"
+    )
+    assert counts["calc"] == counts["Rforce"], (
+        "the friction factor is computed %d times for %d equation-of-motion "
+        "evaluations; the (R,phi,z,v,t) cache is not hitting"
+        % (counts["calc"], counts["Rforce"])
+    )
+    return None


### PR DESCRIPTION
`ChandrasekharDynamicalFrictionForce`'s force cache has never hit — not since the
commit that introduced the class (`32663f334`), where it is already written this
way:

```
101:        self._force_hash= None      <- the only assignment
147:        if new_hash != self._force_hash:
170:        if new_hash != self._force_hash:
193:        if new_hash != self._force_hash:
```

`_Rforce`, `_phitorque` and `_zforce` each compute a hash of
`(R, phi, z, v, t)` and compare it against `self._force_hash` — but **nothing ever
stores it**. `self._force_hash` is assigned in exactly three places (`__init__`
and the `GMs` / `rhm` setters) and all three assign `None`, so the comparison is
always true and `_calc_force` runs on every call.

The three components are queried with identical arguments inside a single
equation-of-motion evaluation, so the friction factor — and the **host-density
evaluation** behind it — is computed three times per step instead of once.

### Measured

Over a 227-step integration: **681** `_calc_force` calls. Exactly 3×.

```
friction orbit, 1001 output times      106.3 s  ->  49.9 s     (2.1x)
test_dynamfric + test_FDMdynamfric     592.3 s  -> 468.7 s     (and that includes
                                                               the new test)
```

### Values are untouched

The cached factor is exactly what the recomputation returns for the same
arguments — this is a pure memoisation of a deterministic function of its
arguments. The same 1001-point friction orbit comes back with an identical max
relative error against the analytic solution, `1.747e-04`, before and after.

### The missing test is the actual story

Nothing ever asserted that the cache *works*, and the values are correct either
way, so a dead cache was invisible — it only ever showed up as the code being
slower than it reads. The new test counts `_calc_force` calls against
equation-of-motion evaluations and requires them equal. Verified to **fail on this
branch's base** (`681 != 227`) and pass with the fix.

`FDMDynamicalFrictionForce` gets its own count test rather than relying on the
base-class one: it overrides `_calc_force` but *inherits* the three force
components, and that inheritance is the only thing making the cache apply to it —
an FDM-specific `_Rforce` would reintroduce the threefold recomputation without
touching the base class or its test. Both branches of the FDM `_calc_force` are
covered, the full kr-regime friction factor and the `const_FDMfactor` shortcut.

All three count tests were verified against **`origin/main`** explicitly, not via
`git checkout --`: once the fix is committed on the branch, that restores the
*committed* file and silently gives a fix-vs-fix A/B that passes and proves
nothing.

```
origin/main    Chandra calc=681   FDM calc=681   FDMcnst calc=681   Rforce=227
with the fix   all three calc=227 == Rforce=227
```

The three duplicated bodies also collapse into one `_cached_force_factor` helper,
which is how the store came to be missing from all three at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
