### PR TITLE
Orbit: a backend IC gets a backend trajectory back, whatever the integrator

### DIFF
--- a/galpy/orbit/Orbits.py
+++ b/galpy/orbit/Orbits.py
@@ -25,7 +25,9 @@ else:
 
 from ..backend import (
     as_numpy,
+    asarray_on_device,
     coerce_coords,
+    device_of,
     get_namespace,
     is_backend_array,
     name_of_namespace,
@@ -307,6 +309,14 @@ def _backend_safe_copy(x):
     copy. ``x`` is always a backend array here (guarded by ``is_backend_array``).
     """
     return x.clone() if hasattr(x, "clone") else x  # torch has .clone(); jax does not
+
+
+def _copy_for_continuation(x):
+    """Independent copy of a stored trajectory for the continuation merge,
+    whatever namespace it is on. numpy and jax arrays have ``.copy()``; a torch
+    tensor has ``.clone()`` instead, which (unlike a detached copy) stays in the
+    autograd graph."""
+    return x.clone() if hasattr(x, "clone") else x.copy()
 
 
 def _backend_T(x):
@@ -1822,18 +1832,19 @@ class Orbit:
             )
         if ic_backend is not None:
             # Reaching here means every differentiable route above declined this
-            # method (in-backend solver, C-STM), so the numpy/C path below returns
-            # a NUMPY trajectory from a backend IC. That fall-through is deliberate
-            # -- it is what lets the suite run under a forced backend, and what
-            # keeps the symplectic default from being silently rerouted (gh#1094)
-            # -- but the type demotion is invisible to the caller, so say it.
+            # method (in-backend solver, C-STM), so the trajectory is COMPUTED in
+            # numpy/C. It is handed back on the IC's backend (the exit cast at the
+            # end of this method), so nothing is demoted -- but the arithmetic that
+            # produced it was numpy's, so it carries no gradient and this method
+            # would refuse a grad-tracking IC outright. That distinction is
+            # invisible in the returned type, so say it.
             warnings.warn(
                 f"this Orbit has a jax/torch initial condition, but method="
-                f"'{method}' integrates in numpy: the orbit is returned as a numpy "
-                "array and is not differentiable. Use method='diffrax' (jax) or "
-                "method='torchdiffeq' (torch) to integrate in the backend, or one "
-                "of the Runge-Kutta C methods (dop853_c, rk4_c, rk6_c, dopr54_c) "
-                "to keep the differentiable C state-transition path",
+                f"'{method}' integrates in numpy: the trajectory is returned on "
+                "the backend but is not differentiable. Use method='diffrax' (jax) "
+                "or method='torchdiffeq' (torch) to integrate in the backend, or "
+                "one of the Runge-Kutta C methods (dop853_c, rk4_c, rk6_c, "
+                "dopr54_c) to keep the differentiable C state-transition path",
                 galpyWarning,
             )
         self.check_integrator(method)
@@ -1899,15 +1910,17 @@ class Orbit:
         # Store old orbit data and vxvv if continuing
         if should_continue:
             old_t = self.t.copy()
-            old_orbit = self.orbit.copy()
+            old_orbit = _copy_for_continuation(self.orbit)
             old_vxvv = self.vxvv.copy()
-            # Update initial conditions to be the final state of previous integration
+            # Update initial conditions to be the final state of previous integration.
+            # self.vxvv is the numpy bookkeeping the C/scipy integrators restart
+            # from, so it stays numpy even when the stored orbit is a backend array.
             if is_forward:
                 # For forward continuation, start from the last state
-                self.vxvv = self.orbit[:, -1, :].copy()
+                self.vxvv = as_numpy(self.orbit[:, -1, :]).copy()
             else:
                 # For backward continuation, start from the first state
-                self.vxvv = self.orbit[:, 0, :].copy()
+                self.vxvv = as_numpy(self.orbit[:, 0, :]).copy()
 
         # Delete attributes for interpolation and rperi etc. determination
         if hasattr(self, "_orbInterp"):
@@ -2010,20 +2023,37 @@ class Orbit:
 
         # Merge with old orbit if continuing integration
         if should_continue:
+            # The stored orbit is a backend array whenever the IC was one, so the
+            # merge runs on its namespace (numpy's own for a numpy orbit, so that
+            # path is byte-identical).
+            _xp = get_namespace(self.orbit) if is_backend_array(self.orbit) else numpy
             if is_forward:
                 # Forward continuation: merge old and new, skip duplicate time point
                 self.t = numpy.concatenate([old_t, self.t[1:]], axis=-1)
-                self.orbit = numpy.concatenate([old_orbit, self.orbit[:, 1:]], axis=1)
+                self.orbit = _xp.concatenate([old_orbit, self.orbit[:, 1:]], axis=1)
             else:
                 # Backward continuation: prepend new orbit to old (reversed), skip duplicate time point
                 # New times go from t[0] to t[-1] in decreasing order (e.g., 0 to -10)
                 # We want the result to be monotonic, so reverse the new times/orbit
                 self.t = numpy.concatenate([self.t[:0:-1], old_t], axis=-1)
-                self.orbit = numpy.concatenate(
-                    [self.orbit[:, :0:-1], old_orbit], axis=1
+                # self.orbit[:, :0:-1] in namespace-agnostic form: torch has no
+                # negative-step slicing, and flip is exact on every namespace.
+                self.orbit = _xp.concatenate(
+                    [_xp.flip(self.orbit[:, 1:], axis=1), old_orbit], axis=1
                 )
             # Restore original initial conditions
             self.vxvv = old_vxvv
+
+        # A backend IC that reaches here is CONCRETE (a traced / grad-tracking one
+        # was refused above), so there is no gradient to carry -- but it is still a
+        # backend orbit, and handing back numpy would make every accessor below it
+        # a silent numpy island. Cast the finished trajectory onto the IC's
+        # namespace. The integration itself ran on numpy/C and is untouched, so the
+        # VALUES are exactly the numpy ones.
+        if ic_backend is not None:
+            self.orbit = asarray_on_device(
+                get_namespace(ic_backend), self.orbit, device_of(ic_backend)
+            )
 
         # Check whether r ever < minr if dynamical friction is included
         # and warn if so

--- a/tests/test_backend_orbit_integrate.py
+++ b/tests/test_backend_orbit_integrate.py
@@ -620,14 +620,19 @@ def test_integrate_diffrax_numpy_times():
 def test_integrate_concrete_backend_ic_numpy_method_works():
     # a CONCRETE (eager) jax-IC Orbit keeps its real values in self.vxvv, so a
     # non-dxdv numpy/C integrator runs normally and matches the numpy-IC result --
-    # this lets the existing suite be driven under a forced jax/torch backend. (A
-    # dxdv-capable C method instead routes to the differentiable C-STM and returns a
-    # backend array; see test_backend_orbit_stm.py::test_orbit_integrate_*.)
+    # this lets the existing suite be driven under a forced jax/torch backend. The
+    # finished trajectory is cast back onto the IC's namespace, so it is a jax
+    # array holding exactly the numpy values. (A dxdv-capable RK C method instead
+    # routes to the differentiable C-STM; see test_backend_orbit_stm.py.)
     pot = PlummerPotential(amp=1.0, b=0.6)
-    o = Orbit(jnp.asarray(_IC))
-    o.integrate(_TS, pot, method="leapfrog_c")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o = Orbit(jnp.asarray(_IC))
+        o.integrate(_TS, pot, method="leapfrog_c")
     ref = Orbit(list(_IC))
     ref.integrate(_TS, pot, method="leapfrog_c")
+    numpy.testing.assert_array_equal(as_numpy(o.getOrbit()), ref.getOrbit())
+    assert is_backend_array(o.orbit), "a jax IC must not come back as numpy"
     numpy.testing.assert_allclose(o.R(_TS), ref.R(_TS), rtol=1e-12, atol=1e-12)
 
 
@@ -875,7 +880,12 @@ def test_accessor_jittable_at_traced_grid_times():
 #   ias15_c                             ndarray   no dxdv, so no C-STM
 #   dop853_c / rk4_c / rk6_c / dopr54_c Tensor    C-STM, differentiable
 ###############################################################################
-_DEMOTES_TO_NUMPY = [
+# Methods whose trajectory is COMPUTED in numpy/C for a concrete backend IC: the
+# Python steppers, the symplectic C family (galpy's default symplec4_c included)
+# and ias15_c, which has no C dxdv Hessian. They still hand the finished orbit
+# back on the backend -- the exit cast -- so nothing is demoted; what they cannot
+# do is carry a gradient, which is what the warning is about.
+_NUMPY_COMPUTED = [
     "dop853",
     "odeint",
     "leapfrog",
@@ -884,6 +894,7 @@ _DEMOTES_TO_NUMPY = [
     "symplec6_c",
     "ias15_c",
 ]
+# The Runge-Kutta dxdv C methods route to the differentiable C-STM instead.
 _KEEPS_BACKEND_ARRAY = ["dop853_c", "rk4_c", "rk6_c", "dopr54_c"]
 
 
@@ -892,14 +903,46 @@ def _demotion_warnings(record):
 
 
 @pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
-@pytest.mark.parametrize("method", _DEMOTES_TO_NUMPY)
+@pytest.mark.parametrize("method", _NUMPY_COMPUTED)
 def test_integrate_concrete_backend_ic_numpy_method_warns(method):
     o = Orbit(torch.tensor(_IC))
     with pytest.warns(galpyWarning, match="integrates in numpy"):
         o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method=method)
-    assert not is_backend_array(o.orbit), (
-        f"{method}: the warning says the orbit is demoted to numpy, but it is not"
+    # what the warning is about is the missing gradient, NOT a numpy return: the
+    # orbit comes back on the backend like every other method's.
+    assert is_backend_array(o.orbit), (
+        f"{method}: a backend IC must not come back as numpy"
     )
+    assert o.orbit.grad_fn is None, (
+        f"{method}: computed in numpy, so there is nothing for a gradient to "
+        "flow through -- a grad_fn here would mean the warning is wrong"
+    )
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("method", _NUMPY_COMPUTED + _KEEPS_BACKEND_ARRAY)
+def test_integrate_concrete_backend_ic_matches_numpy_ic_exactly(method):
+    # The exit cast must not perturb a single bit: a concrete backend IC runs the
+    # same numpy/C integration a numpy IC does, so the two trajectories are the
+    # SAME float64 values, not merely close. (The C-STM methods integrate the
+    # augmented 42-wide system, so they are held to the looser bar their different
+    # step sequence earns.)
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    ref = Orbit(list(_IC))
+    ref.integrate(_TS, pot, method=method)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o = Orbit(torch.tensor(_IC))
+        o.integrate(_TS, pot, method=method)
+    got = as_numpy(o.getOrbit())
+    if method in _KEEPS_BACKEND_ARRAY:
+        numpy.testing.assert_allclose(got, ref.getOrbit(), rtol=1e-9, atol=1e-9)
+    else:
+        numpy.testing.assert_array_equal(
+            got,
+            ref.getOrbit(),
+            err_msg=f"{method}: backend-IC trajectory differs from the numpy-IC one",
+        )
 
 
 @pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
@@ -929,3 +972,42 @@ def test_integrate_numpy_ic_under_forced_backend_does_not_warn():
             warnings.simplefilter("always")
             o.integrate(_TS, PlummerPotential(amp=1.0, b=0.6), method="dop853")
     assert not _demotion_warnings(rec)
+
+
+# ---------------- continuing an integration keeps the backend orbit intact
+_CONTINUATION_TS2 = {
+    "forward": numpy.linspace(6.0, 12.0, 120),
+    "backward": numpy.linspace(0.0, -6.0, 120),
+}
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="torch not installed")
+@pytest.mark.parametrize("direction", list(_CONTINUATION_TS2))
+@pytest.mark.parametrize("method", _NUMPY_COMPUTED)
+def test_integrate_continuation_backend_ic_matches_numpy_ic(method, direction):
+    # Integrating a second time from where the first leg ended MERGES the two
+    # legs. The merge used to be numpy-only -- `self.orbit.copy()` on a torch
+    # tensor raises AttributeError, and the backward branch reverses with a
+    # negative-step slice torch does not support -- which only became reachable
+    # once a backend IC started storing a backend trajectory.
+    pot = PlummerPotential(amp=1.0, b=0.6)
+    ts2 = _CONTINUATION_TS2[direction]
+    ref = Orbit(list(_IC))
+    ref.integrate(_TS, pot, method=method)
+    ref.integrate(ts2, pot, method=method)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o = Orbit(torch.tensor(_IC))
+        o.integrate(_TS, pot, method=method)
+        o.integrate(ts2, pot, method=method)
+    assert is_backend_array(o.orbit), f"{method}/{direction}: merged orbit left torch"
+    assert o.orbit.shape == ref.orbit.shape, (
+        f"{method}/{direction}: merged to {tuple(o.orbit.shape)}, "
+        f"numpy IC gives {ref.orbit.shape} -- a leg was dropped"
+    )
+    numpy.testing.assert_array_equal(
+        as_numpy(o.getOrbit()),
+        ref.getOrbit(),
+        err_msg=f"{method}/{direction}: merged trajectory differs from the numpy one",
+    )
+    numpy.testing.assert_array_equal(as_numpy(o.t), numpy.asarray(ref.t))

--- a/tests/test_backend_orbit_stm.py
+++ b/tests/test_backend_orbit_stm.py
@@ -6,6 +6,8 @@
 # orbit, grad == finite-difference, jacrev == the directly-assembled STM, torch
 # gradcheck, and agreement with the independent in-backend ODE path.
 ###############################################################################
+import warnings
+
 import numpy
 import pytest
 
@@ -888,18 +890,40 @@ def test_lowdim_orbit_integrate_routing(backend):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("method", _SYMPLEC_METHODS)
-def test_symplectic_not_autorouted(backend, method):
-    # The symplectic methods are deliberately NOT auto-routed by Orbit.integrate:
-    # symplec4_c is galpy's DEFAULT integrator, so routing it would silently reroute
-    # every internal default-method integration (e.g. streamspraydf sample orbits)
-    # to the C-STM under a forced backend. So a backend IC + a symplectic method
-    # falls through to the (non-differentiable) numpy/C path -- getOrbit is numpy.
-    # Symplectic C-STM differentiation stays available via orbit_stm.integrate.
+def test_symplectic_not_autorouted(backend, method, monkeypatch):
+    # The symplectic methods are deliberately NOT auto-routed to the C-STM for a
+    # CONCRETE backend IC: symplec4_c is galpy's DEFAULT integrator, so routing it
+    # would send every internal default-method integration (streamspraydf sample
+    # orbits and the like) through the 42-wide augmented system under a forced
+    # backend -- measured at 800x the plain C cost, for an STM a concrete IC can
+    # never differentiate through. So it stays on the numpy/C path.
+    #
+    # The returned type can no longer say that: the finished trajectory is cast
+    # onto the IC's backend, exactly as every other method's is. Assert the
+    # routing itself instead (the C-STM entry must not be reached) plus the
+    # consequence that matters -- the values are the plain-C ones, bit for bit.
     from galpy.orbit import Orbit
 
-    o = Orbit(_arr(backend, _IC))
-    o.integrate(_arr(backend, _LOWDIM_TS), MWPotential2014, method=method)
-    assert isinstance(o.getOrbit(), numpy.ndarray)
+    def _boom(*args, **kwargs):  # pragma: no cover - must never be called
+        raise AssertionError(f"{method}: concrete backend IC routed to the C-STM")
+
+    ref = Orbit(list(_IC))
+    ref.integrate(_LOWDIM_TS, MWPotential2014, method=method)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        o = Orbit(_arr(backend, _IC))
+        monkeypatch.setattr(Orbit, "_integrate_cstm", _boom)
+        o.integrate(_arr(backend, _LOWDIM_TS), MWPotential2014, method=method)
+        monkeypatch.undo()
+    assert _is_backend(backend, o.getOrbit()), (
+        f"{method}: a backend IC must not come back as numpy"
+    )
+    numpy.testing.assert_array_equal(
+        as_numpy(o.getOrbit()),
+        ref.getOrbit(),
+        err_msg=f"{method}: not the plain-C trajectory a numpy IC gets",
+    )
     # the explicit functional interface still differentiates this same method
     assert _is_backend(
         backend,


### PR DESCRIPTION
Stacked on #1485.

`Orbit(<jax/torch IC>).integrate(...)` only handed back a backend array for the
four Runge-Kutta C methods, which auto-route to the differentiable C-STM.
Everything else — the symplectic C family (galpy's **default** `symplec4_c`
included), `ias15_c`, and the Python steppers — silently returned numpy, so any
accessor chain hanging off it was a numpy island the type system could not see.
#1482 made that demotion audible with a warning; this makes it stop happening.
The finished trajectory is cast onto the IC's namespace and device.

This is the "upgrade to the backend (just with no grad)" option, for every
integrator at once rather than `ias15_c` alone.

### It is free, and the values do not move

```
             N        numpy      backend    ratio
symplec4_c   1      1.10 ms      1.11 ms    1.01x
symplec4_c   200    8.29 ms      8.30 ms    1.00x
ias15_c      200   17.88 ms     18.26 ms    1.02x
```

Maximum absolute difference from the numpy-IC trajectory: **0.0**, across
`leapfrog_c` / `symplec4_c` / `symplec6_c` / `ias15_c` / `dop853` / `odeint`,
every phase-space dimension (2, 3, 4, 5, 6) and multi-orbit. The integration
still runs in numpy/C; the cast is all that is new.

### Why not route them to the C-STM instead

That was the first thing I tried, since "symplectic on the backend" sounds like
it should mean the differentiable path. It is bit-identical (4.4e-16) — and it
costs:

```
symplec4_c  N=200   numpy  8.29 ms   backend 6671 ms    801x
dop853_c    N=200   numpy  3.44 ms   backend  976 ms    283x
```

The C-STM integrates the 42-wide augmented system to get `M(t) = dx(t)/dx(0)`,
and a **concrete** backend IC can never differentiate through it — a
grad-tracking IC has no concrete values, fails `numpy.asarray`, and is routed or
refused earlier. So for every orbit that reaches here the STM would be computed
and thrown away, on galpy's default method, under every forced-backend shard.
The gate stays shut (gh#1094 stays fixed).

`test_symplectic_not_autorouted` asserted that by checking for a numpy return
type, which this change takes away from it. It now spies on `_integrate_cstm`
and asserts the values are the plain-C ones bit for bit. Verified both ways:
with the gate opened it fails 6/6, closed it passes 6/6.

### Continuation had to follow the orbit onto the backend

`o.integrate(t1); o.integrate(t2)` merges the two legs, and that merge was
numpy-only in three ways that only became reachable once a backend IC stored a
backend trajectory: `self.orbit.copy()` (a torch tensor has `.clone()`),
`numpy.concatenate`, and the backward branch's `self.orbit[:, :0:-1]` (torch has
no negative-step slicing; `flip` is exact everywhere). `self.vxvv` stays numpy —
it is what the C/scipy integrators restart from. Verified forward **and**
backward, torch and jax, against the numpy-IC continuation: exact values, same
shape, same times.

### Found while doing this, not fixed here

The same continuation is silently **wrong** for the C-STM route on the current
branch:

```python
o = Orbit(torch.tensor(ic)); o.integrate(t1, pot, method="dop853_c")
o.integrate(t2, pot, method="dop853_c")
o.orbit.shape   # (1, 101, 6) -- a numpy IC gets the merged (1, 201, 6)
```

No error, no warning, first leg gone. `_integrate_cstm` returns before the
continuation bookkeeping runs. Next PR in the stack.

### Gates

| | |
|---|---|
| numpy `test_orbit` + `test_orbits` | 939 passed, 4 skipped |
| `test_backend_orbit_{integrate,stm,accessors}` + `inbackend_ode`, torch | 440 passed |
| same, jax | 440 passed |
| `test_streamdf`/`streamspraydf`/`streamTrack`, torch | 0 failures, same as base |
| `test_quantity` + `test_coords`, torch | identical to base (same single pre-existing `streamgapdf_sample` failure) |

The numpy path resolves `_xp` to numpy, so its merge is the same
`numpy.concatenate` it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
