### PR TITLE
OblateStaeckelWrapperPotential: ntab= works on the backend, differentiably

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -982,6 +982,37 @@ class Spline1D:
             )
             self._ppoly_x, self._ppoly_c = spline_to_ppoly(self._spl)
 
+    @classmethod
+    def from_ppoly(cls, pp, ext=0):
+        """A :class:`Spline1D` wrapping an ALREADY-FITTED scipy piecewise polynomial.
+
+        The ``(x, y)`` constructor fits an ``InterpolatedUnivariateSpline``, which
+        is a *different* spline from, say, ``CubicSpline(bc_type="natural")``. A
+        caller that needs a specific one -- because it must match a C
+        implementation knot-for-knot -- builds it itself and passes it here.
+
+        numpy queries call ``pp`` directly (byte-identical to using it), and a
+        backend evaluates ``pp``'s own power-basis coefficients through the
+        namespace, so the two paths interpolate the SAME polynomial.
+
+        ``pp`` must be a scipy ``PPoly`` (``CubicSpline`` is one) with strictly
+        increasing breakpoints; its ``.x``/``.c`` already use ``eval_ppoly``'s
+        layout, so nothing is refitted or converted.
+        """
+        if numpy.any(numpy.diff(pp.x) <= 0.0):
+            raise ValueError("from_ppoly needs strictly increasing breakpoints")
+        self = cls.__new__(cls)
+        self._k = int(pp.c.shape[0]) - 1
+        self._ext = ext
+        self._extrapolate = True if ext in (0, "extrapolate") else "const"
+        self._bc = None
+        self._mode2 = False
+        self._x = numpy.asarray(pp.x, dtype=float)
+        self._spl = pp
+        self._ppoly_x = self._x
+        self._ppoly_c = numpy.asarray(pp.c, dtype=float)
+        return self
+
     def __call__(self, r, nu=0):
         """Evaluate the spline (``nu=0``) or its ``nu``-th derivative at ``r``.
 

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -88,26 +88,66 @@ def spline_to_ppoly(spl):
     return numpy.append(ppoly.x[:-1][keep], ppoly.x[-1]), ppoly.c[:, keep]
 
 
-def _take0(xp, a, idx):
-    """``a[idx]`` along axis 0, written so torch survives ``vmap(grad(...))``.
+def _take(xp, a, idx, axis=0):
+    """``a[..., idx, ...]`` along ``axis``, written so torch survives
+    ``vmap(grad(...))``.
 
     Plain ``a[idx]`` with a *computed* index is fine under vmap alone and under
     grad alone, but raises inside the composition that autodiff.py builds for
     the fE chain. ``take`` is batched correctly; the reshape carries 0-d ``idx``
     (one scalar per vmap element) through, since ``take`` wants a 1-D index.
+
+    ``axis=1`` is how ``eval_ppoly`` pulls all of a piecewise polynomial's
+    coefficient rows in ONE gather: on jax a gather is ~300 us of eager dispatch,
+    so four of them cost more than the rest of the evaluation put together.
     """
     if xp is numpy:
         # numpy stays on the original expression: take() on a 0-d index returns
         # a 0-d ARRAY where a[idx] returns a numpy SCALAR, and callers here
         # (interpSphericalPotential._revaluate) depend on the scalar.
-        return a[idx]
-    flat = xp.reshape(idx, (-1,))
+        return a[idx] if axis == 0 else a[(slice(None),) * axis + (idx,)]
     # xp may be the RAW torch module (not array-api-compat's), whose take() has
-    # no axis kwarg; and jax/numpy have no index_select. Prefer whichever the
-    # namespace actually provides -- both mean "gather along axis 0".
+    # no axis kwarg; and jax has no index_select. Prefer whichever the namespace
+    # actually provides -- both mean "gather along ``axis``".
     sel = getattr(xp, "index_select", None)
-    out = sel(a, 0, flat) if sel is not None else xp.take(a, flat, axis=0)
-    return xp.reshape(out, tuple(idx.shape) + tuple(a.shape[1:]))
+    if sel is None:
+        # take() accepts an index of ANY shape and already returns
+        # a.shape[:axis] + idx.shape + a.shape[axis+1:], so the reshape pair the
+        # index_select path needs is pure overhead here -- and on eager jax each
+        # reshape is ~130 us against ~14 us for the gather itself, i.e. the
+        # reshapes cost 10x the work they wrap.
+        return xp.take(a, idx, axis=axis)
+    # index_select wants a 1-D index; the reshape is also what carries a 0-d
+    # index (one scalar per vmap element) through the vmap(grad(...))
+    # composition autodiff.py builds for the fE chain.
+    out = sel(a, axis, xp.reshape(idx, (-1,)))
+    return xp.reshape(
+        out,
+        tuple(a.shape[:axis]) + tuple(idx.shape) + tuple(a.shape[axis + 1 :]),
+    )
+
+
+def _take0(xp, a, idx):
+    """``a[idx]`` along axis 0; see :func:`_take`."""
+    return _take(xp, a, idx, axis=0)
+
+
+def _unstack0(xp, a):
+    """``a`` split into its rows along axis 0, as a tuple.
+
+    ``a[0], a[1], ...`` would do it, but an integer index into a backend array is
+    a dispatch apiece (~130 us each on eager jax) where ``unstack`` is one call
+    for all of them. It is a pure split -- no arithmetic -- so callers get the
+    same values either way. Namespaces predating the array-API ``unstack`` (the
+    RAW torch module, which ``get_namespace`` can hand back) fall back.
+    """
+    # numpy keeps the indexing form: on a 1-D `a` it yields numpy SCALARS where
+    # unstack yields 0-d ARRAYS, and callers downstream of eval_ppoly
+    # (interpSphericalPotential._revaluate) depend on the scalar.
+    fn = None if xp is numpy else getattr(xp, "unstack", None)
+    if fn is not None:
+        return fn(a)
+    return tuple(a[j] for j in range(a.shape[0]))
 
 
 def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
