### PR TITLE
test_eccentricity: a traced-only bar for the one potential that integrates on GL

### DIFF
--- a/tests/backend_xfail.txt
+++ b/tests/backend_xfail.txt
@@ -216,11 +216,6 @@
 #   * one-offs                               ~9  -- Cautun20, DehnenBinney98,
 #     ExpDisk_special, McMillan17, mass_spheroidal, plotting, ...
 # Only reachable via workflow_dispatch(jit=true); shrink it.
-# test_eccentricity is the same AnyAxisymmetricRazorThinDisk story seen through an
-# orbit: its traced GL forces carry ~1e-6 error, so a circular orbit comes back
-# with e=5.4e-6 against a 1e-8 tolerance. Passes eager jax. Un-ledger if the
-# tolerance is ever made backend-aware.
-jax-jit tests/test_orbit.py::test_eccentricity
 torch-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 jax-jit tests/test_potential.py::test_poisson_surfdens_potential[AnyAxisymmetricRazorThinDiskPotential]
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -16,7 +16,7 @@ import numpy
 import pytest
 from conftest import _to_numpy
 
-from galpy.backend import as_numpy
+from galpy.backend import as_numpy, jit_mode
 
 PY2 = sys.version < "3"
 _APY3 = astropy.__version__ > "3"
@@ -6198,10 +6198,26 @@ def test_eccentricity():
     tol["ExpTruncNFWPotential"] = -12.0  # these are more difficult, like NFW
     tol["MultipoleExpansionPotential"] = -15.0  # slightly more difficult
     tol["DiskMultipoleExpansionPotential"] = -6.0  # these are more difficult
+    # Tolerances that apply only under a TRACE. AnyAxisymmetricRazorThinDisk
+    # evaluates its integrals with Gauss-Legendre on the backend so that
+    # gradients exist, and reuses scipy for concrete input -- see the class
+    # comment: GL cannot resolve the a=R principal value. Under a trace the
+    # input IS a tracer, so the forces carry that quadrature's algebraic ~n^-2
+    # floor and a circular orbit picks up a tiny but non-zero eccentricity.
+    # Measured over every integrator in this test and both orbit types (3D and
+    # planar, axi and phi-tracking), the spread is 1.036e-10 to 1.149e-10 --
+    # integrator-INDEPENDENT, which is the signature of a force error rather
+    # than of accumulation. The bar is set ~2.8x above that worst case, not at a
+    # round number, so it still fails if the quadrature ever gets worse.
+    tol_traced = {}
+    tol_traced["AnyAxisymmetricRazorThinDiskPotential"] = -9.5  # worst 1.149e-10
+    traced = jit_mode() != "off"
     firstTest = True
     for p in pots:
         # Setup instance of potential
-        if p in list(tol.keys()):
+        if traced and p in tol_traced:
+            ttol = tol_traced[p]
+        elif p in list(tol.keys()):
             ttol = tol[p]
         else:
             ttol = tol["default"]


### PR DESCRIPTION
Stacked on #1489. **Ledger 6 → 5 rows.**

`AnyAxisymmetricRazorThinDiskPotential` evaluates its integrals with
Gauss-Legendre on the backend so that gradients exist, and reuses scipy for
concrete input — the class comment: GL cannot resolve the `a=R` principal value.
Under a **trace** the input *is* a tracer, so the traced forces carry that
quadrature's error and a circular orbit comes back with a tiny non-zero
eccentricity against a `1e-16` bar. That is the entire content of the ledger row
this drops, whose own note said: *"un-ledger if the tolerance is ever made
backend-aware."*

### Measured, not guessed

Over every integrator this test uses and all four orbit set-ups (3D and planar,
axi and phi-tracking):

```
jax --jit     1.0356e-10 ... 1.1489e-10
torch --jit   1.0356e-10 ... 1.1489e-10
```

Two things in that table decide the shape of the fix:

- the spread is **integrator-independent** — `dopr54_c`, `dop853_c`, `rk4_c`,
  `rk6_c`, `ias15_c`, `leapfrog_c`, `symplec4_c`, `symplec6_c` all land in the
  same 10% band. That is the signature of a *force* error, not of integration
  accumulating.
- jax and torch agree to five digits, so it is the quadrature and not the
  framework. The new bar therefore keys off `jit_mode()` rather than a backend
  name — which also covers `torch --jit`, which has the identical error and *no
  ledger row*, i.e. a latent failure nobody had recorded.

The bar is `-9.5` (3.16e-10), ~2.8× above the measured worst case rather than a
round number, so a quadrature that gets meaningfully worse still fails it.

It applies **only while traced**: numpy and eager jax keep the `-16` default
(both verified still passing), because eager backend input goes to scipy and
never reaches the GL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
