### PR TITLE
map_coordinates: one gather for the whole cubic tap block, not 4**D

### DIFF
--- a/galpy/backend/interpolate.py
+++ b/galpy/backend/interpolate.py
@@ -915,26 +915,46 @@ def map_coordinates(filtered, coords, order=3, mode="mirror", prefilter=False):
     # combo[d] in {-1,0,1,2} per dim; clamp the (base+offset) index to the edge
     # (mode='nearest'); multiply the per-dim weights; accumulate.
     offs = (-1, 0, 1, 2)
-    out = None
-    for combo in itertools.product(range(4), repeat=D):
-        gather_idx = []
-        wt = None
-        for d in range(D):
-            idx_d = base[d] + offs[combo[d]]
+    # Per-dimension tap indices, folded ONCE. The loop this replaces re-derived
+    # them inside every one of the 4**D combos -- for a 3-D grid that is 192
+    # boundary folds computing the same 12 index arrays.
+    idx_rows = []
+    for d in range(D):
+        hi = shape[d] - 1
+        row = []
+        for k in range(4):
+            idx_d = base[d] + offs[k]
             if mode == "mirror":
                 # Whole-sample symmetric fold, the pair to spline_filter's
                 # mode='mirror': i<0 -> -i ; i>n-1 -> 2(n-1)-i.
-                hi = shape[d] - 1
                 idx_d = hi - xp.abs(hi - xp.abs(idx_d))
             else:  # 'nearest': clamp the tap index to the edge
-                idx_d = xp.clip(idx_d, 0, shape[d] - 1)
-            gather_idx.append(idx_d)
-            w_d = weights[d][combo[d]]
-            wt = w_d if wt is None else wt * w_d
-        vals = cb[tuple(gather_idx)]
-        contrib = vals * wt
-        out = contrib if out is None else out + contrib
-    return out
+                idx_d = xp.clip(idx_d, 0, hi)
+            row.append(idx_d)
+        idx_rows.append(row)
+    # ONE gather for all 4**D taps. The tap block is built by BROADCASTING the
+    # per-dimension indices against C-order strides instead of by 4**D separate
+    # fancy-index gathers -- on eager jax a gather is ~300 us of dispatch, so a
+    # 3-D cubic was paying 64 of them (plus their index arithmetic) to
+    # interpolate at ONE point.
+    strides = [1] * D
+    for d in range(D - 2, -1, -1):
+        strides[d] = strides[d + 1] * shape[d + 1]
+    flat = None
+    wt = None
+    for d in range(D):
+        bshape = [1] * D + [-1]
+        bshape[d] = 4
+        i_d = xp.reshape(xp.stack(idx_rows[d], axis=0), tuple(bshape))
+        w_d = xp.reshape(xp.stack(list(weights[d]), axis=0), tuple(bshape))
+        term = i_d * strides[d]
+        flat = term if flat is None else flat + term
+        wt = w_d if wt is None else wt * w_d
+    npts = flat.shape[-1]
+    vals = _take0(xp, xp.reshape(cb, (-1,)), xp.reshape(flat, (-1,)))
+    # sum over the D tap axes; the taps are the same ones and in the same
+    # C-order the itertools.product loop visited them in.
+    return xp.sum(xp.reshape(vals, (-1, npts)) * xp.reshape(wt, (-1, npts)), axis=0)
 
 
 def _index_dtype(xp):


### PR DESCRIPTION
Stacked on #1494. The third and last of the interpolation dispatch reworks.

`map_coordinates` is the StaeckelGrid `jr`/`jz`/`ecc`/`zmax`/`rperi`/`rap`
evaluator. On eager jax, interpolating at **one** point in a 3-D grid cost
102 ms — and at 200 points, 117 ms. Almost all of it was fixed dispatch:

```
per call, 3-D cubic:   64 fancy-index gathers, 981 jax primitive dispatches
```

`itertools.product(range(4), repeat=D)` visited the 4**D tap combinations one at
a time, gathering separately for each, and re-derived the per-dimension tap index
*inside every combo* — for D=3 that's 192 boundary folds computing the same 12
index arrays.

Both go away without changing which taps are summed: the per-dimension indices
are folded once, and the tap block is built by **broadcasting** them against
C-order strides, so all 4**D flat indices come from D multiply-adds and one
gather off the flattened grid fetches every tap.

```
40x40x40 grid, eager jax
    1 point     101.35 ms -> 10.65 ms     9.5x
  200 points     93.71 ms -> 10.93 ms     8.6x
```

### Accuracy — and what this one does *not* claim

Against `scipy.ndimage.map_coordinates`, the documented contract (~1e-14), old
vs new on identical inputs:

```
3-D mirror    1.70e-14 -> 2.41e-14
3-D nearest   1.76e-13 -> 1.51e-13
2-D mirror    2.86e-14 -> 2.86e-14     identical
2-D nearest   3.17e-14 -> 3.17e-14     identical
1-D mirror    8.17e-15 -> 8.17e-15     identical
1-D nearest   4.63e-14 -> 4.63e-14     identical
```

1-D and 2-D are unchanged *exactly*; only 3-D moves — one way in `mirror`, the
other in `nearest` — at the 1e-14 level. That's the reduction order: the taps and
weights are the same numbers, summed by one `xp.sum` over the flattened tap axes
instead of by sequential accumulation.

So unlike #1485 and #1491, which were pure data movement and **were**
bit-identical, this one is not, and I'm not claiming it is. It stays well inside
the contract the function documents.

The numpy path is untouched — a numpy `coords` is still a literal
`scipy.ndimage` passthrough.

Gates: numpy `test_actionAngle` **234 passed**, matching base exactly; jax
`test_backend_interpolate` + `test_backend_actionAngle` **516 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgPfLBMhm6aEYwVtaQ7jMm