@@ -166,14 +206,22 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         # axis; give dr a matching trailing axis so the Horner step broadcasts.
         dr = dr[..., None]
     k = cb.shape[0] - 1  # polynomial degree
+    # ONE gather for every coefficient row, then ONE unstack into the per-degree
+    # rows the Horner step consumes. Both matter on an eager backend, where a
+    # gather and an integer index are each a full dispatch: for a cubic, four
+    # `cb[j][idx]` gathers plus four `ci[j]` indexes cost ~1.8 ms of jax dispatch
+    # against ~0.12 ms for the gather+unstack pair -- and `unstack` is a pure
+    # split, so the Horner recurrence below is evaluated on exactly the same
+    # numbers it always was.
+    ci = _unstack0(xp, _take(xp, cb, idx, axis=1))
     if nu == 0:
-        out = _take0(xp, cb[0], idx)
+        out = ci[0]
         for j in range(1, cb.shape[0]):
-            out = out * dr + _take0(xp, cb[j], idx)
+            out = out * dr + ci[j]
         return out
     if nu > k:
         # derivative past the degree is identically zero (broadcast over r)
-        return _take0(xp, cb[0], idx) * 0.0
+        return ci[0] * 0.0
     # Analytic nu-th derivative of sum_j c[j]*(dr)**(k-j): the term of original
     # power p=k-j survives with the falling-factorial factor p*(p-1)*...*(p-nu+1)
     # and reduced power p-nu. Horner over the surviving (descending-power) terms.
@@ -183,7 +231,7 @@ def eval_ppoly(xp, x, c, r, *, nu=0, extrapolate=True):
         fall = 1.0
         for m in range(nu):
             fall *= p - m
-        term = _take0(xp, cb[j], idx) * fall
+        term = ci[j] * fall
         out = term if out is None else out * dr + term
     return out
 
@@ -1056,14 +1104,37 @@ class Spline1D:
             return eval_cubic(
                 xp, self._x, self._coeffs, r, nu=nu, extrapolate=self._extrapolate
             )
-        return eval_ppoly(
-            xp,
-            self._ppoly_x,
-            self._ppoly_c,
-            r,
-            nu=nu,
-            extrapolate=self._extrapolate,
-        )
+        xb, cb = self._ppoly_on(xp, r)
+        return eval_ppoly(xp, xb, cb, r, nu=nu, extrapolate=self._extrapolate)
+
+    def _ppoly_on(self, xp, r):
+        """The frozen ``(x, c)`` table as arrays of ``r``'s namespace and device.
+
+        The table is a numpy constant, so without this every evaluation re-uploads
+        it -- for a 3000-knot spline that is a (3000,) and a (4, 2999) transfer per
+        call, ~35% of the eager cost of evaluating the spline at ONE point. Cached
+        per (namespace, device); `eval_ppoly`'s own `asarray_on_device` then takes
+        its "already the right dtype and device" fast path.
+        """
+        dev = device_of(r)
+        key = (xp.__name__, repr(dev))
+        cache = self.__dict__.get("_ppoly_dev_cache")
+        if cache is None:
+            cache = self._ppoly_dev_cache = {}
+        hit = cache.get(key)
+        if hit is None:
+            hit = cache[key] = (
+                asarray_on_device(xp, self._ppoly_x, dev),
+                asarray_on_device(xp, self._ppoly_c, dev),
+            )
+        return hit
+
+    def __getstate__(self):
+        # the cached device copies are backend arrays -- rebuildable, and not
+        # picklable across processes/backends; drop them.
+        state = self.__dict__.copy()
+        state.pop("_ppoly_dev_cache", None)
+        return state
 
     def derivative(self, n=1):
         """Return a callable for the ``n``-th derivative.

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -142,12 +142,17 @@ def _unstack0(xp, a):
     same values either way. Namespaces predating the array-API ``unstack`` (the
     RAW torch module, which ``get_namespace`` can hand back) fall back.
     """
-    # numpy keeps the indexing form: on a 1-D `a` it yields numpy SCALARS where
-    # unstack yields 0-d ARRAYS, and callers downstream of eval_ppoly
-    # (interpSphericalPotential._revaluate) depend on the scalar.
-    fn = None if xp is numpy else getattr(xp, "unstack", None)
-    if fn is not None:
-        return fn(a)
+    # Only jax. numpy must keep the indexing form -- on a 1-D `a` it yields numpy
+    # SCALARS where unstack yields 0-d ARRAYS, and callers downstream of
+    # eval_ppoly (interpSphericalPotential._revaluate) depend on the scalar. And
+    # array-api-compat implements torch's unstack as `tuple(moveaxis(x, axis, 0))`,
+    # which has NO vmap batching rule -- under the vmap(grad(...)) composition
+    # autodiff.py builds for the fE chain it dies with "Batching rule not
+    # implemented for aten::moveaxis.int". Nothing is lost by indexing there:
+    # torch dispatch is ~3.8 us against jax's ~130 us, which is the whole reason
+    # this helper exists.
+    if name_of_namespace(xp) == "jax":
+        return xp.unstack(a)
     return tuple(a[j] for j in range(a.shape[0]))
 
 

--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -44,6 +44,7 @@ from ._namespaces import (
     is_backend_array,
     name_of_namespace,
     prefer_backend_namespace,
+    under_trace,
 )
 from ._resolver import get_namespace
 
@@ -1117,6 +1118,16 @@ class Spline1D:
         its "already the right dtype and device" fast path.
         """
         dev = device_of(r)
+        if under_trace(r):
+            # Inside a trace, jax lifts even a numpy constant into the jaxpr, so
+            # the converted arrays come back as TRACERS -- caching one would leak
+            # this trace's tracers into the next call and blow up there, far from
+            # here. Nothing is lost: a per-trace conversion is constant-folded
+            # once by the compiler, which is the whole point of tracing.
+            return (
+                asarray_on_device(xp, self._ppoly_x, dev),
+                asarray_on_device(xp, self._ppoly_c, dev),
+            )
         key = (xp.__name__, repr(dev))
         cache = self.__dict__.get("_ppoly_dev_cache")
         if cache is None:

--- a/galpy/potential/OblateStaeckelWrapperPotential.py
+++ b/galpy/potential/OblateStaeckelWrapperPotential.py
@@ -13,6 +13,7 @@ from scipy.interpolate import CubicSpline
 from galpy.util import conversion, coords
 
 from ..backend import coerce_coords, get_namespace, promote_scalars
+from ..backend.interpolate import Spline1D
 from .Potential import (
     _APY_LOADED,
     _evaluatePotentials,
@@ -142,9 +143,19 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
             # CubicSpline is the same mathematical object as GSL's cspline on
             # the same knots, so Python and C agree to machine precision
             # also in tabulated mode
+            # Spline1D.from_ppoly keeps THESE CubicSpline objects: numpy calls
+            # them directly (byte-identical, and still GSL-cspline-equivalent so
+            # Python and C agree), while a backend evaluates their own power-basis
+            # coefficients through the namespace -- differentiably. Refitting from
+            # (grid, vals) would silently give a different spline.
+            self._utab_max = float(ugrid[-1])
             self._splines = [
-                CubicSpline(ugrid, vals, bc_type="natural") for vals in uvals
-            ] + [CubicSpline(vgrid, vals, bc_type="natural") for vals in vvals]
+                Spline1D.from_ppoly(CubicSpline(ugrid, vals, bc_type="natural"))
+                for vals in uvals
+            ] + [
+                Spline1D.from_ppoly(CubicSpline(vgrid, vals, bc_type="natural"))
+                for vals in vvals
+            ]
         self.hasC = True
         self._backend_compatible = True
         # Advertise the (planar and 3D) C variational capabilities
@@ -443,25 +454,27 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _evalUspline(self, u, k):
         # same semantics as evalUspline in C: u beyond the table is clamped
-        return self._splines[k](numpy.clip(u, 0.0, self._splines[k].x[-1]))
+        xp = get_namespace(u)
+        return self._splines[k](xp.clip(u, 0.0, self._utab_max))
 
     def _evalVspline(self, v, k):
         # same semantics as evalVspline in C: tables cover v in [0, pi/2];
         # V is even and V' odd about pi/2 (z-symmetry)
-        sgn = 1.0
-        if v > numpy.pi / 2.0:
-            v = numpy.pi - v
-            if k == 1:
-                sgn = -1.0
-        return sgn * self._splines[3 + k](numpy.clip(v, 0.0, numpy.pi / 2.0))
+        # The fold is elementwise (xp.where, not a Python `if`) so it works on an
+        # array and under a trace; `k` is a static Python int, so branching on it
+        # is fine.
+        xp = get_namespace(v)
+        folded = v > numpy.pi / 2.0
+        vv = xp.where(folded, numpy.pi - v, v)
+        out = self._splines[3 + k](xp.clip(vv, 0.0, numpy.pi / 2.0))
+        if k == 1:
+            out = xp.where(folded, -out, out)
+        return out
 
     def _U(self, u):
         """Approximated U(u) = cosh^2(u) Phi(u,pi/2)"""
         xp = get_namespace(u)
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates.
-        if xp is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalUspline(u, 0)
         (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
@@ -469,10 +482,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _dUdu(self, u):
         xp = get_namespace(u)
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates.
-        if xp is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalUspline(u, 1)
         (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
@@ -486,10 +496,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _d2Udu2(self, u):
         xp = get_namespace(u)
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates.
-        if xp is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalUspline(u, 2)
         (u,) = coerce_coords(xp, u)
         Rz0 = coords.uv_to_Rz(u, self._v0, delta=self._delta)
@@ -521,12 +528,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
     def _V(self, v):
         """Approximated
         V(v) = cosh^2(u0) Phi(u0,pi/2) - (sinh^2(u0)+sin^2(v)) Phi(u0,v)"""
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates. (The body itself
-        # needs no namespace -- coords/_evaluatePotentials dispatch internally --
-        # so `xp` is resolved for this gate alone, as in _dVdv/_d2Vdv2 below.)
-        if get_namespace(v) is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalVspline(v, 0)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
         return self._refpot - _staeckel_prefactor(self._u0, v) * _evaluatePotentials(
@@ -535,10 +537,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _dVdv(self, v):
         xp = get_namespace(v)
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates.
-        if xp is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalVspline(v, 1)
         (v,) = coerce_coords(xp, v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)
@@ -551,10 +550,7 @@ class OblateStaeckelWrapperPotential(parentWrapperPotential):
 
     def _d2Vdv2(self, v):
         xp = get_namespace(v)
-        # The tabulated spline (ntab=) is a scipy CubicSpline: numpy-only and
-        # non-differentiable, so it serves the numpy path only. A backend keeps
-        # the analytic evaluation below, which differentiates.
-        if xp is numpy and self._splines is not None:
+        if self._splines is not None:
             return self._evalVspline(v, 2)
         (v,) = coerce_coords(xp, v)
         R0z = coords.uv_to_Rz(self._u0, v, delta=self._delta)

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -172,18 +172,6 @@ jax tests/test_qdf.py::test_sampleV_interpolate  # re-measured 2026-09-06: still
 # passes or times out on runner variance. Already deferred for jax-jit; same test, same loop
 # over Python integrators, so it belongs here too rather than re-run until it happens to be green.
 
-# --- jax: the tabulated OblateStaeckelWrapper agreement test (gh#1468) ---
-# test_oblatestaeckelwrapper_ntab_c checks that the ntab= tables agree with exact
-# evaluation in C AND in Python, and the Python half integrates 1001 steps with
-# method='dop853' -- a scalar Python stepper whose every force evaluation resolves
-# to the ambient namespace. It PASSES under jax, in 464.7s (measured 2026-09-12,
-# --timeout=3000); at the 0.71 CI/local ratio for jax shards that is ~330s against
-# the 300s cap. Deferred on TIME, not capability. torch runs the same test in 73.6s
-# (~52s on CI) and is NOT deferred -- the gap is eager per-op cost, ~17us on jax vs
-# ~3.8us on torch, not anything the tables do. Un-defer with the Track A/D orbit
-# vectorization, same trigger as the entries above.
-jax tests/test_orbit.py::test_oblatestaeckelwrapper_ntab_c  # 464.7s
-
 # --- single-orbit: action-angle accessors -- performance-gated, NOT broken ---
 # These were xfail-ledgered as "actionAngleStaeckel_c is not backend-migrated (Track E) ...
 # numpy .flags on a jax array or NotImplementedError. Un-xfail when Track E lands." Track E

--- a/tests/backend_slow_skip.txt
+++ b/tests/backend_slow_skip.txt
@@ -172,6 +172,18 @@ jax tests/test_qdf.py::test_sampleV_interpolate  # re-measured 2026-09-06: still
 # passes or times out on runner variance. Already deferred for jax-jit; same test, same loop
 # over Python integrators, so it belongs here too rather than re-run until it happens to be green.
 
+# --- jax: the tabulated OblateStaeckelWrapper agreement test (gh#1468) ---
+# test_oblatestaeckelwrapper_ntab_c checks that the ntab= tables agree with exact
+# evaluation in C AND in Python, and the Python half integrates 1001 steps with
+# method='dop853' -- a scalar Python stepper whose every force evaluation resolves
+# to the ambient namespace. It PASSES under jax, in 464.7s (measured 2026-09-12,
+# --timeout=3000); at the 0.71 CI/local ratio for jax shards that is ~330s against
+# the 300s cap. Deferred on TIME, not capability. torch runs the same test in 73.6s
+# (~52s on CI) and is NOT deferred -- the gap is eager per-op cost, ~17us on jax vs
+# ~3.8us on torch, not anything the tables do. Un-defer with the Track A/D orbit
+# vectorization, same trigger as the entries above.
+jax tests/test_orbit.py::test_oblatestaeckelwrapper_ntab_c  # 464.7s
+
 # --- single-orbit: action-angle accessors -- performance-gated, NOT broken ---
 # These were xfail-ledgered as "actionAngleStaeckel_c is not backend-migrated (Track E) ...
 # numpy .flags on a jax array or NotImplementedError. Un-xfail when Track E lands." Track E

--- a/tests/test_actionAngle.py
+++ b/tests/test_actionAngle.py
@@ -4085,7 +4085,9 @@ def test_actionAngle_oblatestaeckelwrapper_cache_c():
             out.extend(aAS.EccZmaxRperiRap(R, vR, vT, z, vz))
             out.extend(aAA(R, vR, vT, z, vz))
             out.extend(aAA.EccZmaxRperiRap(R, vR, vT, z, vz))
-            results.append(out)
+            # under a forced backend these come back as backend arrays; the
+            # reductions below are numpy's
+            results.append([as_numpy(a) for a in out])
         for first, second in zip(*results):
             assert numpy.all(first == second), (
                 "OblateStaeckelWrapperPotential C actionAngle evaluation is not "
@@ -4102,7 +4104,7 @@ def test_actionAngle_oblatestaeckelwrapper_cache_c():
         )
     aASpy = actionAngleStaeckel(pot=swp, delta=0.45, c=False)
     sub = slice(0, n, 16)
-    jpy = aASpy(R[sub], vR[sub], vT[sub], z[sub], vz[sub])
+    jpy = [as_numpy(a) for a in aASpy(R[sub], vR[sub], vT[sub], z[sub], vz[sub])]
     for jc, jp in zip(all_results[0][:3], jpy):
         assert numpy.amax(numpy.fabs(jc[sub] - jp)) < 1e-4, (
             "C and Python actions of the cached OblateStaeckelWrapperPotential disagree"

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1405,3 +1405,30 @@ def test_eval_ppoly_batched_gather_matches_per_row(backend):
         numpy.testing.assert_array_equal(
             got, per_row(rq, nu), err_msg=f"{backend} nu={nu} is not the per-row value"
         )
+
+
+@pytest.mark.skipif(not jax, reason="jax not installed")
+def test_spline1d_device_cache_is_not_populated_under_a_trace():
+    # Inside a jax trace even a numpy CONSTANT is lifted into the jaxpr, so the
+    # converted table comes back as a tracer rather than an array. Caching that
+    # would hand one trace's tracers to the next call, and the failure surfaces
+    # far from here -- it first showed up as jacfwd over a dynamical-friction
+    # force, a module away, with `x = JitTracer(float64[499])` inside eval_ppoly.
+    x = numpy.linspace(0.3, 4.1, 25)
+    s = Spline1D(x, numpy.cos(x) * x)
+    want = s(numpy.array([1.7, 2.9]))
+
+    jax.jit(lambda r: s(r))(jnp.asarray([1.7, 2.9]))
+    assert not s.__dict__.get("_ppoly_dev_cache"), (
+        "a conversion made inside a trace was cached; it holds tracers"
+    )
+    # an ordinary eager call afterwards is still correct (and may cache freely)
+    numpy.testing.assert_allclose(
+        as_numpy(s(jnp.asarray([1.7, 2.9]))), want, rtol=1e-13, atol=0.0
+    )
+    # and a SECOND, different trace must not inherit anything from the first
+    d = jax.jacfwd(lambda r: s(r).sum())(jnp.asarray([1.7, 2.9]))
+    fd = (s(numpy.array([1.7 + 1e-6, 2.9])) - s(numpy.array([1.7 - 1e-6, 2.9])))[
+        0
+    ] / 2e-6
+    numpy.testing.assert_allclose(float(as_numpy(d)[0]), fd, rtol=1e-6)

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -18,6 +18,7 @@ from galpy.backend.interpolate import (
     Spline2D,
     cubic_spline_coeffs,
     eval_cubic,
+    eval_ppoly,
     eval_rect_ppoly,
     interp_linear,
     make_smoothing_spline,
@@ -1334,3 +1335,73 @@ def test_spline1d_from_ppoly_evaluates_the_given_polynomial(backend):
     # first derivative too, on the same polynomial
     d = s(_asarray(backend, xq), nu=1)
     numpy.testing.assert_allclose(as_numpy(d), pp(xq, 1), rtol=1e-13, atol=1e-14)
+
+
+# ------------------------------------------- the frozen table's device cache
+@pytest.mark.parametrize("backend", AD_BACKENDS)
+def test_spline1d_device_cache_survives_pickling(backend):
+    # Spline1D caches the namespace/device copy of its frozen (x, c) table so
+    # every evaluation does not re-upload it. The cache holds BACKEND arrays, so
+    # it must not travel with the object: potentials get pickled (and sent to
+    # worker processes), and a jax/torch array in __dict__ would either fail to
+    # pickle or arrive bound to the wrong runtime.
+    import pickle
+
+    x = numpy.linspace(0.3, 4.1, 25)
+    s = Spline1D(x, numpy.cos(x) * x)
+    xq = numpy.array([0.44, 2.17, 3.98])
+    want = s(xq)
+    got = s(_asarray(backend, xq))  # populates the cache
+    numpy.testing.assert_allclose(as_numpy(got), want, rtol=1e-13, atol=0.0)
+    assert s.__dict__.get("_ppoly_dev_cache"), "the device copy was not cached"
+    assert "_ppoly_dev_cache" not in s.__getstate__()
+
+    back = pickle.loads(pickle.dumps(s))
+    numpy.testing.assert_array_equal(back(xq), want)  # numpy path byte-identical
+    numpy.testing.assert_allclose(
+        as_numpy(back(_asarray(backend, xq))), want, rtol=1e-13, atol=0.0
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_eval_ppoly_batched_gather_matches_per_row(backend):
+    # eval_ppoly pulls every coefficient row in ONE gather and unpacks with
+    # unstack; both are pure data movement, so the Horner recurrence must see
+    # exactly the numbers the per-row form gave it -- assert BIT equality
+    # against the formulation written out here, not a tolerance.
+    rs = numpy.random.RandomState(7)
+    x = numpy.sort(rs.rand(40)) * 6.0
+    c = rs.randn(4, 39)
+
+    def per_row(r, nu):
+        idx = numpy.clip(numpy.searchsorted(x, r, side="right") - 1, 0, c.shape[1] - 1)
+        dr = r - x[idx]
+        if nu == 0:
+            out = c[0][idx]
+            for j in range(1, 4):
+                out = out * dr + c[j][idx]
+            return out
+        out = None
+        for j in range(4 - nu):
+            fall = 1.0
+            for m in range(nu):
+                fall *= (3 - j) - m
+            term = c[j][idx] * fall
+            out = term if out is None else out * dr + term
+        return out
+
+    rq = numpy.array([0.02, 1.31, 3.77, 5.98])
+    xp = _xp(backend)
+    for nu in (0, 1, 2):
+        got = as_numpy(
+            eval_ppoly(
+                xp,
+                _asarray(backend, x),
+                _asarray(backend, c),
+                _asarray(backend, rq),
+                nu=nu,
+            )
+        )
+        numpy.testing.assert_array_equal(
+            got, per_row(rq, nu), err_msg=f"{backend} nu={nu} is not the per-row value"
+        )

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1149,6 +1149,31 @@ def test_eval_ppoly_survives_vmap_of_grad_torch():
     numpy.testing.assert_allclose(as_numpy(got), as_numpy(ref), rtol=1e-11, atol=1e-13)
 
 
+def test_eval_ppoly_survives_plain_vmap_torch():
+    # The sibling above guards vmap(grad(...)); this guards plain vmap, which is
+    # a DIFFERENT path through torch's batching rules and the one that actually
+    # broke. array-api-compat implements torch's `unstack` as
+    # `tuple(moveaxis(x, axis, 0))`, and aten::moveaxis.int has no batching rule:
+    # under bare vmap that raises "Batching rule not implemented", while all four
+    # of vmap(grad), vmap(grad(grad)), vmap(jacrev) and vmap over 1-D slices sail
+    # through it. So eval_ppoly unstacks with `unstack` only on jax and indexes
+    # on torch -- where dispatch is ~3.8 us and there is nothing to win anyway.
+    torch = pytest.importorskip("torch")
+    import array_api_compat.torch as xp
+
+    from galpy.backend.interpolate import cubic_spline_coeffs, eval_ppoly
+
+    x = torch.linspace(0.5, 4.0, 24, dtype=torch.float64)
+    y = torch.sin(x) + 0.3 * x**2
+    c = cubic_spline_coeffs(xp, x, y)
+    rs = torch.tensor([0.8, 1.7, 2.9, 3.6], dtype=torch.float64)
+
+    got = torch.vmap(lambda r: eval_ppoly(xp, x, c, r.reshape(())).reshape(()))(rs)
+    # a real value check: the same spline evaluated directly on the whole array
+    ref = eval_ppoly(xp, x, c, rs)
+    numpy.testing.assert_array_equal(as_numpy(got), as_numpy(ref))
+
+
 @pytest.mark.parametrize("nu", [0, 1, 2, 3, 5])
 def test_eval_ppoly_derivative_orders_match_scipy_numpy(nu):
     # Covers eval_ppoly's three coefficient-read paths on NUMPY: the nu==0

--- a/tests/test_backend_interpolate.py
+++ b/tests/test_backend_interpolate.py
@@ -1287,3 +1287,50 @@ def test_map_coordinates_backend_grid_with_numpy_query_points(backend_name):
         dn[i] -= h
         fd[i] = (total_np(up) - total_np(dn)) / (2 * h)
     numpy.testing.assert_allclose(ad, fd, rtol=1e-6, atol=1e-8)
+
+
+# ---------------------------------------------------------------- from_ppoly
+def test_spline1d_from_ppoly_rejects_nonincreasing_breakpoints():
+    # from_ppoly trusts pp.x as eval_ppoly's breakpoint array, and eval_ppoly
+    # locates an interval by searchsorted -- which on a non-monotonic x silently
+    # picks the wrong polynomial piece rather than failing. Reject it up front.
+    x = numpy.linspace(0.0, 1.0, 5)
+    pp = si.CubicSpline(x, numpy.sin(x))
+    # scipy itself accepts DECREASING breakpoints; eval_ppoly does not.
+    decreasing = si.PPoly(pp.c[:, ::-1].copy(), x[::-1].copy())
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Spline1D.from_ppoly(decreasing)
+    # a repeated breakpoint is a zero-width interval, equally unusable
+    tied = si.CubicSpline(x, numpy.sin(x))
+    tied.x = numpy.array([0.0, 0.25, 0.25, 0.75, 1.0])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Spline1D.from_ppoly(tied)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_spline1d_from_ppoly_evaluates_the_given_polynomial(backend):
+    # The point of from_ppoly is that NOTHING is refitted: the wrapper must
+    # reproduce the caller's own spline, not an InterpolatedUnivariateSpline
+    # through the same points. CubicSpline(bc_type="natural") differs from the
+    # (x, y) constructor's fit, so assert against pp itself -- and check the two
+    # fits really do differ, or this test would pass either way.
+    x = numpy.linspace(0.2, 3.4, 9)
+    y = numpy.sin(2.0 * x) + 0.3 * x**2
+    pp = si.CubicSpline(x, y, bc_type="natural")
+    refit = Spline1D(x, y)
+    xq = numpy.array([0.31, 1.27, 2.02, 3.29])
+    assert numpy.max(numpy.fabs(pp(xq) - refit(xq))) > 1e-6, (
+        "the two fits agree here, so this test could not tell them apart"
+    )
+
+    s = Spline1D.from_ppoly(pp)
+    got = s(_asarray(backend, xq))
+    assert _is_backend(backend, got)
+    if backend == "numpy":
+        # numpy forwards to pp itself, so this is byte-identical
+        numpy.testing.assert_array_equal(got, pp(xq))
+    else:
+        numpy.testing.assert_allclose(as_numpy(got), pp(xq), rtol=1e-14, atol=0.0)
+    # first derivative too, on the same polynomial
+    d = s(_asarray(backend, xq), nu=1)
+    numpy.testing.assert_allclose(as_numpy(d), pp(xq, 1), rtol=1e-13, atol=1e-14)

--- a/tests/test_backend_wrappers.py
+++ b/tests/test_backend_wrappers.py
@@ -757,3 +757,120 @@ def test_composite_surfdens_delegation_runs_on_a_backend(backend_name):
     numpy.testing.assert_allclose(
         float(as_numpy(got_poisson)), want_poisson, rtol=1e-8, atol=0.0
     )
+
+
+###############################################################################
+# OblateStaeckelWrapperPotential's tabulated mode (ntab=) on a backend.
+#
+# The tables are scipy CubicSplines chosen deliberately -- a natural cubic is the
+# same mathematical object as GSL's cspline, which is how the Python and C paths
+# agree to machine precision. Spline1D.from_ppoly keeps those exact objects, so
+# numpy still calls them (byte-identical) while a backend evaluates their own
+# power-basis coefficients through the namespace. Refitting from (grid, values)
+# would give an InterpolatedUnivariateSpline -- a different spline -- and break
+# both properties silently.
+###############################################################################
+_NTAB_PTS = [(1.0, 0.1), (0.8, 0.3), (1.2, -0.25), (0.6, 0.02)]
+
+
+def _ntab_pair():
+    from galpy.potential import MiyamotoNagaiPotential
+    from galpy.potential import OblateStaeckelWrapperPotential as _O
+
+    mn = MiyamotoNagaiPotential(normalize=1.0, a=0.5, b=0.05)
+    return _O(pot=mn, delta=0.5), _O(pot=mn, delta=0.5, ntab=101)
+
+
+@pytest.mark.parametrize("backend_name", BACKENDS)
+def test_oblatestaeckel_ntab_matches_numpy_on_every_backend(backend_name):
+    # The backend must reproduce the TABULATED value, not silently fall back to
+    # the analytic one: the two differ by ~1e-7, so an equality against the
+    # analytic value would pass a fallback and prove nothing.
+    from galpy.backend import as_numpy, is_backend_array, use
+
+    plain, tab = _ntab_pair()
+    for R, z in _NTAB_PTS:
+        ref_tab = tab.Rforce(R, z, use_physical=False)
+        ref_exact = plain.Rforce(R, z, use_physical=False)
+        assert numpy.fabs(ref_tab - ref_exact) > 1e-10, (
+            "the tabulated and analytic values coincide here, so this point "
+            "cannot tell a table evaluation from a fallback"
+        )
+        if backend_name == "numpy":
+            continue
+        with use(backend_name, force=True):
+            got = tab.Rforce(
+                _toscalar(backend_name, R),
+                _toscalar(backend_name, z),
+                use_physical=False,
+            )
+        assert is_backend_array(got), (
+            f"{backend_name}: ntab= returned numpy, so the table is not on the backend"
+        )
+        # Measured: three of these four points are bit-identical to scipy and the
+        # near-axis one (0.6, 0.02) is 8.2e-16 relative (6 ulps), where the
+        # namespace Horner evaluation reassociates differently. 1e-14 is ~12x
+        # that, and still four orders inside the 1e-10 the tabulation itself is
+        # worth -- so this bounds the EVALUATION, not the interpolation error.
+        numpy.testing.assert_allclose(
+            float(as_numpy(got)),
+            ref_tab,
+            rtol=1e-14,
+            err_msg=f"{backend_name}: the backend must reproduce the tabulated "
+            "value, not fall back to the analytic one",
+        )
+    return None
+
+
+@pytest.mark.skipif("torch" not in BACKENDS, reason="torch not installed")
+def test_oblatestaeckel_ntab_is_differentiable_through_the_table():
+    # Differentiability is the point of putting the table on the backend: a scipy
+    # spline would give no gradient at all.
+    from galpy.backend import use
+
+    _, tab = _ntab_pair()
+    R0, z0 = 1.0, 0.1
+    tR = torch.tensor(R0, dtype=torch.float64, requires_grad=True)
+    with use("torch", force=True):
+        tab.Rforce(
+            tR, torch.tensor(z0, dtype=torch.float64), use_physical=False
+        ).backward()
+    h = 1e-6
+    fd = (
+        tab.Rforce(R0 + h, z0, use_physical=False)
+        - tab.Rforce(R0 - h, z0, use_physical=False)
+    ) / (2 * h)
+    numpy.testing.assert_allclose(
+        float(tR.grad),
+        fd,
+        rtol=1e-7,
+        err_msg="d(Rforce)/dR through the tabulated wrapper disagrees with a "
+        "central finite difference of the same tabulated function",
+    )
+    return None
+
+
+@pytest.mark.parametrize("backend_name", [b for b in BACKENDS if b != "numpy"])
+def test_oblatestaeckel_ntab_folds_v_elementwise(backend_name):
+    # _evalVspline folds v about pi/2 for the z-symmetry. That used to be a Python
+    # `if v > pi/2`, which is neither elementwise nor traceable; an array
+    # straddling pi/2 is what distinguishes the two.
+    from galpy.backend import as_numpy, use
+
+    _, tab = _ntab_pair()
+    zs = numpy.array([-0.3, -0.05, 0.05, 0.3])  # both signs -> v either side of pi/2
+    ref = numpy.array([tab.Rforce(0.9, z, use_physical=False) for z in zs])
+    with use(backend_name, force=True):
+        got = tab.Rforce(
+            _toscalar(backend_name, numpy.full_like(zs, 0.9)),
+            _toscalar(backend_name, zs),
+            use_physical=False,
+        )
+    numpy.testing.assert_allclose(
+        as_numpy(got),
+        ref,
+        rtol=1e-12,
+        err_msg=f"{backend_name}: array v straddling pi/2 disagrees with the "
+        "per-point numpy values; the z-symmetry fold is not elementwise",
+    )
+    return None


### PR DESCRIPTION
#1468's tabulated mode (`ntab=`) was numpy-only, so the feat/backends rebase had
to gate its fast path behind `xp is numpy` — otherwise a forced backend would
evaluate a scipy object and silently return numpy from one evaluator while the
rest went analytic. That gate was the conservative integration. This is the fix.

### Why `Spline1D` couldn't just be dropped in

`Spline1D` already does exactly "scipy on numpy, namespace on a backend" — but
only for tables it **fits itself**, as an `InterpolatedUnivariateSpline`. That is
the wrong spline here. #1468 picks `CubicSpline(bc_type="natural")` deliberately,
and says why:

> a natural cubic is the same mathematical object as GSL's cspline on the same
> knots, so Python and C agree to machine precision also in tabulated mode

Refitting would have broken numpy byte-identity *and* that Python/C agreement,
and nothing would have failed loudly.

So `Spline1D` gains the from-pre-fitted constructor its own docstring already
advertised but never implemented:

```python
Spline1D.from_ppoly(pp)
```

A scipy `PPoly` — and a `CubicSpline` is one — already carries `.x`/`.c` in
exactly `eval_ppoly`'s power-basis layout. Nothing is refitted or converted:
numpy calls `pp` itself, a backend evaluates `pp`'s own coefficients.

### Measured

MiyamotoNagai + `OblateStaeckelWrapperPotential(delta=0.5, ntab=101)`, `Rforce`:

| | |
|---|---|
| numpy | tabulated, unchanged — 6.4e-08 from analytic, i.e. #1468's own tabulation accuracy |
| torch / jax | reproduce the **tabulated** value: bit-identical at 3 of 4 probe points, 8.2e-16 (6 ulps) at the near-axis one |
| gradient | `d(Rforce)/dR` = 1.032445854 vs a central FD of the same tabulated function, 1.032445854 (rel 7.7e-12) |

### Two things besides the spline

- `_evalUspline` clamps with `xp.clip`, not `numpy.clip`.
- `_evalVspline`'s z-symmetry fold about π/2 was a Python `if v > pi/2` —
  neither elementwise nor traceable. Now `xp.where`, with the `k == 1` sign flip
  applied the same way (`k` is a static int, so branching on *it* is fine). The
  new array test straddles π/2 in both directions, which is what tells the two
  apart.

### On the assertions

Every test asserts against the **tabulated** value, never the analytic one. The
two differ by ~1e-7, so an assertion against the analytic value would pass a
silent fallback and prove nothing — the test checks that gap is real before using
a point. The one non-exact bound is `rtol=1e-14`, set from the measured 8.2e-16
with ~12× margin, and four orders inside the 1e-10 the tabulation itself is worth:
it bounds the *evaluation*, not the interpolation error.

### Gates

| | |
|---|---|
| numpy `test_potential` + `test_actionAngle` | 1527 passed, 102 skipped |

### Then CI found the cost of actually using the tables

Turning the tables on under a forced backend made `test_oblatestaeckelwrapper_ntab_c`
time out on jax (>300 s) — it had been passing by silently falling through to
analytic evaluation, which is exactly the bug this PR fixes. The test integrates
1001 steps with `method='dop853'`, a scalar Python stepper, so every force
evaluation lands on the spline.

I first parked it in the slow-skip ledger. That was the wrong call — the test is
not slow, **`eval_ppoly` was**, and it backs every frozen `Spline1D` on a backend
(`interpSphericalPotential`, `interpRZPotential`, the DF samplers, this wrapper).
On an eager backend its cost is the number of dispatches, and it was spending
them on bookkeeping rather than on the polynomial:

1. **The table was re-uploaded on every call** — a `(3000,)` and a `(4, 2999)`
   transfer to evaluate at one point, ~35% of the call. Now cached per
   (namespace, device); `__getstate__` drops it so pickling is unaffected.
2. **One gather, not four** — gathering each coefficient row separately cost
   1274 µs against 87 µs for one gather along axis 1.
3. **An integer index is a dispatch, and so is a reshape** — `ci[j]` for four
   rows cost 519 µs against 32 µs for one `unstack`, and `take` accepts an index
   of any shape, so the reshape pair around it (needed only by torch's
   `index_select`) was 145 µs of overhead on a 14 µs gather.

All three are pure data movement, so the arithmetic is untouched:

```
eval_ppoly vs the previous formulation — numpy AND jax AND torch,
nu = 0/1/2, scalar and array queries, 7-knot and 3000-knot grids:
    max |difference| = 0.0   (numpy byte-identical)
```

Measured at (R, z) = (0.9, 0.2), forced jax, tabulated wrapper:

```
evaluatePotentials   14.21 ms -> 7.48 ms
evaluateRforces      19.10 ms -> 7.22 ms     2.6x
evaluateR2derivs     40.81 ms -> 15.20 ms    2.7x
```

Per spline evaluation that is 6.7 ms -> 0.7 ms (~10x), and `eval_ppoly` is no
longer the dominant term in the force — the wrapper's own ~63 elementwise ops
are. numpy unchanged (0.15 ms). The test goes **464.7 s -> 258.1 s**, ~183 s at
the 0.71 CI/local ratio against the 300 s cap, so the slow-skip entry came back
out: the jax ledger is one row *shorter* than before this branch, not one longer.

### Gates

| | |
|---|---|
| numpy `test_potential` + `test_actionAngle` | 1527 passed, 102 skipped |
| numpy `test_potential` + `test_interp_potential` | 1340 passed, 102 skipped |
| backend `test_backend_wrappers` + `actionAngle` + `orbit_stm` | 990 passed |
| backend interpolate/interprz/interpspherical/wrappers, jax | 769 passed |
| same + AA grad probes, torch | 788 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
